### PR TITLE
replace legacy MSI name in package.json keywords

### DIFF
--- a/sdk/identity/identity/package.json
+++ b/sdk/identity/identity/package.json
@@ -67,7 +67,7 @@
     "authentication",
     "credential",
     "certificate",
-    "managed service identity",
+    "managed identity",
     "client secret",
     "access token"
   ],


### PR DESCRIPTION
Drop the word "service" from the name