### PR TITLE
Use default branch when queueing build in docindex

### DIFF
--- a/eng/pipelines/docindex.yml
+++ b/eng/pipelines/docindex.yml
@@ -72,28 +72,6 @@ jobs:
           WorkingDirectory: $(DocRepoLocation)
           ScriptDirectory: $(Build.SourcesDirectory)/eng/common/scripts
 
-      # Enable overriding the branch used by reference automation. The reference
-      # automation repo is used by the Docs CI process to generate
-      # documentation from published packages.
-      # In some cases the reference automation repository might have bugs
-      # that prevent a successful build of JS docs. In these cases that can be
-      # manually overridden to use a branch without those breaking bugs.
-      # - pwsh: |
-      #     $branchName = $env:DAILYDOCSCIBRANCHNAMEOVERRIDE
-      #     if (!$branchName) {
-      #       # DocsBuildSourceBranch must default to "master" as this repo is
-      #       # managed by the docs team and will be updated according to
-      #       # their timeline.
-
-      #       # Pin version to working branch. This should be "master" when the 
-      #       # docs CI is fixed.
-      #       $branchName = "master"
-      #     }
-      #     Write-Host "Docs CI Branch Name: $branchName"
-      #     Write-Host "##vso[task.setvariable variable=DocsBuildSourceBranch;]$branchName"
-      #   displayName: Set branch used for Docs CI reference automation build
-
-      # What happens in the case of an empty branch?
       - task: PowerShell@2
         displayName: Queue Docs CI build
         inputs:
@@ -102,7 +80,6 @@ jobs:
           arguments: >
             -Organization "apidrop"
             -Project "Content%20CI"
-            -SourceBranch ""
             -DefinitionId 3452
             -Base64EncodedAuthToken "$(azuresdk-apidrop-devops-queue-build-pat)"
             -BuildParametersJson '{"params":"{ \"target_repo\": { \"url\": \"https://github.com/MicrosoftDocs/azure-docs-sdk-node\", \"branch\": \"$(DailyDocsBranchName)\", \"folder\": \"./\" }, \"source_repos\": [] }"}'

--- a/eng/pipelines/docindex.yml
+++ b/eng/pipelines/docindex.yml
@@ -72,17 +72,33 @@ jobs:
           WorkingDirectory: $(DocRepoLocation)
           ScriptDirectory: $(Build.SourcesDirectory)/eng/common/scripts
 
+      # Enable overriding the branch used by reference automation. The reference
+      # automation repo is used by the Docs CI process to generate
+      # documentation from published packages.
+      # In some cases the reference automation repository might have bugs
+      # that prevent a successful build of JS docs. In these cases that can be
+      # manually overridden to use a branch without those breaking bugs.
+      - pwsh: |
+          $branchName = $env:DAILYDOCSCIBRANCHNAMEOVERRIDE
+          if (!$branchName) {
+            # DocsBuildSourceBranch must default to "master" as this repo is
+            # managed by the docs team and will be updated according to
+            # their timeline.
+            $branchName = "master"
+          }
+          Write-Host "Docs CI Branch Name: $branchName"
+          Write-Host "##vso[task.setvariable variable=DocsBuildSourceBranch;]$branchName"
+        displayName: Set branch used for Docs CI reference automation build
+
       - task: PowerShell@2
         displayName: Queue Docs CI build
         inputs:
           pwsh: true
           filePath: eng/common/scripts/Queue-Pipeline.ps1
-          # SourceBranch must be "master" as this repo is managed by the docs 
-          # team and will be updated according to their timeline.
           arguments: >
             -Organization "apidrop"
             -Project "Content%20CI"
-            -SourceBranch "master"
+            -SourceBranch "$(DocsBuildSourceBranch)"
             -DefinitionId 3452
             -Base64EncodedAuthToken "$(azuresdk-apidrop-devops-queue-build-pat)"
             -BuildParametersJson '{"params":"{ \"target_repo\": { \"url\": \"https://github.com/MicrosoftDocs/azure-docs-sdk-node\", \"branch\": \"$(DailyDocsBranchName)\", \"folder\": \"./\" }, \"source_repos\": [] }"}'

--- a/eng/pipelines/docindex.yml
+++ b/eng/pipelines/docindex.yml
@@ -24,12 +24,12 @@ jobs:
               WorkingDirectory: $(DocRepoLocation)
 
       # Call update docs ci script to onboard packages
-      - task: Powershell@2
-        inputs:
-          pwsh: true
-          filePath: eng/common/scripts/Update-DocsMsPackages.ps1
-          arguments: -DocRepoLocation $(DocRepoLocation)
-        displayName: Update Docs Onboarding
+      # - task: Powershell@2
+      #   inputs:
+      #     pwsh: true
+      #     filePath: eng/common/scripts/Update-DocsMsPackages.ps1
+      #     arguments: -DocRepoLocation $(DocRepoLocation)
+      #   displayName: Update Docs Onboarding
 
       # Push changes to docs repo
       - template: /eng/common/pipelines/templates/steps/set-default-branch.yml
@@ -56,12 +56,12 @@ jobs:
           git status
         displayName: Checkout daily branch if it exists
         workingDirectory: $(DocRepoLocation)
-      - task: Powershell@2
-        inputs:
-          pwsh: true
-          filePath: eng/common/scripts/Update-DocsMsPackages.ps1
-          arguments: -DocRepoLocation $(DocRepoLocation)
-        displayName: Update Docs Onboarding for Daily branch
+      # - task: Powershell@2
+      #   inputs:
+      #     pwsh: true
+      #     filePath: eng/common/scripts/Update-DocsMsPackages.ps1
+      #     arguments: -DocRepoLocation $(DocRepoLocation)
+      #   displayName: Update Docs Onboarding for Daily branch
       - template: /eng/common/pipelines/templates/steps/git-push-changes.yml
         parameters:
           BaseRepoBranch: $(DailyDocsBranchName)

--- a/eng/pipelines/docindex.yml
+++ b/eng/pipelines/docindex.yml
@@ -78,18 +78,22 @@ jobs:
       # In some cases the reference automation repository might have bugs
       # that prevent a successful build of JS docs. In these cases that can be
       # manually overridden to use a branch without those breaking bugs.
-      - pwsh: |
-          $branchName = $env:DAILYDOCSCIBRANCHNAMEOVERRIDE
-          if (!$branchName) {
-            # DocsBuildSourceBranch must default to "master" as this repo is
-            # managed by the docs team and will be updated according to
-            # their timeline.
-            $branchName = "master"
-          }
-          Write-Host "Docs CI Branch Name: $branchName"
-          Write-Host "##vso[task.setvariable variable=DocsBuildSourceBranch;]$branchName"
-        displayName: Set branch used for Docs CI reference automation build
+      # - pwsh: |
+      #     $branchName = $env:DAILYDOCSCIBRANCHNAMEOVERRIDE
+      #     if (!$branchName) {
+      #       # DocsBuildSourceBranch must default to "master" as this repo is
+      #       # managed by the docs team and will be updated according to
+      #       # their timeline.
 
+      #       # Pin version to working branch. This should be "master" when the 
+      #       # docs CI is fixed.
+      #       $branchName = "master"
+      #     }
+      #     Write-Host "Docs CI Branch Name: $branchName"
+      #     Write-Host "##vso[task.setvariable variable=DocsBuildSourceBranch;]$branchName"
+      #   displayName: Set branch used for Docs CI reference automation build
+
+      # What happens in the case of an empty branch?
       - task: PowerShell@2
         displayName: Queue Docs CI build
         inputs:
@@ -98,7 +102,7 @@ jobs:
           arguments: >
             -Organization "apidrop"
             -Project "Content%20CI"
-            -SourceBranch "$(DocsBuildSourceBranch)"
+            -SourceBranch ""
             -DefinitionId 3452
             -Base64EncodedAuthToken "$(azuresdk-apidrop-devops-queue-build-pat)"
             -BuildParametersJson '{"params":"{ \"target_repo\": { \"url\": \"https://github.com/MicrosoftDocs/azure-docs-sdk-node\", \"branch\": \"$(DailyDocsBranchName)\", \"folder\": \"./\" }, \"source_repos\": [] }"}'

--- a/eng/pipelines/docindex.yml
+++ b/eng/pipelines/docindex.yml
@@ -24,12 +24,12 @@ jobs:
               WorkingDirectory: $(DocRepoLocation)
 
       # Call update docs ci script to onboard packages
-      # - task: Powershell@2
-      #   inputs:
-      #     pwsh: true
-      #     filePath: eng/common/scripts/Update-DocsMsPackages.ps1
-      #     arguments: -DocRepoLocation $(DocRepoLocation)
-      #   displayName: Update Docs Onboarding
+      - task: Powershell@2
+        inputs:
+          pwsh: true
+          filePath: eng/common/scripts/Update-DocsMsPackages.ps1
+          arguments: -DocRepoLocation $(DocRepoLocation)
+        displayName: Update Docs Onboarding
 
       # Push changes to docs repo
       - template: /eng/common/pipelines/templates/steps/set-default-branch.yml
@@ -56,12 +56,12 @@ jobs:
           git status
         displayName: Checkout daily branch if it exists
         workingDirectory: $(DocRepoLocation)
-      # - task: Powershell@2
-      #   inputs:
-      #     pwsh: true
-      #     filePath: eng/common/scripts/Update-DocsMsPackages.ps1
-      #     arguments: -DocRepoLocation $(DocRepoLocation)
-      #   displayName: Update Docs Onboarding for Daily branch
+      - task: Powershell@2
+        inputs:
+          pwsh: true
+          filePath: eng/common/scripts/Update-DocsMsPackages.ps1
+          arguments: -DocRepoLocation $(DocRepoLocation)
+        displayName: Update Docs Onboarding for Daily branch
       - template: /eng/common/pipelines/templates/steps/git-push-changes.yml
         parameters:
           BaseRepoBranch: $(DailyDocsBranchName)

--- a/eng/pipelines/docindex.yml
+++ b/eng/pipelines/docindex.yml
@@ -102,6 +102,7 @@ jobs:
           arguments: >
             -Organization "apidrop"
             -Project "Content%20CI"
+            -SourceBranch ""
             -DefinitionId 3452
             -Base64EncodedAuthToken "$(azuresdk-apidrop-devops-queue-build-pat)"
             -BuildParametersJson '{"params":"{ \"target_repo\": { \"url\": \"https://github.com/MicrosoftDocs/azure-docs-sdk-node\", \"branch\": \"$(DailyDocsBranchName)\", \"folder\": \"./\" }, \"source_repos\": [] }"}'

--- a/eng/pipelines/docindex.yml
+++ b/eng/pipelines/docindex.yml
@@ -102,7 +102,6 @@ jobs:
           arguments: >
             -Organization "apidrop"
             -Project "Content%20CI"
-            -SourceBranch ""
             -DefinitionId 3452
             -Base64EncodedAuthToken "$(azuresdk-apidrop-devops-queue-build-pat)"
             -BuildParametersJson '{"params":"{ \"target_repo\": { \"url\": \"https://github.com/MicrosoftDocs/azure-docs-sdk-node\", \"branch\": \"$(DailyDocsBranchName)\", \"folder\": \"./\" }, \"source_repos\": [] }"}'


### PR DESCRIPTION
This PR requires changes to eng/common -- https://github.com/Azure/azure-sdk-tools/pull/1852/files

Example of successful queuing of a pipeline -- https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1019544&view=logs&j=dc056dfc-c0cf-5958-c8c4-8da4f91a3739&t=dc056dfc-c0cf-5958-c8c4-8da4f91a3739