### PR TITLE
Updating CODEOWNERS for ACS Identity

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -35,6 +35,7 @@
 
 # PRLabel: %Communication
 /sdk/communication/ @DominikMe @0rland0Wats0n @ankitarorabit @Azure/azure-sdk-communication-code-reviewers
+/sdk/communication/communication-identity/ @petrsvihlik @martinbarnas-ms
 
 # PRLabel: %Container Registry
 /sdk/containerregistry/ @jeremymeng


### PR DESCRIPTION
Reason: The ACS SDKs (including Identity) are being handed over to the respective service teams.