### PR TITLE
[Tables] Fix live tests

### DIFF
--- a/sdk/tables/data-tables/test/public/accessPolicy.spec.ts
+++ b/sdk/tables/data-tables/test/public/accessPolicy.spec.ts
@@ -7,17 +7,13 @@ import { record, Recorder, isPlaybackMode } from "@azure/test-utils-recorder";
 import { recordedEnvironmentSetup, createTableClient } from "./utils/recordedClient";
 import { isNode } from "@azure/test-utils";
 import { assert } from "chai";
-import sinon from "sinon";
 
 describe(`Access Policy operations`, () => {
   let client: TableClient;
   let recorder: Recorder;
   const tableName = `AccessPolicy`;
-  let clock: sinon.SinonFakeTimers;
 
   beforeEach(async function(this: Context) {
-    const now = new Date("2021-07-08T09:10:09Z");
-    clock = sinon.useFakeTimers(now.getTime());
     recorder = record(this, recordedEnvironmentSetup);
 
     if (!isNode) {
@@ -37,7 +33,6 @@ describe(`Access Policy operations`, () => {
 
   afterEach(async function() {
     await recorder.stop();
-    clock.restore();
   });
 
   after(async () => {


### PR DESCRIPTION
Live tests are failing because of a clock mock that had been set up. This causes the Authorization header to no longer be valid in live tests.

The clock mock is no longer needed as the signature is being replaced in the Recordings. To fix this issue, we just need to remove the clock mock.