### PR TITLE
[storage] - bump minimum versions of packages that depend on storage-blob

### DIFF
--- a/sdk/quantum/quantum-jobs/package.json
+++ b/sdk/quantum/quantum-jobs/package.json
@@ -70,7 +70,7 @@
     "tslib": "^2.2.0"
   },
   "devDependencies": {
-    "@azure/storage-blob": "^12.6.0-beta.1",
+    "@azure/storage-blob": "^12.7.0",
     "@azure/dev-tool": "^1.0.0",
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
     "@azure/identity": "2.0.0-beta.4",

--- a/sdk/storage/perf-tests/storage-blob/package.json
+++ b/sdk/storage/perf-tests/storage-blob/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "@azure/core-http": "^2.0.0",
     "@azure/core-rest-pipeline": "^1.1.0",
-    "@azure/storage-blob": "^12.6.0-beta.1",
+    "@azure/storage-blob": "^12.7.0",
     "@azure/test-utils-perfstress": "^1.0.0",
     "dotenv": "^8.2.0",
     "uuid": "^8.3.0"

--- a/sdk/storage/storage-blob-changefeed/package.json
+++ b/sdk/storage/storage-blob-changefeed/package.json
@@ -94,7 +94,7 @@
     ]
   },
   "dependencies": {
-    "@azure/storage-blob": "^12.6.0-beta.1",
+    "@azure/storage-blob": "^12.7.0",
     "@azure/abort-controller": "^1.0.0",
     "@azure/core-http": "^2.0.0",
     "@azure/core-lro": "^2.0.0",

--- a/sdk/storage/storage-file-datalake/package.json
+++ b/sdk/storage/storage-file-datalake/package.json
@@ -111,7 +111,7 @@
     "@azure/core-paging": "^1.1.1",
     "@azure/core-tracing": "1.0.0-preview.12",
     "@azure/logger": "^1.0.0",
-    "@azure/storage-blob": "^12.6.0-beta.1",
+    "@azure/storage-blob": "^12.7.0",
     "events": "^3.0.0",
     "tslib": "^2.2.0"
   },


### PR DESCRIPTION
We recently discovered an issue caused by bumping core-http by a major version (#15925) where if a transitive dependency
is still allowing an older version we would end up with two versions of core-http / core-lro.

This is a problem for two reasons:
- bundle size
- incompatibility of enums between two versions

This was discovered via failed nightly tests and while some of this was fixed by #16180, we still need to audit all the packages
and ensure that:

For every package that moved to core-http@2.0.0, all other dependencies of that package are pinned to a min-version that also
uses core-http@2.0.0

Luckily that is a very small number of packages - mainly communication (fixed) and storage (this PR)
