### PR TITLE
[Storage] Update minor version to allow an update for tracing

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -11030,7 +11030,7 @@ packages:
     dev: false
     name: '@rush-temp/perf-storage-blob'
     resolution:
-      integrity: sha512-czd5NHgehoF+yTVUvMKIz+JnRA2f8QZd8bcu3K153y+4Wq8TwWIKu5akJ6ATyDALoNg8tIoxKMMEuVCRCOf38g==
+      integrity: sha512-JvaatDMPTFvpFTZAPBW+XYD19rWf7lSkp9iJPxm/bUwIVKR38e7J8mqA7+/IHAbDosQrdHkWo21+UHL+NYRlVw==
       tarball: file:projects/perf-storage-blob.tgz
     version: 0.0.0
   file:projects/perf-storage-file-datalake.tgz:
@@ -11048,7 +11048,7 @@ packages:
     dev: false
     name: '@rush-temp/perf-storage-file-datalake'
     resolution:
-      integrity: sha512-PJ5n95MlbLuFKMnFbeOyxcigzd9VNz2HAAnL4xk0JuS8dSrSQ7WLol5mwSGZ61aw5waBS2xV5w0/dJ+aMYmI1Q==
+      integrity: sha512-vepQiPpEOpjtZO4CA6FHj5njhGkgztRKmb2q4+Iuf4rlWf2++9tPxdqePngQ48kANbgxA6r0G7Z2s8uYM9AFxA==
       tarball: file:projects/perf-storage-file-datalake.tgz
     version: 0.0.0
   file:projects/perf-storage-file-share.tgz:
@@ -11066,7 +11066,7 @@ packages:
     dev: false
     name: '@rush-temp/perf-storage-file-share'
     resolution:
-      integrity: sha512-19ccpqkNaCG8ZiKpSw+0oauL0ovqq425yjVXFoPHSll6egKRE3guKJOlg6jXIeWUOmztPRQw9FvXUkVatevFLw==
+      integrity: sha512-puMNDli8g8FHzU3hcpWibrKOoXVSBbeZz2/mq+Eoan4HwJzUqyaTOllfsc0NXbFn2aNV9ETSLtcldPLsWckq9w==
       tarball: file:projects/perf-storage-file-share.tgz
     version: 0.0.0
   file:projects/purview-catalog.tgz:
@@ -11497,7 +11497,7 @@ packages:
     dev: false
     name: '@rush-temp/storage-blob-changefeed'
     resolution:
-      integrity: sha512-mG1v+71ero7RhKm9Ewlh8mTVtOUCD6YbVRW+QR5YLl/f2bpNTJGVDpggDOpF9LD/OPv2OeUjRfWY3tzEizCF2g==
+      integrity: sha512-mwGBn01L/7QBV7WzEaMvYiY44RA1v/FFLAjLAsIqDcPsHjjWXsycBycK8rjJa0FSk054LrAT/K1Ff5AWgMn6Bg==
       tarball: file:projects/storage-blob-changefeed.tgz
     version: 0.0.0
   file:projects/storage-blob.tgz:
@@ -11615,7 +11615,7 @@ packages:
     dev: false
     name: '@rush-temp/storage-file-datalake'
     resolution:
-      integrity: sha512-a4zPCcfUb25YsCNPgbarUcmC4Wv+5Nug4Pd50Q5f09G2qHQO8RsNfZYXKFgLC1+Nxyp/2KO4kJU6OMuzQTXh5A==
+      integrity: sha512-OHBBPEh+SdTPsqvcbsNar5v4qV1ptWP1gPG/mW32XXpm9HuSRNTjwUEiO1xeQCbpp01iYsiQXehf7H78SpyD0Q==
       tarball: file:projects/storage-file-datalake.tgz
     version: 0.0.0
   file:projects/storage-file-share.tgz:
@@ -11670,7 +11670,7 @@ packages:
     dev: false
     name: '@rush-temp/storage-file-share'
     resolution:
-      integrity: sha512-ETcduTvswk5Plf/S9xydZUnOBrZ9s13LZImC8xkBtC4s6kQFZFElR5T1MRdeW8NiBpLcmISEmcxzc4G3WZuF6Q==
+      integrity: sha512-mC6M83OChGFyGm3fA8LdX+4AU7UOqxGAHBCI5C4pHYpDWtcDm95gEsqWeFn28Ex3nxFl5mgWFvo/Kc3zPI2pwg==
       tarball: file:projects/storage-file-share.tgz
     version: 0.0.0
   file:projects/storage-internal-avro.tgz:

--- a/sdk/storage/perf-tests/storage-blob/package.json
+++ b/sdk/storage/perf-tests/storage-blob/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "@azure/core-http": "^2.0.0",
     "@azure/core-rest-pipeline": "^1.1.0",
-    "@azure/storage-blob": "^12.7.0-beta.1",
+    "@azure/storage-blob": "^12.8.0-beta.1",
     "@azure/test-utils-perfstress": "^1.0.0",
     "dotenv": "^8.2.0",
     "uuid": "^8.3.0"

--- a/sdk/storage/perf-tests/storage-file-datalake/package.json
+++ b/sdk/storage/perf-tests/storage-file-datalake/package.json
@@ -7,7 +7,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@azure/storage-file-datalake": "^12.6.0-beta.1",
+    "@azure/storage-file-datalake": "^12.7.0-beta.1",
     "@azure/test-utils-perfstress": "^1.0.0",
     "dotenv": "^8.2.0",
     "uuid": "^8.3.0"

--- a/sdk/storage/perf-tests/storage-file-share/package.json
+++ b/sdk/storage/perf-tests/storage-file-share/package.json
@@ -7,7 +7,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@azure/storage-file-share": "^12.7.0-beta.1",
+    "@azure/storage-file-share": "^12.8.0-beta.1",
     "@azure/test-utils-perfstress": "^1.0.0",
     "dotenv": "^8.2.0",
     "uuid": "^8.3.0"

--- a/sdk/storage/storage-blob-changefeed/package.json
+++ b/sdk/storage/storage-blob-changefeed/package.json
@@ -94,7 +94,7 @@
     ]
   },
   "dependencies": {
-    "@azure/storage-blob": "^12.7.0-beta.1",
+    "@azure/storage-blob": "^12.8.0-beta.1",
     "@azure/abort-controller": "^1.0.0",
     "@azure/core-http": "^2.0.0",
     "@azure/core-lro": "^2.0.0",

--- a/sdk/storage/storage-blob/CHANGELOG.md
+++ b/sdk/storage/storage-blob/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 12.7.0-beta.1 (Unreleased)
+## 12.8.0-beta.1 (Unreleased)
 
 ### Features Added
 

--- a/sdk/storage/storage-blob/CHANGELOG.md
+++ b/sdk/storage/storage-blob/CHANGELOG.md
@@ -12,19 +12,14 @@
 - Added support for listing deleted root blobs with versions `ContainerClient.listBlobFlat()` and `ContainerClient.listBlobHierarchy()`.
 - Added support for OAuth copy sources for synchronous copy operations.
 - Added support for Parquet as an input format in `BlockBlobClient.query()`.
+- With the dropping of support for Node.js versions that are no longer in LTS, the dependency on `@types/node` has been updated to version 12. Read our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
+- Changed TS compilation target to ES2017 in order to produce smaller bundles and use more native platform features
 
 ### Breaking Changes
 
 ### Key Bugs Fixed
 
 ### Fixed
-
-## 12.7.0 (Unreleased)
-
-### Features Added
-
-- With the dropping of support for Node.js versions that are no longer in LTS, the dependency on `@types/node` has been updated to version 12. Read our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
-- Changed TS compilation target to ES2017 in order to produce smaller bundles and use more native platform features
 
 ## 12.6.0 (2021-06-09)
 

--- a/sdk/storage/storage-blob/CHANGELOG.md
+++ b/sdk/storage/storage-blob/CHANGELOG.md
@@ -12,14 +12,19 @@
 - Added support for listing deleted root blobs with versions `ContainerClient.listBlobFlat()` and `ContainerClient.listBlobHierarchy()`.
 - Added support for OAuth copy sources for synchronous copy operations.
 - Added support for Parquet as an input format in `BlockBlobClient.query()`.
-- With the dropping of support for Node.js versions that are no longer in LTS, the dependency on `@types/node` has been updated to version 12. Read our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
-- Changed TS compilation target to ES2017 in order to produce smaller bundles and use more native platform features
 
 ### Breaking Changes
 
 ### Key Bugs Fixed
 
 ### Fixed
+
+## 12.7.0 (Unreleased)
+
+### Features Added
+
+- With the dropping of support for Node.js versions that are no longer in LTS, the dependency on `@types/node` has been updated to version 12. Read our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
+- Changed TS compilation target to ES2017 in order to produce smaller bundles and use more native platform features
 
 ## 12.6.0 (2021-06-09)
 

--- a/sdk/storage/storage-blob/package.json
+++ b/sdk/storage/storage-blob/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@azure/storage-blob",
   "sdk-type": "client",
-  "version": "12.7.0-beta.1",
+  "version": "12.8.0-beta.1",
   "description": "Microsoft Azure Storage SDK for JavaScript - Blob",
   "main": "./dist/index.js",
   "module": "./dist-esm/storage-blob/src/index.js",

--- a/sdk/storage/storage-blob/src/utils/constants.ts
+++ b/sdk/storage/storage-blob/src/utils/constants.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-export const SDK_VERSION: string = "12.7.0-beta.1";
+export const SDK_VERSION: string = "12.8.0-beta.1";
 export const SERVICE_VERSION: string = "2020-10-02";
 
 export const BLOCK_BLOB_MAX_UPLOAD_BLOB_BYTES: number = 256 * 1024 * 1024; // 256MB

--- a/sdk/storage/storage-blob/swagger/README.md
+++ b/sdk/storage/storage-blob/swagger/README.md
@@ -20,7 +20,7 @@ disable-async-iterators: true
 add-credentials: false
 use-extension:
   "@autorest/typescript": "6.0.0-dev.20210218.1"
-package-version: 12.7.0-beta.1
+package-version: 12.8.0-beta.1
 ```
 
 ## Customizations for Track 2 Generator

--- a/sdk/storage/storage-file-datalake/CHANGELOG.md
+++ b/sdk/storage/storage-file-datalake/CHANGELOG.md
@@ -6,19 +6,14 @@
 
 - Added support for service version 2020-10-02.
 - Added support for Parquet as an input format in `DataLakeFileClient.query()`.
+- With the dropping of support for Node.js versions that are no longer in LTS, the dependency on `@types/node` has been updated to version 12. Read our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
+- Changed TS compilation target to ES2017 in order to produce smaller bundles and use more native platform features
 
 ### Breaking Changes
 
 ### Key Bugs Fixed
 
 ### Fixed
-
-## 12.6.0 (Unreleased)
-
-### Features Added
-
-- With the dropping of support for Node.js versions that are no longer in LTS, the dependency on `@types/node` has been updated to version 12. Read our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
-- Changed TS compilation target to ES2017 in order to produce smaller bundles and use more native platform features
 
 ## 12.5.0 (2021-06-09)
 

--- a/sdk/storage/storage-file-datalake/CHANGELOG.md
+++ b/sdk/storage/storage-file-datalake/CHANGELOG.md
@@ -6,14 +6,19 @@
 
 - Added support for service version 2020-10-02.
 - Added support for Parquet as an input format in `DataLakeFileClient.query()`.
-- With the dropping of support for Node.js versions that are no longer in LTS, the dependency on `@types/node` has been updated to version 12. Read our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
-- Changed TS compilation target to ES2017 in order to produce smaller bundles and use more native platform features
 
 ### Breaking Changes
 
 ### Key Bugs Fixed
 
 ### Fixed
+
+## 12.6.0 (Unreleased)
+
+### Features Added
+
+- With the dropping of support for Node.js versions that are no longer in LTS, the dependency on `@types/node` has been updated to version 12. Read our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
+- Changed TS compilation target to ES2017 in order to produce smaller bundles and use more native platform features
 
 ## 12.5.0 (2021-06-09)
 

--- a/sdk/storage/storage-file-datalake/CHANGELOG.md
+++ b/sdk/storage/storage-file-datalake/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 12.6.0-beta.1 (Unreleased)
+## 12.7.0-beta.1 (Unreleased)
 
 ### Features Added
 

--- a/sdk/storage/storage-file-datalake/package.json
+++ b/sdk/storage/storage-file-datalake/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/storage-file-datalake",
-  "version": "12.6.0-beta.1",
+  "version": "12.7.0-beta.1",
   "description": "Microsoft Azure Storage SDK for JavaScript - DataLake",
   "sdk-type": "client",
   "main": "./dist/index.js",
@@ -111,7 +111,7 @@
     "@azure/core-paging": "^1.1.1",
     "@azure/core-tracing": "1.0.0-preview.13",
     "@azure/logger": "^1.0.0",
-    "@azure/storage-blob": "^12.7.0-beta.1",
+    "@azure/storage-blob": "^12.8.0-beta.1",
     "events": "^3.0.0",
     "tslib": "^2.2.0"
   },

--- a/sdk/storage/storage-file-datalake/src/generated/src/storageClientContext.ts
+++ b/sdk/storage/storage-file-datalake/src/generated/src/storageClientContext.ts
@@ -10,7 +10,7 @@ import * as coreHttp from "@azure/core-http";
 import { StorageClientOptionalParams } from "./models";
 
 const packageName = "azure-storage-datalake";
-const packageVersion = "12.6.0-beta.1";
+const packageVersion = "12.7.0-beta.1";
 
 export class StorageClientContext extends coreHttp.ServiceClient {
   url: string;

--- a/sdk/storage/storage-file-datalake/src/utils/constants.ts
+++ b/sdk/storage/storage-file-datalake/src/utils/constants.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-export const SDK_VERSION: string = "12.6.0-beta.1";
+export const SDK_VERSION: string = "12.7.0-beta.1";
 export const SERVICE_VERSION: string = "2020-10-02";
 
 export const KB: number = 1024;

--- a/sdk/storage/storage-file-datalake/swagger/README.md
+++ b/sdk/storage/storage-file-datalake/swagger/README.md
@@ -20,7 +20,7 @@ disable-async-iterators: true
 add-credentials: false
 use-extension:
   "@autorest/typescript": "6.0.0-dev.20210223.1"
-package-version: 12.6.0-beta.1
+package-version: 12.7.0-beta.1
 ```
 
 ## Customizations for Track 2 Generator

--- a/sdk/storage/storage-file-share/CHANGELOG.md
+++ b/sdk/storage/storage-file-share/CHANGELOG.md
@@ -7,14 +7,19 @@
 - Added support for service version 2020-10-02.
 - Added support for including additional information in `ShareDirectoryClient.listFilesAndDirectories()`.
 - Added support for OAuth in copying source in `ShareFileClient.uploadRangeFromURL()` when source is a Blob.
-- With the dropping of support for Node.js versions that are no longer in LTS, the dependency on `@types/node` has been updated to version 12. Read our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
-- Changed TS compilation target to ES2017 in order to produce smaller bundles and use more native platform features
 
 ### Breaking Changes
 
 ### Key Bugs Fixed
 
 ### Fixed
+
+## 12.7.0 (Unreleased)
+
+### Features Added
+
+- With the dropping of support for Node.js versions that are no longer in LTS, the dependency on `@types/node` has been updated to version 12. Read our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
+- Changed TS compilation target to ES2017 in order to produce smaller bundles and use more native platform features
 
 ## 12.6.0 (2021-06-09)
 

--- a/sdk/storage/storage-file-share/CHANGELOG.md
+++ b/sdk/storage/storage-file-share/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 12.7.0-beta.1 (Unreleased)
+## 12.8.0-beta.1 (Unreleased)
 
 ### Features Added
 

--- a/sdk/storage/storage-file-share/CHANGELOG.md
+++ b/sdk/storage/storage-file-share/CHANGELOG.md
@@ -7,19 +7,14 @@
 - Added support for service version 2020-10-02.
 - Added support for including additional information in `ShareDirectoryClient.listFilesAndDirectories()`.
 - Added support for OAuth in copying source in `ShareFileClient.uploadRangeFromURL()` when source is a Blob.
+- With the dropping of support for Node.js versions that are no longer in LTS, the dependency on `@types/node` has been updated to version 12. Read our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
+- Changed TS compilation target to ES2017 in order to produce smaller bundles and use more native platform features
 
 ### Breaking Changes
 
 ### Key Bugs Fixed
 
 ### Fixed
-
-## 12.7.0 (Unreleased)
-
-### Features Added
-
-- With the dropping of support for Node.js versions that are no longer in LTS, the dependency on `@types/node` has been updated to version 12. Read our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
-- Changed TS compilation target to ES2017 in order to produce smaller bundles and use more native platform features
 
 ## 12.6.0 (2021-06-09)
 

--- a/sdk/storage/storage-file-share/package.json
+++ b/sdk/storage/storage-file-share/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@azure/storage-file-share",
   "sdk-type": "client",
-  "version": "12.7.0-beta.1",
+  "version": "12.8.0-beta.1",
   "description": "Microsoft Azure Storage SDK for JavaScript - File",
   "main": "./dist/index.js",
   "module": "./dist-esm/src/index.js",
@@ -123,7 +123,7 @@
     "tslib": "^2.2.0"
   },
   "devDependencies": {
-    "@azure/storage-blob": "^12.7.0-beta.1",
+    "@azure/storage-blob": "^12.8.0-beta.1",
     "@azure/dev-tool": "^1.0.0",
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
     "@azure/test-utils": "^1.0.0",

--- a/sdk/storage/storage-file-share/src/utils/constants.ts
+++ b/sdk/storage/storage-file-share/src/utils/constants.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-export const SDK_VERSION: string = "12.7.0-beta.1";
+export const SDK_VERSION: string = "12.8.0-beta.1";
 export const SERVICE_VERSION: string = "2020-10-02";
 
 export const FILE_MAX_SIZE_BYTES: number = 4 * 1024 * 1024 * 1024 * 1024; // 4TB

--- a/sdk/storage/storage-file-share/swagger/README.md
+++ b/sdk/storage/storage-file-share/swagger/README.md
@@ -20,7 +20,7 @@ disable-async-iterators: true
 add-credentials: false
 use-extension:
   "@autorest/typescript": "6.0.0-dev.20210218.1"
-package-version: 12.7.0-beta.1
+package-version: 12.8.0-beta.1
 ```
 
 ## Customizations for Track 2 Generator


### PR DESCRIPTION
Now that `@opentelemetry/api` has gone GA, we have more users attempting to try it. The latest stable releases for storage packages still use an older version of `@azure/core-tracing` that depends on 1.0.0-rc version of `@opentelemetry/api`. This results in problems like the one seen in #16447

Moreover, our recent move to use 2.0.0 of `@azure/core-http` in `@azure/identity` results in different versions of core-http being used in cases like #16389 and failing builds even when the user does not use tracing.

We were hoping that the next storage updates would resolve this as we have already done the work to move to the latest tracing packages in the main branch, but unfortunately the storage packages in the main branch are looking at a beta release

To resolve such issues in the near term, we would like to have a stable release out for the storage packages that uses the latest `@azure/core-tracing` package. This PR updates the minor version of such packages so that we can have the minor version in between to do the core-tracing update.

For example, `@azure/storage-blob` is at `12.7.0-beta.1` in the main branch and all set to be released soon.
This PR updates the version to `12.8.0-beta.1` so that we can release `12.7.0` early next week after updating the package to use the latest of `@azure/core-tracing`.

cc @maorleger 
