### PR TITLE
[service-bus] Fixing issue where links were not removed from our internal cache

### DIFF
--- a/sdk/servicebus/service-bus/CHANGELOG.md
+++ b/sdk/servicebus/service-bus/CHANGELOG.md
@@ -11,7 +11,7 @@
 ### Fixed
 
 - Fixing an issue where the internal link cache would not properly remove closed links.
-  [PR#TBD](TBD)
+  [PR#15929](https://github.com/Azure/azure-sdk-for-js/pull/15929)
 
 ## 7.2.0 (2021-06-10)
 

--- a/sdk/servicebus/service-bus/CHANGELOG.md
+++ b/sdk/servicebus/service-bus/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Fixed
 
+- Fixing an issue where the internal link cache would not properly remove closed links.
+  [PR#TBD](TBD)
 
 ## 7.2.0 (2021-06-10)
 

--- a/sdk/servicebus/service-bus/src/core/batchingReceiver.ts
+++ b/sdk/servicebus/service-bus/src/core/batchingReceiver.ts
@@ -152,6 +152,10 @@ export class BatchingReceiver extends MessageReceiver {
     context.messageReceivers[bReceiver.name] = bReceiver;
     return bReceiver;
   }
+
+  protected removeLinkFromContext(): void {
+    delete this._context.messageReceivers[this.name];
+  }
 }
 
 /**

--- a/sdk/servicebus/service-bus/src/core/linkEntity.ts
+++ b/sdk/servicebus/service-bus/src/core/linkEntity.ts
@@ -299,22 +299,7 @@ export abstract class LinkEntity<LinkT extends Receiver | AwaitableSender | Requ
 
     this._logger.verbose(`${this.logPrefix} permanently closing this link.`);
 
-    // Remove the underlying AMQP link from the cache
-    switch (this._linkType) {
-      case "s": {
-        delete this._context.senders[this.name];
-        break;
-      }
-      case "br":
-      case "sr": {
-        delete this._context.messageReceivers[this.name];
-        break;
-      }
-      case "ms": {
-        delete this._context.messageSessions[this.name];
-        break;
-      }
-    }
+    this.removeLinkFromContext();
 
     await this.closeLink();
     this._logger.verbose(`${this.logPrefix} permanently closed this link.`);
@@ -326,6 +311,11 @@ export abstract class LinkEntity<LinkT extends Receiver | AwaitableSender | Requ
    *
    */
   protected abstract createRheaLink(_options: LinkOptionsT<LinkT>): Promise<LinkT>;
+
+  /**
+   * Clears this link from context's link cache.
+   */
+  protected abstract removeLinkFromContext(): void;
 
   /**
    * Closes the internally held rhea link, stops the token renewal timer and sets

--- a/sdk/servicebus/service-bus/src/core/managementClient.ts
+++ b/sdk/servicebus/service-bus/src/core/managementClient.ts
@@ -1328,6 +1328,10 @@ export class ManagementClient extends LinkEntity<RequestResponseLink> {
       throw error;
     }
   }
+
+  protected removeLinkFromContext(): void {
+    delete this._context.managementClients[this.name];
+  }
 }
 
 /**

--- a/sdk/servicebus/service-bus/src/core/messageSender.ts
+++ b/sdk/servicebus/service-bus/src/core/messageSender.ts
@@ -467,4 +467,8 @@ export class MessageSender extends LinkEntity<AwaitableSender> {
     context.senders[sbSender.name] = sbSender;
     return sbSender;
   }
+
+  protected removeLinkFromContext(): void {
+    delete this._context.senders[this.name];
+  }
 }

--- a/sdk/servicebus/service-bus/src/core/streamingReceiver.ts
+++ b/sdk/servicebus/service-bus/src/core/streamingReceiver.ts
@@ -658,4 +658,8 @@ export class StreamingReceiver extends MessageReceiver {
       this._isDetaching = false;
     }
   }
+
+  protected removeLinkFromContext(): void {
+    delete this._context.messageReceivers[this.name];
+  }
 }

--- a/sdk/servicebus/service-bus/src/session/messageSession.ts
+++ b/sdk/servicebus/service-bus/src/session/messageSession.ts
@@ -925,4 +925,8 @@ export class MessageSession extends LinkEntity<Receiver> {
     await messageSession._init(options?.abortSignal);
     return messageSession;
   }
+
+  protected removeLinkFromContext(): void {
+    delete this._context.messageSessions[this.name];
+  }
 }


### PR DESCRIPTION
Today we cache any opened links in the connectionContext. These links should be removed when the link itself is closed but, due to a mismatch in the values, we weren't. 

I've fixed this by just making an abstract method in LinkEntity (the base for all the link types) and just having each link properly remove itself from the cache.

Fixes #15890