### PR TITLE
Tweak workspace settings for VS Code startup perf

### DIFF
--- a/dataplane.code-workspace
+++ b/dataplane.code-workspace
@@ -298,7 +298,10 @@
       "**/*.d.ts": true,
       "**/test-browser/*": true
     },
-    "typescript.tsdk": "core-http/node_modules/typescript/lib"
+    "typescript.tsdk": "core-http/node_modules/typescript/lib",
+    "files.exclude": {
+      "**/node_modules": true
+    }
   },
   "extensions": {
     "recommendations": [


### PR DESCRIPTION
This greatly improved my first open experience on my laptop. The only tradeoff is `node_modules` folders won't appear in the file tree of VS Code, but I think this is a pretty uncommon place to browse into manually.