### PR TITLE
Supporting reading and setting connection state

### DIFF
--- a/sdk/web-pubsub/web-pubsub-express/CHANGELOG.md
+++ b/sdk/web-pubsub/web-pubsub-express/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Release History
 
-## 1.0.0-beta.2 (UNRELEASED)
+## 1.0.0-beta.3 (UNRELEASED)
+
+- Add support to get and set connection state
+
+## 1.0.0-beta.2 (2021-07-20)
 
 - Removed unnecessary dependencies.
 

--- a/sdk/web-pubsub/web-pubsub-express/package.json
+++ b/sdk/web-pubsub/web-pubsub-express/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/web-pubsub-express",
-  "version": "1.0.0-beta.2",
+  "version": "1.0.0-beta.3",
   "description": "Azure Web PubSub CloudEvents handlers",
   "sdk-type": "client",
   "main": "dist/index.js",

--- a/sdk/web-pubsub/web-pubsub-express/review/web-pubsub-express.api.md
+++ b/sdk/web-pubsub/web-pubsub-express/review/web-pubsub-express.api.md
@@ -47,7 +47,7 @@ export interface ConnectResponse {
 // @public
 export interface ConnectResponseHandler {
     fail(code: 400 | 401 | 500, detail?: string): void;
-    setState(name: string, value: any): ConnectResponseHandler;
+    setState(name: string, value: unknown): ConnectResponseHandler;
     success(response?: ConnectResponse): void;
 }
 
@@ -71,7 +71,7 @@ export type UserEventRequest = {
 // @public
 export interface UserEventResponseHandler {
     fail(code: 400 | 401 | 500, detail?: string): void;
-    setState(name: string, value: any): UserEventResponseHandler;
+    setState(name: string, value: unknown): UserEventResponseHandler;
     success(data?: string | ArrayBuffer, dataType?: "binary" | "text" | "json"): void;
 }
 

--- a/sdk/web-pubsub/web-pubsub-express/review/web-pubsub-express.api.md
+++ b/sdk/web-pubsub/web-pubsub-express/review/web-pubsub-express.api.md
@@ -47,7 +47,7 @@ export interface ConnectResponse {
 // @public
 export interface ConnectResponseHandler {
     fail(code: 400 | 401 | 500, detail?: string): void;
-    setState(name: string, value: unknown): ConnectResponseHandler;
+    setState(name: string, value: unknown): void;
     success(response?: ConnectResponse): void;
 }
 
@@ -71,7 +71,7 @@ export type UserEventRequest = {
 // @public
 export interface UserEventResponseHandler {
     fail(code: 400 | 401 | 500, detail?: string): void;
-    setState(name: string, value: unknown): UserEventResponseHandler;
+    setState(name: string, value: unknown): void;
     success(data?: string | ArrayBuffer, dataType?: "binary" | "text" | "json"): void;
 }
 

--- a/sdk/web-pubsub/web-pubsub-express/review/web-pubsub-express.api.md
+++ b/sdk/web-pubsub/web-pubsub-express/review/web-pubsub-express.api.md
@@ -22,6 +22,7 @@ export interface ConnectionContext {
     eventName: string;
     hub: string;
     origin: string;
+    states: Record<string, any>;
     subprotocol?: string;
     userId?: string;
 }
@@ -46,6 +47,7 @@ export interface ConnectResponse {
 // @public
 export interface ConnectResponseHandler {
     fail(code: 400 | 401 | 500, detail?: string): void;
+    setState(name: string, value: any): ConnectResponseHandler;
     success(response?: ConnectResponse): void;
 }
 
@@ -69,6 +71,7 @@ export type UserEventRequest = {
 // @public
 export interface UserEventResponseHandler {
     fail(code: 400 | 401 | 500, detail?: string): void;
+    setState(name: string, value: any): UserEventResponseHandler;
     success(data?: string | ArrayBuffer, dataType?: "binary" | "text" | "json"): void;
 }
 

--- a/sdk/web-pubsub/web-pubsub-express/samples-dev/server.ts
+++ b/sdk/web-pubsub/web-pubsub-express/samples-dev/server.ts
@@ -13,7 +13,8 @@ const handler = new WebPubSubEventHandler("chat", ["https://xxx.webpubsub.azure.
   handleConnect(req, res) {
     console.log(req);
     // You can set the state for the connection, it lasts throughout the lifetime of the connection
-    res.setState("calledTime", 1).success();
+    res.setState("calledTime", 1);
+    res.success();
     // or fail
     // res.fail(401);
   },
@@ -24,7 +25,8 @@ const handler = new WebPubSubEventHandler("chat", ["https://xxx.webpubsub.azure.
     var calledTime = req.context.states.calledTime++;
     console.log(calledTime);
     // You can also set the state here
-    res.setState("calledTime", calledTime).success("Hello", "text");
+    res.setState("calledTime", calledTime);
+    res.success("Hello", "text");
   }
 });
 

--- a/sdk/web-pubsub/web-pubsub-express/samples-dev/server.ts
+++ b/sdk/web-pubsub/web-pubsub-express/samples-dev/server.ts
@@ -12,7 +12,8 @@ const handler = new WebPubSubEventHandler("chat", ["https://xxx.webpubsub.azure.
   dumpRequest: false,
   handleConnect(req, res) {
     console.log(req);
-    res.success();
+    // You can set the state for the connection, it lasts throughout the lifetime of the connection
+    res.setState("calledTime", 1).success();
     // or fail
     // res.fail(401);
   },
@@ -20,8 +21,10 @@ const handler = new WebPubSubEventHandler("chat", ["https://xxx.webpubsub.azure.
     console.log(connectedRequest);
   },
   handleUserEvent(req, res) {
-    console.log(req);
-    res.success("Hello", "text");
+    var calledTime = req.context.states.calledTime++;
+    console.log(calledTime);
+    // You can also set the state here
+    res.setState("calledTime", calledTime).success("Hello", "text");
   }
 });
 

--- a/sdk/web-pubsub/web-pubsub-express/src/cloudEventsDispatcher.ts
+++ b/sdk/web-pubsub/web-pubsub-express/src/cloudEventsDispatcher.ts
@@ -266,7 +266,7 @@ export class CloudEventsDispatcher {
    * @returns The base64 JSON string
    */
   private stringifyStates(states: Record<string, string>): string {
-    return new Buffer(JSON.stringify(states)).toString("base64");
+    return Buffer.from(JSON.stringify(states)).toString("base64");
   }
 
   /**

--- a/sdk/web-pubsub/web-pubsub-express/src/cloudEventsDispatcher.ts
+++ b/sdk/web-pubsub/web-pubsub-express/src/cloudEventsDispatcher.ts
@@ -33,10 +33,9 @@ function getConnectResponseHandler(
   let states: Record<string, any> = connectRequest.context.states;
   let modified = false;
   const handler = {
-    setState(name: string, value: unknown): ConnectResponseHandler {
+    setState(name: string, value: unknown): void {
       states[name] = value;
       modified = true;
-      return handler;
     },
     success(res?: ConnectResponse): void {
       response.statusCode = 200;
@@ -66,10 +65,9 @@ function getUserEventResponseHandler(
   let states: Record<string, any> = userRequest.context.states;
   let modified = false;
   const handler = {
-    setState(name: string, value: unknown): UserEventResponseHandler {
+    setState(name: string, value: unknown): void {
       modified = true;
       states[name] = value;
-      return handler;
     },
     success(data?: string | ArrayBuffer, dataType?: "binary" | "text" | "json"): void {
       response.statusCode = 200;

--- a/sdk/web-pubsub/web-pubsub-express/src/cloudEventsProtocols.ts
+++ b/sdk/web-pubsub/web-pubsub-express/src/cloudEventsProtocols.ts
@@ -161,7 +161,7 @@ export interface ConnectResponseHandler {
    * @param name The name of the state
    * @param value The value of the state 
    */
-  setState(name: string, value: any): ConnectResponseHandler;
+  setState(name: string, value: unknown): ConnectResponseHandler;
   /**
    * Return success response to the service.
    * @param response The response for the connect event.
@@ -184,7 +184,7 @@ export interface UserEventResponseHandler {
    * @param name The name of the state
    * @param value The value of the state 
    */
-  setState(name: string, value: any): UserEventResponseHandler;
+  setState(name: string, value: unknown): UserEventResponseHandler;
   /**
    * Return success response with data to be delivered to the client WebSocket connection.
    * @param data The payload data to be returned to the client.

--- a/sdk/web-pubsub/web-pubsub-express/src/cloudEventsProtocols.ts
+++ b/sdk/web-pubsub/web-pubsub-express/src/cloudEventsProtocols.ts
@@ -161,7 +161,7 @@ export interface ConnectResponseHandler {
    * @param name The name of the state
    * @param value The value of the state
    */
-  setState(name: string, value: unknown): ConnectResponseHandler;
+  setState(name: string, value: unknown): void;
   /**
    * Return success response to the service.
    * @param response The response for the connect event.
@@ -184,7 +184,7 @@ export interface UserEventResponseHandler {
    * @param name The name of the state
    * @param value The value of the state
    */
-  setState(name: string, value: unknown): UserEventResponseHandler;
+  setState(name: string, value: unknown): void;
   /**
    * Return success response with data to be delivered to the client WebSocket connection.
    * @param data The payload data to be returned to the client.

--- a/sdk/web-pubsub/web-pubsub-express/src/cloudEventsProtocols.ts
+++ b/sdk/web-pubsub/web-pubsub-express/src/cloudEventsProtocols.ts
@@ -159,7 +159,7 @@ export interface ConnectResponseHandler {
   /**
    * Set the state of the connection
    * @param name The name of the state
-   * @param value The value of the state 
+   * @param value The value of the state
    */
   setState(name: string, value: unknown): ConnectResponseHandler;
   /**
@@ -182,7 +182,7 @@ export interface UserEventResponseHandler {
   /**
    * Set the state of the connection
    * @param name The name of the state
-   * @param value The value of the state 
+   * @param value The value of the state
    */
   setState(name: string, value: unknown): UserEventResponseHandler;
   /**

--- a/sdk/web-pubsub/web-pubsub-express/src/cloudEventsProtocols.ts
+++ b/sdk/web-pubsub/web-pubsub-express/src/cloudEventsProtocols.ts
@@ -51,6 +51,10 @@ export interface ConnectionContext {
    * The subprotocol of this connection.
    */
   subprotocol?: string;
+  /**
+   * Get the additional states for the connection, such states are perserved throughout the lifetime of the connection.
+   */
+  states: Record<string, any>;
 }
 
 /**
@@ -153,6 +157,12 @@ export interface DisconnectedRequest {
  */
 export interface ConnectResponseHandler {
   /**
+   * Set the state of the connection
+   * @param name The name of the state
+   * @param value The value of the state 
+   */
+  setState(name: string, value: any): ConnectResponseHandler;
+  /**
    * Return success response to the service.
    * @param response The response for the connect event.
    */
@@ -169,6 +179,12 @@ export interface ConnectResponseHandler {
  * The handler to set user event response
  */
 export interface UserEventResponseHandler {
+  /**
+   * Set the state of the connection
+   * @param name The name of the state
+   * @param value The value of the state 
+   */
+  setState(name: string, value: any): UserEventResponseHandler;
   /**
    * Return success response with data to be delivered to the client WebSocket connection.
    * @param data The payload data to be returned to the client.

--- a/sdk/web-pubsub/web-pubsub-express/src/utils.ts
+++ b/sdk/web-pubsub/web-pubsub-express/src/utils.ts
@@ -1,27 +1,26 @@
-import { IncomingMessage, ServerResponse } from "http";
-import { CloudEvent, Message } from "cloudevents";
+import { IncomingMessage } from "http";
+import { Message } from "cloudevents";
 
-import {
-  ConnectRequest,
-  ConnectResponse,
-  UserEventRequest,
-  ConnectionContext,
-  ConnectResponseHandler,
-  UserEventResponseHandler
-} from "./cloudEventsProtocols";
+function isJsonObject(obj: any) {
+  return obj && typeof obj === "object" && !Array.isArray(obj);
+}
 
-export function toBase64JsonString(obj: any): string {
+export function toBase64JsonString(obj: Record<string, any>): string {
   return Buffer.from(JSON.stringify(obj)).toString("base64");
 }
 
-export function fromBase64JsonString(base64String: string): any {
+export function fromBase64JsonString(base64String: string): Record<string, any> {
+  if (base64String === undefined) {
+    return {};
+  }
+
   try {
     let buf = Buffer.from(base64String, "base64").toString();
     let parsed = JSON.parse(buf);
-    return parsed;
+    return isJsonObject(parsed) ? parsed : {};
   } catch (e) {
     console.warn("Unexpected state format:" + e);
-    return undefined;
+    return {};
   }
 }
 
@@ -36,139 +35,6 @@ export function getHttpHeader(req: IncomingMessage, key: string): string | undef
   }
 
   return value[0];
-}
-
-export enum EventType {
-  Connect,
-  Connected,
-  Disconnected,
-  UserEvent
-}
-
-export function tryGetWebPubSubEvent(req: IncomingMessage): EventType | undefined {
-  // check ce-type to see if it is a valid WebPubSub CloudEvent request
-  const prefix = "azure.webpubsub.";
-  const connect = "azure.webpubsub.sys.connect";
-  const connected = "azure.webpubsub.sys.connected";
-  const disconnectd = "azure.webpubsub.sys.disconnected";
-  const userPrefix = "azure.webpubsub.user.";
-  const type = getHttpHeader(req, "ce-type");
-  if (!type?.startsWith(prefix)) {
-    return undefined;
-  }
-  if (type.startsWith(userPrefix)) {
-    return EventType.UserEvent;
-  }
-  switch (type) {
-    case connect:
-      return EventType.Connect;
-    case connected:
-      return EventType.Connected;
-    case disconnectd:
-      return EventType.Disconnected;
-    default:
-      return undefined;
-  }
-}
-
-export function getContext(ce: CloudEvent, origin: string): ConnectionContext {
-  const states: Record<string, any> = {};
-  const state = ce["connectionstate"] as string;
-  if (state !== undefined) {
-    const parsed = fromBase64JsonString(state);
-    if (parsed !== undefined) {
-      for (const key in parsed) {
-        if (Object.prototype.hasOwnProperty.call(parsed, key)) {
-          states[key] = parsed[key];
-        }
-      }
-    }
-  }
-
-  const context = {
-    signature: ce["signature"] as string,
-    userId: ce["userid"] as string,
-    hub: ce["hub"] as string,
-    connectionId: ce["connectionid"] as string,
-    eventName: ce["eventname"] as string,
-    origin: origin,
-    states: states
-  };
-
-  // TODO: validation
-  return context;
-}
-
-export function getConnectResponseHandler(
-  connectRequest: ConnectRequest,
-  response: ServerResponse
-): ConnectResponseHandler {
-  let states: Record<string, any> = connectRequest.context.states;
-  let modified = false;
-  const handler = {
-    setState(name: string, value: unknown): ConnectResponseHandler {
-      states[name] = value;
-      modified = true;
-      return handler;
-    },
-    success(res?: ConnectResponse): void {
-      response.statusCode = 200;
-      if (modified) {
-        response.setHeader("ce-connectionState", toBase64JsonString(states));
-      }
-      if (res === undefined) {
-        response.end();
-      } else {
-        response.setHeader("Content-Type", "application/json; charset=utf-8");
-        response.end(JSON.stringify(res));
-      }
-    },
-    fail(code: 400 | 401 | 500, detail?: string): void {
-      response.statusCode = code;
-      response.end(detail ?? "");
-    }
-  };
-
-  return handler;
-}
-
-export function getUserEventResponseHandler(
-  userRequest: UserEventRequest,
-  response: ServerResponse
-): UserEventResponseHandler {
-  let states: Record<string, any> = userRequest.context.states;
-  let modified = false;
-  const handler = {
-    setState(name: string, value: unknown): UserEventResponseHandler {
-      modified = true;
-      states[name] = value;
-      return handler;
-    },
-    success(data?: string | ArrayBuffer, dataType?: "binary" | "text" | "json"): void {
-      response.statusCode = 200;
-      if (modified) {
-        response.setHeader("ce-connectionState", toBase64JsonString(states));
-      }
-
-      switch (dataType) {
-        case "json":
-          response.setHeader("Content-Type", "application/json; charset=utf-8");
-          break;
-        case "text":
-          response.setHeader("Content-Type", "text/plain; charset=utf-8");
-          break;
-        default:
-          response.setHeader("Content-Type", "application/octet-stream");
-          break;
-      }
-      response.end(data ?? "");
-    },
-    fail(code: 400 | 401 | 500, detail?: string): void {
-      response.statusCode = code;
-      response.end(detail ?? "");
-    }
-  };
-  return handler;
 }
 
 export async function convertHttpToEvent(request: IncomingMessage): Promise<Message> {
@@ -191,7 +57,7 @@ export async function convertHttpToEvent(request: IncomingMessage): Promise<Mess
   return normalized;
 }
 
-function readRequestBody(req: IncomingMessage): Promise<string> {
+export function readRequestBody(req: IncomingMessage): Promise<string> {
   return new Promise(function(resolve, reject) {
     const chunks: any = [];
     req.on("data", function(chunk) {

--- a/sdk/web-pubsub/web-pubsub-express/src/utils.ts
+++ b/sdk/web-pubsub/web-pubsub-express/src/utils.ts
@@ -1,0 +1,207 @@
+import { IncomingMessage, ServerResponse } from "http";
+import { CloudEvent, Message } from "cloudevents";
+
+import {
+  ConnectRequest,
+  ConnectResponse,
+  UserEventRequest,
+  ConnectionContext,
+  ConnectResponseHandler,
+  UserEventResponseHandler
+} from "./cloudEventsProtocols";
+
+export function toBase64JsonString(obj: any): string {
+  return Buffer.from(JSON.stringify(obj)).toString("base64");
+}
+
+export function fromBase64Json(base64String: string): any {
+  try {
+    let buf = Buffer.from(base64String, "base64").toString();
+    let parsed = JSON.parse(buf);
+    return parsed;
+  } catch (e) {
+    console.warn("Unexpected state format:" + e);
+    return undefined;
+  }
+}
+
+export function getHttpHeader(req: IncomingMessage, key: string): string | undefined {
+  const value = req.headers[key];
+  if (value === undefined) {
+    return undefined;
+  }
+
+  if (typeof value === "string") {
+    return value;
+  }
+
+  return value[0];
+}
+
+export enum EventType {
+  Connect,
+  Connected,
+  Disconnected,
+  UserEvent
+}
+
+export function tryGetWebPubSubEvent(req: IncomingMessage): EventType | undefined {
+  // check ce-type to see if it is a valid WebPubSub CloudEvent request
+  const prefix = "azure.webpubsub.";
+  const connect = "azure.webpubsub.sys.connect";
+  const connected = "azure.webpubsub.sys.connected";
+  const disconnectd = "azure.webpubsub.sys.disconnected";
+  const userPrefix = "azure.webpubsub.user.";
+  const type = getHttpHeader(req, "ce-type");
+  if (!type?.startsWith(prefix)) {
+    return undefined;
+  }
+  if (type.startsWith(userPrefix)) {
+    return EventType.UserEvent;
+  }
+  switch (type) {
+    case connect:
+      return EventType.Connect;
+    case connected:
+      return EventType.Connected;
+    case disconnectd:
+      return EventType.Disconnected;
+    default:
+      return undefined;
+  }
+}
+
+export function getContext(ce: CloudEvent, origin: string): ConnectionContext {
+  const states: Record<string, any> = {};
+  const state = ce["connectionstate"] as string;
+  if (state !== undefined) {
+    const parsed = fromBase64Json(state);
+    if (parsed !== undefined) {
+      for (const key in parsed) {
+        if (Object.prototype.hasOwnProperty.call(parsed, key)) {
+          states[key] = parsed[key];
+        }
+      }
+    }
+  }
+
+  const context = {
+    signature: ce["signature"] as string,
+    userId: ce["userid"] as string,
+    hub: ce["hub"] as string,
+    connectionId: ce["connectionid"] as string,
+    eventName: ce["eventname"] as string,
+    origin: origin,
+    states: states
+  };
+
+  // TODO: validation
+  return context;
+}
+
+export function getConnectResponseHandler(
+  connectRequest: ConnectRequest,
+  response: ServerResponse
+): ConnectResponseHandler {
+  let states: Record<string, any> = connectRequest.context.states;
+  let modified = false;
+  return {
+    setState(name: string, value: unknown): ConnectResponseHandler {
+      states[name] = value;
+      modified = true;
+      return this;
+    },
+    success(res?: ConnectResponse): void {
+      response.statusCode = 200;
+      if (modified) {
+        response.setHeader("ce-connectionState", toBase64JsonString(states));
+      }
+      if (res === undefined) {
+        response.end();
+      } else {
+        response.setHeader("Content-Type", "application/json; charset=utf-8");
+        response.end(JSON.stringify(res));
+      }
+    },
+    fail(code: 400 | 401 | 500, detail?: string): void {
+      response.statusCode = code;
+      response.end(detail ?? "");
+    }
+  };
+}
+
+export function getUserEventResponseHandler(
+  userRequest: UserEventRequest,
+  response: ServerResponse
+): UserEventResponseHandler {
+  let states: Record<string, any> = userRequest.context.states;
+  let modified = false;
+  return {
+    setState(name: string, value: unknown): UserEventResponseHandler {
+      modified = true;
+      states[name] = value;
+      return this;
+    },
+    success(data?: string | ArrayBuffer, dataType?: "binary" | "text" | "json"): void {
+      response.statusCode = 200;
+      if (modified) {
+        response.setHeader("ce-connectionState", toBase64JsonString(states));
+      }
+
+      switch (dataType) {
+        case "json":
+          response.setHeader("Content-Type", "application/json; charset=utf-8");
+          break;
+        case "text":
+          response.setHeader("Content-Type", "text/plain; charset=utf-8");
+          break;
+        default:
+          response.setHeader("Content-Type", "application/octet-stream");
+          break;
+      }
+      response.end(data ?? "");
+    },
+    fail(code: 400 | 401 | 500, detail?: string): void {
+      response.statusCode = code;
+      response.end(detail ?? "");
+    }
+  };
+}
+
+export async function convertHttpToEvent(request: IncomingMessage): Promise<Message> {
+  const normalized: Message = {
+    headers: {},
+    body: ""
+  };
+  if (request.headers) {
+    for (const key in request.headers) {
+      if (Object.prototype.hasOwnProperty.call(request.headers, key)) {
+        const element = request.headers[key];
+        if (element !== undefined) {
+          normalized.headers[key.toLowerCase()] = element;
+        }
+      }
+    }
+  }
+
+  normalized.body = await readRequestBody(request);
+  return normalized;
+}
+
+function readRequestBody(req: IncomingMessage): Promise<string> {
+  return new Promise(function(resolve, reject) {
+    const chunks: any = [];
+    req.on("data", function(chunk) {
+      chunks.push(chunk);
+    });
+    req.on("end", function() {
+      const buffer = Buffer.concat(chunks);
+      resolve(buffer.toString());
+    });
+    // reject on request error
+    req.on("error", function(err) {
+      // This is not a "Second reject", just a different sort of failure
+      reject(err);
+    });
+  });
+}

--- a/sdk/web-pubsub/web-pubsub-express/src/webPubSubEventHandler.ts
+++ b/sdk/web-pubsub/web-pubsub-express/src/webPubSubEventHandler.ts
@@ -69,7 +69,7 @@ export class WebPubSubEventHandler {
 
       // normalize the Url
       requestUrl = requestUrl.endsWith("/") ? requestUrl : requestUrl + "/";
-      if (requestUrl === this.path) {
+      if (requestUrl.startsWith(this.path)) {
         if (req.method === "OPTIONS") {
           if (this._cloudEventsHandler.processValidateRequest(req, res)) {
             return;

--- a/sdk/web-pubsub/web-pubsub-express/test/connect.spec.ts
+++ b/sdk/web-pubsub/web-pubsub-express/test/connect.spec.ts
@@ -143,12 +143,11 @@ describe("Can handle connect event", function() {
 
     const dispatcher = new CloudEventsDispatcher("hub", ["*"], {
       handleConnect: async (_, res) => {
-        res
-          .setState("key1", "val1")
-          .setState("key2", "val2")
-          .setState("key1", ["val3"])
-          .setState("key3", "")
-          .success({ userId: "vic" });
+        res.setState("key1", "val1");
+        res.setState("key2", "val2");
+        res.setState("key1", ["val3"]);
+        res.setState("key3", "");
+        res.success({ userId: "vic" });
       }
     });
     var process = dispatcher.processRequest(req, res);

--- a/sdk/web-pubsub/web-pubsub-express/test/connect.spec.ts
+++ b/sdk/web-pubsub/web-pubsub-express/test/connect.spec.ts
@@ -6,6 +6,7 @@ import { assert } from "chai";
 import { IncomingMessage, ServerResponse } from "http";
 import { Socket } from "net";
 import * as sinon from "sinon";
+import { toBase64JsonString } from "../src/utils";
 
 function buildRequest(
   req: IncomingMessage,
@@ -156,13 +157,11 @@ describe("Can handle connect event", function() {
     assert.isTrue(result, "should handle");
     assert.isTrue(endSpy.calledOnce, "should call once");
     assert.equal(
-      Buffer.from(
-        JSON.stringify({
-          key1: ["val3"],
-          key2: "val2",
-          key3: ""
-        })
-      ).toString("base64"),
+      toBase64JsonString({
+        key1: ["val3"],
+        key2: "val2",
+        key3: ""
+      }),
       res.getHeader("ce-connectionState"),
       "should contain multiple state headers"
     );
@@ -170,13 +169,11 @@ describe("Can handle connect event", function() {
 
   it("Should be able to get the connection states if it exists in the header", async function() {
     const endSpy = sinon.spy(res, "end");
-    const states = Buffer.from(
-      JSON.stringify({
-        key1: ["val3"],
-        key2: "val2",
-        key3: ""
-      })
-    ).toString("base64");
+    const states = toBase64JsonString({
+      key1: ["val3"],
+      key2: "val2",
+      key3: ""
+    });
     buildRequest(req, "hub1", "conn1", undefined, states);
     const dispatcher = new CloudEventsDispatcher("hub1", ["*"], {
       handleConnect: (req, response) => {

--- a/sdk/web-pubsub/web-pubsub-express/test/connect.spec.ts
+++ b/sdk/web-pubsub/web-pubsub-express/test/connect.spec.ts
@@ -156,7 +156,7 @@ describe("Can handle connect event", function() {
     assert.isTrue(result, "should handle");
     assert.isTrue(endSpy.calledOnce, "should call once");
     assert.equal(
-      new Buffer(
+      Buffer.from(
         JSON.stringify({
           key1: ["val3"],
           key2: "val2",
@@ -170,7 +170,7 @@ describe("Can handle connect event", function() {
 
   it("Should be able to get the connection states if it exists in the header", async function() {
     const endSpy = sinon.spy(res, "end");
-    const states = new Buffer(
+    const states = Buffer.from(
       JSON.stringify({
         key1: ["val3"],
         key2: "val2",

--- a/sdk/web-pubsub/web-pubsub-express/test/user.spec.ts
+++ b/sdk/web-pubsub/web-pubsub-express/test/user.spec.ts
@@ -195,7 +195,7 @@ describe("Can handle user event", function() {
     assert.isTrue(result, "should handle");
     assert.isTrue(endSpy.calledOnce, "should call once");
     assert.equal(200, res.statusCode, "should be success");
-    
+
     assert.equal(
       Buffer.from(
         JSON.stringify({

--- a/sdk/web-pubsub/web-pubsub-express/test/user.spec.ts
+++ b/sdk/web-pubsub/web-pubsub-express/test/user.spec.ts
@@ -197,7 +197,7 @@ describe("Can handle user event", function() {
     assert.equal(200, res.statusCode, "should be success");
     
     assert.equal(
-      new Buffer(
+      Buffer.from(
         JSON.stringify({
           key1: "val3",
           key2: "val2",

--- a/sdk/web-pubsub/web-pubsub-express/test/user.spec.ts
+++ b/sdk/web-pubsub/web-pubsub-express/test/user.spec.ts
@@ -181,12 +181,11 @@ describe("Can handle user event", function() {
 
     const dispatcher = new CloudEventsDispatcher("hub", ["*"], {
       handleUserEvent: async (_, res) => {
-        res
-          .setState("key1", "val1")
-          .setState("key2", "val2")
-          .setState("key1", "val3")
-          .setState("key3", "")
-          .success();
+        res.setState("key1", "val1");
+        res.setState("key2", "val2");
+        res.setState("key1", "val3");
+        res.setState("key3", "");
+        res.success();
       }
     });
     var process = dispatcher.processRequest(req, res);


### PR DESCRIPTION
For feature request: https://github.com/Azure/azure-webpubsub/issues/156
Spec described here: https://github.com/Azure/azure-webpubsub/pull/172
Sample: 
```js
const handler = new WebPubSubEventHandler("chat", ["https://xxx.webpubsub.azure.com"], {
  handleConnect(req, res) {
    // You can set the state for the connection, it lasts throughout the lifetime of the connection
    res.setState("calledTime", 1);
    res.success();
  },
  handleUserEvent(req, res) {
    var calledTime = req.context.states.calledTime++;
    console.log(calledTime);
    // You can also set the state here
    res.setState("calledTime", calledTime);
    res.success();
  }
});
```