### PR TITLE
Skip Semantic Test

### DIFF
--- a/sdk/search/search-documents/test/public/node/searchClient.spec.ts
+++ b/sdk/search/search-documents/test/public/node/searchClient.spec.ts
@@ -265,6 +265,9 @@ describe("SearchClient", function(this: Suite) {
     assert.equal(searchResults.count, 6);
   });
 
+  // Currently semantic search is available only with
+  // certain subscriptions and could not be tested in CI.
+  // So, skipping this test for now.
   it.skip("search with semantic ranking", async function() {
     const searchResults = await searchClient.search("luxury", {
       skip: 0,

--- a/sdk/search/search-documents/test/public/node/searchClient.spec.ts
+++ b/sdk/search/search-documents/test/public/node/searchClient.spec.ts
@@ -265,7 +265,7 @@ describe("SearchClient", function(this: Suite) {
     assert.equal(searchResults.count, 6);
   });
 
-  it("search with semantic ranking", async function() {
+  it.skip("search with semantic ranking", async function() {
     const searchResults = await searchClient.search("luxury", {
       skip: 0,
       top: 5,


### PR DESCRIPTION
The Semantic Test is enabled only for certain subscriptions and could not be executed now in CI (which causes the test failures). So, skipping it for now. 

@xirzec Please review and approve. 

