### PR TITLE
support track2 codegen in swagger pipeline

### DIFF
--- a/.scripts/automation_generate.sh
+++ b/.scripts/automation_generate.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# rush install
+npm install -g @microsoft/rush
+rush install
+# generate
+npm install -g azure-track2-js-sdk-release-tools
+track2-codegen-automation-for-pipeline --inputJsonPath=$1 --outputJsonPath=$2 --use=@autorest/typescript@6.0.0-beta.5

--- a/.scripts/automation_generate.sh
+++ b/.scripts/automation_generate.sh
@@ -1,7 +1,2 @@
 #!/usr/bin/env bash
-# rush install
-npm install -g @microsoft/rush
-rush install
-# generate
-npm install -g azure-track2-js-sdk-release-tools
 track2-codegen-automation-for-pipeline --inputJsonPath=$1 --outputJsonPath=$2 --use=@autorest/typescript@6.0.0-beta.5

--- a/.scripts/automation_init.sh
+++ b/.scripts/automation_init.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# rush install
+npm install -g @microsoft/rush
+rush install
+# install release tools
+npm install -g azure-track2-js-sdk-release-tools

--- a/swagger_to_sdk_config.json
+++ b/swagger_to_sdk_config.json
@@ -3,13 +3,18 @@
     "createSdkPullRequests": true,
     "generationCallMode": "one-per-config"
   },
+  "initOptions": {
+    "initScript": {
+      "path": "sh .scripts/automation_init.sh"
+    }
+  },
   "generateOptions": {
     "generateScript": {
       "path": "sh .scripts/automation_generate.sh",
       "stderr": {
-          "showInComment": "^\\[AUTOREST\\]",
-          "scriptError": "^\\[ERROR\\]",
-          "scriptWarning": "^\\[WARNING\\]"
+        "showInComment": "^\\[AUTOREST\\]",
+        "scriptError": "^\\[ERROR\\]",
+        "scriptWarning": "^\\[WARNING\\]"
       }
     },
     "parseGenerateOutput": true

--- a/swagger_to_sdk_config.json
+++ b/swagger_to_sdk_config.json
@@ -1,18 +1,17 @@
 {
-  "$schema": "https://openapistorageprod.blob.core.windows.net/sdkautomation/prod/schemas/swagger_to_sdk_config.schema.json",
-  "meta": {
-    "autorest_options": {
-      "version": "V2",
-      "typescript": "",
-      "license-header": "MICROSOFT_MIT_NO_VERSION",
-      "sdkrel:typescript-sdks-folder": ".",
-      "use": "@microsoft.azure/autorest.typescript@4.7.0"
+  "advancedOptions": {
+    "createSdkPullRequests": true,
+    "generationCallMode": "one-per-config"
+  },
+  "generateOptions": {
+    "generateScript": {
+      "path": "sh .scripts/automation_generate.sh",
+      "stderr": {
+          "showInComment": "^\\[AUTOREST\\]",
+          "scriptError": "^\\[ERROR\\]",
+          "scriptWarning": "^\\[WARNING\\]"
+      }
     },
-    "advanced_options": {
-      "clone_dir": "./azure-sdk-for-js",
-      "create_sdk_pull_requests": true,
-      "sdk_generation_pull_request_base": "integration_branch"
-    },
-    "version": "0.2.0"
+    "parseGenerateOutput": true
   }
 }


### PR DESCRIPTION
This PR is used to integrate track2 js mgmt codegen to swagger pipeline. After it's merged, I will create a PR to make changes in swagger repository.
When codegen is in peview, we specify the verison of codegen.
When codegen is GA, we will always use the latest codegen.