### PR TITLE
Skip version increment for track2 management package

### DIFF
--- a/eng/tools/versioning/increment.js
+++ b/eng/tools/versioning/increment.js
@@ -42,6 +42,11 @@ async function main(argv) {
     (packageSpec) => packageSpec.packageName.replace("@", "").replace("/", "-") == artifactName
   );
 
+  if (targetPackage.versionPolicyName == "management") {
+    console.log("Skipping version increment for management package");
+    return;
+  }
+
   const targetPackagePath = path.join(repoRoot, targetPackage.projectFolder);
   const packageJsonLocation = path.join(targetPackagePath, "package.json");
 


### PR DESCRIPTION
TRack2 management packages uses auto generation tools to properly set version and do not want version increment PRs to be created for these packages. Skipping version increment for management packages.