### PR TITLE
Create alpha version for track2 management packages

### DIFF
--- a/eng/tools/versioning/set-dev.js
+++ b/eng/tools/versioning/set-dev.js
@@ -199,7 +199,7 @@ async function main(argv) {
   let targetPackages = [];
   for (const package of Object.keys(rushPackages)) {
     if (
-      ["client", "core"].includes(rushPackages[package].versionPolicy) &&
+      ["client", "core", "management"].includes(rushPackages[package].versionPolicy) &&
       rushPackages[package].projectFolder.startsWith(`sdk/${service}`) &&
       !rushPackages[package].json["private"]
     ) {


### PR DESCRIPTION
Alpha version is not created for management packages but we need to publish alpha versions for track2 management packages.