### PR TITLE
Combine changelog for unreleased versions

### DIFF
--- a/sdk/communication/communication-chat/CHANGELOG.md
+++ b/sdk/communication/communication-chat/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.1.0-beta.1 (Unreleased)
 
 ### Features Added
+
 - With the dropping of support for Node.js versions that are no longer in LTS, the dependency on `@types/node` has been updated to version 12. Read our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 - Added support to add `metadata` for `message`
 - Added `senderDisplayName` in `sendTypingNotification` operation.

--- a/sdk/communication/communication-chat/CHANGELOG.md
+++ b/sdk/communication/communication-chat/CHANGELOG.md
@@ -6,17 +6,14 @@
 - With the dropping of support for Node.js versions that are no longer in LTS, the dependency on `@types/node` has been updated to version 12. Read our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 - Added support to add `metadata` for `message`
 - Added `senderDisplayName` in `sendTypingNotification` operation.
+- Updated to @azure/communication-signaling@1.0.0-beta.5.
+- Enabled real-time notification for React Native.
 
 ### Breaking Changes
 
 ### Key Bugs Fixed
 
 ### Fixed
-
-## 1.0.1 (Unreleased)
-
-- Updated to @azure/communication-signaling@1.0.0-beta.5.
-- Enabled real-time notification for React Native.
 
 ## 1.0.0 (2021-03-29)
 


### PR DESCRIPTION
Looks like 1.0.1 for communication-chat was never released. Merging its changelog with the one for 1.1.0-beta.1