### PR TITLE
[eventhubs] - Update checkpointstore to latest version of event-hubs

### DIFF
--- a/common/config/rush/common-versions.json
+++ b/common/config/rush/common-versions.json
@@ -41,13 +41,6 @@
    * This design avoids unnecessary churn in this file.
    */
   "allowedAlternativeVersions": {
-    // "^12.4.1" is required for eventhubs-checkpointstore-blob to use the latest GA version
-    // when there is a new beta version which is being maintained in the repo.
-    // Remove "^12.4.1" when the storage-blob releases a stable version.
-    // Add a new entry in case a new version is being tested through the perf tests (Example: "12.2.0").
-    "@azure/storage-blob": [
-      "^12.4.1"
-    ],
     "@azure/ms-rest-js": [
       "^2.0.0"
     ],

--- a/sdk/eventhub/eventhubs-checkpointstore-blob/package.json
+++ b/sdk/eventhub/eventhubs-checkpointstore-blob/package.json
@@ -61,7 +61,7 @@
   },
   "dependencies": {
     "@azure/abort-controller": "^1.0.0",
-    "@azure/event-hubs": "^5.5.0",
+    "@azure/event-hubs": "^5.6.0",
     "@azure/logger": "^1.0.0",
     "@azure/storage-blob": "^12.4.1",
     "events": "^3.0.0",

--- a/sdk/eventhub/eventhubs-checkpointstore-blob/package.json
+++ b/sdk/eventhub/eventhubs-checkpointstore-blob/package.json
@@ -63,7 +63,7 @@
     "@azure/abort-controller": "^1.0.0",
     "@azure/event-hubs": "^5.6.0",
     "@azure/logger": "^1.0.0",
-    "@azure/storage-blob": "^12.4.1",
+    "@azure/storage-blob": "^12.7.0",
     "events": "^3.0.0",
     "tslib": "^2.2.0"
   },


### PR DESCRIPTION
## What 

- Updates @azure/eventhubs-checkpoint-blobstore min version to the latest @azure/eventhubs 

## Why

This resolves the build error when set-dev-version is run, ensuring that the @azure/core-tracing versions are compatible.