### PR TITLE
[core-rest-pipeline] Fix handling of typed arrays in request bodies

### DIFF
--- a/sdk/core/core-rest-pipeline/src/nodeHttpClient.ts
+++ b/sdk/core/core-rest-pipeline/src/nodeHttpClient.ts
@@ -157,7 +157,14 @@ class NodeHttpClient implements HttpClient {
         if (body && isReadableStream(body)) {
           body.pipe(req);
         } else if (body) {
-          req.end(body);
+          if (typeof body === "string" || Buffer.isBuffer(body)) {
+            req.end(body);
+          } else if (isArrayBuffer(body)) {
+            req.end(ArrayBuffer.isView(body) ? Buffer.from(body.buffer) : Buffer.from(body));
+          } else {
+            logger.error("Unrecognized body type", body);
+            throw new RestError("Unrecognized body type");
+          }
         } else {
           // streams don't like "undefined" being passed as data
           req.end();


### PR DESCRIPTION
NodeJS does not support directly passing typed arrays or ArrayBuffers to `http.ClientRequest` streams. This means we must correctly wrap these types in a `Buffer` for them to be serialized correctly.