### PR TITLE
[EventGrid] Support TokenCredential

### DIFF
--- a/sdk/eventgrid/eventgrid/CHANGELOG.md
+++ b/sdk/eventgrid/eventgrid/CHANGELOG.md
@@ -3,7 +3,12 @@
 ## 4.4.0 (Unreleased)
 
 ### Features Added
+
 - With the dropping of support for Node.js versions that are no longer in LTS, the dependency on `@types/node` has been updated to version 12. Read our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
+
+- `EventGridPublisherClient` now supports Azure Active Directory (AAD) for authentication. When constructing an `EventGridPublisherClient` you may now pass an instance
+  of a `TokenCredential` as the credential. See the readme for [`@azure/identity`](https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/identity/identity) to learn
+  more about using Azure Active Directory for authentication.
 
 ### Breaking Changes
 

--- a/sdk/eventgrid/eventgrid/README.md
+++ b/sdk/eventgrid/eventgrid/README.md
@@ -110,6 +110,27 @@ const token = generateSharedAccessSignature(
 );
 ```
 
+#### Using Azure Active Directory (AAD)
+
+Azure EventGrid provides integration with Azure Active Directory (Azure AD) for identity-based authentication of requests. With Azure AD, you can use role-based access control (RBAC) to grant access to your Azure Event Grid resources to users, groups, or applications.
+
+To send events to a topic or domain with a `TokenCredential`, the authenticated identity should have the "EventGrid Data Sender" role assigned.
+
+With the `@azure/identity` package, you can seamlessly authorize requests in both development and production environments. To learn more about Azure Active Directory, see the [`@azure/identity` README](https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/identity/identity/README.md).
+
+For example, use can use `DefaultAzureCredential` to construct a client which will authenticate using Azure Active Directory:
+
+```js
+const { EventGridPublisherClient } = require("@azure/eventgrid");
+const { DefaultAzureCredential } = require("@azure/identity");
+
+const client = new EventGridPublisherClient(
+  "<endpoint>",
+  "<endpoint schema>",
+  new DefaultAzureCredential()
+);
+```
+
 ## Key concepts
 
 ### EventGridPublisherClient

--- a/sdk/eventgrid/eventgrid/review/eventgrid.api.md
+++ b/sdk/eventgrid/eventgrid/review/eventgrid.api.md
@@ -10,6 +10,7 @@ import { CommonClientOptions } from '@azure/core-client';
 import { KeyCredential } from '@azure/core-auth';
 import { OperationOptions } from '@azure/core-client';
 import { SASCredential } from '@azure/core-auth';
+import { TokenCredential } from '@azure/core-auth';
 
 // @public
 export interface AcsChatEventBase {
@@ -400,7 +401,7 @@ export interface EventGridEvent<T> {
 
 // @public
 export class EventGridPublisherClient<T extends InputSchema> {
-    constructor(endpointUrl: string, inputSchema: T, credential: KeyCredential | SASCredential, options?: EventGridPublisherClientOptions);
+    constructor(endpointUrl: string, inputSchema: T, credential: KeyCredential | SASCredential | TokenCredential, options?: EventGridPublisherClientOptions);
     readonly apiVersion: string;
     readonly endpointUrl: string;
     send(events: InputSchemaToInputTypeMap[T][], options?: SendOptions): Promise<void>;

--- a/sdk/eventgrid/eventgrid/src/constants.ts
+++ b/sdk/eventgrid/eventgrid/src/constants.ts
@@ -3,3 +3,4 @@
 
 export const SDK_VERSION: string = "4.4.0";
 export const DEFAULT_API_VERSION = "2018-01-01";
+export const DEFAULT_EVENTGRID_SCOPE = "https://eventgrid.azure.net/.default";


### PR DESCRIPTION
This change adds support for using Azure AD to authenticate when send
events using `EventGridPublisherClient`.