### PR TITLE
[synapse] - Ignore known rollup warnings

### DIFF
--- a/sdk/synapse/synapse-access-control/rollup.config.js
+++ b/sdk/synapse/synapse-access-control/rollup.config.js
@@ -4,12 +4,30 @@ import sourcemaps from "rollup-plugin-sourcemaps";
 import cjs from "@rollup/plugin-commonjs";
 import { openTelemetryCommonJs } from "@azure/dev-tool/shared-config/rollup";
 
+
+const ignoreKnownWarnings = (warning) => {
+  if (warning.code === "THIS_IS_UNDEFINED") {
+    // This error happens frequently due to TypeScript emitting `this` at the
+    // top-level of a module. In this case its fine if it gets rewritten to
+    // undefined, so ignore this error.
+    return;
+  }
+
+  if (warning.code === "CIRCULAR_DEPENDENCY" && warning.importer.indexOf("@opentelemetry/api") >= 0) {
+    // OpenTelemetry contains circular references as of 1.0.0, but they are not fatal and can be ignored.
+    return;
+  }
+
+  console.error(`(!) ${warning.message}`);
+}
+
 /**
  * @type {rollup.RollupFileOptions}
  */
 const config = {
   input: "./dist-esm/accessControlClient.js",
   external: ["@azure/core-http", "@azure/core-arm"],
+  onwarn: ignoreKnownWarnings,
   output: {
     file: "./dist/index.js",
     format: "cjs",

--- a/sdk/synapse/synapse-managed-private-endpoints/rollup.config.js
+++ b/sdk/synapse/synapse-managed-private-endpoints/rollup.config.js
@@ -4,12 +4,29 @@ import sourcemaps from "rollup-plugin-sourcemaps";
 import cjs from "@rollup/plugin-commonjs";
 import { openTelemetryCommonJs } from "@azure/dev-tool/shared-config/rollup";
 
+const ignoreKnownWarnings = (warning) => {
+  if (warning.code === "THIS_IS_UNDEFINED") {
+    // This error happens frequently due to TypeScript emitting `this` at the
+    // top-level of a module. In this case its fine if it gets rewritten to
+    // undefined, so ignore this error.
+    return;
+  }
+
+  if (warning.code === "CIRCULAR_DEPENDENCY" && warning.importer.indexOf("@opentelemetry/api") >= 0) {
+    // OpenTelemetry contains circular references as of 1.0.0, but they are not fatal and can be ignored.
+    return;
+  }
+
+  console.error(`(!) ${warning.message}`);
+}
+
 /**
  * @type {rollup.RollupFileOptions}
  */
 const config = {
   input: "./dist-esm/managedPrivateEndpointsClient.js",
   external: ["@azure/core-http", "@azure/core-arm"],
+  onwarn: ignoreKnownWarnings,
   output: {
     file: "./dist/index.js",
     format: "cjs",

--- a/sdk/synapse/synapse-monitoring/rollup.config.js
+++ b/sdk/synapse/synapse-monitoring/rollup.config.js
@@ -4,12 +4,30 @@ import sourcemaps from "rollup-plugin-sourcemaps";
 import cjs from "@rollup/plugin-commonjs";
 import { openTelemetryCommonJs } from "@azure/dev-tool/shared-config/rollup";
 
+
+const ignoreKnownWarnings = (warning) => {
+  if (warning.code === "THIS_IS_UNDEFINED") {
+    // This error happens frequently due to TypeScript emitting `this` at the
+    // top-level of a module. In this case its fine if it gets rewritten to
+    // undefined, so ignore this error.
+    return;
+  }
+
+  if (warning.code === "CIRCULAR_DEPENDENCY" && warning.importer.indexOf("@opentelemetry/api") >= 0) {
+    // OpenTelemetry contains circular references as of 1.0.0, but they are not fatal and can be ignored.
+    return;
+  }
+
+  console.error(`(!) ${warning.message}`);
+}
+
 /**
  * @type {rollup.RollupFileOptions}
  */
 const config = {
   input: "./dist-esm/monitoringClient.js",
   external: ["@azure/core-http", "@azure/core-arm"],
+  onwarn: ignoreKnownWarnings,
   output: {
     file: "./dist/index.js",
     format: "cjs",

--- a/sdk/synapse/synapse-spark/rollup.config.js
+++ b/sdk/synapse/synapse-spark/rollup.config.js
@@ -4,12 +4,30 @@ import sourcemaps from "rollup-plugin-sourcemaps";
 import cjs from "@rollup/plugin-commonjs";
 import { openTelemetryCommonJs } from "@azure/dev-tool/shared-config/rollup";
 
+
+const ignoreKnownWarnings = (warning) => {
+  if (warning.code === "THIS_IS_UNDEFINED") {
+    // This error happens frequently due to TypeScript emitting `this` at the
+    // top-level of a module. In this case its fine if it gets rewritten to
+    // undefined, so ignore this error.
+    return;
+  }
+
+  if (warning.code === "CIRCULAR_DEPENDENCY" && warning.importer.indexOf("@opentelemetry/api") >= 0) {
+    // OpenTelemetry contains circular references as of 1.0.0, but they are not fatal and can be ignored.
+    return;
+  }
+
+  console.error(`(!) ${warning.message}`);
+}
+
 /**
  * @type {rollup.RollupFileOptions}
  */
 const config = {
   input: "./dist-esm/sparkClient.js",
   external: ["@azure/core-http", "@azure/core-arm"],
+  onwarn: ignoreKnownWarnings,
   output: {
     file: "./dist/index.js",
     format: "cjs",


### PR DESCRIPTION
## What

- Adds warning filter to ignore known rollup warnings that are safe to ignore
- Ignore `this has been rewritten to undefined` in synapse
- Ignore circular dependencies in synapse

## Why

These are both known warnings, are safe to ignore, and add noise to the build output unnecessarily. 

The first is totally safe to ignore:

```
var __spreadArray = (this && this.__spreadArray) || function (to, from) {
```

Is emitted from TypeScript in the OTel ESM and is safe to use.

The second is a known issue in OTel 1.0.0 that is not harmful at runtime.