### PR TITLE
[MetricsAdvisor] Fix readme data feed creation example

### DIFF
--- a/sdk/metricsadvisor/ai-metrics-advisor/README.md
+++ b/sdk/metricsadvisor/ai-metrics-advisor/README.md
@@ -191,10 +191,8 @@ async function createDataFeed(adminClient, sqlServerConnectionString, sqlServerQ
     name: "test_datafeed_" + new Date().getTime().toString(),
     source: {
       dataSourceType: "SqlServer",
-      dataSourceParameter: {
-        connectionString: sqlServerConnectionString,
-        query: sqlServerQuery
-      },
+      connectionString: sqlServerConnectionString,
+      query: sqlServerQuery,
       authenticationType: "Basic"
     },
     granularity: {

--- a/sdk/metricsadvisor/ai-metrics-advisor/src/models.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/src/models.ts
@@ -817,9 +817,6 @@ export type DataFeedPatch = {
 
 /**
  * A alias type of supported data sources to pass to Update Data Feed operation.
- *
- * When not changing the data source type, the dataSourceParameter is not required.
- * When changing to a different data source type, both dataSourceType and dataSourceParameter are required.
  */
 export type DataFeedSourcePatch = Partial<DataFeedSource> & {
   /** dataSource type for patch */


### PR DESCRIPTION
The `dataSourceParameter` property has been flattened in latest Api.

Fixes #16105 