### PR TITLE
Daily docs exclude packages which have no 'dev' tags

### DIFF
--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -132,16 +132,22 @@ function Get-javascript-DocsMsMetadataForPackage($PackageInfo) {
 # published at the "dev" tag. To prevent using a version which does not exist in 
 # NPM, use the "dev" tag instead.
 function Get-javascript-DocsMsDevLanguageSpecificPackageInfo($packageInfo) {
-  try { 
+  try
+  {
     $npmPackageInfo = Invoke-RestMethod -Uri "https://registry.npmjs.com/$($packageInfo.Name)"
 
-    if ($npmPackageInfo.'dist-tags'.dev) {
+    if ($npmPackageInfo.'dist-tags'.dev)
+    {
       Write-Host "Using published version at 'dev' tag: '$($npmPackageInfo.'dist-tags'.dev)'"
       $packageInfo.Version = $npmPackageInfo.'dist-tags'.dev
-    } else {
+    }
+    else
+    {
       Write-Warning "No 'dev' dist-tag available for '$($packageInfo.Name)'. Keeping current version '$($packageInfo.Version)'"
     }
-  } catch { 
+  }
+  catch
+  {
     Write-Warning "Error getting package info from NPM for $($packageInfo.Name)"
     Write-Warning $_.Exception
     Write-Warning $_.Exception.StackTrace

--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -142,7 +142,7 @@ function Get-javascript-DocsMsDevLanguageSpecificPackageInfo($packageInfo) {
       Write-Warning "No 'dev' dist-tag available for '$($packageInfo.Name)'. Keeping current version '$($packageInfo.Version)'"
     }
   } catch { 
-    Write-Warning "Error getting package info from NPM"
+    Write-Warning "Error getting package info from NPM for $($packageInfo.Name)"
     Write-Warning $_.Exception
     Write-Warning $_.Exception.StackTrace
   }

--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -132,7 +132,21 @@ function Get-javascript-DocsMsMetadataForPackage($PackageInfo) {
 # published at the "dev" tag. To prevent using a version which does not exist in 
 # NPM, use the "dev" tag instead.
 function Get-javascript-DocsMsDevLanguageSpecificPackageInfo($packageInfo) {
-  $packageInfo.Version = 'dev'
+  try { 
+    $npmPackageInfo = Invoke-RestMethod -Uri "https://registry.npmjs.com/$($packageInfo.Name)"
+
+    if ($npmPackageInfo.'dist-tags'.dev) {
+      Write-Host "Using published version at 'dev' tag: '$($npmPackageInfo.'dist-tags'.dev)'"
+      $packageInfo.Version = $npmPackageInfo.'dist-tags'.dev
+    } else {
+      Write-Warning "No 'dev' dist-tag available for '$($packageInfo.Name)'. Keeping current version '$($packageInfo.Version)'"
+    }
+  } catch { 
+    Write-Warning "Error getting package info from NPM"
+    Write-Warning $_.Exception
+    Write-Warning $_.Exception.StackTrace
+  }
+
   return $packageInfo
 }
 
@@ -205,14 +219,6 @@ function Get-DocsMsPackageName($packageName, $packageVersion) {
 $PackageExclusions = @{ 
   '@azure/identity-vscode' = 'Fails type2docfx execution https://github.com/Azure/azure-sdk-for-js/issues/16303';
   '@azure/identity-cache-persistence' = 'Fails typedoc2fx execution https://github.com/Azure/azure-sdk-for-js/issues/16310';
-  '@azure/arm-links' = 'No dev version published https://github.com/Azure/azure-sdk-for-js/issues/16457';
-  '@azure/arm-features' = 'No dev version published https://github.com/Azure/azure-sdk-for-js/issues/16458';
-  '@azure/arm-storage' = 'No dev version published https://github.com/Azure/azure-sdk-for-js/issues/16459';
-  '@azure/arm-compute' = 'No dev version published https://github.com/Azure/azure-sdk-for-js/issues/16460';
-  '@azure/arm-policy' = 'No dev version published https://github.com/Azure/azure-sdk-for-js/issues/16461';
-  '@azure/arm-managedapplication' = 'No dev version published https://github.com/Azure/azure-sdk-for-js/issues/16462';
-  '@azure/arm-resources' = 'No dev version published https://github.com/Azure/azure-sdk-for-js/issues/16463';
-  '@azure/arm-network' = 'No dev version published https://github.com/Azure/azure-sdk-for-js/issues/16464';
 }
 
 function Update-javascript-DocsMsPackages($DocsRepoLocation, $DocsMetadata) {
@@ -258,7 +264,7 @@ function UpdateDocsMsPackages($DocConfigFile, $Mode, $DocsMetadata) {
     # This handles packages which are not tracked in metadata but still need to
     # be built in Docs CI.
     if ($matchingPublishedPackageArray.Count -eq 0) {
-      Write-Host "Keep non-tracked preview package: $($package.name)"
+      Write-Host "Keep non-tracked package: $($package.name)"
       $outputPackages += $package
       continue
     }

--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -219,6 +219,8 @@ function Get-DocsMsPackageName($packageName, $packageVersion) {
 $PackageExclusions = @{ 
   '@azure/identity-vscode' = 'Fails type2docfx execution https://github.com/Azure/azure-sdk-for-js/issues/16303';
   '@azure/identity-cache-persistence' = 'Fails typedoc2fx execution https://github.com/Azure/azure-sdk-for-js/issues/16310';
+  '@azure/arm-network' = 'Fails type2docfx execution https://github.com/Azure/azure-sdk-for-js/issues/16474';
+  '@azure/arm-compute' = 'Fails type2docfx execution https://github.com/Azure/azure-sdk-for-js/issues/16476';
 }
 
 function Update-javascript-DocsMsPackages($DocsRepoLocation, $DocsMetadata) {


### PR DESCRIPTION
Daily docs will fail in cases where packages do not have a `dev` tagged version in NPM. This checks with NPM for the version and uses that version directly instead of the tag. This has the [added benefit of showing the published dev version in the README content](https://github.com/MicrosoftDocs/azure-docs-sdk-node/blob/daily/2021-07-20/docs-ref-services/preview/storage-blob-readme.md). 

docindex pipeline running and succeeding -- https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1006534&view=results 

Outputs from docindex in daily branch -- https://github.com/MicrosoftDocs/azure-docs-sdk-node/commit/1a5568f794f29beda8028a02511d8c115c5ffe95 ... Note that dev versions are only expanded for the `storage` service which had its daily pipeline executed against this branch. other services are using what is in `main` and will have the default behavior. 

Docs CI pipeline running and succeeding -- https://apidrop.visualstudio.com/Content%20CI/_build/results?buildId=232795&view=results

@scbedd 