### PR TITLE
[core-rest] - Update core-client-paging-rest to use the latest core-rest-pipeline

### DIFF
--- a/sdk/core/core-client-paging-rest/package.json
+++ b/sdk/core/core-client-paging-rest/package.json
@@ -62,7 +62,7 @@
   "prettier": "@azure/eslint-plugin-azure-sdk/prettier.json",
   "dependencies": {
     "@azure/core-paging": "^1.1.1",
-    "@azure/core-rest-pipeline": "^1.0.3",
+    "@azure/core-rest-pipeline": "^1.1.0",
     "@azure-rest/core-client": "1.0.0-beta.5",
     "tslib": "^2.2.0"
   },


### PR DESCRIPTION
This PR updates the newly added `@azure-rest/core-client-paging` package to use the same version of `@azure/core-rest-pipeline` that the other packages use.

We recently GA'd (on main, not released yet) version 1.1.0 of `@azure/core-rest-pipeline` and want to keep everyone on the latest version.