### PR TITLE
[MetricsAdvisor][Sample] fix sample runtime errors

### DIFF
--- a/sdk/metricsadvisor/ai-metrics-advisor/samples-dev/detectionConfig.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/samples-dev/detectionConfig.ts
@@ -73,7 +73,7 @@ async function createDetectionConfig(
       sensitivity: 50,
       anomalyDetectorDirection: "Both",
       suppressCondition: {
-        minNumber: 50,
+        minNumber: 5,
         minRatio: 50
       }
     },

--- a/sdk/metricsadvisor/ai-metrics-advisor/samples-dev/seriesData.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/samples-dev/seriesData.ts
@@ -81,7 +81,7 @@ async function getMetricSeriesData(client: MetricsAdvisorClient, metricId: strin
 
     for (const series of result) {
       console.log(series.definition);
-      if (series.timestamps?.length)
+      if (series.timestamps && series.timestamps.length)
         for (let i = 0; i < series.timestamps!.length; i++) {
           console.log(`  ${series.timestamps![i]}`);
           console.log(`  ${series.values![i]}`);

--- a/sdk/metricsadvisor/ai-metrics-advisor/samples/v1/javascript/detectionConfig.js
+++ b/sdk/metricsadvisor/ai-metrics-advisor/samples/v1/javascript/detectionConfig.js
@@ -62,7 +62,7 @@ async function createDetectionConfig(adminClient, metricId) {
       sensitivity: 50,
       anomalyDetectorDirection: "Both",
       suppressCondition: {
-        minNumber: 50,
+        minNumber: 5,
         minRatio: 50
       }
     },

--- a/sdk/metricsadvisor/ai-metrics-advisor/samples/v1/javascript/seriesData.js
+++ b/sdk/metricsadvisor/ai-metrics-advisor/samples/v1/javascript/seriesData.js
@@ -80,7 +80,7 @@ async function getMetricSeriesData(client, metricId) {
 
     for (const series of result) {
       console.log(series.definition);
-      if (series.timestamps?.length)
+      if (series.timestamps && series.timestamps.length)
         for (let i = 0; i < series.timestamps.length; i++) {
           console.log(`  ${series.timestamps[i]}`);
           console.log(`  ${series.values[i]}`);

--- a/sdk/metricsadvisor/ai-metrics-advisor/samples/v1/typescript/src/detectionConfig.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/samples/v1/typescript/src/detectionConfig.ts
@@ -72,7 +72,7 @@ async function createDetectionConfig(
       sensitivity: 50,
       anomalyDetectorDirection: "Both",
       suppressCondition: {
-        minNumber: 50,
+        minNumber: 5,
         minRatio: 50
       }
     },

--- a/sdk/metricsadvisor/ai-metrics-advisor/samples/v1/typescript/src/seriesData.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/samples/v1/typescript/src/seriesData.ts
@@ -80,7 +80,7 @@ async function getMetricSeriesData(client: MetricsAdvisorClient, metricId: strin
 
     for (const series of result) {
       console.log(series.definition);
-      if (series.timestamps?.length)
+      if (series.timestamps && series.timestamps.length)
         for (let i = 0; i < series.timestamps!.length; i++) {
           console.log(`  ${series.timestamps![i]}`);
           console.log(`  ${series.values![i]}`);


### PR DESCRIPTION
- detectionConfig

  RestError: Invalid parameter. suppress number should be less than or equal to 14.

- `?.` not supported in NodeJS v12

Fixes #16234
Fixes #16105