### PR TITLE
JS Package Exclusions

### DIFF
--- a/eng/pipelines/templates/stages/archetype-js-release.yml
+++ b/eng/pipelines/templates/stages/archetype-js-release.yml
@@ -103,9 +103,7 @@ stages:
           - ${{if ne(artifact.skipPublishDocMs, 'true')}}:
             - deployment: PublishDocs
               displayName: Docs.MS Release
-              # Skip publishing metadata to default branch if this is a test 
-              # package (e.g. @azure/template)
-              condition: and(succeeded(), ne(variables['Skip.PublishDocs'], 'true'), ne('${{ parameters.TestPipeline }}', 'true'))
+              condition: and(succeeded(), ne(variables['Skip.PublishDocs'], 'true'))
               environment: githubio
               dependsOn: PublishPackage
 

--- a/eng/pipelines/templates/stages/archetype-js-release.yml
+++ b/eng/pipelines/templates/stages/archetype-js-release.yml
@@ -103,7 +103,9 @@ stages:
           - ${{if ne(artifact.skipPublishDocMs, 'true')}}:
             - deployment: PublishDocs
               displayName: Docs.MS Release
-              condition: and(succeeded(), ne(variables['Skip.PublishDocs'], 'true'))
+              # Skip publishing metadata to default branch if this is a test 
+              # package (e.g. @azure/template)
+              condition: and(succeeded(), ne(variables['Skip.PublishDocs'], 'true'), ne('${{ parameters.TestPipeline }}', 'true'))
               environment: githubio
               dependsOn: PublishPackage
 

--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -206,16 +206,23 @@ function Get-DocsMsPackageName($packageName, $packageVersion) {
   return "$(Get-PackageNameFromDocsMsConfig $packageName)@$packageVersion"
 }
 
+$PackageExclusions = @{ 
+  '@azure/identity-vscode' = $true # Fails type2docfx execution https://github.com/Azure/azure-sdk-for-js/issues/16303
+}
+
 function Update-javascript-DocsMsPackages($DocsRepoLocation, $DocsMetadata) {
+
+  $FilteredMetadata = $DocsMetadata.Where({ !($PackageExclusions.ContainsKey($_.Package)) })
+
   UpdateDocsMsPackages `
     (Join-Path $DocsRepoLocation 'ci-configs/packages-preview.json') `
     'preview' `
-    $DocsMetadata 
+    $FilteredMetadata 
 
   UpdateDocsMsPackages `
     (Join-Path $DocsRepoLocation 'ci-configs/packages-latest.json') `
     'latest' `
-    $DocsMetadata
+    $FilteredMetadata
 }
 
 function UpdateDocsMsPackages($DocConfigFile, $Mode, $DocsMetadata) {

--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -207,10 +207,16 @@ function Get-DocsMsPackageName($packageName, $packageVersion) {
 }
 
 $PackageExclusions = @{ 
-  '@azure/identity-vscode' = $true # Fails type2docfx execution https://github.com/Azure/azure-sdk-for-js/issues/16303
+  '@azure/identity-vscode' = 'Fails type2docfx execution https://github.com/Azure/azure-sdk-for-js/issues/16303';
+  '@azure/identity-cache-persistence' = 'Fails typedoc2fx execution https://github.com/Azure/azure-sdk-for-js/issues/16310';
 }
 
 function Update-javascript-DocsMsPackages($DocsRepoLocation, $DocsMetadata) {
+
+  Write-Host "Excluded packages:"
+  foreach ($excludedPackage in $PackageExclusions.Keys) {
+    Write-Host "  $excludedPackage - $($PackageExclusions[$excludedPackage])"
+  }
 
   $FilteredMetadata = $DocsMetadata.Where({ !($PackageExclusions.ContainsKey($_.Package)) })
 
@@ -231,9 +237,10 @@ function UpdateDocsMsPackages($DocConfigFile, $Mode, $DocsMetadata) {
 
   $outputPackages = @()
   foreach ($package in $packageConfig.npm_package_sources) {
+    $packageName = Get-PackageNameFromDocsMsConfig $package.name
     # If Get-PackageNameFromDocsMsConfig cannot find the package name, keep the
     # entry but do no additional processing on it.
-    if (!(Get-PackageNameFromDocsMsConfig $package.name)) {
+    if (!$packageName) {
       LogWarning "Package name is not valid: ($($package.name)). Keeping entry in docs config but not updating."
       $outputPackages += $package
       continue
@@ -241,7 +248,7 @@ function UpdateDocsMsPackages($DocConfigFile, $Mode, $DocsMetadata) {
 
     # Do not filter by GA/Preview status because we want differentiate between
     # tracked and non-tracked packages
-    $matchingPublishedPackageArray = $DocsMetadata.Where({ $_.Package -eq (Get-PackageNameFromDocsMsConfig $package.name) })
+    $matchingPublishedPackageArray = $DocsMetadata.Where( { $_.Package -eq $packageName })
 
     # If this package does not match any published packages keep it in the list.
     # This handles packages which are not tracked in metadata but still need to


### PR DESCRIPTION
A couple packages have been failing in Docs CI since their release. This is a first cut at creating an exclusion list pattern for JS and other docs onboarding business logic. 

This version excludes packages by name and doesn't have other configuration for package exclusion (e.g. version exclusion or version pinning). 