### PR TITLE
July Release Search SDK Code Changes

### DIFF
--- a/sdk/search/search-documents/CHANGELOG.md
+++ b/sdk/search/search-documents/CHANGELOG.md
@@ -1,15 +1,19 @@
 # Release History
 
-## 11.3.0-beta.1 (Unreleased)
+## 11.3.0-beta.1 (2021-07-07)
 
-### Features Added
 - With the dropping of support for Node.js versions that are no longer in LTS, the dependency on `@types/node` has been updated to version 12. Read our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
-### Breaking Changes
+- Regenerated the search SDK with the latest swaggers that includes the following changes:
 
-### Key Bugs Fixed
-
-### Fixed
+  - Support for `TokenCredential` has been added.
+  - Identity types - `SearchIndexerDataNoneIdentity` & `SearchIndexerDataUserAssignedIdentity` have been added.
+  - The following new skills have been added:
+    - SentimentSkill(V3)
+    - EntityLinkingSkill(V3)
+    - EntityRecognitionSkill(V3)
+    - PIIDetectionSkill
+  - A new property `lineEnding` has been added to the skill `OcrSkill`.
 
 ## 11.2.0 (2021-06-08)
 

--- a/sdk/search/search-documents/CHANGELOG.md
+++ b/sdk/search/search-documents/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - Regenerated the search SDK with the latest swaggers that includes the following changes:
 
-  - Support for `TokenCredential` has been added.
+  - Support for `TokenCredential` has been added. With this addition, the Search SDK supports authentication via AAD.
   - Identity types - `SearchIndexerDataNoneIdentity` & `SearchIndexerDataUserAssignedIdentity` have been added.
   - The following new skills have been added:
     - SentimentSkill(V3)

--- a/sdk/search/search-documents/review/search-documents.api.md
+++ b/sdk/search/search-documents/review/search-documents.api.md
@@ -10,6 +10,7 @@ import { OperationOptions } from '@azure/core-http';
 import { PagedAsyncIterableIterator } from '@azure/core-paging';
 import { PipelineOptions } from '@azure/core-http';
 import { RestError } from '@azure/core-http';
+import { TokenCredential } from '@azure/core-auth';
 
 // @public
 export interface AnalyzedTokenInfo {
@@ -106,7 +107,7 @@ export interface BaseCognitiveServicesAccount {
 
 // @public
 export interface BaseDataChangeDetectionPolicy {
-    odatatype: "#Microsoft.Azure.Search.HighWaterMarkChangeDetectionPolicy" | "#Microsoft.Azure.Search.SqlIntegratedChangeTrackingPolicy";
+    odatatype: "#Microsoft.Azure.Search.SearchIndexerDataNoneIdentity" | "#Microsoft.Azure.Search.SearchIndexerDataUserAssignedIdentity" | "#Microsoft.Azure.Search.HighWaterMarkChangeDetectionPolicy" | "#Microsoft.Azure.Search.SqlIntegratedChangeTrackingPolicy";
 }
 
 // @public
@@ -146,7 +147,7 @@ export interface BaseSearchIndexerSkill {
     description?: string;
     inputs: InputFieldMappingEntry[];
     name?: string;
-    odatatype: "#Microsoft.Skills.Util.ConditionalSkill" | "#Microsoft.Skills.Text.KeyPhraseExtractionSkill" | "#Microsoft.Skills.Vision.OcrSkill" | "#Microsoft.Skills.Vision.ImageAnalysisSkill" | "#Microsoft.Skills.Text.LanguageDetectionSkill" | "#Microsoft.Skills.Util.ShaperSkill" | "#Microsoft.Skills.Text.MergeSkill" | "#Microsoft.Skills.Text.EntityRecognitionSkill" | "#Microsoft.Skills.Text.SentimentSkill" | "#Microsoft.Skills.Text.SplitSkill" | "#Microsoft.Skills.Text.CustomEntityLookupSkill" | "#Microsoft.Skills.Text.TranslationSkill" | "#Microsoft.Skills.Util.DocumentExtractionSkill" | "#Microsoft.Skills.Custom.WebApiSkill";
+    odatatype: "#Microsoft.Skills.Util.ConditionalSkill" | "#Microsoft.Skills.Text.KeyPhraseExtractionSkill" | "#Microsoft.Skills.Vision.OcrSkill" | "#Microsoft.Skills.Vision.ImageAnalysisSkill" | "#Microsoft.Skills.Text.LanguageDetectionSkill" | "#Microsoft.Skills.Util.ShaperSkill" | "#Microsoft.Skills.Text.MergeSkill" | "#Microsoft.Skills.Text.EntityRecognitionSkill" | "#Microsoft.Skills.Text.SentimentSkill" | "#Microsoft.Skills.Text.V3.SentimentSkill" | "#Microsoft.Skills.Text.V3.EntityLinkingSkill" | "#Microsoft.Skills.Text.V3.EntityRecognitionSkill" | "#Microsoft.Skills.Text.PIIDetectionSkill" | "#Microsoft.Skills.Text.SplitSkill" | "#Microsoft.Skills.Text.CustomEntityLookupSkill" | "#Microsoft.Skills.Text.TranslationSkill" | "#Microsoft.Skills.Util.DocumentExtractionSkill" | "#Microsoft.Skills.Custom.WebApiSkill";
     outputs: OutputFieldMappingEntry[];
 }
 
@@ -181,6 +182,9 @@ export interface CaptionResult {
     readonly highlights?: string | null;
     readonly text?: string;
 }
+
+// @public
+export type Captions = string;
 
 // @public
 export type CharFilter = MappingCharFilter | PatternReplaceCharFilter;
@@ -349,7 +353,7 @@ export type CustomNormalizer = BaseLexicalNormalizer & {
 };
 
 // @public
-export type DataChangeDetectionPolicy = HighWaterMarkChangeDetectionPolicy | SqlIntegratedChangeTrackingPolicy;
+export type DataChangeDetectionPolicy = HighWaterMarkChangeDetectionPolicy | SqlIntegratedChangeTrackingPolicy | SearchIndexerDataUserAssignedIdentity | SearchIndexerDataNoneIdentity;
 
 // @public
 export type DataDeletionDetectionPolicy = SoftDeleteColumnDeletionDetectionPolicy;
@@ -458,6 +462,14 @@ export type ElisionTokenFilter = BaseTokenFilter & {
 export type EntityCategory = string;
 
 // @public
+export type EntityLinkingSkill = BaseSearchIndexerSkill & {
+    odatatype: "#Microsoft.Skills.Text.V3.EntityLinkingSkill";
+    defaultLanguageCode?: string | null;
+    minimumPrecision?: number | null;
+    modelVersion?: string | null;
+};
+
+// @public
 export type EntityRecognitionSkill = BaseSearchIndexerSkill & {
     odatatype: "#Microsoft.Skills.Text.EntityRecognitionSkill";
     categories?: EntityCategory[];
@@ -468,6 +480,15 @@ export type EntityRecognitionSkill = BaseSearchIndexerSkill & {
 
 // @public
 export type EntityRecognitionSkillLanguage = string;
+
+// @public
+export type EntityRecognitionSkillV3 = BaseSearchIndexerSkill & {
+    odatatype: "#Microsoft.Skills.Text.V3.EntityRecognitionSkill";
+    categories?: string[];
+    defaultLanguageCode?: string | null;
+    minimumPrecision?: number | null;
+    modelVersion?: string | null;
+};
 
 // @public
 export interface FacetResult {
@@ -1043,6 +1064,14 @@ export const enum KnownLexicalNormalizerName {
 }
 
 // @public
+export const enum KnownLineEnding {
+    CarriageReturn = "carriageReturn",
+    CarriageReturnLineFeed = "carriageReturnLineFeed",
+    LineFeed = "lineFeed",
+    Space = "space"
+}
+
+// @public
 export const enum KnownOcrSkillLanguage {
     Ar = "ar",
     Cs = "cs",
@@ -1070,6 +1099,12 @@ export const enum KnownOcrSkillLanguage {
     Tr = "tr",
     ZhHans = "zh-Hans",
     ZhHant = "zh-Hant"
+}
+
+// @public
+export const enum KnownPIIDetectionSkillMaskingMode {
+    None = "none",
+    Replace = "replace"
 }
 
 // @public
@@ -1165,6 +1200,7 @@ export const enum KnownTextTranslationSkillLanguage {
     Fil = "fil",
     Fj = "fj",
     Fr = "fr",
+    Ga = "ga",
     He = "he",
     Hi = "hi",
     Hr = "hr",
@@ -1174,18 +1210,24 @@ export const enum KnownTextTranslationSkillLanguage {
     Is = "is",
     It = "it",
     Ja = "ja",
+    Kn = "kn",
     Ko = "ko",
     Lt = "lt",
     Lv = "lv",
     Mg = "mg",
+    Mi = "mi",
+    Ml = "ml",
     Ms = "ms",
     Mt = "mt",
     Mww = "mww",
     Nb = "nb",
     Nl = "nl",
     Otq = "otq",
+    Pa = "pa",
     Pl = "pl",
     Pt = "pt",
+    PtBr = "pt-br",
+    PtPT = "pt-PT",
     Ro = "ro",
     Ru = "ru",
     Sk = "sk",
@@ -1199,6 +1241,8 @@ export const enum KnownTextTranslationSkillLanguage {
     Te = "te",
     Th = "th",
     Tlh = "tlh",
+    TlhLatn = "tlh-Latn",
+    TlhPiqd = "tlh-Piqd",
     To = "to",
     Tr = "tr",
     Ty = "ty",
@@ -1352,6 +1396,9 @@ export type LimitTokenFilter = BaseTokenFilter & {
 };
 
 // @public
+export type LineEnding = string;
+
+// @public
 export type ListDataSourceConnectionsOptions = OperationOptions;
 
 // @public
@@ -1460,6 +1507,7 @@ export type OcrSkill = BaseSearchIndexerSkill & {
     odatatype: "#Microsoft.Skills.Vision.OcrSkill";
     defaultLanguageCode?: OcrSkillLanguage;
     shouldDetectOrientation?: boolean;
+    lineEnding?: LineEnding;
 };
 
 // @public
@@ -1535,6 +1583,21 @@ export type PhoneticTokenFilter = BaseTokenFilter & {
 };
 
 // @public
+export type PIIDetectionSkill = BaseSearchIndexerSkill & {
+    odatatype: "#Microsoft.Skills.Text.PIIDetectionSkill";
+    defaultLanguageCode?: string | null;
+    minimumPrecision?: number | null;
+    maskingMode?: PIIDetectionSkillMaskingMode;
+    maskingCharacter?: string | null;
+    modelVersion?: string | null;
+    piiCategories?: string[];
+    domain?: string | null;
+};
+
+// @public
+export type PIIDetectionSkillMaskingMode = string;
+
+// @public
 export type QueryLanguage = string;
 
 // @public
@@ -1577,7 +1640,7 @@ export type ScoringStatistics = "local" | "global";
 
 // @public
 export class SearchClient<T> implements IndexDocumentsClient<T> {
-    constructor(endpoint: string, indexName: string, credential: KeyCredential, options?: SearchClientOptions);
+    constructor(endpoint: string, indexName: string, credential: KeyCredential | TokenCredential, options?: SearchClientOptions);
     readonly apiVersion: string;
     autocomplete<Fields extends keyof T>(searchText: string, suggesterName: string, options?: AutocompleteOptions<Fields>): Promise<AutocompleteResult>;
     deleteDocuments(documents: T[], options?: DeleteDocumentsOptions): Promise<IndexDocumentsResult>;
@@ -1646,7 +1709,7 @@ export interface SearchIndex {
 
 // @public
 export class SearchIndexClient {
-    constructor(endpoint: string, credential: KeyCredential, options?: SearchIndexClientOptions);
+    constructor(endpoint: string, credential: KeyCredential | TokenCredential, options?: SearchIndexClientOptions);
     analyzeText(indexName: string, options: AnalyzeTextOptions): Promise<AnalyzeResult>;
     readonly apiVersion: string;
     createIndex(index: SearchIndex, options?: CreateIndexOptions): Promise<SearchIndex>;
@@ -1690,7 +1753,7 @@ export interface SearchIndexer {
 
 // @public
 export class SearchIndexerClient {
-    constructor(endpoint: string, credential: KeyCredential, options?: SearchIndexerClientOptions);
+    constructor(endpoint: string, credential: KeyCredential | TokenCredential, options?: SearchIndexerClientOptions);
     readonly apiVersion: string;
     createDataSourceConnection(dataSourceConnection: SearchIndexerDataSourceConnection, options?: CreateDataSourceConnectionOptions): Promise<SearchIndexerDataSourceConnection>;
     createIndexer(indexer: SearchIndexer, options?: CreateIndexerOptions): Promise<SearchIndexer>;
@@ -1728,6 +1791,16 @@ export interface SearchIndexerDataContainer {
 }
 
 // @public
+export interface SearchIndexerDataIdentity {
+    odatatype: "undefined";
+}
+
+// @public
+export type SearchIndexerDataNoneIdentity = BaseDataChangeDetectionPolicy & {
+    odatatype: "#Microsoft.Azure.Search.SearchIndexerDataNoneIdentity";
+};
+
+// @public
 export interface SearchIndexerDataSourceConnection {
     connectionString?: string;
     container: SearchIndexerDataContainer;
@@ -1736,12 +1809,19 @@ export interface SearchIndexerDataSourceConnection {
     description?: string;
     encryptionKey?: SearchResourceEncryptionKey | null;
     etag?: string;
+    identity?: SearchIndexerDataIdentity | null;
     name: string;
     type: SearchIndexerDataSourceType;
 }
 
 // @public
 export type SearchIndexerDataSourceType = string;
+
+// @public
+export type SearchIndexerDataUserAssignedIdentity = BaseDataChangeDetectionPolicy & {
+    odatatype: "#Microsoft.Azure.Search.SearchIndexerDataUserAssignedIdentity";
+    userAssignedIdentity: string;
+};
 
 // @public
 export interface SearchIndexerError {
@@ -1799,7 +1879,7 @@ export interface SearchIndexerLimits {
 }
 
 // @public
-export type SearchIndexerSkill = ConditionalSkill | KeyPhraseExtractionSkill | OcrSkill | ImageAnalysisSkill | LanguageDetectionSkill | ShaperSkill | MergeSkill | EntityRecognitionSkill | SentimentSkill | SplitSkill | CustomEntityLookupSkill | TextTranslationSkill | DocumentExtractionSkill | WebApiSkill;
+export type SearchIndexerSkill = ConditionalSkill | KeyPhraseExtractionSkill | OcrSkill | ImageAnalysisSkill | LanguageDetectionSkill | ShaperSkill | MergeSkill | EntityRecognitionSkill | SentimentSkill | SplitSkill | PIIDetectionSkill | EntityRecognitionSkillV3 | EntityLinkingSkill | SentimentSkillV3 | CustomEntityLookupSkill | TextTranslationSkill | DocumentExtractionSkill | WebApiSkill;
 
 // @public
 export interface SearchIndexerSkillset {
@@ -1897,6 +1977,7 @@ export type SearchOptions<Fields> = OperationOptions & SearchRequestOptions<Fiel
 // @public
 export interface SearchRequest {
     answers?: Answers;
+    captions?: Captions;
     facets?: string[];
     filter?: string;
     highlightFields?: string;
@@ -1914,6 +1995,7 @@ export interface SearchRequest {
     searchMode?: SearchMode;
     searchText?: string;
     select?: string;
+    semanticFields?: string;
     sessionId?: string;
     skip?: number;
     speller?: Speller;
@@ -1949,6 +2031,7 @@ export interface SearchRequestOptions<Fields> {
 export interface SearchResourceEncryptionKey {
     applicationId?: string;
     applicationSecret?: string;
+    identity?: SearchIndexerDataIdentity | null;
     keyName: string;
     keyVersion: string;
     vaultUrl: string;
@@ -1986,6 +2069,14 @@ export type SentimentSkill = BaseSearchIndexerSkill & {
 
 // @public
 export type SentimentSkillLanguage = string;
+
+// @public
+export type SentimentSkillV3 = BaseSearchIndexerSkill & {
+    odatatype: "#Microsoft.Skills.Text.V3.SentimentSkill";
+    defaultLanguageCode?: string | null;
+    includeOpinionMining?: boolean;
+    modelVersion?: string | null;
+};
 
 // @public
 export interface ServiceCounters {

--- a/sdk/search/search-documents/review/search-documents.api.md
+++ b/sdk/search/search-documents/review/search-documents.api.md
@@ -107,7 +107,7 @@ export interface BaseCognitiveServicesAccount {
 
 // @public
 export interface BaseDataChangeDetectionPolicy {
-    odatatype: "#Microsoft.Azure.Search.SearchIndexerDataNoneIdentity" | "#Microsoft.Azure.Search.SearchIndexerDataUserAssignedIdentity" | "#Microsoft.Azure.Search.HighWaterMarkChangeDetectionPolicy" | "#Microsoft.Azure.Search.SqlIntegratedChangeTrackingPolicy";
+    odatatype: "#Microsoft.Azure.Search.HighWaterMarkChangeDetectionPolicy" | "#Microsoft.Azure.Search.SqlIntegratedChangeTrackingPolicy";
 }
 
 // @public
@@ -139,6 +139,11 @@ export interface BaseScoringFunction {
     fieldName: string;
     interpolation?: ScoringFunctionInterpolation;
     type: "distance" | "freshness" | "magnitude" | "tag";
+}
+
+// @public
+export interface BaseSearchIndexerDataIdentity {
+    odatatype: "#Microsoft.Azure.Search.SearchIndexerDataNoneIdentity" | "#Microsoft.Azure.Search.SearchIndexerDataUserAssignedIdentity";
 }
 
 // @public
@@ -353,7 +358,7 @@ export type CustomNormalizer = BaseLexicalNormalizer & {
 };
 
 // @public
-export type DataChangeDetectionPolicy = HighWaterMarkChangeDetectionPolicy | SqlIntegratedChangeTrackingPolicy | SearchIndexerDataUserAssignedIdentity | SearchIndexerDataNoneIdentity;
+export type DataChangeDetectionPolicy = HighWaterMarkChangeDetectionPolicy | SqlIntegratedChangeTrackingPolicy;
 
 // @public
 export type DataDeletionDetectionPolicy = SoftDeleteColumnDeletionDetectionPolicy;
@@ -1791,12 +1796,10 @@ export interface SearchIndexerDataContainer {
 }
 
 // @public
-export interface SearchIndexerDataIdentity {
-    odatatype: "undefined";
-}
+export type SearchIndexerDataIdentity = SearchIndexerDataNoneIdentity | SearchIndexerDataUserAssignedIdentity;
 
 // @public
-export type SearchIndexerDataNoneIdentity = BaseDataChangeDetectionPolicy & {
+export type SearchIndexerDataNoneIdentity = BaseSearchIndexerDataIdentity & {
     odatatype: "#Microsoft.Azure.Search.SearchIndexerDataNoneIdentity";
 };
 
@@ -1818,7 +1821,7 @@ export interface SearchIndexerDataSourceConnection {
 export type SearchIndexerDataSourceType = string;
 
 // @public
-export type SearchIndexerDataUserAssignedIdentity = BaseDataChangeDetectionPolicy & {
+export type SearchIndexerDataUserAssignedIdentity = BaseSearchIndexerDataIdentity & {
     odatatype: "#Microsoft.Azure.Search.SearchIndexerDataUserAssignedIdentity";
     userAssignedIdentity: string;
 };

--- a/sdk/search/search-documents/src/generated/data/models/index.ts
+++ b/sdk/search/search-documents/src/generated/data/models/index.ts
@@ -149,6 +149,10 @@ export interface SearchRequest {
   skip?: number;
   /** The number of search results to retrieve. This can be used in conjunction with $skip to implement client-side paging of search results. If results are truncated due to server-side paging, the response will include a continuation token that can be used to issue another Search request for the next page of results. */
   top?: number;
+  /** A value that specifies whether captions should be returned as part of the search response. */
+  captions?: Captions;
+  /** The comma-separated list of field names used for semantic search. */
+  semanticFields?: string;
 }
 
 /** Contains a document found by a search query, plus associated metadata. */
@@ -393,6 +397,10 @@ export interface SearchOptions {
   skip?: number;
   /** The number of search results to retrieve. This can be used in conjunction with $skip to implement client-side paging of search results. If results are truncated due to server-side paging, the response will include a continuation token that can be used to issue another Search request for the next page of results. */
   top?: number;
+  /** This parameter is only valid if the query type is 'semantic'. If set, the query returns captions extracted from key passages in the highest ranked documents. When Captions is set to 'extractive', highlighting is enabled by default, and can be configured by appending the pipe character '|' followed by the 'highlight-<true/false>' option, such as 'extractive|highlight-true'. Defaults to 'None'. */
+  captions?: Captions;
+  /** The list of field names used for semantic search. */
+  semanticFields?: string[];
 }
 
 /** Parameter group */
@@ -437,20 +445,20 @@ export interface AutocompleteOptions {
   top?: number;
 }
 
-/** Known values of {@link ApiVersion20200630Preview} that the service accepts. */
-export const enum KnownApiVersion20200630Preview {
-  /** Api Version '2020-06-30-Preview' */
-  TwoThousandTwenty0630Preview = "2020-06-30-Preview"
+/** Known values of {@link ApiVersion20210430Preview} that the service accepts. */
+export const enum KnownApiVersion20210430Preview {
+  /** Api Version '2021-04-30-Preview' */
+  TwoThousandTwentyOne0430Preview = "2021-04-30-Preview"
 }
 
 /**
- * Defines values for ApiVersion20200630Preview. \
- * {@link KnownApiVersion20200630Preview} can be used interchangeably with ApiVersion20200630Preview,
+ * Defines values for ApiVersion20210430Preview. \
+ * {@link KnownApiVersion20210430Preview} can be used interchangeably with ApiVersion20210430Preview,
  *  this enum contains the known values that the service supports.
  * ### Know values supported by the service
- * **2020-06-30-Preview**: Api Version '2020-06-30-Preview'
+ * **2021-04-30-Preview**: Api Version '2021-04-30-Preview'
  */
-export type ApiVersion20200630Preview = string;
+export type ApiVersion20210430Preview = string;
 
 /** Known values of {@link QueryLanguage} that the service accepts. */
 export const enum KnownQueryLanguage {
@@ -505,6 +513,24 @@ export const enum KnownAnswers {
  * **extractive**: Extracts answer candidates from the contents of the documents returned in response to a query expressed as a question in natural language.
  */
 export type Answers = string;
+
+/** Known values of {@link Captions} that the service accepts. */
+export const enum KnownCaptions {
+  /** Do not return captions for the query. */
+  None = "none",
+  /** Extracts captions from the matching documents that contain passages relevant to the search query. */
+  Extractive = "extractive"
+}
+
+/**
+ * Defines values for Captions. \
+ * {@link KnownCaptions} can be used interchangeably with Captions,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **none**: Do not return captions for the query. \
+ * **extractive**: Extracts captions from the matching documents that contain passages relevant to the search query.
+ */
+export type Captions = string;
 /** Defines values for QueryType. */
 export type QueryType = "simple" | "full" | "semantic";
 /** Defines values for SearchMode. */

--- a/sdk/search/search-documents/src/generated/data/models/mappers.ts
+++ b/sdk/search/search-documents/src/generated/data/models/mappers.ts
@@ -331,6 +331,18 @@ export const SearchRequest: coreHttp.CompositeMapper = {
         type: {
           name: "Number"
         }
+      },
+      captions: {
+        serializedName: "captions",
+        type: {
+          name: "String"
+        }
+      },
+      semanticFields: {
+        serializedName: "semanticFields",
+        type: {
+          name: "String"
+        }
       }
     }
   }

--- a/sdk/search/search-documents/src/generated/data/models/parameters.ts
+++ b/sdk/search/search-documents/src/generated/data/models/parameters.ts
@@ -334,6 +334,32 @@ export const top: OperationQueryParameter = {
   }
 };
 
+export const captions: OperationQueryParameter = {
+  parameterPath: ["options", "searchOptions", "captions"],
+  mapper: {
+    serializedName: "captions",
+    type: {
+      name: "String"
+    }
+  }
+};
+
+export const semanticFields: OperationQueryParameter = {
+  parameterPath: ["options", "searchOptions", "semanticFields"],
+  mapper: {
+    serializedName: "semanticFields",
+    type: {
+      name: "Sequence",
+      element: {
+        type: {
+          name: "String"
+        }
+      }
+    }
+  },
+  collectionFormat: QueryCollectionFormat.Csv
+};
+
 export const contentType: OperationParameter = {
   parameterPath: ["options", "contentType"],
   mapper: {

--- a/sdk/search/search-documents/src/generated/data/operations/documents.ts
+++ b/sdk/search/search-documents/src/generated/data/operations/documents.ts
@@ -274,7 +274,9 @@ const searchGetOperationSpec: coreHttp.OperationSpec = {
     Parameters.sessionId,
     Parameters.select,
     Parameters.skip,
-    Parameters.top
+    Parameters.top,
+    Parameters.captions,
+    Parameters.semanticFields
   ],
   urlParameters: [Parameters.endpoint, Parameters.indexName],
   headerParameters: [Parameters.accept, Parameters.xMsClientRequestId],

--- a/sdk/search/search-documents/src/generated/data/searchClient.ts
+++ b/sdk/search/search-documents/src/generated/data/searchClient.ts
@@ -10,7 +10,7 @@ import { Documents } from "./operations";
 import { SearchClientContext } from "./searchClientContext";
 import {
   SearchClientOptionalParams,
-  ApiVersion20200630Preview
+  ApiVersion20210430Preview
 } from "./models";
 
 /** @internal */
@@ -25,7 +25,7 @@ export class SearchClient extends SearchClientContext {
   constructor(
     endpoint: string,
     indexName: string,
-    apiVersion: ApiVersion20200630Preview,
+    apiVersion: ApiVersion20210430Preview,
     options?: SearchClientOptionalParams
   ) {
     super(endpoint, indexName, apiVersion, options);

--- a/sdk/search/search-documents/src/generated/data/searchClientContext.ts
+++ b/sdk/search/search-documents/src/generated/data/searchClientContext.ts
@@ -8,7 +8,7 @@
 
 import * as coreHttp from "@azure/core-http";
 import {
-  ApiVersion20200630Preview,
+  ApiVersion20210430Preview,
   SearchClientOptionalParams
 } from "./models";
 
@@ -19,7 +19,7 @@ const packageVersion = "11.3.0-beta.1";
 export class SearchClientContext extends coreHttp.ServiceClient {
   endpoint: string;
   indexName: string;
-  apiVersion: ApiVersion20200630Preview;
+  apiVersion: ApiVersion20210430Preview;
 
   /**
    * Initializes a new instance of the SearchClientContext class.
@@ -31,7 +31,7 @@ export class SearchClientContext extends coreHttp.ServiceClient {
   constructor(
     endpoint: string,
     indexName: string,
-    apiVersion: ApiVersion20200630Preview,
+    apiVersion: ApiVersion20210430Preview,
     options?: SearchClientOptionalParams
   ) {
     if (endpoint === undefined) {

--- a/sdk/search/search-documents/src/generated/service/models/index.ts
+++ b/sdk/search/search-documents/src/generated/service/models/index.ts
@@ -8,10 +8,12 @@
 
 import * as coreHttp from "@azure/core-http";
 
+export type SearchIndexerDataIdentityUnion =
+  | SearchIndexerDataIdentity
+  | SearchIndexerDataNoneIdentity
+  | SearchIndexerDataUserAssignedIdentity;
 export type DataChangeDetectionPolicyUnion =
   | DataChangeDetectionPolicy
-  | SearchIndexerDataNoneIdentity
-  | SearchIndexerDataUserAssignedIdentity
   | HighWaterMarkChangeDetectionPolicy
   | SqlIntegratedChangeTrackingPolicy;
 export type DataDeletionDetectionPolicyUnion =
@@ -114,7 +116,7 @@ export interface SearchIndexerDataSource {
   /** The data container for the datasource. */
   container: SearchIndexerDataContainer;
   /** An explicit managed identity to use for this datasource. If not specified and the connection string is a managed identity, the system-assigned managed identity is used. If not specified, the value remains unchanged. If "none" is specified, the value of this property is cleared. */
-  identity?: SearchIndexerDataIdentity | null;
+  identity?: SearchIndexerDataIdentityUnion | null;
   /** The data change detection policy for the datasource. */
   dataChangeDetectionPolicy?: DataChangeDetectionPolicyUnion | null;
   /** The data deletion detection policy for the datasource. */
@@ -139,18 +141,18 @@ export interface SearchIndexerDataContainer {
   query?: string;
 }
 
-/** Base type for data identities. */
+/** Abstract base type for data identities. */
 export interface SearchIndexerDataIdentity {
   /** Polymorphic discriminator, which specifies the different types this object can be */
-  odatatype: "undefined";
+  odatatype:
+    | "#Microsoft.Azure.Search.SearchIndexerDataNoneIdentity"
+    | "#Microsoft.Azure.Search.SearchIndexerDataUserAssignedIdentity";
 }
 
 /** Base type for data change detection policies. */
 export interface DataChangeDetectionPolicy {
   /** Polymorphic discriminator, which specifies the different types this object can be */
   odatatype:
-    | "#Microsoft.Azure.Search.SearchIndexerDataNoneIdentity"
-    | "#Microsoft.Azure.Search.SearchIndexerDataUserAssignedIdentity"
     | "#Microsoft.Azure.Search.HighWaterMarkChangeDetectionPolicy"
     | "#Microsoft.Azure.Search.SqlIntegratedChangeTrackingPolicy";
 }
@@ -172,7 +174,7 @@ export interface SearchResourceEncryptionKey {
   /** Optional Azure Active Directory credentials used for accessing your Azure Key Vault. Not required if using managed identity instead. */
   accessCredentials?: AzureActiveDirectoryApplicationCredentials;
   /** An explicit managed identity to use for this encryption key. If not specified and the access credentials property is null, the system-assigned managed identity is used. On update to the resource, if the explicit identity is unspecified, it remains unchanged. If "none" is specified, the value of this property is cleared. */
-  identity?: SearchIndexerDataIdentity | null;
+  identity?: SearchIndexerDataIdentityUnion | null;
 }
 
 /** Credentials of a registered application created for your search service, used for authenticated access to the encryption keys stored in Azure Key Vault. */
@@ -1016,13 +1018,13 @@ export interface CustomEntityAlias {
 }
 
 /** Clears the identity property of a datasource. */
-export type SearchIndexerDataNoneIdentity = DataChangeDetectionPolicy & {
+export type SearchIndexerDataNoneIdentity = SearchIndexerDataIdentity & {
   /** Polymorphic discriminator, which specifies the different types this object can be */
   odatatype: "#Microsoft.Azure.Search.SearchIndexerDataNoneIdentity";
 };
 
 /** Specifies the identity for a datasource to use. */
-export type SearchIndexerDataUserAssignedIdentity = DataChangeDetectionPolicy & {
+export type SearchIndexerDataUserAssignedIdentity = SearchIndexerDataIdentity & {
   /** Polymorphic discriminator, which specifies the different types this object can be */
   odatatype: "#Microsoft.Azure.Search.SearchIndexerDataUserAssignedIdentity";
   /** The fully qualified Azure resource Id of a user assigned managed identity typically in the form "/subscriptions/12345678-1234-1234-1234-1234567890ab/resourceGroups/rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/myId" that should have been assigned to the search service. */

--- a/sdk/search/search-documents/src/generated/service/models/mappers.ts
+++ b/sdk/search/search-documents/src/generated/service/models/mappers.ts
@@ -2470,11 +2470,11 @@ export const SearchIndexerDataNoneIdentity: coreHttp.CompositeMapper = {
   type: {
     name: "Composite",
     className: "SearchIndexerDataNoneIdentity",
-    uberParent: "DataChangeDetectionPolicy",
+    uberParent: "SearchIndexerDataIdentity",
     polymorphicDiscriminator:
-      DataChangeDetectionPolicy.type.polymorphicDiscriminator,
+      SearchIndexerDataIdentity.type.polymorphicDiscriminator,
     modelProperties: {
-      ...DataChangeDetectionPolicy.type.modelProperties
+      ...SearchIndexerDataIdentity.type.modelProperties
     }
   }
 };
@@ -2485,11 +2485,11 @@ export const SearchIndexerDataUserAssignedIdentity: coreHttp.CompositeMapper = {
   type: {
     name: "Composite",
     className: "SearchIndexerDataUserAssignedIdentity",
-    uberParent: "DataChangeDetectionPolicy",
+    uberParent: "SearchIndexerDataIdentity",
     polymorphicDiscriminator:
-      DataChangeDetectionPolicy.type.polymorphicDiscriminator,
+      SearchIndexerDataIdentity.type.polymorphicDiscriminator,
     modelProperties: {
-      ...DataChangeDetectionPolicy.type.modelProperties,
+      ...SearchIndexerDataIdentity.type.modelProperties,
       userAssignedIdentity: {
         serializedName: "userAssignedIdentity",
         required: true,
@@ -5103,7 +5103,7 @@ export const SearchIndexerKnowledgeStoreFileProjectionSelector: coreHttp.Composi
 };
 
 export let discriminators = {
-  "SearchIndexerDataIdentity.undefined": SearchIndexerDataIdentity,
+  SearchIndexerDataIdentity: SearchIndexerDataIdentity,
   DataChangeDetectionPolicy: DataChangeDetectionPolicy,
   DataDeletionDetectionPolicy: DataDeletionDetectionPolicy,
   SearchIndexerSkill: SearchIndexerSkill,
@@ -5115,8 +5115,8 @@ export let discriminators = {
   CharFilter: CharFilter,
   LexicalNormalizer: LexicalNormalizer,
   Similarity: Similarity,
-  "DataChangeDetectionPolicy.#Microsoft.Azure.Search.SearchIndexerDataNoneIdentity": SearchIndexerDataNoneIdentity,
-  "DataChangeDetectionPolicy.#Microsoft.Azure.Search.SearchIndexerDataUserAssignedIdentity": SearchIndexerDataUserAssignedIdentity,
+  "SearchIndexerDataIdentity.#Microsoft.Azure.Search.SearchIndexerDataNoneIdentity": SearchIndexerDataNoneIdentity,
+  "SearchIndexerDataIdentity.#Microsoft.Azure.Search.SearchIndexerDataUserAssignedIdentity": SearchIndexerDataUserAssignedIdentity,
   "DataChangeDetectionPolicy.#Microsoft.Azure.Search.HighWaterMarkChangeDetectionPolicy": HighWaterMarkChangeDetectionPolicy,
   "DataChangeDetectionPolicy.#Microsoft.Azure.Search.SqlIntegratedChangeTrackingPolicy": SqlIntegratedChangeTrackingPolicy,
   "DataDeletionDetectionPolicy.#Microsoft.Azure.Search.SoftDeleteColumnDeletionDetectionPolicy": SoftDeleteColumnDeletionDetectionPolicy,

--- a/sdk/search/search-documents/src/generated/service/models/mappers.ts
+++ b/sdk/search/search-documents/src/generated/service/models/mappers.ts
@@ -47,6 +47,13 @@ export const SearchIndexerDataSource: coreHttp.CompositeMapper = {
           className: "SearchIndexerDataContainer"
         }
       },
+      identity: {
+        serializedName: "identity",
+        type: {
+          name: "Composite",
+          className: "SearchIndexerDataIdentity"
+        }
+      },
       dataChangeDetectionPolicy: {
         serializedName: "dataChangeDetectionPolicy",
         type: {
@@ -107,6 +114,27 @@ export const SearchIndexerDataContainer: coreHttp.CompositeMapper = {
       },
       query: {
         serializedName: "query",
+        type: {
+          name: "String"
+        }
+      }
+    }
+  }
+};
+
+export const SearchIndexerDataIdentity: coreHttp.CompositeMapper = {
+  type: {
+    name: "Composite",
+    className: "SearchIndexerDataIdentity",
+    uberParent: "SearchIndexerDataIdentity",
+    polymorphicDiscriminator: {
+      serializedName: "@odata\\.type",
+      clientName: "@odata\\.type"
+    },
+    modelProperties: {
+      odatatype: {
+        serializedName: "@odata\\.type",
+        required: true,
         type: {
           name: "String"
         }
@@ -188,6 +216,13 @@ export const SearchResourceEncryptionKey: coreHttp.CompositeMapper = {
         type: {
           name: "Composite",
           className: "AzureActiveDirectoryApplicationCredentials"
+        }
+      },
+      identity: {
+        serializedName: "identity",
+        type: {
+          name: "Composite",
+          className: "SearchIndexerDataIdentity"
         }
       }
     }
@@ -2430,6 +2465,42 @@ export const CustomEntityAlias: coreHttp.CompositeMapper = {
   }
 };
 
+export const SearchIndexerDataNoneIdentity: coreHttp.CompositeMapper = {
+  serializedName: "#Microsoft.Azure.Search.SearchIndexerDataNoneIdentity",
+  type: {
+    name: "Composite",
+    className: "SearchIndexerDataNoneIdentity",
+    uberParent: "DataChangeDetectionPolicy",
+    polymorphicDiscriminator:
+      DataChangeDetectionPolicy.type.polymorphicDiscriminator,
+    modelProperties: {
+      ...DataChangeDetectionPolicy.type.modelProperties
+    }
+  }
+};
+
+export const SearchIndexerDataUserAssignedIdentity: coreHttp.CompositeMapper = {
+  serializedName:
+    "#Microsoft.Azure.Search.SearchIndexerDataUserAssignedIdentity",
+  type: {
+    name: "Composite",
+    className: "SearchIndexerDataUserAssignedIdentity",
+    uberParent: "DataChangeDetectionPolicy",
+    polymorphicDiscriminator:
+      DataChangeDetectionPolicy.type.polymorphicDiscriminator,
+    modelProperties: {
+      ...DataChangeDetectionPolicy.type.modelProperties,
+      userAssignedIdentity: {
+        serializedName: "userAssignedIdentity",
+        required: true,
+        type: {
+          name: "String"
+        }
+      }
+    }
+  }
+};
+
 export const HighWaterMarkChangeDetectionPolicy: coreHttp.CompositeMapper = {
   serializedName: "#Microsoft.Azure.Search.HighWaterMarkChangeDetectionPolicy",
   type: {
@@ -2557,6 +2628,12 @@ export const OcrSkill: coreHttp.CompositeMapper = {
         serializedName: "detectOrientation",
         type: {
           name: "Boolean"
+        }
+      },
+      lineEnding: {
+        serializedName: "lineEnding",
+        type: {
+          name: "String"
         }
       }
     }
@@ -2726,6 +2803,198 @@ export const SentimentSkill: coreHttp.CompositeMapper = {
       ...SearchIndexerSkill.type.modelProperties,
       defaultLanguageCode: {
         serializedName: "defaultLanguageCode",
+        type: {
+          name: "String"
+        }
+      }
+    }
+  }
+};
+
+export const SentimentSkillV3: coreHttp.CompositeMapper = {
+  serializedName: "#Microsoft.Skills.Text.V3.SentimentSkill",
+  type: {
+    name: "Composite",
+    className: "SentimentSkillV3",
+    uberParent: "SearchIndexerSkill",
+    polymorphicDiscriminator: SearchIndexerSkill.type.polymorphicDiscriminator,
+    modelProperties: {
+      ...SearchIndexerSkill.type.modelProperties,
+      defaultLanguageCode: {
+        serializedName: "defaultLanguageCode",
+        nullable: true,
+        type: {
+          name: "String"
+        }
+      },
+      includeOpinionMining: {
+        serializedName: "includeOpinionMining",
+        type: {
+          name: "Boolean"
+        }
+      },
+      modelVersion: {
+        serializedName: "modelVersion",
+        nullable: true,
+        type: {
+          name: "String"
+        }
+      }
+    }
+  }
+};
+
+export const EntityLinkingSkill: coreHttp.CompositeMapper = {
+  serializedName: "#Microsoft.Skills.Text.V3.EntityLinkingSkill",
+  type: {
+    name: "Composite",
+    className: "EntityLinkingSkill",
+    uberParent: "SearchIndexerSkill",
+    polymorphicDiscriminator: SearchIndexerSkill.type.polymorphicDiscriminator,
+    modelProperties: {
+      ...SearchIndexerSkill.type.modelProperties,
+      defaultLanguageCode: {
+        serializedName: "defaultLanguageCode",
+        nullable: true,
+        type: {
+          name: "String"
+        }
+      },
+      minimumPrecision: {
+        constraints: {
+          InclusiveMaximum: 1,
+          InclusiveMinimum: 0
+        },
+        serializedName: "minimumPrecision",
+        nullable: true,
+        type: {
+          name: "Number"
+        }
+      },
+      modelVersion: {
+        serializedName: "modelVersion",
+        nullable: true,
+        type: {
+          name: "String"
+        }
+      }
+    }
+  }
+};
+
+export const EntityRecognitionSkillV3: coreHttp.CompositeMapper = {
+  serializedName: "#Microsoft.Skills.Text.V3.EntityRecognitionSkill",
+  type: {
+    name: "Composite",
+    className: "EntityRecognitionSkillV3",
+    uberParent: "SearchIndexerSkill",
+    polymorphicDiscriminator: SearchIndexerSkill.type.polymorphicDiscriminator,
+    modelProperties: {
+      ...SearchIndexerSkill.type.modelProperties,
+      categories: {
+        serializedName: "categories",
+        type: {
+          name: "Sequence",
+          element: {
+            type: {
+              name: "String"
+            }
+          }
+        }
+      },
+      defaultLanguageCode: {
+        serializedName: "defaultLanguageCode",
+        nullable: true,
+        type: {
+          name: "String"
+        }
+      },
+      minimumPrecision: {
+        constraints: {
+          InclusiveMaximum: 1,
+          InclusiveMinimum: 0
+        },
+        serializedName: "minimumPrecision",
+        nullable: true,
+        type: {
+          name: "Number"
+        }
+      },
+      modelVersion: {
+        serializedName: "modelVersion",
+        nullable: true,
+        type: {
+          name: "String"
+        }
+      }
+    }
+  }
+};
+
+export const PIIDetectionSkill: coreHttp.CompositeMapper = {
+  serializedName: "#Microsoft.Skills.Text.PIIDetectionSkill",
+  type: {
+    name: "Composite",
+    className: "PIIDetectionSkill",
+    uberParent: "SearchIndexerSkill",
+    polymorphicDiscriminator: SearchIndexerSkill.type.polymorphicDiscriminator,
+    modelProperties: {
+      ...SearchIndexerSkill.type.modelProperties,
+      defaultLanguageCode: {
+        serializedName: "defaultLanguageCode",
+        nullable: true,
+        type: {
+          name: "String"
+        }
+      },
+      minimumPrecision: {
+        constraints: {
+          InclusiveMaximum: 1,
+          InclusiveMinimum: 0
+        },
+        serializedName: "minimumPrecision",
+        nullable: true,
+        type: {
+          name: "Number"
+        }
+      },
+      maskingMode: {
+        serializedName: "maskingMode",
+        type: {
+          name: "String"
+        }
+      },
+      maskingCharacter: {
+        constraints: {
+          MaxLength: 1
+        },
+        serializedName: "maskingCharacter",
+        nullable: true,
+        type: {
+          name: "String"
+        }
+      },
+      modelVersion: {
+        serializedName: "modelVersion",
+        nullable: true,
+        type: {
+          name: "String"
+        }
+      },
+      piiCategories: {
+        serializedName: "piiCategories",
+        type: {
+          name: "Sequence",
+          element: {
+            type: {
+              name: "String"
+            }
+          }
+        }
+      },
+      domain: {
+        serializedName: "domain",
+        nullable: true,
         type: {
           name: "String"
         }
@@ -4834,6 +5103,7 @@ export const SearchIndexerKnowledgeStoreFileProjectionSelector: coreHttp.Composi
 };
 
 export let discriminators = {
+  "SearchIndexerDataIdentity.undefined": SearchIndexerDataIdentity,
   DataChangeDetectionPolicy: DataChangeDetectionPolicy,
   DataDeletionDetectionPolicy: DataDeletionDetectionPolicy,
   SearchIndexerSkill: SearchIndexerSkill,
@@ -4845,6 +5115,8 @@ export let discriminators = {
   CharFilter: CharFilter,
   LexicalNormalizer: LexicalNormalizer,
   Similarity: Similarity,
+  "DataChangeDetectionPolicy.#Microsoft.Azure.Search.SearchIndexerDataNoneIdentity": SearchIndexerDataNoneIdentity,
+  "DataChangeDetectionPolicy.#Microsoft.Azure.Search.SearchIndexerDataUserAssignedIdentity": SearchIndexerDataUserAssignedIdentity,
   "DataChangeDetectionPolicy.#Microsoft.Azure.Search.HighWaterMarkChangeDetectionPolicy": HighWaterMarkChangeDetectionPolicy,
   "DataChangeDetectionPolicy.#Microsoft.Azure.Search.SqlIntegratedChangeTrackingPolicy": SqlIntegratedChangeTrackingPolicy,
   "DataDeletionDetectionPolicy.#Microsoft.Azure.Search.SoftDeleteColumnDeletionDetectionPolicy": SoftDeleteColumnDeletionDetectionPolicy,
@@ -4857,6 +5129,10 @@ export let discriminators = {
   "SearchIndexerSkill.#Microsoft.Skills.Text.MergeSkill": MergeSkill,
   "SearchIndexerSkill.#Microsoft.Skills.Text.EntityRecognitionSkill": EntityRecognitionSkill,
   "SearchIndexerSkill.#Microsoft.Skills.Text.SentimentSkill": SentimentSkill,
+  "SearchIndexerSkill.#Microsoft.Skills.Text.V3.SentimentSkill": SentimentSkillV3,
+  "SearchIndexerSkill.#Microsoft.Skills.Text.V3.EntityLinkingSkill": EntityLinkingSkill,
+  "SearchIndexerSkill.#Microsoft.Skills.Text.V3.EntityRecognitionSkill": EntityRecognitionSkillV3,
+  "SearchIndexerSkill.#Microsoft.Skills.Text.PIIDetectionSkill": PIIDetectionSkill,
   "SearchIndexerSkill.#Microsoft.Skills.Text.SplitSkill": SplitSkill,
   "SearchIndexerSkill.#Microsoft.Skills.Text.CustomEntityLookupSkill": CustomEntityLookupSkill,
   "SearchIndexerSkill.#Microsoft.Skills.Text.TranslationSkill": TextTranslationSkill,

--- a/sdk/search/search-documents/src/generated/service/searchServiceClient.ts
+++ b/sdk/search/search-documents/src/generated/service/searchServiceClient.ts
@@ -19,7 +19,7 @@ import * as Mappers from "./models/mappers";
 import { SearchServiceClientContext } from "./searchServiceClientContext";
 import {
   SearchServiceClientOptionalParams,
-  ApiVersion20200630Preview,
+  ApiVersion20210430Preview,
   SearchServiceClientGetServiceStatisticsOptionalParams,
   SearchServiceClientGetServiceStatisticsResponse
 } from "./models";
@@ -34,7 +34,7 @@ export class SearchServiceClient extends SearchServiceClientContext {
    */
   constructor(
     endpoint: string,
-    apiVersion: ApiVersion20200630Preview,
+    apiVersion: ApiVersion20210430Preview,
     options?: SearchServiceClientOptionalParams
   ) {
     super(endpoint, apiVersion, options);

--- a/sdk/search/search-documents/src/generated/service/searchServiceClientContext.ts
+++ b/sdk/search/search-documents/src/generated/service/searchServiceClientContext.ts
@@ -8,7 +8,7 @@
 
 import * as coreHttp from "@azure/core-http";
 import {
-  ApiVersion20200630Preview,
+  ApiVersion20210430Preview,
   SearchServiceClientOptionalParams
 } from "./models";
 
@@ -18,7 +18,7 @@ const packageVersion = "11.3.0-beta.1";
 /** @internal */
 export class SearchServiceClientContext extends coreHttp.ServiceClient {
   endpoint: string;
-  apiVersion: ApiVersion20200630Preview;
+  apiVersion: ApiVersion20210430Preview;
 
   /**
    * Initializes a new instance of the SearchServiceClientContext class.
@@ -28,7 +28,7 @@ export class SearchServiceClientContext extends coreHttp.ServiceClient {
    */
   constructor(
     endpoint: string,
-    apiVersion: ApiVersion20200630Preview,
+    apiVersion: ApiVersion20210430Preview,
     options?: SearchServiceClientOptionalParams
   ) {
     if (endpoint === undefined) {

--- a/sdk/search/search-documents/src/index.ts
+++ b/sdk/search/search-documents/src/index.ts
@@ -111,7 +111,8 @@ export {
   SearchIndexStatistics,
   SearchServiceStatistics,
   SearchIndexer,
-  LexicalNormalizer
+  LexicalNormalizer,
+  SearchIndexerDataIdentity
 } from "./serviceModels";
 export { default as GeographyPoint } from "./geographyPoint";
 export { odata } from "./odata";
@@ -310,7 +311,7 @@ export {
   KnownPIIDetectionSkillMaskingMode,
   LineEnding,
   KnownLineEnding,
-  SearchIndexerDataIdentity
+  SearchIndexerDataIdentity as BaseSearchIndexerDataIdentity
 } from "./generated/service/models";
 export { AzureKeyCredential } from "@azure/core-auth";
 export { createSynonymMapFromFile } from "./synonymMapHelper";

--- a/sdk/search/search-documents/src/index.ts
+++ b/sdk/search/search-documents/src/index.ts
@@ -134,7 +134,8 @@ export {
   Speller,
   KnownSpeller,
   CaptionResult,
-  AnswerResult
+  AnswerResult,
+  Captions
 } from "./generated/data/models";
 export {
   RegexFlags,
@@ -212,6 +213,10 @@ export {
   CustomEntity,
   CustomEntityAlias,
   SplitSkill,
+  PIIDetectionSkill,
+  EntityRecognitionSkillV3,
+  EntityLinkingSkill,
+  SentimentSkillV3,
   TextTranslationSkill,
   WebApiSkill,
   SentimentSkillLanguage,
@@ -257,6 +262,8 @@ export {
   SoftDeleteColumnDeletionDetectionPolicy,
   SqlIntegratedChangeTrackingPolicy,
   HighWaterMarkChangeDetectionPolicy,
+  SearchIndexerDataUserAssignedIdentity,
+  SearchIndexerDataNoneIdentity,
   ServiceCounters,
   ServiceLimits,
   ResourceCounter,
@@ -298,7 +305,12 @@ export {
   SearchIndexerKnowledgeStoreBlobProjectionSelector,
   SearchIndexerKnowledgeStoreProjectionSelector,
   SearchIndexerKnowledgeStoreObjectProjectionSelector,
-  SearchIndexerKnowledgeStoreTableProjectionSelector
+  SearchIndexerKnowledgeStoreTableProjectionSelector,
+  PIIDetectionSkillMaskingMode,
+  KnownPIIDetectionSkillMaskingMode,
+  LineEnding,
+  KnownLineEnding,
+  SearchIndexerDataIdentity
 } from "./generated/service/models";
 export { AzureKeyCredential } from "@azure/core-auth";
 export { createSynonymMapFromFile } from "./synonymMapHelper";

--- a/sdk/search/search-documents/src/indexModels.ts
+++ b/sdk/search/search-documents/src/indexModels.ts
@@ -13,7 +13,8 @@ import {
   Speller,
   Answers,
   CaptionResult,
-  AnswerResult
+  AnswerResult,
+  Captions
 } from "./generated/data/models";
 import { PagedAsyncIterableIterator } from "@azure/core-paging";
 
@@ -289,6 +290,10 @@ export interface SearchRequest {
    * Search request for the next page of results.
    */
   top?: number;
+  /** A value that specifies whether captions should be returned as part of the search response. */
+  captions?: Captions;
+  /** The comma-separated list of field names used for semantic search. */
+  semanticFields?: string;
 }
 
 /**

--- a/sdk/search/search-documents/src/searchIndexerClient.ts
+++ b/sdk/search/search-documents/src/searchIndexerClient.ts
@@ -1,12 +1,14 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { KeyCredential } from "@azure/core-auth";
+import { KeyCredential, TokenCredential, isTokenCredential } from "@azure/core-auth";
 import {
   createPipelineFromOptions,
   InternalPipelineOptions,
   operationOptionsToRequestOptionsBase,
-  PipelineOptions
+  PipelineOptions,
+  RequestPolicyFactory,
+  bearerTokenAuthenticationPolicy
 } from "@azure/core-http";
 import { SpanStatusCode } from "@azure/core-tracing";
 import { SDK_VERSION } from "./constants";
@@ -92,7 +94,7 @@ export class SearchIndexerClient {
    */
   constructor(
     endpoint: string,
-    credential: KeyCredential,
+    credential: KeyCredential | TokenCredential,
     options: SearchIndexerClientOptions = {}
   ) {
     this.endpoint = endpoint;
@@ -124,10 +126,11 @@ export class SearchIndexerClient {
       }
     };
 
-    const pipeline = createPipelineFromOptions(
-      internalPipelineOptions,
-      createSearchApiKeyCredentialPolicy(credential)
-    );
+    const requestPolicyFactory: RequestPolicyFactory = isTokenCredential(credential)
+      ? bearerTokenAuthenticationPolicy(credential, utils.DEFAULT_SEARCH_SCOPE)
+      : createSearchApiKeyCredentialPolicy(credential);
+
+    const pipeline = createPipelineFromOptions(internalPipelineOptions, requestPolicyFactory);
 
     if (Array.isArray(pipeline.requestPolicyFactories)) {
       pipeline.requestPolicyFactories.unshift(odataMetadataPolicy("minimal"));
@@ -136,7 +139,7 @@ export class SearchIndexerClient {
     let apiVersion = this.apiVersion;
 
     if (options.apiVersion) {
-      if (!["2020-06-30-Preview", "2020-06-30"].includes(options.apiVersion)) {
+      if (!["2020-06-30", "2021-04-30-Preview"].includes(options.apiVersion)) {
         throw new Error(`Invalid Api Version: ${options.apiVersion}`);
       }
       apiVersion = options.apiVersion;

--- a/sdk/search/search-documents/src/serviceModels.ts
+++ b/sdk/search/search-documents/src/serviceModels.ts
@@ -82,8 +82,7 @@ import {
   IndexingSchedule,
   LexicalNormalizerName,
   CustomNormalizer,
-  SearchIndexerKnowledgeStore,
-  SearchIndexerDataIdentity
+  SearchIndexerKnowledgeStore
 } from "./generated/service/models";
 
 import { PagedAsyncIterableIterator } from "@azure/core-paging";
@@ -1793,9 +1792,14 @@ export enum KnownAnalyzerNames {
  */
 export type DataChangeDetectionPolicy =
   | HighWaterMarkChangeDetectionPolicy
-  | SqlIntegratedChangeTrackingPolicy
-  | SearchIndexerDataUserAssignedIdentity
-  | SearchIndexerDataNoneIdentity;
+  | SqlIntegratedChangeTrackingPolicy;
+
+/**
+ * Contains the possible cases for SearchIndexerDataIdentity.
+ */
+export type SearchIndexerDataIdentity =
+  | SearchIndexerDataNoneIdentity
+  | SearchIndexerDataUserAssignedIdentity;
 
 /**
  * Contains the possible cases for DataDeletionDetectionPolicy.

--- a/sdk/search/search-documents/src/serviceModels.ts
+++ b/sdk/search/search-documents/src/serviceModels.ts
@@ -54,6 +54,10 @@ import {
   EntityRecognitionSkill,
   SentimentSkill,
   SplitSkill,
+  PIIDetectionSkill,
+  EntityRecognitionSkillV3,
+  EntityLinkingSkill,
+  SentimentSkillV3,
   CustomEntityLookupSkill,
   DocumentExtractionSkill,
   TextTranslationSkill,
@@ -62,6 +66,8 @@ import {
   CognitiveServicesAccountKey,
   HighWaterMarkChangeDetectionPolicy,
   SqlIntegratedChangeTrackingPolicy,
+  SearchIndexerDataUserAssignedIdentity,
+  SearchIndexerDataNoneIdentity,
   SoftDeleteColumnDeletionDetectionPolicy,
   SearchIndexerDataSourceType,
   SearchIndexerDataContainer,
@@ -76,7 +82,8 @@ import {
   IndexingSchedule,
   LexicalNormalizerName,
   CustomNormalizer,
-  SearchIndexerKnowledgeStore
+  SearchIndexerKnowledgeStore,
+  SearchIndexerDataIdentity
 } from "./generated/service/models";
 
 import { PagedAsyncIterableIterator } from "@azure/core-paging";
@@ -458,6 +465,10 @@ export type SearchIndexerSkill =
   | EntityRecognitionSkill
   | SentimentSkill
   | SplitSkill
+  | PIIDetectionSkill
+  | EntityRecognitionSkillV3
+  | EntityLinkingSkill
+  | SentimentSkillV3
   | CustomEntityLookupSkill
   | TextTranslationSkill
   | DocumentExtractionSkill
@@ -1056,6 +1067,13 @@ export interface SearchResourceEncryptionKey {
    * The authentication key of the specified AAD application.
    */
   applicationSecret?: string;
+  /**
+   * An explicit managed identity to use for this encryption key. If not specified and the access
+   * credentials property is null, the system-assigned managed identity is used. On update to the
+   * resource, if the explicit identity is unspecified, it remains unchanged. If "none" is specified,
+   * the value of this property is cleared.
+   */
+  identity?: SearchIndexerDataIdentity | null;
 }
 
 /**
@@ -1775,7 +1793,9 @@ export enum KnownAnalyzerNames {
  */
 export type DataChangeDetectionPolicy =
   | HighWaterMarkChangeDetectionPolicy
-  | SqlIntegratedChangeTrackingPolicy;
+  | SqlIntegratedChangeTrackingPolicy
+  | SearchIndexerDataUserAssignedIdentity
+  | SearchIndexerDataNoneIdentity;
 
 /**
  * Contains the possible cases for DataDeletionDetectionPolicy.
@@ -1807,6 +1827,12 @@ export interface SearchIndexerDataSourceConnection {
    * The data container for the datasource.
    */
   container: SearchIndexerDataContainer;
+  /**
+   * An explicit managed identity to use for this datasource. If not specified and the connection
+   * string is a managed identity, the system-assigned managed identity is used. If not specified,
+   * the value remains unchanged. If "none" is specified, the value of this property is cleared.
+   */
+  identity?: SearchIndexerDataIdentity | null;
   /**
    * The data change detection policy for the datasource.
    */

--- a/sdk/search/search-documents/src/serviceUtils.ts
+++ b/sdk/search/search-documents/src/serviceUtils.ts
@@ -52,7 +52,8 @@ import {
   PatternAnalyzer as GeneratedPatternAnalyzer,
   CustomAnalyzer,
   PatternTokenizer,
-  LexicalNormalizerName
+  LexicalNormalizerName,
+  SearchIndexerDataIdentityUnion
 } from "./generated/service/models";
 import {
   LexicalAnalyzer,
@@ -76,7 +77,8 @@ import {
   SimilarityAlgorithm,
   SearchResourceEncryptionKey,
   PatternAnalyzer,
-  LexicalNormalizer
+  LexicalNormalizer,
+  SearchIndexerDataIdentity
 } from "./serviceModels";
 import { SuggestDocumentsResult, SuggestResult, SearchResult } from "./indexModels";
 import {
@@ -413,7 +415,7 @@ export function convertEncryptionKeyToPublic(
     keyName: encryptionKey.keyName,
     keyVersion: encryptionKey.keyVersion,
     vaultUrl: encryptionKey.vaultUri,
-    identity: encryptionKey.identity
+    identity: convertSearchIndexerDataIdentityToPublic(encryptionKey.identity)
   };
 
   if (encryptionKey.accessCredentials) {
@@ -639,7 +641,7 @@ export function generatedDataSourceToPublicDataSource(
     type: dataSource.type,
     connectionString: dataSource.credentials.connectionString,
     container: dataSource.container,
-    identity: dataSource.identity,
+    identity: convertSearchIndexerDataIdentityToPublic(dataSource.identity),
     etag: dataSource.etag,
     dataChangeDetectionPolicy: convertDataChangeDetectionPolicyToPublic(
       dataSource.dataChangeDetectionPolicy
@@ -649,6 +651,22 @@ export function generatedDataSourceToPublicDataSource(
     ),
     encryptionKey: convertEncryptionKeyToPublic(dataSource.encryptionKey)
   };
+}
+
+export function convertSearchIndexerDataIdentityToPublic(
+  searchIndexerDataIdentity?: SearchIndexerDataIdentityUnion | null
+): SearchIndexerDataIdentity | undefined | null {
+  if (!searchIndexerDataIdentity) {
+    return searchIndexerDataIdentity;
+  }
+
+  if (
+    searchIndexerDataIdentity.odatatype === "#Microsoft.Azure.Search.SearchIndexerDataNoneIdentity"
+  ) {
+    return searchIndexerDataIdentity as SearchIndexerDataNoneIdentity;
+  } else {
+    return searchIndexerDataIdentity as SearchIndexerDataUserAssignedIdentity;
+  }
 }
 
 export function convertDataChangeDetectionPolicyToPublic(
@@ -663,18 +681,8 @@ export function convertDataChangeDetectionPolicyToPublic(
     "#Microsoft.Azure.Search.HighWaterMarkChangeDetectionPolicy"
   ) {
     return dataChangeDetectionPolicy as HighWaterMarkChangeDetectionPolicy;
-  } else if (
-    dataChangeDetectionPolicy.odatatype ===
-    "#Microsoft.Azure.Search.SqlIntegratedChangeTrackingPolicy"
-  ) {
-    return dataChangeDetectionPolicy as SqlIntegratedChangeTrackingPolicy;
-  } else if (
-    dataChangeDetectionPolicy.odatatype ===
-    "#Microsoft.Azure.Search.SearchIndexerDataUserAssignedIdentity"
-  ) {
-    return dataChangeDetectionPolicy as SearchIndexerDataUserAssignedIdentity;
   } else {
-    return dataChangeDetectionPolicy as SearchIndexerDataNoneIdentity;
+    return dataChangeDetectionPolicy as SqlIntegratedChangeTrackingPolicy;
   }
 }
 

--- a/sdk/search/search-documents/swagger/Data.md
+++ b/sdk/search/search-documents/swagger/Data.md
@@ -10,7 +10,7 @@ generate-metadata: false
 license-header: MICROSOFT_MIT_NO_VERSION
 output-folder: ../
 source-code-folder-path: ./src/generated/data
-input-file: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/d95c18e2d5fc678a1453c454d746fdce22d30122/specification/search/data-plane/Azure.Search/preview/2020-06-30-Preview/searchindex.json
+input-file: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/9ce6855af34e9bda71314006d7e8a1bf872cd1ce/specification/search/data-plane/Azure.Search/preview/2021-04-30-Preview/searchindex.json
 add-credentials: false
 title: SearchClient
 use-extension:

--- a/sdk/search/search-documents/swagger/Data.md
+++ b/sdk/search/search-documents/swagger/Data.md
@@ -10,7 +10,7 @@ generate-metadata: false
 license-header: MICROSOFT_MIT_NO_VERSION
 output-folder: ../
 source-code-folder-path: ./src/generated/data
-input-file: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/9ce6855af34e9bda71314006d7e8a1bf872cd1ce/specification/search/data-plane/Azure.Search/preview/2021-04-30-Preview/searchindex.json
+input-file: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/7601061bfbb72b2f19cb29c46cbf9a397c2d8893/specification/search/data-plane/Azure.Search/preview/2021-04-30-Preview/searchindex.json
 add-credentials: false
 title: SearchClient
 use-extension:

--- a/sdk/search/search-documents/swagger/Service.md
+++ b/sdk/search/search-documents/swagger/Service.md
@@ -10,7 +10,7 @@ generate-metadata: false
 license-header: MICROSOFT_MIT_NO_VERSION
 output-folder: ../
 source-code-folder-path: ./src/generated/service
-input-file: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/d95c18e2d5fc678a1453c454d746fdce22d30122/specification/search/data-plane/Azure.Search/preview/2020-06-30-Preview/searchservice.json
+input-file: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/9ce6855af34e9bda71314006d7e8a1bf872cd1ce/specification/search/data-plane/Azure.Search/preview/2021-04-30-Preview/searchservice.json
 add-credentials: false
 use-extension:
   "@autorest/typescript": "6.0.0-dev.20210121.1"

--- a/sdk/search/search-documents/swagger/Service.md
+++ b/sdk/search/search-documents/swagger/Service.md
@@ -10,7 +10,7 @@ generate-metadata: false
 license-header: MICROSOFT_MIT_NO_VERSION
 output-folder: ../
 source-code-folder-path: ./src/generated/service
-input-file: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/9ce6855af34e9bda71314006d7e8a1bf872cd1ce/specification/search/data-plane/Azure.Search/preview/2021-04-30-Preview/searchservice.json
+input-file: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/7601061bfbb72b2f19cb29c46cbf9a397c2d8893/specification/search/data-plane/Azure.Search/preview/2021-04-30-Preview/searchservice.json
 add-credentials: false
 use-extension:
   "@autorest/typescript": "6.0.0-dev.20210121.1"


### PR DESCRIPTION
This PR is for the July release of the search-documents SDK. Basically, this PR does 2 things:

1. Regenerate SDK based on latest swaggers (and update the custom layer as required)
2. Add `TokenCredential` to the constructor. 

Updating the SDK to latest version of generator has been moved to next release. 

@xirzec Please review and approve the PR.
