### PR TITLE
[dev-tool] update samples publish to populate @types/* devDeps

### DIFF
--- a/common/tools/dev-tool/src/commands/samples/publish.ts
+++ b/common/tools/dev-tool/src/commands/samples/publish.ts
@@ -364,6 +364,8 @@ async function makeSampleGenerationInfo(
       {} as SampleConfiguration["customSnippets"]
     ),
     computeSampleDependencies(outputKind: OutputKind) {
+      // Store the `@types/*` packages the TS samples might need.
+      const typesDependencies: {[packageName: string]: string} = {};
       return {
         dependencies: moduleInfos.reduce((prev, source) => {
           const current: Record<string, string> = {};
@@ -383,6 +385,19 @@ async function makeSampleGenerationInfo(
               }
 
               current[dependency] = dependencyVersion;
+              // It would be really weird to depend on `@types/*` in a source file but if we did
+              // it'd be handled above.
+              if (dependency.indexOf("@types/") !== 0) {
+                const typeDependency = `@types/${dependency}`;
+                const typeDependencyVersion =
+                  sampleConfiguration.dependencyOverrides?.[typeDependency] ??
+                  packageJson.devDependencies[typeDependency] ??
+                  packageJson.dependencies[typeDependency];
+
+                if (typeDependencyVersion) {
+                  typesDependencies[typeDependency] = typeDependencyVersion;
+                }
+              }
             }
           }
           return {
@@ -395,6 +410,7 @@ async function makeSampleGenerationInfo(
               // In TypeScript samples, we include TypeScript and `rimraf`, because they're used
               // in the package scripts.
               devDependencies: {
+                ...typesDependencies,
                 typescript: devToolPackageJson.dependencies.typescript,
                 rimraf: "latest"
               }


### PR DESCRIPTION
Needed to allow the dev-tool to fix https://github.com/Azure/azure-sdk-for-js/issues/15666.

This change updates the `dev-tool samples publish` command so that it pulls in any `@types/*` packages that are in the SDK's package.json that are associated with a runtime package.

### Service Bus Example:
__service-bus/package.json__
```json
{
  "dependencies": {
    "@azure/abort-controller": "^1.0.0",
    "@azure/core-amqp": "^3.0.0",
    "@azure/core-asynciterator-polyfill": "^1.0.0",
    "@azure/core-http": "^2.0.0",
    "@azure/core-tracing": "1.0.0-preview.12",
    "@azure/core-paging": "^1.1.1",
    "@azure/core-auth": "^1.3.0",
    "@azure/logger": "^1.0.0",
    "@types/is-buffer": "^2.0.0",
    "@types/long": "^4.0.0",
    "buffer": "^5.2.1",
    "is-buffer": "^2.0.3",
    "jssha": "^3.1.0",
    "long": "^4.0.0",
    "process": "^0.11.10",
    "tslib": "^2.2.0",
    "rhea-promise": "^2.1.0"
  },
  "devDependencies": {
    "@azure/dev-tool": "^1.0.0",
    "@azure/eslint-plugin-azure-sdk": "^3.0.0",
    "@azure/identity": "2.0.0-beta.4",
    "@azure/test-utils-perfstress": "^1.0.0",
    "@microsoft/api-extractor": "7.7.11",
    "@rollup/plugin-commonjs": "11.0.2",
    "@rollup/plugin-inject": "^4.0.0",
    "@rollup/plugin-json": "^4.0.0",
    "@rollup/plugin-multi-entry": "^3.0.0",
    "@rollup/plugin-node-resolve": "^8.0.0",
    "@rollup/plugin-replace": "^2.2.0",
    "@types/chai": "^4.1.6",
    "@types/chai-as-promised": "^7.1.0",
    "@types/debug": "^4.1.4",
    "@types/glob": "^7.1.1",
    "@types/mocha": "^7.0.2",
    "@types/node": "^12.0.0",
    "@types/ws": "^7.2.4",
    "assert": "^1.4.1",
    "chai": "^4.2.0",
    "chai-as-promised": "^7.1.1",
    "chai-exclude": "^2.0.2",
    "cross-env": "^7.0.2",
    "debug": "^4.1.1",
    "delay": "^4.2.0",
    "dotenv": "^8.2.0",
    "downlevel-dts": "~0.4.0",
    "eslint": "^7.15.0",
    "esm": "^3.2.18",
    "glob": "^7.1.2",
    "https-proxy-agent": "^5.0.0",
    "karma": "^6.2.0",
    "karma-chrome-launcher": "^3.0.0",
    "karma-coverage": "^2.0.0",
    "karma-edge-launcher": "^0.4.2",
    "karma-env-preprocessor": "^0.1.1",
    "karma-firefox-launcher": "^1.1.0",
    "karma-ie-launcher": "^1.0.0",
    "karma-junit-reporter": "^2.0.1",
    "karma-mocha": "^2.0.1",
    "karma-mocha-reporter": "^2.2.5",
    "karma-sourcemap-loader": "^0.3.8",
    "mocha": "^7.1.1",
    "mocha-junit-reporter": "^1.18.0",
    "moment": "^2.24.0",
    "nyc": "^14.0.0",
    "prettier": "^1.16.4",
    "promise": "^8.0.3",
    "puppeteer": "^3.3.0",
    "rimraf": "^3.0.0",
    "rollup": "^1.16.3",
    "rollup-plugin-shim": "^1.0.0",
    "rollup-plugin-sourcemaps": "^0.4.2",
    "rollup-plugin-terser": "^5.1.1",
    "ts-node": "^9.0.0",
    "typescript": "~4.2.0",
    "ws": "^7.1.1",
    "sinon": "^9.0.2",
    "@types/sinon": "^9.0.4",
    "events": "^3.0.0",
    "typedoc": "0.15.2"
  }
}
```

__Generated TS samples package.json__
```json
{
  "dependencies": {
    "@azure/service-bus": "latest",
    "dotenv": "latest",
    "ws": "^7.1.1",
    "https-proxy-agent": "^5.0.0",
    "@azure/identity": "^1.1.0",
    "@azure/abort-controller": "^1.0.0"
  },
  "devDependencies": {
    "@types/ws": "^7.2.4",
    "typescript": "~4.2.0",
    "rimraf": "latest"
  }
}
```

In the service-bus example, `@types/ws` is added as a devDependency in the TypeScript samples package.json because one of the samples depends on `ws`, and `@types/ws` is defined in the `devDependencies` of the `@azure/service-bus` package.json.