### PR TITLE
[service-bus] add @types/ws to TypeScript samples package.json

### DIFF
--- a/sdk/servicebus/service-bus/samples/v7/javascript/README.md
+++ b/sdk/servicebus/service-bus/samples/v7/javascript/README.md
@@ -32,7 +32,7 @@ These sample programs show how to use the JavaScript client libraries for Azure 
 
 ## Prerequisites
 
-The sample programs are compatible with Node.js >=12.0.0.
+The sample programs are compatible with [LTS versions of Node.js](https://nodejs.org/about/releases/).
 
 You need [an Azure subscription][freesub] and the following Azure resources to run these sample programs:
 

--- a/sdk/servicebus/service-bus/samples/v7/javascript/package.json
+++ b/sdk/servicebus/service-bus/samples/v7/javascript/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/servicebus/service-bus",
   "dependencies": {
-    "@azure/service-bus": "next",
+    "@azure/service-bus": "latest",
     "dotenv": "latest",
     "ws": "^7.1.1",
     "https-proxy-agent": "^5.0.0",

--- a/sdk/servicebus/service-bus/samples/v7/typescript/README.md
+++ b/sdk/servicebus/service-bus/samples/v7/typescript/README.md
@@ -32,7 +32,7 @@ These sample programs show how to use the TypeScript client libraries for Azure 
 
 ## Prerequisites
 
-The sample programs are compatible with Node.js >=12.0.0.
+The sample programs are compatible with [LTS versions of Node.js](https://nodejs.org/about/releases/).
 
 Before running the samples in Node, they must be compiled to JavaScript using the TypeScript compiler. For more information on TypeScript, see the [TypeScript documentation][typescript]. Install the TypeScript compiler using:
 

--- a/sdk/servicebus/service-bus/samples/v7/typescript/package.json
+++ b/sdk/servicebus/service-bus/samples/v7/typescript/package.json
@@ -29,7 +29,7 @@
   },
   "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/servicebus/service-bus",
   "dependencies": {
-    "@azure/service-bus": "next",
+    "@azure/service-bus": "latest",
     "dotenv": "latest",
     "ws": "^7.1.1",
     "https-proxy-agent": "^5.0.0",
@@ -37,6 +37,7 @@
     "@azure/abort-controller": "^1.0.0"
   },
   "devDependencies": {
+    "@types/ws": "^7.2.4",
     "typescript": "~4.2.0",
     "rimraf": "latest"
   }


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-sdk-for-js/issues/15666

It also turns out the samples depended on the `next` tag for service-bus, which is no longer published on NPM, so this update fixes that issue by depending on the `latest` tag.