### PR TITLE
[Identity] Referencing the type related to authorityHost

### DIFF
--- a/sdk/identity/identity/src/client/identityClient.ts
+++ b/sdk/identity/identity/src/client/identityClient.ts
@@ -310,6 +310,7 @@ export class IdentityClient extends ServiceClient implements INetworkModule {
 export interface TokenCredentialOptions extends PipelineOptions {
   /**
    * The authority host to use for authentication requests.
+   * Possible values are available through {@link AzureAuthorityHosts}.
    * The default is "https://login.microsoftonline.com".
    */
   authorityHost?: string;


### PR DESCRIPTION
The lack of the reference makes this property a bit confusing. The reference does make it clearer.