### PR TITLE
[digital-twins-core] address typo in method name

### DIFF
--- a/sdk/digitaltwins/digital-twins-core/review/digital-twins-core.api.md
+++ b/sdk/digitaltwins/digital-twins-core/review/digital-twins-core.api.md
@@ -84,7 +84,9 @@ export type DigitalTwinsAddResponse = DigitalTwinsAddHeaders & {
 export class DigitalTwinsClient {
     constructor(endpointUrl: string, credential: TokenCredential, options?: DigitalTwinsClientOptions);
     createModels(dtdlModels: any[], options?: OperationOptions): Promise<DigitalTwinModelsAddResponse>;
-    decomissionModel(modelId: string, options?: OperationOptions): Promise<RestResponse>;
+    // @deprecated (undocumented)
+    decomissionModel: (modelId: string, options?: OperationOptions) => Promise<RestResponse>;
+    decommissionModel(modelId: string, options?: OperationOptions): Promise<RestResponse>;
     deleteDigitalTwin(digitalTwinId: string, options?: DigitalTwinsDeleteOptionalParams): Promise<RestResponse>;
     deleteEventRoute(eventRouteId: string, options?: OperationOptions): Promise<RestResponse>;
     deleteModel(modelId: string, options?: OperationOptions): Promise<RestResponse>;

--- a/sdk/digitaltwins/digital-twins-core/src/digitalTwinsClient.ts
+++ b/sdk/digitaltwins/digital-twins-core/src/digitalTwinsClient.ts
@@ -859,9 +859,9 @@ export class DigitalTwinsClient {
 
   /**
    * Decommission a model using a json patch.
-   * When a model is decomissioned, new digital twins will no longer be able to be
+   * When a model is decommissioned, new digital twins will no longer be able to be
    * defined by this model. However, existing digital twins may continue to use this model.
-   * Once a model is decomissioned, it may not be recommissioned.
+   * Once a model is decommissioned, it may not be recommissioned.
    *
    * @param modelId - The Id of the model to decommission.
    * property can be replaced.
@@ -869,10 +869,10 @@ export class DigitalTwinsClient {
    * @returns The http response.
    *
    */
-  public decomissionModel(modelId: string, options: OperationOptions = {}): Promise<RestResponse> {
+  public decommissionModel(modelId: string, options: OperationOptions = {}): Promise<RestResponse> {
     const jsonPatch = [{ op: "replace", path: "/decommissioned", value: true }];
 
-    const { span, updatedOptions } = createSpan("DigitalTwinsClient-decomissionModel", options);
+    const { span, updatedOptions } = createSpan("DigitalTwinsClient-decommissionModel", options);
     try {
       return this.client.digitalTwinModels.update(modelId, jsonPatch, updatedOptions);
     } catch (e) {
@@ -885,6 +885,11 @@ export class DigitalTwinsClient {
       span.end();
     }
   }
+
+  /**
+   * @deprecated Please use {@link DigitalTwinsClient.decommissionModel} instead.
+   */
+  public decomissionModel = this.decommissionModel;
 
   /**
    * Delete a model.


### PR DESCRIPTION
Unfortunately, there is a typo in a method name that is exposed to the user. This PR attempts to correct this. Let me know if there's a better way to address this.