### PR TITLE
[Storage] Updates in main branch to reflect changes from hotfix branch

### DIFF
--- a/sdk/storage/storage-blob/CHANGELOG.md
+++ b/sdk/storage/storage-blob/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 12.8.0-beta.1 (2021-07-26)
+## 12.8.0-beta.1 (2021-07-27)
 
 ### Features Added
 
@@ -13,7 +13,12 @@
 - Added support for OAuth copy sources for synchronous copy operations.
 - Added support for Parquet as an input format in `BlockBlobClient.query()`.
 - With the dropping of support for Node.js versions that are no longer in LTS, the dependency on `@types/node` has been updated to version 12. Read our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
+
+## 12.7.0 (2021-07-27)
+
+- Support for Node.js 8 and IE 11 has been dropped. Please see our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 - Changed TS compilation target to ES2017 in order to produce smaller bundles and use more native platform features
+- Updated our internal core package dependencies to their latest versions in order to add support for Opentelemetry 1.0.0 which is compatible with the latest versions of our other client libraries.
 
 ## 12.6.0 (2021-06-09)
 

--- a/sdk/storage/storage-blob/CHANGELOG.md
+++ b/sdk/storage/storage-blob/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 12.8.0-beta.1 (2021-07-27)
+## 12.8.0-beta.1 (2021-07-28)
 
 ### Features Added
 
@@ -14,7 +14,7 @@
 - Added support for Parquet as an input format in `BlockBlobClient.query()`.
 - With the dropping of support for Node.js versions that are no longer in LTS, the dependency on `@types/node` has been updated to version 12. Read our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
-## 12.7.0 (2021-07-27)
+## 12.7.0 (2021-08-02)
 
 - Support for Node.js 8 and IE 11 has been dropped. Please see our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 - Changed TS compilation target to ES2017 in order to produce smaller bundles and use more native platform features

--- a/sdk/storage/storage-file-datalake/CHANGELOG.md
+++ b/sdk/storage/storage-file-datalake/CHANGELOG.md
@@ -1,13 +1,18 @@
 # Release History
 
-## 12.7.0-beta.1 (2021-07-26)
+## 12.7.0-beta.1 (2021-07-27)
 
 ### Features Added
 
 - Added support for service version 2020-10-02.
 - Added support for Parquet as an input format in `DataLakeFileClient.query()`.
 - With the dropping of support for Node.js versions that are no longer in LTS, the dependency on `@types/node` has been updated to version 12. Read our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
+
+## 12.6.0 (2021-07-27)
+
+- Support for Node.js 8 and IE 11 has been dropped. Please see our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 - Changed TS compilation target to ES2017 in order to produce smaller bundles and use more native platform features
+- Updated our internal core package dependencies to their latest versions in order to add support for Opentelemetry 1.0.0 which is compatible with the latest versions of our other client libraries.
 
 ## 12.5.0 (2021-06-09)
 

--- a/sdk/storage/storage-file-datalake/CHANGELOG.md
+++ b/sdk/storage/storage-file-datalake/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 12.7.0-beta.1 (2021-07-27)
+## 12.7.0-beta.1 (2021-07-28)
 
 ### Features Added
 
@@ -8,7 +8,7 @@
 - Added support for Parquet as an input format in `DataLakeFileClient.query()`.
 - With the dropping of support for Node.js versions that are no longer in LTS, the dependency on `@types/node` has been updated to version 12. Read our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
-## 12.6.0 (2021-07-27)
+## 12.6.0 (2021-08-02)
 
 - Support for Node.js 8 and IE 11 has been dropped. Please see our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 - Changed TS compilation target to ES2017 in order to produce smaller bundles and use more native platform features

--- a/sdk/storage/storage-file-share/CHANGELOG.md
+++ b/sdk/storage/storage-file-share/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 12.8.0-beta.1 (2021-07-27)
+## 12.8.0-beta.1 (2021-07-28)
 
 ### Features Added
 
@@ -9,7 +9,7 @@
 - Added support for OAuth in copying source in `ShareFileClient.uploadRangeFromURL()` when source is a Blob.
 - With the dropping of support for Node.js versions that are no longer in LTS, the dependency on `@types/node` has been updated to version 12. Read our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
-## 12.7.0 (2021-07-27)
+## 12.7.0 (2021-08-02)
 
 - Support for Node.js 8 and IE 11 has been dropped. Please see our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 - Changed TS compilation target to ES2017 in order to produce smaller bundles and use more native platform features

--- a/sdk/storage/storage-file-share/CHANGELOG.md
+++ b/sdk/storage/storage-file-share/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 12.8.0-beta.1 (2021-07-26)
+## 12.8.0-beta.1 (2021-07-27)
 
 ### Features Added
 
@@ -8,7 +8,12 @@
 - Added support for including additional information in `ShareDirectoryClient.listFilesAndDirectories()`.
 - Added support for OAuth in copying source in `ShareFileClient.uploadRangeFromURL()` when source is a Blob.
 - With the dropping of support for Node.js versions that are no longer in LTS, the dependency on `@types/node` has been updated to version 12. Read our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
+
+## 12.7.0 (2021-07-27)
+
+- Support for Node.js 8 and IE 11 has been dropped. Please see our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 - Changed TS compilation target to ES2017 in order to produce smaller bundles and use more native platform features
+- Updated our internal core package dependencies to their latest versions in order to add support for Opentelemetry 1.0.0 which is compatible with the latest versions of our other client libraries.
 
 ## 12.6.0 (2021-06-09)
 

--- a/sdk/storage/storage-queue/CHANGELOG.md
+++ b/sdk/storage/storage-queue/CHANGELOG.md
@@ -1,16 +1,22 @@
 # Release History
 
-## 12.6.0 (Unreleased)
+## 12.7.0 (Unreleased)
 
 ### Features Added
+
 - With the dropping of support for Node.js versions that are no longer in LTS, the dependency on `@types/node` has been updated to version 12. Read our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
-- Changed TS compilation target to ES2017 in order to produce smaller bundles and use more native platform features
 
 ### Breaking Changes
 
 ### Key Bugs Fixed
 
 ### Fixed
+
+## 12.6.0 (2021-07-27)
+
+- Support for Node.js 8 and IE 11 has been dropped. Please see our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
+- Changed TS compilation target to ES2017 in order to produce smaller bundles and use more native platform features
+- Updated our internal core package dependencies to their latest versions in order to add support for Opentelemetry 1.0.0 which is compatible with the latest versions of our other client libraries.
 
 ## 12.5.0 (2021-06-09)
 

--- a/sdk/storage/storage-queue/CHANGELOG.md
+++ b/sdk/storage/storage-queue/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ### Fixed
 
-## 12.6.0 (2021-07-27)
+## 12.6.0 (2021-08-02)
 
 - Support for Node.js 8 and IE 11 has been dropped. Please see our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 - Changed TS compilation target to ES2017 in order to produce smaller bundles and use more native platform features

--- a/sdk/storage/storage-queue/package.json
+++ b/sdk/storage/storage-queue/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@azure/storage-queue",
   "sdk-type": "client",
-  "version": "12.6.0",
+  "version": "12.7.0",
   "description": "Microsoft Azure Storage SDK for JavaScript - Queue",
   "main": "./dist/index.js",
   "module": "./dist-esm/src/index.js",

--- a/sdk/storage/storage-queue/src/utils/constants.ts
+++ b/sdk/storage/storage-queue/src/utils/constants.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-export const SDK_VERSION: string = "12.6.0";
+export const SDK_VERSION: string = "12.7.0";
 export const SERVICE_VERSION: string = "2020-08-04";
 
 /**

--- a/sdk/storage/storage-queue/swagger/README.md
+++ b/sdk/storage/storage-queue/swagger/README.md
@@ -20,7 +20,7 @@ disable-async-iterators: true
 add-credentials: false
 use-extension:
   "@autorest/typescript": "6.0.0-dev.20210218.1"
-package-version: 12.6.0
+package-version: 12.7.0
 ```
 
 ## Customizations for Track 2 Generator


### PR DESCRIPTION
#16529 has the changes to ship stable versions of storage packages as part of a hotfix
This PR has the following changes in the main branch

- changelog updates in the main branch to include the changes from the hotfix
- version update for storage-queue as that package is also being shipped along with the others in the hot fix branch.
- update the release dates

cc @maorleger 

@EmmaZhu, This PR is not a blocker for you to release the storage beta packages from the main branch. If you do merge this before before the beta releases, you get the advantage of the changelogs having the right entries when someone looks at the git tags corresponding to the beta release

 