### PR TITLE
Prepare Storage packages to move to @types/node v12 

### DIFF
--- a/sdk/storage/storage-blob/src/utils/utils.node.ts
+++ b/sdk/storage/storage-blob/src/utils/utils.node.ts
@@ -18,7 +18,7 @@ export async function streamToBuffer(
   buffer: Buffer,
   offset: number,
   end: number,
-  encoding?: string
+  encoding?: BufferEncoding
 ): Promise<void> {
   let pos = 0; // Position in stream
   const count = end - offset; // Total amount of data needed in stream
@@ -72,7 +72,7 @@ export async function streamToBuffer(
 export async function streamToBuffer2(
   stream: NodeJS.ReadableStream,
   buffer: Buffer,
-  encoding?: string
+  encoding?: BufferEncoding
 ): Promise<number> {
   let pos = 0; // Position in stream
   const bufferSize = buffer.length;
@@ -113,7 +113,7 @@ export async function streamToBuffer2(
  */
 export async function streamToBuffer3(
   readableStream: NodeJS.ReadableStream,
-  encoding?: string
+  encoding?: BufferEncoding
 ): Promise<Buffer> {
   return new Promise((resolve, reject) => {
     const chunks: Buffer[] = [];

--- a/sdk/storage/storage-common/src/BufferScheduler.ts
+++ b/sdk/storage/storage-common/src/BufferScheduler.ts
@@ -92,7 +92,7 @@ export class BufferScheduler {
   /**
    * Encoding of the input Readable stream which has string data type instead of Buffer.
    */
-  private encoding?: string;
+  private encoding?: BufferEncoding;
 
   /**
    * How many buffers have been allocated.
@@ -141,7 +141,7 @@ export class BufferScheduler {
     maxBuffers: number,
     outgoingHandler: OutgoingHandler,
     concurrency: number,
-    encoding?: string
+    encoding?: BufferEncoding
   ) {
     if (bufferSize <= 0) {
       throw new RangeError(`bufferSize must be larger than 0, current is ${bufferSize}`);

--- a/sdk/storage/storage-file-datalake/src/utils/BufferScheduler.ts
+++ b/sdk/storage/storage-file-datalake/src/utils/BufferScheduler.ts
@@ -87,7 +87,7 @@ export class BufferScheduler {
   /**
    * Encoding of the input Readable stream which has string data type instead of Buffer.
    */
-  private encoding?: string;
+  private encoding?: BufferEncoding;
 
   /**
    * How many buffers have been allocated.
@@ -136,7 +136,7 @@ export class BufferScheduler {
     maxBuffers: number,
     outgoingHandler: OutgoingHandler,
     concurrency: number,
-    encoding?: string
+    encoding?: BufferEncoding
   ) {
     if (bufferSize <= 0) {
       throw new RangeError(`bufferSize must be larger than 0, current is ${bufferSize}`);

--- a/sdk/storage/storage-file-datalake/src/utils/utils.node.ts
+++ b/sdk/storage/storage-file-datalake/src/utils/utils.node.ts
@@ -3,7 +3,6 @@
 
 import * as fs from "fs";
 import * as util from "util";
-import { isNode } from "@azure/core-http";
 
 /**
  * Reads a readable stream into buffer. Fill the buffer from offset to end.
@@ -110,6 +109,6 @@ export async function streamToBuffer2(
  *
  * Promisified version of fs.stat().
  */
-export const fsStat = util.promisify(isNode ? fs.stat : function stat() {});
+export const fsStat = util.promisify(fs.stat);
 
 export const fsCreateReadStream = fs.createReadStream;

--- a/sdk/storage/storage-file-datalake/src/utils/utils.node.ts
+++ b/sdk/storage/storage-file-datalake/src/utils/utils.node.ts
@@ -19,7 +19,7 @@ export async function streamToBuffer(
   buffer: Buffer,
   offset: number,
   end: number,
-  encoding?: string
+  encoding?: BufferEncoding
 ): Promise<void> {
   let pos = 0; // Position in stream
   const count = end - offset; // Total amount of data needed in stream
@@ -73,7 +73,7 @@ export async function streamToBuffer(
 export async function streamToBuffer2(
   stream: NodeJS.ReadableStream,
   buffer: Buffer,
-  encoding?: string
+  encoding?: BufferEncoding
 ): Promise<number> {
   let pos = 0; // Position in stream
   const bufferSize = buffer.length;

--- a/sdk/storage/storage-file-share/src/utils/BufferScheduler.ts
+++ b/sdk/storage/storage-file-share/src/utils/BufferScheduler.ts
@@ -87,7 +87,7 @@ export class BufferScheduler {
   /**
    * Encoding of the input Readable stream which has string data type instead of Buffer.
    */
-  private encoding?: string;
+  private encoding?: BufferEncoding;
 
   /**
    * How many buffers have been allocated.
@@ -136,7 +136,7 @@ export class BufferScheduler {
     maxBuffers: number,
     outgoingHandler: OutgoingHandler,
     concurrency: number,
-    encoding?: string
+    encoding?: BufferEncoding
   ) {
     if (bufferSize <= 0) {
       throw new RangeError(`bufferSize must be larger than 0, current is ${bufferSize}`);

--- a/sdk/storage/storage-file-share/src/utils/utils.node.ts
+++ b/sdk/storage/storage-file-share/src/utils/utils.node.ts
@@ -18,7 +18,7 @@ export async function streamToBuffer(
   buffer: Buffer,
   offset: number,
   end: number,
-  encoding?: string
+  encoding?: BufferEncoding
 ): Promise<void> {
   let pos = 0; // Position in stream
   const count = end - offset; // Total amount of data needed in stream


### PR DESCRIPTION
As part of #7022, we will be moving the version of `@types/node` from 8 to 12
This PR has the changes required to fix the build errors that occurred in the Storage packages when trying out this change.
The net changes are:

- Use BufferEncoding in the storage packages as the `encoding` in `Buffer.from(string, encoding)` overload is not a string, but a union of string literals called `BufferEncoding` in Node.js 12 & above
- The promisfied `fs.stat()` returns `Promise<unknown>` for non node case. Updated to ignore the case when isNode is false as the entire file is only used in node due to there being a separate utils file for the browser 