### PR TITLE
Prepare to move to @types/node v12

### DIFF
--- a/sdk/core/core-rest-pipeline/src/nodeHttpClient.ts
+++ b/sdk/core/core-rest-pipeline/src/nodeHttpClient.ts
@@ -207,7 +207,7 @@ class NodeHttpClient implements HttpClient {
       throw new Error(`Cannot connect to ${request.url} while allowInsecureConnection is false.`);
     }
 
-    const agent = request.agent ?? this.getOrCreateAgent(request, isInsecure);
+    const agent = (request.agent as http.Agent) ?? this.getOrCreateAgent(request, isInsecure);
     const options: http.RequestOptions = {
       agent,
       hostname: url.hostname,

--- a/sdk/identity/identity/test/internal/node/interactiveBrowserCredential.spec.ts
+++ b/sdk/identity/identity/test/internal/node/interactiveBrowserCredential.spec.ts
@@ -12,8 +12,6 @@ import { InteractiveBrowserCredential } from "../../../src";
 import { MsalTestCleanup, msalNodeTestSetup } from "../../msalTestUtils";
 import { interactiveBrowserMockable } from "../../../src/msal/nodeFlows/msalOpenBrowser";
 
-import { URL } from "url";
-
 declare global {
   namespace NodeJS {
     interface Global {
@@ -38,11 +36,6 @@ describe("InteractiveBrowserCredential (internal)", function() {
   const scope = "https://vault.azure.net/.default";
 
   it("Throws an expected error if no browser is available", async function(this: Context) {
-    // On Node 8, URL is not defined. We use URL on the msalOpenBrowser.ts file.
-    if (process.version.startsWith("v8.")) {
-      global.URL = URL;
-    }
-
     // The SinonStub type does not include this second parameter to throws().
     const testErrorMessage = "No browsers available on this test.";
     (sandbox.stub(interactiveBrowserMockable, "open") as any).throws("TestError", testErrorMessage);

--- a/sdk/test-utils/perfstress/src/policy.ts
+++ b/sdk/test-utils/perfstress/src/policy.ts
@@ -14,7 +14,7 @@ import * as url from "url";
  */
 export class PerfStressPolicy extends BaseRequestPolicy {
   private host: string;
-  private port?: string;
+  private port?: string | null;
 
   /**
    * It receives the common parameters sent to any core-http policy, plus the host and the port.
@@ -27,7 +27,7 @@ export class PerfStressPolicy extends BaseRequestPolicy {
     nextPolicy: RequestPolicy,
     options: RequestPolicyOptions,
     host: string,
-    port?: string
+    port?: string | null
   ) {
     super(nextPolicy, options);
     this.host = host;


### PR DESCRIPTION
As part of #7022, we will be moving the version of `@types/node` from 8 to 12
This PR has the changes required to fix the build errors that occurred when trying out this change
- The [Agent](https://nodejs.org/docs/latest-v12.x/api/http.html#http_class_http_agent) class in Node.js 12 has an extra property `maxTotalSockets`. The docs say there is a default value for this, but it it is still marked as a mandatory property in the types. We use our own interface for this class for the purposes of user providing their own custom agent. Am casting it in this PR to the expected type. If anyone has better ideas here, am all ears :)
- `global.URL` is not a thing as per the types for Node.js 12. We needed this to support Node.js 8
- Fixing the types for `port` in the parsed url

The actual move to v12 for `@types/node` will be done in a separate PR