### PR TITLE
[Perf framework] Remove run method - cleaning up

### DIFF
--- a/sdk/test-utils/perfstress/CHANGELOG.md
+++ b/sdk/test-utils/perfstress/CHANGELOG.md
@@ -2,4 +2,10 @@
 
 ## 1.0.0 (Unreleased)
 
+### 2021-07-14
+
+- Removed the run method in the `PerfStressTest` class as we only deal with the async methods when it comes to performance.
+
+### 2020-04-22
+
 - Merged the first working implementation of perfstress.

--- a/sdk/test-utils/perfstress/src/options.ts
+++ b/sdk/test-utils/perfstress/src/options.ts
@@ -65,7 +65,6 @@ export interface DefaultPerfStressOptions {
   iterations: number;
   "no-cleanup": boolean;
   "milliseconds-to-log": number;
-  sync: boolean;
 }
 
 /**
@@ -95,10 +94,6 @@ export const defaultPerfStressOptions: PerfStressOptionDictionary<DefaultPerfStr
     description: "Times to repeat the whole process, after warmup",
     shortName: "i",
     defaultValue: 1
-  },
-  sync: {
-    description: "Only runs the 'run' method instead of the 'runAsync' method",
-    defaultValue: false
   },
   "no-cleanup": {
     description: "Disables test cleanup"

--- a/sdk/test-utils/perfstress/src/tests.ts
+++ b/sdk/test-utils/perfstress/src/tests.ts
@@ -47,7 +47,6 @@ export abstract class PerfStressTest<TOptions = {}> {
   public setup?(): void | Promise<void>;
   public cleanup?(): void | Promise<void>;
 
-  public run?(abortSignal?: AbortSignalLike): void;
   public async runAsync?(abortSignal?: AbortSignalLike): Promise<void>;
 }
 

--- a/sdk/test-utils/perfstress/test/exception.spec.ts
+++ b/sdk/test-utils/perfstress/test/exception.spec.ts
@@ -11,14 +11,6 @@ import { PerfStressTest } from "../src";
 export class Exception extends PerfStressTest {
   public options = {};
 
-  run(): void {
-    try {
-      throw new Error();
-    } catch (e) {
-      // Nothing to do here
-    }
-  }
-
   async runAsync(): Promise<void> {
     try {
       throw new Error();

--- a/sdk/test-utils/perfstress/test/noop.spec.ts
+++ b/sdk/test-utils/perfstress/test/noop.spec.ts
@@ -9,7 +9,5 @@ import { PerfStressTest } from "../src";
 export class NoOp extends PerfStressTest {
   public options = {};
 
-  run(): void {}
-
   async runAsync(): Promise<void> {}
 }

--- a/sdk/test-utils/perfstress/test/options.spec.ts
+++ b/sdk/test-utils/perfstress/test/options.spec.ts
@@ -71,7 +71,7 @@ export class OptionsTest extends PerfStressTest<OptionsTestOptions> {
     }
   }
 
-  run(): void {
+  async runAsync() {
     for (const key in this.options) {
       this.compare(key as keyof OptionsTestOptions);
     }

--- a/sdk/test-utils/perfstress/test/setupCleanup.spec.ts
+++ b/sdk/test-utils/perfstress/test/setupCleanup.spec.ts
@@ -47,5 +47,5 @@ export class SetupCleanupTest extends PerfStressTest {
     }
   }
 
-  run(): void {}
+  async runAsync() {}
 }


### PR DESCRIPTION
##Issue  https://github.com/Azure/azure-sdk-for-js/issues/13209

As we only ever offer async methods for our APIs through the SDKs unlike other languages, it makes sense to remove the "run" method and related code.

Reference - https://github.com/Azure/azure-sdk-for-js/pull/13125#discussion_r554159841