### PR TITLE
[Cosmos] Adds deep object find for bulk partition key value path finding

### DIFF
--- a/sdk/cosmosdb/cosmos/CHANGELOG.md
+++ b/sdk/cosmosdb/cosmos/CHANGELOG.md
@@ -1,14 +1,10 @@
 # Release History
 
-## 3.12.3 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
+## 3.12.3 (2021-07-23)
 
 ### Bugs Fixed
 
-### Other Changes
+- Fix bulk operations on containers with multiple partitions with nested partition keys
 
 ## 3.12.2 (2021-07-21)
 

--- a/sdk/cosmosdb/cosmos/src/utils/batch.ts
+++ b/sdk/cosmosdb/cosmos/src/utils/batch.ts
@@ -134,8 +134,9 @@ export function hasResource(
 }
 
 export function getPartitionKeyToHash(operation: Operation, partitionProperty: string): any {
+  console.log(partitionProperty);
   const toHashKey = hasResource(operation)
-    ? (operation.resourceBody as any)[partitionProperty]
+    ? deepFind(operation.resourceBody, partitionProperty)
     : (operation.partitionKey && operation.partitionKey.replace(/[[\]"']/g, "")) ||
       operation.partitionKey;
   // We check for empty object since replace will stringify the value
@@ -185,4 +186,14 @@ export function decorateOperation(
     return { ...operation, partitionKey: "[{}]" };
   }
   return operation as Operation;
+}
+
+function deepFind<T, P extends string>(document: T, path: P): JSONObject {
+  const apath = path.split("/");
+  let h: any = document;
+  for (const p of apath) {
+    if (p in h) h = h[p];
+    else throw new Error(`Invalid path: ${path} at ${p}`);
+  }
+  return h;
 }

--- a/sdk/cosmosdb/cosmos/src/utils/batch.ts
+++ b/sdk/cosmosdb/cosmos/src/utils/batch.ts
@@ -134,7 +134,6 @@ export function hasResource(
 }
 
 export function getPartitionKeyToHash(operation: Operation, partitionProperty: string): any {
-  console.log(partitionProperty);
   const toHashKey = hasResource(operation)
     ? deepFind(operation.resourceBody, partitionProperty)
     : (operation.partitionKey && operation.partitionKey.replace(/[[\]"']/g, "")) ||
@@ -188,7 +187,11 @@ export function decorateOperation(
   return operation as Operation;
 }
 
-function deepFind<T, P extends string>(document: T, path: P): JSONObject {
+/**
+ * Util function for finding partition key values nested in objects at slash (/) separated paths
+ * @hidden
+ */
+export function deepFind<T, P extends string>(document: T, path: P): JSONObject {
   const apath = path.split("/");
   let h: any = document;
   for (const p of apath) {

--- a/sdk/cosmosdb/cosmos/test/internal/unit/utils/batch.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/internal/unit/utils/batch.spec.ts
@@ -1,0 +1,28 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import assert from "assert";
+import { deepFind } from "../../../../src/utils/batch";
+
+describe.only("batch utils", function() {
+  it("deep finds nested partition key values in objects", function() {
+    const testTwiceNested = {
+      nested: {
+        nested2: {
+          key: "value"
+        }
+      }
+    };
+    const testNested = {
+      nested: {
+        key: "value"
+      }
+    };
+    const testBase = {
+      key: "value"
+    };
+    assert.equal(deepFind(testNested, "nested/key"), "value");
+    assert.equal(deepFind(testBase, "key"), "value");
+    assert.equal(deepFind(testTwiceNested, "nested/nested2/key"), "value");
+  });
+});

--- a/sdk/cosmosdb/cosmos/test/internal/unit/utils/batch.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/internal/unit/utils/batch.spec.ts
@@ -4,7 +4,7 @@
 import assert from "assert";
 import { deepFind } from "../../../../src/utils/batch";
 
-describe.only("batch utils", function() {
+describe("batch utils", function() {
   it("deep finds nested partition key values in objects", function() {
     const testTwiceNested = {
       nested: {

--- a/sdk/cosmosdb/cosmos/test/public/functional/item.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/public/functional/item.spec.ts
@@ -523,6 +523,48 @@ describe("bulk item operations", function() {
       assert.equal(deleteResponse[0].statusCode, 204);
     });
   });
+  describe("v2 multi partition container", async function() {
+    let container: Container;
+    let createItemId: string;
+    let upsertItemId: string;
+    before(async function() {
+      container = await getTestContainer("bulk container", undefined, {
+        partitionKey: {
+          paths: ["/nested/key"],
+          version: 2
+        },
+        throughput: 25100
+      });
+      createItemId = addEntropy("createItem");
+      upsertItemId = addEntropy("upsertItem");
+    });
+    it("creates an item with nested object partition key", async function() {
+      const operations: OperationInput[] = [
+        {
+          operationType: BulkOperationType.Create,
+          resourceBody: {
+            id: createItemId,
+            nested: {
+              key: "A"
+            }
+          }
+        },
+        {
+          operationType: BulkOperationType.Upsert,
+          resourceBody: {
+            id: upsertItemId,
+            nested: {
+              key: false
+            }
+          }
+        }
+      ];
+
+      const createResponse = await container.items.bulk(operations);
+      console.log(createResponse);
+      assert.equal(createResponse[0].statusCode, 201);
+    });
+  });
 
   // TODO: Non-deterministic test. We can't guarantee we see any response with a 429 status code since the retries happen within the response
   describe("item read retries", async function() {

--- a/sdk/cosmosdb/cosmos/test/public/functional/item.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/public/functional/item.spec.ts
@@ -561,7 +561,6 @@ describe("bulk item operations", function() {
       ];
 
       const createResponse = await container.items.bulk(operations);
-      console.log(createResponse);
       assert.equal(createResponse[0].statusCode, 201);
     });
   });


### PR DESCRIPTION
Fixes: https://github.com/Azure/azure-sdk-for-js/issues/16445

Bulk was failing to correctly create each set of operations per partition for nested object partition key values, this should fix it.