### PR TITLE
[Tables] Add missing browser mappings

### DIFF
--- a/sdk/tables/data-tables/CHANGELOG.md
+++ b/sdk/tables/data-tables/CHANGELOG.md
@@ -16,6 +16,7 @@ Thank you to our developer community members who helped to make the Azure Tables
 
 - Fix [#15664](https://github.com/Azure/azure-sdk-for-js/issues/15701), adding check to make sure we always have only one forward slash (`/`) added to the end of the URL [#15698](https://github.com/Azure/azure-sdk-for-js/pull/15698) (A community contribution, courtesy of _[eestein](https://github.com/eestein))_
 - Fix [#15701](https://github.com/Azure/azure-sdk-for-js/issues/15701) by improving error handling and reporting on `submitTransaction`. [#15852](https://github.com/Azure/azure-sdk-for-js/pull/15852)
+- Fix [#15921](https://github.com/Azure/azure-sdk-for-js/issues/15921) incorrect `url` import and missing browser mapping for `computeHMACSHA256` [#15944](https://github.com/Azure/azure-sdk-for-js/pull/15944)
 
 ## 12.0.0 (2021-06-09)
 

--- a/sdk/tables/data-tables/package.json
+++ b/sdk/tables/data-tables/package.json
@@ -9,6 +9,7 @@
     "./dist-esm/src/tablesNamedCredentialPolicy.js": "./dist-esm/src/tablesNamedCredentialPolicy.browser.js",
     "./dist-esm/src/utils/accountConnectionString.js": "./dist-esm/src/utils/accountConnectionString.browser.js",
     "./dist-esm/src/utils/url.js": "./dist-esm/src/utils/url.browser.js",
+    "./dist-esm/src/utils/computeHMACSHA256.js": "./dist-esm/src/utils/computeHMACSHA256.browser.js",
     "./dist-esm/src/utils/bufferSerializer.js": "./dist-esm/src/utils/bufferSerializer.browser.js",
     "./dist-esm/src/utils/transactionHeaders.js": "./dist-esm/src/utils/transactionHeaders.browser.js",
     "./dist-esm/test/public/utils/env.js": "./dist-esm/test/public/utils/env.browser.js"

--- a/sdk/tables/data-tables/src/utils/computeHMACSHA256.browser.ts
+++ b/sdk/tables/data-tables/src/utils/computeHMACSHA256.browser.ts
@@ -1,0 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+export function computeHMACSHA256(_stringToSign: string, _accountKey: string): string {
+  throw new Error("computeHMACSHA256 is not supported in the browser");
+}

--- a/sdk/tables/data-tables/src/utils/isCosmosEndpoint.ts
+++ b/sdk/tables/data-tables/src/utils/isCosmosEndpoint.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { URL } from "url";
+import { URL } from "./url";
 
 export function isCosmosEndpoint(url: string): boolean {
   const parsedURL = new URL(url);


### PR DESCRIPTION
Fixes #15921 

There were 2 issues related to browsers:

1. In one of the util files we are importing "url" instead of the util "./url" which causes URL not to be present in browsers.
2. Missing browser mapping for  `computeHMACSHA256`. Tables don't support NamedKey authentication on browsers for security reasons (risky to have the keys in the browser).
   * Added a shim function that throws if it is attempted to be used in browser. All entry points to this function are already throwing
   * Note: I looked into using `@azure/core-crypto` however I wasn't able to use it because it exposes an async function and the public API that consumes this is synchronous 😢  