### PR TITLE
[DO NOT MERGE] - test longer timeouts

### DIFF
--- a/sdk/keyvault/keyvault-certificates/tests.yml
+++ b/sdk/keyvault/keyvault-certificates/tests.yml
@@ -5,7 +5,7 @@ stages:
     parameters:
       PackageName: "@azure/keyvault-certificates"
       ServiceDirectory: keyvault
-      TimeoutInMinutes: 90
+      TimeoutInMinutes: 360
       EnvVars:
         AZURE_CLIENT_ID: $(aad-azure-sdk-test-client-id)
         AZURE_TENANT_ID: $(aad-azure-sdk-test-tenant-id)

--- a/sdk/keyvault/keyvault-keys/tests.yml
+++ b/sdk/keyvault/keyvault-keys/tests.yml
@@ -5,7 +5,7 @@ stages:
     parameters:
       PackageName: "@azure/keyvault-keys"
       ServiceDirectory: keyvault
-      TimeoutInMinutes: 90
+      TimeoutInMinutes: 360
       # KV HSM limitation prevents us from running live tests
       # against multiple platforms in parallel (we're limited to a single
       # instance per region per subscription) so we're only running

--- a/sdk/keyvault/keyvault-secrets/tests.yml
+++ b/sdk/keyvault/keyvault-secrets/tests.yml
@@ -5,7 +5,7 @@ stages:
     parameters:
       PackageName: "@azure/keyvault-secrets"
       ServiceDirectory: keyvault
-      TimeoutInMinutes: 59
+      TimeoutInMinutes: 360
       EnvVars:
         AZURE_CLIENT_ID: $(aad-azure-sdk-test-client-id)
         AZURE_TENANT_ID: $(aad-azure-sdk-test-tenant-id)


### PR DESCRIPTION
We're seeing service degradation when deleting items from keyvault across languages. I want to see how bad things are.