### PR TITLE
Code to fix return value for HEAD HttpMethod

### DIFF
--- a/sdk/core/core-client/CHANGELOG.md
+++ b/sdk/core/core-client/CHANGELOG.md
@@ -1,15 +1,12 @@
 # Release History
 
-## 1.2.2 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
+## 1.2.2 (2021-07-13)
 
 ### Key Bugs Fixed
 
-### Fixed
+- Fixed the return value during the flattening the response for `HEAD` HTTP Requests. This will ensure that the return value will indicate the presence/absence of the resource. Please refer [#1037](https://github.com/Azure/autorest.typescript/issues/1037) for more details.
 
+### Fixed
 
 ## 1.2.1 (2021-06-30)
 

--- a/sdk/core/core-client/src/utils.ts
+++ b/sdk/core/core-client/src/utils.ts
@@ -122,14 +122,12 @@ export function flattenResponse(
 ): unknown {
   const parsedHeaders = fullResponse.parsedHeaders;
 
-  /**
-   * If body is not asked for, only response headers are returned. If the response
-   * has a body anyway, that body must be ignored.
-   */
   if (fullResponse.request.method === "HEAD") {
-    return parsedHeaders;
+    return {
+      ...parsedHeaders,
+      body: fullResponse.parsedBody
+    };
   }
-
   const bodyMapper = responseSpec && responseSpec.bodyMapper;
   const isNullable = Boolean(bodyMapper?.nullable);
   const expectedBodyTypeName = bodyMapper?.type.name;

--- a/sdk/core/core-client/src/utils.ts
+++ b/sdk/core/core-client/src/utils.ts
@@ -122,6 +122,8 @@ export function flattenResponse(
 ): unknown {
   const parsedHeaders = fullResponse.parsedHeaders;
 
+  // head methods never have a body, but we return a boolean set to body property
+  // to indicate presence/absence of the resource
   if (fullResponse.request.method === "HEAD") {
     return {
       ...parsedHeaders,

--- a/sdk/core/core-client/test/serviceClient.spec.ts
+++ b/sdk/core/core-client/test/serviceClient.spec.ts
@@ -571,7 +571,9 @@ describe("ServiceClient", function() {
           }
         }
       },
-      undefined
+      {
+        body: undefined
+      }
     );
   });
 

--- a/sdk/core/core-rest-pipeline/CHANGELOG.md
+++ b/sdk/core/core-rest-pipeline/CHANGELOG.md
@@ -1,15 +1,12 @@
 # Release History
 
-## 1.1.1 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
+## 1.1.1 (2021-07-13)
 
 ### Key Bugs Fixed
 
-### Fixed
+- Fixed an issue with `HEAD` HTTP Requests. Destroyed the response before resolving the promise which will ensure that the code does not hang up. Please refer [#1037](https://github.com/Azure/autorest.typescript/issues/1037) for more details.
 
+### Fixed
 
 ## 1.1.0 (2021-06-30)
 

--- a/sdk/core/core-rest-pipeline/src/nodeHttpClient.ts
+++ b/sdk/core/core-rest-pipeline/src/nodeHttpClient.ts
@@ -129,6 +129,14 @@ class NodeHttpClient implements HttpClient {
             request
           };
 
+          // Responses to HEAD must not have a body.
+          // If they do return a body, that body must be ignored.
+          if (request.method === "HEAD") {
+            res.destroy();
+            resolve(response);
+            return;
+          }
+
           responseStream = shouldDecompress ? getDecodedResponseStream(res, headers) : res;
 
           const onDownloadProgress = request.onDownloadProgress;

--- a/sdk/core/core-rest-pipeline/src/nodeHttpClient.ts
+++ b/sdk/core/core-rest-pipeline/src/nodeHttpClient.ts
@@ -129,13 +129,6 @@ class NodeHttpClient implements HttpClient {
             request
           };
 
-          // Responses to HEAD must not have a body.
-          // If they do return a body, that body must be ignored.
-          if (request.method === "HEAD") {
-            resolve(response);
-            return;
-          }
-
           responseStream = shouldDecompress ? getDecodedResponseStream(res, headers) : res;
 
           const onDownloadProgress = request.onDownloadProgress;


### PR DESCRIPTION
This is to fix the issue reported in https://github.com/Azure/autorest.typescript/issues/1037. Originally, it was returning the correct values. But, with PR https://github.com/Azure/azure-sdk-for-js/pull/14366, this was changed to not return the `body` value. 

With this PR, I am bringing it back.

@deyaaeldeen @xirzec Please review and approve.

@ramya-rao-a FYI...