### PR TITLE
Verify common change to resolve core pipeline failure

### DIFF
--- a/eng/common/scripts/Package-Properties.ps1
+++ b/eng/common/scripts/Package-Properties.ps1
@@ -15,6 +15,7 @@ class PackageProps
     [boolean]$IsNewSdk
     [string]$ArtifactName
     [string]$ReleaseStatus
+    [string]$DocsReadMeName
 
     PackageProps([string]$name, [string]$version, [string]$directoryPath, [string]$serviceDirectory)
     {
@@ -60,6 +61,11 @@ class PackageProps
         else
         {
             $this.ChangeLogPath = $null
+        }
+
+        if (Test-Path $directoryPath)
+        {
+          $this.DocsReadMeName = Split-Path -Path $directoryPath -Leaf
         }
     }
 

--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -120,8 +120,8 @@ function Get-javascript-PackageInfoFromPackageFile ($pkg, $workingDirectory)
 
 function Get-javascript-DocsMsMetadataForPackage($PackageInfo) { 
   New-Object PSObject -Property @{ 
-    DocsMsReadMeName = $PackageInfo.Name -replace "^@azure/" , ""
-    LatestReadMeLocation = 'docs-ref-services/latest'
+    DocsMsReadMeName      = $PackageInfo.DocsReadMeName
+    LatestReadMeLocation  = 'docs-ref-services/latest'
     PreviewReadMeLocation = 'docs-ref-services/preview'
     Suffix = ''
   }


### PR DESCRIPTION
Currently @azure scope if replaced with empty string to generate docs.ms readme name and this works fine in most cases except when a service has a package with same name but in different scope than @azure. For e.g. core service now has few packages from @azure-rest scope and this causes issue when docs are published. Change in this PR is to generate docs.ms readme name using package folder name instead of replacing @azure from package name.