### PR TITLE
[core-rest-pipeline] Unblock recording new tests

### DIFF
--- a/sdk/core/core-rest-pipeline/src/nodeHttpClient.ts
+++ b/sdk/core/core-rest-pipeline/src/nodeHttpClient.ts
@@ -210,7 +210,9 @@ class NodeHttpClient implements HttpClient {
     return new Promise<http.IncomingMessage>((resolve, reject) => {
       const resolveCallback = (res: http.IncomingMessage) => resolve(res);
 
-      const req = isInsecure ? http.request(options, resolveCallback) : https.request(options, resolveCallback);
+      const req = isInsecure
+        ? http.request(options, resolveCallback)
+        : https.request(options, resolveCallback);
 
       req.once("error", (err) => {
         reject(new RestError(err.message, { code: RestError.REQUEST_SEND_ERROR, request }));

--- a/sdk/core/core-rest-pipeline/src/nodeHttpClient.ts
+++ b/sdk/core/core-rest-pipeline/src/nodeHttpClient.ts
@@ -208,11 +208,9 @@ class NodeHttpClient implements HttpClient {
     };
 
     return new Promise<http.IncomingMessage>((resolve, reject) => {
-      const resolveCallback = (res: http.IncomingMessage) => resolve(res);
-
       const req = isInsecure
-        ? http.request(options, resolveCallback)
-        : https.request(options, resolveCallback);
+        ? http.request(options, resolve)
+        : https.request(options, resolve);
 
       req.once("error", (err) => {
         reject(new RestError(err.message, { code: RestError.REQUEST_SEND_ERROR, request }));

--- a/sdk/core/core-rest-pipeline/src/nodeHttpClient.ts
+++ b/sdk/core/core-rest-pipeline/src/nodeHttpClient.ts
@@ -208,11 +208,10 @@ class NodeHttpClient implements HttpClient {
     };
 
     return new Promise<http.IncomingMessage>((resolve, reject) => {
-      const req = isInsecure ? http.request(options) : https.request(options);
+      const resolveCallback = (res: http.IncomingMessage) => resolve(res);
 
-      req.once("response", (res: http.IncomingMessage) => {
-        resolve(res);
-      });
+      const req = isInsecure ? http.request(options, resolveCallback) : https.request(options, resolveCallback);
+
       req.once("error", (err) => {
         reject(new RestError(err.message, { code: RestError.REQUEST_SEND_ERROR, request }));
       });

--- a/sdk/core/core-rest-pipeline/src/nodeHttpClient.ts
+++ b/sdk/core/core-rest-pipeline/src/nodeHttpClient.ts
@@ -208,9 +208,7 @@ class NodeHttpClient implements HttpClient {
     };
 
     return new Promise<http.IncomingMessage>((resolve, reject) => {
-      const req = isInsecure
-        ? http.request(options, resolve)
-        : https.request(options, resolve);
+      const req = isInsecure ? http.request(options, resolve) : https.request(options, resolve);
 
       req.once("error", (err) => {
         reject(new RestError(err.message, { code: RestError.REQUEST_SEND_ERROR, request }));

--- a/sdk/core/core-rest-pipeline/test/node/nodeHttpClient.spec.ts
+++ b/sdk/core/core-rest-pipeline/test/node/nodeHttpClient.spec.ts
@@ -235,8 +235,8 @@ describe("NodeHttpClient", function () {
       );
     }
   });
-  
-  it.only("shouldn't throw when accessing HTTP and allowInsecureConnection is true", async function () {
+
+  it("shouldn't throw when accessing HTTP and allowInsecureConnection is true", async function () {
     const client = createDefaultHttpClient();
     const clientRequest = createRequest();
     stubbedHttpRequest.returns(clientRequest);

--- a/sdk/core/core-rest-pipeline/test/node/nodeHttpClient.spec.ts
+++ b/sdk/core/core-rest-pipeline/test/node/nodeHttpClient.spec.ts
@@ -38,10 +38,7 @@ const httpRequestChecker = {
   },
   end(chunk: unknown) {
     const isString = typeof chunk === "string";
-    assert(
-      isString || Buffer.isBuffer(chunk),
-      "Expected either string or Buffer"
-    );
+    assert(isString || Buffer.isBuffer(chunk), "Expected either string or Buffer");
   }
 };
 
@@ -60,23 +57,23 @@ function createRequest(): ClientRequest {
   return (request as unknown) as ClientRequest;
 }
 
-describe("NodeHttpClient", function () {
+describe("NodeHttpClient", function() {
   let stubbedHttpsRequest: sinon.SinonStub;
   let stubbedHttpRequest: sinon.SinonStub;
   let clock: sinon.SinonFakeTimers;
 
-  beforeEach(function () {
+  beforeEach(function() {
     stubbedHttpsRequest = sinon.stub(https, "request");
     stubbedHttpRequest = sinon.stub(http, "request");
     clock = sinon.useFakeTimers();
   });
 
-  afterEach(function () {
+  afterEach(function() {
     clock.restore();
     sinon.restore();
   });
 
-  it("shouldn't throw on 404", async function () {
+  it("shouldn't throw on 404", async function() {
     const client = createDefaultHttpClient();
     const clientRequest = createRequest();
     stubbedHttpsRequest.returns(clientRequest);
@@ -87,7 +84,7 @@ describe("NodeHttpClient", function () {
     assert.strictEqual(response.status, 404);
   });
 
-  it("should allow canceling of requests", async function () {
+  it("should allow canceling of requests", async function() {
     const client = createDefaultHttpClient();
     const controller = new AbortController();
     const clientRequest = createRequest();
@@ -106,7 +103,7 @@ describe("NodeHttpClient", function () {
     }
   });
 
-  it("shouldn't be affected by requests cancelled late", async function () {
+  it("shouldn't be affected by requests cancelled late", async function() {
     const client = createDefaultHttpClient();
     const controller = new AbortController();
     const clientRequest = createRequest();
@@ -122,7 +119,7 @@ describe("NodeHttpClient", function () {
     assert.strictEqual(response.status, 200);
   });
 
-  it("should allow canceling of requests before the request is made", async function () {
+  it("should allow canceling of requests before the request is made", async function() {
     const client = createDefaultHttpClient();
     const controller = new AbortController();
     controller.abort();
@@ -141,7 +138,7 @@ describe("NodeHttpClient", function () {
     }
   });
 
-  it("should report upload and download progress", async function () {
+  it("should report upload and download progress", async function() {
     const client = createDefaultHttpClient();
     const clientRequest = createRequest();
     stubbedHttpsRequest.returns(clientRequest);
@@ -150,11 +147,11 @@ describe("NodeHttpClient", function () {
     const request = createPipelineRequest({
       url: "https://example.com",
       body: "Some kinda witty message",
-      onDownloadProgress: ev => {
+      onDownloadProgress: (ev) => {
         assert.isNumber(ev.loadedBytes);
         downloadCalled = true;
       },
-      onUploadProgress: ev => {
+      onUploadProgress: (ev) => {
         assert.isNumber(ev.loadedBytes);
         uploadCalled = true;
       }
@@ -168,7 +165,7 @@ describe("NodeHttpClient", function () {
     assert.isTrue(uploadCalled, "no upload progress");
   });
 
-  it("should honor timeout", async function () {
+  it("should honor timeout", async function() {
     const client = createDefaultHttpClient();
 
     const timeoutLength = 2000;
@@ -188,7 +185,7 @@ describe("NodeHttpClient", function () {
     }
   });
 
-  it("should stream response body on matching status code", async function () {
+  it("should stream response body on matching status code", async function() {
     const client = createDefaultHttpClient();
     const clientRequest = createRequest();
     stubbedHttpsRequest.returns(clientRequest);
@@ -203,7 +200,7 @@ describe("NodeHttpClient", function () {
     assert.ok(response.readableStreamBody);
   });
 
-  it("should not stream response body on non-matching status code", async function () {
+  it("should not stream response body on non-matching status code", async function() {
     const client = createDefaultHttpClient();
     const clientRequest = createRequest();
     stubbedHttpsRequest.returns(clientRequest);
@@ -218,7 +215,7 @@ describe("NodeHttpClient", function () {
     assert.strictEqual(response.readableStreamBody, undefined);
   });
 
-  it("should throw when accessing HTTP and allowInsecureConnection is false", async function () {
+  it("should throw when accessing HTTP and allowInsecureConnection is false", async function() {
     const client = createDefaultHttpClient();
     const request = createPipelineRequest({
       url: "http://example.com"
@@ -228,15 +225,11 @@ describe("NodeHttpClient", function () {
       await promise;
       assert.fail("Expected await to throw");
     } catch (e) {
-      assert.match(
-        e.message,
-        /^Cannot connect/,
-        "Error should refuse connection"
-      );
+      assert.match(e.message, /^Cannot connect/, "Error should refuse connection");
     }
   });
 
-  it("shouldn't throw when accessing HTTP and allowInsecureConnection is true", async function () {
+  it("shouldn't throw when accessing HTTP and allowInsecureConnection is true", async function() {
     const client = createDefaultHttpClient();
     const clientRequest = createRequest();
     stubbedHttpRequest.returns(clientRequest);
@@ -250,7 +243,7 @@ describe("NodeHttpClient", function () {
     assert.strictEqual(response.status, 200);
   });
 
-  it("Should decode chunked responses properly", async function () {
+  it("Should decode chunked responses properly", async function() {
     const client = createDefaultHttpClient();
     const clientRequest = createRequest();
     stubbedHttpsRequest.returns(clientRequest);
@@ -277,7 +270,7 @@ describe("NodeHttpClient", function () {
     assert.strictEqual(response.bodyAsText, inputString);
   });
 
-  it("should handle typed array bodies correctly", async function () {
+  it("should handle typed array bodies correctly", async function() {
     const client = createDefaultHttpClient();
     stubbedHttpsRequest.returns(httpRequestChecker);
 
@@ -296,7 +289,7 @@ describe("NodeHttpClient", function () {
     assert.strictEqual(response.status, 200);
   });
 
-  it("should handle ArrayBuffer bodies correctly", async function () {
+  it("should handle ArrayBuffer bodies correctly", async function() {
     const client = createDefaultHttpClient();
     stubbedHttpsRequest.returns(httpRequestChecker);
 
@@ -315,7 +308,7 @@ describe("NodeHttpClient", function () {
     assert.strictEqual(response.status, 200);
   });
 
-  it("should handle Buffer bodies correctly", async function () {
+  it("should handle Buffer bodies correctly", async function() {
     const client = createDefaultHttpClient();
     stubbedHttpsRequest.returns(httpRequestChecker);
 
@@ -331,7 +324,7 @@ describe("NodeHttpClient", function () {
     assert.strictEqual(response.status, 200);
   });
 
-  it("should handle string bodies correctly", async function () {
+  it("should handle string bodies correctly", async function() {
     const client = createDefaultHttpClient();
     stubbedHttpsRequest.returns(httpRequestChecker);
 


### PR DESCRIPTION
### Issue https://github.com/Azure/azure-sdk-for-js/issues/16592

### Background
@LarryOsterman reached out regarding the issue with recording the attestation tests.
Some of the tests are hanging forever, some are saving incorrect recordings.

### Investigation
We(with @LarryOsterman) observed that there is a race condition in processing the responses. While the live test is fine, the test in record mode either drops part of the initial response or loses the response completely and hangs. This points fingers towards nock which we use to record tests in node.

On the other hand, with a simple binary search, we realized that https://github.com/Azure/azure-sdk-for-js/pull/16372 made this problem visible.
So, it was either that PR caused the issue or the PR uncovered some problem that existed always.

Upon more investigation, it was indeed nock doing things incorrectly.

https://github.com/Azure/azure-sdk-for-js/pull/16372 changed things on how we handle the responses (@xirzec's summary below)
- We yield the response here before subscribing to any methods on it: https://github.com/Azure/azure-sdk-for-js/blob/a1b6df4ab4ca15b401e649537f2cf4d97a0a5709/sdk/core/core-rest-pipeline/src/nodeHttpClient.ts#L214
- This is different from before, but still valid since streams aren’t supposed to start emitting data until you subscribe to them:
   - https://nodejs.org/dist/latest-v14.x/docs/api/stream.html#stream_event_data
      - The 'data' event is emitted whenever the stream is relinquishing ownership of a chunk of data to a consumer. This may occur whenever the stream is switched in flowing mode by calling readable.pipe(), readable.resume(), or by attaching a listener callback to the 'data' event. The 'data' event will also be emitted whenever the readable.read() method is called and a chunk of data is available to be returned.
     - Since we’re not doing any of the above things (calling pipe, resume, read, or attaching a data handler), there’s no reason the data should already be flowing to the response stream they handed back to us, unless they implemented a mock that doesn’t follow Node’s behavior, which seems likely.

### Fix
- As it would be a longer process to report and wait for nock to fix this somehow and to upgrade the version, we are going with a simpler fix as @xirzec suggested.
We pass the callback to the `https.request` method instead of subscribing to the “response” event.

### Todo
Give a repro to the nock team so that they can improve in the next version.
  
📌 Thanks a ton to @LarryOsterman and @xirzec for the whole investigation and the resolution. 

Fixes #16592 
Fixes #16562