### PR TITLE
[core] - Bump core-http to 2.0.0 and core-lro to 2.0.0

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -21,6 +21,7 @@ dependencies:
   '@rush-temp/core-auth': file:projects/core-auth.tgz
   '@rush-temp/core-client': file:projects/core-client.tgz
   '@rush-temp/core-client-1': file:projects/core-client-1.tgz
+  '@rush-temp/core-client-paging': file:projects/core-client-paging.tgz
   '@rush-temp/core-crypto': file:projects/core-crypto.tgz
   '@rush-temp/core-http': file:projects/core-http.tgz
   '@rush-temp/core-lro': file:projects/core-lro.tgz
@@ -8154,7 +8155,7 @@ packages:
     dev: false
     name: '@rush-temp/agrifood-farming'
     resolution:
-      integrity: sha512-hB9uwUMq9gTndRQvyJ9F3OeBBNGxKCi5mB1IDwkIZEDTo60A/yztkDnvIz32tV3lzDFSGiaTeczTeXm8DstWfg==
+      integrity: sha512-zxH3z0da7M7HliJFRufLVPCbrJZvGYX+bkJITR0xUJf4mRfWvfkboNOxjbKwxGVawQ1quKiqTmyZsPpLw9HIEQ==
       tarball: file:projects/agrifood-farming.tgz
     version: 0.0.0
   file:projects/ai-anomaly-detector.tgz:
@@ -8245,7 +8246,7 @@ packages:
     dev: false
     name: '@rush-temp/ai-document-translator'
     resolution:
-      integrity: sha512-yPNgSDkF09VrTQ57zRNO+rD8wMdjcc9Nh0sxGtQAVcoRub3f3DSaCVB8S5fUy5zwJtXMKkAAhOXe+QmTWrI5Kw==
+      integrity: sha512-3YHPFrjR8WULy8t7MNaoiNCoYBNkDfM9aRwRE1xbf80I5qtPfA7BD4mbo7sxMYesQdGiLSl9V1UARbbN4fy2pA==
       tarball: file:projects/ai-document-translator.tgz
     version: 0.0.0
   file:projects/ai-form-recognizer.tgz:
@@ -8846,7 +8847,7 @@ packages:
     dev: false
     name: '@rush-temp/confidential-ledger'
     resolution:
-      integrity: sha512-zvQhwVNWkg2D3n8uakwhCE6xvo+W9XbcKGq1ToOpbP7OJjQzg+BWFoYmECg6yz2GqMSRbsBpj61zz2jImxb6OQ==
+      integrity: sha512-jPiYbuPxYfVKkWJVYow1irqzxO/9Pyx68cONy0qLfzwOi4OC8TkXQVI0p23E5Wm/kvd46aWD+aaRD7nCKlPvZw==
       tarball: file:projects/confidential-ledger.tgz
     version: 0.0.0
   file:projects/container-registry.tgz:
@@ -9045,6 +9046,44 @@ packages:
     resolution:
       integrity: sha512-DrijA2NS4/XmZj1662Y6vb7WdQYW3/fyOjeAtDpkusGwA3qf0QRQoivCfvxTtRLTJH4XYH20Z5i375iAoOMYWQ==
       tarball: file:projects/core-client-1.tgz
+    version: 0.0.0
+  file:projects/core-client-paging.tgz:
+    dependencies:
+      '@azure/core-rest-pipeline': 1.0.4
+      '@microsoft/api-extractor': 7.13.2
+      '@types/chai': 4.2.19
+      '@types/mocha': 7.0.2
+      '@types/node': 8.10.66
+      chai: 4.3.4
+      cross-env: 7.0.3
+      eslint: 7.29.0
+      inherits: 2.0.4
+      karma: 6.3.4
+      karma-chrome-launcher: 3.1.0
+      karma-coverage: 2.0.3
+      karma-edge-launcher: 0.4.2_karma@6.3.4
+      karma-env-preprocessor: 0.1.1
+      karma-firefox-launcher: 1.3.0
+      karma-ie-launcher: 1.0.0_karma@6.3.4
+      karma-junit-reporter: 2.0.1_karma@6.3.4
+      karma-mocha: 2.0.1
+      karma-mocha-reporter: 2.2.5_karma@6.3.4
+      karma-sourcemap-loader: 0.3.8
+      mocha: 7.2.0
+      mocha-junit-reporter: 1.23.3_mocha@7.2.0
+      prettier: 2.2.1
+      rimraf: 3.0.2
+      rollup: 1.32.1
+      sinon: 9.2.4
+      tslib: 2.3.0
+      typedoc: 0.15.2
+      typescript: 4.2.4
+      util: 0.12.4
+    dev: false
+    name: '@rush-temp/core-client-paging'
+    resolution:
+      integrity: sha512-cILnMe2cNW8wClpKU+i6EyZHXtI9FyIkDCrLvd4I8utQ/Cw6x2l4T88rx/nbdN2qTm/QfY1Oi49xgNPEqoam4A==
+      tarball: file:projects/core-client-paging.tgz
     version: 0.0.0
   file:projects/core-client.tgz:
     dependencies:
@@ -9512,6 +9551,7 @@ packages:
       '@azure/core-rest-pipeline': 1.0.4
       '@azure/core-tracing': 1.0.0-preview.11
       '@azure/core-xml': 1.0.0-beta.1
+      '@azure/identity': 2.0.0-beta.3
       '@microsoft/api-extractor': 7.7.11
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-inject': 4.0.2_rollup@1.32.1
@@ -9561,7 +9601,7 @@ packages:
     dev: false
     name: '@rush-temp/data-tables'
     resolution:
-      integrity: sha512-KZQs9rqSZFYWLHRHyvHVPTkz13BRU3zPyfy/Ev9Ei2cMnZaCbugeNcdJ9OOU2gGf7oIHeHGahd2hdyk9U3iILw==
+      integrity: sha512-JnJ5r5pu8XHpQxCvIJFi0KWwk3XECT5OCXekLOqH2kXVxFzrI0IEwX9ToJwfFvXkmIaZYmFKKRc4NAhQ14TsdA==
       tarball: file:projects/data-tables.tgz
     version: 0.0.0
   file:projects/dev-tool.tgz:
@@ -10801,7 +10841,7 @@ packages:
     dev: false
     name: '@rush-temp/purview-catalog'
     resolution:
-      integrity: sha512-xzCg+2x1QQNJwPPmiSCcFmZW9lvGrlSm4iwJ9l8qJ3Qpp0Cr+jdECA+d6ofmDZrBKHpDtNdnj2poUDbn28AKLg==
+      integrity: sha512-WPSEZTapYdZwHdzDo8F+4Tzx6W49pvnyQQFcRraQOqgeUkrCF6wfDW0JtkR2xU2GWjnuif/ilg4NoanFQcidbQ==
       tarball: file:projects/purview-catalog.tgz
     version: 0.0.0
   file:projects/purview-scanning.tgz:
@@ -10844,7 +10884,7 @@ packages:
     dev: false
     name: '@rush-temp/purview-scanning'
     resolution:
-      integrity: sha512-v8lWS2NhUJXjaUbaInWCqOkJgkAeSyBqQEKyu0gBkOWHyyTiAyYQ5Q6YF43bEcfisxX+xB8hQ1X7hxJcirBwkA==
+      integrity: sha512-xO9TV5e8I9WEWBc9dsOEzbx9j+l2NSgyz7s1vy4b3vsFGtOJMkeAIOKK6dXOcvf+QVOp8FOSk5XwSNAggDIyqA==
       tarball: file:projects/purview-scanning.tgz
     version: 0.0.0
   file:projects/quantum-jobs.tgz:
@@ -11920,6 +11960,7 @@ specifiers:
   '@rush-temp/core-auth': file:./projects/core-auth.tgz
   '@rush-temp/core-client': file:./projects/core-client.tgz
   '@rush-temp/core-client-1': file:./projects/core-client-1.tgz
+  '@rush-temp/core-client-paging': file:./projects/core-client-paging.tgz
   '@rush-temp/core-crypto': file:./projects/core-crypto.tgz
   '@rush-temp/core-http': file:./projects/core-http.tgz
   '@rush-temp/core-lro': file:./projects/core-lro.tgz

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -21,7 +21,6 @@ dependencies:
   '@rush-temp/core-auth': file:projects/core-auth.tgz
   '@rush-temp/core-client': file:projects/core-client.tgz
   '@rush-temp/core-client-1': file:projects/core-client-1.tgz
-  '@rush-temp/core-client-paging': file:projects/core-client-paging.tgz
   '@rush-temp/core-crypto': file:projects/core-crypto.tgz
   '@rush-temp/core-http': file:projects/core-http.tgz
   '@rush-temp/core-lro': file:projects/core-lro.tgz
@@ -1042,6 +1041,18 @@ packages:
       node: '>=8.0.0'
     resolution:
       integrity: sha512-GtpMGd6vkzDMYcpu2t9LlhEgMy/SzBwRnz48EejlRArYqZzqSzAsKmegUK7zHgl+EOIaK9mKHhnRaQu3qw20cA==
+  /@opentelemetry/api/0.18.1:
+    dev: false
+    engines:
+      node: '>=8.0.0'
+    resolution:
+      integrity: sha512-pKNxHe3AJ5T2N5G3AlT9gx6FyF5K2FS9ZNc+FipC+f1CpVF/EY+JHTJ749dnM2kWIgZTbDJFiGMuc0FYjNSCOg==
+  /@opentelemetry/api/0.21.0:
+    dev: false
+    engines:
+      node: '>=8.0.0'
+    resolution:
+      integrity: sha512-Q7hHb3nidPgnBS2fi+y3K64F3EV48d9v09/6EtigIgVF43NFNhw/dboDKC7gECEkbTwuvFeLCbwKs9JaC8LDEw==
   /@opentelemetry/api/1.0.0:
     dev: false
     engines:
@@ -1054,104 +1065,140 @@ packages:
       node: '>=8.0.0'
     resolution:
       integrity: sha512-iXKByCMfrlO5S6Oh97BuM56tM2cIBB0XsL/vWF/AtJrJEKx4MC/Xdu0xDsGXMGcNWpqF7ujMsjjnp0+UHBwnDQ==
-  /@opentelemetry/context-async-hooks/0.22.0_@opentelemetry+api@1.0.0:
+  /@opentelemetry/context-async-hooks/0.21.0_@opentelemetry+api@0.21.0:
     dependencies:
-      '@opentelemetry/api': 1.0.0
+      '@opentelemetry/api': 0.21.0
     dev: false
     engines:
       node: '>=8.1.0'
     peerDependencies:
-      '@opentelemetry/api': ^1.0.0
+      '@opentelemetry/api': ^0.21.0
     resolution:
-      integrity: sha512-JakZ9NJCiaf8FJ6lcR2Fle9xkBKxSFbXK4mk9gZ14totNh9SOTiUBUk08bAnATWUINrQlN8/5hpGKi5gs+FUxQ==
+      integrity: sha512-3XxzT7jiDLbohUy66NWsYuWFtXsMI0qMhetWVlFmmBfMPLMR+U6xWA4xhfRMb6kMEjR5XJHbyDSxYwzxrd10sg==
   /@opentelemetry/context-base/0.10.2:
     dev: false
     engines:
       node: '>=8.0.0'
     resolution:
       integrity: sha512-hZNKjKOYsckoOEgBziGMnBcX0M7EtstnCmwz5jZUOUYwlZ+/xxX6z3jPu1XVO2Jivk0eLfuP9GP+vFD49CMetw==
-  /@opentelemetry/core/0.22.0_@opentelemetry+api@1.0.0:
+  /@opentelemetry/core/0.18.2:
     dependencies:
-      '@opentelemetry/api': 1.0.0
-      '@opentelemetry/semantic-conventions': 0.22.0
+      '@opentelemetry/api': 0.18.1
+      semver: 7.3.5
+    dev: false
+    engines:
+      node: '>=8.5.0'
+    resolution:
+      integrity: sha512-WG8veOEd8xZHuBaOHddzWQg5yj794lrEPAe6W1qI0YkV7pyqYXvhJdCxOU5Lyo1SWzTAjI5xrCUQ9J2WlrqzYA==
+  /@opentelemetry/core/0.21.0_@opentelemetry+api@0.21.0:
+    dependencies:
+      '@opentelemetry/api': 0.21.0
+      '@opentelemetry/semantic-conventions': 0.21.0
       semver: 7.3.5
     dev: false
     engines:
       node: '>=8.5.0'
     peerDependencies:
-      '@opentelemetry/api': ^1.0.0
+      '@opentelemetry/api': ^0.21.0
     resolution:
-      integrity: sha512-x6JxuQ4rY2x39GEXJSqMgyf8XZPNNiZrGcCMhZSrtypq/WXlsJuxMNnUAl2hj2rpSGGukhhWn5cMpCmMJJz1hw==
-  /@opentelemetry/node/0.22.0_@opentelemetry+api@1.0.0:
+      integrity: sha512-sZZQThBuqhCdBPgzPq4y9L4dhnpXXCCEqNsR6IUmMc/kQ8Bcw3lmI5fymLlliSt+lnTc26xJPVKZlwoQfwhThg==
+  /@opentelemetry/node/0.21.0_@opentelemetry+api@0.21.0:
     dependencies:
-      '@opentelemetry/api': 1.0.0
-      '@opentelemetry/context-async-hooks': 0.22.0_@opentelemetry+api@1.0.0
-      '@opentelemetry/core': 0.22.0_@opentelemetry+api@1.0.0
-      '@opentelemetry/propagator-b3': 0.22.0_@opentelemetry+api@1.0.0
-      '@opentelemetry/propagator-jaeger': 0.22.0_@opentelemetry+api@1.0.0
-      '@opentelemetry/tracing': 0.22.0_@opentelemetry+api@1.0.0
+      '@opentelemetry/api': 0.21.0
+      '@opentelemetry/context-async-hooks': 0.21.0_@opentelemetry+api@0.21.0
+      '@opentelemetry/core': 0.21.0_@opentelemetry+api@0.21.0
+      '@opentelemetry/propagator-b3': 0.21.0_@opentelemetry+api@0.21.0
+      '@opentelemetry/propagator-jaeger': 0.21.0_@opentelemetry+api@0.21.0
+      '@opentelemetry/tracing': 0.21.0_@opentelemetry+api@0.21.0
       semver: 7.3.5
     dev: false
     engines:
       node: '>=8.0.0'
     peerDependencies:
-      '@opentelemetry/api': ^1.0.0
+      '@opentelemetry/api': ^0.21.0
     resolution:
-      integrity: sha512-+HhGbDruQ7cwejVOIYyxRa28uosnG8W95NiQZ6qE8PXXPsDSyGeftAPbtYpGit0H2f5hrVcMlwmWHeAo9xkSLA==
-  /@opentelemetry/propagator-b3/0.22.0_@opentelemetry+api@1.0.0:
+      integrity: sha512-PCA3pFmzTMN3iIlZ6Bz2BgPe8jEIdKRK7WyjfT9qqrLrHZ/dXNmX4MIz2IKTyQtS6tGt2jayD0IpWsVFctPOIA==
+  /@opentelemetry/propagator-b3/0.21.0_@opentelemetry+api@0.21.0:
     dependencies:
-      '@opentelemetry/api': 1.0.0
-      '@opentelemetry/core': 0.22.0_@opentelemetry+api@1.0.0
+      '@opentelemetry/api': 0.21.0
+      '@opentelemetry/core': 0.21.0_@opentelemetry+api@0.21.0
     dev: false
     engines:
       node: '>=8.0.0'
     peerDependencies:
-      '@opentelemetry/api': ^1.0.0
+      '@opentelemetry/api': ^0.21.0
     resolution:
-      integrity: sha512-7UESJWUUmInXrlux9whSjoIMfpmajKbu2UBU/ux7TVkLTeaJwebLHoqDhuUTS4dbmvg3fnkpfmocyUgby16NwQ==
-  /@opentelemetry/propagator-jaeger/0.22.0_@opentelemetry+api@1.0.0:
+      integrity: sha512-KXQKXa76ilzBNdwr7hze9251g0AqBmwhCPnt17UCgb+97DFcOyEy5Rc7nnjZNxNGYYqUbk8116MK9hMZO2icGw==
+  /@opentelemetry/propagator-jaeger/0.21.0_@opentelemetry+api@0.21.0:
     dependencies:
-      '@opentelemetry/api': 1.0.0
-      '@opentelemetry/core': 0.22.0_@opentelemetry+api@1.0.0
+      '@opentelemetry/api': 0.21.0
+      '@opentelemetry/core': 0.21.0_@opentelemetry+api@0.21.0
     dev: false
     engines:
       node: '>=8.5.0'
     peerDependencies:
-      '@opentelemetry/api': ^1.0.0
+      '@opentelemetry/api': ^0.21.0
     resolution:
-      integrity: sha512-Xclq+eLfc0Zk1UAbY6clYjoCZqikk4SzvG8C/ODJ6LfDHnqMr/fKXaHHhh/DdHdi6d73o9S8ytblryc+CaTkrw==
-  /@opentelemetry/resources/0.22.0_@opentelemetry+api@1.0.0:
+      integrity: sha512-H0TaYBvDi4stz19UJNPFR1IRikQYjoKYuV6tZV4V5NnPAFTjBhvj/Heb0fNDUWK5G1tVB5NPrEsNSZjjdfvjLw==
+  /@opentelemetry/resources/0.18.2:
     dependencies:
-      '@opentelemetry/api': 1.0.0
-      '@opentelemetry/core': 0.22.0_@opentelemetry+api@1.0.0
-      '@opentelemetry/semantic-conventions': 0.22.0
+      '@opentelemetry/api': 0.18.1
+      '@opentelemetry/core': 0.18.2
+    dev: false
+    engines:
+      node: '>=8.0.0'
+    resolution:
+      integrity: sha512-EBPqFsreXgFaqkMmWCE8vh6pFhbWExRHSO24qSeGhxFmM5SQP/D1jJqMp/jVUSmrF97fPkMS0aEH5z7NOWdxQA==
+  /@opentelemetry/resources/0.21.0_@opentelemetry+api@0.21.0:
+    dependencies:
+      '@opentelemetry/api': 0.21.0
+      '@opentelemetry/core': 0.21.0_@opentelemetry+api@0.21.0
+      '@opentelemetry/semantic-conventions': 0.21.0
     dev: false
     engines:
       node: '>=8.0.0'
     peerDependencies:
-      '@opentelemetry/api': ^1.0.0
+      '@opentelemetry/api': ^0.21.0
     resolution:
-      integrity: sha512-LiX6/JyuD2eHi7Ewrq/PUP79azDqshd0r2oksNTJ+VwgbGfMlq79ykd4FhiEEk23fFbajGt+9ginadXoRk17dg==
-  /@opentelemetry/semantic-conventions/0.22.0:
+      integrity: sha512-xQUL2/2npP/isH8sbOSdynIRWmlM6p02L9Ex8x/BhUuSkGrMoxO2ezLPPYnfYam1py6ubaz8m1C54O2IRCmgQQ==
+  /@opentelemetry/semantic-conventions/0.18.2:
     dev: false
     engines:
       node: '>=8.0.0'
     resolution:
-      integrity: sha512-t4fKikazahwNKmwD+CE/icHyuZldWvNMupJhjxdk9T/KxHFx3zCGjHT3MKavwYP6abzgAAm5WwzD1oHlmj7dyg==
-  /@opentelemetry/tracing/0.22.0_@opentelemetry+api@1.0.0:
+      integrity: sha512-+0P+PrP9qSFVaayNdek4P1OAGE+PEl2SsufuHDRmUpOY25Wzjo7Atyar56Trjc32jkNy4lID6ZFT6BahsR9P9A==
+  /@opentelemetry/semantic-conventions/0.21.0:
+    dev: false
+    engines:
+      node: '>=8.0.0'
+    resolution:
+      integrity: sha512-qQtZJ8Q+bO/gemBELsZbz5s//tNnyc+mQD/0RHc77XhI6ZBb+tprU6KN/7l0fl5z29smmai0hcJ9UNILC/7nIw==
+  /@opentelemetry/tracing/0.18.2:
     dependencies:
-      '@opentelemetry/api': 1.0.0
-      '@opentelemetry/core': 0.22.0_@opentelemetry+api@1.0.0
-      '@opentelemetry/resources': 0.22.0_@opentelemetry+api@1.0.0
-      '@opentelemetry/semantic-conventions': 0.22.0
+      '@opentelemetry/api': 0.18.1
+      '@opentelemetry/core': 0.18.2
+      '@opentelemetry/resources': 0.18.2
+      '@opentelemetry/semantic-conventions': 0.18.2
+      lodash.merge: 4.6.2
+    dev: false
+    engines:
+      node: '>=8.0.0'
+    resolution:
+      integrity: sha512-IQSu+NwMhX8O9Wkjc4HjNqs/aKfkcInCE3dQuAOBBec/saLrM6jqd+Fa5QUzg03WMOqpDuZm5KTkr5+6DUrr0g==
+  /@opentelemetry/tracing/0.21.0_@opentelemetry+api@0.21.0:
+    dependencies:
+      '@opentelemetry/api': 0.21.0
+      '@opentelemetry/core': 0.21.0_@opentelemetry+api@0.21.0
+      '@opentelemetry/resources': 0.21.0_@opentelemetry+api@0.21.0
+      '@opentelemetry/semantic-conventions': 0.21.0
       lodash.merge: 4.6.2
     dev: false
     engines:
       node: '>=8.0.0'
     peerDependencies:
-      '@opentelemetry/api': ^1.0.0
+      '@opentelemetry/api': ^0.21.0
     resolution:
-      integrity: sha512-EFrKTFndiEdh/KnzwDgo/EcphG/5z/NyLck8oiUUY+YMP7hskXNYHjTWSAv9UxtYe1MzgLbjmAateTuMmFIVNw==
+      integrity: sha512-6+2pfFpu7Yo2DwmBK9sHDUSIL7UshcEMwDF6+LghGK68ILRaEMqqBPgKarjhFH9ERgJB9GOkJ2snK96qIzMZNA==
   /@rollup/plugin-commonjs/11.0.2_rollup@1.32.1:
     dependencies:
       '@rollup/pluginutils': 3.1.0_rollup@1.32.1
@@ -8107,7 +8154,7 @@ packages:
     dev: false
     name: '@rush-temp/agrifood-farming'
     resolution:
-      integrity: sha512-zxH3z0da7M7HliJFRufLVPCbrJZvGYX+bkJITR0xUJf4mRfWvfkboNOxjbKwxGVawQ1quKiqTmyZsPpLw9HIEQ==
+      integrity: sha512-hB9uwUMq9gTndRQvyJ9F3OeBBNGxKCi5mB1IDwkIZEDTo60A/yztkDnvIz32tV3lzDFSGiaTeczTeXm8DstWfg==
       tarball: file:projects/agrifood-farming.tgz
     version: 0.0.0
   file:projects/ai-anomaly-detector.tgz:
@@ -8156,7 +8203,7 @@ packages:
     dev: false
     name: '@rush-temp/ai-anomaly-detector'
     resolution:
-      integrity: sha512-UAqCxcDDBSZGFVOEnudBw/8NhxgecArsuqft804NK03x42otRc88mxgBvkl+CNnhfdowlmOcZMsIOduXGOqt4w==
+      integrity: sha512-HOZBZxEhHXas5ja/2SIPBxPI0wj2T9wbE72i0ejPvI/A1qUJlirCnroCn0+OtyvYDPai5/CMhEHPPVf1CFg2vQ==
       tarball: file:projects/ai-anomaly-detector.tgz
     version: 0.0.0
   file:projects/ai-document-translator.tgz:
@@ -8198,7 +8245,7 @@ packages:
     dev: false
     name: '@rush-temp/ai-document-translator'
     resolution:
-      integrity: sha512-3YHPFrjR8WULy8t7MNaoiNCoYBNkDfM9aRwRE1xbf80I5qtPfA7BD4mbo7sxMYesQdGiLSl9V1UARbbN4fy2pA==
+      integrity: sha512-yPNgSDkF09VrTQ57zRNO+rD8wMdjcc9Nh0sxGtQAVcoRub3f3DSaCVB8S5fUy5zwJtXMKkAAhOXe+QmTWrI5Kw==
       tarball: file:projects/ai-document-translator.tgz
     version: 0.0.0
   file:projects/ai-form-recognizer.tgz:
@@ -8240,7 +8287,7 @@ packages:
     dev: false
     name: '@rush-temp/ai-form-recognizer'
     resolution:
-      integrity: sha512-cZozO8m3e5wJ5clV7rFbEMfhe7gj+3cmqPcOrgoBiCQ4c4yQFD/lP7srZMlqM6zaIThKh6Yt5YkzUX1nrdahcw==
+      integrity: sha512-eeELrx6Y+ZcgaQGADM3tA4FxB4EpCf9WrWF/a4wwu87JOcwrqxYIzXhg3EvidKzvjSt3bpcekpARBCpKhHt+XA==
       tarball: file:projects/ai-form-recognizer.tgz
     version: 0.0.0
   file:projects/ai-metrics-advisor.tgz:
@@ -8284,7 +8331,7 @@ packages:
     dev: false
     name: '@rush-temp/ai-metrics-advisor'
     resolution:
-      integrity: sha512-JMwh8/HxWV1MhZ3lnPMve/8d95HROYOC+Z89D1zRzcr2LnSYQfDgFbIphKN7tqk7l+C+jFwELsFDwG7SWzmx0Q==
+      integrity: sha512-tw7TT8iwedlf8tZJxN3B/niOclO4Y+3lEym1gpkNr03VHvMdCwEe92U07MDwwr4mgC8An3nn5HCaTQYVL87Y2g==
       tarball: file:projects/ai-metrics-advisor.tgz
     version: 0.0.0
   file:projects/ai-text-analytics.tgz:
@@ -8385,7 +8432,7 @@ packages:
     dev: false
     name: '@rush-temp/app-configuration'
     resolution:
-      integrity: sha512-hYJ2Lj/Ytr0bj0SwC6UlHWkmFFm7c0z9H5Caic14Cd9liyHs/6ae8yP+N+Rqd9PNV/JstbjHlcbtgpyH/hvZFA==
+      integrity: sha512-hnxdxVITPVLYJIeSx6vf7SXvuzyKSo06rX/A37blEI12OFSYPmenR23ZTMvc7tuVrjS6VBAlNy710wd/DMx5vQ==
       tarball: file:projects/app-configuration.tgz
     version: 0.0.0
   file:projects/attestation.tgz:
@@ -8496,7 +8543,7 @@ packages:
     dev: false
     name: '@rush-temp/communication-chat'
     resolution:
-      integrity: sha512-TbNfdBPlkCqa1Ex1ZDR7akp5ILR/faYeTq54BII+aFgN12J2GoGgayYzQkXQc/8jlBU2wBaZld5uROkdlNAGUw==
+      integrity: sha512-x9R12DgmsAeN8ncSUNj7I0mdKT992y/8v1WLisNcJn7OW14IfCITuJx4JLmCEfOo7vbNe2pulwYlTqQ5MUNt9w==
       tarball: file:projects/communication-chat.tgz
     version: 0.0.0
   file:projects/communication-common.tgz:
@@ -8549,7 +8596,7 @@ packages:
     dev: false
     name: '@rush-temp/communication-common'
     resolution:
-      integrity: sha512-3r1o3XqYCECrYUxeVFLvgWACp8Hg2LBQw0eDflZDHWUsXmNyXdNJpnBHQuY8A/b5i7myuv7u0DUiBwGPg8gmTQ==
+      integrity: sha512-NsvGPAqTmqJyCBQ/EeksY2zWcD7tusREqXMAWsxmHzmO0zG4uUb8ordkkb09keCbRUFVCQBkN3sScKy4MZJjqw==
       tarball: file:projects/communication-common.tgz
     version: 0.0.0
   file:projects/communication-identity.tgz:
@@ -8601,7 +8648,7 @@ packages:
     dev: false
     name: '@rush-temp/communication-identity'
     resolution:
-      integrity: sha512-JAq+J4bnU999yJ1xDMY33cUBRvPMMO8SaOflGAECSC+3CQAwiW/JxryHFlpwaA8lWqhmbgJMT1J/pSiTAqigFg==
+      integrity: sha512-2rR7RK7ItGB4jqi2WGfxN8NzHGrs4BaZ/7uuFWdo4t2fYp/OFFGh+lYzTNk9JxzUgoU7PsceSZ8OXRprkl4DAA==
       tarball: file:projects/communication-identity.tgz
     version: 0.0.0
   file:projects/communication-network-traversal.tgz:
@@ -8654,7 +8701,7 @@ packages:
     dev: false
     name: '@rush-temp/communication-network-traversal'
     resolution:
-      integrity: sha512-F1T6zU4yFjAaG3tkEUgBLRSMrMsmDvsuEWzSlJVYIrHfTZygDNR/eDQWAmjgF3TQwcn5btAEJFBNjripDSnkiQ==
+      integrity: sha512-4flsoWfGKC+zhYkduTncSI22tlrJ18C9lDtSscghuOZM/i2U8J04RVPUH2HJJYwh6vB4qJgpclic1AUpytOQ3w==
       tarball: file:projects/communication-network-traversal.tgz
     version: 0.0.0
   file:projects/communication-phone-numbers.tgz:
@@ -8706,7 +8753,7 @@ packages:
     dev: false
     name: '@rush-temp/communication-phone-numbers'
     resolution:
-      integrity: sha512-e4wloANn5FgQplBYioWale2py47636k+n9AhvBxEv2zYAAGT8h6Y6fDAUUu+2ghFZGZQ5r9wAplzJG+T69E3Qw==
+      integrity: sha512-2weNFkSRK+BeWKuEq2iMv1bZYJJAMWvX8H4WRkSANexWFcMY6JmUvG3L/rcxBvGr3fvn/Y4l3jsrCjnqM5baqw==
       tarball: file:projects/communication-phone-numbers.tgz
     version: 0.0.0
   file:projects/communication-sms.tgz:
@@ -8757,7 +8804,7 @@ packages:
     dev: false
     name: '@rush-temp/communication-sms'
     resolution:
-      integrity: sha512-zUaVWSyuQ9ddNUiWJ8XLHHJfIaRPnuXMxPN67Gve0Orx95YTyectyZmJSFK8qMUKuvcNsKP7cMg4hhhkejM8IA==
+      integrity: sha512-sLFrpFT/bZo8ppBxJnw0KkGHXVFw39cOKN3yj+TLispv0m9w/RfEdqi68SgrRM4BBPwAEmjSF7r8k9GbZAolHA==
       tarball: file:projects/communication-sms.tgz
     version: 0.0.0
   file:projects/confidential-ledger.tgz:
@@ -8799,7 +8846,7 @@ packages:
     dev: false
     name: '@rush-temp/confidential-ledger'
     resolution:
-      integrity: sha512-jPiYbuPxYfVKkWJVYow1irqzxO/9Pyx68cONy0qLfzwOi4OC8TkXQVI0p23E5Wm/kvd46aWD+aaRD7nCKlPvZw==
+      integrity: sha512-zvQhwVNWkg2D3n8uakwhCE6xvo+W9XbcKGq1ToOpbP7OJjQzg+BWFoYmECg6yz2GqMSRbsBpj61zz2jImxb6OQ==
       tarball: file:projects/confidential-ledger.tgz
     version: 0.0.0
   file:projects/container-registry.tgz:
@@ -8999,43 +9046,6 @@ packages:
       integrity: sha512-DrijA2NS4/XmZj1662Y6vb7WdQYW3/fyOjeAtDpkusGwA3qf0QRQoivCfvxTtRLTJH4XYH20Z5i375iAoOMYWQ==
       tarball: file:projects/core-client-1.tgz
     version: 0.0.0
-  file:projects/core-client-paging.tgz:
-    dependencies:
-      '@microsoft/api-extractor': 7.13.2
-      '@types/chai': 4.2.19
-      '@types/mocha': 7.0.2
-      '@types/node': 8.10.66
-      chai: 4.3.4
-      cross-env: 7.0.3
-      eslint: 7.29.0
-      inherits: 2.0.4
-      karma: 6.3.4
-      karma-chrome-launcher: 3.1.0
-      karma-coverage: 2.0.3
-      karma-edge-launcher: 0.4.2_karma@6.3.4
-      karma-env-preprocessor: 0.1.1
-      karma-firefox-launcher: 1.3.0
-      karma-ie-launcher: 1.0.0_karma@6.3.4
-      karma-junit-reporter: 2.0.1_karma@6.3.4
-      karma-mocha: 2.0.1
-      karma-mocha-reporter: 2.2.5_karma@6.3.4
-      karma-sourcemap-loader: 0.3.8
-      mocha: 7.2.0
-      mocha-junit-reporter: 1.23.3_mocha@7.2.0
-      prettier: 2.2.1
-      rimraf: 3.0.2
-      rollup: 1.32.1
-      sinon: 9.2.4
-      tslib: 2.3.0
-      typedoc: 0.15.2
-      typescript: 4.2.4
-      util: 0.12.4
-    dev: false
-    name: '@rush-temp/core-client-paging'
-    resolution:
-      integrity: sha512-cILnMe2cNW8wClpKU+i6EyZHXtI9FyIkDCrLvd4I8utQ/Cw6x2l4T88rx/nbdN2qTm/QfY1Oi49xgNPEqoam4A==
-      tarball: file:projects/core-client-paging.tgz
-    version: 0.0.0
   file:projects/core-client.tgz:
     dependencies:
       '@azure/core-rest-pipeline': 1.0.4
@@ -9232,7 +9242,7 @@ packages:
     dev: false
     name: '@rush-temp/core-lro'
     resolution:
-      integrity: sha512-qGsbhY42+yb7/ZND4jJU68QDnFa1/q2Aw++lfViXx/wohdotqvkmY08PS6+ma9e62WFwrFjItZvQU/sw4yYvFQ==
+      integrity: sha512-BBFyzmuJV6yP3Bd7Q1woBHOV5zTLGzpv3I89Ax8nkQWgkunvGYiWt27DFoVPaYN+58yyfSPCQ+NW9CHqIrGiNg==
       tarball: file:projects/core-lro.tgz
     version: 0.0.0
   file:projects/core-paging.tgz:
@@ -9502,7 +9512,6 @@ packages:
       '@azure/core-rest-pipeline': 1.0.4
       '@azure/core-tracing': 1.0.0-preview.11
       '@azure/core-xml': 1.0.0-beta.1
-      '@azure/identity': 2.0.0-beta.3
       '@microsoft/api-extractor': 7.7.11
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-inject': 4.0.2_rollup@1.32.1
@@ -9552,7 +9561,7 @@ packages:
     dev: false
     name: '@rush-temp/data-tables'
     resolution:
-      integrity: sha512-JnJ5r5pu8XHpQxCvIJFi0KWwk3XECT5OCXekLOqH2kXVxFzrI0IEwX9ToJwfFvXkmIaZYmFKKRc4NAhQ14TsdA==
+      integrity: sha512-KZQs9rqSZFYWLHRHyvHVPTkz13BRU3zPyfy/Ev9Ei2cMnZaCbugeNcdJ9OOU2gGf7oIHeHGahd2hdyk9U3iILw==
       tarball: file:projects/data-tables.tgz
     version: 0.0.0
   file:projects/dev-tool.tgz:
@@ -9644,7 +9653,7 @@ packages:
     dev: false
     name: '@rush-temp/digital-twins-core'
     resolution:
-      integrity: sha512-ZDdMr3qllyTdU+WuhJSoEb3eVwuGddKn79fKcdajDoJMqde0PIFjAjMg61bR+iR4Ij2AfznBrvjl0DshNTgB9Q==
+      integrity: sha512-/rP1evOkdU5PuvNi5ZPNSeZcrnMXoPVk4iKPM4xjLRnbv20NKsZAB6BfyNyOQaozDNFDtG/YfwYItrPz7m+C7g==
       tarball: file:projects/digital-twins-core.tgz
     version: 0.0.0
   file:projects/eslint-plugin-azure-sdk.tgz:
@@ -10033,7 +10042,7 @@ packages:
     dev: false
     name: '@rush-temp/identity'
     resolution:
-      integrity: sha512-WhzQXtuVDAdYFtQtAqj9om+FireeOVVkgmVP/bZwh4vYueDup+Nlp6slAq9lMJz/auX80Y9LXy1VzErjNxWtsA==
+      integrity: sha512-hx8wOkNk9gdLdTKfNQ3H5vR+k1Bnis30iELhVW13dlQvS7Opo26T+vK5+P55hZqZSCAZX5WqU1IRPL/WH0nRKQ==
       tarball: file:projects/identity.tgz
     version: 0.0.0
   file:projects/iot-device-update.tgz:
@@ -10059,7 +10068,7 @@ packages:
     dev: false
     name: '@rush-temp/iot-device-update'
     resolution:
-      integrity: sha512-6tJv5E6OLIpAoRhOoofXqsG5/QqEXSyXHRY0pPfegzAsUPd6Q9/nOCdnJdEcJefSzE8gtUotJVUr0wT3kFtW1w==
+      integrity: sha512-BpN759UQhFDm8UYFjZC+9fwEp6fZVZpuc19yYGdugKdWF+D4i245U5la7afkTbYhS7gKLoH+ii+PhCm+3Kuv2A==
       tarball: file:projects/iot-device-update.tgz
     version: 0.0.0
   file:projects/iot-modelsrepository.tgz:
@@ -10156,7 +10165,7 @@ packages:
     dev: false
     name: '@rush-temp/keyvault-admin'
     resolution:
-      integrity: sha512-LlmRCxSakkuseakBlCLSHrPvJPhBanDgaYXv9uAz2/L44BajmfkYbZ5CASZ69fsC8w+YsF9n0dbcmO2S4w56hA==
+      integrity: sha512-NsA/IYbyDtD9dz3tCGR3sLUQe/Y2hSjBD6jp2EUq+yOTGE0gO8XwiNSQRx1SgSFArmqC2/Osr4dRxh/GdOU0BQ==
       tarball: file:projects/keyvault-admin.tgz
     version: 0.0.0
   file:projects/keyvault-certificates.tgz:
@@ -10213,7 +10222,7 @@ packages:
     dev: false
     name: '@rush-temp/keyvault-certificates'
     resolution:
-      integrity: sha512-q9D1kEeUD+ZVft65Cy2mrzcf/V1RHCvwKNhMqN+Y4jFAEVMHADxIoFbXHkjpBQStioMCR0ydk2OS7x1t1GBahQ==
+      integrity: sha512-9eKwZI730BCthRhn/EPW4xMVQdD1vmtFTWqevy7OFdKGloM3szt7y27Zqpz0DETcvB3AiPpY/CfxyaEuu5OUew==
       tarball: file:projects/keyvault-certificates.tgz
     version: 0.0.0
   file:projects/keyvault-common.tgz:
@@ -10226,7 +10235,7 @@ packages:
     dev: false
     name: '@rush-temp/keyvault-common'
     resolution:
-      integrity: sha512-GRiP+Js7NDvQqLYkl8FpmDyaJbN+DdiHA97LxaNliDBYMb+9O9h5716lJYbtFAq0K4f5BcN1VWHlW0xIVfrYPg==
+      integrity: sha512-bPRo3thH2+A9xkidN62waMvwoiZ/lL5ZEo1g1HDcaFudx4D6UY1otc/GHflEXvEMG5SFdOvJWiADMFsKCD3EXA==
       tarball: file:projects/keyvault-common.tgz
     version: 0.0.0
   file:projects/keyvault-keys.tgz:
@@ -10284,7 +10293,7 @@ packages:
     dev: false
     name: '@rush-temp/keyvault-keys'
     resolution:
-      integrity: sha512-pUChOaNDr/umom/rVHeSgyfxRGweU8oP32WL1r882KNYnXg5q5HQIJ4RXz+HF9xX1aMqyBgvdAJubaKIEZrYWA==
+      integrity: sha512-M0vL2R0DPodMwmcuhoQ7/her+e/nfwOpTKlM0PZB3qmaAPn/ZhczZC9KFuepBQS+XkjnYa9Q0b4kwJTjKwY/Mg==
       tarball: file:projects/keyvault-keys.tgz
     version: 0.0.0
   file:projects/keyvault-secrets.tgz:
@@ -10340,7 +10349,7 @@ packages:
     dev: false
     name: '@rush-temp/keyvault-secrets'
     resolution:
-      integrity: sha512-D1laiUgAUGtDk6TKiiEAXE4uwusgDMoRRQ3pDZ2U9olRZR0HAfc/NaCKFyOaKGc4k3iMc1E9uO/q4TEBdb41TA==
+      integrity: sha512-XMNlMtog99caBzBx95ktcaSQ8OVjJrK89r+UA1t/llNNbZ+cma0tyDMHQOIEEet51/SRexwwT/HXXSYWKqvJng==
       tarball: file:projects/keyvault-secrets.tgz
     version: 0.0.0
   file:projects/logger.tgz:
@@ -10430,7 +10439,7 @@ packages:
     dev: false
     name: '@rush-temp/mixedreality-authentication'
     resolution:
-      integrity: sha512-Wotv/XF90O+vucRT0Tq6IEdgaSlERZ2GU0DO6hx5h/tg6DTyjeJvZ1wCt0YdjT2lUb9IuWFOOevpO4vwQzQkUw==
+      integrity: sha512-J3o/wRGxiLoaX9H26cUyJ24rF9cmZ3fmsKpQZWIX8fZdKOYd8/FYyY562CkjEmC0tdzQw65h/eWoorg8hFRb3w==
       tarball: file:projects/mixedreality-authentication.tgz
     version: 0.0.0
   file:projects/mock-hub.tgz:
@@ -10452,11 +10461,11 @@ packages:
   file:projects/monitor-opentelemetry-exporter.tgz:
     dependencies:
       '@microsoft/api-extractor': 7.7.11
-      '@opentelemetry/api': 1.0.0
-      '@opentelemetry/core': 0.22.0_@opentelemetry+api@1.0.0
-      '@opentelemetry/resources': 0.22.0_@opentelemetry+api@1.0.0
-      '@opentelemetry/semantic-conventions': 0.22.0
-      '@opentelemetry/tracing': 0.22.0_@opentelemetry+api@1.0.0
+      '@opentelemetry/api': 0.18.1
+      '@opentelemetry/core': 0.18.2
+      '@opentelemetry/resources': 0.18.2
+      '@opentelemetry/semantic-conventions': 0.18.2
+      '@opentelemetry/tracing': 0.18.2
       '@types/mocha': 7.0.2
       '@types/node': 10.17.60
       eslint: 7.29.0
@@ -10476,16 +10485,16 @@ packages:
     dev: false
     name: '@rush-temp/monitor-opentelemetry-exporter'
     resolution:
-      integrity: sha512-aZpEWfv4GO5hp+TrhXmiB4PQCA1cTDjeTWq2Qyk+ckCPt42cNTscgaulw2mjyPfZmPk6YzIJ/5vbZAvxfpoO7Q==
+      integrity: sha512-fWU4hcmUB+0oYiIbvs0MGB6B6tlgsFZdgX8jKajH+Chm5yHncg2hXSmSBgxGuSLEuso/kgOq2feJrcChZDbz3A==
       tarball: file:projects/monitor-opentelemetry-exporter.tgz
     version: 0.0.0
   file:projects/monitor-query.tgz:
     dependencies:
       '@azure/identity': 1.3.0
       '@microsoft/api-extractor': 7.7.11
-      '@opentelemetry/api': 1.0.0
-      '@opentelemetry/node': 0.22.0_@opentelemetry+api@1.0.0
-      '@opentelemetry/tracing': 0.22.0_@opentelemetry+api@1.0.0
+      '@opentelemetry/api': 0.21.0
+      '@opentelemetry/node': 0.21.0_@opentelemetry+api@0.21.0
+      '@opentelemetry/tracing': 0.18.2
       '@types/chai': 4.2.19
       '@types/chai-as-promised': 7.1.4
       '@types/mocha': 7.0.2
@@ -10524,7 +10533,7 @@ packages:
     dev: false
     name: '@rush-temp/monitor-query'
     resolution:
-      integrity: sha512-sKEbHURwQ0W5MZKWdtDb9GCLNhzi9FZlfjkZLdSYsdVEwHEv/lwp8cqtVr7IkJ5KD21UnyexhmvRzTtHMvwXPA==
+      integrity: sha512-twrlnCuihbPPgdhDddN+eN40Hco0IamvL9Hiotno/SpDD/WqERw/uKRnSMojnYFMwtz57QQPW+kZubl3bFHTdA==
       tarball: file:projects/monitor-query.tgz
     version: 0.0.0
   file:projects/perf-ai-form-recognizer.tgz:
@@ -10713,7 +10722,7 @@ packages:
     dev: false
     name: '@rush-temp/perf-storage-blob'
     resolution:
-      integrity: sha512-h1YaI4Uhhooobl0kV7ArC9qdp4YS6nOuRsfRX0xt621Ag6o8Sk5IeYHTo+mezVebEZFvPNiuTHIzBBdPhISOKg==
+      integrity: sha512-qgt/1g9b5WF7t/MgCo8AIzGZWtEUogkGYw1ynmOaJIyzJg7F9xT7LggSbz6djkydtTveJ6/qe1rg1/H1hEnGMQ==
       tarball: file:projects/perf-storage-blob.tgz
     version: 0.0.0
   file:projects/perf-storage-file-datalake.tgz:
@@ -10792,7 +10801,7 @@ packages:
     dev: false
     name: '@rush-temp/purview-catalog'
     resolution:
-      integrity: sha512-WPSEZTapYdZwHdzDo8F+4Tzx6W49pvnyQQFcRraQOqgeUkrCF6wfDW0JtkR2xU2GWjnuif/ilg4NoanFQcidbQ==
+      integrity: sha512-xzCg+2x1QQNJwPPmiSCcFmZW9lvGrlSm4iwJ9l8qJ3Qpp0Cr+jdECA+d6ofmDZrBKHpDtNdnj2poUDbn28AKLg==
       tarball: file:projects/purview-catalog.tgz
     version: 0.0.0
   file:projects/purview-scanning.tgz:
@@ -10835,7 +10844,7 @@ packages:
     dev: false
     name: '@rush-temp/purview-scanning'
     resolution:
-      integrity: sha512-xO9TV5e8I9WEWBc9dsOEzbx9j+l2NSgyz7s1vy4b3vsFGtOJMkeAIOKK6dXOcvf+QVOp8FOSk5XwSNAggDIyqA==
+      integrity: sha512-v8lWS2NhUJXjaUbaInWCqOkJgkAeSyBqQEKyu0gBkOWHyyTiAyYQ5Q6YF43bEcfisxX+xB8hQ1X7hxJcirBwkA==
       tarball: file:projects/purview-scanning.tgz
     version: 0.0.0
   file:projects/quantum-jobs.tgz:
@@ -10888,7 +10897,7 @@ packages:
     dev: false
     name: '@rush-temp/quantum-jobs'
     resolution:
-      integrity: sha512-upn0yiRQfNXukzJK3UktrUiKGxVYOq83fsqT1AUnXtVKE/Skg7vF7GgPqXmZ7WZfYFfkZBTWvqTnPUD+ZXSsuQ==
+      integrity: sha512-EkskcLw/yARmVBVNoHwawqSzEyiiu1G6rbH+6SSQiTSJg2DF3AqdrwAibkaRjFeHRRGGApYvb+vADefmWXZaNg==
       tarball: file:projects/quantum-jobs.tgz
     version: 0.0.0
   file:projects/schema-registry-avro.tgz:
@@ -10942,7 +10951,7 @@ packages:
     dev: false
     name: '@rush-temp/schema-registry-avro'
     resolution:
-      integrity: sha512-YThr/Ltxi5X65AtKzecvNSoDN7p+74dXCgDLZN6h6+bhUN2GIyZvyNPwCUrG0MSeRvF1DC7HYvYwo00/2hFnMw==
+      integrity: sha512-FFj5S9ii1kaeUrp/Rjax+J5jGBh7arsAlAJQxigXMOUm9KCAsSLNtMManqAbpvsML7TSL+6cBmqmjF0L+28Xfg==
       tarball: file:projects/schema-registry-avro.tgz
     version: 0.0.0
   file:projects/schema-registry.tgz:
@@ -10992,7 +11001,7 @@ packages:
     dev: false
     name: '@rush-temp/schema-registry'
     resolution:
-      integrity: sha512-YT9wQqawJcplFXXt8QMZBzCTnMrtlMAzLZGpWw73hfhr94oPAjEFol54qJd3O7HL4ZAoeIUM8Lip1gGTgcqiYw==
+      integrity: sha512-SJQMGaVqwgt7MBCEDaGza5srjmLnmbrakVpMEO+b9n7+PP1qc90d50PEQJolapHFM3RDNfSbon+kOK19q9FK9g==
       tarball: file:projects/schema-registry.tgz
     version: 0.0.0
   file:projects/search-documents.tgz:
@@ -11045,7 +11054,7 @@ packages:
     dev: false
     name: '@rush-temp/search-documents'
     resolution:
-      integrity: sha512-RaYfwmjKEeuaRMKTLJvd1bhl3zRNKNXm8jMgbQCtAvbztsqMUa1nER1//BRRttdhZyocX6bTQwxoaWyurC9ySw==
+      integrity: sha512-gYgY1PygI2bfmIB4TDx/BzHCuoOXWZbZchbmuf4dMTHawr2jPuVZrTcGdods1jlBY7doAq4muoudrSWyyDlUGA==
       tarball: file:projects/search-documents.tgz
     version: 0.0.0
   file:projects/service-bus.tgz:
@@ -11119,7 +11128,7 @@ packages:
     dev: false
     name: '@rush-temp/service-bus'
     resolution:
-      integrity: sha512-nmjsnu4i71YU0BKjM5mWBOotfzNPx9n9qhFWxeRhQ1vRepucjY1e5e2opdyRuVM3jJabE/nJL1f0SU1lOeTwwA==
+      integrity: sha512-WmD50C2zdjAvRU3aqyHKU8Mu6Yr76u9VczCNZVx9FeQPtDX6zIySgroMNlrjFX2EC/5HF2aUdOsTtpYFFSN83g==
       tarball: file:projects/service-bus.tgz
     version: 0.0.0
   file:projects/storage-blob-changefeed.tgz:
@@ -11175,7 +11184,7 @@ packages:
     dev: false
     name: '@rush-temp/storage-blob-changefeed'
     resolution:
-      integrity: sha512-ArM0rdnKrpM+JYqEanwwlK2vDlT9qYw/vTS8kRKsneHFcWIqf8VefCbhMS961NxEhyoU0vXmpqMIcPo9xlpMFg==
+      integrity: sha512-6Z1P3+UAPehEHuO4dOoklN10kYxD0ssJLHyq0yBjG+rmMRjSTP+JznAcUkoYhuAlRhUpfeVpmtSp0mxmVqzTcg==
       tarball: file:projects/storage-blob-changefeed.tgz
     version: 0.0.0
   file:projects/storage-blob.tgz:
@@ -11233,7 +11242,7 @@ packages:
     dev: false
     name: '@rush-temp/storage-blob'
     resolution:
-      integrity: sha512-vDjrlt3aRme+YkIbvsx56A9FZpNC+7u96T0wFb2R+oVQy1UQpcvbsMD0ztuI59ao7b830JOeObLzHdwbiQg8Aw==
+      integrity: sha512-iTNrQH6fXi6uz1wntr55I2Wy7J09X7kWka8m4+xEBggm0/8MTq70/lPZTwc65qJfLjp515Mf5wG5FV19uUP/kQ==
       tarball: file:projects/storage-blob.tgz
     version: 0.0.0
   file:projects/storage-file-datalake.tgz:
@@ -11291,7 +11300,7 @@ packages:
     dev: false
     name: '@rush-temp/storage-file-datalake'
     resolution:
-      integrity: sha512-GSXIBdYBUFknYcqm0yyf0BQFERTz4Gp0wL68GrZzV+8R955SE1mrWaQHj/P0FdieF8OhtjkRpdqL7lLkV0h0wg==
+      integrity: sha512-WadrudqhN+4o2y/lIxJfIOw2XhIbzM578cULuCnQUIjq/sxraUQ6VT4ruWRRqkpBJYXAkvKGFKU1nk9hZI21Pw==
       tarball: file:projects/storage-file-datalake.tgz
     version: 0.0.0
   file:projects/storage-file-share.tgz:
@@ -11345,7 +11354,7 @@ packages:
     dev: false
     name: '@rush-temp/storage-file-share'
     resolution:
-      integrity: sha512-j2TuqNfjmOV+hVI9t3sRto2kAX0tNEJGKRxgO3ZKWEBPKi2m9qiOqIoCw0cT4u7Hsri8WYckxBC+Fy9n0vXabg==
+      integrity: sha512-tm+npdfU7HW8bDAXmLHl7SkTVE0R0OkQkj6Ao1VtZxbaNsV2yHgino//7zrzTHm5NXYM1T9/UZd5lAxUkUg2YA==
       tarball: file:projects/storage-file-share.tgz
     version: 0.0.0
   file:projects/storage-internal-avro.tgz:
@@ -11449,7 +11458,7 @@ packages:
     dev: false
     name: '@rush-temp/storage-queue'
     resolution:
-      integrity: sha512-GpLMmYAA4M3r4FAqNw06BFVyx8/be7iP+YuqBZF54QwowCpoUbU/NnBN4lCmTYg/QfbPxN3lfLTcw8xqUWqB2w==
+      integrity: sha512-uTyj9p7/aIjlEkguZAVtnCxV8fU7iOxRZV0j/GwWWIpuFKaK92rtWJGRBrQ/IRVRehNuS81GgRBEVb5tIyLIvA==
       tarball: file:projects/storage-queue.tgz
     version: 0.0.0
   file:projects/synapse-access-control.tgz:
@@ -11468,7 +11477,7 @@ packages:
     dev: false
     name: '@rush-temp/synapse-access-control'
     resolution:
-      integrity: sha512-cTj+TIV66H+n36HhogXdHLPHo+qBWVx6/A3/c/tAa0YdMMGUNLrS7m2f2WcANDJivLHl38gkAY9Nzm5kWIg6Vg==
+      integrity: sha512-B6ZNAWWZamD+jFqi0Z5UrXPb407k7n22KotiiBdG17Kvb5+IFZHvB2XSb6UqXKX6acTH2oTPGnhqJX9zNu7bnQ==
       tarball: file:projects/synapse-access-control.tgz
     version: 0.0.0
   file:projects/synapse-artifacts.tgz:
@@ -11517,7 +11526,7 @@ packages:
     dev: false
     name: '@rush-temp/synapse-artifacts'
     resolution:
-      integrity: sha512-vt9kUozRHF9Bo1L4dUupFdfDtnLDMChwVh+/aJ1YWAXDAqoPa6Bl1JWdz/7ENOwqfdt3GxZjWD5uQ0QzyZNUzQ==
+      integrity: sha512-mwTBfQbREgi+WQsGacFphKMFqRqMXblql1V0ZR8z10SdJ52WX5saolncGY6xREt5hLuWa+0BF+Z2QuMA8wjIrg==
       tarball: file:projects/synapse-artifacts.tgz
     version: 0.0.0
   file:projects/synapse-managed-private-endpoints.tgz:
@@ -11536,7 +11545,7 @@ packages:
     dev: false
     name: '@rush-temp/synapse-managed-private-endpoints'
     resolution:
-      integrity: sha512-TxDjc/JaUiPvOTSomuZm5zbnZYGV7PHbmn6jACR/TKb174c/qA58bTOcsk5NgpJGYM5bsGICVLlc1zcme8mf6Q==
+      integrity: sha512-n3HmGyFWLvYD13xpEZDbDR/UTytR45c8RaaFn4S+RvgMl9qbSLKF2HNtdj/9Kizg70MsfHITsevCObkrF1MAaw==
       tarball: file:projects/synapse-managed-private-endpoints.tgz
     version: 0.0.0
   file:projects/synapse-monitoring.tgz:
@@ -11555,7 +11564,7 @@ packages:
     dev: false
     name: '@rush-temp/synapse-monitoring'
     resolution:
-      integrity: sha512-czBS9LdKdlhgQTikMWqNQJZrvH6lLWREePSMOrc14+a3a0m8AuqukIG9oP4ChtxMU460+uiP85SUIBD3m6DynA==
+      integrity: sha512-ZP/mUHpmJecIKZu5BgZ7KMs1RpcGx+gvvhcqfQPHjsXHItdYRw2SZaNeYWe5EPnmB/bIAxWnh0UgMIKXAmQ0+Q==
       tarball: file:projects/synapse-monitoring.tgz
     version: 0.0.0
   file:projects/synapse-spark.tgz:
@@ -11574,7 +11583,7 @@ packages:
     dev: false
     name: '@rush-temp/synapse-spark'
     resolution:
-      integrity: sha512-0EQSRYbZpxXr2lIJNnJBzLnxNtIg8vvKbZgP8m4BEY/Bh6zePj/040ofZb7oyjDTJ2GBG/6xGSXe6rWcQYbueQ==
+      integrity: sha512-K+6F+RZEd5QAlbJlquMsiXPVc39i9C9CR9eQik5HhMV0tkWrk9DnKEx+l4nqIBvJ4yFAcew448mS+Fcp3HpQxA==
       tarball: file:projects/synapse-spark.tgz
     version: 0.0.0
   file:projects/template.tgz:
@@ -11618,11 +11627,12 @@ packages:
     dev: false
     name: '@rush-temp/template'
     resolution:
-      integrity: sha512-3fbGqkIaKqvCh8c+NNU0di1d3N/83L3/4VReIw0YOCpTSUOABqCeyJXuI4CrlcuvPjR4W8e+FS4bJU3WknmxJg==
+      integrity: sha512-hQI0Ql4AZ4XWrILH/tsta0ICSinVvE+Bus/7L8tuBRza+LJUlaJVgEG16kY/mex7qaCRZkn8FiIJkD2mlywRLg==
       tarball: file:projects/template.tgz
     version: 0.0.0
   file:projects/test-utils-perfstress.tgz:
     dependencies:
+      '@azure/core-http': 1.2.6
       '@types/minimist': 1.2.1
       '@types/node': 8.10.66
       '@types/node-fetch': 2.5.10
@@ -11640,7 +11650,7 @@ packages:
     dev: false
     name: '@rush-temp/test-utils-perfstress'
     resolution:
-      integrity: sha512-7ahu0ZcXw1v5iEXcsI5CSvKzXrEZnq7PfbVYC8UrJGYkTHENmDD9RPBPcNgUqLsfWS0VUCsYOmr7+jv0Gi4rDA==
+      integrity: sha512-G01AKC+QVmgEMfC2qhx04eGCjF263vxZi+gl5okAPVDSdU0VVksM/RTytC5FuJtedCuNnKIiCDsTRXY8jPGwlQ==
       tarball: file:projects/test-utils-perfstress.tgz
     version: 0.0.0
   file:projects/test-utils-recorder.tgz:
@@ -11696,7 +11706,7 @@ packages:
     dev: false
     name: '@rush-temp/test-utils-recorder'
     resolution:
-      integrity: sha512-fGHrJYrVCdiA8F/jXpnMAdz1b/Xz68JAMfGSHwdiEki22yPna09NHn0kSceTlHuj4OGetNAxk0+ZeY7hhICaHA==
+      integrity: sha512-AmE/h0wK80qWpCOM+dLXlhMjLYIM7A3UFZIALzlOVy3BiGlN/3Sr3c6/7uNXTp2q6C0vqrl8wpnH3zP59oZkXQ==
       tarball: file:projects/test-utils-recorder.tgz
     version: 0.0.0
   file:projects/test-utils.tgz:
@@ -11765,7 +11775,7 @@ packages:
     dev: false
     name: '@rush-temp/video-analyzer-edge'
     resolution:
-      integrity: sha512-989HvDXIApeDGqoTNg6I8JUTUtpBn6pzLuYST0JYrKE7/2sJq7x1yp8CtKi+jeqhnG7aiDa9GjacpxgdrQbXEQ==
+      integrity: sha512-EmFXjIs+Itmn0tO3VRG4C3jHBRvXmUCgXRotTtnHy3MjmfDPcW9Ad9/3ZAxs+yhAdVTfQ4eZAkcyCUAS99Weqg==
       tarball: file:projects/video-analyzer-edge.tgz
     version: 0.0.0
   file:projects/web-pubsub-express.tgz:
@@ -11826,7 +11836,7 @@ packages:
     dev: false
     name: '@rush-temp/web-pubsub-express'
     resolution:
-      integrity: sha512-Lr9G7CThq8ki5jg+j6J8n8kGVpRlCHDtlZWjahAwvL0Y+xHD0CdeHW5Ey95lTdtLQkRUm4LRXrgQezq9J81+XA==
+      integrity: sha512-nQ+4E7biXcZfZGOfGQjqRGDnh53ktgWERarLRnUPJXlTNG0/ex0hAPL+BRXji6UIqlX1/NTcXPPc3KAu5gZbmQ==
       tarball: file:projects/web-pubsub-express.tgz
     version: 0.0.0
   file:projects/web-pubsub.tgz:
@@ -11883,7 +11893,7 @@ packages:
     dev: false
     name: '@rush-temp/web-pubsub'
     resolution:
-      integrity: sha512-vR4Y02jE/bLss6v013XQnI7fHgUp+r4ENYXoaHKRAtNMixhfeobUozzrZuMQJjCTyh0ps8FxxEn3BB3It5SySQ==
+      integrity: sha512-gWCUFpMhKrd5v3cvLLkcJIYn8C1lQgg487WLD4H040NGB6hY89G1JQyfrihPi4h059Oi9fHq4mCwbqvWVHHocg==
       tarball: file:projects/web-pubsub.tgz
     version: 0.0.0
 registry: ''
@@ -11910,7 +11920,6 @@ specifiers:
   '@rush-temp/core-auth': file:./projects/core-auth.tgz
   '@rush-temp/core-client': file:./projects/core-client.tgz
   '@rush-temp/core-client-1': file:./projects/core-client-1.tgz
-  '@rush-temp/core-client-paging': file:./projects/core-client-paging.tgz
   '@rush-temp/core-crypto': file:./projects/core-crypto.tgz
   '@rush-temp/core-http': file:./projects/core-http.tgz
   '@rush-temp/core-lro': file:./projects/core-lro.tgz

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -1042,18 +1042,6 @@ packages:
       node: '>=8.0.0'
     resolution:
       integrity: sha512-GtpMGd6vkzDMYcpu2t9LlhEgMy/SzBwRnz48EejlRArYqZzqSzAsKmegUK7zHgl+EOIaK9mKHhnRaQu3qw20cA==
-  /@opentelemetry/api/0.18.1:
-    dev: false
-    engines:
-      node: '>=8.0.0'
-    resolution:
-      integrity: sha512-pKNxHe3AJ5T2N5G3AlT9gx6FyF5K2FS9ZNc+FipC+f1CpVF/EY+JHTJ749dnM2kWIgZTbDJFiGMuc0FYjNSCOg==
-  /@opentelemetry/api/0.21.0:
-    dev: false
-    engines:
-      node: '>=8.0.0'
-    resolution:
-      integrity: sha512-Q7hHb3nidPgnBS2fi+y3K64F3EV48d9v09/6EtigIgVF43NFNhw/dboDKC7gECEkbTwuvFeLCbwKs9JaC8LDEw==
   /@opentelemetry/api/1.0.0:
     dev: false
     engines:
@@ -1066,140 +1054,104 @@ packages:
       node: '>=8.0.0'
     resolution:
       integrity: sha512-iXKByCMfrlO5S6Oh97BuM56tM2cIBB0XsL/vWF/AtJrJEKx4MC/Xdu0xDsGXMGcNWpqF7ujMsjjnp0+UHBwnDQ==
-  /@opentelemetry/context-async-hooks/0.21.0_@opentelemetry+api@0.21.0:
+  /@opentelemetry/context-async-hooks/0.22.0_@opentelemetry+api@1.0.0:
     dependencies:
-      '@opentelemetry/api': 0.21.0
+      '@opentelemetry/api': 1.0.0
     dev: false
     engines:
       node: '>=8.1.0'
     peerDependencies:
-      '@opentelemetry/api': ^0.21.0
+      '@opentelemetry/api': ^1.0.0
     resolution:
-      integrity: sha512-3XxzT7jiDLbohUy66NWsYuWFtXsMI0qMhetWVlFmmBfMPLMR+U6xWA4xhfRMb6kMEjR5XJHbyDSxYwzxrd10sg==
+      integrity: sha512-JakZ9NJCiaf8FJ6lcR2Fle9xkBKxSFbXK4mk9gZ14totNh9SOTiUBUk08bAnATWUINrQlN8/5hpGKi5gs+FUxQ==
   /@opentelemetry/context-base/0.10.2:
     dev: false
     engines:
       node: '>=8.0.0'
     resolution:
       integrity: sha512-hZNKjKOYsckoOEgBziGMnBcX0M7EtstnCmwz5jZUOUYwlZ+/xxX6z3jPu1XVO2Jivk0eLfuP9GP+vFD49CMetw==
-  /@opentelemetry/core/0.18.2:
+  /@opentelemetry/core/0.22.0_@opentelemetry+api@1.0.0:
     dependencies:
-      '@opentelemetry/api': 0.18.1
-      semver: 7.3.5
-    dev: false
-    engines:
-      node: '>=8.5.0'
-    resolution:
-      integrity: sha512-WG8veOEd8xZHuBaOHddzWQg5yj794lrEPAe6W1qI0YkV7pyqYXvhJdCxOU5Lyo1SWzTAjI5xrCUQ9J2WlrqzYA==
-  /@opentelemetry/core/0.21.0_@opentelemetry+api@0.21.0:
-    dependencies:
-      '@opentelemetry/api': 0.21.0
-      '@opentelemetry/semantic-conventions': 0.21.0
+      '@opentelemetry/api': 1.0.0
+      '@opentelemetry/semantic-conventions': 0.22.0
       semver: 7.3.5
     dev: false
     engines:
       node: '>=8.5.0'
     peerDependencies:
-      '@opentelemetry/api': ^0.21.0
+      '@opentelemetry/api': ^1.0.0
     resolution:
-      integrity: sha512-sZZQThBuqhCdBPgzPq4y9L4dhnpXXCCEqNsR6IUmMc/kQ8Bcw3lmI5fymLlliSt+lnTc26xJPVKZlwoQfwhThg==
-  /@opentelemetry/node/0.21.0_@opentelemetry+api@0.21.0:
+      integrity: sha512-x6JxuQ4rY2x39GEXJSqMgyf8XZPNNiZrGcCMhZSrtypq/WXlsJuxMNnUAl2hj2rpSGGukhhWn5cMpCmMJJz1hw==
+  /@opentelemetry/node/0.22.0_@opentelemetry+api@1.0.0:
     dependencies:
-      '@opentelemetry/api': 0.21.0
-      '@opentelemetry/context-async-hooks': 0.21.0_@opentelemetry+api@0.21.0
-      '@opentelemetry/core': 0.21.0_@opentelemetry+api@0.21.0
-      '@opentelemetry/propagator-b3': 0.21.0_@opentelemetry+api@0.21.0
-      '@opentelemetry/propagator-jaeger': 0.21.0_@opentelemetry+api@0.21.0
-      '@opentelemetry/tracing': 0.21.0_@opentelemetry+api@0.21.0
+      '@opentelemetry/api': 1.0.0
+      '@opentelemetry/context-async-hooks': 0.22.0_@opentelemetry+api@1.0.0
+      '@opentelemetry/core': 0.22.0_@opentelemetry+api@1.0.0
+      '@opentelemetry/propagator-b3': 0.22.0_@opentelemetry+api@1.0.0
+      '@opentelemetry/propagator-jaeger': 0.22.0_@opentelemetry+api@1.0.0
+      '@opentelemetry/tracing': 0.22.0_@opentelemetry+api@1.0.0
       semver: 7.3.5
     dev: false
     engines:
       node: '>=8.0.0'
     peerDependencies:
-      '@opentelemetry/api': ^0.21.0
+      '@opentelemetry/api': ^1.0.0
     resolution:
-      integrity: sha512-PCA3pFmzTMN3iIlZ6Bz2BgPe8jEIdKRK7WyjfT9qqrLrHZ/dXNmX4MIz2IKTyQtS6tGt2jayD0IpWsVFctPOIA==
-  /@opentelemetry/propagator-b3/0.21.0_@opentelemetry+api@0.21.0:
+      integrity: sha512-+HhGbDruQ7cwejVOIYyxRa28uosnG8W95NiQZ6qE8PXXPsDSyGeftAPbtYpGit0H2f5hrVcMlwmWHeAo9xkSLA==
+  /@opentelemetry/propagator-b3/0.22.0_@opentelemetry+api@1.0.0:
     dependencies:
-      '@opentelemetry/api': 0.21.0
-      '@opentelemetry/core': 0.21.0_@opentelemetry+api@0.21.0
+      '@opentelemetry/api': 1.0.0
+      '@opentelemetry/core': 0.22.0_@opentelemetry+api@1.0.0
     dev: false
     engines:
       node: '>=8.0.0'
     peerDependencies:
-      '@opentelemetry/api': ^0.21.0
+      '@opentelemetry/api': ^1.0.0
     resolution:
-      integrity: sha512-KXQKXa76ilzBNdwr7hze9251g0AqBmwhCPnt17UCgb+97DFcOyEy5Rc7nnjZNxNGYYqUbk8116MK9hMZO2icGw==
-  /@opentelemetry/propagator-jaeger/0.21.0_@opentelemetry+api@0.21.0:
+      integrity: sha512-7UESJWUUmInXrlux9whSjoIMfpmajKbu2UBU/ux7TVkLTeaJwebLHoqDhuUTS4dbmvg3fnkpfmocyUgby16NwQ==
+  /@opentelemetry/propagator-jaeger/0.22.0_@opentelemetry+api@1.0.0:
     dependencies:
-      '@opentelemetry/api': 0.21.0
-      '@opentelemetry/core': 0.21.0_@opentelemetry+api@0.21.0
+      '@opentelemetry/api': 1.0.0
+      '@opentelemetry/core': 0.22.0_@opentelemetry+api@1.0.0
     dev: false
     engines:
       node: '>=8.5.0'
     peerDependencies:
-      '@opentelemetry/api': ^0.21.0
+      '@opentelemetry/api': ^1.0.0
     resolution:
-      integrity: sha512-H0TaYBvDi4stz19UJNPFR1IRikQYjoKYuV6tZV4V5NnPAFTjBhvj/Heb0fNDUWK5G1tVB5NPrEsNSZjjdfvjLw==
-  /@opentelemetry/resources/0.18.2:
+      integrity: sha512-Xclq+eLfc0Zk1UAbY6clYjoCZqikk4SzvG8C/ODJ6LfDHnqMr/fKXaHHhh/DdHdi6d73o9S8ytblryc+CaTkrw==
+  /@opentelemetry/resources/0.22.0_@opentelemetry+api@1.0.0:
     dependencies:
-      '@opentelemetry/api': 0.18.1
-      '@opentelemetry/core': 0.18.2
-    dev: false
-    engines:
-      node: '>=8.0.0'
-    resolution:
-      integrity: sha512-EBPqFsreXgFaqkMmWCE8vh6pFhbWExRHSO24qSeGhxFmM5SQP/D1jJqMp/jVUSmrF97fPkMS0aEH5z7NOWdxQA==
-  /@opentelemetry/resources/0.21.0_@opentelemetry+api@0.21.0:
-    dependencies:
-      '@opentelemetry/api': 0.21.0
-      '@opentelemetry/core': 0.21.0_@opentelemetry+api@0.21.0
-      '@opentelemetry/semantic-conventions': 0.21.0
+      '@opentelemetry/api': 1.0.0
+      '@opentelemetry/core': 0.22.0_@opentelemetry+api@1.0.0
+      '@opentelemetry/semantic-conventions': 0.22.0
     dev: false
     engines:
       node: '>=8.0.0'
     peerDependencies:
-      '@opentelemetry/api': ^0.21.0
+      '@opentelemetry/api': ^1.0.0
     resolution:
-      integrity: sha512-xQUL2/2npP/isH8sbOSdynIRWmlM6p02L9Ex8x/BhUuSkGrMoxO2ezLPPYnfYam1py6ubaz8m1C54O2IRCmgQQ==
-  /@opentelemetry/semantic-conventions/0.18.2:
+      integrity: sha512-LiX6/JyuD2eHi7Ewrq/PUP79azDqshd0r2oksNTJ+VwgbGfMlq79ykd4FhiEEk23fFbajGt+9ginadXoRk17dg==
+  /@opentelemetry/semantic-conventions/0.22.0:
     dev: false
     engines:
       node: '>=8.0.0'
     resolution:
-      integrity: sha512-+0P+PrP9qSFVaayNdek4P1OAGE+PEl2SsufuHDRmUpOY25Wzjo7Atyar56Trjc32jkNy4lID6ZFT6BahsR9P9A==
-  /@opentelemetry/semantic-conventions/0.21.0:
-    dev: false
-    engines:
-      node: '>=8.0.0'
-    resolution:
-      integrity: sha512-qQtZJ8Q+bO/gemBELsZbz5s//tNnyc+mQD/0RHc77XhI6ZBb+tprU6KN/7l0fl5z29smmai0hcJ9UNILC/7nIw==
-  /@opentelemetry/tracing/0.18.2:
+      integrity: sha512-t4fKikazahwNKmwD+CE/icHyuZldWvNMupJhjxdk9T/KxHFx3zCGjHT3MKavwYP6abzgAAm5WwzD1oHlmj7dyg==
+  /@opentelemetry/tracing/0.22.0_@opentelemetry+api@1.0.0:
     dependencies:
-      '@opentelemetry/api': 0.18.1
-      '@opentelemetry/core': 0.18.2
-      '@opentelemetry/resources': 0.18.2
-      '@opentelemetry/semantic-conventions': 0.18.2
-      lodash.merge: 4.6.2
-    dev: false
-    engines:
-      node: '>=8.0.0'
-    resolution:
-      integrity: sha512-IQSu+NwMhX8O9Wkjc4HjNqs/aKfkcInCE3dQuAOBBec/saLrM6jqd+Fa5QUzg03WMOqpDuZm5KTkr5+6DUrr0g==
-  /@opentelemetry/tracing/0.21.0_@opentelemetry+api@0.21.0:
-    dependencies:
-      '@opentelemetry/api': 0.21.0
-      '@opentelemetry/core': 0.21.0_@opentelemetry+api@0.21.0
-      '@opentelemetry/resources': 0.21.0_@opentelemetry+api@0.21.0
-      '@opentelemetry/semantic-conventions': 0.21.0
+      '@opentelemetry/api': 1.0.0
+      '@opentelemetry/core': 0.22.0_@opentelemetry+api@1.0.0
+      '@opentelemetry/resources': 0.22.0_@opentelemetry+api@1.0.0
+      '@opentelemetry/semantic-conventions': 0.22.0
       lodash.merge: 4.6.2
     dev: false
     engines:
       node: '>=8.0.0'
     peerDependencies:
-      '@opentelemetry/api': ^0.21.0
+      '@opentelemetry/api': ^1.0.0
     resolution:
-      integrity: sha512-6+2pfFpu7Yo2DwmBK9sHDUSIL7UshcEMwDF6+LghGK68ILRaEMqqBPgKarjhFH9ERgJB9GOkJ2snK96qIzMZNA==
+      integrity: sha512-EFrKTFndiEdh/KnzwDgo/EcphG/5z/NyLck8oiUUY+YMP7hskXNYHjTWSAv9UxtYe1MzgLbjmAateTuMmFIVNw==
   /@rollup/plugin-commonjs/11.0.2_rollup@1.32.1:
     dependencies:
       '@rollup/pluginutils': 3.1.0_rollup@1.32.1
@@ -8288,7 +8240,7 @@ packages:
     dev: false
     name: '@rush-temp/ai-form-recognizer'
     resolution:
-      integrity: sha512-eeELrx6Y+ZcgaQGADM3tA4FxB4EpCf9WrWF/a4wwu87JOcwrqxYIzXhg3EvidKzvjSt3bpcekpARBCpKhHt+XA==
+      integrity: sha512-PG6KP/nYmP5pFVwSv1MHC+bEPEIP02GHMIkhzn4UhD6ibW97V/QdZ2n4BQlGWmccMGA8axhbFsZRSLU/BBGPTw==
       tarball: file:projects/ai-form-recognizer.tgz
     version: 0.0.0
   file:projects/ai-metrics-advisor.tgz:
@@ -8332,7 +8284,7 @@ packages:
     dev: false
     name: '@rush-temp/ai-metrics-advisor'
     resolution:
-      integrity: sha512-tw7TT8iwedlf8tZJxN3B/niOclO4Y+3lEym1gpkNr03VHvMdCwEe92U07MDwwr4mgC8An3nn5HCaTQYVL87Y2g==
+      integrity: sha512-jR1S5XpW18t2/lVo4/hkNpG9N0ztS1p1peq8u+XMcIGX7uoDQgFBMWkOra8tv6QGivsoMQ0xWwAOswG7A+oVqg==
       tarball: file:projects/ai-metrics-advisor.tgz
     version: 0.0.0
   file:projects/ai-text-analytics.tgz:
@@ -8380,7 +8332,7 @@ packages:
     dev: false
     name: '@rush-temp/ai-text-analytics'
     resolution:
-      integrity: sha512-PwfQ6A/U3Da95CRcCnbn/txOlXbzGxeAOIDNrlZXTr8TXitD4PIYgrl8k25NeztMKg76BICQv3QL+V6d4Li8zQ==
+      integrity: sha512-d2IVGQX1cy4qBc/4qANWXKVMLRbvYr8PF5qL/tj6aTomya5fHI+sbKXmvXMZG4lJV1dUG5OSrxq34QYaVbcBFQ==
       tarball: file:projects/ai-text-analytics.tgz
     version: 0.0.0
   file:projects/app-configuration.tgz:
@@ -8649,7 +8601,7 @@ packages:
     dev: false
     name: '@rush-temp/communication-identity'
     resolution:
-      integrity: sha512-2rR7RK7ItGB4jqi2WGfxN8NzHGrs4BaZ/7uuFWdo4t2fYp/OFFGh+lYzTNk9JxzUgoU7PsceSZ8OXRprkl4DAA==
+      integrity: sha512-OrBwofz9RC/Uof8DsCbPPKOf9qGLMqUsOeZe7Q/nIbfnbZYFV7jcf/FaRIlKm6ouIM/i5Juj2rEzKy7LWx5VsA==
       tarball: file:projects/communication-identity.tgz
     version: 0.0.0
   file:projects/communication-network-traversal.tgz:
@@ -8754,7 +8706,7 @@ packages:
     dev: false
     name: '@rush-temp/communication-phone-numbers'
     resolution:
-      integrity: sha512-2weNFkSRK+BeWKuEq2iMv1bZYJJAMWvX8H4WRkSANexWFcMY6JmUvG3L/rcxBvGr3fvn/Y4l3jsrCjnqM5baqw==
+      integrity: sha512-ZMZNMp8xGJWX+SYkH9BN4HjdxXIlhCtnztjuUGS53VtbRT81S/fJ8YzjbtskJNCI07RyC0dlvIZccsKEUb/iXA==
       tarball: file:projects/communication-phone-numbers.tgz
     version: 0.0.0
   file:projects/communication-sms.tgz:
@@ -9049,7 +9001,6 @@ packages:
     version: 0.0.0
   file:projects/core-client-paging.tgz:
     dependencies:
-      '@azure/core-rest-pipeline': 1.0.4
       '@microsoft/api-extractor': 7.13.2
       '@types/chai': 4.2.19
       '@types/mocha': 7.0.2
@@ -10205,7 +10156,7 @@ packages:
     dev: false
     name: '@rush-temp/keyvault-admin'
     resolution:
-      integrity: sha512-NsA/IYbyDtD9dz3tCGR3sLUQe/Y2hSjBD6jp2EUq+yOTGE0gO8XwiNSQRx1SgSFArmqC2/Osr4dRxh/GdOU0BQ==
+      integrity: sha512-N1mMTHFZ+L+1jJGw0FmU/nYy2Tx41AWtzxAT4eKotj+ix1PhQW7tu712sfGSK8rJciA9z2YaXnq2KlCalpJrHw==
       tarball: file:projects/keyvault-admin.tgz
     version: 0.0.0
   file:projects/keyvault-certificates.tgz:
@@ -10262,7 +10213,7 @@ packages:
     dev: false
     name: '@rush-temp/keyvault-certificates'
     resolution:
-      integrity: sha512-9eKwZI730BCthRhn/EPW4xMVQdD1vmtFTWqevy7OFdKGloM3szt7y27Zqpz0DETcvB3AiPpY/CfxyaEuu5OUew==
+      integrity: sha512-SZIpvWi1Oh0fR52xInZ1rEJlPDGJGJIuPwdLaZED57YjEaO+s8x42Ud/n5xJ+gC+1sZP8aRdwDYzvKllCLggRg==
       tarball: file:projects/keyvault-certificates.tgz
     version: 0.0.0
   file:projects/keyvault-common.tgz:
@@ -10333,7 +10284,7 @@ packages:
     dev: false
     name: '@rush-temp/keyvault-keys'
     resolution:
-      integrity: sha512-M0vL2R0DPodMwmcuhoQ7/her+e/nfwOpTKlM0PZB3qmaAPn/ZhczZC9KFuepBQS+XkjnYa9Q0b4kwJTjKwY/Mg==
+      integrity: sha512-mZg+MNTvoPCKHfVVEBCZomsF8N4LpjbZoWexpAC1iTKaHvj8ILjxuGH6YP8WJssvDdQUH3xOhPAScIOMYdGTnA==
       tarball: file:projects/keyvault-keys.tgz
     version: 0.0.0
   file:projects/keyvault-secrets.tgz:
@@ -10389,7 +10340,7 @@ packages:
     dev: false
     name: '@rush-temp/keyvault-secrets'
     resolution:
-      integrity: sha512-XMNlMtog99caBzBx95ktcaSQ8OVjJrK89r+UA1t/llNNbZ+cma0tyDMHQOIEEet51/SRexwwT/HXXSYWKqvJng==
+      integrity: sha512-W5dDV1QHJ+u9+NJWNi11koGkXachZAB66ASayigW7tdmGyyRzIKubOZvKaXKQCN1jlsABXK6Q7GQvVzM5/0M2Q==
       tarball: file:projects/keyvault-secrets.tgz
     version: 0.0.0
   file:projects/logger.tgz:
@@ -10501,11 +10452,11 @@ packages:
   file:projects/monitor-opentelemetry-exporter.tgz:
     dependencies:
       '@microsoft/api-extractor': 7.7.11
-      '@opentelemetry/api': 0.18.1
-      '@opentelemetry/core': 0.18.2
-      '@opentelemetry/resources': 0.18.2
-      '@opentelemetry/semantic-conventions': 0.18.2
-      '@opentelemetry/tracing': 0.18.2
+      '@opentelemetry/api': 1.0.0
+      '@opentelemetry/core': 0.22.0_@opentelemetry+api@1.0.0
+      '@opentelemetry/resources': 0.22.0_@opentelemetry+api@1.0.0
+      '@opentelemetry/semantic-conventions': 0.22.0
+      '@opentelemetry/tracing': 0.22.0_@opentelemetry+api@1.0.0
       '@types/mocha': 7.0.2
       '@types/node': 10.17.60
       eslint: 7.29.0
@@ -10525,16 +10476,16 @@ packages:
     dev: false
     name: '@rush-temp/monitor-opentelemetry-exporter'
     resolution:
-      integrity: sha512-fWU4hcmUB+0oYiIbvs0MGB6B6tlgsFZdgX8jKajH+Chm5yHncg2hXSmSBgxGuSLEuso/kgOq2feJrcChZDbz3A==
+      integrity: sha512-Lq8fsz2BpYqrWz1cYDlNTjLaReTJFmj13Wqq5M59N+jw0QYt8G+hAlyu4vx6G/S8EFBBcA8CCLehrkVJVMnf5g==
       tarball: file:projects/monitor-opentelemetry-exporter.tgz
     version: 0.0.0
   file:projects/monitor-query.tgz:
     dependencies:
       '@azure/identity': 1.3.0
       '@microsoft/api-extractor': 7.7.11
-      '@opentelemetry/api': 0.21.0
-      '@opentelemetry/node': 0.21.0_@opentelemetry+api@0.21.0
-      '@opentelemetry/tracing': 0.18.2
+      '@opentelemetry/api': 1.0.0
+      '@opentelemetry/node': 0.22.0_@opentelemetry+api@1.0.0
+      '@opentelemetry/tracing': 0.22.0_@opentelemetry+api@1.0.0
       '@types/chai': 4.2.19
       '@types/chai-as-promised': 7.1.4
       '@types/mocha': 7.0.2
@@ -10573,7 +10524,7 @@ packages:
     dev: false
     name: '@rush-temp/monitor-query'
     resolution:
-      integrity: sha512-twrlnCuihbPPgdhDddN+eN40Hco0IamvL9Hiotno/SpDD/WqERw/uKRnSMojnYFMwtz57QQPW+kZubl3bFHTdA==
+      integrity: sha512-ZqbLi+vZHrI+Vz3RzDS2+A/pyL3d+jhv/mtt3kIBz7MNhrR2U3LChG5y3je2HY06XRuyhg7O/gz0TBrSTQHt/Q==
       tarball: file:projects/monitor-query.tgz
     version: 0.0.0
   file:projects/perf-ai-form-recognizer.tgz:
@@ -11224,7 +11175,7 @@ packages:
     dev: false
     name: '@rush-temp/storage-blob-changefeed'
     resolution:
-      integrity: sha512-6Z1P3+UAPehEHuO4dOoklN10kYxD0ssJLHyq0yBjG+rmMRjSTP+JznAcUkoYhuAlRhUpfeVpmtSp0mxmVqzTcg==
+      integrity: sha512-ksbw8dPxjkpa1QLxHQeDSg9+cQJ6xVwwNFD00yYN+ew7TKQF/lpB06PtVONdU1YzYZ/c3d7P9qSajZXDqbmoEQ==
       tarball: file:projects/storage-blob-changefeed.tgz
     version: 0.0.0
   file:projects/storage-blob.tgz:
@@ -11282,7 +11233,7 @@ packages:
     dev: false
     name: '@rush-temp/storage-blob'
     resolution:
-      integrity: sha512-iTNrQH6fXi6uz1wntr55I2Wy7J09X7kWka8m4+xEBggm0/8MTq70/lPZTwc65qJfLjp515Mf5wG5FV19uUP/kQ==
+      integrity: sha512-Y2PYAaYTgmGrVfnf3V9wNGDMpbHvqGUbWVyOumm/ZcGyoYk5GJLEfzyfrcu/Km+q6vInYa6DJIvyhtGIMpRGpw==
       tarball: file:projects/storage-blob.tgz
     version: 0.0.0
   file:projects/storage-file-datalake.tgz:
@@ -11566,7 +11517,7 @@ packages:
     dev: false
     name: '@rush-temp/synapse-artifacts'
     resolution:
-      integrity: sha512-mwTBfQbREgi+WQsGacFphKMFqRqMXblql1V0ZR8z10SdJ52WX5saolncGY6xREt5hLuWa+0BF+Z2QuMA8wjIrg==
+      integrity: sha512-FGswIITasIIQLmyG+RTFkrm6PPW6DZvclEJM8OZjR7a2Wo3X6F/dXVx04wOQXkyOpEGhS9Q4t1zeQGx1kqoibw==
       tarball: file:projects/synapse-artifacts.tgz
     version: 0.0.0
   file:projects/synapse-managed-private-endpoints.tgz:

--- a/sdk/anomalydetector/ai-anomaly-detector/package.json
+++ b/sdk/anomalydetector/ai-anomaly-detector/package.json
@@ -62,7 +62,7 @@
   "sideEffects": false,
   "prettier": "@azure/eslint-plugin-azure-sdk/prettier.json",
   "dependencies": {
-    "@azure/core-http": "^1.2.7",
+    "@azure/core-http": "^2.0.0",
     "@azure/core-auth": "^1.3.0",
     "@azure/core-paging": "^1.1.1",
     "@azure/logger": "^1.0.0",

--- a/sdk/anomalydetector/ai-anomaly-detector/package.json
+++ b/sdk/anomalydetector/ai-anomaly-detector/package.json
@@ -62,7 +62,7 @@
   "sideEffects": false,
   "prettier": "@azure/eslint-plugin-azure-sdk/prettier.json",
   "dependencies": {
-    "@azure/core-http": "^1.2.0",
+    "@azure/core-http": "^1.2.7",
     "@azure/core-auth": "^1.3.0",
     "@azure/core-paging": "^1.1.1",
     "@azure/logger": "^1.0.0",

--- a/sdk/appconfiguration/app-configuration/package.json
+++ b/sdk/appconfiguration/app-configuration/package.json
@@ -88,7 +88,7 @@
   "dependencies": {
     "@azure/abort-controller": "^1.0.0",
     "@azure/core-asynciterator-polyfill": "^1.0.0",
-    "@azure/core-http": "^1.2.0",
+    "@azure/core-http": "^1.2.7",
     "@azure/core-paging": "^1.1.1",
     "@azure/core-tracing": "1.0.0-preview.12",
     "tslib": "^2.2.0"

--- a/sdk/appconfiguration/app-configuration/package.json
+++ b/sdk/appconfiguration/app-configuration/package.json
@@ -88,7 +88,7 @@
   "dependencies": {
     "@azure/abort-controller": "^1.0.0",
     "@azure/core-asynciterator-polyfill": "^1.0.0",
-    "@azure/core-http": "^1.2.7",
+    "@azure/core-http": "^2.0.0",
     "@azure/core-paging": "^1.1.1",
     "@azure/core-tracing": "1.0.0-preview.12",
     "tslib": "^2.2.0"

--- a/sdk/communication/communication-chat/package.json
+++ b/sdk/communication/communication-chat/package.json
@@ -68,7 +68,7 @@
     "@azure/communication-common": "^1.0.0",
     "@azure/communication-signaling": "1.0.0-beta.6",
     "@azure/core-auth": "^1.3.0",
-    "@azure/core-http": "^1.2.0",
+    "@azure/core-http": "^1.2.7",
     "@azure/core-tracing": "1.0.0-preview.12",
     "@azure/logger": "^1.0.0",
     "events": "^3.0.0",

--- a/sdk/communication/communication-chat/package.json
+++ b/sdk/communication/communication-chat/package.json
@@ -68,7 +68,7 @@
     "@azure/communication-common": "^1.0.0",
     "@azure/communication-signaling": "1.0.0-beta.6",
     "@azure/core-auth": "^1.3.0",
-    "@azure/core-http": "^1.2.7",
+    "@azure/core-http": "^2.0.0",
     "@azure/core-tracing": "1.0.0-preview.12",
     "@azure/logger": "^1.0.0",
     "events": "^3.0.0",

--- a/sdk/communication/communication-common/package.json
+++ b/sdk/communication/communication-common/package.json
@@ -65,7 +65,7 @@
   "dependencies": {
     "@azure/abort-controller": "^1.0.0",
     "@azure/core-auth": "^1.3.0",
-    "@azure/core-http": "^1.2.0",
+    "@azure/core-http": "^1.2.7",
     "@azure/core-tracing": "1.0.0-preview.12",
     "events": "^3.0.0",
     "jwt-decode": "~2.2.0",

--- a/sdk/communication/communication-common/package.json
+++ b/sdk/communication/communication-common/package.json
@@ -65,7 +65,7 @@
   "dependencies": {
     "@azure/abort-controller": "^1.0.0",
     "@azure/core-auth": "^1.3.0",
-    "@azure/core-http": "^1.2.7",
+    "@azure/core-http": "^2.0.0",
     "@azure/core-tracing": "1.0.0-preview.12",
     "events": "^3.0.0",
     "jwt-decode": "~2.2.0",

--- a/sdk/communication/communication-identity/package.json
+++ b/sdk/communication/communication-identity/package.json
@@ -77,7 +77,7 @@
     "@azure/communication-common": "^1.0.0",
     "@azure/core-auth": "^1.3.0",
     "@azure/core-http": "^2.0.0",
-    "@azure/core-lro": "^1.0.6",
+    "@azure/core-lro": "^2.0.0",
     "@azure/core-paging": "^1.1.1",
     "@azure/core-tracing": "1.0.0-preview.12",
     "@azure/logger": "^1.0.0",

--- a/sdk/communication/communication-identity/package.json
+++ b/sdk/communication/communication-identity/package.json
@@ -76,7 +76,7 @@
     "@azure/abort-controller": "^1.0.0",
     "@azure/communication-common": "^1.0.0",
     "@azure/core-auth": "^1.3.0",
-    "@azure/core-http": "^1.2.7",
+    "@azure/core-http": "^2.0.0",
     "@azure/core-lro": "^1.0.6",
     "@azure/core-paging": "^1.1.1",
     "@azure/core-tracing": "1.0.0-preview.12",

--- a/sdk/communication/communication-identity/package.json
+++ b/sdk/communication/communication-identity/package.json
@@ -76,7 +76,7 @@
     "@azure/abort-controller": "^1.0.0",
     "@azure/communication-common": "^1.0.0",
     "@azure/core-auth": "^1.3.0",
-    "@azure/core-http": "^1.2.0",
+    "@azure/core-http": "^1.2.7",
     "@azure/core-lro": "^1.0.6",
     "@azure/core-paging": "^1.1.1",
     "@azure/core-tracing": "1.0.0-preview.12",

--- a/sdk/communication/communication-network-traversal/package.json
+++ b/sdk/communication/communication-network-traversal/package.json
@@ -76,7 +76,7 @@
     "@azure/abort-controller": "^1.0.0",
     "@azure/communication-common": "^1.0.0",
     "@azure/core-auth": "^1.3.0",
-    "@azure/core-http": "^1.2.7",
+    "@azure/core-http": "^2.0.0",
     "@azure/core-tracing": "1.0.0-preview.12",
     "@azure/logger": "^1.0.0",
     "events": "^3.0.0",

--- a/sdk/communication/communication-network-traversal/package.json
+++ b/sdk/communication/communication-network-traversal/package.json
@@ -76,7 +76,7 @@
     "@azure/abort-controller": "^1.0.0",
     "@azure/communication-common": "^1.0.0",
     "@azure/core-auth": "^1.3.0",
-    "@azure/core-http": "^1.2.0",
+    "@azure/core-http": "^1.2.7",
     "@azure/core-tracing": "1.0.0-preview.12",
     "@azure/logger": "^1.0.0",
     "events": "^3.0.0",

--- a/sdk/communication/communication-phone-numbers/package.json
+++ b/sdk/communication/communication-phone-numbers/package.json
@@ -64,7 +64,7 @@
     "@azure/communication-common": "^1.0.0",
     "@azure/abort-controller": "^1.0.0",
     "@azure/core-auth": "^1.3.0",
-    "@azure/core-http": "^1.2.0",
+    "@azure/core-http": "^1.2.7",
     "@azure/core-lro": "^1.0.6",
     "@azure/core-paging": "^1.1.1",
     "@azure/core-tracing": "1.0.0-preview.12",

--- a/sdk/communication/communication-phone-numbers/package.json
+++ b/sdk/communication/communication-phone-numbers/package.json
@@ -65,7 +65,7 @@
     "@azure/abort-controller": "^1.0.0",
     "@azure/core-auth": "^1.3.0",
     "@azure/core-http": "^2.0.0",
-    "@azure/core-lro": "^1.0.6",
+    "@azure/core-lro": "^2.0.0",
     "@azure/core-paging": "^1.1.1",
     "@azure/core-tracing": "1.0.0-preview.12",
     "@azure/logger": "^1.0.0",

--- a/sdk/communication/communication-phone-numbers/package.json
+++ b/sdk/communication/communication-phone-numbers/package.json
@@ -64,7 +64,7 @@
     "@azure/communication-common": "^1.0.0",
     "@azure/abort-controller": "^1.0.0",
     "@azure/core-auth": "^1.3.0",
-    "@azure/core-http": "^1.2.7",
+    "@azure/core-http": "^2.0.0",
     "@azure/core-lro": "^1.0.6",
     "@azure/core-paging": "^1.1.1",
     "@azure/core-tracing": "1.0.0-preview.12",

--- a/sdk/communication/communication-sms/package.json
+++ b/sdk/communication/communication-sms/package.json
@@ -68,7 +68,7 @@
     "@azure/abort-controller": "^1.0.0",
     "@azure/communication-common": "^1.0.0",
     "@azure/core-auth": "^1.3.0",
-    "@azure/core-http": "^1.2.0",
+    "@azure/core-http": "^1.2.7",
     "@azure/core-tracing": "1.0.0-preview.12",
     "@azure/logger": "^1.0.0",
     "events": "^3.0.0",

--- a/sdk/communication/communication-sms/package.json
+++ b/sdk/communication/communication-sms/package.json
@@ -68,7 +68,7 @@
     "@azure/abort-controller": "^1.0.0",
     "@azure/communication-common": "^1.0.0",
     "@azure/core-auth": "^1.3.0",
-    "@azure/core-http": "^1.2.7",
+    "@azure/core-http": "^2.0.0",
     "@azure/core-tracing": "1.0.0-preview.12",
     "@azure/logger": "^1.0.0",
     "events": "^3.0.0",

--- a/sdk/core/core-http/CHANGELOG.md
+++ b/sdk/core/core-http/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.2.7 (Unreleased)
+## 2.0.0 (Unreleased)
 
 ### Features Added
 

--- a/sdk/core/core-http/package.json
+++ b/sdk/core/core-http/package.json
@@ -2,7 +2,7 @@
   "name": "@azure/core-http",
   "sdk-type": "client",
   "author": "Microsoft Corporation",
-  "version": "1.2.7",
+  "version": "2.0.0",
   "description": "Isomorphic client Runtime for Typescript/node.js/browser javascript client libraries generated using AutoRest",
   "tags": [
     "isomorphic",

--- a/sdk/core/core-http/src/util/constants.ts
+++ b/sdk/core/core-http/src/util/constants.ts
@@ -5,7 +5,7 @@ export const Constants = {
   /**
    * The core-http version
    */
-  coreHttpVersion: "1.2.7",
+  coreHttpVersion: "2.0.0",
 
   /**
    * Specifies HTTP.

--- a/sdk/core/core-lro/CHANGELOG.md
+++ b/sdk/core/core-lro/CHANGELOG.md
@@ -1,7 +1,6 @@
 # Release History
 
-## 1.0.6 (Unreleased)
-
+## 2.0.0 (Unreleased)
 
 ## 1.0.5 (2021-04-12)
 

--- a/sdk/core/core-lro/package.json
+++ b/sdk/core/core-lro/package.json
@@ -101,7 +101,7 @@
     "tslib": "^2.2.0"
   },
   "devDependencies": {
-    "@azure/core-http": "^1.2.0",
+    "@azure/core-http": "^1.2.7",
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
     "@azure/dev-tool": "^1.0.0",
     "@microsoft/api-extractor": "7.7.11",

--- a/sdk/core/core-lro/package.json
+++ b/sdk/core/core-lro/package.json
@@ -101,7 +101,7 @@
     "tslib": "^2.2.0"
   },
   "devDependencies": {
-    "@azure/core-http": "^1.2.7",
+    "@azure/core-http": "^2.0.0",
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
     "@azure/dev-tool": "^1.0.0",
     "@microsoft/api-extractor": "7.7.11",

--- a/sdk/core/core-lro/package.json
+++ b/sdk/core/core-lro/package.json
@@ -2,7 +2,7 @@
   "name": "@azure/core-lro",
   "author": "Microsoft Corporation",
   "sdk-type": "client",
-  "version": "1.0.6",
+  "version": "2.0.0",
   "description": "LRO Polling strategy for the Azure SDK in TypeScript",
   "tags": [
     "isomorphic",

--- a/sdk/deviceupdate/iot-device-update/package.json
+++ b/sdk/deviceupdate/iot-device-update/package.json
@@ -5,7 +5,7 @@
   "description": "Device Update for IoT Hub is an Azure service that enables customers to publish update for their IoT devices to the cloud, and then deploy that update to their devices (approve updates to groups of devices managed and provisioned in IoT Hub). It leverages the proven security and reliability of the Windows Update platform, optimized for IoT devices. It works globally and knows when and how to update devices, enabling customers to focus on their business goals and let Device Update for IoT Hub handle the updates.",
   "version": "1.0.0-beta.2",
   "dependencies": {
-    "@azure/core-http": "^1.2.0",
+    "@azure/core-http": "^1.2.7",
     "@azure/core-paging": "^1.1.1",
     "@azure/core-tracing": "1.0.0-preview.12",
     "tslib": "^2.2.0"

--- a/sdk/deviceupdate/iot-device-update/package.json
+++ b/sdk/deviceupdate/iot-device-update/package.json
@@ -5,7 +5,7 @@
   "description": "Device Update for IoT Hub is an Azure service that enables customers to publish update for their IoT devices to the cloud, and then deploy that update to their devices (approve updates to groups of devices managed and provisioned in IoT Hub). It leverages the proven security and reliability of the Windows Update platform, optimized for IoT devices. It works globally and knows when and how to update devices, enabling customers to focus on their business goals and let Device Update for IoT Hub handle the updates.",
   "version": "1.0.0-beta.2",
   "dependencies": {
-    "@azure/core-http": "^1.2.7",
+    "@azure/core-http": "^2.0.0",
     "@azure/core-paging": "^1.1.1",
     "@azure/core-tracing": "1.0.0-preview.12",
     "tslib": "^2.2.0"

--- a/sdk/digitaltwins/digital-twins-core/package.json
+++ b/sdk/digitaltwins/digital-twins-core/package.json
@@ -66,7 +66,7 @@
     "url": "https://github.com/Azure/azure-sdk-for-js/issues"
   },
   "dependencies": {
-    "@azure/core-http": "^1.2.0",
+    "@azure/core-http": "^1.2.7",
     "@azure/core-paging": "^1.1.1",
     "@azure/core-tracing": "1.0.0-preview.12",
     "@azure/logger": "^1.0.0",

--- a/sdk/digitaltwins/digital-twins-core/package.json
+++ b/sdk/digitaltwins/digital-twins-core/package.json
@@ -66,7 +66,7 @@
     "url": "https://github.com/Azure/azure-sdk-for-js/issues"
   },
   "dependencies": {
-    "@azure/core-http": "^1.2.7",
+    "@azure/core-http": "^2.0.0",
     "@azure/core-paging": "^1.1.1",
     "@azure/core-tracing": "1.0.0-preview.12",
     "@azure/logger": "^1.0.0",

--- a/sdk/formrecognizer/ai-form-recognizer/package.json
+++ b/sdk/formrecognizer/ai-form-recognizer/package.json
@@ -81,7 +81,7 @@
     "@azure/core-auth": "^1.3.0",
     "@azure/core-lro": "^1.0.6",
     "@azure/core-paging": "^1.1.1",
-    "@azure/core-http": "^1.2.7",
+    "@azure/core-http": "^2.0.0",
     "@azure/core-tracing": "1.0.0-preview.12",
     "@azure/logger": "^1.0.0",
     "tslib": "^2.2.0"

--- a/sdk/formrecognizer/ai-form-recognizer/package.json
+++ b/sdk/formrecognizer/ai-form-recognizer/package.json
@@ -79,7 +79,7 @@
   "prettier": "@azure/eslint-plugin-azure-sdk/prettier.json",
   "dependencies": {
     "@azure/core-auth": "^1.3.0",
-    "@azure/core-lro": "^1.0.6",
+    "@azure/core-lro": "^2.0.0",
     "@azure/core-paging": "^1.1.1",
     "@azure/core-http": "^2.0.0",
     "@azure/core-tracing": "1.0.0-preview.12",

--- a/sdk/formrecognizer/ai-form-recognizer/package.json
+++ b/sdk/formrecognizer/ai-form-recognizer/package.json
@@ -81,7 +81,7 @@
     "@azure/core-auth": "^1.3.0",
     "@azure/core-lro": "^1.0.6",
     "@azure/core-paging": "^1.1.1",
-    "@azure/core-http": "^1.2.0",
+    "@azure/core-http": "^1.2.7",
     "@azure/core-tracing": "1.0.0-preview.12",
     "@azure/logger": "^1.0.0",
     "tslib": "^2.2.0"

--- a/sdk/identity/identity/package.json
+++ b/sdk/identity/identity/package.json
@@ -80,7 +80,7 @@
   "sideEffects": false,
   "dependencies": {
     "@azure/core-auth": "^1.3.0",
-    "@azure/core-http": "^1.2.7",
+    "@azure/core-http": "^2.0.0",
     "@azure/core-tracing": "1.0.0-preview.12",
     "@azure/logger": "^1.0.0",
     "@azure/abort-controller": "^1.0.0",

--- a/sdk/identity/identity/package.json
+++ b/sdk/identity/identity/package.json
@@ -80,7 +80,7 @@
   "sideEffects": false,
   "dependencies": {
     "@azure/core-auth": "^1.3.0",
-    "@azure/core-http": "^1.2.0",
+    "@azure/core-http": "^1.2.7",
     "@azure/core-tracing": "1.0.0-preview.12",
     "@azure/logger": "^1.0.0",
     "@azure/abort-controller": "^1.0.0",

--- a/sdk/keyvault/keyvault-admin/package.json
+++ b/sdk/keyvault/keyvault-admin/package.json
@@ -106,7 +106,7 @@
     "@azure/abort-controller": "^1.0.0",
     "@azure/core-auth": "^1.3.0",
     "@azure/core-client": "^1.0.0",
-    "@azure/core-http": "^1.2.7",
+    "@azure/core-http": "^2.0.0",
     "@azure/core-lro": "^1.0.6",
     "@azure/core-paging": "^1.1.1",
     "@azure/core-rest-pipeline": "^1.1.0",

--- a/sdk/keyvault/keyvault-admin/package.json
+++ b/sdk/keyvault/keyvault-admin/package.json
@@ -107,7 +107,7 @@
     "@azure/core-auth": "^1.3.0",
     "@azure/core-client": "^1.0.0",
     "@azure/core-http": "^2.0.0",
-    "@azure/core-lro": "^1.0.6",
+    "@azure/core-lro": "^2.0.0",
     "@azure/core-paging": "^1.1.1",
     "@azure/core-rest-pipeline": "^1.1.0",
     "@azure/core-tracing": "1.0.0-preview.12",

--- a/sdk/keyvault/keyvault-admin/package.json
+++ b/sdk/keyvault/keyvault-admin/package.json
@@ -106,7 +106,7 @@
     "@azure/abort-controller": "^1.0.0",
     "@azure/core-auth": "^1.3.0",
     "@azure/core-client": "^1.0.0",
-    "@azure/core-http": "^1.2.0",
+    "@azure/core-http": "^1.2.7",
     "@azure/core-lro": "^1.0.6",
     "@azure/core-paging": "^1.1.1",
     "@azure/core-rest-pipeline": "^1.1.0",

--- a/sdk/keyvault/keyvault-certificates/package.json
+++ b/sdk/keyvault/keyvault-certificates/package.json
@@ -108,7 +108,7 @@
   },
   "dependencies": {
     "@azure/abort-controller": "^1.0.0",
-    "@azure/core-http": "^1.2.0",
+    "@azure/core-http": "^1.2.7",
     "@azure/core-lro": "^1.0.6",
     "@azure/core-paging": "^1.1.1",
     "@azure/core-tracing": "1.0.0-preview.12",

--- a/sdk/keyvault/keyvault-certificates/package.json
+++ b/sdk/keyvault/keyvault-certificates/package.json
@@ -108,7 +108,7 @@
   },
   "dependencies": {
     "@azure/abort-controller": "^1.0.0",
-    "@azure/core-http": "^1.2.7",
+    "@azure/core-http": "^2.0.0",
     "@azure/core-lro": "^1.0.6",
     "@azure/core-paging": "^1.1.1",
     "@azure/core-tracing": "1.0.0-preview.12",

--- a/sdk/keyvault/keyvault-certificates/package.json
+++ b/sdk/keyvault/keyvault-certificates/package.json
@@ -109,7 +109,7 @@
   "dependencies": {
     "@azure/abort-controller": "^1.0.0",
     "@azure/core-http": "^2.0.0",
-    "@azure/core-lro": "^1.0.6",
+    "@azure/core-lro": "^2.0.0",
     "@azure/core-paging": "^1.1.1",
     "@azure/core-tracing": "1.0.0-preview.12",
     "@azure/logger": "^1.0.0",

--- a/sdk/keyvault/keyvault-common/package.json
+++ b/sdk/keyvault/keyvault-common/package.json
@@ -57,7 +57,7 @@
     "docs": "echo Skipped."
   },
   "dependencies": {
-    "@azure/core-http": "^1.2.7",
+    "@azure/core-http": "^2.0.0",
     "@azure/core-tracing": "1.0.0-preview.12",
     "tslib": "^2.2.0"
   },

--- a/sdk/keyvault/keyvault-common/package.json
+++ b/sdk/keyvault/keyvault-common/package.json
@@ -57,7 +57,7 @@
     "docs": "echo Skipped."
   },
   "dependencies": {
-    "@azure/core-http": "^1.2.0",
+    "@azure/core-http": "^1.2.7",
     "@azure/core-tracing": "1.0.0-preview.12",
     "tslib": "^2.2.0"
   },

--- a/sdk/keyvault/keyvault-keys/package.json
+++ b/sdk/keyvault/keyvault-keys/package.json
@@ -104,7 +104,7 @@
   },
   "dependencies": {
     "@azure/abort-controller": "^1.0.0",
-    "@azure/core-http": "^1.2.7",
+    "@azure/core-http": "^2.0.0",
     "@azure/core-lro": "^1.0.6",
     "@azure/core-paging": "^1.1.1",
     "@azure/core-tracing": "1.0.0-preview.12",

--- a/sdk/keyvault/keyvault-keys/package.json
+++ b/sdk/keyvault/keyvault-keys/package.json
@@ -105,7 +105,7 @@
   "dependencies": {
     "@azure/abort-controller": "^1.0.0",
     "@azure/core-http": "^2.0.0",
-    "@azure/core-lro": "^1.0.6",
+    "@azure/core-lro": "^2.0.0",
     "@azure/core-paging": "^1.1.1",
     "@azure/core-tracing": "1.0.0-preview.12",
     "@azure/logger": "^1.0.0",

--- a/sdk/keyvault/keyvault-keys/package.json
+++ b/sdk/keyvault/keyvault-keys/package.json
@@ -104,7 +104,7 @@
   },
   "dependencies": {
     "@azure/abort-controller": "^1.0.0",
-    "@azure/core-http": "^1.2.0",
+    "@azure/core-http": "^1.2.7",
     "@azure/core-lro": "^1.0.6",
     "@azure/core-paging": "^1.1.1",
     "@azure/core-tracing": "1.0.0-preview.12",

--- a/sdk/keyvault/keyvault-secrets/package.json
+++ b/sdk/keyvault/keyvault-secrets/package.json
@@ -104,7 +104,7 @@
   },
   "dependencies": {
     "@azure/abort-controller": "^1.0.0",
-    "@azure/core-http": "^1.2.7",
+    "@azure/core-http": "^2.0.0",
     "@azure/core-lro": "^1.0.6",
     "@azure/core-paging": "^1.1.1",
     "@azure/core-tracing": "1.0.0-preview.12",

--- a/sdk/keyvault/keyvault-secrets/package.json
+++ b/sdk/keyvault/keyvault-secrets/package.json
@@ -105,7 +105,7 @@
   "dependencies": {
     "@azure/abort-controller": "^1.0.0",
     "@azure/core-http": "^2.0.0",
-    "@azure/core-lro": "^1.0.6",
+    "@azure/core-lro": "^2.0.0",
     "@azure/core-paging": "^1.1.1",
     "@azure/core-tracing": "1.0.0-preview.12",
     "@azure/logger": "^1.0.0",

--- a/sdk/keyvault/keyvault-secrets/package.json
+++ b/sdk/keyvault/keyvault-secrets/package.json
@@ -104,7 +104,7 @@
   },
   "dependencies": {
     "@azure/abort-controller": "^1.0.0",
-    "@azure/core-http": "^1.2.0",
+    "@azure/core-http": "^1.2.7",
     "@azure/core-lro": "^1.0.6",
     "@azure/core-paging": "^1.1.1",
     "@azure/core-tracing": "1.0.0-preview.12",

--- a/sdk/metricsadvisor/ai-metrics-advisor/package.json
+++ b/sdk/metricsadvisor/ai-metrics-advisor/package.json
@@ -82,7 +82,7 @@
   "prettier": "@azure/eslint-plugin-azure-sdk/prettier.json",
   "dependencies": {
     "@azure/core-auth": "^1.3.0",
-    "@azure/core-lro": "^1.0.6",
+    "@azure/core-lro": "^2.0.0",
     "@azure/core-paging": "^1.1.1",
     "@azure/core-http": "^2.0.0",
     "@azure/core-tracing": "1.0.0-preview.12",

--- a/sdk/metricsadvisor/ai-metrics-advisor/package.json
+++ b/sdk/metricsadvisor/ai-metrics-advisor/package.json
@@ -84,7 +84,7 @@
     "@azure/core-auth": "^1.3.0",
     "@azure/core-lro": "^1.0.6",
     "@azure/core-paging": "^1.1.1",
-    "@azure/core-http": "^1.2.0",
+    "@azure/core-http": "^1.2.7",
     "@azure/core-tracing": "1.0.0-preview.12",
     "@azure/logger": "^1.0.0",
     "tslib": "^2.2.0"

--- a/sdk/metricsadvisor/ai-metrics-advisor/package.json
+++ b/sdk/metricsadvisor/ai-metrics-advisor/package.json
@@ -84,7 +84,7 @@
     "@azure/core-auth": "^1.3.0",
     "@azure/core-lro": "^1.0.6",
     "@azure/core-paging": "^1.1.1",
-    "@azure/core-http": "^1.2.7",
+    "@azure/core-http": "^2.0.0",
     "@azure/core-tracing": "1.0.0-preview.12",
     "@azure/logger": "^1.0.0",
     "tslib": "^2.2.0"

--- a/sdk/mixedreality/mixedreality-authentication/package.json
+++ b/sdk/mixedreality/mixedreality-authentication/package.json
@@ -68,7 +68,7 @@
   "prettier": "@azure/eslint-plugin-azure-sdk/prettier.json",
   "dependencies": {
     "@azure/core-auth": "^1.3.0",
-    "@azure/core-http": "^1.2.7",
+    "@azure/core-http": "^2.0.0",
     "@azure/core-tracing": "1.0.0-preview.12",
     "@azure/logger": "^1.0.0",
     "tslib": "^2.2.0"

--- a/sdk/mixedreality/mixedreality-authentication/package.json
+++ b/sdk/mixedreality/mixedreality-authentication/package.json
@@ -68,7 +68,7 @@
   "prettier": "@azure/eslint-plugin-azure-sdk/prettier.json",
   "dependencies": {
     "@azure/core-auth": "^1.3.0",
-    "@azure/core-http": "^1.2.0",
+    "@azure/core-http": "^1.2.7",
     "@azure/core-tracing": "1.0.0-preview.12",
     "@azure/logger": "^1.0.0",
     "tslib": "^2.2.0"

--- a/sdk/monitor/monitor-opentelemetry-exporter/package.json
+++ b/sdk/monitor/monitor-opentelemetry-exporter/package.json
@@ -94,7 +94,7 @@
     "typedoc": "0.15.2"
   },
   "dependencies": {
-    "@azure/core-http": "^1.2.7",
+    "@azure/core-http": "^2.0.0",
     "@opentelemetry/api": "^1.0.0",
     "@opentelemetry/core": "^0.22.0",
     "@opentelemetry/resources": "^0.22.0",

--- a/sdk/monitor/monitor-opentelemetry-exporter/package.json
+++ b/sdk/monitor/monitor-opentelemetry-exporter/package.json
@@ -94,7 +94,7 @@
     "typedoc": "0.15.2"
   },
   "dependencies": {
-    "@azure/core-http": "^1.2.0",
+    "@azure/core-http": "^1.2.7",
     "@opentelemetry/api": "^1.0.0",
     "@opentelemetry/core": "^0.22.0",
     "@opentelemetry/resources": "^0.22.0",

--- a/sdk/monitor/monitor-query/package.json
+++ b/sdk/monitor/monitor-query/package.json
@@ -99,7 +99,7 @@
   "prettier": "@azure/eslint-plugin-azure-sdk/prettier.json",
   "dependencies": {
     "@azure/core-auth": "^1.3.0",
-    "@azure/core-http": "^1.2.7",
+    "@azure/core-http": "^2.0.0",
     "@azure/core-tracing": "1.0.0-preview.12",
     "@azure/logger": "^1.0.0",
     "tslib": "^2.2.0"

--- a/sdk/monitor/monitor-query/package.json
+++ b/sdk/monitor/monitor-query/package.json
@@ -99,7 +99,7 @@
   "prettier": "@azure/eslint-plugin-azure-sdk/prettier.json",
   "dependencies": {
     "@azure/core-auth": "^1.3.0",
-    "@azure/core-http": "^1.2.0",
+    "@azure/core-http": "^1.2.7",
     "@azure/core-tracing": "1.0.0-preview.12",
     "@azure/logger": "^1.0.0",
     "tslib": "^2.2.0"

--- a/sdk/quantum/quantum-jobs/package.json
+++ b/sdk/quantum/quantum-jobs/package.json
@@ -65,7 +65,7 @@
   },
   "dependencies": {
     "@azure/core-paging": "^1.1.1",
-    "@azure/core-http": "^1.2.0",
+    "@azure/core-http": "^1.2.7",
     "@azure/core-tracing": "1.0.0-preview.12",
     "tslib": "^2.2.0"
   },

--- a/sdk/quantum/quantum-jobs/package.json
+++ b/sdk/quantum/quantum-jobs/package.json
@@ -65,7 +65,7 @@
   },
   "dependencies": {
     "@azure/core-paging": "^1.1.1",
-    "@azure/core-http": "^1.2.7",
+    "@azure/core-http": "^2.0.0",
     "@azure/core-tracing": "1.0.0-preview.12",
     "tslib": "^2.2.0"
   },

--- a/sdk/schemaregistry/schema-registry-avro/package.json
+++ b/sdk/schemaregistry/schema-registry-avro/package.json
@@ -71,7 +71,7 @@
   },
   "dependencies": {
     "@azure/schema-registry": "1.0.0-beta.2",
-    "@azure/core-http": "^1.2.7",
+    "@azure/core-http": "^2.0.0",
     "@azure/core-tracing": "1.0.0-preview.12",
     "@azure/logger": "^1.0.0",
     "avsc": "^5.5.1",

--- a/sdk/schemaregistry/schema-registry-avro/package.json
+++ b/sdk/schemaregistry/schema-registry-avro/package.json
@@ -71,7 +71,7 @@
   },
   "dependencies": {
     "@azure/schema-registry": "1.0.0-beta.2",
-    "@azure/core-http": "^1.2.0",
+    "@azure/core-http": "^1.2.7",
     "@azure/core-tracing": "1.0.0-preview.12",
     "@azure/logger": "^1.0.0",
     "avsc": "^5.5.1",

--- a/sdk/schemaregistry/schema-registry/package.json
+++ b/sdk/schemaregistry/schema-registry/package.json
@@ -86,7 +86,7 @@
   "sideEffects": false,
   "prettier": "@azure/eslint-plugin-azure-sdk/prettier.json",
   "dependencies": {
-    "@azure/core-http": "^1.2.0",
+    "@azure/core-http": "^1.2.7",
     "@azure/core-tracing": "1.0.0-preview.12",
     "@azure/logger": "^1.0.0",
     "tslib": "^2.2.0"

--- a/sdk/schemaregistry/schema-registry/package.json
+++ b/sdk/schemaregistry/schema-registry/package.json
@@ -86,7 +86,7 @@
   "sideEffects": false,
   "prettier": "@azure/eslint-plugin-azure-sdk/prettier.json",
   "dependencies": {
-    "@azure/core-http": "^1.2.7",
+    "@azure/core-http": "^2.0.0",
     "@azure/core-tracing": "1.0.0-preview.12",
     "@azure/logger": "^1.0.0",
     "tslib": "^2.2.0"

--- a/sdk/search/search-documents/package.json
+++ b/sdk/search/search-documents/package.json
@@ -76,7 +76,7 @@
   "sideEffects": false,
   "dependencies": {
     "@azure/core-auth": "^1.3.0",
-    "@azure/core-http": "^1.2.0",
+    "@azure/core-http": "^1.2.7",
     "@azure/core-paging": "^1.1.1",
     "@azure/core-tracing": "1.0.0-preview.12",
     "@azure/logger": "^1.0.0",

--- a/sdk/search/search-documents/package.json
+++ b/sdk/search/search-documents/package.json
@@ -76,7 +76,7 @@
   "sideEffects": false,
   "dependencies": {
     "@azure/core-auth": "^1.3.0",
-    "@azure/core-http": "^1.2.7",
+    "@azure/core-http": "^2.0.0",
     "@azure/core-paging": "^1.1.1",
     "@azure/core-tracing": "1.0.0-preview.12",
     "@azure/logger": "^1.0.0",

--- a/sdk/servicebus/service-bus/package.json
+++ b/sdk/servicebus/service-bus/package.json
@@ -113,7 +113,7 @@
     "@azure/abort-controller": "^1.0.0",
     "@azure/core-amqp": "^3.0.0",
     "@azure/core-asynciterator-polyfill": "^1.0.0",
-    "@azure/core-http": "^1.2.0",
+    "@azure/core-http": "^1.2.7",
     "@azure/core-tracing": "1.0.0-preview.12",
     "@azure/core-paging": "^1.1.1",
     "@azure/core-auth": "^1.3.0",

--- a/sdk/servicebus/service-bus/package.json
+++ b/sdk/servicebus/service-bus/package.json
@@ -113,7 +113,7 @@
     "@azure/abort-controller": "^1.0.0",
     "@azure/core-amqp": "^3.0.0",
     "@azure/core-asynciterator-polyfill": "^1.0.0",
-    "@azure/core-http": "^1.2.7",
+    "@azure/core-http": "^2.0.0",
     "@azure/core-tracing": "1.0.0-preview.12",
     "@azure/core-paging": "^1.1.1",
     "@azure/core-auth": "^1.3.0",

--- a/sdk/storage/perf-tests/storage-blob/package.json
+++ b/sdk/storage/perf-tests/storage-blob/package.json
@@ -7,7 +7,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@azure/core-http": "^1.2.7",
+    "@azure/core-http": "^2.0.0",
     "@azure/core-rest-pipeline": "^1.1.0",
     "@azure/storage-blob": "^12.6.0-beta.1",
     "@azure/test-utils-perfstress": "^1.0.0",

--- a/sdk/storage/perf-tests/storage-blob/package.json
+++ b/sdk/storage/perf-tests/storage-blob/package.json
@@ -7,7 +7,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@azure/core-http": "^1.2.0",
+    "@azure/core-http": "^1.2.7",
     "@azure/core-rest-pipeline": "^1.1.0",
     "@azure/storage-blob": "^12.6.0-beta.1",
     "@azure/test-utils-perfstress": "^1.0.0",

--- a/sdk/storage/storage-blob-changefeed/package.json
+++ b/sdk/storage/storage-blob-changefeed/package.json
@@ -97,7 +97,7 @@
     "@azure/storage-blob": "^12.6.0-beta.1",
     "@azure/abort-controller": "^1.0.0",
     "@azure/core-http": "^2.0.0",
-    "@azure/core-lro": "^1.0.6",
+    "@azure/core-lro": "^2.0.0",
     "@azure/core-paging": "^1.1.1",
     "@azure/core-tracing": "1.0.0-preview.12",
     "@azure/logger": "^1.0.0",

--- a/sdk/storage/storage-blob-changefeed/package.json
+++ b/sdk/storage/storage-blob-changefeed/package.json
@@ -96,7 +96,7 @@
   "dependencies": {
     "@azure/storage-blob": "^12.6.0-beta.1",
     "@azure/abort-controller": "^1.0.0",
-    "@azure/core-http": "^1.2.7",
+    "@azure/core-http": "^2.0.0",
     "@azure/core-lro": "^1.0.6",
     "@azure/core-paging": "^1.1.1",
     "@azure/core-tracing": "1.0.0-preview.12",

--- a/sdk/storage/storage-blob-changefeed/package.json
+++ b/sdk/storage/storage-blob-changefeed/package.json
@@ -96,7 +96,7 @@
   "dependencies": {
     "@azure/storage-blob": "^12.6.0-beta.1",
     "@azure/abort-controller": "^1.0.0",
-    "@azure/core-http": "^1.2.0",
+    "@azure/core-http": "^1.2.7",
     "@azure/core-lro": "^1.0.6",
     "@azure/core-paging": "^1.1.1",
     "@azure/core-tracing": "1.0.0-preview.12",

--- a/sdk/storage/storage-blob/package.json
+++ b/sdk/storage/storage-blob/package.json
@@ -127,7 +127,7 @@
   },
   "dependencies": {
     "@azure/abort-controller": "^1.0.0",
-    "@azure/core-http": "^1.2.7",
+    "@azure/core-http": "^2.0.0",
     "@azure/core-lro": "^1.0.6",
     "@azure/core-paging": "^1.1.1",
     "@azure/core-tracing": "1.0.0-preview.12",

--- a/sdk/storage/storage-blob/package.json
+++ b/sdk/storage/storage-blob/package.json
@@ -128,7 +128,7 @@
   "dependencies": {
     "@azure/abort-controller": "^1.0.0",
     "@azure/core-http": "^2.0.0",
-    "@azure/core-lro": "^1.0.6",
+    "@azure/core-lro": "^2.0.0",
     "@azure/core-paging": "^1.1.1",
     "@azure/core-tracing": "1.0.0-preview.12",
     "@azure/logger": "^1.0.0",

--- a/sdk/storage/storage-blob/package.json
+++ b/sdk/storage/storage-blob/package.json
@@ -127,7 +127,7 @@
   },
   "dependencies": {
     "@azure/abort-controller": "^1.0.0",
-    "@azure/core-http": "^1.2.0",
+    "@azure/core-http": "^1.2.7",
     "@azure/core-lro": "^1.0.6",
     "@azure/core-paging": "^1.1.1",
     "@azure/core-tracing": "1.0.0-preview.12",

--- a/sdk/storage/storage-file-datalake/package.json
+++ b/sdk/storage/storage-file-datalake/package.json
@@ -107,7 +107,7 @@
   },
   "dependencies": {
     "@azure/abort-controller": "^1.0.0",
-    "@azure/core-http": "^1.2.0",
+    "@azure/core-http": "^1.2.7",
     "@azure/core-paging": "^1.1.1",
     "@azure/core-tracing": "1.0.0-preview.12",
     "@azure/logger": "^1.0.0",

--- a/sdk/storage/storage-file-datalake/package.json
+++ b/sdk/storage/storage-file-datalake/package.json
@@ -107,7 +107,7 @@
   },
   "dependencies": {
     "@azure/abort-controller": "^1.0.0",
-    "@azure/core-http": "^1.2.7",
+    "@azure/core-http": "^2.0.0",
     "@azure/core-paging": "^1.1.1",
     "@azure/core-tracing": "1.0.0-preview.12",
     "@azure/logger": "^1.0.0",

--- a/sdk/storage/storage-file-share/package.json
+++ b/sdk/storage/storage-file-share/package.json
@@ -115,7 +115,7 @@
   },
   "dependencies": {
     "@azure/abort-controller": "^1.0.0",
-    "@azure/core-http": "^1.2.7",
+    "@azure/core-http": "^2.0.0",
     "@azure/core-paging": "^1.1.1",
     "@azure/core-tracing": "1.0.0-preview.12",
     "@azure/logger": "^1.0.0",

--- a/sdk/storage/storage-file-share/package.json
+++ b/sdk/storage/storage-file-share/package.json
@@ -115,7 +115,7 @@
   },
   "dependencies": {
     "@azure/abort-controller": "^1.0.0",
-    "@azure/core-http": "^1.2.0",
+    "@azure/core-http": "^1.2.7",
     "@azure/core-paging": "^1.1.1",
     "@azure/core-tracing": "1.0.0-preview.12",
     "@azure/logger": "^1.0.0",

--- a/sdk/storage/storage-queue/package.json
+++ b/sdk/storage/storage-queue/package.json
@@ -110,7 +110,7 @@
   },
   "dependencies": {
     "@azure/abort-controller": "^1.0.0",
-    "@azure/core-http": "^1.2.0",
+    "@azure/core-http": "^1.2.7",
     "@azure/core-paging": "^1.1.1",
     "@azure/core-tracing": "1.0.0-preview.12",
     "@azure/logger": "^1.0.0",

--- a/sdk/storage/storage-queue/package.json
+++ b/sdk/storage/storage-queue/package.json
@@ -110,7 +110,7 @@
   },
   "dependencies": {
     "@azure/abort-controller": "^1.0.0",
-    "@azure/core-http": "^1.2.7",
+    "@azure/core-http": "^2.0.0",
     "@azure/core-paging": "^1.1.1",
     "@azure/core-tracing": "1.0.0-preview.12",
     "@azure/logger": "^1.0.0",

--- a/sdk/synapse/synapse-access-control/package.json
+++ b/sdk/synapse/synapse-access-control/package.json
@@ -8,7 +8,7 @@
   "version": "1.0.0-beta.3",
   "dependencies": {
     "@azure/core-paging": "^1.1.1",
-    "@azure/core-http": "^1.2.7",
+    "@azure/core-http": "^2.0.0",
     "@azure/core-tracing": "1.0.0-preview.12",
     "tslib": "^2.2.0"
   },

--- a/sdk/synapse/synapse-access-control/package.json
+++ b/sdk/synapse/synapse-access-control/package.json
@@ -8,7 +8,7 @@
   "version": "1.0.0-beta.3",
   "dependencies": {
     "@azure/core-paging": "^1.1.1",
-    "@azure/core-http": "^1.2.0",
+    "@azure/core-http": "^1.2.7",
     "@azure/core-tracing": "1.0.0-preview.12",
     "tslib": "^2.2.0"
   },

--- a/sdk/synapse/synapse-artifacts/package.json
+++ b/sdk/synapse/synapse-artifacts/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "@azure/core-lro": "^1.0.6",
     "@azure/core-paging": "^1.1.1",
-    "@azure/core-http": "^1.2.7",
+    "@azure/core-http": "^2.0.0",
     "@azure/core-tracing": "1.0.0-preview.12",
     "tslib": "^2.2.0"
   },

--- a/sdk/synapse/synapse-artifacts/package.json
+++ b/sdk/synapse/synapse-artifacts/package.json
@@ -7,7 +7,7 @@
   "homepage": "https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/synapse/synapse-artifacts/README.md",
   "repository": "github:Azure/azure-sdk-for-js",
   "dependencies": {
-    "@azure/core-lro": "^1.0.6",
+    "@azure/core-lro": "^2.0.0",
     "@azure/core-paging": "^1.1.1",
     "@azure/core-http": "^2.0.0",
     "@azure/core-tracing": "1.0.0-preview.12",

--- a/sdk/synapse/synapse-artifacts/package.json
+++ b/sdk/synapse/synapse-artifacts/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "@azure/core-lro": "^1.0.6",
     "@azure/core-paging": "^1.1.1",
-    "@azure/core-http": "^1.2.0",
+    "@azure/core-http": "^1.2.7",
     "@azure/core-tracing": "1.0.0-preview.12",
     "tslib": "^2.2.0"
   },

--- a/sdk/synapse/synapse-managed-private-endpoints/package.json
+++ b/sdk/synapse/synapse-managed-private-endpoints/package.json
@@ -8,7 +8,7 @@
   "version": "1.0.0-beta.3",
   "dependencies": {
     "@azure/core-paging": "^1.1.1",
-    "@azure/core-http": "^1.2.7",
+    "@azure/core-http": "^2.0.0",
     "@azure/core-tracing": "1.0.0-preview.12",
     "tslib": "^2.2.0"
   },

--- a/sdk/synapse/synapse-managed-private-endpoints/package.json
+++ b/sdk/synapse/synapse-managed-private-endpoints/package.json
@@ -8,7 +8,7 @@
   "version": "1.0.0-beta.3",
   "dependencies": {
     "@azure/core-paging": "^1.1.1",
-    "@azure/core-http": "^1.2.0",
+    "@azure/core-http": "^1.2.7",
     "@azure/core-tracing": "1.0.0-preview.12",
     "tslib": "^2.2.0"
   },

--- a/sdk/synapse/synapse-monitoring/package.json
+++ b/sdk/synapse/synapse-monitoring/package.json
@@ -7,7 +7,7 @@
   "sdk-type": "client",
   "version": "1.0.0-beta.3",
   "dependencies": {
-    "@azure/core-http": "^1.2.7",
+    "@azure/core-http": "^2.0.0",
     "@azure/core-tracing": "1.0.0-preview.12",
     "tslib": "^2.2.0"
   },

--- a/sdk/synapse/synapse-monitoring/package.json
+++ b/sdk/synapse/synapse-monitoring/package.json
@@ -7,7 +7,7 @@
   "sdk-type": "client",
   "version": "1.0.0-beta.3",
   "dependencies": {
-    "@azure/core-http": "^1.2.0",
+    "@azure/core-http": "^1.2.7",
     "@azure/core-tracing": "1.0.0-preview.12",
     "tslib": "^2.2.0"
   },

--- a/sdk/synapse/synapse-spark/package.json
+++ b/sdk/synapse/synapse-spark/package.json
@@ -7,7 +7,7 @@
   "sdk-type": "client",
   "version": "1.0.0-beta.3",
   "dependencies": {
-    "@azure/core-http": "^1.2.7",
+    "@azure/core-http": "^2.0.0",
     "@azure/core-tracing": "1.0.0-preview.12",
     "tslib": "^2.2.0"
   },

--- a/sdk/synapse/synapse-spark/package.json
+++ b/sdk/synapse/synapse-spark/package.json
@@ -7,7 +7,7 @@
   "sdk-type": "client",
   "version": "1.0.0-beta.3",
   "dependencies": {
-    "@azure/core-http": "^1.2.0",
+    "@azure/core-http": "^1.2.7",
     "@azure/core-tracing": "1.0.0-preview.12",
     "tslib": "^2.2.0"
   },

--- a/sdk/template/template/package.json
+++ b/sdk/template/template/package.json
@@ -82,7 +82,7 @@
   "prettier": "@azure/eslint-plugin-azure-sdk/prettier.json",
   "dependencies": {
     "@azure/core-auth": "^1.3.0",
-    "@azure/core-http": "^1.2.0",
+    "@azure/core-http": "^1.2.7",
     "@azure/core-tracing": "1.0.0-preview.12",
     "@azure/logger": "^1.0.0",
     "tslib": "^2.2.0"

--- a/sdk/template/template/package.json
+++ b/sdk/template/template/package.json
@@ -82,7 +82,7 @@
   "prettier": "@azure/eslint-plugin-azure-sdk/prettier.json",
   "dependencies": {
     "@azure/core-auth": "^1.3.0",
-    "@azure/core-http": "^1.2.7",
+    "@azure/core-http": "^2.0.0",
     "@azure/core-tracing": "1.0.0-preview.12",
     "@azure/logger": "^1.0.0",
     "tslib": "^2.2.0"

--- a/sdk/test-utils/recorder/package.json
+++ b/sdk/test-utils/recorder/package.json
@@ -63,7 +63,7 @@
   "sideEffects": false,
   "private": true,
   "dependencies": {
-    "@azure/core-http": "^1.2.0",
+    "@azure/core-http": "^1.2.7",
     "@azure/core-tracing": "1.0.0-preview.12",
     "fs-extra": "^8.1.0",
     "nise": "^4.0.3",

--- a/sdk/test-utils/recorder/package.json
+++ b/sdk/test-utils/recorder/package.json
@@ -63,7 +63,7 @@
   "sideEffects": false,
   "private": true,
   "dependencies": {
-    "@azure/core-http": "^1.2.7",
+    "@azure/core-http": "^2.0.0",
     "@azure/core-tracing": "1.0.0-preview.12",
     "fs-extra": "^8.1.0",
     "nise": "^4.0.3",

--- a/sdk/textanalytics/ai-text-analytics/package.json
+++ b/sdk/textanalytics/ai-text-analytics/package.json
@@ -94,7 +94,7 @@
     "@azure/core-auth": "^1.3.0",
     "@azure/core-client": "^1.0.0",
     "@azure/core-rest-pipeline": "^1.1.0",
-    "@azure/core-lro": "^1.0.6",
+    "@azure/core-lro": "^2.0.0",
     "@azure/core-paging": "^1.1.1",
     "@azure/core-tracing": "1.0.0-preview.12",
     "@azure/logger": "^1.0.0",

--- a/sdk/videoanalyzer/video-analyzer-edge/package.json
+++ b/sdk/videoanalyzer/video-analyzer-edge/package.json
@@ -60,7 +60,7 @@
   "prettier": "@azure/eslint-plugin-azure-sdk/prettier.json",
   "dependencies": {
     "@azure/core-auth": "^1.3.0",
-    "@azure/core-http": "^1.2.0",
+    "@azure/core-http": "^1.2.7",
     "@azure/core-tracing": "1.0.0-preview.12",
     "@azure/logger": "^1.0.0",
     "events": "^3.0.0",

--- a/sdk/videoanalyzer/video-analyzer-edge/package.json
+++ b/sdk/videoanalyzer/video-analyzer-edge/package.json
@@ -60,7 +60,7 @@
   "prettier": "@azure/eslint-plugin-azure-sdk/prettier.json",
   "dependencies": {
     "@azure/core-auth": "^1.3.0",
-    "@azure/core-http": "^1.2.7",
+    "@azure/core-http": "^2.0.0",
     "@azure/core-tracing": "1.0.0-preview.12",
     "@azure/logger": "^1.0.0",
     "events": "^3.0.0",

--- a/sdk/web-pubsub/web-pubsub-express/package.json
+++ b/sdk/web-pubsub/web-pubsub-express/package.json
@@ -58,7 +58,7 @@
   "sideEffects": false,
   "dependencies": {
     "@azure/core-auth": "^1.3.0",
-    "@azure/core-http": "^1.2.7",
+    "@azure/core-http": "^2.0.0",
     "@azure/core-tracing": "1.0.0-preview.12",
     "@azure/logger": "^1.0.0",
     "tslib": "^2.2.0",

--- a/sdk/web-pubsub/web-pubsub-express/package.json
+++ b/sdk/web-pubsub/web-pubsub-express/package.json
@@ -58,7 +58,7 @@
   "sideEffects": false,
   "dependencies": {
     "@azure/core-auth": "^1.3.0",
-    "@azure/core-http": "^1.2.0",
+    "@azure/core-http": "^1.2.7",
     "@azure/core-tracing": "1.0.0-preview.12",
     "@azure/logger": "^1.0.0",
     "tslib": "^2.2.0",

--- a/sdk/web-pubsub/web-pubsub/package.json
+++ b/sdk/web-pubsub/web-pubsub/package.json
@@ -61,7 +61,7 @@
   "sideEffects": false,
   "dependencies": {
     "@azure/core-auth": "^1.3.0",
-    "@azure/core-http": "^1.2.7",
+    "@azure/core-http": "^2.0.0",
     "@azure/core-tracing": "1.0.0-preview.12",
     "@azure/logger": "^1.0.0",
     "tslib": "^2.2.0",

--- a/sdk/web-pubsub/web-pubsub/package.json
+++ b/sdk/web-pubsub/web-pubsub/package.json
@@ -61,7 +61,7 @@
   "sideEffects": false,
   "dependencies": {
     "@azure/core-auth": "^1.3.0",
-    "@azure/core-http": "^1.2.0",
+    "@azure/core-http": "^1.2.7",
     "@azure/core-tracing": "1.0.0-preview.12",
     "@azure/logger": "^1.0.0",
     "tslib": "^2.2.0",


### PR DESCRIPTION
## What

- Update core-http to 2.0.0
- Update core-lro to 2.0.0
- Update packages to use latest version

## Why

This will support our last breaking change for core-tracing, and allow everyone to be on the same minimum version. This will also allow us to target ES2017 across the board.