### PR TITLE
Docs CI pre-validation: Exclude packages which fail npm install

### DIFF
--- a/eng/pipelines/docindex.yml
+++ b/eng/pipelines/docindex.yml
@@ -5,7 +5,7 @@ jobs:
 
   - job: UpdateDocsMsBuildConfig
     pool:
-      vmImage: windows-2019
+      vmImage: ubuntu-20.04
     variables:
       DocRepoLocation: $(Pipeline.Workspace)/docs
       DocRepoOwner: MicrosoftDocs

--- a/eng/pipelines/docindex.yml
+++ b/eng/pipelines/docindex.yml
@@ -5,7 +5,7 @@ jobs:
 
   - job: UpdateDocsMsBuildConfig
     pool:
-      vmImage: ubuntu-20.04
+      vmImage: windows-2019
     variables:
       DocRepoLocation: $(Pipeline.Workspace)/docs
       DocRepoOwner: MicrosoftDocs

--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -232,7 +232,8 @@ function Get-DocsMsPackageName($packageName, $packageVersion) {
 #   ...
 # }
 function ValidatePackagesForDocs($packages) {
-  $tempDirectory = Join-Path $env:TEMP ([System.IO.Path]::GetRandomFileName())
+  # Using GetTempPath because it works on linux and windows
+  $tempDirectory = Join-Path ([System.IO.Path]::GetTempPath()) ([System.IO.Path]::GetRandomFileName())
   New-Item -ItemType Directory -Force -Path $tempDirectory | Out-Null
 
   $scriptRoot = $PSScriptRoot

--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -143,14 +143,14 @@ function Get-javascript-DocsMsDevLanguageSpecificPackageInfo($packageInfo) {
     }
     else
     {
-      Write-Warning "No 'dev' dist-tag available for '$($packageInfo.Name)'. Keeping current version '$($packageInfo.Version)'"
+      LogWarning "No 'dev' dist-tag available for '$($packageInfo.Name)'. Keeping current version '$($packageInfo.Version)'"
     }
   }
   catch
   {
-    Write-Warning "Error getting package info from NPM for $($packageInfo.Name)"
-    Write-Warning $_.Exception
-    Write-Warning $_.Exception.StackTrace
+    LogWarning "Error getting package info from NPM for $($packageInfo.Name)"
+    LogWarning $_.Exception
+    LogWarning $_.Exception.StackTrace
   }
 
   return $packageInfo
@@ -222,6 +222,34 @@ function Get-DocsMsPackageName($packageName, $packageVersion) {
   return "$(Get-PackageNameFromDocsMsConfig $packageName)@$packageVersion"
 }
 
+
+# Performs package validation for a list of packages provided in the doc 
+# onboarding format ("name" is the only required field): 
+# @{
+#   name = "@azure/attestation@dev";
+#   folder = "./types";
+#   registry = "<url>";
+#   ...
+# }
+function ValidatePackagesForDocs($packages) {
+  $tempDirectory = Join-Path $env:TEMP ([System.IO.Path]::GetRandomFileName())
+  New-Item -ItemType Directory -Force -Path $tempDirectory | Out-Null
+
+  $scriptRoot = $PSScriptRoot
+  # Run this in parallel as each step takes a long time to run
+  $validationOutput = $packages | Foreach-Object -Parallel {
+    # Get value for variables outside of the Foreach-Object scope
+    $scriptRoot = "$using:scriptRoot"
+    $workingDirectory = "$using:tempDirectory"
+    return ."$scriptRoot\validate-docs-package.ps1" -Package $_ -WorkingDirectory $workingDirectory
+  }
+
+  # Clean up temp folder
+  Remove-Item -Path $tempDirectory -Force -Recurse -ErrorAction Ignore | Out-Null
+
+  return $validationOutput
+}
+
 $PackageExclusions = @{ 
   '@azure/identity-vscode' = 'Fails type2docfx execution https://github.com/Azure/azure-sdk-for-js/issues/16303';
   '@azure/identity-cache-persistence' = 'Fails typedoc2fx execution https://github.com/Azure/azure-sdk-for-js/issues/16310';
@@ -241,15 +269,17 @@ function Update-javascript-DocsMsPackages($DocsRepoLocation, $DocsMetadata) {
   UpdateDocsMsPackages `
     (Join-Path $DocsRepoLocation 'ci-configs/packages-preview.json') `
     'preview' `
-    $FilteredMetadata 
+    $FilteredMetadata `
+    (Join-Path $DocsRepoLocation 'ci-configs/packages-preview.json.log')
 
   UpdateDocsMsPackages `
     (Join-Path $DocsRepoLocation 'ci-configs/packages-latest.json') `
     'latest' `
-    $FilteredMetadata
+    $FilteredMetadata `
+    (Join-Path $DocsRepoLocation 'ci-configs/packages-latest.json.log') 
 }
 
-function UpdateDocsMsPackages($DocConfigFile, $Mode, $DocsMetadata) {
+function UpdateDocsMsPackages($DocConfigFile, $Mode, $DocsMetadata, $PackageHistoryLogFile) {
   Write-Host "Updating configuration: $DocConfigFile with mode: $Mode"
   $packageConfig = Get-Content $DocConfigFile -Raw | ConvertFrom-Json
 
@@ -340,8 +370,34 @@ function UpdateDocsMsPackages($DocConfigFile, $Mode, $DocsMetadata) {
     $outputPackages += @{ name = $packageName }
   }
 
-  $packageConfig.npm_package_sources = $outputPackages
+  $packageValidation = ValidatePackagesForDocs $outputPackages
+  $validationHash = @{}
+  foreach ($result in $packageValidation) {
+    $validationHash[$result.Package.name] = $result
+  }
+
+  # Remove invalid packages
+  $finalOutput = @()
+  foreach ($package in $outputPackages) {
+    if (!$validationHash[$package.name].Success) {
+      LogWarning "Removing invalid package: $($package.name)"
+
+      # If a package is removed create log entry for the removal
+      Add-Content `
+        -Path $PackageHistoryLogFile `
+        -Value @"
+Removed $($package.name) because of docs package validation failure on $(Get-Date -Format 'yyyy-MM-dd HH:mm K')
+`t$($validationHash[$package.name].Output -join "`n`t")
+"@
+      continue
+    }
+
+    $finalOutput += $package
+  }
+
+  $packageConfig.npm_package_sources = $finalOutput
   $packageConfig | ConvertTo-Json -Depth 100 | Set-Content $DocConfigFile
+  Write-Host "Onboarding configuration written to: $DocConfigFile"
 }
 
 # function is used to auto generate API View

--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -271,13 +271,13 @@ function Update-javascript-DocsMsPackages($DocsRepoLocation, $DocsMetadata) {
     (Join-Path $DocsRepoLocation 'ci-configs/packages-preview.json') `
     'preview' `
     $FilteredMetadata `
-    (Join-Path $DocsRepoLocation 'ci-configs/packages-preview.json.log')
+    (Join-Path $DocsRepoLocation 'ci-configs/packages-preview.json.log') # Log file for package validation
 
   UpdateDocsMsPackages `
     (Join-Path $DocsRepoLocation 'ci-configs/packages-latest.json') `
     'latest' `
     $FilteredMetadata `
-    (Join-Path $DocsRepoLocation 'ci-configs/packages-latest.json.log') 
+    (Join-Path $DocsRepoLocation 'ci-configs/packages-latest.json.log') # Log file for package validation
 }
 
 function UpdateDocsMsPackages($DocConfigFile, $Mode, $DocsMetadata, $PackageHistoryLogFile) {

--- a/eng/scripts/validate-docs-package.ps1
+++ b/eng/scripts/validate-docs-package.ps1
@@ -1,0 +1,54 @@
+<#
+.SYNOPSIS
+Validates packages by simulating docs CI steps
+
+.PARAMETER Package
+An object describing a package configuration to validate in the format used by
+docs CI onboarding format.
+
+Required attributes: 
+  - name: The name of the package
+
+  Supported optional attributes:
+  - registry: The registry to use for the package if it's not NPM
+
+Example: 
+
+```
+@{
+  name = "@azure/attestation@dev";
+  folder = "./types";
+  registry = "<url>";
+  ...
+}
+```
+
+.PARAMETER WorkingDirectory
+Supplied to `npm install ... --prefix $WorkingDirectory`. The place where the 
+node_modules folder is created and the package is installed
+#>
+
+param(
+  [object] $Package,
+  [string] $WorkingDirectory
+)
+."$PSScriptRoot\..\common\scripts\common.ps1"
+
+function GetResult($success, $package, $output) { 
+  return @{ Success = $success; Package = $package; Output = $output }
+}
+
+$additionalParameters = @()
+if ($Package.registry) {
+  Write-Host $Package.registry
+  $additionalParameters += @("--registry", $Package.registry)
+}
+
+Write-Host "npm install $($Package.name) --prefix $WorkingDirectory $additionalParameters"
+$installOutput = npm install $Package.name --prefix $WorkingDirectory @additionalParameters 2>&1
+if ($LASTEXITCODE -ne 0) {
+  LogWarning "Package install failed: $($Package.name)"
+  return GetResult $false $package $installOutput
+}
+
+return GetResult $true $package $installOutput

--- a/eng/scripts/validate-docs-package.ps1
+++ b/eng/scripts/validate-docs-package.ps1
@@ -38,14 +38,16 @@ function GetResult($success, $package, $output) {
   return @{ Success = $success; Package = $package; Output = $output }
 }
 
+$prefixDirectory = New-Item -ItemType Directory -Force -Path "$WorkingDirectory\$($Package.name)"
+
 $additionalParameters = @()
 if ($Package.registry) {
   Write-Host $Package.registry
   $additionalParameters += @("--registry", $Package.registry)
 }
 
-Write-Host "npm install $($Package.name) --prefix $WorkingDirectory $additionalParameters"
-$installOutput = npm install $Package.name --prefix $WorkingDirectory @additionalParameters 2>&1
+Write-Host "npm install $($Package.name) --prefix $prefixDirectory $additionalParameters"
+$installOutput = npm install $Package.name --prefix $prefixDirectory @additionalParameters 2>&1
 if ($LASTEXITCODE -ne 0) {
   LogWarning "Package install failed: $($Package.name)"
   return GetResult $false $package $installOutput


### PR DESCRIPTION
This eliminates the class of problems where `npm install` does not succeed. `validate-docs-package.ps1` can be extended to support other steps like running `typedoc` etc. 

There is at least one interesting edge case which logging attempts to address: packages which are not tracked in our metadata CSV, in the `metadata` folder after release failing validation. In that case we still remove the package but later versions of the package which successfully install will not be re-added because they are not tracked in metadata. Since we log that the package was removed and the problems associated with the package we will have a history explaining why the package was removed. 