### PR TITLE
Update communication-common dependency to fix core-http transitive de…

### DIFF
--- a/sdk/communication/communication-chat/package.json
+++ b/sdk/communication/communication-chat/package.json
@@ -65,7 +65,7 @@
   "prettier": "@azure/eslint-plugin-azure-sdk/prettier.json",
   "dependencies": {
     "@azure/abort-controller": "^1.0.0",
-    "@azure/communication-common": "^1.0.0",
+    "@azure/communication-common": "^1.1.0",
     "@azure/communication-signaling": "1.0.0-beta.7",
     "@azure/core-auth": "^1.3.0",
     "@azure/core-http": "^2.0.0",

--- a/sdk/communication/communication-identity/package.json
+++ b/sdk/communication/communication-identity/package.json
@@ -74,7 +74,7 @@
   "prettier": "@azure/eslint-plugin-azure-sdk/prettier.json",
   "dependencies": {
     "@azure/abort-controller": "^1.0.0",
-    "@azure/communication-common": "^1.0.0",
+    "@azure/communication-common": "^1.1.0",
     "@azure/core-auth": "^1.3.0",
     "@azure/core-http": "^2.0.0",
     "@azure/core-lro": "^2.0.0",

--- a/sdk/communication/communication-network-traversal/package.json
+++ b/sdk/communication/communication-network-traversal/package.json
@@ -74,7 +74,7 @@
   "prettier": "@azure/eslint-plugin-azure-sdk/prettier.json",
   "dependencies": {
     "@azure/abort-controller": "^1.0.0",
-    "@azure/communication-common": "^1.0.0",
+    "@azure/communication-common": "^1.1.0",
     "@azure/core-auth": "^1.3.0",
     "@azure/core-http": "^2.0.0",
     "@azure/core-tracing": "1.0.0-preview.12",

--- a/sdk/communication/communication-phone-numbers/package.json
+++ b/sdk/communication/communication-phone-numbers/package.json
@@ -61,7 +61,7 @@
   "sideEffects": false,
   "prettier": "@azure/eslint-plugin-azure-sdk/prettier.json",
   "dependencies": {
-    "@azure/communication-common": "^1.0.0",
+    "@azure/communication-common": "^1.1.0",
     "@azure/abort-controller": "^1.0.0",
     "@azure/core-auth": "^1.3.0",
     "@azure/core-http": "^2.0.0",

--- a/sdk/communication/communication-sms/package.json
+++ b/sdk/communication/communication-sms/package.json
@@ -66,7 +66,7 @@
   "prettier": "@azure/eslint-plugin-azure-sdk/prettier.json",
   "dependencies": {
     "@azure/abort-controller": "^1.0.0",
-    "@azure/communication-common": "^1.0.0",
+    "@azure/communication-common": "^1.1.0",
     "@azure/core-auth": "^1.3.0",
     "@azure/core-http": "^2.0.0",
     "@azure/core-tracing": "1.0.0-preview.12",


### PR DESCRIPTION
…pendency

Communication-identity says it works with communication-common ^1.0.0 and core-http ^2.0.0

Communication-common is currently 1.1.0 when core-http dependency was updated to ^2.0.0. But communication-common 1.0.0 is compatible with core-http 1.2.6



So below combination will be a problem for users:

communication-identity@1.1.0

communication-common@1.0.0

core-http@1.2.6