### PR TITLE
[Tables] Fix batch operations against emulators

### DIFF
--- a/sdk/tables/data-tables/CHANGELOG.md
+++ b/sdk/tables/data-tables/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Fix [#15854](https://github.com/Azure/azure-sdk-for-js/issues/15701) when submitting transactions by ensuring the `allowInsecureConnection` client option is respected.
+
 ### Other Changes
 
 ## 12.1.0 (2021-07-07)
@@ -28,7 +30,7 @@ Thank you to our developer community members who helped to make the Azure Tables
 - Fix [#15664](https://github.com/Azure/azure-sdk-for-js/issues/15701), adding check to make sure we always have only one forward slash (`/`) added to the end of the URL [#15698](https://github.com/Azure/azure-sdk-for-js/pull/15698) (A community contribution, courtesy of _[eestein](https://github.com/eestein))_
 - Fix [#15701](https://github.com/Azure/azure-sdk-for-js/issues/15701) by improving error handling and reporting on `submitTransaction`. [#15852](https://github.com/Azure/azure-sdk-for-js/pull/15852)
 - Fix [#15921](https://github.com/Azure/azure-sdk-for-js/issues/15921) incorrect `url` import and missing browser mapping for `computeHMACSHA256` [#15944](https://github.com/Azure/azure-sdk-for-js/pull/15944)
-- Fix [#15854](https://github.com/Azure/autorest.typescript/issues/892) by setting `allowInsecureConnection` to true when using the development connection string.
+- Fix [#15854]https://github.com/Azure/azure-sdk-for-js/issues/15854) by setting `allowInsecureConnection` to true when using the development connection string.
 
 ## 12.0.0 (2021-06-09)
 

--- a/sdk/tables/data-tables/src/TableClient.ts
+++ b/sdk/tables/data-tables/src/TableClient.ts
@@ -82,6 +82,7 @@ export class TableClient {
   private table: Table;
   private credential?: NamedKeyCredential | SASCredential | TokenCredential;
   private transactionClient?: InternalTableTransaction;
+  private readonly allowInsecureConnection: boolean;
 
   /**
    * Name of the table to perform operations on.
@@ -221,6 +222,7 @@ export class TableClient {
     const clientOptions =
       (!isCredential(credentialOrOptions) ? credentialOrOptions : options) || {};
 
+    this.allowInsecureConnection = clientOptions.allowInsecureConnection ?? false;
     clientOptions.endpoint = clientOptions.endpoint || this.url;
 
     if (!clientOptions.userAgentOptions) {
@@ -880,7 +882,8 @@ export class TableClient {
         transactionId,
         changesetId,
         new TableClient(this.url, this.tableName),
-        this.credential
+        this.credential,
+        this.allowInsecureConnection
       );
     } else {
       this.transactionClient.reset(transactionId, changesetId, partitionKey);

--- a/sdk/tables/data-tables/src/TableTransaction.ts
+++ b/sdk/tables/data-tables/src/TableTransaction.ts
@@ -132,6 +132,7 @@ export class InternalTableTransaction {
   };
   private interceptClient: TableClientLike;
   private credential?: NamedKeyCredential | SASCredential | TokenCredential;
+  private allowInsecureConnection: boolean;
 
   /**
    * @param url - Tables account url
@@ -144,11 +145,13 @@ export class InternalTableTransaction {
     transactionId: string,
     changesetId: string,
     interceptClient: TableClientLike,
-    credential?: NamedKeyCredential | SASCredential | TokenCredential
+    credential?: NamedKeyCredential | SASCredential | TokenCredential,
+    allowInsecureConnection: boolean = false
   ) {
     this.credential = credential;
     this.url = url;
     this.interceptClient = interceptClient;
+    this.allowInsecureConnection = allowInsecureConnection;
 
     // Initialize Reset-able properties
     this.resetableState = this.initializeSharedState(transactionId, changesetId, partitionKey);
@@ -291,7 +294,8 @@ export class InternalTableTransaction {
       method: "POST",
       body,
       headers: createHttpHeaders(headers),
-      tracingOptions: updatedOptions.tracingOptions
+      tracingOptions: updatedOptions.tracingOptions,
+      allowInsecureConnection: this.allowInsecureConnection
     });
 
     if (isNamedKeyCredential(this.credential)) {


### PR DESCRIPTION
In #15938 we exposed the `allowInsecureConnection` option to allow
connections to the service over HTTP instead of HTTPS. However, even
if a table client was created allowing insecure connections, we would
still require a secure connection when submitting a batch transaction,
since the implementation of batch operations interact with the
pipeline directly. We now record if the client was created allowing
insecure connections and thread that information along when creating
requests for batch operations.

With this change, you can now submit batch transactions to storage
emulators, which commonly run over HTTP instead of HTTPS.

Fixes #15854