### PR TITLE
[Cosmos] Return default fixedRetry interval to 0

### DIFF
--- a/sdk/cosmosdb/cosmos/CHANGELOG.md
+++ b/sdk/cosmosdb/cosmos/CHANGELOG.md
@@ -1,14 +1,10 @@
 # Release History
 
-## 3.12.1 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
+## 3.12.1 (2021-07-16)
 
 ### Bugs Fixed
 
-### Other Changes
+- Returned default retryPolicy option `fixedRetryIntervalInMilliseconds` to its original default 0.
 
 ## 3.12.0 (2021-07-06)
 

--- a/sdk/cosmosdb/cosmos/src/documents/ConnectionPolicy.ts
+++ b/sdk/cosmosdb/cosmos/src/documents/ConnectionPolicy.ts
@@ -41,7 +41,7 @@ export const defaultConnectionPolicy: ConnectionPolicy = Object.freeze({
   preferredLocations: [],
   retryOptions: {
     maxRetryAttemptCount: 9,
-    fixedRetryIntervalInMilliseconds: 100,
+    fixedRetryIntervalInMilliseconds: 0,
     maxWaitTimeInSeconds: 30
   },
   useMultipleWriteLocations: true,

--- a/sdk/cosmosdb/cosmos/test/public/functional/item.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/public/functional/item.spec.ts
@@ -524,20 +524,24 @@ describe("bulk item operations", function() {
     });
   });
 
-  describe("item read retries", async function () {
-    it('retries on 429', async function () {
-      const client = new CosmosClient({ key: masterKey, endpoint })
-      const { resource: db } = await client.databases.create({ id: `small db ${Math.random() * 1000}` })
-      const containerResponse = await client.database(db.id).containers.create({ id: `small container ${Math.random() * 1000}`, throughput: 400 }) 
+  describe("item read retries", async function() {
+    it("retries on 429", async function() {
+      const client = new CosmosClient({ key: masterKey, endpoint });
+      const { resource: db } = await client.databases.create({
+        id: `small db ${Math.random() * 1000}`
+      });
+      const containerResponse = await client
+        .database(db.id)
+        .containers.create({ id: `small container ${Math.random() * 1000}`, throughput: 400 });
       const container = containerResponse.container;
-      await container.items.create({ id: 'readme' })
-      const arr = new Array(400)
-      const promises = []
+      await container.items.create({ id: "readme" });
+      const arr = new Array(400);
+      const promises = [];
       for (let i = 0; i < arr.length; i++) {
-        promises.push(container.item('readme').read());
+        promises.push(container.item("readme").read());
       }
       const resp = await Promise.all(promises);
-      assert.equal(resp[0].statusCode, 200)
-    })
-  })
+      assert.equal(resp[0].statusCode, 200);
+    });
+  });
 });

--- a/sdk/cosmosdb/cosmos/test/public/functional/item.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/public/functional/item.spec.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 import assert from "assert";
 import { Suite } from "mocha";
-import { Container } from "../../../src";
+import { Container, CosmosClient } from "../../../src";
 import { ItemDefinition } from "../../../src";
 import {
   bulkDeleteItems,
@@ -18,6 +18,7 @@ import {
   getTestContainer
 } from "../common/TestHelpers";
 import { BulkOperationType, OperationInput } from "../../../src";
+import { endpoint, masterKey } from "../common/_testConfig";
 
 interface TestItem {
   id?: string;
@@ -522,4 +523,21 @@ describe("bulk item operations", function() {
       assert.equal(deleteResponse[0].statusCode, 204);
     });
   });
+
+  describe("item read retries", async function () {
+    it('retries on 429', async function () {
+      const client = new CosmosClient({ key: masterKey, endpoint })
+      const { resource: db } = await client.databases.create({ id: `small db ${Math.random() * 1000}` })
+      const containerResponse = await client.database(db.id).containers.create({ id: `small container ${Math.random() * 1000}`, throughput: 400 }) 
+      const container = containerResponse.container;
+      await container.items.create({ id: 'readme' })
+      const arr = new Array(400)
+      const promises = []
+      for (let i = 0; i < arr.length; i++) {
+        promises.push(container.item('readme').read());
+      }
+      const resp = await Promise.all(promises);
+      assert.equal(resp[0].statusCode, 200)
+    })
+  })
 });

--- a/sdk/cosmosdb/cosmos/test/public/functional/item.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/public/functional/item.spec.ts
@@ -524,6 +524,7 @@ describe("bulk item operations", function() {
     });
   });
 
+  // TODO: Non-deterministic test. We can't guarantee we see any response with a 429 status code since the retries happen within the response
   describe("item read retries", async function() {
     it("retries on 429", async function() {
       const client = new CosmosClient({ key: masterKey, endpoint });


### PR DESCRIPTION
By specifying the `retryOptions` defaults specifically in the defaultConnectionPolicy to comply with types in the 3.12.0 release, we erroneously changed the default fixedRetry interval to 100ms. This returns to let our retryPolicy handle 429 throttling retries on its own