### PR TITLE
[Key Vault] - getRandomBytes returns a model instead of raw byte array

### DIFF
--- a/sdk/keyvault/keyvault-keys/CHANGELOG.md
+++ b/sdk/keyvault/keyvault-keys/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Breaking Changes
 
+- `KeyClient.getRandomBytes` now returns an object containing the random bytes under the `value` property.
+
 ### Bugs Fixed
 
 ### Other Changes

--- a/sdk/keyvault/keyvault-keys/CHANGELOG.md
+++ b/sdk/keyvault/keyvault-keys/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Breaking Changes
 
-- `KeyClient.getRandomBytes` now returns an object containing the random bytes under the `value` property.
+- `KeyClient.getRandomBytes` (new for 4.3.0) now returns an object containing the random bytes under the `value` property.
 
 ### Bugs Fixed
 

--- a/sdk/keyvault/keyvault-keys/review/keyvault-keys.api.md
+++ b/sdk/keyvault/keyvault-keys/review/keyvault-keys.api.md
@@ -222,7 +222,7 @@ export class KeyClient {
     createRsaKey(name: string, options?: CreateRsaKeyOptions): Promise<KeyVaultKey>;
     getDeletedKey(name: string, options?: GetDeletedKeyOptions): Promise<DeletedKey>;
     getKey(name: string, options?: GetKeyOptions): Promise<KeyVaultKey>;
-    getRandomBytes(count: number, options?: GetRandomBytesOptions): Promise<Uint8Array>;
+    getRandomBytes(count: number, options?: GetRandomBytesOptions): Promise<RandomBytes>;
     importKey(name: string, key: JsonWebKey, options?: ImportKeyOptions): Promise<KeyVaultKey>;
     listDeletedKeys(options?: ListDeletedKeysOptions): PagedAsyncIterableIterator<DeletedKey>;
     listPropertiesOfKeys(options?: ListPropertiesOfKeysOptions): PagedAsyncIterableIterator<KeyProperties>;
@@ -397,6 +397,11 @@ export { PollOperationState }
 
 // @public
 export interface PurgeDeletedKeyOptions extends coreHttp.OperationOptions {
+}
+
+// @public
+export interface RandomBytes {
+    value: Uint8Array;
 }
 
 // @public

--- a/sdk/keyvault/keyvault-keys/src/index.ts
+++ b/sdk/keyvault/keyvault-keys/src/index.ts
@@ -60,7 +60,8 @@ import {
   CryptographyClientOptions,
   LATEST_API_VERSION,
   CreateOctKeyOptions,
-  GetRandomBytesOptions
+  GetRandomBytesOptions,
+  RandomBytes
 } from "./keysModels";
 
 import { CryptographyClient } from "./cryptographyClient";
@@ -167,6 +168,7 @@ export {
   PollOperationState,
   PollerLike,
   PurgeDeletedKeyOptions,
+  RandomBytes,
   RestoreKeyBackupOptions,
   SignOptions,
   SignResult,
@@ -663,10 +665,10 @@ export class KeyClient {
    * @param count - The number of bytes to generate between 1 and 128 inclusive.
    * @param options - The optional parameters.
    */
-  public getRandomBytes(count: number, options: GetRandomBytesOptions = {}): Promise<Uint8Array> {
+  public getRandomBytes(count: number, options: GetRandomBytesOptions = {}): Promise<RandomBytes> {
     return withTrace("getRandomBytes", options, async (updatedOptions) => {
       const response = await this.client.getRandomBytes(this.vaultUrl, count, updatedOptions);
-      return response.value!;
+      return { value: response.value! };
     });
   }
 

--- a/sdk/keyvault/keyvault-keys/src/keysModels.ts
+++ b/sdk/keyvault/keyvault-keys/src/keysModels.ts
@@ -480,20 +480,30 @@ export interface CryptographyOptions extends coreHttp.OperationOptions {}
  */
 export interface GetRandomBytesOptions extends coreHttp.OperationOptions {}
 
+/**
+ * An interface representing the result of calling {@link KeyClient.getRandomBytes}.
+ */
+export interface RandomBytes {
+  /**
+   * The random bytes returned by the service.
+   */
+  value: Uint8Array;
+}
+
 /** Known values of {@link KeyOperation} that the service accepts. */
 export enum KnownKeyOperations {
   /** Key operation - encrypt */
   Encrypt = "encrypt",
-  /** Key operation - encrypt */
+  /** Key operation - decrypt */
   Decrypt = "decrypt",
-  /** Key operation - encrypt */
+  /** Key operation - sign */
   Sign = "sign",
-  /** Key operation - encrypt */
+  /** Key operation - verify */
   Verify = "verify",
-  /** Key operation - encrypt */
+  /** Key operation - wrapKey */
   WrapKey = "wrapKey",
-  /** Key operation - encrypt */
+  /** Key operation - unwrapKey */
   UnwrapKey = "unwrapKey",
-  /** Key operation - encrypt */
+  /** Key operation - import */
   Import = "import"
 }

--- a/sdk/keyvault/keyvault-keys/test/public/keyClient.hsm.spec.ts
+++ b/sdk/keyvault/keyvault-keys/test/public/keyClient.hsm.spec.ts
@@ -54,8 +54,8 @@ onVersions({ minVer: "7.2" }).describe(
     onVersions({ minVer: "7.3-preview" }).describe("getRandomBytes", () => {
       it("can return the required number of bytes", async () => {
         const randomBytes = await hsmClient.getRandomBytes(10);
-        assert.exists(randomBytes);
-        assert.equal(randomBytes!.length, 10);
+        assert.exists(randomBytes.value);
+        assert.equal(randomBytes.value.length, 10);
       });
 
       it("returns an error when bytes is out of range", async () => {


### PR DESCRIPTION
## What

- Change the return type of `getRandomBytes` to return a `Promise<RandomBytes>` instead of just the raw byte array

## Why

- This came up in discussion, but returning a raw type that we do not own is against the guidelines. We want to return a model where we can to leave room for extensibility.

Note that conversation is still ongoing but it was not hard to create the PR for now. I can always close it if we decide to stick with raw byte array.