### PR TITLE
[dev-tool] check-node-versions no longer defaults to test node v8

### DIFF
--- a/common/tools/dev-tool/src/commands/samples/checkNodeVersions.ts
+++ b/common/tools/dev-tool/src/commands/samples/checkNodeVersions.ts
@@ -224,7 +224,7 @@ export const commandInfo = makeCommandInfo(
     "node-versions": {
       kind: "string",
       description: "A comma separated list of node versions to use",
-      default: "8,10,12"
+      default: "12,14,15"
     },
     "node-version": {
       kind: "string",


### PR DESCRIPTION
We only support LTS versoins!