### PR TITLE
Add step to install package to be published

### DIFF
--- a/eng/pipelines/templates/stages/archetype-js-release.yml
+++ b/eng/pipelines/templates/stages/archetype-js-release.yml
@@ -86,8 +86,8 @@ stages:
                         displayName: 'Set Tag and Additional Tag'
 
                       - script: |
-                          npm install {{parameters.ArtifactPath}}
-                        displayName: Install package {{parameters.ArtifactPath}}
+                          npm install $(Package.Archive)
+                        displayName: Install package $(Package.Archive)
                         condition: succeeded()
 
                       - task: PowerShell@2

--- a/eng/pipelines/templates/stages/archetype-js-release.yml
+++ b/eng/pipelines/templates/stages/archetype-js-release.yml
@@ -87,7 +87,7 @@ stages:
 
                       - script: |
                           npm install $(Package.Archive)
-                        displayName: Install package $(Package.Archive)
+                        displayName: Install package
                         condition: succeeded()
 
                       - task: PowerShell@2

--- a/eng/pipelines/templates/stages/archetype-js-release.yml
+++ b/eng/pipelines/templates/stages/archetype-js-release.yml
@@ -87,7 +87,7 @@ stages:
 
                       - script: |
                           npm install $(Package.Archive)
-                        displayName: Install package
+                        displayName: 'Validating package can be installed'
                         condition: succeeded()
 
                       - task: PowerShell@2

--- a/eng/pipelines/templates/stages/archetype-js-release.yml
+++ b/eng/pipelines/templates/stages/archetype-js-release.yml
@@ -85,6 +85,11 @@ stages:
                         condition: and(succeeded(), ne(variables['Skip.AutoAddTag'], 'true'))
                         displayName: 'Set Tag and Additional Tag'
 
+                      - script: |
+                          npm install {{parameters.ArtifactPath}}
+                        displayName: Install package {{parameters.ArtifactPath}}
+                        condition: succeeded()
+
                       - task: PowerShell@2
                         displayName: 'Publish to npmjs.org'
                         inputs:
@@ -92,6 +97,7 @@ stages:
                           filePath: "eng/tools/publish-to-npm.ps1"
                           arguments: '-pathToArtifacts $(Package.Archive) -accessLevel "public" -tag "$(Tag)" -additionalTag "$(AdditionalTag)" -registry ${{parameters.Registry}} -npmToken $(azure-sdk-npm-token)'
                           pwsh: true
+                        condition: succeeded()
 
                       - pwsh: |
                           write-host "$(Package.Archive)"


### PR DESCRIPTION
Install package artifact locally using npm and ensure all dependency packages are available npm. This is to ensure packages are released in order.