### PR TITLE
Move to @azure/msal-node-extensions 1.0.0-alpha.7

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -622,18 +622,18 @@ packages:
       node: '>=0.8.0'
     resolution:
       integrity: sha512-jFqUWe83wVb6O8cNGGBFg2QlKvqM1ezUgJTEV7kIsAPX0RXhGFE4B1DLNt6hCnkTXDbw+KGW0zgxOEr4MJQwLw==
-  /@azure/msal-node-extensions/1.0.0-alpha.6:
+  /@azure/msal-node-extensions/1.0.0-alpha.7:
     dependencies:
       '@azure/msal-common': 1.7.2
       bindings: 1.5.0
-      keytar: 7.0.0
+      keytar: 7.7.0
       nan: 2.14.2
     dev: false
     engines:
       node: '>=10'
     requiresBuild: true
     resolution:
-      integrity: sha512-fVufHc02C+daYOMAHBnE998abB4qUIeJ9gmTxmSelHhGfBGvvzMbCohCu4sTlSVDKUndF3yD/Nxvw/cEtpcZKg==
+      integrity: sha512-fz+4sTFCnpFDYrJ/FrJ3bx3atUEQ5sUhsZYohUyC9yACxII9kn908hBsxl+xeuzheTN/bq45EZureMioSEogNw==
   /@azure/msal-node/1.0.0-beta.6:
     dependencies:
       '@azure/msal-common': 4.3.0
@@ -5075,14 +5075,6 @@ packages:
       debug: '*'
     resolution:
       integrity: sha512-hbhRogUYIulfkBTZT7xoPrCYhRBnBoqbbL4fszWD0ReFGUxU+LYBr3dwKdAluaDQ/ynT9/7C+Lf7pPNW4gSx4Q==
-  /keytar/7.0.0:
-    dependencies:
-      node-addon-api: 3.2.1
-      prebuild-install: 5.3.5
-    dev: false
-    requiresBuild: true
-    resolution:
-      integrity: sha512-uvmdb5ZE2NgegcUDrmhutI9BUh+bTbt8+bwPliOMiLiWmrV76Tfg6DyI7Ud903a/4xlkJpKGnR0TyRpRyFOc3A==
   /keytar/7.7.0:
     dependencies:
       node-addon-api: 3.2.1
@@ -5633,10 +5625,6 @@ packages:
     dev: false
     resolution:
       integrity: sha512-uW7fodD6pyW2FZNZnp/Z3hvWKeEW1Y8R1+1CnErE8cXFXzl5blBOoVB41CvMer6P6Q0S5FXDwcHgFd1Wj0U9zg==
-  /noop-logger/0.1.1:
-    dev: false
-    resolution:
-      integrity: sha1-lKKxYzxPExdVMAfYlm/Q6EG2pMI=
   /normalize-package-data/2.5.0:
     dependencies:
       hosted-git-info: 2.8.9
@@ -6101,29 +6089,6 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==
-  /prebuild-install/5.3.5:
-    dependencies:
-      detect-libc: 1.0.3
-      expand-template: 2.0.3
-      github-from-package: 0.0.0
-      minimist: 1.2.5
-      mkdirp: 0.5.5
-      napi-build-utils: 1.0.2
-      node-abi: 2.30.0
-      noop-logger: 0.1.1
-      npmlog: 4.1.2
-      pump: 3.0.0
-      rc: 1.2.8
-      simple-get: 3.1.0
-      tar-fs: 2.1.1
-      tunnel-agent: 0.6.0
-      which-pm-runs: 1.0.0
-    dev: false
-    engines:
-      node: '>=6'
-    hasBin: true
-    resolution:
-      integrity: sha512-YmMO7dph9CYKi5IR/BzjOJlRzpxGGVo1EsLSUZ0mt/Mq0HWZIHOKHHcHdT69yG54C9m6i45GpItwRHpk0Py7Uw==
   /prebuild-install/6.1.3:
     dependencies:
       detect-libc: 1.0.3
@@ -7830,10 +7795,6 @@ packages:
     dev: false
     resolution:
       integrity: sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=
-  /which-pm-runs/1.0.0:
-    dev: false
-    resolution:
-      integrity: sha1-Zws6+8VS4LVd9rd4DKdGFfI60cs=
   /which-typed-array/1.1.4:
     dependencies:
       available-typed-arrays: 1.0.4
@@ -9299,6 +9260,7 @@ packages:
     version: 0.0.0
   file:projects/core-rest-pipeline.tgz:
     dependencies:
+      '@azure/core-tracing': 1.0.0-preview.11
       '@microsoft/api-extractor': 7.7.11
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-json': 4.1.0_rollup@1.32.1
@@ -9347,7 +9309,7 @@ packages:
     dev: false
     name: '@rush-temp/core-rest-pipeline'
     resolution:
-      integrity: sha512-B30gNDjvYMKn9TTL3Li38tIe02Gn9y/2pz9MLrKoWFzITzyQwaht729dCk6oSYXfesN+LipPoM26kw5lkOQ0rg==
+      integrity: sha512-zojuz/HSp53v8H/nOSzpSDLTCo1p6cjkcVQ+F4bNKUJ6TPNNKlo7++PBthtyS8TT/rwXhpIAeKuke+RaifY1fA==
       tarball: file:projects/core-rest-pipeline.tgz
     version: 0.0.0
   file:projects/core-tracing.tgz:
@@ -9969,7 +9931,7 @@ packages:
   file:projects/identity-cache-persistence.tgz:
     dependencies:
       '@azure/msal-node': 1.1.0
-      '@azure/msal-node-extensions': 1.0.0-alpha.6
+      '@azure/msal-node-extensions': 1.0.0-alpha.7
       '@microsoft/api-extractor': 7.7.11
       '@types/jws': 3.2.3
       '@types/mocha': 7.0.2
@@ -9997,7 +9959,7 @@ packages:
     dev: false
     name: '@rush-temp/identity-cache-persistence'
     resolution:
-      integrity: sha512-4kcOh05iPn1Q/OPFhlcPgE8+2HNI/hTed17+qMabC68jt8SzX7c1Llhiu8uJfmrvyg/ws83dgWnd38dEYDDqEA==
+      integrity: sha512-ghvnAviHt/DkYNKLTDyXUyBHUwHzsJNUjxEfu0BDFigjI3GIhL4sj4b9tC1zM/BEz5WcX+iNwGyyxli9rpQ/qA==
       tarball: file:projects/identity-cache-persistence.tgz
     version: 0.0.0
   file:projects/identity-vscode.tgz:

--- a/sdk/identity/identity-cache-persistence/package.json
+++ b/sdk/identity/identity-cache-persistence/package.json
@@ -67,7 +67,7 @@
     "@azure/core-auth": "^1.3.0",
     "@azure/identity": "^2.0.0-beta.4",
     "@azure/msal-node": "^1.1.0",
-    "@azure/msal-node-extensions": "1.0.0-alpha.6",
+    "@azure/msal-node-extensions": "1.0.0-alpha.7",
     "keytar": "^7.6.0",
     "tslib": "^2.2.0"
   },


### PR DESCRIPTION
This version unpins the `keytar` dependency, resolving build issues for some developers, and allowing keytar 7.7.0 (which uses NAPI, reducing prebuild complexity).