### PR TITLE
[App Config] Put node test in a node only file

### DIFF
--- a/sdk/appconfiguration/app-configuration/test/internal/node/throttlingRetryPolicy.spec.ts
+++ b/sdk/appconfiguration/app-configuration/test/internal/node/throttlingRetryPolicy.spec.ts
@@ -1,0 +1,67 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import chai from "chai";
+import { AppConfigurationClient } from "../../../src";
+import { AbortController } from "@azure/abort-controller";
+import nock from "nock";
+import { generateUuid } from "@azure/core-http";
+
+describe("Should not retry forever - honors the abort signal passed", () => {
+  let client: AppConfigurationClient;
+  const connectionString = "Endpoint=https://myappconfig.azconfig.io;Id=key:ai/u/fake;Secret=abcd=";
+
+  beforeEach(function() {
+    if (!nock.isActive()) {
+      nock.activate();
+    }
+    nock("https://myappconfig.azconfig.io:443")
+      .persist()
+      .put(/.*/g)
+      .reply(
+        429,
+        {
+          type: "https://azconfig.io/errors/too-many-requests",
+          title: "Resource utilization has surpassed the assigned quota",
+          policy: "Total Requests",
+          status: 429
+        },
+        ["retry-after-ms", "123456"]
+      );
+
+    client = new AppConfigurationClient(connectionString);
+  });
+
+  afterEach(async function() {
+    nock.restore();
+    nock.cleanAll();
+    nock.enableNetConnect();
+  });
+
+  it("simulate the service throttling", async () => {
+    const key = generateUuid();
+    const numberOfSettings = 200;
+    const promises = [];
+    let errorWasThrown = false;
+    try {
+      for (let index = 0; index < numberOfSettings; index++) {
+        promises.push(
+          client.addConfigurationSetting(
+            {
+              key: key + "-" + index,
+              value: "added"
+            },
+            {
+              abortSignal: AbortController.timeout(1000)
+            }
+          )
+        );
+      }
+      await Promise.all(promises);
+    } catch (error) {
+      errorWasThrown = true;
+      chai.assert.equal((error as any).name, "AbortError", "Unexpected error thrown");
+    }
+    chai.assert.equal(errorWasThrown, true, "Error was not thrown");
+  });
+});

--- a/sdk/appconfiguration/app-configuration/test/internal/throttlingRetryPolicyTests.spec.ts
+++ b/sdk/appconfiguration/app-configuration/test/internal/throttlingRetryPolicyTests.spec.ts
@@ -13,10 +13,6 @@ import {
 } from "@azure/core-http";
 import { ThrottlingRetryPolicy, getDelayInMs } from "../../src/policies/throttlingRetryPolicy";
 import { assertThrowsRestError } from "../public/utils/testHelpers";
-import { AppConfigurationClient } from "../../src";
-import { AbortController } from "@azure/abort-controller";
-import nock from "nock";
-import { generateUuid } from "@azure/core-http";
 
 describe("ThrottlingRetryPolicy", () => {
   class PassThroughPolicy {
@@ -190,64 +186,5 @@ describe("ThrottlingRetryPolicy", () => {
       clock.restore();
       done();
     });
-  });
-});
-
-describe("Should not retry forever - honors the abort signal passed", () => {
-  let client: AppConfigurationClient;
-  const connectionString = "Endpoint=https://myappconfig.azconfig.io;Id=key:ai/u/fake;Secret=abcd=";
-
-  beforeEach(function() {
-    if (!nock.isActive()) {
-      nock.activate();
-    }
-    nock("https://myappconfig.azconfig.io:443")
-      .persist()
-      .put(/.*/g)
-      .reply(
-        429,
-        {
-          type: "https://azconfig.io/errors/too-many-requests",
-          title: "Resource utilization has surpassed the assigned quota",
-          policy: "Total Requests",
-          status: 429
-        },
-        ["retry-after-ms", "123456"]
-      );
-
-    client = new AppConfigurationClient(connectionString);
-  });
-
-  afterEach(async function() {
-    nock.restore();
-    nock.cleanAll();
-    nock.enableNetConnect();
-  });
-
-  it("simulate the service throttling", async () => {
-    const key = generateUuid();
-    const numberOfSettings = 200;
-    const promises = [];
-    let errorWasThrown = false;
-    try {
-      for (let index = 0; index < numberOfSettings; index++) {
-        promises.push(
-          client.addConfigurationSetting(
-            {
-              key: key + "-" + index,
-              value: "added"
-            },
-            {
-              abortSignal: AbortController.timeout(1000)
-            }
-          )
-        );
-      }
-      await Promise.all(promises);
-    } catch (error) {
-      errorWasThrown = true;
-      chai.assert.equal((error as any).name, "AbortError", "Unexpected error thrown");
-    }
-    chai.assert.equal(errorWasThrown, true, "Error was not thrown");
   });
 });


### PR DESCRIPTION
This is meant to unblock AppConfig GA release.
I can port to a browser/node test after the release https://github.com/Azure/azure-sdk-for-js/issues/16230

Fixes https://github.com/Azure/azure-sdk-for-js/issues/16231