### PR TITLE
update core-client version to 1.2.1

### DIFF
--- a/sdk/core/core-client/CHANGELOG.md
+++ b/sdk/core/core-client/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.2.0 (2021-06-30)
+## 1.2.1 (2021-06-30)
 
 ### Features Added
 

--- a/sdk/core/core-client/package.json
+++ b/sdk/core/core-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/core-client",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Core library for interfacing with AutoRest generated code",
   "sdk-type": "client",
   "main": "dist/index.js",


### PR DESCRIPTION
See #16094 for details. This PR just updates core-client to 1.2.1 so I can release it