### PR TITLE
[Identity] node-fetch takes above 2 seconds to send the request on some environments

### DIFF
--- a/sdk/identity/identity/src/credentials/managedIdentityCredential/imdsMsi.ts
+++ b/sdk/identity/identity/src/credentials/managedIdentityCredential/imdsMsi.ts
@@ -90,7 +90,11 @@ export const imdsMsi: MSI = {
       // not having a "Metadata" header should cause an error to be
       // returned quickly from the endpoint, proving its availability.
       const webResource = identityClient.createWebResource(request);
-      webResource.timeout = updatedOptions?.requestOptions?.timeout || 500;
+
+      // In Kubernetes pods, node-fetch (used by core-http) takes longer than 2 seconds to begin sending the network request,
+      // So smaller timeouts will cause this credential to be immediately aborted.
+      // This won't be a problem once we move Identity to core-rest-pipeline.
+      webResource.timeout = updatedOptions?.requestOptions?.timeout || 3000;
 
       try {
         logger.info(`Pinging IMDS endpoint`);


### PR DESCRIPTION
While we stopped using node-fetch on core-rest-pipeline, core-http does use it. Node fetch takes above 2 seconds to begin sending network requests in some environments. We’re able to reproduce this issue in Kubernetes pods, but it could be present elsewhere.

This PR increases the timeout to 3 seconds.

I believe this should be ok as a temporary solution, since in many cases, we will get a response (any response) before that time.

For Identity. we should be able to solve this as soon as we move Identity to core-rest-pipeline: https://github.com/Azure/azure-sdk-for-js/issues/15595 We’re planning to do this during July. However, that won’t solve the issue in core-http.

This issue is related to: https://github.com/Azure/azure-sdk-for-js/issues/15935

It won’t fix https://github.com/Azure/azure-sdk-for-js/issues/15935, but it will help us have an immediate aid for our customers.