### PR TITLE
[Identity] [Hotfix] 1.4.1: 3 seconds were not enough

### DIFF
--- a/sdk/identity/identity/CHANGELOG.md
+++ b/sdk/identity/identity/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+## 1.4.1 (2021-07-14)
+
+- The default timeout of the `ManagedIdentityCredential`'s ping to the IMDS endpoint has been increased to 10 seconds to be on the safe side.
+
 ## 1.4.0 (2021-07-09)
 
 - With this release, we drop support for Node.js versions that have reached the end of life, like Node.js 8. Read our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.

--- a/sdk/identity/identity/package.json
+++ b/sdk/identity/identity/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@azure/identity",
   "sdk-type": "client",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Provides credential implementations for Azure SDK libraries that can authenticate with Azure Active Directory",
   "main": "dist/index.js",
   "module": "dist-esm/src/index.js",

--- a/sdk/identity/identity/src/credentials/managedIdentityCredential/imdsMsi.ts
+++ b/sdk/identity/identity/src/credentials/managedIdentityCredential/imdsMsi.ts
@@ -79,8 +79,9 @@ export const imdsMsi: MSI = {
 
       // In Kubernetes pods, node-fetch (used by core-http) takes longer than 2 seconds to begin sending the network request,
       // So smaller timeouts will cause this credential to be immediately aborted.
+      // During our tests, we've had consistent success with 5 seconds of timeout, but to be on the safe side, we're setting 10 seconds as the default.
       // This won't be a problem once we move Identity to core-rest-pipeline.
-      webResource.timeout = (options.requestOptions && options.requestOptions.timeout) || 3000;
+      webResource.timeout = (options.requestOptions && options.requestOptions.timeout) || 10000;
 
       try {
         logger.info(`Pinging IMDS endpoint`);


### PR DESCRIPTION
We went from 500 milliseconds to 3 seconds. 3 seconds happens to be unreliable. 5 seconds should be enough, but let’s be on the safe side.

Cons of this change:
- The IMDS endpoint many times won’t be available, so 10 seconds is rough for a timeout. Python has 300 milliseconds.

**Reminder:**  
The real fix is to release v2 depending on core-rest-pipeline instead of core-http.
