### PR TITLE
Replace master with main in homepage links.

### DIFF
--- a/common/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-homepage.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-homepage.ts
@@ -37,7 +37,7 @@ export = {
             const nodeValue = node.value as Literal;
 
             if (
-              !/^https:\/\/github.com\/Azure\/azure-sdk-for-js\/(blob|tree)\/master\/sdk\/(([a-z]+-)*[a-z]+\/)+(README\.md)?$/.test(
+              !/^https:\/\/github.com\/Azure\/azure-sdk-for-js\/(blob|tree)\/main\/sdk\/(([a-z]+-)*[a-z]+\/)+(README\.md)?$/.test(
                 nodeValue.value as string
               )
             ) {

--- a/sdk/advisor/arm-advisor/package.json
+++ b/sdk/advisor/arm-advisor/package.json
@@ -27,7 +27,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.6.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/advisor/arm-advisor",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/advisor/arm-advisor",
   "repository": {
     "type": "git",
     "url": "https://github.com/Azure/azure-sdk-for-js.git"

--- a/sdk/agrifood/agrifood-farming-rest/package.json
+++ b/sdk/agrifood/agrifood-farming-rest/package.json
@@ -16,7 +16,7 @@
   "main": "./dist/index.js",
   "module": "./dist-esm/src/index.js",
   "types": "./types/agrifood-farming-rest.d.ts",
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/agrifood/agrifood-farming/README.md",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/agrifood/agrifood-farming/README.md",
   "repository": "github:Azure/azure-sdk-for-js",
   "bugs": {
     "url": "https://github.com/Azure/azure-sdk-for-js/issues"

--- a/sdk/analysisservices/arm-analysisservices/package.json
+++ b/sdk/analysisservices/arm-analysisservices/package.json
@@ -26,7 +26,7 @@
     "rollup-plugin-node-resolve": "^3.4.0",
     "uglify-js": "^3.4.9"
   },
-  "homepage": "https://github.com/azure/azure-sdk-for-js/tree/master/sdk/analysisservices/arm-analysisservices",
+  "homepage": "https://github.com/azure/azure-sdk-for-js/tree/main/sdk/analysisservices/arm-analysisservices",
   "repository": {
     "type": "git",
     "url": "https://github.com/azure/azure-sdk-for-js.git"

--- a/sdk/anomalydetector/ai-anomaly-detector/package.json
+++ b/sdk/anomalydetector/ai-anomaly-detector/package.json
@@ -58,7 +58,7 @@
   "bugs": {
     "url": "https://github.com/Azure/azure-sdk-for-js/issues"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/anomalydetector/ai-anomaly-detector/",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/anomalydetector/ai-anomaly-detector/",
   "sideEffects": false,
   "prettier": "@azure/eslint-plugin-azure-sdk/prettier.json",
   "dependencies": {

--- a/sdk/apimanagement/arm-apimanagement/package.json
+++ b/sdk/apimanagement/arm-apimanagement/package.json
@@ -27,7 +27,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.6.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/apimanagement/arm-apimanagement",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/apimanagement/arm-apimanagement",
   "repository": {
     "type": "git",
     "url": "https://github.com/Azure/azure-sdk-for-js.git"

--- a/sdk/appconfiguration/app-configuration/package.json
+++ b/sdk/appconfiguration/app-configuration/package.json
@@ -16,7 +16,7 @@
   "main": "./dist/index.js",
   "module": "./dist-esm/src/index.js",
   "types": "./types/app-configuration.d.ts",
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/appconfiguration/app-configuration/",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/appconfiguration/app-configuration/",
   "repository": "github:Azure/azure-sdk-for-js",
   "bugs": {
     "url": "https://github.com/Azure/azure-sdk-for-js/issues"

--- a/sdk/appconfiguration/arm-appconfiguration/package.json
+++ b/sdk/appconfiguration/arm-appconfiguration/package.json
@@ -27,7 +27,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.6.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/appconfiguration/arm-appconfiguration",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/appconfiguration/arm-appconfiguration",
   "repository": {
     "type": "git",
     "url": "https://github.com/Azure/azure-sdk-for-js.git"

--- a/sdk/applicationinsights/applicationinsights-query/package.json
+++ b/sdk/applicationinsights/applicationinsights-query/package.json
@@ -24,7 +24,7 @@
     "rollup-plugin-node-resolve": "^3.4.0",
     "uglify-js": "^3.4.9"
   },
-  "homepage": "https://github.com/azure/azure-sdk-for-js/tree/master/sdk/applicationinsights/applicationinsights-query",
+  "homepage": "https://github.com/azure/azure-sdk-for-js/tree/main/sdk/applicationinsights/applicationinsights-query",
   "repository": {
     "type": "git",
     "url": "https://github.com/azure/azure-sdk-for-js.git"

--- a/sdk/applicationinsights/arm-appinsights/package.json
+++ b/sdk/applicationinsights/arm-appinsights/package.json
@@ -27,7 +27,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.6.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/applicationinsights/arm-appinsights",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/applicationinsights/arm-appinsights",
   "repository": {
     "type": "git",
     "url": "https://github.com/Azure/azure-sdk-for-js.git"

--- a/sdk/appplatform/arm-appplatform/package.json
+++ b/sdk/appplatform/arm-appplatform/package.json
@@ -27,7 +27,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.6.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/appplatform/arm-appplatform",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/appplatform/arm-appplatform",
   "repository": {
     "type": "git",
     "url": "https://github.com/Azure/azure-sdk-for-js.git"

--- a/sdk/appservice/arm-appservice-profile-2020-09-01-hybrid/package.json
+++ b/sdk/appservice/arm-appservice-profile-2020-09-01-hybrid/package.json
@@ -27,7 +27,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.6.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/appservice/arm-appservice-profile-2020-09-01-hybrid",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/appservice/arm-appservice-profile-2020-09-01-hybrid",
   "repository": {
     "type": "git",
     "url": "https://github.com/Azure/azure-sdk-for-js.git"

--- a/sdk/appservice/arm-appservice/package.json
+++ b/sdk/appservice/arm-appservice/package.json
@@ -27,7 +27,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.6.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/appservice/arm-appservice",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/appservice/arm-appservice",
   "repository": {
     "type": "git",
     "url": "https://github.com/Azure/azure-sdk-for-js.git"

--- a/sdk/attestation/arm-attestation/package.json
+++ b/sdk/attestation/arm-attestation/package.json
@@ -27,7 +27,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.6.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/attestation/arm-attestation",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/attestation/arm-attestation",
   "repository": {
     "type": "git",
     "url": "https://github.com/Azure/azure-sdk-for-js.git"

--- a/sdk/attestation/attestation/package.json
+++ b/sdk/attestation/attestation/package.json
@@ -83,7 +83,7 @@
   "bugs": {
     "url": "https://github.com/Azure/azure-sdk-for-js/issues"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/attestation/attestation/README.md",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/attestation/attestation/README.md",
   "sideEffects": false,
   "prettier": "@azure/eslint-plugin-azure-sdk/prettier.json",
   "dependencies": {

--- a/sdk/authorization/arm-authorization-profile-2019-03-01-hybrid/package.json
+++ b/sdk/authorization/arm-authorization-profile-2019-03-01-hybrid/package.json
@@ -28,7 +28,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.4.9"
   },
-  "homepage": "https://github.com/azure/azure-sdk-for-js/tree/master/sdk/authorization/arm-authorization-profile-2019-03-01-hybrid",
+  "homepage": "https://github.com/azure/azure-sdk-for-js/tree/main/sdk/authorization/arm-authorization-profile-2019-03-01-hybrid",
   "repository": {
     "type": "git",
     "url": "https://github.com/azure/azure-sdk-for-js.git"

--- a/sdk/authorization/arm-authorization-profile-2020-09-01-hybrid/package.json
+++ b/sdk/authorization/arm-authorization-profile-2020-09-01-hybrid/package.json
@@ -27,7 +27,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.6.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/authorization/arm-authorization-profile-2020-09-01-hybrid",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/authorization/arm-authorization-profile-2020-09-01-hybrid",
   "repository": {
     "type": "git",
     "url": "https://github.com/Azure/azure-sdk-for-js.git"

--- a/sdk/authorization/arm-authorization/package.json
+++ b/sdk/authorization/arm-authorization/package.json
@@ -27,7 +27,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.4.9"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/authorization/arm-authorization",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/authorization/arm-authorization",
   "repository": {
     "type": "git",
     "url": "https://github.com/Azure/azure-sdk-for-js.git"

--- a/sdk/automation/arm-automation/package.json
+++ b/sdk/automation/arm-automation/package.json
@@ -27,7 +27,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.6.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/automation/arm-automation",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/automation/arm-automation",
   "repository": {
     "type": "git",
     "url": "https://github.com/Azure/azure-sdk-for-js.git"

--- a/sdk/avs/arm-avs/package.json
+++ b/sdk/avs/arm-avs/package.json
@@ -27,7 +27,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.6.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/avs/arm-avs",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/avs/arm-avs",
   "repository": {
     "type": "git",
     "url": "https://github.com/Azure/azure-sdk-for-js.git"

--- a/sdk/azurestack/arm-azurestack/package.json
+++ b/sdk/azurestack/arm-azurestack/package.json
@@ -27,7 +27,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.6.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/azurestack/arm-azurestack",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/azurestack/arm-azurestack",
   "repository": {
     "type": "git",
     "url": "https://github.com/Azure/azure-sdk-for-js.git"

--- a/sdk/azurestackhci/arm-azurestackhci/package.json
+++ b/sdk/azurestackhci/arm-azurestackhci/package.json
@@ -27,7 +27,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.6.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/azurestackhci/arm-azurestackhci",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/azurestackhci/arm-azurestackhci",
   "repository": {
     "type": "git",
     "url": "https://github.com/Azure/azure-sdk-for-js.git"

--- a/sdk/batch/batch/package.json
+++ b/sdk/batch/batch/package.json
@@ -47,7 +47,7 @@
     "esm": "^3.2.25",
     "ts-node": "^8.3.0"
   },
-  "homepage": "https://github.com/azure/azure-sdk-for-js/tree/master/sdk/batch/batch",
+  "homepage": "https://github.com/azure/azure-sdk-for-js/tree/main/sdk/batch/batch",
   "repository": {
     "type": "git",
     "url": "https://github.com/Azure/azure-sdk-for-js.git"

--- a/sdk/batchai/arm-batchai/package.json
+++ b/sdk/batchai/arm-batchai/package.json
@@ -26,7 +26,7 @@
     "rollup-plugin-node-resolve": "^3.4.0",
     "uglify-js": "^3.4.9"
   },
-  "homepage": "https://github.com/azure/azure-sdk-for-js/tree/master/sdk/batchai/arm-batchai",
+  "homepage": "https://github.com/azure/azure-sdk-for-js/tree/main/sdk/batchai/arm-batchai",
   "repository": {
     "type": "git",
     "url": "https://github.com/azure/azure-sdk-for-js.git"

--- a/sdk/billing/arm-billing/package.json
+++ b/sdk/billing/arm-billing/package.json
@@ -27,7 +27,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.6.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/billing/arm-billing",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/billing/arm-billing",
   "repository": {
     "type": "git",
     "url": "https://github.com/Azure/azure-sdk-for-js.git"

--- a/sdk/botservice/arm-botservice/package.json
+++ b/sdk/botservice/arm-botservice/package.json
@@ -27,7 +27,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.6.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/botservice/arm-botservice",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/botservice/arm-botservice",
   "repository": {
     "type": "git",
     "url": "https://github.com/Azure/azure-sdk-for-js.git"

--- a/sdk/cdn/arm-cdn/package.json
+++ b/sdk/cdn/arm-cdn/package.json
@@ -27,7 +27,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.6.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/cdn/arm-cdn",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/cdn/arm-cdn",
   "repository": {
     "type": "git",
     "url": "https://github.com/Azure/azure-sdk-for-js.git"

--- a/sdk/changeanalysis/arm-changeanalysis/package.json
+++ b/sdk/changeanalysis/arm-changeanalysis/package.json
@@ -27,7 +27,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.6.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/changeanalysis/arm-changeanalysis",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/changeanalysis/arm-changeanalysis",
   "repository": {
     "type": "git",
     "url": "https://github.com/Azure/azure-sdk-for-js.git"

--- a/sdk/cognitiveservices/arm-cognitiveservices/package.json
+++ b/sdk/cognitiveservices/arm-cognitiveservices/package.json
@@ -27,7 +27,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.6.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/cognitiveservices/arm-cognitiveservices",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/cognitiveservices/arm-cognitiveservices",
   "repository": {
     "type": "git",
     "url": "https://github.com/Azure/azure-sdk-for-js.git"

--- a/sdk/cognitiveservices/cognitiveservices-anomalydetector/package.json
+++ b/sdk/cognitiveservices/cognitiveservices-anomalydetector/package.json
@@ -25,7 +25,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.6.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/cognitiveservices/cognitiveservices-anomalydetector",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/cognitiveservices/cognitiveservices-anomalydetector",
   "repository": {
     "type": "git",
     "url": "https://github.com/Azure/azure-sdk-for-js.git"

--- a/sdk/cognitiveservices/cognitiveservices-autosuggest/package.json
+++ b/sdk/cognitiveservices/cognitiveservices-autosuggest/package.json
@@ -25,7 +25,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.6.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/cognitiveservices/cognitiveservices-autosuggest",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/cognitiveservices/cognitiveservices-autosuggest",
   "repository": {
     "type": "git",
     "url": "https://github.com/Azure/azure-sdk-for-js.git"

--- a/sdk/cognitiveservices/cognitiveservices-computervision/package.json
+++ b/sdk/cognitiveservices/cognitiveservices-computervision/package.json
@@ -25,7 +25,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.6.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/cognitiveservices/cognitiveservices-computervision",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/cognitiveservices/cognitiveservices-computervision",
   "repository": {
     "type": "git",
     "url": "https://github.com/Azure/azure-sdk-for-js.git"

--- a/sdk/cognitiveservices/cognitiveservices-contentmoderator/package.json
+++ b/sdk/cognitiveservices/cognitiveservices-contentmoderator/package.json
@@ -25,7 +25,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.6.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/cognitiveservices/cognitiveservices-contentmoderator",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/cognitiveservices/cognitiveservices-contentmoderator",
   "repository": {
     "type": "git",
     "url": "https://github.com/Azure/azure-sdk-for-js.git"

--- a/sdk/cognitiveservices/cognitiveservices-customimagesearch/package.json
+++ b/sdk/cognitiveservices/cognitiveservices-customimagesearch/package.json
@@ -25,7 +25,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.6.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/cognitiveservices/cognitiveservices-customimagesearch",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/cognitiveservices/cognitiveservices-customimagesearch",
   "repository": {
     "type": "git",
     "url": "https://github.com/Azure/azure-sdk-for-js.git"

--- a/sdk/cognitiveservices/cognitiveservices-customsearch/package.json
+++ b/sdk/cognitiveservices/cognitiveservices-customsearch/package.json
@@ -25,7 +25,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.6.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/cognitiveservices/cognitiveservices-customsearch",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/cognitiveservices/cognitiveservices-customsearch",
   "repository": {
     "type": "git",
     "url": "https://github.com/Azure/azure-sdk-for-js.git"

--- a/sdk/cognitiveservices/cognitiveservices-customvision-prediction/package.json
+++ b/sdk/cognitiveservices/cognitiveservices-customvision-prediction/package.json
@@ -25,7 +25,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.6.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/cognitiveservices/cognitiveservices-customvision-prediction",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/cognitiveservices/cognitiveservices-customvision-prediction",
   "repository": {
     "type": "git",
     "url": "https://github.com/Azure/azure-sdk-for-js.git"

--- a/sdk/cognitiveservices/cognitiveservices-customvision-training/package.json
+++ b/sdk/cognitiveservices/cognitiveservices-customvision-training/package.json
@@ -25,7 +25,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.6.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/cognitiveservices/cognitiveservices-customvision-training",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/cognitiveservices/cognitiveservices-customvision-training",
   "repository": {
     "type": "git",
     "url": "https://github.com/Azure/azure-sdk-for-js.git"

--- a/sdk/cognitiveservices/cognitiveservices-entitysearch/package.json
+++ b/sdk/cognitiveservices/cognitiveservices-entitysearch/package.json
@@ -25,7 +25,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.6.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/cognitiveservices/cognitiveservices-entitysearch",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/cognitiveservices/cognitiveservices-entitysearch",
   "repository": {
     "type": "git",
     "url": "https://github.com/Azure/azure-sdk-for-js.git"

--- a/sdk/cognitiveservices/cognitiveservices-face/package.json
+++ b/sdk/cognitiveservices/cognitiveservices-face/package.json
@@ -25,7 +25,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.6.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/cognitiveservices/cognitiveservices-face",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/cognitiveservices/cognitiveservices-face",
   "repository": {
     "type": "git",
     "url": "https://github.com/Azure/azure-sdk-for-js.git"

--- a/sdk/cognitiveservices/cognitiveservices-formrecognizer/package.json
+++ b/sdk/cognitiveservices/cognitiveservices-formrecognizer/package.json
@@ -25,7 +25,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.6.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/cognitiveservices/cognitiveservices-formrecognizer",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/cognitiveservices/cognitiveservices-formrecognizer",
   "repository": {
     "type": "git",
     "url": "https://github.com/Azure/azure-sdk-for-js.git"

--- a/sdk/cognitiveservices/cognitiveservices-imagesearch/package.json
+++ b/sdk/cognitiveservices/cognitiveservices-imagesearch/package.json
@@ -25,7 +25,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.6.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/cognitiveservices/cognitiveservices-imagesearch",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/cognitiveservices/cognitiveservices-imagesearch",
   "repository": {
     "type": "git",
     "url": "https://github.com/Azure/azure-sdk-for-js.git"

--- a/sdk/cognitiveservices/cognitiveservices-localsearch/package.json
+++ b/sdk/cognitiveservices/cognitiveservices-localsearch/package.json
@@ -25,7 +25,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.6.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/cognitiveservices/cognitiveservices-localsearch",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/cognitiveservices/cognitiveservices-localsearch",
   "repository": {
     "type": "git",
     "url": "https://github.com/Azure/azure-sdk-for-js.git"

--- a/sdk/cognitiveservices/cognitiveservices-luis-authoring/package.json
+++ b/sdk/cognitiveservices/cognitiveservices-luis-authoring/package.json
@@ -32,7 +32,7 @@
     "uglify-js": "^3.4.9",
     "ts-mocha": "^6.0.0"
   },
-  "homepage": "https://github.com/azure/azure-sdk-for-js/tree/master/sdk/cognitiveservices/cognitiveservices-luis-authoring",
+  "homepage": "https://github.com/azure/azure-sdk-for-js/tree/main/sdk/cognitiveservices/cognitiveservices-luis-authoring",
   "repository": {
     "type": "git",
     "url": "https://github.com/Azure/azure-sdk-for-js.git"

--- a/sdk/cognitiveservices/cognitiveservices-luis-runtime/package.json
+++ b/sdk/cognitiveservices/cognitiveservices-luis-runtime/package.json
@@ -32,7 +32,7 @@
     "uglify-js": "^3.4.9",
     "ts-mocha": "^6.0.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/cognitiveservices/cognitiveservices-luis-runtime",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/cognitiveservices/cognitiveservices-luis-runtime",
   "repository": {
     "type": "git",
     "url": "https://github.com/Azure/azure-sdk-for-js.git"

--- a/sdk/cognitiveservices/cognitiveservices-newssearch/package.json
+++ b/sdk/cognitiveservices/cognitiveservices-newssearch/package.json
@@ -25,7 +25,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.6.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/cognitiveservices/cognitiveservices-newssearch",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/cognitiveservices/cognitiveservices-newssearch",
   "repository": {
     "type": "git",
     "url": "https://github.com/Azure/azure-sdk-for-js.git"

--- a/sdk/cognitiveservices/cognitiveservices-personalizer/package.json
+++ b/sdk/cognitiveservices/cognitiveservices-personalizer/package.json
@@ -25,7 +25,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.6.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/cognitiveservices/cognitiveservices-personalizer",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/cognitiveservices/cognitiveservices-personalizer",
   "repository": {
     "type": "git",
     "url": "https://github.com/Azure/azure-sdk-for-js.git"

--- a/sdk/cognitiveservices/cognitiveservices-qnamaker-runtime/package.json
+++ b/sdk/cognitiveservices/cognitiveservices-qnamaker-runtime/package.json
@@ -25,7 +25,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.6.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/cognitiveservices/cognitiveservices-qnamaker-runtime",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/cognitiveservices/cognitiveservices-qnamaker-runtime",
   "repository": {
     "type": "git",
     "url": "https://github.com/Azure/azure-sdk-for-js.git"

--- a/sdk/cognitiveservices/cognitiveservices-qnamaker/package.json
+++ b/sdk/cognitiveservices/cognitiveservices-qnamaker/package.json
@@ -25,7 +25,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.6.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/cognitiveservices/cognitiveservices-qnamaker",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/cognitiveservices/cognitiveservices-qnamaker",
   "repository": {
     "type": "git",
     "url": "https://github.com/Azure/azure-sdk-for-js.git"

--- a/sdk/cognitiveservices/cognitiveservices-spellcheck/package.json
+++ b/sdk/cognitiveservices/cognitiveservices-spellcheck/package.json
@@ -25,7 +25,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.6.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/cognitiveservices/cognitiveservices-spellcheck",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/cognitiveservices/cognitiveservices-spellcheck",
   "repository": {
     "type": "git",
     "url": "https://github.com/Azure/azure-sdk-for-js.git"

--- a/sdk/cognitiveservices/cognitiveservices-textanalytics/package.json
+++ b/sdk/cognitiveservices/cognitiveservices-textanalytics/package.json
@@ -25,7 +25,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.6.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/cognitiveservices/cognitiveservices-textanalytics",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/cognitiveservices/cognitiveservices-textanalytics",
   "repository": {
     "type": "git",
     "url": "https://github.com/Azure/azure-sdk-for-js.git"

--- a/sdk/cognitiveservices/cognitiveservices-translatortext/package.json
+++ b/sdk/cognitiveservices/cognitiveservices-translatortext/package.json
@@ -25,7 +25,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.6.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/cognitiveservices/cognitiveservices-translatortext",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/cognitiveservices/cognitiveservices-translatortext",
   "repository": {
     "type": "git",
     "url": "https://github.com/Azure/azure-sdk-for-js.git"

--- a/sdk/cognitiveservices/cognitiveservices-videosearch/package.json
+++ b/sdk/cognitiveservices/cognitiveservices-videosearch/package.json
@@ -25,7 +25,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.6.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/cognitiveservices/cognitiveservices-videosearch",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/cognitiveservices/cognitiveservices-videosearch",
   "repository": {
     "type": "git",
     "url": "https://github.com/Azure/azure-sdk-for-js.git"

--- a/sdk/cognitiveservices/cognitiveservices-visualsearch/package.json
+++ b/sdk/cognitiveservices/cognitiveservices-visualsearch/package.json
@@ -25,7 +25,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.6.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/cognitiveservices/cognitiveservices-visualsearch",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/cognitiveservices/cognitiveservices-visualsearch",
   "repository": {
     "type": "git",
     "url": "https://github.com/Azure/azure-sdk-for-js.git"

--- a/sdk/cognitiveservices/cognitiveservices-websearch/package.json
+++ b/sdk/cognitiveservices/cognitiveservices-websearch/package.json
@@ -25,7 +25,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.6.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/cognitiveservices/cognitiveservices-websearch",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/cognitiveservices/cognitiveservices-websearch",
   "repository": {
     "type": "git",
     "url": "https://github.com/Azure/azure-sdk-for-js.git"

--- a/sdk/commerce/arm-commerce-profile-2020-09-01-hybrid/package.json
+++ b/sdk/commerce/arm-commerce-profile-2020-09-01-hybrid/package.json
@@ -27,7 +27,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.6.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/commerce/arm-commerce-profile-2020-09-01-hybrid",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/commerce/arm-commerce-profile-2020-09-01-hybrid",
   "repository": {
     "type": "git",
     "url": "https://github.com/Azure/azure-sdk-for-js.git"

--- a/sdk/commerce/arm-commerce/package.json
+++ b/sdk/commerce/arm-commerce/package.json
@@ -27,7 +27,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.4.9"
   },
-  "homepage": "https://github.com/azure/azure-sdk-for-js/tree/master/sdk/commerce/arm-commerce",
+  "homepage": "https://github.com/azure/azure-sdk-for-js/tree/main/sdk/commerce/arm-commerce",
   "repository": {
     "type": "git",
     "url": "https://github.com/azure/azure-sdk-for-js.git"

--- a/sdk/communication/arm-communication/package.json
+++ b/sdk/communication/arm-communication/package.json
@@ -27,7 +27,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.6.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/communication/arm-communication",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/communication/arm-communication",
   "repository": {
     "type": "git",
     "url": "https://github.com/Azure/azure-sdk-for-js.git"

--- a/sdk/communication/communication-chat/package.json
+++ b/sdk/communication/communication-chat/package.json
@@ -60,7 +60,7 @@
   "engines": {
     "node": ">=8.0.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/communication/communication-chat/",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/communication/communication-chat/",
   "sideEffects": false,
   "prettier": "@azure/eslint-plugin-azure-sdk/prettier.json",
   "dependencies": {

--- a/sdk/communication/communication-common/package.json
+++ b/sdk/communication/communication-common/package.json
@@ -59,7 +59,7 @@
   "engines": {
     "node": ">=8.0.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/communication/communication-common/",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/communication/communication-common/",
   "sideEffects": false,
   "prettier": "@azure/eslint-plugin-azure-sdk/prettier.json",
   "dependencies": {

--- a/sdk/communication/communication-identity/package.json
+++ b/sdk/communication/communication-identity/package.json
@@ -65,7 +65,7 @@
   "engines": {
     "node": ">=8.0.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/communication/communication-identity/",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/communication/communication-identity/",
   "repository": "github:Azure/azure-sdk-for-js",
   "bugs": {
     "url": "https://github.com/Azure/azure-sdk-for-js/issues"

--- a/sdk/communication/communication-network-traversal/package.json
+++ b/sdk/communication/communication-network-traversal/package.json
@@ -65,7 +65,7 @@
   "engines": {
     "node": ">=8.0.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/communication/",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/communication/",
   "repository": "github:Azure/azure-sdk-for-js",
   "bugs": {
     "url": "https://github.com/Azure/azure-sdk-for-js/issues"

--- a/sdk/communication/communication-phone-numbers/package.json
+++ b/sdk/communication/communication-phone-numbers/package.json
@@ -53,7 +53,7 @@
   "engines": {
     "node": ">=8.0.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/communication/communication-phone-numbers/",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/communication/communication-phone-numbers/",
   "repository": "github:Azure/azure-sdk-for-js",
   "bugs": {
     "url": "https://github.com/Azure/azure-sdk-for-js/issues"

--- a/sdk/communication/communication-sms/package.json
+++ b/sdk/communication/communication-sms/package.json
@@ -61,7 +61,7 @@
   "engines": {
     "node": ">=8.0.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/communication/communication-sms/",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/communication/communication-sms/",
   "sideEffects": false,
   "prettier": "@azure/eslint-plugin-azure-sdk/prettier.json",
   "dependencies": {

--- a/sdk/compute/arm-compute-profile-2019-03-01-hybrid/package.json
+++ b/sdk/compute/arm-compute-profile-2019-03-01-hybrid/package.json
@@ -28,7 +28,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.4.9"
   },
-  "homepage": "https://github.com/azure/azure-sdk-for-js/tree/master/sdk/compute/arm-compute-profile-2019-03-01-hybrid",
+  "homepage": "https://github.com/azure/azure-sdk-for-js/tree/main/sdk/compute/arm-compute-profile-2019-03-01-hybrid",
   "repository": {
     "type": "git",
     "url": "https://github.com/azure/azure-sdk-for-js.git"

--- a/sdk/compute/arm-compute-profile-2020-09-01-hybrid/package.json
+++ b/sdk/compute/arm-compute-profile-2020-09-01-hybrid/package.json
@@ -27,7 +27,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.6.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/compute/arm-compute-profile-2020-09-01-hybrid",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/compute/arm-compute-profile-2020-09-01-hybrid",
   "repository": {
     "type": "git",
     "url": "https://github.com/Azure/azure-sdk-for-js.git"

--- a/sdk/compute/arm-compute/package.json
+++ b/sdk/compute/arm-compute/package.json
@@ -27,7 +27,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.6.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/compute/arm-compute",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/compute/arm-compute",
   "repository": {
     "type": "git",
     "url": "https://github.com/Azure/azure-sdk-for-js.git"

--- a/sdk/confidentialledger/confidential-ledger-rest/package.json
+++ b/sdk/confidentialledger/confidential-ledger-rest/package.json
@@ -16,7 +16,7 @@
   "main": "./dist/index.js",
   "module": "./dist-esm/src/index.js",
   "types": "./types/confidential-ledger.d.ts",
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/confidentialledger/confidential-ledger-rest/README.md",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/confidentialledger/confidential-ledger-rest/README.md",
   "repository": "github:Azure/azure-sdk-for-js",
   "bugs": {
     "url": "https://github.com/Azure/azure-sdk-for-js/issues"

--- a/sdk/confluent/arm-confluent/package.json
+++ b/sdk/confluent/arm-confluent/package.json
@@ -27,7 +27,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.6.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/confluent/arm-confluent",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/confluent/arm-confluent",
   "repository": {
     "type": "git",
     "url": "https://github.com/Azure/azure-sdk-for-js.git"

--- a/sdk/consumption/arm-consumption/package.json
+++ b/sdk/consumption/arm-consumption/package.json
@@ -27,7 +27,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.6.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/consumption/arm-consumption",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/consumption/arm-consumption",
   "repository": {
     "type": "git",
     "url": "https://github.com/Azure/azure-sdk-for-js.git"

--- a/sdk/containerinstance/arm-containerinstance/package.json
+++ b/sdk/containerinstance/arm-containerinstance/package.json
@@ -27,7 +27,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.6.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/containerinstance/arm-containerinstance",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/containerinstance/arm-containerinstance",
   "repository": {
     "type": "git",
     "url": "https://github.com/Azure/azure-sdk-for-js.git"

--- a/sdk/containerregistry/arm-containerregistry/package.json
+++ b/sdk/containerregistry/arm-containerregistry/package.json
@@ -27,7 +27,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.6.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/containerregistry/arm-containerregistry",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/containerregistry/arm-containerregistry",
   "repository": {
     "type": "git",
     "url": "https://github.com/Azure/azure-sdk-for-js.git"

--- a/sdk/containerregistry/container-registry/package.json
+++ b/sdk/containerregistry/container-registry/package.json
@@ -76,7 +76,7 @@
   "bugs": {
     "url": "https://github.com/Azure/azure-sdk-for-js/issues"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/containerregistry/container-registry/README.md",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/containerregistry/container-registry/README.md",
   "sideEffects": false,
   "prettier": "@azure/eslint-plugin-azure-sdk/prettier.json",
   "dependencies": {

--- a/sdk/containerservice/arm-containerservice/package.json
+++ b/sdk/containerservice/arm-containerservice/package.json
@@ -27,7 +27,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.6.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/containerservice/arm-containerservice",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/containerservice/arm-containerservice",
   "repository": {
     "type": "git",
     "url": "https://github.com/Azure/azure-sdk-for-js.git"

--- a/sdk/core/abort-controller/package.json
+++ b/sdk/core/abort-controller/package.json
@@ -74,7 +74,7 @@
   "bugs": {
     "url": "https://github.com/Azure/azure-sdk-for-js/issues"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/core/abort-controller/README.md",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/core/abort-controller/README.md",
   "sideEffects": false,
   "dependencies": {
     "tslib": "^2.2.0"

--- a/sdk/core/core-amqp/package.json
+++ b/sdk/core/core-amqp/package.json
@@ -62,7 +62,7 @@
   "engines": {
     "node": ">=8.0.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/core/core-amqp/README.md",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/core/core-amqp/README.md",
   "sideEffects": false,
   "repository": "github:Azure/azure-sdk-for-js",
   "bugs": {

--- a/sdk/core/core-asynciterator-polyfill/package.json
+++ b/sdk/core/core-asynciterator-polyfill/package.json
@@ -25,7 +25,7 @@
     "node": ">=8.0.0"
   },
   "license": "MIT",
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/core/core-asynciterator-polyfill/README.md",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/core/core-asynciterator-polyfill/README.md",
   "repository": "github:Azure/azure-sdk-for-js",
   "bugs": {
     "url": "https://github.com/Azure/azure-sdk-for-js/issues"

--- a/sdk/core/core-auth/package.json
+++ b/sdk/core/core-auth/package.json
@@ -63,7 +63,7 @@
   "engines": {
     "node": ">=8.0.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/core/core-auth/README.md",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/core/core-auth/README.md",
   "sideEffects": false,
   "dependencies": {
     "@azure/abort-controller": "^1.0.0",

--- a/sdk/core/core-client-rest/package.json
+++ b/sdk/core/core-client-rest/package.json
@@ -57,7 +57,7 @@
   "engines": {
     "node": ">=8.0.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/core/core-client-rest/",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/core/core-client-rest/",
   "sideEffects": false,
   "prettier": "@azure/eslint-plugin-azure-sdk/prettier.json",
   "dependencies": {

--- a/sdk/core/core-client/package.json
+++ b/sdk/core/core-client/package.json
@@ -72,7 +72,7 @@
   "engines": {
     "node": ">=8.0.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/core/core-client/",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/core/core-client/",
   "sideEffects": false,
   "prettier": "@azure/eslint-plugin-azure-sdk/prettier.json",
   "dependencies": {

--- a/sdk/core/core-crypto/package.json
+++ b/sdk/core/core-crypto/package.json
@@ -71,7 +71,7 @@
   "engines": {
     "node": ">=8.0.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/core/core-crypto/",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/core/core-crypto/",
   "sideEffects": false,
   "prettier": "@azure/eslint-plugin-azure-sdk/prettier.json",
   "dependencies": {

--- a/sdk/core/core-http/package.json
+++ b/sdk/core/core-http/package.json
@@ -57,7 +57,7 @@
     "./dist-esm/src/util/url.js": "./dist-esm/src/util/url.browser.js"
   },
   "license": "MIT",
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/core/core-http/README.md",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/core/core-http/README.md",
   "repository": "github:Azure/azure-sdk-for-js",
   "bugs": {
     "url": "https://github.com/Azure/azure-sdk-for-js/issues"

--- a/sdk/core/core-lro/package.json
+++ b/sdk/core/core-lro/package.json
@@ -42,7 +42,7 @@
     "process": false
   },
   "license": "MIT",
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/core/core-lro/README.md",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/core/core-lro/README.md",
   "repository": "github:Azure/azure-sdk-for-js",
   "bugs": {
     "url": "https://github.com/Azure/azure-sdk-for-js/issues"

--- a/sdk/core/core-paging/package.json
+++ b/sdk/core/core-paging/package.json
@@ -36,7 +36,7 @@
     "node": ">=8.0.0"
   },
   "license": "MIT",
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/core/core-paging/README.md",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/core/core-paging/README.md",
   "repository": "github:Azure/azure-sdk-for-js",
   "bugs": {
     "url": "https://github.com/Azure/azure-sdk-for-js/issues"

--- a/sdk/core/core-rest-pipeline/package.json
+++ b/sdk/core/core-rest-pipeline/package.json
@@ -79,7 +79,7 @@
   "engines": {
     "node": ">=8.0.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/core/core-rest-pipeline/",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/core/core-rest-pipeline/",
   "sideEffects": false,
   "prettier": "@azure/eslint-plugin-azure-sdk/prettier.json",
   "//metadata": {

--- a/sdk/core/core-tracing/package.json
+++ b/sdk/core/core-tracing/package.json
@@ -57,7 +57,7 @@
   "engines": {
     "node": ">=8.0.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/core/core-tracing/README.md",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/core/core-tracing/README.md",
   "sideEffects": false,
   "dependencies": {
     "@opentelemetry/api": "0.20.0",

--- a/sdk/core/core-util/package.json
+++ b/sdk/core/core-util/package.json
@@ -64,7 +64,7 @@
   "engines": {
     "node": ">=8.0.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/core/core-util/",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/core/core-util/",
   "sideEffects": false,
   "prettier": "@azure/eslint-plugin-azure-sdk/prettier.json",
   "dependencies": {

--- a/sdk/core/core-xml/package.json
+++ b/sdk/core/core-xml/package.json
@@ -71,7 +71,7 @@
   "engines": {
     "node": ">=8.0.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/core/core-xml/",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/core/core-xml/",
   "sideEffects": false,
   "prettier": "@azure/eslint-plugin-azure-sdk/prettier.json",
   "dependencies": {

--- a/sdk/core/logger/package.json
+++ b/sdk/core/logger/package.json
@@ -65,7 +65,7 @@
   "bugs": {
     "url": "https://github.com/Azure/azure-sdk-for-js/issues"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/core/logger/README.md",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/core/logger/README.md",
   "sideEffects": false,
   "dependencies": {
     "tslib": "^2.2.0"

--- a/sdk/cosmosdb/arm-cosmosdb/package.json
+++ b/sdk/cosmosdb/arm-cosmosdb/package.json
@@ -27,7 +27,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.6.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/cosmosdb/arm-cosmosdb",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/cosmosdb/arm-cosmosdb",
   "repository": {
     "type": "git",
     "url": "https://github.com/Azure/azure-sdk-for-js.git"

--- a/sdk/cosmosdb/cosmos/package.json
+++ b/sdk/cosmosdb/cosmos/package.json
@@ -32,7 +32,7 @@
     "README.md",
     "LICENSE"
   ],
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/cosmosdb/cosmos/README.md",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/cosmosdb/cosmos/README.md",
   "sideEffects": false,
   "types": "./dist/types/latest/cosmos.d.ts",
   "typesVersions": {

--- a/sdk/customer-insights/arm-customerinsights/package.json
+++ b/sdk/customer-insights/arm-customerinsights/package.json
@@ -26,7 +26,7 @@
     "rollup-plugin-node-resolve": "^3.4.0",
     "uglify-js": "^3.4.9"
   },
-  "homepage": "https://github.com/azure/azure-sdk-for-js/tree/master/sdk/customer-insights/arm-customerinsights",
+  "homepage": "https://github.com/azure/azure-sdk-for-js/tree/main/sdk/customer-insights/arm-customerinsights",
   "repository": {
     "type": "git",
     "url": "https://github.com/azure/azure-sdk-for-js.git"

--- a/sdk/databox/arm-databox/package.json
+++ b/sdk/databox/arm-databox/package.json
@@ -27,7 +27,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.6.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/databox/arm-databox",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/databox/arm-databox",
   "repository": {
     "type": "git",
     "url": "https://github.com/Azure/azure-sdk-for-js.git"

--- a/sdk/databoxedge/arm-databoxedge-profile-2020-09-01-hybrid/package.json
+++ b/sdk/databoxedge/arm-databoxedge-profile-2020-09-01-hybrid/package.json
@@ -27,7 +27,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.6.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/databoxedge/arm-databoxedge-profile-2020-09-01-hybrid",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/databoxedge/arm-databoxedge-profile-2020-09-01-hybrid",
   "repository": {
     "type": "git",
     "url": "https://github.com/Azure/azure-sdk-for-js.git"

--- a/sdk/databoxedge/arm-databoxedge/package.json
+++ b/sdk/databoxedge/arm-databoxedge/package.json
@@ -27,7 +27,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.6.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/databoxedge/arm-databoxedge",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/databoxedge/arm-databoxedge",
   "repository": {
     "type": "git",
     "url": "https://github.com/Azure/azure-sdk-for-js.git"

--- a/sdk/databricks/arm-databricks/package.json
+++ b/sdk/databricks/arm-databricks/package.json
@@ -25,7 +25,7 @@
     "rollup-plugin-node-resolve": "^3.4.0",
     "uglify-js": "^3.4.9"
   },
-  "homepage": "https://github.com/azure/azure-sdk-for-js/tree/master/sdk/databricks/arm-databricks",
+  "homepage": "https://github.com/azure/azure-sdk-for-js/tree/main/sdk/databricks/arm-databricks",
   "repository": {
     "type": "git",
     "url": "https://github.com/azure/azure-sdk-for-js.git"

--- a/sdk/datacatalog/arm-datacatalog/package.json
+++ b/sdk/datacatalog/arm-datacatalog/package.json
@@ -26,7 +26,7 @@
     "rollup-plugin-node-resolve": "^3.4.0",
     "uglify-js": "^3.4.9"
   },
-  "homepage": "https://github.com/azure/azure-sdk-for-js/tree/master/sdk/datacatalog/arm-datacatalog",
+  "homepage": "https://github.com/azure/azure-sdk-for-js/tree/main/sdk/datacatalog/arm-datacatalog",
   "repository": {
     "type": "git",
     "url": "https://github.com/azure/azure-sdk-for-js.git"

--- a/sdk/datadog/arm-datadog/package.json
+++ b/sdk/datadog/arm-datadog/package.json
@@ -27,7 +27,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.6.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/datadog/arm-datadog",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/datadog/arm-datadog",
   "repository": {
     "type": "git",
     "url": "https://github.com/Azure/azure-sdk-for-js.git"

--- a/sdk/datafactory/arm-datafactory/package.json
+++ b/sdk/datafactory/arm-datafactory/package.json
@@ -27,7 +27,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.6.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/datafactory/arm-datafactory",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/datafactory/arm-datafactory",
   "repository": {
     "type": "git",
     "url": "https://github.com/Azure/azure-sdk-for-js.git"

--- a/sdk/datalake-analytics/arm-datalake-analytics/package.json
+++ b/sdk/datalake-analytics/arm-datalake-analytics/package.json
@@ -27,7 +27,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.6.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/datalake-analytics/arm-datalake-analytics",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/datalake-analytics/arm-datalake-analytics",
   "repository": {
     "type": "git",
     "url": "https://github.com/Azure/azure-sdk-for-js.git"

--- a/sdk/datamigration/arm-datamigration/package.json
+++ b/sdk/datamigration/arm-datamigration/package.json
@@ -27,7 +27,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.6.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/datamigration/arm-datamigration",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/datamigration/arm-datamigration",
   "repository": {
     "type": "git",
     "url": "https://github.com/Azure/azure-sdk-for-js.git"

--- a/sdk/deploymentmanager/arm-deploymentmanager/package.json
+++ b/sdk/deploymentmanager/arm-deploymentmanager/package.json
@@ -27,7 +27,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.6.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/deploymentmanager/arm-deploymentmanager",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/deploymentmanager/arm-deploymentmanager",
   "repository": {
     "type": "git",
     "url": "https://github.com/Azure/azure-sdk-for-js.git"

--- a/sdk/deviceprovisioningservices/arm-deviceprovisioningservices/package.json
+++ b/sdk/deviceprovisioningservices/arm-deviceprovisioningservices/package.json
@@ -26,7 +26,7 @@
     "rollup-plugin-node-resolve": "^3.4.0",
     "uglify-js": "^3.4.9"
   },
-  "homepage": "https://github.com/azure/azure-sdk-for-js/tree/master/sdk/deviceprovisioningservices/arm-deviceprovisioningservices",
+  "homepage": "https://github.com/azure/azure-sdk-for-js/tree/main/sdk/deviceprovisioningservices/arm-deviceprovisioningservices",
   "repository": {
     "type": "git",
     "url": "https://github.com/azure/azure-sdk-for-js.git"

--- a/sdk/devspaces/arm-devspaces/package.json
+++ b/sdk/devspaces/arm-devspaces/package.json
@@ -26,7 +26,7 @@
     "rollup-plugin-node-resolve": "^3.4.0",
     "uglify-js": "^3.4.9"
   },
-  "homepage": "https://github.com/azure/azure-sdk-for-js/tree/master/sdk/devspaces/arm-devspaces",
+  "homepage": "https://github.com/azure/azure-sdk-for-js/tree/main/sdk/devspaces/arm-devspaces",
   "repository": {
     "type": "git",
     "url": "https://github.com/azure/azure-sdk-for-js.git"

--- a/sdk/devtestlabs/arm-devtestlabs/package.json
+++ b/sdk/devtestlabs/arm-devtestlabs/package.json
@@ -27,7 +27,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.4.9"
   },
-  "homepage": "https://github.com/azure/azure-sdk-for-js/tree/master/sdk/devtestlabs/arm-devtestlabs",
+  "homepage": "https://github.com/azure/azure-sdk-for-js/tree/main/sdk/devtestlabs/arm-devtestlabs",
   "repository": {
     "type": "git",
     "url": "https://github.com/azure/azure-sdk-for-js.git"

--- a/sdk/digitaltwins/arm-digitaltwins/package.json
+++ b/sdk/digitaltwins/arm-digitaltwins/package.json
@@ -27,7 +27,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.6.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/digitaltwins/arm-digitaltwins",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/digitaltwins/arm-digitaltwins",
   "repository": {
     "type": "git",
     "url": "https://github.com/Azure/azure-sdk-for-js.git"

--- a/sdk/digitaltwins/digital-twins-core/package.json
+++ b/sdk/digitaltwins/digital-twins-core/package.json
@@ -61,7 +61,7 @@
     "isomorphic"
   ],
   "repository": "github:Azure/azure-sdk-for-js",
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/digitaltwins/digital-twins-core/",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/digitaltwins/digital-twins-core/",
   "bugs": {
     "url": "https://github.com/Azure/azure-sdk-for-js/issues"
   },

--- a/sdk/dns/arm-dns-profile-2019-03-01-hybrid/package.json
+++ b/sdk/dns/arm-dns-profile-2019-03-01-hybrid/package.json
@@ -28,7 +28,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.4.9"
   },
-  "homepage": "https://github.com/azure/azure-sdk-for-js/tree/master/sdk/dns/arm-dns-profile-2019-03-01-hybrid",
+  "homepage": "https://github.com/azure/azure-sdk-for-js/tree/main/sdk/dns/arm-dns-profile-2019-03-01-hybrid",
   "repository": {
     "type": "git",
     "url": "https://github.com/azure/azure-sdk-for-js.git"

--- a/sdk/dns/arm-dns-profile-2020-09-01-hybrid/package.json
+++ b/sdk/dns/arm-dns-profile-2020-09-01-hybrid/package.json
@@ -27,7 +27,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.6.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/dns/arm-dns-profile-2020-09-01-hybrid",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/dns/arm-dns-profile-2020-09-01-hybrid",
   "repository": {
     "type": "git",
     "url": "https://github.com/Azure/azure-sdk-for-js.git"

--- a/sdk/dns/arm-dns/package.json
+++ b/sdk/dns/arm-dns/package.json
@@ -27,7 +27,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.6.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/dns/arm-dns",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/dns/arm-dns",
   "repository": {
     "type": "git",
     "url": "https://github.com/Azure/azure-sdk-for-js.git"

--- a/sdk/documenttranslator/ai-document-translator-rest/package.json
+++ b/sdk/documenttranslator/ai-document-translator-rest/package.json
@@ -16,7 +16,7 @@
   "main": "./dist/index.js",
   "module": "./dist-esm/src/index.js",
   "types": "./types/ai-document-translator.d.ts",
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/documenttranslator/ai-document-translator/README.md",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/documenttranslator/ai-document-translator/README.md",
   "repository": "github:Azure/azure-sdk-for-js",
   "bugs": {
     "url": "https://github.com/Azure/azure-sdk-for-js/issues"

--- a/sdk/domainservices/arm-domainservices/package.json
+++ b/sdk/domainservices/arm-domainservices/package.json
@@ -26,7 +26,7 @@
     "rollup-plugin-node-resolve": "^3.4.0",
     "uglify-js": "^3.4.9"
   },
-  "homepage": "https://github.com/azure/azure-sdk-for-js/tree/master/sdk/domainservices/arm-domainservices",
+  "homepage": "https://github.com/azure/azure-sdk-for-js/tree/main/sdk/domainservices/arm-domainservices",
   "repository": {
     "type": "git",
     "url": "https://github.com/azure/azure-sdk-for-js.git"

--- a/sdk/edgegateway/arm-edgegateway/package.json
+++ b/sdk/edgegateway/arm-edgegateway/package.json
@@ -26,7 +26,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.4.9"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/edgegateway/arm-edgegateway",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/edgegateway/arm-edgegateway",
   "repository": {
     "type": "git",
     "url": "https://github.com/Azure/azure-sdk-for-js.git"

--- a/sdk/eventgrid/arm-eventgrid/package.json
+++ b/sdk/eventgrid/arm-eventgrid/package.json
@@ -26,7 +26,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.6.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/eventgrid/arm-eventgrid",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/eventgrid/arm-eventgrid",
   "repository": {
     "type": "git",
     "url": "https://github.com/Azure/azure-sdk-for-js.git"

--- a/sdk/eventgrid/eventgrid/package.json
+++ b/sdk/eventgrid/eventgrid/package.json
@@ -16,7 +16,7 @@
   "main": "./dist/index.js",
   "module": "./dist-esm/src/index.js",
   "types": "./types/eventgrid.d.ts",
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/eventgrid/eventgrid/README.md",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/eventgrid/eventgrid/README.md",
   "repository": "github:Azure/azure-sdk-for-js",
   "bugs": {
     "url": "https://github.com/Azure/azure-sdk-for-js/issues"

--- a/sdk/eventhub/arm-eventhub-profile-2020-09-01-hybrid/package.json
+++ b/sdk/eventhub/arm-eventhub-profile-2020-09-01-hybrid/package.json
@@ -26,7 +26,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.6.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/eventhub/arm-eventhub-profile-2020-09-01-hybrid",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/eventhub/arm-eventhub-profile-2020-09-01-hybrid",
   "repository": {
     "type": "git",
     "url": "https://github.com/Azure/azure-sdk-for-js.git"

--- a/sdk/eventhub/arm-eventhub/package.json
+++ b/sdk/eventhub/arm-eventhub/package.json
@@ -27,7 +27,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.4.9"
   },
-  "homepage": "https://github.com/azure/azure-sdk-for-js/tree/master/sdk/eventhub/arm-eventhub",
+  "homepage": "https://github.com/azure/azure-sdk-for-js/tree/main/sdk/eventhub/arm-eventhub",
   "repository": {
     "type": "git",
     "url": "https://github.com/azure/azure-sdk-for-js.git"

--- a/sdk/eventhub/event-hubs/package.json
+++ b/sdk/eventhub/event-hubs/package.json
@@ -5,7 +5,7 @@
   "description": "Azure Event Hubs SDK for JS.",
   "author": "Microsoft Corporation",
   "license": "MIT",
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/eventhub/event-hubs/",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/eventhub/event-hubs/",
   "repository": "github:Azure/azure-sdk-for-js",
   "sideEffects": false,
   "keywords": [

--- a/sdk/eventhub/event-processor-host/package.json
+++ b/sdk/eventhub/event-processor-host/package.json
@@ -5,7 +5,7 @@
   "description": "Azure Event Processor Host (Event Hubs) SDK for JS.",
   "author": "Microsoft Corporation",
   "license": "MIT",
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/eventhub/event-processor-host/",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/eventhub/event-processor-host/",
   "repository": "github:Azure/azure-sdk-for-js",
   "sideEffects": false,
   "keywords": [

--- a/sdk/eventhub/eventhubs-checkpointstore-blob/package.json
+++ b/sdk/eventhub/eventhubs-checkpointstore-blob/package.json
@@ -5,7 +5,7 @@
   "description": "An Azure Storage Blob solution to store checkpoints when using Event Hubs.",
   "author": "Microsoft Corporation",
   "license": "MIT",
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/eventhub/eventhubs-checkpointstore-blob/",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/eventhub/eventhubs-checkpointstore-blob/",
   "repository": "github:Azure/azure-sdk-for-js",
   "sideEffects": false,
   "keywords": [

--- a/sdk/eventhub/mock-hub/package.json
+++ b/sdk/eventhub/mock-hub/package.json
@@ -48,7 +48,7 @@
     "README.md",
     "License"
   ],
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/eventhub/mock-hub/README.md",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/eventhub/mock-hub/README.md",
   "devDependencies": {
     "@azure/dev-tool": "^1.0.0",
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",

--- a/sdk/features/arm-features/package.json
+++ b/sdk/features/arm-features/package.json
@@ -26,7 +26,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.4.9"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/features/arm-features",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/features/arm-features",
   "repository": {
     "type": "git",
     "url": "https://github.com/Azure/azure-sdk-for-js.git"

--- a/sdk/formrecognizer/ai-form-recognizer/package.json
+++ b/sdk/formrecognizer/ai-form-recognizer/package.json
@@ -19,7 +19,7 @@
     "./dist-esm/src/utils/utils.node.js": "./dist-esm/src/utils/utils.browser.js"
   },
   "types": "./types/ai-form-recognizer.d.ts",
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/formrecognizer/ai-form-recognizer/",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/formrecognizer/ai-form-recognizer/",
   "repository": "github:Azure/azure-sdk-for-js",
   "bugs": {
     "url": "https://github.com/Azure/azure-sdk-for-js/issues"

--- a/sdk/frontdoor/arm-frontdoor/package.json
+++ b/sdk/frontdoor/arm-frontdoor/package.json
@@ -26,7 +26,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.6.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/frontdoor/arm-frontdoor",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/frontdoor/arm-frontdoor",
   "repository": {
     "type": "git",
     "url": "https://github.com/Azure/azure-sdk-for-js.git"

--- a/sdk/graphrbac/graph/package.json
+++ b/sdk/graphrbac/graph/package.json
@@ -26,7 +26,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.4.9"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/graphrbac/graph",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/graphrbac/graph",
   "repository": {
     "type": "git",
     "url": "https://github.com/Azure/azure-sdk-for-js.git"

--- a/sdk/hanaonazure/arm-hanaonazure/package.json
+++ b/sdk/hanaonazure/arm-hanaonazure/package.json
@@ -26,7 +26,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.6.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/hanaonazure/arm-hanaonazure",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/hanaonazure/arm-hanaonazure",
   "repository": {
     "type": "git",
     "url": "https://github.com/Azure/azure-sdk-for-js.git"

--- a/sdk/hdinsight/arm-hdinsight/package.json
+++ b/sdk/hdinsight/arm-hdinsight/package.json
@@ -27,7 +27,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.6.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/hdinsight/arm-hdinsight",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/hdinsight/arm-hdinsight",
   "repository": {
     "type": "git",
     "url": "https://github.com/Azure/azure-sdk-for-js.git"

--- a/sdk/healthbot/arm-healthbot/package.json
+++ b/sdk/healthbot/arm-healthbot/package.json
@@ -26,7 +26,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.6.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/healthbot/arm-healthbot",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/healthbot/arm-healthbot",
   "repository": {
     "type": "git",
     "url": "https://github.com/Azure/azure-sdk-for-js.git"

--- a/sdk/healthcareapis/arm-healthcareapis/package.json
+++ b/sdk/healthcareapis/arm-healthcareapis/package.json
@@ -26,7 +26,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.6.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/healthcareapis/arm-healthcareapis",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/healthcareapis/arm-healthcareapis",
   "repository": {
     "type": "git",
     "url": "https://github.com/Azure/azure-sdk-for-js.git"

--- a/sdk/hybridcompute/arm-hybridcompute/package.json
+++ b/sdk/hybridcompute/arm-hybridcompute/package.json
@@ -26,7 +26,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.6.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/hybridcompute/arm-hybridcompute",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/hybridcompute/arm-hybridcompute",
   "repository": {
     "type": "git",
     "url": "https://github.com/Azure/azure-sdk-for-js.git"

--- a/sdk/hybridkubernetes/arm-hybridkubernetes/package.json
+++ b/sdk/hybridkubernetes/arm-hybridkubernetes/package.json
@@ -26,7 +26,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.6.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/hybridkubernetes/arm-hybridkubernetes",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/hybridkubernetes/arm-hybridkubernetes",
   "repository": {
     "type": "git",
     "url": "https://github.com/Azure/azure-sdk-for-js.git"

--- a/sdk/identity/identity/package.json
+++ b/sdk/identity/identity/package.json
@@ -76,7 +76,7 @@
   "bugs": {
     "url": "https://github.com/Azure/azure-sdk-for-js/issues"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/identity/identity/README.md",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/identity/identity/README.md",
   "sideEffects": false,
   "dependencies": {
     "@azure/core-auth": "^1.3.0",

--- a/sdk/iot/iot-modelsrepository/package.json
+++ b/sdk/iot/iot-modelsrepository/package.json
@@ -60,7 +60,7 @@
   "bugs": {
     "url": "https://github.com/Azure/azure-sdk-for-js/issues"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/iot/iot-modelsrepository/",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/iot/iot-modelsrepository/",
   "sideEffects": false,
   "prettier": "@azure/eslint-plugin-azure-sdk/prettier.json",
   "dependencies": {

--- a/sdk/iotcentral/arm-iotcentral/package.json
+++ b/sdk/iotcentral/arm-iotcentral/package.json
@@ -26,7 +26,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.6.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/iotcentral/arm-iotcentral",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/iotcentral/arm-iotcentral",
   "repository": {
     "type": "git",
     "url": "https://github.com/Azure/azure-sdk-for-js.git"

--- a/sdk/iothub/arm-iothub-profile-2020-09-01-hybrid/package.json
+++ b/sdk/iothub/arm-iothub-profile-2020-09-01-hybrid/package.json
@@ -26,7 +26,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.6.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/iothub/arm-iothub-profile-2020-09-01-hybrid",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/iothub/arm-iothub-profile-2020-09-01-hybrid",
   "repository": {
     "type": "git",
     "url": "https://github.com/Azure/azure-sdk-for-js.git"

--- a/sdk/iothub/arm-iothub/package.json
+++ b/sdk/iothub/arm-iothub/package.json
@@ -26,7 +26,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.6.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/iothub/arm-iothub",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/iothub/arm-iothub",
   "repository": {
     "type": "git",
     "url": "https://github.com/Azure/azure-sdk-for-js.git"

--- a/sdk/iotspaces/arm-iotspaces/package.json
+++ b/sdk/iotspaces/arm-iotspaces/package.json
@@ -25,7 +25,7 @@
     "rollup-plugin-node-resolve": "^3.4.0",
     "uglify-js": "^3.4.9"
   },
-  "homepage": "https://github.com/azure/azure-sdk-for-js/tree/master/sdk/iotspaces/arm-iotspaces",
+  "homepage": "https://github.com/azure/azure-sdk-for-js/tree/main/sdk/iotspaces/arm-iotspaces",
   "repository": {
     "type": "git",
     "url": "https://github.com/azure/azure-sdk-for-js.git"

--- a/sdk/keyvault/arm-keyvault-profile-2019-03-01-hybrid/package.json
+++ b/sdk/keyvault/arm-keyvault-profile-2019-03-01-hybrid/package.json
@@ -27,7 +27,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.4.9"
   },
-  "homepage": "https://github.com/azure/azure-sdk-for-js/tree/master/sdk/keyvault/arm-keyvault-profile-2019-03-01-hybrid",
+  "homepage": "https://github.com/azure/azure-sdk-for-js/tree/main/sdk/keyvault/arm-keyvault-profile-2019-03-01-hybrid",
   "repository": {
     "type": "git",
     "url": "https://github.com/azure/azure-sdk-for-js.git"

--- a/sdk/keyvault/arm-keyvault-profile-2020-09-01-hybrid/package.json
+++ b/sdk/keyvault/arm-keyvault-profile-2020-09-01-hybrid/package.json
@@ -26,7 +26,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.6.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/keyvault/arm-keyvault-profile-2020-09-01-hybrid",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/keyvault/arm-keyvault-profile-2020-09-01-hybrid",
   "repository": {
     "type": "git",
     "url": "https://github.com/Azure/azure-sdk-for-js.git"

--- a/sdk/keyvault/keyvault-admin/package.json
+++ b/sdk/keyvault/keyvault-admin/package.json
@@ -5,7 +5,7 @@
   "version": "4.1.0-beta.1",
   "license": "MIT",
   "description": "Isomorphic client library for Azure KeyVault's administrative functions.",
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/keyvault/keyvault-admin/README.md",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/keyvault/keyvault-admin/README.md",
   "repository": "github:Azure/azure-sdk-for-js",
   "keywords": [
     "node",

--- a/sdk/keyvault/keyvault-certificates/package.json
+++ b/sdk/keyvault/keyvault-certificates/package.json
@@ -5,7 +5,7 @@
   "version": "4.3.0-beta.1",
   "license": "MIT",
   "description": "Isomorphic client library for Azure KeyVault's certificates.",
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/keyvault/keyvault-certificates/README.md",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/keyvault/keyvault-certificates/README.md",
   "repository": "github:Azure/azure-sdk-for-js",
   "keywords": [
     "node",

--- a/sdk/keyvault/keyvault-keys/package.json
+++ b/sdk/keyvault/keyvault-keys/package.json
@@ -5,7 +5,7 @@
   "version": "4.3.0-beta.1",
   "license": "MIT",
   "description": "Isomorphic client library for Azure KeyVault's keys.",
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/keyvault/keyvault-keys/README.md",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/keyvault/keyvault-keys/README.md",
   "repository": "github:Azure/azure-sdk-for-js",
   "keywords": [
     "node",

--- a/sdk/keyvault/keyvault-secrets/package.json
+++ b/sdk/keyvault/keyvault-secrets/package.json
@@ -5,7 +5,7 @@
   "version": "4.3.0-beta.1",
   "license": "MIT",
   "description": "Isomorphic client library for Azure KeyVault's secrets.",
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/keyvault/keyvault-secrets/README.md",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/keyvault/keyvault-secrets/README.md",
   "repository": "github:Azure/azure-sdk-for-js",
   "keywords": [
     "node",

--- a/sdk/kubernetesconfiguration/arm-kubernetesconfiguration/package.json
+++ b/sdk/kubernetesconfiguration/arm-kubernetesconfiguration/package.json
@@ -26,7 +26,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.6.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/kubernetesconfiguration/arm-kubernetesconfiguration",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/kubernetesconfiguration/arm-kubernetesconfiguration",
   "repository": {
     "type": "git",
     "url": "https://github.com/Azure/azure-sdk-for-js.git"

--- a/sdk/kusto/arm-kusto/package.json
+++ b/sdk/kusto/arm-kusto/package.json
@@ -26,7 +26,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.6.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/kusto/arm-kusto",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/kusto/arm-kusto",
   "repository": {
     "type": "git",
     "url": "https://github.com/Azure/azure-sdk-for-js.git"

--- a/sdk/labservices/arm-labservices/package.json
+++ b/sdk/labservices/arm-labservices/package.json
@@ -26,7 +26,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.4.9"
   },
-  "homepage": "https://github.com/azure/azure-sdk-for-js/tree/master/sdk/labservices/arm-labservices",
+  "homepage": "https://github.com/azure/azure-sdk-for-js/tree/main/sdk/labservices/arm-labservices",
   "repository": {
     "type": "git",
     "url": "https://github.com/azure/azure-sdk-for-js.git"

--- a/sdk/links/arm-links/package.json
+++ b/sdk/links/arm-links/package.json
@@ -26,7 +26,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.4.9"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/links/arm-links",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/links/arm-links",
   "repository": {
     "type": "git",
     "url": "https://github.com/Azure/azure-sdk-for-js.git"

--- a/sdk/locks/arm-locks-profile-2020-09-01-hybrid/package.json
+++ b/sdk/locks/arm-locks-profile-2020-09-01-hybrid/package.json
@@ -26,7 +26,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.6.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/locks/arm-locks-profile-2020-09-01-hybrid",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/locks/arm-locks-profile-2020-09-01-hybrid",
   "repository": {
     "type": "git",
     "url": "https://github.com/Azure/azure-sdk-for-js.git"

--- a/sdk/locks/arm-locks-profile-hybrid-2019-03-01/package.json
+++ b/sdk/locks/arm-locks-profile-hybrid-2019-03-01/package.json
@@ -27,7 +27,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.4.9"
   },
-  "homepage": "https://github.com/azure/azure-sdk-for-js/tree/master/sdk/locks/arm-locks-profile-hybrid-2019-03-01",
+  "homepage": "https://github.com/azure/azure-sdk-for-js/tree/main/sdk/locks/arm-locks-profile-hybrid-2019-03-01",
   "repository": {
     "type": "git",
     "url": "https://github.com/azure/azure-sdk-for-js.git"

--- a/sdk/locks/arm-locks/package.json
+++ b/sdk/locks/arm-locks/package.json
@@ -26,7 +26,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.4.9"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/locks/arm-locks",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/locks/arm-locks",
   "repository": {
     "type": "git",
     "url": "https://github.com/Azure/azure-sdk-for-js.git"

--- a/sdk/logic/arm-logic/package.json
+++ b/sdk/logic/arm-logic/package.json
@@ -26,7 +26,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.6.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/logic/arm-logic",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/logic/arm-logic",
   "repository": {
     "type": "git",
     "url": "https://github.com/Azure/azure-sdk-for-js.git"

--- a/sdk/machinelearning/arm-commitmentplans/package.json
+++ b/sdk/machinelearning/arm-commitmentplans/package.json
@@ -25,7 +25,7 @@
     "rollup-plugin-node-resolve": "^3.4.0",
     "uglify-js": "^3.4.9"
   },
-  "homepage": "https://github.com/azure/azure-sdk-for-js/tree/master/sdk/machinelearning/arm-commitmentplans",
+  "homepage": "https://github.com/azure/azure-sdk-for-js/tree/main/sdk/machinelearning/arm-commitmentplans",
   "repository": {
     "type": "git",
     "url": "https://github.com/azure/azure-sdk-for-js.git"

--- a/sdk/machinelearning/arm-webservices/package.json
+++ b/sdk/machinelearning/arm-webservices/package.json
@@ -25,7 +25,7 @@
     "rollup-plugin-node-resolve": "^3.4.0",
     "uglify-js": "^3.4.9"
   },
-  "homepage": "https://github.com/azure/azure-sdk-for-js/tree/master/sdk/webservices/arm-webservices",
+  "homepage": "https://github.com/azure/azure-sdk-for-js/tree/main/sdk/webservices/arm-webservices",
   "repository": {
     "type": "git",
     "url": "https://github.com/azure/azure-sdk-for-js.git"

--- a/sdk/machinelearning/arm-workspaces/package.json
+++ b/sdk/machinelearning/arm-workspaces/package.json
@@ -25,7 +25,7 @@
     "rollup-plugin-node-resolve": "^3.4.0",
     "uglify-js": "^3.4.9"
   },
-  "homepage": "https://github.com/azure/azure-sdk-for-js/tree/master/sdk/machinelearning/arm-workspaces",
+  "homepage": "https://github.com/azure/azure-sdk-for-js/tree/main/sdk/machinelearning/arm-workspaces",
   "repository": {
     "type": "git",
     "url": "https://github.com/azure/azure-sdk-for-js.git"

--- a/sdk/machinelearningcompute/arm-machinelearningcompute/package.json
+++ b/sdk/machinelearningcompute/arm-machinelearningcompute/package.json
@@ -26,7 +26,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.6.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/machinelearningcompute/arm-machinelearningcompute",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/machinelearningcompute/arm-machinelearningcompute",
   "repository": {
     "type": "git",
     "url": "https://github.com/Azure/azure-sdk-for-js.git"

--- a/sdk/machinelearningexperimentation/arm-machinelearningexperimentation/package.json
+++ b/sdk/machinelearningexperimentation/arm-machinelearningexperimentation/package.json
@@ -25,7 +25,7 @@
     "rollup-plugin-node-resolve": "^3.4.0",
     "uglify-js": "^3.4.9"
   },
-  "homepage": "https://github.com/azure/azure-sdk-for-js/tree/master/sdk/machinelearningexperimentation/arm-machinelearningexperimentation",
+  "homepage": "https://github.com/azure/azure-sdk-for-js/tree/main/sdk/machinelearningexperimentation/arm-machinelearningexperimentation",
   "repository": {
     "type": "git",
     "url": "https://github.com/azure/azure-sdk-for-js.git"

--- a/sdk/machinelearningservices/arm-machinelearningservices/package.json
+++ b/sdk/machinelearningservices/arm-machinelearningservices/package.json
@@ -26,7 +26,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.6.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/machinelearningservices/arm-machinelearningservices",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/machinelearningservices/arm-machinelearningservices",
   "repository": {
     "type": "git",
     "url": "https://github.com/Azure/azure-sdk-for-js.git"

--- a/sdk/managedapplications/arm-managedapplications/package.json
+++ b/sdk/managedapplications/arm-managedapplications/package.json
@@ -26,7 +26,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.4.9"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/managedapplications/arm-managedapplications",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/managedapplications/arm-managedapplications",
   "repository": {
     "type": "git",
     "url": "https://github.com/Azure/azure-sdk-for-js.git"

--- a/sdk/managementgroups/arm-managementgroups/package.json
+++ b/sdk/managementgroups/arm-managementgroups/package.json
@@ -25,7 +25,7 @@
     "rollup-plugin-node-resolve": "^3.4.0",
     "uglify-js": "^3.4.9"
   },
-  "homepage": "https://github.com/azure/azure-sdk-for-js/tree/master/sdk/managementgroups/arm-managementgroups",
+  "homepage": "https://github.com/azure/azure-sdk-for-js/tree/main/sdk/managementgroups/arm-managementgroups",
   "repository": {
     "type": "git",
     "url": "https://github.com/azure/azure-sdk-for-js.git"

--- a/sdk/managementpartner/arm-managementpartner/package.json
+++ b/sdk/managementpartner/arm-managementpartner/package.json
@@ -25,7 +25,7 @@
     "rollup-plugin-node-resolve": "^3.4.0",
     "uglify-js": "^3.4.9"
   },
-  "homepage": "https://github.com/azure/azure-sdk-for-js/tree/master/sdk/managementpartner/arm-managementpartner",
+  "homepage": "https://github.com/azure/azure-sdk-for-js/tree/main/sdk/managementpartner/arm-managementpartner",
   "repository": {
     "type": "git",
     "url": "https://github.com/azure/azure-sdk-for-js.git"

--- a/sdk/maps/arm-maps/package.json
+++ b/sdk/maps/arm-maps/package.json
@@ -26,7 +26,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.6.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/maps/arm-maps",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/maps/arm-maps",
   "repository": {
     "type": "git",
     "url": "https://github.com/Azure/azure-sdk-for-js.git"

--- a/sdk/mariadb/arm-mariadb/package.json
+++ b/sdk/mariadb/arm-mariadb/package.json
@@ -26,7 +26,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.4.9"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/mariadb/arm-mariadb",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/mariadb/arm-mariadb",
   "repository": {
     "type": "git",
     "url": "https://github.com/Azure/azure-sdk-for-js.git"

--- a/sdk/marketplaceordering/arm-marketplaceordering/package.json
+++ b/sdk/marketplaceordering/arm-marketplaceordering/package.json
@@ -26,7 +26,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.6.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/marketplaceordering/arm-marketplaceordering",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/marketplaceordering/arm-marketplaceordering",
   "repository": {
     "type": "git",
     "url": "https://github.com/Azure/azure-sdk-for-js.git"

--- a/sdk/mediaservices/arm-mediaservices/package.json
+++ b/sdk/mediaservices/arm-mediaservices/package.json
@@ -26,7 +26,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.6.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/mediaservices/arm-mediaservices",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/mediaservices/arm-mediaservices",
   "repository": {
     "type": "git",
     "url": "https://github.com/Azure/azure-sdk-for-js.git"

--- a/sdk/metricsadvisor/ai-metrics-advisor/package.json
+++ b/sdk/metricsadvisor/ai-metrics-advisor/package.json
@@ -20,7 +20,7 @@
   "engines": {
     "node": ">=8.0.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/metricsadvisor/ai-metrics-advisor/README.md",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/metricsadvisor/ai-metrics-advisor/README.md",
   "repository": "github:Azure/azure-sdk-for-js",
   "bugs": {
     "url": "https://github.com/Azure/azure-sdk-for-js/issues"

--- a/sdk/migrate/arm-migrate/package.json
+++ b/sdk/migrate/arm-migrate/package.json
@@ -25,7 +25,7 @@
     "rollup-plugin-node-resolve": "^3.4.0",
     "uglify-js": "^3.4.9"
   },
-  "homepage": "https://github.com/azure/azure-sdk-for-js/tree/master/sdk/migrate/arm-migrate",
+  "homepage": "https://github.com/azure/azure-sdk-for-js/tree/main/sdk/migrate/arm-migrate",
   "repository": {
     "type": "git",
     "url": "https://github.com/azure/azure-sdk-for-js.git"

--- a/sdk/mixedreality/arm-mixedreality/package.json
+++ b/sdk/mixedreality/arm-mixedreality/package.json
@@ -26,7 +26,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.6.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/mixedreality/arm-mixedreality",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/mixedreality/arm-mixedreality",
   "repository": {
     "type": "git",
     "url": "https://github.com/Azure/azure-sdk-for-js.git"

--- a/sdk/mixedreality/mixedreality-authentication/package.json
+++ b/sdk/mixedreality/mixedreality-authentication/package.json
@@ -63,7 +63,7 @@
   "bugs": {
     "url": "https://github.com/Azure/azure-sdk-for-js/issues"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/mixedreality/mixedreality-authentication/",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/mixedreality/mixedreality-authentication/",
   "sideEffects": false,
   "prettier": "@azure/eslint-plugin-azure-sdk/prettier.json",
   "dependencies": {

--- a/sdk/monitor/arm-monitor-profile-2019-03-01-hybrid/package.json
+++ b/sdk/monitor/arm-monitor-profile-2019-03-01-hybrid/package.json
@@ -27,7 +27,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.4.9"
   },
-  "homepage": "https://github.com/azure/azure-sdk-for-js/tree/master/sdk/monitor/arm-monitor-profile-2019-03-01-hybrid",
+  "homepage": "https://github.com/azure/azure-sdk-for-js/tree/main/sdk/monitor/arm-monitor-profile-2019-03-01-hybrid",
   "repository": {
     "type": "git",
     "url": "https://github.com/azure/azure-sdk-for-js.git"

--- a/sdk/monitor/arm-monitor-profile-2020-09-01-hybrid/package.json
+++ b/sdk/monitor/arm-monitor-profile-2020-09-01-hybrid/package.json
@@ -26,7 +26,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.6.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/monitor/arm-monitor-profile-2020-09-01-hybrid",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/monitor/arm-monitor-profile-2020-09-01-hybrid",
   "repository": {
     "type": "git",
     "url": "https://github.com/Azure/azure-sdk-for-js.git"

--- a/sdk/monitor/arm-monitor/package.json
+++ b/sdk/monitor/arm-monitor/package.json
@@ -26,7 +26,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.6.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/monitor/arm-monitor",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/monitor/arm-monitor",
   "repository": {
     "type": "git",
     "url": "https://github.com/Azure/azure-sdk-for-js.git"

--- a/sdk/monitor/monitor-opentelemetry-exporter/package.json
+++ b/sdk/monitor/monitor-opentelemetry-exporter/package.json
@@ -51,7 +51,7 @@
     "LICENSE"
   ],
   "license": "MIT",
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/monitor/monitor-opentelemetry-exporter/",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/monitor/monitor-opentelemetry-exporter/",
   "repository": "github:Azure/azure-sdk-for-js",
   "bugs": {
     "url": "https://github.com/Azure/azure-sdk-for-js/issues"

--- a/sdk/monitor/monitor-query/package.json
+++ b/sdk/monitor/monitor-query/package.json
@@ -94,7 +94,7 @@
   "bugs": {
     "url": "https://github.com/Azure/azure-sdk-for-js/issues"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/monitor/monitor-query/README.md",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/monitor/monitor-query/README.md",
   "sideEffects": false,
   "prettier": "@azure/eslint-plugin-azure-sdk/prettier.json",
   "dependencies": {

--- a/sdk/msi/arm-msi/package.json
+++ b/sdk/msi/arm-msi/package.json
@@ -25,7 +25,7 @@
     "rollup-plugin-node-resolve": "^3.4.0",
     "uglify-js": "^3.4.9"
   },
-  "homepage": "https://github.com/azure/azure-sdk-for-js/tree/master/sdk/msi/arm-msi",
+  "homepage": "https://github.com/azure/azure-sdk-for-js/tree/main/sdk/msi/arm-msi",
   "repository": {
     "type": "git",
     "url": "https://github.com/azure/azure-sdk-for-js.git"

--- a/sdk/mysql/arm-mysql/package.json
+++ b/sdk/mysql/arm-mysql/package.json
@@ -26,7 +26,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.4.9"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/mysql/arm-mysql",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/mysql/arm-mysql",
   "repository": {
     "type": "git",
     "url": "https://github.com/Azure/azure-sdk-for-js.git"

--- a/sdk/netapp/arm-netapp/package.json
+++ b/sdk/netapp/arm-netapp/package.json
@@ -27,7 +27,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.6.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/netapp/arm-netapp",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/netapp/arm-netapp",
   "repository": {
     "type": "git",
     "url": "https://github.com/Azure/azure-sdk-for-js.git"

--- a/sdk/network/arm-network-profile-2019-03-01-hybrid/package.json
+++ b/sdk/network/arm-network-profile-2019-03-01-hybrid/package.json
@@ -27,7 +27,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.4.9"
   },
-  "homepage": "https://github.com/azure/azure-sdk-for-js/tree/master/sdk/network/arm-network-profile-2019-03-01-hybrid",
+  "homepage": "https://github.com/azure/azure-sdk-for-js/tree/main/sdk/network/arm-network-profile-2019-03-01-hybrid",
   "repository": {
     "type": "git",
     "url": "https://github.com/azure/azure-sdk-for-js.git"

--- a/sdk/network/arm-network-profile-2020-09-01-hybrid/package.json
+++ b/sdk/network/arm-network-profile-2020-09-01-hybrid/package.json
@@ -26,7 +26,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.6.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/network/arm-network-profile-2020-09-01-hybrid",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/network/arm-network-profile-2020-09-01-hybrid",
   "repository": {
     "type": "git",
     "url": "https://github.com/Azure/azure-sdk-for-js.git"

--- a/sdk/network/arm-network/package.json
+++ b/sdk/network/arm-network/package.json
@@ -27,7 +27,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.6.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/network/arm-network",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/network/arm-network",
   "repository": {
     "type": "git",
     "url": "https://github.com/Azure/azure-sdk-for-js.git"

--- a/sdk/notificationhubs/arm-notificationhubs/package.json
+++ b/sdk/notificationhubs/arm-notificationhubs/package.json
@@ -25,7 +25,7 @@
     "rollup-plugin-node-resolve": "^3.4.0",
     "uglify-js": "^3.4.9"
   },
-  "homepage": "https://github.com/azure/azure-sdk-for-js/tree/master/sdk/notificationhubs/arm-notificationhubs",
+  "homepage": "https://github.com/azure/azure-sdk-for-js/tree/main/sdk/notificationhubs/arm-notificationhubs",
   "repository": {
     "type": "git",
     "url": "https://github.com/azure/azure-sdk-for-js.git"

--- a/sdk/operationalinsights/arm-operationalinsights/package.json
+++ b/sdk/operationalinsights/arm-operationalinsights/package.json
@@ -26,7 +26,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.6.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/operationalinsights/arm-operationalinsights",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/operationalinsights/arm-operationalinsights",
   "repository": {
     "type": "git",
     "url": "https://github.com/Azure/azure-sdk-for-js.git"

--- a/sdk/operationalinsights/loganalytics/package.json
+++ b/sdk/operationalinsights/loganalytics/package.json
@@ -24,7 +24,7 @@
     "rollup-plugin-node-resolve": "^3.4.0",
     "uglify-js": "^3.4.9"
   },
-  "homepage": "https://github.com/azure/azure-sdk-for-js/tree/master/sdk/operationalinsights/loganalytics",
+  "homepage": "https://github.com/azure/azure-sdk-for-js/tree/main/sdk/operationalinsights/loganalytics",
   "repository": {
     "type": "git",
     "url": "https://github.com/azure/azure-sdk-for-js.git"

--- a/sdk/operationsmanagement/arm-operations/package.json
+++ b/sdk/operationsmanagement/arm-operations/package.json
@@ -25,7 +25,7 @@
     "rollup-plugin-node-resolve": "^3.4.0",
     "uglify-js": "^3.4.9"
   },
-  "homepage": "https://github.com/azure/azure-sdk-for-js/tree/master/sdk/operationsmanagement/arm-operations",
+  "homepage": "https://github.com/azure/azure-sdk-for-js/tree/main/sdk/operationsmanagement/arm-operations",
   "repository": {
     "type": "git",
     "url": "https://github.com/azure/azure-sdk-for-js.git"

--- a/sdk/peering/arm-peering/package.json
+++ b/sdk/peering/arm-peering/package.json
@@ -26,7 +26,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.6.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/peering/arm-peering",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/peering/arm-peering",
   "repository": {
     "type": "git",
     "url": "https://github.com/Azure/azure-sdk-for-js.git"

--- a/sdk/policy/arm-policy-profile-2020-09-01-hybrid/package.json
+++ b/sdk/policy/arm-policy-profile-2020-09-01-hybrid/package.json
@@ -26,7 +26,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.6.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/policy/arm-policy-profile-2020-09-01-hybrid",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/policy/arm-policy-profile-2020-09-01-hybrid",
   "repository": {
     "type": "git",
     "url": "https://github.com/Azure/azure-sdk-for-js.git"

--- a/sdk/policy/arm-policy-profile-hybrid-2019-03-01/package.json
+++ b/sdk/policy/arm-policy-profile-hybrid-2019-03-01/package.json
@@ -27,7 +27,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.4.9"
   },
-  "homepage": "https://github.com/azure/azure-sdk-for-js/tree/master/sdk/policy/arm-policy-profile-hybrid-2019-03-01",
+  "homepage": "https://github.com/azure/azure-sdk-for-js/tree/main/sdk/policy/arm-policy-profile-hybrid-2019-03-01",
   "repository": {
     "type": "git",
     "url": "https://github.com/azure/azure-sdk-for-js.git"

--- a/sdk/policy/arm-policy/package.json
+++ b/sdk/policy/arm-policy/package.json
@@ -26,7 +26,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.6.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/policy/arm-policy",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/policy/arm-policy",
   "repository": {
     "type": "git",
     "url": "https://github.com/Azure/azure-sdk-for-js.git"

--- a/sdk/policyinsights/arm-policyinsights/package.json
+++ b/sdk/policyinsights/arm-policyinsights/package.json
@@ -26,7 +26,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.6.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/policyinsights/arm-policyinsights",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/policyinsights/arm-policyinsights",
   "repository": {
     "type": "git",
     "url": "https://github.com/Azure/azure-sdk-for-js.git"

--- a/sdk/postgresql/arm-postgresql-flexible/package.json
+++ b/sdk/postgresql/arm-postgresql-flexible/package.json
@@ -27,7 +27,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.6.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/postgresql/arm-postgresql-flexible",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/postgresql/arm-postgresql-flexible",
   "repository": {
     "type": "git",
     "url": "https://github.com/Azure/azure-sdk-for-js.git"

--- a/sdk/postgresql/arm-postgresql/package.json
+++ b/sdk/postgresql/arm-postgresql/package.json
@@ -26,7 +26,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.6.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/postgresql/arm-postgresql",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/postgresql/arm-postgresql",
   "repository": {
     "type": "git",
     "url": "https://github.com/Azure/azure-sdk-for-js.git"

--- a/sdk/powerbidedicated/arm-powerbidedicated/package.json
+++ b/sdk/powerbidedicated/arm-powerbidedicated/package.json
@@ -26,7 +26,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.6.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/powerbidedicated/arm-powerbidedicated",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/powerbidedicated/arm-powerbidedicated",
   "repository": {
     "type": "git",
     "url": "https://github.com/Azure/azure-sdk-for-js.git"

--- a/sdk/powerbiembedded/arm-powerbiembedded/package.json
+++ b/sdk/powerbiembedded/arm-powerbiembedded/package.json
@@ -25,7 +25,7 @@
     "rollup-plugin-node-resolve": "^3.4.0",
     "uglify-js": "^3.4.9"
   },
-  "homepage": "https://github.com/azure/azure-sdk-for-js/tree/master/sdk/powerbiembedded/arm-powerbiembedded",
+  "homepage": "https://github.com/azure/azure-sdk-for-js/tree/main/sdk/powerbiembedded/arm-powerbiembedded",
   "repository": {
     "type": "git",
     "url": "https://github.com/azure/azure-sdk-for-js.git"

--- a/sdk/privatedns/arm-privatedns/package.json
+++ b/sdk/privatedns/arm-privatedns/package.json
@@ -26,7 +26,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.6.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/privatedns/arm-privatedns",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/privatedns/arm-privatedns",
   "repository": {
     "type": "git",
     "url": "https://github.com/Azure/azure-sdk-for-js.git"

--- a/sdk/purview/purview-catalog-rest/package.json
+++ b/sdk/purview/purview-catalog-rest/package.json
@@ -16,7 +16,7 @@
   "main": "./dist/index.js",
   "module": "./dist-esm/src/index.js",
   "types": "./types/purview-catalog-rest.d.ts",
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/purview/purview-catalog/README.md",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/purview/purview-catalog/README.md",
   "repository": "github:Azure/azure-sdk-for-js",
   "bugs": {
     "url": "https://github.com/Azure/azure-sdk-for-js/issues"

--- a/sdk/purview/purview-scanning-rest/package.json
+++ b/sdk/purview/purview-scanning-rest/package.json
@@ -16,7 +16,7 @@
   "main": "./dist/index.js",
   "module": "./dist-esm/src/index.js",
   "types": "./types/purview-scanning-rest.d.ts",
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/purview/purview-scanning-rest/README.md",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/purview/purview-scanning-rest/README.md",
   "repository": "github:Azure/azure-sdk-for-js",
   "bugs": {
     "url": "https://github.com/Azure/azure-sdk-for-js/issues"

--- a/sdk/quantum/quantum-jobs/package.json
+++ b/sdk/quantum/quantum-jobs/package.json
@@ -59,7 +59,7 @@
     "isomorphic"
   ],
   "repository": "github:Azure/azure-sdk-for-js",
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/quantum/quantum-jobs/",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/quantum/quantum-jobs/",
   "bugs": {
     "url": "https://github.com/Azure/azure-sdk-for-js/issues"
   },

--- a/sdk/recoveryservices/arm-recoveryservices/package.json
+++ b/sdk/recoveryservices/arm-recoveryservices/package.json
@@ -26,7 +26,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.6.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/recoveryservices/arm-recoveryservices",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/recoveryservices/arm-recoveryservices",
   "repository": {
     "type": "git",
     "url": "https://github.com/Azure/azure-sdk-for-js.git"

--- a/sdk/recoveryservicesbackup/arm-recoveryservicesbackup/package.json
+++ b/sdk/recoveryservicesbackup/arm-recoveryservicesbackup/package.json
@@ -27,7 +27,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.6.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/recoveryservicesbackup/arm-recoveryservicesbackup",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/recoveryservicesbackup/arm-recoveryservicesbackup",
   "repository": {
     "type": "git",
     "url": "https://github.com/Azure/azure-sdk-for-js.git"

--- a/sdk/recoveryservicessiterecovery/arm-recoveryservices-siterecovery/package.json
+++ b/sdk/recoveryservicessiterecovery/arm-recoveryservices-siterecovery/package.json
@@ -25,7 +25,7 @@
     "rollup-plugin-node-resolve": "^3.4.0",
     "uglify-js": "^3.4.9"
   },
-  "homepage": "https://github.com/azure/azure-sdk-for-js/tree/master/sdk/recoveryservicessiterecovery/arm-recoveryservices-siterecovery",
+  "homepage": "https://github.com/azure/azure-sdk-for-js/tree/main/sdk/recoveryservicessiterecovery/arm-recoveryservices-siterecovery",
   "repository": {
     "type": "git",
     "url": "https://github.com/azure/azure-sdk-for-js.git"

--- a/sdk/redis/arm-rediscache/package.json
+++ b/sdk/redis/arm-rediscache/package.json
@@ -26,7 +26,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.6.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/redis/arm-rediscache",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/redis/arm-rediscache",
   "repository": {
     "type": "git",
     "url": "https://github.com/Azure/azure-sdk-for-js.git"

--- a/sdk/redisenterprise/arm-redisenterprisecache/package.json
+++ b/sdk/redisenterprise/arm-redisenterprisecache/package.json
@@ -26,7 +26,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.6.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/redisenterprise/arm-redisenterprisecache",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/redisenterprise/arm-redisenterprisecache",
   "repository": {
     "type": "git",
     "url": "https://github.com/Azure/azure-sdk-for-js.git"

--- a/sdk/relay/arm-relay/package.json
+++ b/sdk/relay/arm-relay/package.json
@@ -25,7 +25,7 @@
     "rollup-plugin-node-resolve": "^3.4.0",
     "uglify-js": "^3.4.9"
   },
-  "homepage": "https://github.com/azure/azure-sdk-for-js/tree/master/sdk/relay/arm-relay",
+  "homepage": "https://github.com/azure/azure-sdk-for-js/tree/main/sdk/relay/arm-relay",
   "repository": {
     "type": "git",
     "url": "https://github.com/azure/azure-sdk-for-js.git"

--- a/sdk/reservations/arm-reservations/package.json
+++ b/sdk/reservations/arm-reservations/package.json
@@ -26,7 +26,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.6.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/reservations/arm-reservations",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/reservations/arm-reservations",
   "repository": {
     "type": "git",
     "url": "https://github.com/Azure/azure-sdk-for-js.git"

--- a/sdk/resourcegraph/arm-resourcegraph/package.json
+++ b/sdk/resourcegraph/arm-resourcegraph/package.json
@@ -26,7 +26,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.6.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/resourcegraph/arm-resourcegraph",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/resourcegraph/arm-resourcegraph",
   "repository": {
     "type": "git",
     "url": "https://github.com/Azure/azure-sdk-for-js.git"

--- a/sdk/resourcehealth/arm-resourcehealth/package.json
+++ b/sdk/resourcehealth/arm-resourcehealth/package.json
@@ -25,7 +25,7 @@
     "rollup-plugin-node-resolve": "^3.4.0",
     "uglify-js": "^3.4.9"
   },
-  "homepage": "https://github.com/azure/azure-sdk-for-js/tree/master/sdk/resourcehealth/arm-resourcehealth",
+  "homepage": "https://github.com/azure/azure-sdk-for-js/tree/main/sdk/resourcehealth/arm-resourcehealth",
   "repository": {
     "type": "git",
     "url": "https://github.com/azure/azure-sdk-for-js.git"

--- a/sdk/resourcemover/arm-resourcemover/package.json
+++ b/sdk/resourcemover/arm-resourcemover/package.json
@@ -26,7 +26,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.6.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/resourcemover/arm-resourcemover",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/resourcemover/arm-resourcemover",
   "repository": {
     "type": "git",
     "url": "https://github.com/Azure/azure-sdk-for-js.git"

--- a/sdk/resources/arm-resources-profile-2020-09-01-hybrid/package.json
+++ b/sdk/resources/arm-resources-profile-2020-09-01-hybrid/package.json
@@ -26,7 +26,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.6.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/resources/arm-resources-profile-2020-09-01-hybrid",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/resources/arm-resources-profile-2020-09-01-hybrid",
   "repository": {
     "type": "git",
     "url": "https://github.com/Azure/azure-sdk-for-js.git"

--- a/sdk/resources/arm-resources-profile-hybrid-2019-03-01/package.json
+++ b/sdk/resources/arm-resources-profile-hybrid-2019-03-01/package.json
@@ -27,7 +27,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.4.9"
   },
-  "homepage": "https://github.com/azure/azure-sdk-for-js/tree/master/sdk/resources/arm-resources-profile-hybrid-2019-03-01",
+  "homepage": "https://github.com/azure/azure-sdk-for-js/tree/main/sdk/resources/arm-resources-profile-hybrid-2019-03-01",
   "repository": {
     "type": "git",
     "url": "https://github.com/azure/azure-sdk-for-js.git"

--- a/sdk/resources/arm-resources/package.json
+++ b/sdk/resources/arm-resources/package.json
@@ -27,7 +27,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.6.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/resources/arm-resources",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/resources/arm-resources",
   "repository": {
     "type": "git",
     "url": "https://github.com/Azure/azure-sdk-for-js.git"

--- a/sdk/schemaregistry/schema-registry-avro/package.json
+++ b/sdk/schemaregistry/schema-registry-avro/package.json
@@ -55,7 +55,7 @@
   "bugs": {
     "url": "https://github.com/Azure/azure-sdk-for-js/issues"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/schemaregistry/schema-registry-avro/",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/schemaregistry/schema-registry-avro/",
   "sideEffects": false,
   "prettier": "@azure/eslint-plugin-azure-sdk/prettier.json",
   "//sampleConfiguration": {

--- a/sdk/schemaregistry/schema-registry/package.json
+++ b/sdk/schemaregistry/schema-registry/package.json
@@ -82,7 +82,7 @@
   "bugs": {
     "url": "https://github.com/Azure/azure-sdk-for-js/issues"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/schemaregistry/schema-registry/",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/schemaregistry/schema-registry/",
   "sideEffects": false,
   "prettier": "@azure/eslint-plugin-azure-sdk/prettier.json",
   "dependencies": {

--- a/sdk/search/arm-search/package.json
+++ b/sdk/search/arm-search/package.json
@@ -25,7 +25,7 @@
     "rollup-plugin-node-resolve": "^3.4.0",
     "uglify-js": "^3.4.9"
   },
-  "homepage": "https://github.com/azure/azure-sdk-for-js/tree/master/sdk/search/arm-search",
+  "homepage": "https://github.com/azure/azure-sdk-for-js/tree/main/sdk/search/arm-search",
   "repository": {
     "type": "git",
     "url": "https://github.com/azure/azure-sdk-for-js.git"

--- a/sdk/search/search-documents/package.json
+++ b/sdk/search/search-documents/package.json
@@ -72,7 +72,7 @@
   "engines": {
     "node": ">=8.0.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/search/search-documents/",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/search/search-documents/",
   "sideEffects": false,
   "dependencies": {
     "@azure/core-auth": "^1.3.0",

--- a/sdk/security/arm-security/package.json
+++ b/sdk/security/arm-security/package.json
@@ -26,7 +26,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.6.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/security/arm-security",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/security/arm-security",
   "repository": {
     "type": "git",
     "url": "https://github.com/Azure/azure-sdk-for-js.git"

--- a/sdk/service-map/arm-servicemap/package.json
+++ b/sdk/service-map/arm-servicemap/package.json
@@ -26,7 +26,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.4.9"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/service-map/arm-servicemap",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/service-map/arm-servicemap",
   "repository": {
     "type": "git",
     "url": "https://github.com/Azure/azure-sdk-for-js.git"

--- a/sdk/servicebus/arm-servicebus/package.json
+++ b/sdk/servicebus/arm-servicebus/package.json
@@ -26,7 +26,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.6.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/servicebus/arm-servicebus",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/servicebus/arm-servicebus",
   "repository": {
     "type": "git",
     "url": "https://github.com/Azure/azure-sdk-for-js.git"

--- a/sdk/servicebus/service-bus/package.json
+++ b/sdk/servicebus/service-bus/package.json
@@ -5,7 +5,7 @@
   "version": "7.2.1",
   "license": "MIT",
   "description": "Azure Service Bus SDK for JavaScript",
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/servicebus/service-bus/",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/servicebus/service-bus/",
   "repository": "github:Azure/azure-sdk-for-js",
   "keywords": [
     "azure",

--- a/sdk/servicefabric/arm-servicefabric/package.json
+++ b/sdk/servicefabric/arm-servicefabric/package.json
@@ -26,7 +26,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.6.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/servicefabric/arm-servicefabric",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/servicefabric/arm-servicefabric",
   "repository": {
     "type": "git",
     "url": "https://github.com/Azure/azure-sdk-for-js.git"

--- a/sdk/servicefabric/servicefabric/package.json
+++ b/sdk/servicefabric/servicefabric/package.json
@@ -25,7 +25,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.6.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/servicefabric/servicefabric",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/servicefabric/servicefabric",
   "repository": {
     "type": "git",
     "url": "https://github.com/Azure/azure-sdk-for-js.git"

--- a/sdk/servicefabricmesh/arm-servicefabricmesh/package.json
+++ b/sdk/servicefabricmesh/arm-servicefabricmesh/package.json
@@ -25,7 +25,7 @@
     "rollup-plugin-node-resolve": "^3.4.0",
     "uglify-js": "^3.4.9"
   },
-  "homepage": "https://github.com/azure/azure-sdk-for-js/tree/master/sdk/servicefabricmesh/arm-servicefabricmesh",
+  "homepage": "https://github.com/azure/azure-sdk-for-js/tree/main/sdk/servicefabricmesh/arm-servicefabricmesh",
   "repository": {
     "type": "git",
     "url": "https://github.com/azure/azure-sdk-for-js.git"

--- a/sdk/signalr/arm-signalr/package.json
+++ b/sdk/signalr/arm-signalr/package.json
@@ -26,7 +26,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.6.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/signalr/arm-signalr",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/signalr/arm-signalr",
   "repository": {
     "type": "git",
     "url": "https://github.com/Azure/azure-sdk-for-js.git"

--- a/sdk/sql/arm-sql/package.json
+++ b/sdk/sql/arm-sql/package.json
@@ -27,7 +27,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.6.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/sql/arm-sql",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/sql/arm-sql",
   "repository": {
     "type": "git",
     "url": "https://github.com/Azure/azure-sdk-for-js.git"

--- a/sdk/sqlvirtualmachine/arm-sqlvirtualmachine/package.json
+++ b/sdk/sqlvirtualmachine/arm-sqlvirtualmachine/package.json
@@ -26,7 +26,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.6.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/sqlvirtualmachine/arm-sqlvirtualmachine",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/sqlvirtualmachine/arm-sqlvirtualmachine",
   "repository": {
     "type": "git",
     "url": "https://github.com/Azure/azure-sdk-for-js.git"

--- a/sdk/storage/arm-storage-profile-2020-09-01-hybrid/package.json
+++ b/sdk/storage/arm-storage-profile-2020-09-01-hybrid/package.json
@@ -26,7 +26,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.6.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/storage/arm-storage-profile-2020-09-01-hybrid",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/storage/arm-storage-profile-2020-09-01-hybrid",
   "repository": {
     "type": "git",
     "url": "https://github.com/Azure/azure-sdk-for-js.git"

--- a/sdk/storage/arm-storage/package.json
+++ b/sdk/storage/arm-storage/package.json
@@ -26,7 +26,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.6.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/storage/arm-storage",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/storage/arm-storage",
   "repository": {
     "type": "git",
     "url": "https://github.com/Azure/azure-sdk-for-js.git"

--- a/sdk/storage/storage-blob-changefeed/package.json
+++ b/sdk/storage/storage-blob-changefeed/package.json
@@ -83,7 +83,7 @@
   "bugs": {
     "url": "https://github.com/Azure/azure-sdk-for-js/issues"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/storage/storage-blob-changefeed/",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/storage/storage-blob-changefeed/",
   "sideEffects": false,
   "//metadata": {
     "constantPaths": [

--- a/sdk/storage/storage-blob/package.json
+++ b/sdk/storage/storage-blob/package.json
@@ -91,7 +91,7 @@
   "bugs": {
     "url": "https://github.com/Azure/azure-sdk-for-js/issues"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/storage/storage-blob/",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/storage/storage-blob/",
   "sideEffects": false,
   "//metadata": {
     "constantPaths": [

--- a/sdk/storage/storage-datalake/package.json
+++ b/sdk/storage/storage-datalake/package.json
@@ -26,7 +26,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.6.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/storage/storage-datalake",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/storage/storage-datalake",
   "repository": {
     "type": "git",
     "url": "https://github.com/Azure/azure-sdk-for-js.git"

--- a/sdk/storage/storage-file-datalake/package.json
+++ b/sdk/storage/storage-file-datalake/package.json
@@ -88,7 +88,7 @@
   "bugs": {
     "url": "https://github.com/Azure/azure-sdk-for-js/issues"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/storage/storage-file-datalake/",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/storage/storage-file-datalake/",
   "//metadata": {
     "constantPaths": [
       {

--- a/sdk/storage/storage-file-share/package.json
+++ b/sdk/storage/storage-file-share/package.json
@@ -84,7 +84,7 @@
   "bugs": {
     "url": "https://github.com/Azure/azure-sdk-for-js/issues"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/storage/storage-file-share/",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/storage/storage-file-share/",
   "sideEffects": false,
   "//metadata": {
     "constantPaths": [

--- a/sdk/storage/storage-internal-avro/package.json
+++ b/sdk/storage/storage-internal-avro/package.json
@@ -7,7 +7,7 @@
   "description": "internal avro parser",
   "license": "MIT",
   "repository": "github:Azure/azure-sdk-for-js",
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/storage/storage-internal-avro/",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/storage/storage-internal-avro/",
   "bugs": {
     "url": "https://github.com/Azure/azure-sdk-for-js/issues"
   },

--- a/sdk/storage/storage-queue/package.json
+++ b/sdk/storage/storage-queue/package.json
@@ -80,7 +80,7 @@
   "bugs": {
     "url": "https://github.com/Azure/azure-sdk-for-js/issues"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/storage/storage-queue/",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/storage/storage-queue/",
   "sideEffects": false,
   "//metadata": {
     "constantPaths": [

--- a/sdk/storagecache/arm-storagecache/package.json
+++ b/sdk/storagecache/arm-storagecache/package.json
@@ -26,7 +26,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.6.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/storagecache/arm-storagecache",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/storagecache/arm-storagecache",
   "repository": {
     "type": "git",
     "url": "https://github.com/Azure/azure-sdk-for-js.git"

--- a/sdk/storageimportexport/arm-storageimportexport/package.json
+++ b/sdk/storageimportexport/arm-storageimportexport/package.json
@@ -25,7 +25,7 @@
     "rollup-plugin-node-resolve": "^3.4.0",
     "uglify-js": "^3.4.9"
   },
-  "homepage": "https://github.com/azure/azure-sdk-for-js/tree/master/sdk/storageimportexport/arm-storageimportexport",
+  "homepage": "https://github.com/azure/azure-sdk-for-js/tree/main/sdk/storageimportexport/arm-storageimportexport",
   "repository": {
     "type": "git",
     "url": "https://github.com/azure/azure-sdk-for-js.git"

--- a/sdk/storagesync/arm-storagesync/package.json
+++ b/sdk/storagesync/arm-storagesync/package.json
@@ -26,7 +26,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.6.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/storagesync/arm-storagesync",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/storagesync/arm-storagesync",
   "repository": {
     "type": "git",
     "url": "https://github.com/Azure/azure-sdk-for-js.git"

--- a/sdk/storsimple1200series/arm-storsimple1200series/package.json
+++ b/sdk/storsimple1200series/arm-storsimple1200series/package.json
@@ -25,7 +25,7 @@
     "rollup-plugin-node-resolve": "^3.4.0",
     "uglify-js": "^3.4.9"
   },
-  "homepage": "https://github.com/azure/azure-sdk-for-js/tree/master/sdk/storsimple1200series/arm-storsimple1200series",
+  "homepage": "https://github.com/azure/azure-sdk-for-js/tree/main/sdk/storsimple1200series/arm-storsimple1200series",
   "repository": {
     "type": "git",
     "url": "https://github.com/azure/azure-sdk-for-js.git"

--- a/sdk/storsimple8000series/arm-storsimple8000series/package.json
+++ b/sdk/storsimple8000series/arm-storsimple8000series/package.json
@@ -25,7 +25,7 @@
     "rollup-plugin-node-resolve": "^3.4.0",
     "uglify-js": "^3.4.9"
   },
-  "homepage": "https://github.com/azure/azure-sdk-for-js/tree/master/sdk/storsimple8000series/arm-storsimple8000series",
+  "homepage": "https://github.com/azure/azure-sdk-for-js/tree/main/sdk/storsimple8000series/arm-storsimple8000series",
   "repository": {
     "type": "git",
     "url": "https://github.com/azure/azure-sdk-for-js.git"

--- a/sdk/streamanalytics/arm-streamanalytics/package.json
+++ b/sdk/streamanalytics/arm-streamanalytics/package.json
@@ -26,7 +26,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.6.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/streamanalytics/arm-streamanalytics",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/streamanalytics/arm-streamanalytics",
   "repository": {
     "type": "git",
     "url": "https://github.com/Azure/azure-sdk-for-js.git"

--- a/sdk/subscription/arm-subscriptions-profile-2020-09-01-hybrid/package.json
+++ b/sdk/subscription/arm-subscriptions-profile-2020-09-01-hybrid/package.json
@@ -26,7 +26,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.6.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/subscription/arm-subscriptions-profile-2020-09-01-hybrid",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/subscription/arm-subscriptions-profile-2020-09-01-hybrid",
   "repository": {
     "type": "git",
     "url": "https://github.com/Azure/azure-sdk-for-js.git"

--- a/sdk/subscription/arm-subscriptions-profile-hybrid-2019-03-01/package.json
+++ b/sdk/subscription/arm-subscriptions-profile-hybrid-2019-03-01/package.json
@@ -27,7 +27,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.4.9"
   },
-  "homepage": "https://github.com/azure/azure-sdk-for-js/tree/master/sdk/subscription/arm-subscriptions-profile-hybrid-2019-03-01",
+  "homepage": "https://github.com/azure/azure-sdk-for-js/tree/main/sdk/subscription/arm-subscriptions-profile-hybrid-2019-03-01",
   "repository": {
     "type": "git",
     "url": "https://github.com/azure/azure-sdk-for-js.git"

--- a/sdk/subscription/arm-subscriptions/package.json
+++ b/sdk/subscription/arm-subscriptions/package.json
@@ -26,7 +26,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.6.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/subscription/arm-subscriptions",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/subscription/arm-subscriptions",
   "repository": {
     "type": "git",
     "url": "https://github.com/Azure/azure-sdk-for-js.git"

--- a/sdk/support/arm-support/package.json
+++ b/sdk/support/arm-support/package.json
@@ -26,7 +26,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.6.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/support/arm-support",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/support/arm-support",
   "repository": {
     "type": "git",
     "url": "https://github.com/Azure/azure-sdk-for-js.git"

--- a/sdk/synapse/arm-synapse/package.json
+++ b/sdk/synapse/arm-synapse/package.json
@@ -26,7 +26,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.6.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/synapse/arm-synapse",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/synapse/arm-synapse",
   "repository": {
     "type": "git",
     "url": "https://github.com/Azure/azure-sdk-for-js.git"

--- a/sdk/synapse/synapse-access-control/package.json
+++ b/sdk/synapse/synapse-access-control/package.json
@@ -2,7 +2,7 @@
   "name": "@azure/synapse-access-control",
   "author": "Microsoft Corporation",
   "description": "A generated SDK for AccessControlClient.",
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/synapse/synapse-access-control/README.md",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/synapse/synapse-access-control/README.md",
   "repository": "github:Azure/azure-sdk-for-js",
   "sdk-type": "client",
   "version": "1.0.0-beta.3",

--- a/sdk/synapse/synapse-artifacts/package.json
+++ b/sdk/synapse/synapse-artifacts/package.json
@@ -4,7 +4,7 @@
   "description": "A generated SDK for ArtifactsClient.",
   "sdk-type": "client",
   "version": "1.0.0-beta.5",
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/synapse/synapse-artifacts/README.md",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/synapse/synapse-artifacts/README.md",
   "repository": "github:Azure/azure-sdk-for-js",
   "dependencies": {
     "@azure/core-lro": "^1.0.2",

--- a/sdk/synapse/synapse-managed-private-endpoints/package.json
+++ b/sdk/synapse/synapse-managed-private-endpoints/package.json
@@ -2,7 +2,7 @@
   "name": "@azure/synapse-managed-private-endpoints",
   "author": "Microsoft Corporation",
   "description": "A generated SDK for ManagedPrivateEndpointsClient.",
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/synapse/synapse-managed-private-endpoints/README.md",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/synapse/synapse-managed-private-endpoints/README.md",
   "repository": "github:Azure/azure-sdk-for-js",
   "sdk-type": "client",
   "version": "1.0.0-beta.3",

--- a/sdk/synapse/synapse-monitoring/package.json
+++ b/sdk/synapse/synapse-monitoring/package.json
@@ -2,7 +2,7 @@
   "name": "@azure/synapse-monitoring",
   "author": "Microsoft Corporation",
   "description": "A generated SDK for MonitoringClient.",
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/synapse/synapse-monitoring/README.md",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/synapse/synapse-monitoring/README.md",
   "repository": "github:Azure/azure-sdk-for-js",
   "sdk-type": "client",
   "version": "1.0.0-beta.3",

--- a/sdk/synapse/synapse-spark/package.json
+++ b/sdk/synapse/synapse-spark/package.json
@@ -2,7 +2,7 @@
   "name": "@azure/synapse-spark",
   "author": "Microsoft Corporation",
   "description": "A generated SDK for SparkClient.",
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/synapse/synapse-spark/README.md",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/synapse/synapse-spark/README.md",
   "repository": "github:Azure/azure-sdk-for-js",
   "sdk-type": "client",
   "version": "1.0.0-beta.3",

--- a/sdk/tables/data-tables/package.json
+++ b/sdk/tables/data-tables/package.json
@@ -72,7 +72,7 @@
   "engines": {
     "node": ">=8.0.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/tables/data-tables/",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/tables/data-tables/",
   "sideEffects": false,
   "prettier": "@azure/eslint-plugin-azure-sdk/prettier.json",
   "dependencies": {

--- a/sdk/template/template/package.json
+++ b/sdk/template/template/package.json
@@ -77,7 +77,7 @@
   "bugs": {
     "url": "https://github.com/Azure/azure-sdk-for-js/issues"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/template/template/README.md",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/template/template/README.md",
   "sideEffects": false,
   "prettier": "@azure/eslint-plugin-azure-sdk/prettier.json",
   "dependencies": {

--- a/sdk/test-utils/perfstress/package.json
+++ b/sdk/test-utils/perfstress/package.json
@@ -56,7 +56,7 @@
   "bugs": {
     "url": "https://github.com/Azure/azure-sdk-for-js/issues"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/test-utils/perfstress/README.md",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/test-utils/perfstress/README.md",
   "sideEffects": false,
   "private": true,
   "dependencies": {

--- a/sdk/test-utils/recorder/package.json
+++ b/sdk/test-utils/recorder/package.json
@@ -59,7 +59,7 @@
   "engines": {
     "node": ">=8.0.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/test-utils/recorder/",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/test-utils/recorder/",
   "sideEffects": false,
   "private": true,
   "dependencies": {

--- a/sdk/test-utils/test-utils/package.json
+++ b/sdk/test-utils/test-utils/package.json
@@ -52,7 +52,7 @@
   "bugs": {
     "url": "https://github.com/Azure/azure-sdk-for-js/issues"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/test-utils/test-utils/README.md",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/test-utils/test-utils/README.md",
   "sideEffects": false,
   "private": true,
   "dependencies": {

--- a/sdk/textanalytics/ai-text-analytics/package.json
+++ b/sdk/textanalytics/ai-text-analytics/package.json
@@ -16,7 +16,7 @@
   "main": "./dist/index.js",
   "module": "./dist-esm/src/index.js",
   "types": "./types/ai-text-analytics.d.ts",
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/textanalytics/ai-text-analytics/README.md",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/textanalytics/ai-text-analytics/README.md",
   "repository": "github:Azure/azure-sdk-for-js",
   "bugs": {
     "url": "https://github.com/Azure/azure-sdk-for-js/issues"

--- a/sdk/timeseriesinsights/arm-timeseriesinsights/package.json
+++ b/sdk/timeseriesinsights/arm-timeseriesinsights/package.json
@@ -26,7 +26,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.6.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/timeseriesinsights/arm-timeseriesinsights",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/timeseriesinsights/arm-timeseriesinsights",
   "repository": {
     "type": "git",
     "url": "https://github.com/Azure/azure-sdk-for-js.git"

--- a/sdk/trafficmanager/arm-trafficmanager/package.json
+++ b/sdk/trafficmanager/arm-trafficmanager/package.json
@@ -26,7 +26,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.6.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/trafficmanager/arm-trafficmanager",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/trafficmanager/arm-trafficmanager",
   "repository": {
     "type": "git",
     "url": "https://github.com/Azure/azure-sdk-for-js.git"

--- a/sdk/videoanalyzer/video-analyzer-edge/package.json
+++ b/sdk/videoanalyzer/video-analyzer-edge/package.json
@@ -55,7 +55,7 @@
   "bugs": {
     "url": "https://github.com/Azure/azure-sdk-for-js/issues"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/videoanalyzer/",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/videoanalyzer/",
   "sideEffects": false,
   "prettier": "@azure/eslint-plugin-azure-sdk/prettier.json",
   "dependencies": {

--- a/sdk/visualstudio/arm-visualstudio/package.json
+++ b/sdk/visualstudio/arm-visualstudio/package.json
@@ -25,7 +25,7 @@
     "rollup-plugin-node-resolve": "^3.4.0",
     "uglify-js": "^3.4.9"
   },
-  "homepage": "https://github.com/azure/azure-sdk-for-js/tree/master/sdk/visualstudio/arm-visualstudio",
+  "homepage": "https://github.com/azure/azure-sdk-for-js/tree/main/sdk/visualstudio/arm-visualstudio",
   "repository": {
     "type": "git",
     "url": "https://github.com/azure/azure-sdk-for-js.git"

--- a/sdk/vmwarecloudsimple/arm-vmwarecloudsimple/package.json
+++ b/sdk/vmwarecloudsimple/arm-vmwarecloudsimple/package.json
@@ -26,7 +26,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.6.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/vmwarecloudsimple/arm-vmwarecloudsimple",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/vmwarecloudsimple/arm-vmwarecloudsimple",
   "repository": {
     "type": "git",
     "url": "https://github.com/Azure/azure-sdk-for-js.git"

--- a/sdk/web-pubsub/web-pubsub-express/package.json
+++ b/sdk/web-pubsub/web-pubsub-express/package.json
@@ -54,7 +54,7 @@
   "engines": {
     "node": ">=8.0.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/search/search/",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/search/search/",
   "sideEffects": false,
   "dependencies": {
     "@azure/core-auth": "^1.3.0",

--- a/sdk/web-pubsub/web-pubsub/package.json
+++ b/sdk/web-pubsub/web-pubsub/package.json
@@ -57,7 +57,7 @@
   "engines": {
     "node": ">=8.0.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/search/search/",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/search/search/",
   "sideEffects": false,
   "dependencies": {
     "@azure/core-auth": "^1.3.0",


### PR DESCRIPTION
This changes our homepage links in every package.json to use `main` instead of `master`. It also fixes the linter rule so that it accepts `main`.