### PR TITLE
[KeyVault] - Update changelog after 4.2.2

### DIFF
--- a/sdk/keyvault/keyvault-keys/CHANGELOG.md
+++ b/sdk/keyvault/keyvault-keys/CHANGELOG.md
@@ -18,6 +18,8 @@
 - Added support for `KeyClient.getRandomBytes` which, when connected to a managed HSM, can be used to generate a byte array of a given length with random values.
 - Updated the service version to 7.3-preview.
 
+## 4.2.2 (2021-07-07)
+
 ### Key Bugs Fixed
 
 - Fixed an issue where `CryptographyClient.signData` and `CryptographyClient.verifyData` convenience methods would fail to find a valid hashing algorithm when using Elliptic Curve keys.


### PR DESCRIPTION
Update the changelog to reflect that the signData and verifyData fix was backported into 4.2