### PR TITLE
Fix path for template types in package.json

### DIFF
--- a/sdk/template/template/api-extractor.json
+++ b/sdk/template/template/api-extractor.json
@@ -11,7 +11,7 @@
   "dtsRollup": {
     "enabled": true,
     "untrimmedFilePath": "",
-    "publicTrimmedFilePath": "./types/template.d.ts"
+    "publicTrimmedFilePath": "./types/latest/template.d.ts"
   },
   "messages": {
     "tsdocMessageReporting": {

--- a/sdk/template/template/package.json
+++ b/sdk/template/template/package.json
@@ -59,7 +59,8 @@
   "files": [
     "dist/",
     "dist-esm/src/",
-    "types/template.d.ts",
+    "types/latest/",
+    "types/3.1/",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/template/template/package.json
+++ b/sdk/template/template/package.json
@@ -18,7 +18,7 @@
       }
     ]
   },
-  "types": "types/template.d.ts",
+  "types": "types/latest/template.d.ts",
   "typesVersions": {
     "<3.6": {
       "*": [

--- a/sdk/template/template/package.json
+++ b/sdk/template/template/package.json
@@ -18,7 +18,7 @@
       }
     ]
   },
-  "types": "types/latest/template.d.ts",
+  "types": "types/template.d.ts",
   "typesVersions": {
     "<3.6": {
       "*": [


### PR DESCRIPTION
Attempt to fix an issue uncovered in the docs build: https://apidrop.visualstudio.com/Content%20CI/_build/results?buildId=229991&view=logs&j=fd490c07-0b22-5182-fac9-6d67fe1e939b&t=a04569be-1b08-5c9a-7e65-a83076350a0c&l=525

Given that farther down in the file is a line: 

```
"build:types": "downlevel-dts types/latest types/3.1",
```

I'm not sure if this change is complete. 