### PR TITLE
[event-hubs] prevent invalid spans from instrumenting EventData

### DIFF
--- a/sdk/eventhub/event-hubs/src/diagnostics/instrumentEventData.ts
+++ b/sdk/eventhub/event-hubs/src/diagnostics/instrumentEventData.ts
@@ -1,7 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { extractSpanContextFromTraceParentHeader, getTraceParentHeader, isSpanContextValid } from "@azure/core-tracing";
+import {
+  extractSpanContextFromTraceParentHeader,
+  getTraceParentHeader,
+  isSpanContextValid
+} from "@azure/core-tracing";
 import { Span, SpanContext } from "@azure/core-tracing";
 import { AmqpAnnotatedMessage } from "@azure/core-amqp";
 import { EventData, isAmqpAnnotatedMessage } from "../eventData";

--- a/sdk/eventhub/event-hubs/src/diagnostics/instrumentEventData.ts
+++ b/sdk/eventhub/event-hubs/src/diagnostics/instrumentEventData.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { extractSpanContextFromTraceParentHeader, getTraceParentHeader } from "@azure/core-tracing";
+import { extractSpanContextFromTraceParentHeader, getTraceParentHeader, isSpanContextValid } from "@azure/core-tracing";
 import { Span, SpanContext } from "@azure/core-tracing";
 import { AmqpAnnotatedMessage } from "@azure/core-amqp";
 import { EventData, isAmqpAnnotatedMessage } from "../eventData";
@@ -40,7 +40,7 @@ export function instrumentEventData(
   }
 
   const traceParent = getTraceParentHeader(span.spanContext());
-  if (traceParent) {
+  if (traceParent && isSpanContextValid(span.spanContext())) {
     copiedProps[TRACEPARENT_PROPERTY] = traceParent;
   }
 


### PR DESCRIPTION
The live tests for event hubs currently have 3 test failures due to some changes introduced in core-tracing preview 13. The changes to core-tracing cause EventData to be instrumented (via Diagnostic-Id) with invalid span context data.

This change adds a check to ensure the span context is valid before instrumenting the EventData to be sent to the service.

Note: I didn't add a changelog entry because from a user's point of view, nothing has changed, since this issue did not exist in the previously released version of the event-hubs package.