### PR TITLE
[core] - Make spanOptions and tracingContext unknown

### DIFF
--- a/sdk/core/core-auth/review/core-auth.api.md
+++ b/sdk/core/core-auth/review/core-auth.api.md
@@ -48,8 +48,8 @@ export interface GetTokenOptions {
         timeout?: number;
     };
     tracingOptions?: {
-        spanOptions?: SpanOptions;
-        tracingContext?: Context;
+        spanOptions?: unknown;
+        tracingContext?: unknown;
     };
 }
 

--- a/sdk/core/core-auth/src/tokenCredential.ts
+++ b/sdk/core/core-auth/src/tokenCredential.ts
@@ -2,7 +2,6 @@
 // Licensed under the MIT license.
 
 import { AbortSignalLike } from "@azure/abort-controller";
-import { Context, SpanOptions } from "./tracing";
 
 /**
  * Represents a credential capable of providing an authentication token.
@@ -45,12 +44,12 @@ export interface GetTokenOptions {
     /**
      * OpenTelemetry SpanOptions used to create a span when tracing is enabled.
      */
-    spanOptions?: SpanOptions;
+    spanOptions?: unknown;
 
     /**
      * OpenTelemetry context
      */
-    tracingContext?: Context;
+    tracingContext?: unknown;
   };
 }
 

--- a/sdk/core/core-http/review/core-http.api.md
+++ b/sdk/core/core-http/review/core-http.api.md
@@ -6,13 +6,11 @@
 
 import { AbortSignalLike } from '@azure/abort-controller';
 import { AccessToken } from '@azure/core-auth';
-import { Context } from '@azure/core-tracing';
 import { Debugger } from '@azure/logger';
 import { GetTokenOptions } from '@azure/core-auth';
 import { isTokenCredential } from '@azure/core-auth';
 import { OperationTracingOptions } from '@azure/core-tracing';
 import { Span } from '@azure/core-tracing';
-import { SpanOptions } from '@azure/core-tracing';
 import { TokenCredential } from '@azure/core-auth';
 
 export { AbortSignalLike }
@@ -611,9 +609,9 @@ export interface RequestOptionsBase {
     onUploadProgress?: (progress: TransferProgressEvent) => void;
     serializerOptions?: SerializerOptions;
     shouldDeserialize?: boolean | ((response: HttpOperationResponse) => boolean);
-    spanOptions?: SpanOptions;
+    spanOptions?: unknown;
     timeout?: number;
-    tracingContext?: Context;
+    tracingContext?: unknown;
 }
 
 // @public (undocumented)
@@ -673,8 +671,8 @@ export interface RequestPrepareOptions {
         [key: string]: any | ParameterValue;
     };
     serializationMapper?: Mapper;
-    spanOptions?: SpanOptions;
-    tracingContext?: Context;
+    spanOptions?: unknown;
+    tracingContext?: unknown;
     url?: string;
 }
 
@@ -937,13 +935,13 @@ export class WebResource implements WebResourceLike {
     // (undocumented)
     requestId: string;
     shouldDeserialize?: boolean | ((response: HttpOperationResponse) => boolean);
-    spanOptions?: SpanOptions;
+    spanOptions?: unknown;
     // @deprecated (undocumented)
     streamResponseBody?: boolean;
     streamResponseStatusCodes?: Set<number>;
     // (undocumented)
     timeout: number;
-    tracingContext?: Context;
+    tracingContext?: unknown;
     // (undocumented)
     url: string;
     validateRequestProperties(): void;
@@ -973,12 +971,12 @@ export interface WebResourceLike {
     };
     requestId: string;
     shouldDeserialize?: boolean | ((response: HttpOperationResponse) => boolean);
-    spanOptions?: SpanOptions;
+    spanOptions?: unknown;
     // @deprecated (undocumented)
     streamResponseBody?: boolean;
     streamResponseStatusCodes?: Set<number>;
     timeout: number;
-    tracingContext?: Context;
+    tracingContext?: unknown;
     url: string;
     validateRequestProperties(): void;
     withCredentials: boolean;

--- a/sdk/core/core-http/src/policies/tracingPolicy.ts
+++ b/sdk/core/core-http/src/policies/tracingPolicy.ts
@@ -57,7 +57,7 @@ export class TracingPolicy extends BaseRequestPolicy {
     const { span } = createSpan(path, {
       tracingOptions: {
         spanOptions: {
-          ...request.spanOptions,
+          ...(request.spanOptions as object),
           kind: SpanKind.CLIENT
         },
         tracingContext: request.tracingContext

--- a/sdk/core/core-http/src/webResource.ts
+++ b/sdk/core/core-http/src/webResource.ts
@@ -9,7 +9,6 @@ import { HttpOperationResponse } from "./httpOperationResponse";
 import { OperationResponse } from "./operationResponse";
 import { ProxySettings } from "./serviceClient";
 import { AbortSignalLike } from "@azure/abort-controller";
-import { SpanOptions, Context } from "@azure/core-tracing";
 import { SerializerOptions } from "./util/serializer.common";
 
 export type HttpMethods =
@@ -129,12 +128,12 @@ export interface WebResourceLike {
   /**
    * Tracing: Options used to create a span when tracing is enabled.
    */
-  spanOptions?: SpanOptions;
+  spanOptions?: unknown;
 
   /**
    * Tracing: Context used when creating spans.
    */
-  tracingContext?: Context;
+  tracingContext?: unknown;
 
   /**
    * Validates that the required properties such as method, url, headers["Content-Type"],
@@ -236,12 +235,12 @@ export class WebResource implements WebResourceLike {
   /**
    * Tracing: Options used to create a span when tracing is enabled.
    */
-  spanOptions?: SpanOptions;
+  spanOptions?: unknown;
 
   /**
    * Tracing: Context used when creating Spans.
    */
-  tracingContext?: Context;
+  tracingContext?: unknown;
 
   constructor(
     url?: string,
@@ -648,11 +647,11 @@ export interface RequestPrepareOptions {
   /**
    * Tracing: Options used to create a span when tracing is enabled.
    */
-  spanOptions?: SpanOptions;
+  spanOptions?: unknown;
   /**
    * Tracing: Context used when creating spans.
    */
-  tracingContext?: Context;
+  tracingContext?: unknown;
 }
 
 /**
@@ -703,12 +702,12 @@ export interface RequestOptionsBase {
   /**
    * Tracing: Options used to create a span when tracing is enabled.
    */
-  spanOptions?: SpanOptions;
+  spanOptions?: unknown;
 
   /**
    * Tracing: Context used when creating spans.
    */
-  tracingContext?: Context;
+  tracingContext?: unknown;
 
   [key: string]: any;
 

--- a/sdk/core/core-rest-pipeline/src/policies/tracingPolicy.ts
+++ b/sdk/core/core-rest-pipeline/src/policies/tracingPolicy.ts
@@ -5,7 +5,8 @@ import {
   getTraceParentHeader,
   OperationTracingOptions,
   createSpanFunction,
-  SpanStatusCode
+  SpanStatusCode,
+  Context
 } from "@azure/core-tracing";
 import { SpanKind } from "@azure/core-tracing";
 import { PipelineResponse, PipelineRequest, SendRequest } from "../interfaces";
@@ -55,7 +56,7 @@ export function tracingPolicy(options: TracingPolicyOptions = {}): PipelinePolic
       const tracingOptions: OperationTracingOptions = {
         ...request.tracingOptions,
         spanOptions: {
-          ...request.tracingOptions.spanOptions,
+          ...(request.tracingOptions.spanOptions as Context),
           kind: SpanKind.CLIENT
         }
       };

--- a/sdk/core/core-tracing/review/core-tracing.api.md
+++ b/sdk/core/core-tracing/review/core-tracing.api.md
@@ -107,8 +107,8 @@ export class NoOpTracer implements Tracer {
 
 // @public
 export interface OperationTracingOptions {
-    spanOptions?: SpanOptions;
-    tracingContext?: Context;
+    spanOptions?: unknown;
+    tracingContext?: unknown;
 }
 
 // @public

--- a/sdk/core/core-tracing/src/interfaces.ts
+++ b/sdk/core/core-tracing/src/interfaces.ts
@@ -445,12 +445,12 @@ export interface OperationTracingOptions {
   /**
    * OpenTelemetry SpanOptions used to create a span when tracing is enabled.
    */
-  spanOptions?: SpanOptions;
+  spanOptions?: unknown;
 
   /**
    * OpenTelemetry context to use for created Spans.
    */
-  tracingContext?: Context;
+  tracingContext?: unknown;
 }
 
 /**

--- a/sdk/core/core-tracing/test/createSpan.spec.ts
+++ b/sdk/core/core-tracing/test/createSpan.spec.ts
@@ -191,7 +191,7 @@ describe("createSpan", () => {
       const { span, updatedOptions } = createSpanFn("parent", op);
       assert.ok(span);
 
-      parentContext = updatedOptions.tracingOptions!.tracingContext!;
+      parentContext = updatedOptions.tracingOptions!.tracingContext! as Context;
 
       assert.ok(parentContext);
       assert.notDeepEqual(parentContext, otContext.active(), "new child context should be created");

--- a/sdk/core/core-tracing/test/interfaces.spec.ts
+++ b/sdk/core/core-tracing/test/interfaces.spec.ts
@@ -78,7 +78,7 @@ describe("interface compatibility", () => {
     >> = {};
     assert.ok(t2, "core-tracing and core-auth should have the same properties");
 
-    const authTracingOptions: coreAuth.GetTokenOptions["tracingOptions"] = coreTracingOptions;
+    const authTracingOptions = coreTracingOptions;
     assert.ok(authTracingOptions);
   });
 });

--- a/sdk/digitaltwins/digital-twins-core/test/internal/digitalTwinsClient.spec.ts
+++ b/sdk/digitaltwins/digital-twins-core/test/internal/digitalTwinsClient.spec.ts
@@ -33,7 +33,7 @@ import {
 } from "../../src/generated/models";
 import { DigitalTwinsClient } from "../../src/index";
 import { createSpan } from "../../src/tracing";
-import { getSpanContext } from "@azure/core-tracing";
+import { Context, getSpanContext } from "@azure/core-tracing";
 
 describe("DigitalTwinsClient", () => {
   let operationOptions: OperationOptions;
@@ -749,8 +749,8 @@ function operationOptionsSinonMatcher<T extends OperationOptions>(
     const expectedContext = _expectedOptions!.tracingOptions!.tracingContext!;
 
     assert.deepEqual(
-      getSpanContext(expectedContext),
-      getSpanContext(actualOptions.tracingOptions!.tracingContext!)
+      getSpanContext(expectedContext as Context),
+      getSpanContext(actualOptions.tracingOptions!.tracingContext! as Context)
     );
 
     // check all the other properties that aren't interestingly unique

--- a/sdk/eventhub/event-hubs/src/diagnostics/tracing.ts
+++ b/sdk/eventhub/event-hubs/src/diagnostics/tracing.ts
@@ -35,7 +35,7 @@ export function createEventHubSpan(
     tracingOptions: {
       ...operationOptions?.tracingOptions,
       spanOptions: {
-        ...operationOptions?.tracingOptions?.spanOptions,
+        ...(operationOptions?.tracingOptions?.spanOptions as object),
         ...additionalSpanOptions
       }
     }

--- a/sdk/servicebus/service-bus/src/diagnostics/tracing.ts
+++ b/sdk/servicebus/service-bus/src/diagnostics/tracing.ts
@@ -55,7 +55,7 @@ export function createServiceBusSpan(
     tracingOptions: {
       ...operationOptions?.tracingOptions,
       spanOptions: {
-        ...operationOptions?.tracingOptions?.spanOptions,
+        ...(operationOptions?.tracingOptions?.spanOptions as object),
         ...additionalSpanOptions
       }
     }

--- a/sdk/servicebus/service-bus/test/internal/unit/tracing.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/unit/tracing.spec.ts
@@ -3,6 +3,7 @@
 
 import chai from "chai";
 import {
+  Context,
   context as otContext,
   Context as OTContext,
   getSpanContext,
@@ -106,7 +107,7 @@ describe("Tracing tests", () => {
     );
 
     assert.equal(
-      getSpanContext(options?.tracingOptions?.tracingContext!)?.spanId,
+      getSpanContext(options?.tracingOptions?.tracingContext! as Context)?.spanId,
       "my parent span id",
       "Parent span should be properly passed in."
     );
@@ -289,7 +290,7 @@ describe("Tracing tests", () => {
       assert.isFalse(Array.isArray(messages));
 
       assert.equal(
-        getSpanContext(options?.tracingOptions?.tracingContext!)!.spanId,
+        getSpanContext(options?.tracingOptions?.tracingContext! as Context)!.spanId,
         "my parent span id"
       );
 


### PR DESCRIPTION
## What

- Change spanOptions and tracingContext to unknown

## Why

- When the shape of these change we end up with incompatible changes that are pervasive throughout the codebase. But we really don't need to know what the type is across the board since we're just shepherding it through.