### PR TITLE
[KeyVault] - Fix double-purge of the same key in test

### DIFF
--- a/sdk/keyvault/keyvault-keys/test/public/crypto.spec.ts
+++ b/sdk/keyvault/keyvault-keys/test/public/crypto.spec.ts
@@ -248,7 +248,6 @@ describe("CryptographyClient (all decrypts happen remotely)", () => {
       const unwrappedResult = await cryptoClient.unwrapKey("RSA1_5", wrapped.result);
       const unwrappedText = uint8ArrayToString(unwrappedResult.result);
       assert.equal(text, unwrappedText);
-      await testClient.flushKey(keyName);
     });
 
     it("sign and verify with RS256 through an RSA-HSM key", async function(this: Context): Promise<


### PR DESCRIPTION
After a month of not being able to run live tests due to a service performance issue, we have finally been able to run live Key Vault
tests. The live test run showed a single failure, which is caused by a test purging a key which later is purged by the afterEach hook 
as well. The second purge would fail, since the key doesn't exist.