### PR TITLE
Remove ^1.0.3 from common-versions for core-rest-pipeline

### DIFF
--- a/common/config/rush/common-versions.json
+++ b/common/config/rush/common-versions.json
@@ -78,10 +78,6 @@
     ],
     "prettier": [
       "2.2.1"
-    ],
-    // @azure/cosmos was unable to upgrade due to test failures, Issue #15928 tracks making this upgrade
-    "@azure/core-rest-pipeline": [
-      "^1.0.3"
     ]
   }
 }

--- a/sdk/cosmosdb/cosmos/package.json
+++ b/sdk/cosmosdb/cosmos/package.json
@@ -87,7 +87,7 @@
   },
   "dependencies": {
     "@azure/core-auth": "^1.3.0",
-    "@azure/core-rest-pipeline": "^1.0.3",
+    "@azure/core-rest-pipeline": "^1.1.0",
     "debug": "^4.1.1",
     "fast-json-stable-stringify": "^2.0.0",
     "jsbi": "^3.1.3",

--- a/sdk/remoterendering/mixed-reality-remote-rendering/package.json
+++ b/sdk/remoterendering/mixed-reality-remote-rendering/package.json
@@ -75,7 +75,7 @@
   "prettier": "@azure/eslint-plugin-azure-sdk/prettier.json",
   "dependencies": {
     "@azure/core-auth": "^1.3.0",
-    "@azure/core-rest-pipeline": "^1.0.3",
+    "@azure/core-rest-pipeline": "^1.1.0",
     "@azure/core-client": "^1.0.0",
     "@azure/core-tracing": "1.0.0-preview.12",
     "@azure/logger": "^1.0.0",


### PR DESCRIPTION
In #15923, we updated the version of core-rest-pipeline in the dependencies of all packages except cosmos which had a recurring build/test failure which has since been fixed.

This PR updates the version of core-rest-pipeline in cosmosdb package as well as the new remoterendering package.

Resolves #15928