### PR TITLE
update pipeline to releae/track1

### DIFF
--- a/eng/pipelines/mgmt-ci.yml
+++ b/eng/pipelines/mgmt-ci.yml
@@ -1,7 +1,7 @@
 trigger:
   branches:
     include:
-      - track1/release
+      - feature/v4
   paths:
     include:
     - eng/pipelines/mgmt-pr.yml

--- a/eng/pipelines/mgmt-ci.yml
+++ b/eng/pipelines/mgmt-ci.yml
@@ -1,7 +1,7 @@
 trigger:
   branches:
     include:
-      - release/track1
+      - track1/release
   paths:
     include:
     - eng/pipelines/mgmt-pr.yml

--- a/eng/pipelines/mgmt-ci.yml
+++ b/eng/pipelines/mgmt-ci.yml
@@ -1,7 +1,7 @@
 trigger:
   branches:
     include:
-      - main
+      - release/track1
   paths:
     include:
     - eng/pipelines/mgmt-pr.yml

--- a/eng/pipelines/mgmt-ci.yml
+++ b/eng/pipelines/mgmt-ci.yml
@@ -1,7 +1,7 @@
 trigger:
   branches:
     include:
-      - feature/v4
+      - feature/*
   paths:
     include:
     - eng/pipelines/mgmt-pr.yml

--- a/eng/pipelines/mgmt-pr.yml
+++ b/eng/pipelines/mgmt-pr.yml
@@ -1,7 +1,7 @@
 pr:
   branches:
     include:
-    - feature/v4
+    - feature/*
     - '*-preview'
   paths:
     include:

--- a/eng/pipelines/mgmt-pr.yml
+++ b/eng/pipelines/mgmt-pr.yml
@@ -1,7 +1,7 @@
 pr:
   branches:
     include:
-    - main
+    - release/track1
     - '*-preview'
   paths:
     include:

--- a/eng/pipelines/mgmt-pr.yml
+++ b/eng/pipelines/mgmt-pr.yml
@@ -1,7 +1,7 @@
 pr:
   branches:
     include:
-    - release/track1
+    - track1/release
     - '*-preview'
   paths:
     include:

--- a/eng/pipelines/mgmt-pr.yml
+++ b/eng/pipelines/mgmt-pr.yml
@@ -1,7 +1,7 @@
 pr:
   branches:
     include:
-    - track1/release
+    - feature/v4
     - '*-preview'
   paths:
     include:


### PR DESCRIPTION
In the period of track2 sdk preview, we are going to use branch `feature/v4` to continue the release of track1 sdk.
Besides this PR, I will also change the the [release pipeline](https://dev.azure.com/azure-sdk/internal/_release?_a=releases&view=mine&definitionId=42) to trigger in branch `feature/v4`