### PR TITLE
rename adminEmails and viewerEmails

### DIFF
--- a/sdk/metricsadvisor/ai-metrics-advisor/CHANGELOG.md
+++ b/sdk/metricsadvisor/ai-metrics-advisor/CHANGELOG.md
@@ -11,6 +11,7 @@ The Metrics Advisor library is now in GA with this release.
 - Removed support for granularity type `PerSecond`
 - Renamed "createFeedback" to "addFeedback"
 - `seriesToFilter` parameter renamed to `seriesKey` in methods `getmetricenrichedseriesdata` and `getmetricseriesdata` and ordering updated
+- Renamed `adminEmails` to `admins` in `MetricsAdvisorDataFeed` and `NotificationHook` and `viewerEmails` to `viewers` in `MetricsAdvisorDataFeed`
 - Renamed type `DetectionConditionsOperator` to `DetectionConditionOperator`
 - Renamed property `splitAlertByDimension` to `dimensionsToSplitAlert` in `AnomalyAlertConfiguration`
 - Renamed `datasource` to `DataSource`

--- a/sdk/metricsadvisor/ai-metrics-advisor/README.md
+++ b/sdk/metricsadvisor/ai-metrics-advisor/README.md
@@ -235,7 +235,7 @@ async function createDataFeed(adminClient, sqlServerConnectionString, sqlServerQ
       fillType: "SmartFilling"
     },
     accessMode: "Private",
-    adminEmails: ["xyz@example.com"]
+    admins: ["xyz@example.com"]
   };
   const result = await adminClient.createDataFeed(dataFeed);
 

--- a/sdk/metricsadvisor/ai-metrics-advisor/review/ai-metrics-advisor.api.md
+++ b/sdk/metricsadvisor/ai-metrics-advisor/review/ai-metrics-advisor.api.md
@@ -97,8 +97,8 @@ export type AnomalyValue = "AutoDetect" | "Anomaly" | "NotAnomaly";
 // @public
 export type AzureApplicationInsightsDataFeedSource = {
     dataSourceType: "AzureApplicationInsights";
-    azureCloud?: string;
-    applicationId?: string;
+    azureCloud: string;
+    applicationId: string;
     apiKey?: string;
     query: string;
     authenticationType: "Basic";
@@ -994,7 +994,7 @@ export type MySqlDataFeedSource = {
 
 // @public
 export interface NotificationHook {
-    readonly admins?: string[];
+    admins?: string[];
     description?: string;
     externalLink?: string;
     readonly id?: string;

--- a/sdk/metricsadvisor/ai-metrics-advisor/review/ai-metrics-advisor.api.md
+++ b/sdk/metricsadvisor/ai-metrics-advisor/review/ai-metrics-advisor.api.md
@@ -287,8 +287,8 @@ export type DataFeedPatch = {
     rollupSettings?: DataFeedRollupSettings;
     missingDataPointFillSettings?: DataFeedMissingDataPointFillSettings;
     accessMode?: DataFeedAccessMode;
-    adminEmails?: string[];
-    viewerEmails?: string[];
+    admins?: string[];
+    viewers?: string[];
     actionLinkTemplate?: string;
     status?: DataFeedDetailStatus;
 };
@@ -928,8 +928,8 @@ export type MetricsAdvisorDataFeed = {
     rollupSettings?: DataFeedRollupSettings;
     missingDataPointFillSettings?: DataFeedMissingDataPointFillSettings;
     accessMode?: DataFeedAccessMode;
-    adminEmails?: string[];
-    viewerEmails?: string[];
+    admins?: string[];
+    viewers?: string[];
     actionLinkTemplate?: string;
 };
 
@@ -994,7 +994,7 @@ export type MySqlDataFeedSource = {
 
 // @public
 export interface NotificationHook {
-    readonly adminEmails?: string[];
+    readonly admins?: string[];
     description?: string;
     externalLink?: string;
     readonly id?: string;

--- a/sdk/metricsadvisor/ai-metrics-advisor/review/ai-metrics-advisor.api.md
+++ b/sdk/metricsadvisor/ai-metrics-advisor/review/ai-metrics-advisor.api.md
@@ -1006,6 +1006,7 @@ export type NotificationHookPatch = {
     hookName?: string;
     description?: string;
     externalLink?: string;
+    admins?: string[];
 };
 
 // @public

--- a/sdk/metricsadvisor/ai-metrics-advisor/samples-dev/hooks.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/samples-dev/hooks.ts
@@ -82,7 +82,7 @@ async function getHook(client: MetricsAdvisorAdministrationClient, hookId: strin
   const result = await client.getHook(hookId);
   console.log(result.name);
   console.log(result.description);
-  console.log(result.adminEmails);
+  console.log(result.admins);
 }
 
 async function updateEmailHook(client: MetricsAdvisorAdministrationClient, hookId: string) {

--- a/sdk/metricsadvisor/ai-metrics-advisor/samples-dev/quickstart.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/samples-dev/quickstart.ts
@@ -139,7 +139,7 @@ async function createDataFeed(
       fillType: "SmartFilling"
     },
     accessMode: "Private",
-    adminEmails: ["xyz@microsoft.com"]
+    admins: ["xyz@microsoft.com"]
   };
   const result = await adminClient.createDataFeed(dataFeed);
 

--- a/sdk/metricsadvisor/ai-metrics-advisor/samples/v1/javascript/hooks.js
+++ b/sdk/metricsadvisor/ai-metrics-advisor/samples/v1/javascript/hooks.js
@@ -78,7 +78,7 @@ async function getHook(client, hookId) {
   const result = await client.getHook(hookId);
   console.log(result.name);
   console.log(result.description);
-  console.log(result.adminEmails);
+  console.log(result.admins);
 }
 
 async function updateEmailHook(client, hookId) {

--- a/sdk/metricsadvisor/ai-metrics-advisor/samples/v1/javascript/quickstart.js
+++ b/sdk/metricsadvisor/ai-metrics-advisor/samples/v1/javascript/quickstart.js
@@ -128,7 +128,7 @@ async function createDataFeed(adminClient, sqlServerConnectionString, sqlServerQ
       fillType: "SmartFilling"
     },
     accessMode: "Private",
-    adminEmails: ["xyz@microsoft.com"]
+    admins: ["xyz@microsoft.com"]
   };
   const result = await adminClient.createDataFeed(dataFeed);
 

--- a/sdk/metricsadvisor/ai-metrics-advisor/samples/v1/typescript/src/hooks.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/samples/v1/typescript/src/hooks.ts
@@ -81,7 +81,7 @@ async function getHook(client: MetricsAdvisorAdministrationClient, hookId: strin
   const result = await client.getHook(hookId);
   console.log(result.name);
   console.log(result.description);
-  console.log(result.adminEmails);
+  console.log(result.admins);
 }
 
 async function updateEmailHook(client: MetricsAdvisorAdministrationClient, hookId: string) {

--- a/sdk/metricsadvisor/ai-metrics-advisor/samples/v1/typescript/src/quickstart.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/samples/v1/typescript/src/quickstart.ts
@@ -138,7 +138,7 @@ async function createDataFeed(
       fillType: "SmartFilling"
     },
     accessMode: "Private",
-    adminEmails: ["xyz@microsoft.com"]
+    admins: ["xyz@microsoft.com"]
   };
   const result = await adminClient.createDataFeed(dataFeed);
 

--- a/sdk/metricsadvisor/ai-metrics-advisor/src/metricsAdvisorAdministrationClient.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/src/metricsAdvisorAdministrationClient.ts
@@ -714,7 +714,7 @@ export class MetricsAdvisorAdministrationClient {
   /**
    * Updates an anomaly alert configuration for the given configuration id
    * @param id - id of the anomaly alert configuration to update
-   * @param patch - Input to the update anomaly alert configuration operation {@link AnomalyAlertConfigurationPatch}
+   * @param patch - Input to the update anomaly alert configuration operation
    * @param options - The options parameter
    */
   public async updateAlertConfig(
@@ -1115,7 +1115,7 @@ export class MetricsAdvisorAdministrationClient {
   /**
    * Updates hook for the given hook id
    * @param id - id of the hook to update
-   * @param patch - Input to the update hook of type Email {@link EmailHookPatch} or WebHook {@link WebhookHookPatch}
+   * @param patch - Input to the update hook of type Email {@link EmailNotificationHookPatch} or WebHook {@link WebhookNotificationHookPatch}
    * @param options - The options parameter
    */
   public async updateHook(

--- a/sdk/metricsadvisor/ai-metrics-advisor/src/metricsAdvisorAdministrationClient.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/src/metricsAdvisorAdministrationClient.ts
@@ -209,8 +209,8 @@ export class MetricsAdvisorAdministrationClient {
       rollupSettings,
       missingDataPointFillSettings,
       accessMode,
-      adminEmails,
-      viewerEmails,
+      admins,
+      viewers,
       description
     } = feed;
 
@@ -262,8 +262,8 @@ export class MetricsAdvisorAdministrationClient {
         fillMissingPointType,
         fillMissingPointValue,
         viewMode: accessMode,
-        admins: adminEmails,
-        viewers: viewerEmails,
+        admins: admins,
+        viewers: viewers,
         dataFeedDescription: description,
         ...finalOptions
       };
@@ -495,8 +495,8 @@ export class MetricsAdvisorAdministrationClient {
             : undefined,
         // other options
         viewMode: patch.accessMode,
-        admins: patch.adminEmails,
-        viewers: patch.viewerEmails,
+        admins: patch.admins,
+        viewers: patch.viewers,
         status: patch.status,
         actionLinkTemplate: patch.actionLinkTemplate
       };

--- a/sdk/metricsadvisor/ai-metrics-advisor/src/metricsAdvisorAdministrationClient.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/src/metricsAdvisorAdministrationClient.ts
@@ -936,13 +936,14 @@ export class MetricsAdvisorAdministrationClient {
 
     try {
       const requestOptions = operationOptionsToRequestOptionsBase(finalOptions);
-      const { hookType, name, description, externalLink, hookParameter } = hookInfo;
+      const { hookType, name, description, externalLink, admins, hookParameter } = hookInfo;
       const result = await this.client.createHook(
         {
           hookType,
           name,
           description,
           externalLink,
+          admins,
           hookParameter
         } as HookInfoUnion,
         requestOptions

--- a/sdk/metricsadvisor/ai-metrics-advisor/src/models.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/src/models.ts
@@ -258,14 +258,14 @@ export type MetricsAdvisorDataFeed = {
   accessMode?: DataFeedAccessMode;
 
   /**
-   * email addresses of data feed administrators
+   * data feed administrators email addresses or client id
    */
-  adminEmails?: string[];
+  admins?: string[];
 
   /**
-   * email addresses of data feed viewers
+   * data feed viewers email addresses or client id
    */
-  viewerEmails?: string[];
+  viewers?: string[];
 
   /**
    * action link template for alert
@@ -774,14 +774,14 @@ export type DataFeedPatch = {
   accessMode?: DataFeedAccessMode;
 
   /**
-   * email addresses of data feed administrators
+   * data feed administrators email addresses or client id
    */
-  adminEmails?: string[];
+  admins?: string[];
 
   /**
-   * email addresses of data feed viewers
+   * data feed viewers email addresses or client id
    */
-  viewerEmails?: string[];
+  viewers?: string[];
 
   /**
    * action link template for alert
@@ -1121,9 +1121,9 @@ export interface NotificationHook {
    */
   externalLink?: string;
   /**
-   * email addresses of hook administrators
+   * hook administrators email addresses or client id
    */
-  readonly adminEmails?: string[];
+  readonly admins?: string[];
 }
 
 /**

--- a/sdk/metricsadvisor/ai-metrics-advisor/src/models.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/src/models.ts
@@ -796,7 +796,12 @@ export type DataFeedPatch = {
   admins?: string[];
 
   /**
-   * data feed viewers email addresses or client id
+   * The viewers of this {@link MetricsAdvisorDataFeed }.
+   * Viewers have read-only access to a data feed. Each element in this list represents a user with viewer access,
+   * but the value of each `string` element depends on the type of authentication to be used by this viewer when communicating with the service.
+   * If {@link MetricsAdvisorKeyCredential } authentication will be used, the `string` must be the user's email address.
+   * If AAD authentication will be used instead, the `string` must uniquely identify the user's principal.
+   * For instance, for a `ClientSecretCredential`, the `string` must be the client ID.
    */
   viewers?: string[];
 
@@ -1188,6 +1193,16 @@ export type NotificationHookPatch = {
    * new hook external link
    */
   externalLink?: string;
+  /**
+   * The administrators of this {@link NotificationHook }.
+   * Administrators have total control over a NotificationHook, being allowed to update or delete.
+   * Each element in this list represents a user with administrator access, but the value of each `string` element
+   * depends on the type of authentication to be used by this administrator when communicating with the service.
+   * If {@link MetricsAdvisorKeyCredential } authentication will be used, the `string` must be the user's email address.
+   * If AAD authentication will be used instead, the `string` must uniquely identify the user's principal.
+   * For instance, for a `ClientSecretCredential`, the `string` must be the client ID.
+   */
+  admins?: string[];
 };
 
 /**

--- a/sdk/metricsadvisor/ai-metrics-advisor/src/models.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/src/models.ts
@@ -258,12 +258,23 @@ export type MetricsAdvisorDataFeed = {
   accessMode?: DataFeedAccessMode;
 
   /**
-   * data feed administrators email addresses or client id
+   * The administrators of this {@link MetricsAdvisorDataFeed }.
+   * Administrators have total control over a data feed, being allowed to update, delete, or pause them.
+   * Each element in this list represents a user with administrator access, but the value of each `string` element
+   * depends on the type of authentication to be used by this administrator when communicating with the service.
+   * If {@link MetricsAdvisorKeyCredential } authentication will be used, the `string` must be the user's email address.
+   * If AAD authentication will be used instead, the `string` must uniquely identify the user's principal.
+   * For instance, for a `ClientSecretCredential`, the `string` must be the client ID.
    */
   admins?: string[];
 
   /**
-   * data feed viewers email addresses or client id
+   * The viewers of this {@link MetricsAdvisorDataFeed }.
+   * Viewers have read-only access to a data feed. Each element in this list represents a user with viewer access,
+   * but the value of each `string` element depends on the type of authentication to be used by this viewer when communicating with the service.
+   * If {@link MetricsAdvisorKeyCredential } authentication will be used, the `string` must be the user's email address.
+   * If AAD authentication will be used instead, the `string` must uniquely identify the user's principal.
+   * For instance, for a `ClientSecretCredential`, the `string` must be the client ID.
    */
   viewers?: string[];
 
@@ -280,10 +291,10 @@ export type MetricsAdvisorDataFeed = {
  */
 export type AzureApplicationInsightsDataFeedSource = {
   dataSourceType: "AzureApplicationInsights";
-  /** The Azure cloud that this Azure Application Insights in. Required by user for Create*/
-  azureCloud?: string;
-  /** The application id of this Azure Application Insights. Required by user for Create*/
-  applicationId?: string;
+  /** The Azure cloud that this Azure Application Insights in.*/
+  azureCloud: string;
+  /** The application id of this Azure Application Insights.*/
+  applicationId: string;
   /** The API Key that can access this Azure Application Insights. Required by user for Create. Not returned by service */
   apiKey?: string;
   /** The statement to query this Azure Application Insights */
@@ -774,7 +785,13 @@ export type DataFeedPatch = {
   accessMode?: DataFeedAccessMode;
 
   /**
-   * data feed administrators email addresses or client id
+   * The administrators of this {@link MetricsAdvisorDataFeed }.
+   * Administrators have total control over a data feed, being allowed to update, delete, or pause them.
+   * Each element in this list represents a user with administrator access, but the value of each `string` element
+   * depends on the type of authentication to be used by this administrator when communicating with the service.
+   * If {@link MetricsAdvisorKeyCredential } authentication will be used, the `string` must be the user's email address.
+   * If AAD authentication will be used instead, the `string` must uniquely identify the user's principal.
+   * For instance, for a `ClientSecretCredential`, the `string` must be the client ID.
    */
   admins?: string[];
 
@@ -1121,9 +1138,15 @@ export interface NotificationHook {
    */
   externalLink?: string;
   /**
-   * hook administrators email addresses or client id
+   * The administrators of this {@link NotificationHook }.
+   * Administrators have total control over a NotificationHook, being allowed to update or delete.
+   * Each element in this list represents a user with administrator access, but the value of each `string` element
+   * depends on the type of authentication to be used by this administrator when communicating with the service.
+   * If {@link MetricsAdvisorKeyCredential } authentication will be used, the `string` must be the user's email address.
+   * If AAD authentication will be used instead, the `string` must uniquely identify the user's principal.
+   * For instance, for a `ClientSecretCredential`, the `string` must be the client ID.
    */
-  readonly admins?: string[];
+  admins?: string[];
 }
 
 /**

--- a/sdk/metricsadvisor/ai-metrics-advisor/src/transforms.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/src/transforms.ts
@@ -921,8 +921,8 @@ export function fromServiceDataFeedDetailUnion(
             fillType: original.fillMissingPointType!
           },
     accessMode: original.viewMode,
-    adminEmails: original.admins,
-    viewerEmails: original.viewers
+    admins: original.admins,
+    viewers: original.viewers
   };
   switch (original.dataSourceType) {
     case "AzureApplicationInsights": {
@@ -1205,7 +1205,7 @@ export function fromServiceHookInfoUnion(original: ServiceHookInfoUnion): Notifi
     name: original.name,
     description: original.description,
     externalLink: original.externalLink,
-    adminEmails: original.admins
+    admins: original.admins
   };
   switch (original.hookType) {
     case "Email": {

--- a/sdk/metricsadvisor/ai-metrics-advisor/src/transforms.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/src/transforms.ts
@@ -931,8 +931,8 @@ export function fromServiceDataFeedDetailUnion(
         ...common,
         source: {
           dataSourceType: "AzureApplicationInsights",
-          azureCloud: orig.dataSourceParameter.azureCloud,
-          applicationId: orig.dataSourceParameter.applicationId,
+          azureCloud: orig.dataSourceParameter.azureCloud!,
+          applicationId: orig.dataSourceParameter.applicationId!,
           apiKey: orig.dataSourceParameter.apiKey,
           query: orig.dataSourceParameter.query,
           authenticationType: "Basic"

--- a/sdk/metricsadvisor/ai-metrics-advisor/test/public/datafeed.spec.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/test/public/datafeed.spec.ts
@@ -343,7 +343,7 @@ matrix([[true, false]] as const, async (useAad) => {
               fillType: "PreviousValue"
             },
             accessMode: "Public",
-            viewerEmails: ["viewer1@example.com"],
+            viewers: ["viewer1@example.com"],
             actionLinkTemplate: "Updated Azure Blob action link template"
           };
           const updated = await client.updateDataFeed(createdAzureBlobDataFeedId, patch);
@@ -364,7 +364,7 @@ matrix([[true, false]] as const, async (useAad) => {
           assert.equal((updated.rollupSettings! as any).rollupIdentificationValue, "__Existing__");
           assert.equal(updated.missingDataPointFillSettings?.fillType, "PreviousValue");
           assert.equal(updated.accessMode, "Public");
-          assert.deepStrictEqual(updated.viewerEmails, ["viewer1@example.com"]);
+          assert.deepStrictEqual(updated.viewers, ["viewer1@example.com"]);
           assert.equal(updated.actionLinkTemplate, "Updated Azure Blob action link template");
         });
 


### PR DESCRIPTION
rename adminEmails to admins
rename viewerEmails to viewers 
Since these represent UUId too not just email addresses
- admins in NotificationHook is not readonly anymore