### PR TITLE
Default live test timeout to 60 minutes

### DIFF
--- a/eng/pipelines/templates/jobs/live.tests.yml
+++ b/eng/pipelines/templates/jobs/live.tests.yml
@@ -13,7 +13,7 @@ parameters:
   default: 0
 - name: TimeoutInMinutes
   type: number
-  default: 0
+  default: 60
 - name: PublishCodeCoverage
   type: boolean
   default: false

--- a/eng/pipelines/templates/stages/archetype-sdk-tests.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-tests.yml
@@ -13,7 +13,7 @@ parameters:
     default: 0
   - name: TimeoutInMinutes
     type: number
-    default: 0
+    default: 60
   - name: PublishCodeCoverage
     type: boolean
     default: false


### PR DESCRIPTION
The live test timeout is currently set to infinite. I think that with our prior use of the hosted agents, this ended up defaulting to the hosted agent timeout. Since we're on self-hosted agents now, there is no timeout, and occasionally we end up with zombie jobs that we would rather time out.