### PR TITLE
[monitor-query] Regenerate client with stable swaggers and add in includeVisualization option.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -107,7 +107,7 @@
 
 # PRLabel: %Monitor
 /sdk/monitor/ @hectorhdzg @applicationinsights-js-owners @richardpark-msft
-/sdk/monitor/monitor-query @richardpark-msft @maorleger
+/sdk/monitor/monitor-query @KarishmaGhiya @maorleger @richardpark-msft
 
 ###########
 # Tools

--- a/sdk/monitor/monitor-query/review/monitor-query.api.md
+++ b/sdk/monitor/monitor-query/review/monitor-query.api.md
@@ -81,12 +81,6 @@ export interface GetMetricNamespacesResult {
 }
 
 // @public
-export interface LogsColumn {
-    name?: string;
-    type?: ColumnDataType;
-}
-
-// @public
 export class LogsQueryClient {
     constructor(tokenCredential: TokenCredential, options?: LogsQueryClientOptions);
     queryLogs(workspaceId: string, query: string, timespan: string, options?: QueryLogsOptions): Promise<QueryLogsResult>;
@@ -101,7 +95,7 @@ export interface LogsQueryClientOptions extends PipelineOptions {
 
 // @public
 export interface LogsTable {
-    columns: LogsColumn[];
+    columns: MetricColumn[];
     name: string;
     rows: (Date | string | number | Record<string, unknown> | boolean)[][];
 }
@@ -114,7 +108,7 @@ export interface MetadataValue {
 
 // @public
 export interface Metric {
-    displayDescription: string;
+    displayDescription?: string;
     errorCode?: string;
     id: string;
     name: string;
@@ -130,6 +124,15 @@ export interface MetricAvailability {
 }
 
 // @public
+export type MetricClass = string;
+
+// @public
+export interface MetricColumn {
+    name?: string;
+    type?: ColumnDataType;
+}
+
+// @public
 export interface MetricDefinition {
     category?: string;
     dimensions?: string[];
@@ -140,6 +143,23 @@ export interface MetricDefinition {
     name?: string;
     primaryAggregationType?: AggregationType;
     resourceId?: string;
+    unit?: MetricUnit;
+}
+
+// @public
+export interface MetricDefinition {
+    category?: string;
+    dimensions?: string[];
+    displayDescription?: string;
+    id?: string;
+    isDimensionRequired?: boolean;
+    metricAvailabilities?: MetricAvailability[];
+    metricClass?: MetricClass;
+    name?: string;
+    namespace?: string;
+    primaryAggregationType?: AggregationType;
+    resourceId?: string;
+    supportedAggregationTypes?: AggregationType[];
     unit?: MetricUnit;
 }
 
@@ -207,6 +227,7 @@ export interface QueryLogsBatchResult {
 // @public
 export interface QueryLogsOptions extends OperationOptions {
     includeQueryStatistics?: boolean;
+    includeVisualization?: boolean;
     serverTimeoutInSeconds?: number;
 }
 
@@ -214,6 +235,7 @@ export interface QueryLogsOptions extends OperationOptions {
 export interface QueryLogsResult {
     statistics?: any;
     tables: LogsTable[];
+    visualization?: any;
 }
 
 // @public

--- a/sdk/monitor/monitor-query/src/generated/logquery/src/azureLogAnalyticsContext.ts
+++ b/sdk/monitor/monitor-query/src/generated/logquery/src/azureLogAnalyticsContext.ts
@@ -10,7 +10,7 @@ import * as coreHttp from "@azure/core-http";
 import { AzureLogAnalyticsOptionalParams } from "./models";
 
 const packageName = "monitor-log-query";
-const packageVersion = "1.0.0-beta.3";
+const packageVersion = "1.0.0";
 
 /** @hidden */
 export class AzureLogAnalyticsContext extends coreHttp.ServiceClient {

--- a/sdk/monitor/monitor-query/src/generated/logquery/src/models/index.ts
+++ b/sdk/monitor/monitor-query/src/generated/logquery/src/models/index.ts
@@ -14,6 +14,10 @@ export interface QueryResults {
   tables: Table[];
   /** Statistics represented in JSON format. */
   statistics?: any;
+  /** Visualization data in JSON format. */
+  render?: any;
+  /** The code and message for an error. */
+  error?: ErrorInfo;
 }
 
 /** Contains the columns and rows for one table in a query response. */
@@ -23,7 +27,7 @@ export interface Table {
   /** The list of columns in this table. */
   columns: Column[];
   /** The resulting rows from this query. */
-  rows: string[][];
+  rows: any[][];
 }
 
 /** A column in a table. */
@@ -31,13 +35,7 @@ export interface Column {
   /** The name of this column. */
   name?: string;
   /** The data type of this column. */
-  type?: ColumnDataType;
-}
-
-/** Contains details when the response code indicates an error. */
-export interface ErrorResponse {
-  /** The error details. */
-  error: ErrorInfo;
+  type?: LogsColumnType;
 }
 
 /** The code and message for an error. */
@@ -70,6 +68,12 @@ export interface ErrorDetail {
   additionalProperties?: any;
 }
 
+/** Contains details when the response code indicates an error. */
+export interface ErrorResponse {
+  /** The error details. */
+  error: ErrorInfo;
+}
+
 /** The Analytics query. Learn more about the [Analytics query syntax](https://azure.microsoft.com/documentation/articles/app-insights-analytics-reference/) */
 export interface QueryBody {
   /** The query to execute. */
@@ -78,12 +82,6 @@ export interface QueryBody {
   timespan?: string;
   /** A list of workspaces that are included in the query. */
   workspaces?: string[];
-  /** A list of qualified workspace names that are included in the query. */
-  qualifiedNames?: string[];
-  /** A list of workspace IDs that are included in the query. */
-  workspaceIds?: string[];
-  /** A list of Azure resource IDs that are included in the query. */
-  azureResourceIds?: string[];
 }
 
 /** The metadata response for the app, including available tables, etc. */
@@ -405,60 +403,67 @@ export interface MetadataPermissionsApplicationsItem {
 /** An array of requests. */
 export interface BatchRequest {
   /** An single request in a batch. */
-  requests?: LogQueryRequest[];
+  requests: BatchQueryRequest[];
 }
 
 /** An single request in a batch. */
-export interface LogQueryRequest {
+export interface BatchQueryRequest {
   /** The error details. */
-  id?: string;
+  id: string;
   /** Dictionary of <string> */
   headers?: { [propertyName: string]: string };
   /** The Analytics query. Learn more about the [Analytics query syntax](https://azure.microsoft.com/documentation/articles/app-insights-analytics-reference/) */
-  body?: QueryBody;
+  body: QueryBody;
   path?: "/query";
   method?: "POST";
   /** Workspace Id to be included in the query */
-  workspace?: string;
+  workspace: string;
 }
 
-/** Response to a batch. */
+/** Response to a batch query. */
 export interface BatchResponse {
   /** An array of responses corresponding to each individual request in a batch. */
-  responses?: LogQueryResponse[];
+  responses?: BatchQueryResponse[];
 }
 
-export interface LogQueryResponse {
+export interface BatchQueryResponse {
   id?: string;
   status?: number;
-  /** Contains the tables, columns & rows resulting from the query or the error details if the query failed. */
-  body?: LogQueryResult;
+  /** Contains the tables, columns & rows resulting from a query. */
+  body?: BatchQueryResults;
   /** Dictionary of <string> */
   headers?: { [propertyName: string]: string };
 }
 
-/** Contains the tables, columns & rows resulting from the query or the error details if the query failed. */
-export interface LogQueryResult {
+/** Contains the tables, columns & rows resulting from a query. */
+export interface BatchQueryResults {
   /** The list of tables, columns and rows. */
   tables?: Table[];
+  /** Statistics represented in JSON format. */
+  statistics?: any;
+  /** Visualization data in JSON format. */
+  render?: any;
   /** The code and message for an error. */
   error?: ErrorInfo;
 }
 
-/** Known values of {@link ColumnDataType} that the service accepts. */
-export const enum KnownColumnDataType {
+/** Known values of {@link LogsColumnType} that the service accepts. */
+export const enum KnownLogsColumnType {
   Bool = "bool",
   Datetime = "datetime",
   Dynamic = "dynamic",
   Int = "int",
   Long = "long",
   Real = "real",
-  String = "string"
+  String = "string",
+  Guid = "guid",
+  Decimal = "decimal",
+  Timespan = "timespan"
 }
 
 /**
- * Defines values for ColumnDataType. \
- * {@link KnownColumnDataType} can be used interchangeably with ColumnDataType,
+ * Defines values for LogsColumnType. \
+ * {@link KnownLogsColumnType} can be used interchangeably with LogsColumnType,
  *  this enum contains the known values that the service supports.
  * ### Know values supported by the service
  * **bool** \
@@ -467,9 +472,12 @@ export const enum KnownColumnDataType {
  * **int** \
  * **long** \
  * **real** \
- * **string**
+ * **string** \
+ * **guid** \
+ * **decimal** \
+ * **timespan**
  */
-export type ColumnDataType = string;
+export type LogsColumnType = string;
 
 /** Known values of {@link MetadataColumnDataType} that the service accepts. */
 export const enum KnownMetadataColumnDataType {
@@ -479,7 +487,10 @@ export const enum KnownMetadataColumnDataType {
   Int = "int",
   Long = "long",
   Real = "real",
-  String = "string"
+  String = "string",
+  Guid = "guid",
+  Decimal = "decimal",
+  Timespan = "timespan"
 }
 
 /**
@@ -493,7 +504,10 @@ export const enum KnownMetadataColumnDataType {
  * **int** \
  * **long** \
  * **real** \
- * **string**
+ * **string** \
+ * **guid** \
+ * **decimal** \
+ * **timespan**
  */
 export type MetadataColumnDataType = string;
 
@@ -517,7 +531,7 @@ export type QueryGetResponse = QueryResults & {
 
 /** Optional parameters. */
 export interface QueryExecuteOptionalParams extends coreHttp.OperationOptions {
-  /** Optional. The prefer header to set server timeout, */
+  /** Optional. The prefer header to set server timeout, query statistics and visualization information. */
   prefer?: string;
 }
 

--- a/sdk/monitor/monitor-query/src/generated/logquery/src/models/mappers.ts
+++ b/sdk/monitor/monitor-query/src/generated/logquery/src/models/mappers.ts
@@ -31,6 +31,19 @@ export const QueryResults: coreHttp.CompositeMapper = {
         type: {
           name: "any"
         }
+      },
+      render: {
+        serializedName: "render",
+        type: {
+          name: "any"
+        }
+      },
+      error: {
+        serializedName: "error",
+        type: {
+          name: "Composite",
+          className: "ErrorInfo"
+        }
       }
     }
   }
@@ -71,7 +84,7 @@ export const Table: coreHttp.CompositeMapper = {
               name: "Sequence",
               element: {
                 type: {
-                  name: "String"
+                  name: "any"
                 }
               }
             }
@@ -97,22 +110,6 @@ export const Column: coreHttp.CompositeMapper = {
         serializedName: "type",
         type: {
           name: "String"
-        }
-      }
-    }
-  }
-};
-
-export const ErrorResponse: coreHttp.CompositeMapper = {
-  type: {
-    name: "Composite",
-    className: "ErrorResponse",
-    modelProperties: {
-      error: {
-        serializedName: "error",
-        type: {
-          name: "Composite",
-          className: "ErrorInfo"
         }
       }
     }
@@ -219,6 +216,22 @@ export const ErrorDetail: coreHttp.CompositeMapper = {
   }
 };
 
+export const ErrorResponse: coreHttp.CompositeMapper = {
+  type: {
+    name: "Composite",
+    className: "ErrorResponse",
+    modelProperties: {
+      error: {
+        serializedName: "error",
+        type: {
+          name: "Composite",
+          className: "ErrorInfo"
+        }
+      }
+    }
+  }
+};
+
 export const QueryBody: coreHttp.CompositeMapper = {
   type: {
     name: "Composite",
@@ -239,39 +252,6 @@ export const QueryBody: coreHttp.CompositeMapper = {
       },
       workspaces: {
         serializedName: "workspaces",
-        type: {
-          name: "Sequence",
-          element: {
-            type: {
-              name: "String"
-            }
-          }
-        }
-      },
-      qualifiedNames: {
-        serializedName: "qualifiedNames",
-        type: {
-          name: "Sequence",
-          element: {
-            type: {
-              name: "String"
-            }
-          }
-        }
-      },
-      workspaceIds: {
-        serializedName: "workspaceIds",
-        type: {
-          name: "Sequence",
-          element: {
-            type: {
-              name: "String"
-            }
-          }
-        }
-      },
-      azureResourceIds: {
-        serializedName: "azureResourceIds",
         type: {
           name: "Sequence",
           element: {
@@ -1550,12 +1530,13 @@ export const BatchRequest: coreHttp.CompositeMapper = {
     modelProperties: {
       requests: {
         serializedName: "requests",
+        required: true,
         type: {
           name: "Sequence",
           element: {
             type: {
               name: "Composite",
-              className: "LogQueryRequest"
+              className: "BatchQueryRequest"
             }
           }
         }
@@ -1564,13 +1545,14 @@ export const BatchRequest: coreHttp.CompositeMapper = {
   }
 };
 
-export const LogQueryRequest: coreHttp.CompositeMapper = {
+export const BatchQueryRequest: coreHttp.CompositeMapper = {
   type: {
     name: "Composite",
-    className: "LogQueryRequest",
+    className: "BatchQueryRequest",
     modelProperties: {
       id: {
         serializedName: "id",
+        required: true,
         type: {
           name: "String"
         }
@@ -1607,6 +1589,7 @@ export const LogQueryRequest: coreHttp.CompositeMapper = {
       },
       workspace: {
         serializedName: "workspace",
+        required: true,
         type: {
           name: "String"
         }
@@ -1627,7 +1610,7 @@ export const BatchResponse: coreHttp.CompositeMapper = {
           element: {
             type: {
               name: "Composite",
-              className: "LogQueryResponse"
+              className: "BatchQueryResponse"
             }
           }
         }
@@ -1636,10 +1619,10 @@ export const BatchResponse: coreHttp.CompositeMapper = {
   }
 };
 
-export const LogQueryResponse: coreHttp.CompositeMapper = {
+export const BatchQueryResponse: coreHttp.CompositeMapper = {
   type: {
     name: "Composite",
-    className: "LogQueryResponse",
+    className: "BatchQueryResponse",
     modelProperties: {
       id: {
         serializedName: "id",
@@ -1657,7 +1640,7 @@ export const LogQueryResponse: coreHttp.CompositeMapper = {
         serializedName: "body",
         type: {
           name: "Composite",
-          className: "LogQueryResult"
+          className: "BatchQueryResults"
         }
       },
       headers: {
@@ -1671,10 +1654,10 @@ export const LogQueryResponse: coreHttp.CompositeMapper = {
   }
 };
 
-export const LogQueryResult: coreHttp.CompositeMapper = {
+export const BatchQueryResults: coreHttp.CompositeMapper = {
   type: {
     name: "Composite",
-    className: "LogQueryResult",
+    className: "BatchQueryResults",
     modelProperties: {
       tables: {
         serializedName: "tables",
@@ -1686,6 +1669,18 @@ export const LogQueryResult: coreHttp.CompositeMapper = {
               className: "Table"
             }
           }
+        }
+      },
+      statistics: {
+        serializedName: "statistics",
+        type: {
+          name: "any"
+        }
+      },
+      render: {
+        serializedName: "render",
+        type: {
+          name: "any"
         }
       },
       error: {

--- a/sdk/monitor/monitor-query/src/generated/metrics/src/models/index.ts
+++ b/sdk/monitor/monitor-query/src/generated/metrics/src/models/index.ts
@@ -16,9 +16,9 @@ export interface Response {
   timespan: string;
   /** The interval (window size) for which the metric data was returned in.  This may be adjusted in the future and returned back from what was originally requested.  This is not present if a metadata request was made. */
   interval?: string;
-  /** The namespace of the metrics been queried */
+  /** The namespace of the metrics being queried */
   namespace?: string;
-  /** The region of the resource been queried for metrics. */
+  /** The region of the resource being queried for metrics. */
   resourceregion?: string;
   /** the value of the collection. */
   value: Metric[];
@@ -33,10 +33,12 @@ export interface Metric {
   /** the name and the display name of the metric, i.e. it is localizable string. */
   name: LocalizableString;
   /** Detailed description of this metric. */
-  displayDescription: string;
+  displayDescription?: string;
   /** 'Success' or the error details on query failures for this metric. */
   errorCode?: string;
-  /** the unit of the metric. */
+  /** Error message encountered querying this specific metric. */
+  errorMessage?: string;
+  /** The unit of the metric. */
   unit: MetricUnit;
   /** the time series returned when a data query is performed. */
   timeseries: TimeSeriesElement[];
@@ -90,20 +92,20 @@ export interface ErrorResponse {
   message?: string;
 }
 
-/** Known values of {@link ApiVersion20170501Preview} that the service accepts. */
-export const enum KnownApiVersion20170501Preview {
-  /** Api Version '2017-05-01-preview' */
-  TwoThousandSeventeen0501Preview = "2017-05-01-preview"
+/** Known values of {@link ApiVersion201801} that the service accepts. */
+export const enum KnownApiVersion201801 {
+  /** Api Version '2018-01-01' */
+  TwoThousandEighteen0101 = "2018-01-01"
 }
 
 /**
- * Defines values for ApiVersion20170501Preview. \
- * {@link KnownApiVersion20170501Preview} can be used interchangeably with ApiVersion20170501Preview,
+ * Defines values for ApiVersion201801. \
+ * {@link KnownApiVersion201801} can be used interchangeably with ApiVersion201801,
  *  this enum contains the known values that the service supports.
  * ### Know values supported by the service
- * **2017-05-01-preview**: Api Version '2017-05-01-preview'
+ * **2018-01-01**: Api Version '2018-01-01'
  */
-export type ApiVersion20170501Preview = string;
+export type ApiVersion201801 = string;
 
 /** Known values of {@link MetricUnit} that the service accepts. */
 export const enum KnownMetricUnit {
@@ -151,8 +153,8 @@ export interface MetricsListOptionalParams extends coreHttp.OperationOptions {
   timespan?: string;
   /** The interval (i.e. timegrain) of the query. */
   interval?: string;
-  /** The name of the metric to retrieve. */
-  metric?: string;
+  /** The names of the metrics (comma separated) to retrieve. Special case: If a metricname itself has a comma in it then use %2 to indicate it. Eg: 'Metric,Name1' should be **'Metric%2Name1'** */
+  metricnames?: string;
   /** The list of aggregation types (comma separated) to retrieve. */
   aggregation?: string;
   /**
@@ -167,7 +169,7 @@ export interface MetricsListOptionalParams extends coreHttp.OperationOptions {
    * Examples: sum asc.
    */
   orderby?: string;
-  /** The **$filter** is used to reduce the set of metric data returned.<br>Example:<br>Metric contains metadata A, B and C.<br>- Return all time series of C where A = a1 and B = b1 or b2<br>**$filter=A eq ‘a1’ and B eq ‘b1’ or B eq ‘b2’ and C eq ‘*’**<br>- Invalid variant:<br>**$filter=A eq ‘a1’ and B eq ‘b1’ and C eq ‘*’ or B = ‘b2’**<br>This is invalid because the logical or operator cannot separate two different metadata names.<br>- Return all time series where A = a1, B = b1 and C = c1:<br>**$filter=A eq ‘a1’ and B eq ‘b1’ and C eq ‘c1’**<br>- Return all time series where A = a1<br>**$filter=A eq ‘a1’ and B eq ‘*’ and C eq ‘*’**. */
+  /** The **$filter** is used to reduce the set of metric data returned. Example: Metric contains metadata A, B and C. - Return all time series of C where A = a1 and B = b1 or b2 **$filter=A eq 'a1' and B eq 'b1' or B eq 'b2' and C eq '*'** - Invalid variant: **$filter=A eq 'a1' and B eq 'b1' and C eq '*' or B = 'b2'** This is invalid because the logical or operator cannot separate two different metadata names. - Return all time series where A = a1, B = b1 and C = c1: **$filter=A eq 'a1' and B eq 'b1' and C eq 'c1'** - Return all time series where A = a1 **$filter=A eq 'a1' and B eq '*' and C eq '*'**. Special case: When dimension name or dimension value uses round brackets. Eg: When dimension name is **dim (test) 1** Instead of using $filter= "dim (test) 1 eq '*' " use **$filter= "dim %2528test%2529 1 eq '*' "** When dimension name is **dim (test) 3** and dimension value is **dim3 (test) val** Instead of using $filter= "dim (test) 3 eq 'dim3 (test) val' " use **$filter= "dim %2528test%2529 3 eq 'dim3 %2528test%2529 val' "** */
   filter?: string;
   /** Reduces the set of data collected. The syntax allowed depends on the operation. See the operation's description for details. */
   resultType?: ResultType;

--- a/sdk/monitor/monitor-query/src/generated/metrics/src/models/mappers.ts
+++ b/sdk/monitor/monitor-query/src/generated/metrics/src/models/mappers.ts
@@ -92,13 +92,18 @@ export const Metric: coreHttp.CompositeMapper = {
       },
       displayDescription: {
         serializedName: "displayDescription",
-        required: true,
         type: {
           name: "String"
         }
       },
       errorCode: {
         serializedName: "errorCode",
+        type: {
+          name: "String"
+        }
+      },
+      errorMessage: {
+        serializedName: "errorMessage",
         type: {
           name: "String"
         }

--- a/sdk/monitor/monitor-query/src/generated/metrics/src/models/parameters.ts
+++ b/sdk/monitor/monitor-query/src/generated/metrics/src/models/parameters.ts
@@ -68,10 +68,10 @@ export const interval: OperationQueryParameter = {
   }
 };
 
-export const metric: OperationQueryParameter = {
-  parameterPath: ["options", "metric"],
+export const metricnames: OperationQueryParameter = {
+  parameterPath: ["options", "metricnames"],
   mapper: {
-    serializedName: "metric",
+    serializedName: "metricnames",
     type: {
       name: "String"
     }

--- a/sdk/monitor/monitor-query/src/generated/metrics/src/monitorManagementClient.ts
+++ b/sdk/monitor/monitor-query/src/generated/metrics/src/monitorManagementClient.ts
@@ -10,7 +10,7 @@ import { Metrics } from "./operations";
 import { MonitorManagementClientContext } from "./monitorManagementClientContext";
 import {
   MonitorManagementClientOptionalParams,
-  ApiVersion20170501Preview
+  ApiVersion201801
 } from "./models";
 
 /** @hidden */
@@ -21,7 +21,7 @@ export class MonitorManagementClient extends MonitorManagementClientContext {
    * @param options The parameter options
    */
   constructor(
-    apiVersion: ApiVersion20170501Preview,
+    apiVersion: ApiVersion201801,
     options?: MonitorManagementClientOptionalParams
   ) {
     super(apiVersion, options);

--- a/sdk/monitor/monitor-query/src/generated/metrics/src/monitorManagementClientContext.ts
+++ b/sdk/monitor/monitor-query/src/generated/metrics/src/monitorManagementClientContext.ts
@@ -7,28 +7,22 @@
  */
 
 import * as coreHttp from "@azure/core-http";
-import {
-  ApiVersion20170501Preview,
-  MonitorManagementClientOptionalParams
-} from "./models";
+import { ApiVersion201801, MonitorManagementClientOptionalParams } from "./models";
 
 const packageName = "monitor-metrics";
-const packageVersion = "1.0.0-beta.3";
+const packageVersion = "1.0.0";
 
 /** @hidden */
 export class MonitorManagementClientContext extends coreHttp.ServiceClient {
   $host: string;
-  apiVersion: ApiVersion20170501Preview;
+  apiVersion: ApiVersion201801;
 
   /**
    * Initializes a new instance of the MonitorManagementClientContext class.
    * @param apiVersion Api Version
    * @param options The parameter options
    */
-  constructor(
-    apiVersion: ApiVersion20170501Preview,
-    options?: MonitorManagementClientOptionalParams
-  ) {
+  constructor(apiVersion: ApiVersion201801, options?: MonitorManagementClientOptionalParams) {
     if (apiVersion === undefined) {
       throw new Error("'apiVersion' cannot be null");
     }

--- a/sdk/monitor/monitor-query/src/generated/metrics/src/operations/metrics.ts
+++ b/sdk/monitor/monitor-query/src/generated/metrics/src/operations/metrics.ts
@@ -47,7 +47,7 @@ export class Metrics {
 const serializer = new coreHttp.Serializer(Mappers, /* isXml */ false);
 
 const listOperationSpec: coreHttp.OperationSpec = {
-  path: "/{resourceUri}/providers/microsoft.insights/metrics",
+  path: "/{resourceUri}/providers/Microsoft.Insights/metrics",
   httpMethod: "GET",
   responses: {
     200: {
@@ -60,7 +60,7 @@ const listOperationSpec: coreHttp.OperationSpec = {
   queryParameters: [
     Parameters.timespan,
     Parameters.interval,
-    Parameters.metric,
+    Parameters.metricnames,
     Parameters.aggregation,
     Parameters.top,
     Parameters.orderby,

--- a/sdk/monitor/monitor-query/src/generated/metricsdefinitions/src/index.ts
+++ b/sdk/monitor/monitor-query/src/generated/metricsdefinitions/src/index.ts
@@ -7,5 +7,5 @@
  */
 
 export * from "./models";
-export { MetricsDefinitionsClient } from "./metricsDefinitionsClient";
-export { MetricsDefinitionsClientContext } from "./metricsDefinitionsClientContext";
+export { MonitorManagementClient } from "./monitorManagementClient";
+export { MonitorManagementClientContext } from "./monitorManagementClientContext";

--- a/sdk/monitor/monitor-query/src/generated/metricsdefinitions/src/models/index.ts
+++ b/sdk/monitor/monitor-query/src/generated/metricsdefinitions/src/models/index.ts
@@ -20,16 +20,22 @@ export interface MetricDefinition {
   isDimensionRequired?: boolean;
   /** the resource identifier of the resource that emitted the metric. */
   resourceId?: string;
+  /** the namespace the metric belongs to. */
+  namespace?: string;
   /** the name and the display name of the metric, i.e. it is a localizable string. */
   name?: LocalizableString;
   /** Detailed description of this metric. */
   displayDescription?: string;
   /** Custom category name for this metric. */
   category?: string;
-  /** the unit of the metric. */
+  /** The class of the metric. */
+  metricClass?: MetricClass;
+  /** The unit of the metric. */
   unit?: MetricUnit;
   /** the primary aggregation type value defining how to use the values for display. */
   primaryAggregationType?: AggregationType;
+  /** the collection of what aggregation types are supported. */
+  supportedAggregationTypes?: AggregationType[];
   /** the collection of what aggregation intervals are available to be queried. */
   metricAvailabilities?: MetricAvailability[];
   /** the resource identifier of the metric definition. */
@@ -62,20 +68,42 @@ export interface ErrorResponse {
   message?: string;
 }
 
-/** Known values of {@link ApiVersion20170501Preview} that the service accepts. */
-export const enum KnownApiVersion20170501Preview {
-  /** Api Version '2017-05-01-preview' */
-  TwoThousandSeventeen0501Preview = "2017-05-01-preview"
+/** Known values of {@link ApiVersion201801} that the service accepts. */
+export const enum KnownApiVersion201801 {
+  /** Api Version '2018-01-01' */
+  TwoThousandEighteen0101 = "2018-01-01"
 }
 
 /**
- * Defines values for ApiVersion20170501Preview. \
- * {@link KnownApiVersion20170501Preview} can be used interchangeably with ApiVersion20170501Preview,
+ * Defines values for ApiVersion201801. \
+ * {@link KnownApiVersion201801} can be used interchangeably with ApiVersion201801,
  *  this enum contains the known values that the service supports.
  * ### Know values supported by the service
- * **2017-05-01-preview**: Api Version '2017-05-01-preview'
+ * **2018-01-01**: Api Version '2018-01-01'
  */
-export type ApiVersion20170501Preview = string;
+export type ApiVersion201801 = string;
+
+/** Known values of {@link MetricClass} that the service accepts. */
+export const enum KnownMetricClass {
+  Availability = "Availability",
+  Transactions = "Transactions",
+  Errors = "Errors",
+  Latency = "Latency",
+  Saturation = "Saturation"
+}
+
+/**
+ * Defines values for MetricClass. \
+ * {@link KnownMetricClass} can be used interchangeably with MetricClass,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Availability** \
+ * **Transactions** \
+ * **Errors** \
+ * **Latency** \
+ * **Saturation**
+ */
+export type MetricClass = string;
 
 /** Known values of {@link MetricUnit} that the service accepts. */
 export const enum KnownMetricUnit {
@@ -143,7 +171,7 @@ export type MetricDefinitionsListResponse = MetricDefinitionCollection & {
 };
 
 /** Optional parameters. */
-export interface MetricsDefinitionsClientOptionalParams
+export interface MonitorManagementClientOptionalParams
   extends coreHttp.ServiceClientOptions {
   /** server parameter */
   $host?: string;

--- a/sdk/monitor/monitor-query/src/generated/metricsdefinitions/src/models/mappers.ts
+++ b/sdk/monitor/monitor-query/src/generated/metricsdefinitions/src/models/mappers.ts
@@ -47,6 +47,12 @@ export const MetricDefinition: coreHttp.CompositeMapper = {
           name: "String"
         }
       },
+      namespace: {
+        serializedName: "namespace",
+        type: {
+          name: "String"
+        }
+      },
       name: {
         serializedName: "name",
         type: {
@@ -62,6 +68,12 @@ export const MetricDefinition: coreHttp.CompositeMapper = {
       },
       category: {
         serializedName: "category",
+        type: {
+          name: "String"
+        }
+      },
+      metricClass: {
+        serializedName: "metricClass",
         type: {
           name: "String"
         }
@@ -84,6 +96,25 @@ export const MetricDefinition: coreHttp.CompositeMapper = {
             "Maximum",
             "Total"
           ]
+        }
+      },
+      supportedAggregationTypes: {
+        serializedName: "supportedAggregationTypes",
+        type: {
+          name: "Sequence",
+          element: {
+            type: {
+              name: "Enum",
+              allowedValues: [
+                "None",
+                "Average",
+                "Count",
+                "Minimum",
+                "Maximum",
+                "Total"
+              ]
+            }
+          }
         }
       },
       metricAvailabilities: {

--- a/sdk/monitor/monitor-query/src/generated/metricsdefinitions/src/monitorManagementClient.ts
+++ b/sdk/monitor/monitor-query/src/generated/metricsdefinitions/src/monitorManagementClient.ts
@@ -7,22 +7,22 @@
  */
 
 import { MetricDefinitions } from "./operations";
-import { MetricsDefinitionsClientContext } from "./metricsDefinitionsClientContext";
+import { MonitorManagementClientContext } from "./monitorManagementClientContext";
 import {
-  MetricsDefinitionsClientOptionalParams,
-  ApiVersion20170501Preview
+  MonitorManagementClientOptionalParams,
+  ApiVersion201801
 } from "./models";
 
 /** @hidden */
-export class MetricsDefinitionsClient extends MetricsDefinitionsClientContext {
+export class MonitorManagementClient extends MonitorManagementClientContext {
   /**
-   * Initializes a new instance of the MetricsDefinitionsClient class.
+   * Initializes a new instance of the MonitorManagementClient class.
    * @param apiVersion Api Version
    * @param options The parameter options
    */
   constructor(
-    apiVersion: ApiVersion20170501Preview,
-    options?: MetricsDefinitionsClientOptionalParams
+    apiVersion: ApiVersion201801,
+    options?: MonitorManagementClientOptionalParams
   ) {
     super(apiVersion, options);
     this.metricDefinitions = new MetricDefinitions(this);

--- a/sdk/monitor/monitor-query/src/generated/metricsdefinitions/src/monitorManagementClientContext.ts
+++ b/sdk/monitor/monitor-query/src/generated/metricsdefinitions/src/monitorManagementClientContext.ts
@@ -7,28 +7,22 @@
  */
 
 import * as coreHttp from "@azure/core-http";
-import {
-  ApiVersion20171201Preview,
-  MetricsNamespacesClientOptionalParams
-} from "./models";
+import { ApiVersion201801, MonitorManagementClientOptionalParams } from "./models";
 
-const packageName = "monitor-metrics-namespaces";
-const packageVersion = "1.0.0-beta.3";
+const packageName = "monitor-metrics-definitions";
+const packageVersion = "1.0.0";
 
 /** @hidden */
-export class MetricsNamespacesClientContext extends coreHttp.ServiceClient {
+export class MonitorManagementClientContext extends coreHttp.ServiceClient {
   $host: string;
-  apiVersion: ApiVersion20171201Preview;
+  apiVersion: ApiVersion201801;
 
   /**
-   * Initializes a new instance of the MetricsNamespacesClientContext class.
+   * Initializes a new instance of the MonitorManagementClientContext class.
    * @param apiVersion Api Version
    * @param options The parameter options
    */
-  constructor(
-    apiVersion: ApiVersion20171201Preview,
-    options?: MetricsNamespacesClientOptionalParams
-  ) {
+  constructor(apiVersion: ApiVersion201801, options?: MonitorManagementClientOptionalParams) {
     if (apiVersion === undefined) {
       throw new Error("'apiVersion' cannot be null");
     }

--- a/sdk/monitor/monitor-query/src/generated/metricsdefinitions/src/operations/metricDefinitions.ts
+++ b/sdk/monitor/monitor-query/src/generated/metricsdefinitions/src/operations/metricDefinitions.ts
@@ -9,7 +9,7 @@
 import * as coreHttp from "@azure/core-http";
 import * as Mappers from "../models/mappers";
 import * as Parameters from "../models/parameters";
-import { MetricsDefinitionsClient } from "../metricsDefinitionsClient";
+import { MonitorManagementClient } from "../monitorManagementClient";
 import {
   MetricDefinitionsListOptionalParams,
   MetricDefinitionsListResponse
@@ -17,13 +17,13 @@ import {
 
 /** Class representing a MetricDefinitions. */
 export class MetricDefinitions {
-  private readonly client: MetricsDefinitionsClient;
+  private readonly client: MonitorManagementClient;
 
   /**
    * Initialize a new instance of the class MetricDefinitions class.
    * @param client Reference to the service client
    */
-  constructor(client: MetricsDefinitionsClient) {
+  constructor(client: MonitorManagementClient) {
     this.client = client;
   }
 
@@ -50,7 +50,7 @@ export class MetricDefinitions {
 const serializer = new coreHttp.Serializer(Mappers, /* isXml */ false);
 
 const listOperationSpec: coreHttp.OperationSpec = {
-  path: "/{resourceUri}/providers/microsoft.insights/metricDefinitions",
+  path: "/{resourceUri}/providers/Microsoft.Insights/metricDefinitions",
   httpMethod: "GET",
   responses: {
     200: {

--- a/sdk/monitor/monitor-query/src/generated/metricsnamespaces/src/index.ts
+++ b/sdk/monitor/monitor-query/src/generated/metricsnamespaces/src/index.ts
@@ -7,5 +7,5 @@
  */
 
 export * from "./models";
-export { MetricsNamespacesClient } from "./metricsNamespacesClient";
-export { MetricsNamespacesClientContext } from "./metricsNamespacesClientContext";
+export { MonitorManagementClient } from "./monitorManagementClient";
+export { MonitorManagementClientContext } from "./monitorManagementClientContext";

--- a/sdk/monitor/monitor-query/src/generated/metricsnamespaces/src/models/index.ts
+++ b/sdk/monitor/monitor-query/src/generated/metricsnamespaces/src/models/index.ts
@@ -95,7 +95,7 @@ export type MetricNamespacesListResponse = MetricNamespaceCollection & {
 };
 
 /** Optional parameters. */
-export interface MetricsNamespacesClientOptionalParams
+export interface MonitorManagementClientOptionalParams
   extends coreHttp.ServiceClientOptions {
   /** server parameter */
   $host?: string;

--- a/sdk/monitor/monitor-query/src/generated/metricsnamespaces/src/monitorManagementClient.ts
+++ b/sdk/monitor/monitor-query/src/generated/metricsnamespaces/src/monitorManagementClient.ts
@@ -7,22 +7,22 @@
  */
 
 import { MetricNamespaces } from "./operations";
-import { MetricsNamespacesClientContext } from "./metricsNamespacesClientContext";
+import { MonitorManagementClientContext } from "./monitorManagementClientContext";
 import {
-  MetricsNamespacesClientOptionalParams,
+  MonitorManagementClientOptionalParams,
   ApiVersion20171201Preview
 } from "./models";
 
 /** @hidden */
-export class MetricsNamespacesClient extends MetricsNamespacesClientContext {
+export class MonitorManagementClient extends MonitorManagementClientContext {
   /**
-   * Initializes a new instance of the MetricsNamespacesClient class.
+   * Initializes a new instance of the MonitorManagementClient class.
    * @param apiVersion Api Version
    * @param options The parameter options
    */
   constructor(
     apiVersion: ApiVersion20171201Preview,
-    options?: MetricsNamespacesClientOptionalParams
+    options?: MonitorManagementClientOptionalParams
   ) {
     super(apiVersion, options);
     this.metricNamespaces = new MetricNamespaces(this);

--- a/sdk/monitor/monitor-query/src/generated/metricsnamespaces/src/monitorManagementClientContext.ts
+++ b/sdk/monitor/monitor-query/src/generated/metricsnamespaces/src/monitorManagementClientContext.ts
@@ -7,27 +7,24 @@
  */
 
 import * as coreHttp from "@azure/core-http";
-import {
-  ApiVersion20170501Preview,
-  MetricsDefinitionsClientOptionalParams
-} from "./models";
+import { ApiVersion20171201Preview, MonitorManagementClientOptionalParams } from "./models";
 
-const packageName = "monitor-metrics-definitions";
-const packageVersion = "1.0.0-beta.3";
+const packageName = "monitor-metrics-namespaces";
+const packageVersion = "1.0.0";
 
 /** @hidden */
-export class MetricsDefinitionsClientContext extends coreHttp.ServiceClient {
+export class MonitorManagementClientContext extends coreHttp.ServiceClient {
   $host: string;
-  apiVersion: ApiVersion20170501Preview;
+  apiVersion: ApiVersion20171201Preview;
 
   /**
-   * Initializes a new instance of the MetricsDefinitionsClientContext class.
+   * Initializes a new instance of the MonitorManagementClientContext class.
    * @param apiVersion Api Version
    * @param options The parameter options
    */
   constructor(
-    apiVersion: ApiVersion20170501Preview,
-    options?: MetricsDefinitionsClientOptionalParams
+    apiVersion: ApiVersion20171201Preview,
+    options?: MonitorManagementClientOptionalParams
   ) {
     if (apiVersion === undefined) {
       throw new Error("'apiVersion' cannot be null");

--- a/sdk/monitor/monitor-query/src/generated/metricsnamespaces/src/operations/metricNamespaces.ts
+++ b/sdk/monitor/monitor-query/src/generated/metricsnamespaces/src/operations/metricNamespaces.ts
@@ -9,7 +9,7 @@
 import * as coreHttp from "@azure/core-http";
 import * as Mappers from "../models/mappers";
 import * as Parameters from "../models/parameters";
-import { MetricsNamespacesClient } from "../metricsNamespacesClient";
+import { MonitorManagementClient } from "../monitorManagementClient";
 import {
   MetricNamespacesListOptionalParams,
   MetricNamespacesListResponse
@@ -17,13 +17,13 @@ import {
 
 /** Class representing a MetricNamespaces. */
 export class MetricNamespaces {
-  private readonly client: MetricsNamespacesClient;
+  private readonly client: MonitorManagementClient;
 
   /**
    * Initialize a new instance of the class MetricNamespaces class.
    * @param client Reference to the service client
    */
-  constructor(client: MetricsNamespacesClient) {
+  constructor(client: MonitorManagementClient) {
     this.client = client;
   }
 

--- a/sdk/monitor/monitor-query/src/index.ts
+++ b/sdk/monitor/monitor-query/src/index.ts
@@ -42,8 +42,9 @@ export { Durations } from "./models/constants";
 export {
   // TODO: these are the generated model names. We probably want to run them
   // through a manual review to make them consistent with style.
-  Column as LogsColumn,
-  ColumnDataType,
+  Column as MetricColumn,
+  // TODO: LogsColumnType might actually be a better name!
+  LogsColumnType as ColumnDataType,
   ErrorDetail,
   ErrorInfo
 } from "./generated/logquery/src";
@@ -59,7 +60,11 @@ export {
   MetricUnit
 } from "./generated/metrics/src";
 
-export { AggregationType, MetricAvailability } from "./generated/metricsdefinitions/src";
+export {
+  AggregationType,
+  MetricAvailability,
+  MetricClass
+} from "./generated/metricsdefinitions/src";
 export {
   MetricNamespace,
   MetricNamespaceName,

--- a/sdk/monitor/monitor-query/src/internal/util.ts
+++ b/sdk/monitor/monitor-query/src/internal/util.ts
@@ -7,7 +7,12 @@ import { QueryLogsOptions } from "../models/publicLogsModels";
  * @internal
  */
 export function formatPreferHeader(
-  args: Pick<QueryLogsOptions, "serverTimeoutInSeconds" | "includeQueryStatistics"> | undefined
+  args:
+    | Pick<
+        QueryLogsOptions,
+        "serverTimeoutInSeconds" | "includeQueryStatistics" | "includeVisualization"
+      >
+    | undefined
 ): { Prefer: string } | undefined {
   if (!args) {
     return undefined;
@@ -23,6 +28,10 @@ export function formatPreferHeader(
 
   if (args.includeQueryStatistics) {
     pairs.push("include-statistics=true");
+  }
+
+  if (args.includeVisualization) {
+    pairs.push("include-render=true");
   }
 
   if (pairs.length > 0) {

--- a/sdk/monitor/monitor-query/src/logsQueryClient.ts
+++ b/sdk/monitor/monitor-query/src/logsQueryClient.ts
@@ -105,7 +105,8 @@ export class LogsQueryClient {
 
     return {
       tables: result.tables.map(convertGeneratedTable),
-      statistics: result.statistics
+      statistics: result.statistics,
+      visualization: result.render
     };
   }
 

--- a/sdk/monitor/monitor-query/src/metricsQueryClient.ts
+++ b/sdk/monitor/monitor-query/src/metricsQueryClient.ts
@@ -17,16 +17,16 @@ import {
 } from "./models/publicMetricsModels";
 
 import {
-  KnownApiVersion20170501Preview as MetricsApiVersion,
+  KnownApiVersion201801 as MetricsApiVersion,
   MonitorManagementClient as GeneratedMetricsClient
 } from "./generated/metrics/src";
 import {
-  KnownApiVersion20170501Preview as MetricDefinitionsApiVersion,
-  MetricsDefinitionsClient as GeneratedMetricsDefinitionsClient
+  KnownApiVersion201801 as MetricDefinitionsApiVersion,
+  MonitorManagementClient as GeneratedMetricsDefinitionsClient
 } from "./generated/metricsdefinitions/src";
 import {
   KnownApiVersion20171201Preview as MetricNamespacesApiVersion,
-  MetricsNamespacesClient as GeneratedMetricsNamespacesClient
+  MonitorManagementClient as GeneratedMetricsNamespacesClient
 } from "./generated/metricsnamespaces/src";
 import {
   convertRequestForMetrics,
@@ -70,12 +70,12 @@ export class MetricsQueryClient {
     };
 
     this._metricsClient = new GeneratedMetricsClient(
-      MetricsApiVersion.TwoThousandSeventeen0501Preview,
+      MetricsApiVersion.TwoThousandEighteen0101,
       serviceClientOptions
     );
 
     this._definitionsClient = new GeneratedMetricsDefinitionsClient(
-      MetricDefinitionsApiVersion.TwoThousandSeventeen0501Preview,
+      MetricDefinitionsApiVersion.TwoThousandEighteen0101,
       serviceClientOptions
     );
 

--- a/sdk/monitor/monitor-query/src/models/publicLogsModels.ts
+++ b/sdk/monitor/monitor-query/src/models/publicLogsModels.ts
@@ -21,6 +21,11 @@ export interface QueryLogsOptions extends OperationOptions {
    * Results will also include statistics about the query.
    */
   includeQueryStatistics?: boolean; // TODO: this data is not modeled in the current response object.
+
+  /**
+   * Results will also include visualization information, in JSON format.
+   */
+  includeVisualization?: boolean;
 }
 
 /**
@@ -42,6 +47,8 @@ export interface QueryLogsResult {
   tables: LogsTable[];
   /** Statistics represented in JSON format. */
   statistics?: any;
+  /** Visualization data in JSON format. */
+  visualization?: any;
 }
 
 /** Options when query logs with a batch. */

--- a/sdk/monitor/monitor-query/src/models/publicMetricsModels.ts
+++ b/sdk/monitor/monitor-query/src/models/publicMetricsModels.ts
@@ -7,6 +7,7 @@ import {
   MetricValue,
   ResultType,
   MetricUnit,
+  MetricClass,
   AggregationType,
   MetricAvailability
 } from "..";
@@ -50,7 +51,7 @@ export interface Metric {
   /** the name of the metric */
   name: string;
   /** Detailed description of this metric. */
-  displayDescription: string;
+  displayDescription?: string;
   /** 'Success' or the error details on query failures for this metric. */
   errorCode?: string;
   /** the unit of the metric. */
@@ -158,4 +159,36 @@ export interface GetMetricNamespacesResult {
 
   /** The metric namespaces. */
   namespaces: MetricNamespace[];
+}
+
+/**
+ * Metric definition.
+ */
+export interface MetricDefinition {
+  /** Flag to indicate whether the dimension is required. */
+  isDimensionRequired?: boolean;
+  /** the resource identifier of the resource that emitted the metric. */
+  resourceId?: string;
+  /** the namespace the metric belongs to. */
+  namespace?: string;
+  /** the name and the display name of the metric, i.e. it is a localizable string. */
+  name?: string;
+  /** Detailed description of this metric. */
+  displayDescription?: string;
+  /** Custom category name for this metric. */
+  category?: string;
+  /** The class of the metric. */
+  metricClass?: MetricClass;
+  /** The unit of the metric. */
+  unit?: MetricUnit;
+  /** the primary aggregation type value defining how to use the values for display. */
+  primaryAggregationType?: AggregationType;
+  /** the collection of what aggregation types are supported. */
+  supportedAggregationTypes?: AggregationType[];
+  /** the collection of what aggregation intervals are available to be queried. */
+  metricAvailabilities?: MetricAvailability[];
+  /** the resource identifier of the metric definition. */
+  id?: string;
+  /** the name and the display name of the dimension, i.e. it is a localizable string. */
+  dimensions?: string[];
 }

--- a/sdk/monitor/monitor-query/swagger/README.md
+++ b/sdk/monitor/monitor-query/swagger/README.md
@@ -1,9 +1,14 @@
 ## Configuration file for autorest for JavaScript
 
+<!-- 
+(TODO)
+https://github.com/Azure/azure-rest-api-specs/blob/master/specification/monitor/resource-manager/Microsoft.Insights/preview/2017-12-01-preview/metricNamespaces_API.json
+-->
+
 ## Log Query
 
 ```yaml $(tag) == 'logquery'
-input-file: "https://raw.githubusercontent.com/srnagar/azure-rest-api-specs/azmon-query-swagger/specification/operationalinsights/data-plane/Microsoft.OperationalInsights/preview/2021-05-19/OperationalInsights.json"
+input-file: "https://github.com/Azure/azure-rest-api-specs/blob/86408a8777e623f5f41e260472ed831309b85086/specification/operationalinsights/data-plane/Microsoft.OperationalInsights/preview/2021-05-19_Preview/OperationalInsights.json"
 output-folder: ../src/generated/logquery
 package-name: "monitor-log-query"
 clear-output-folder: true
@@ -21,7 +26,7 @@ hide-clients: true
 ```
 
 ```yaml $(tag) == 'metrics'
-input-file: "https://raw.githubusercontent.com/srnagar/azure-rest-api-specs/azmon-query-swagger/specification/monitor/resource-manager/Microsoft.Insights/preview/2017-05-01-preview/metrics_API.json"
+input-file: "https://github.com/Azure/azure-rest-api-specs/blob/86408a8777e623f5f41e260472ed831309b85086/specification/monitor/resource-manager/Microsoft.Insights/stable/2018-01-01/metrics_API.json"
 output-folder: ../src/generated/metrics
 package-name: "monitor-metrics"
 clear-output-folder: true
@@ -39,7 +44,7 @@ hide-clients: true
 ```
 
 ```yaml $(tag) == 'metrics-definitions'
-input-file: "https://raw.githubusercontent.com/srnagar/azure-rest-api-specs/azmon-query-swagger/specification/monitor/resource-manager/Microsoft.Insights/preview/2017-05-01-preview/metricDefinitions_API.json"
+input-file: "https://github.com/Azure/azure-rest-api-specs/blob/86408a8777e623f5f41e260472ed831309b85086/specification/monitor/resource-manager/Microsoft.Insights/stable/2018-01-01/metricDefinitions_API.json"
 output-folder: ../src/generated/metricsdefinitions
 package-name: "monitor-metrics-definitions"
 clear-output-folder: true
@@ -57,7 +62,7 @@ hide-clients: true
 ```
 
 ```yaml $(tag) == 'metrics-namespaces'
-input-file: "https://raw.githubusercontent.com/srnagar/azure-rest-api-specs/azmon-query-swagger/specification/monitor/resource-manager/Microsoft.Insights/preview/2017-12-01-preview/metricNamespaces_API.json"
+input-file: "https://github.com/Azure/azure-rest-api-specs/blob/86408a8777e623f5f41e260472ed831309b85086/specification/monitor/resource-manager/Microsoft.Insights/preview/2017-12-01-preview/metricNamespaces_API.json"
 output-folder: ../src/generated/metricsnamespaces
 package-name: "monitor-metrics-namespaces"
 clear-output-folder: true

--- a/sdk/monitor/monitor-query/test/internal/unit/modelConverters.unittest.spec.ts
+++ b/sdk/monitor/monitor-query/test/internal/unit/modelConverters.unittest.spec.ts
@@ -4,7 +4,7 @@
 import * as assert from "assert";
 import {
   BatchRequest as GeneratedBatchRequest,
-  LogQueryRequest
+  BatchQueryRequest
 } from "../../../src/generated/logquery/src";
 import {
   MetricsListOptionalParams as GeneratedMetricsListOptionalParams,
@@ -80,7 +80,7 @@ describe("Model unit tests", () => {
         ]
       });
 
-      assert.deepEqual(generatedRequest.requests?.[1], <LogQueryRequest>{
+      assert.deepEqual(generatedRequest.requests?.[1], <BatchQueryRequest>{
         id: "1", // auto-generated (increments by 1 for each query in the batch)
         workspace: "the primary workspace id",
         headers: {
@@ -126,12 +126,12 @@ describe("Model unit tests", () => {
         track2Model
       );
 
-      assert.deepEqual(actualMetricsRequest, {
+      const expectedMetricsRequest: GeneratedMetricsListOptionalParams = {
         abortSignal,
         aggregation: "agg1,agg2",
         filter: "arbitraryFilter",
         interval: "arbitraryInterval",
-        metric: "name1,name2",
+        metricnames: "name1,name2",
         metricnamespace: "myMetricNamespace",
         orderby: "orderByClause",
         requestOptions,
@@ -139,7 +139,9 @@ describe("Model unit tests", () => {
         timespan: "arbitraryTimespan",
         top: 10,
         tracingOptions
-      });
+      };
+
+      assert.deepEqual(actualMetricsRequest, expectedMetricsRequest);
     });
 
     it("convertRequestForMetrics (only required fields)", () => {

--- a/sdk/monitor/monitor-query/test/public/logsQueryClient.spec.ts
+++ b/sdk/monitor/monitor-query/test/public/logsQueryClient.spec.ts
@@ -119,7 +119,7 @@ describe("LogsQueryClient live tests", function() {
   });
 
   it("includeQueryStatistics", async () => {
-    const query = await createClient().queryLogs(
+    const results = await createClient().queryLogs(
       monitorWorkspaceId,
       "AppEvents | limit 1",
       Durations.last24Hours,
@@ -130,8 +130,28 @@ describe("LogsQueryClient live tests", function() {
 
     // TODO: statistics are not currently modeled in the generated code but
     // the executionTime field is pretty useful.
-    assert.isOk(query.statistics);
-    assert.isNumber(query.statistics?.query?.executionTime);
+    assert.isOk(results.statistics);
+    assert.isNumber(results.statistics?.query?.executionTime);
+  });
+
+  it("includeRender/includeVisualization", async () => {
+    const results = await createClient().queryLogs(
+      monitorWorkspaceId,
+      `datatable (s: string, i: long) [ "a", 1, "b", 2, "c", 3 ] | render columnchart with (title="the chart title", xtitle="the x axis title")`,
+      Durations.last24Hours,
+      {
+        includeVisualization: true
+      }
+    );
+
+    // TODO: render/visualizations are not currently modeled in the generated
+    // code
+    assert.deepNestedInclude(results.visualization, {
+      // an example of the data (not currently modeled)
+      visualization: "columnchart",
+      xTitle: "the x axis title",
+      title: "the chart title"
+    });
   });
 
   it("query with types", async () => {

--- a/sdk/monitor/monitor-query/test/public/metricsQueryClient.spec.ts
+++ b/sdk/monitor/monitor-query/test/public/metricsQueryClient.spec.ts
@@ -9,11 +9,10 @@ import { createTestClientSecretCredential, getMetricsArmResourceId } from "./sha
 
 describe("MetricsClient live tests", function() {
   let resourceId: string;
-  let resourceNamespace: string;
   let metricsQueryClient: MetricsQueryClient;
 
   beforeEach(function(this: Context) {
-    ({ resourceNamespace, resourceId } = getMetricsArmResourceId(this));
+    ({ resourceId } = getMetricsArmResourceId(this));
     metricsQueryClient = new MetricsQueryClient(createTestClientSecretCredential());
   });
 
@@ -55,11 +54,24 @@ describe("MetricsClient live tests", function() {
       assert.isNotEmpty(newResults.metrics);
     }
 
-    // query for a metric we do know about
-    metricsQueryClient.queryMetrics(resourceId, Durations.last24Hours, {
-      metricNames: ["Average_Uptime"],
-      metricNamespace: resourceNamespace
-    });
+    // pick the first query and use the namespace as well.
+
+    const firstMetricDefinition = metricDefinitions.definitions[0];
+
+    assert.isNotNull(firstMetricDefinition);
+    assert.isNotEmpty(firstMetricDefinition.name);
+    assert.isNotEmpty(firstMetricDefinition.namespace);
+
+    const individualMetricWithNamespace = metricsQueryClient.queryMetrics(
+      resourceId,
+      Durations.last24Hours,
+      {
+        metricNames: [firstMetricDefinition.name!],
+        metricNamespace: firstMetricDefinition.namespace
+      }
+    );
+
+    assert.ok(individualMetricWithNamespace);
   });
 
   it("listNamespaces", async () => {

--- a/sdk/monitor/monitor-query/test/public/shared/testShared.ts
+++ b/sdk/monitor/monitor-query/test/public/shared/testShared.ts
@@ -91,11 +91,9 @@ export function getMetricsArmResourceId(
   mochaContext: Pick<Context, "skip">
 ): {
   resourceId: string;
-  resourceNamespace: string;
 } {
   return {
-    resourceId: getRequiredEnvVar(mochaContext, "METRICS_RESOURCE_ID"),
-    resourceNamespace: getRequiredEnvVar(mochaContext, "METRICS_RESOURCE_NAMESPACE")
+    resourceId: getRequiredEnvVar(mochaContext, "METRICS_RESOURCE_ID")
   };
 }
 
@@ -117,7 +115,7 @@ export function getAppInsightsConnectionString(mochaContext: Pick<Context, "skip
 
 function getRequiredEnvVar(mochaContext: Pick<Context, "skip">, variableName: string): string {
   if (!env[variableName]) {
-    console.log(`TODO: live tests skipped until test-resources + data population is set up.`);
+    console.log(`TODO: live tests skipped until test-resources + data population is set up (missing ${variableName} env var).`);
     mochaContext.skip();
   }
 

--- a/sdk/monitor/monitor-query/test/public/shared/testShared.ts
+++ b/sdk/monitor/monitor-query/test/public/shared/testShared.ts
@@ -115,7 +115,9 @@ export function getAppInsightsConnectionString(mochaContext: Pick<Context, "skip
 
 function getRequiredEnvVar(mochaContext: Pick<Context, "skip">, variableName: string): string {
   if (!env[variableName]) {
-    console.log(`TODO: live tests skipped until test-resources + data population is set up (missing ${variableName} env var).`);
+    console.log(
+      `TODO: live tests skipped until test-resources + data population is set up (missing ${variableName} env var).`
+    );
     mochaContext.skip();
   }
 


### PR DESCRIPTION
Big update to use the latest stable swagger files for all of the Log Analytics services. Each reference is by git commit ID this time to prevent any accidental drift.  

Added in the includeRender header (via the `includeVisualization` option).
    
Fixes #15771