### PR TITLE
debugging for response for tables rows

### DIFF
--- a/sdk/monitor/monitor-query/src/logsQueryClient.ts
+++ b/sdk/monitor/monitor-query/src/logsQueryClient.ts
@@ -102,7 +102,8 @@ export class LogsQueryClient {
         }
       }
     );
-
+    console.log("inside query logs .. ");
+    console.dir(result._response.parsedBody.tables[0].rows);
     return {
       tables: result.tables.map(convertGeneratedTable),
       statistics: result.statistics,

--- a/sdk/monitor/monitor-query/src/models/publicLogsModels.ts
+++ b/sdk/monitor/monitor-query/src/models/publicLogsModels.ts
@@ -120,5 +120,5 @@ export interface LogsTable {
   /** The list of columns in this table. */
   columns: LogsColumn[];
   /** The resulting rows from this query. */
-  rows: (Date | string | number | Record<string, unknown> | boolean)[][];
+  rows: (Date | string | number | boolean | Record<string, unknown>)[][];
 }

--- a/sdk/monitor/monitor-query/test/public/logsQueryClient.spec.ts
+++ b/sdk/monitor/monitor-query/test/public/logsQueryClient.spec.ts
@@ -154,7 +154,7 @@ describe("LogsQueryClient live tests", function() {
     });
   });
 
-  it("query with types", async () => {
+  it.only("query with types", async () => {
     const constantsQuery = `print "hello", true, make_datetime("2000-01-02 03:04:05Z"), toint(100), long(101), 102.1, dynamic({ "hello": "world" })
       | project 
           stringcolumn=print_0, 
@@ -173,7 +173,8 @@ describe("LogsQueryClient live tests", function() {
     );
 
     const table = results.tables[0];
-
+    console.dir(table);
+    console.dir(table.rows);
     // check the column types all match what we expect.
     assert.deepEqual(
       [


### PR DESCRIPTION
- Issue where rows that are being returned like the following 
[
  [
    { '0': 'h', '1': 'e', '2': 'l', '3': 'l', '4': 'o' },
    {},
    Invalid Date,
    {},
    {},
    {},
    '{"hello":"world"}'
  ]
]

instead of an array of strings/bool/date etc

The service returns this response - 
```
HTTP/1.1 200 OK
Date: Tue, 27 Jul 2021 21:32:48 GMT
Content-Type: application/json; charset=utf-8
Connection: close
Vary: Accept-Encoding
Strict-Transport-Security: max-age=15724800; includeSubDomains
via: 1.1 draft-oms-7456f684c8-4fc67
X-Content-Type-Options: nosniff
Access-Control-Allow-Origin: *
Access-Control-Expose-Headers: Retry-After,Age,WWW-Authenticate,x-resource-identities,x-ms-status-location
Vary: Accept-Encoding
Content-Length: 398



{"tables":[{"name":"PrimaryResult","columns":[{"name":"stringcolumn","type":"string"},{"name":"boolcolumn","type":"bool"},{"name":"datecolumn","type":"datetime"},{"name":"intcolumn","type":"int"},{"name":"longcolumn","type":"long"},{"name":"realcolumn","type":"real"},{"name":"dynamiccolumn","type":"dynamic"}],"rows":[["hello",true,"2000-01-02T03:04:05Z",100,101,102.1,"{\"hello\":\"world\"}"]]}]}
```
Somewhere the type conversions is not happening correctly. Need to look into the layers beneath our convenience layer. Tried debugging function `convertGeneratedTable` as shown in this PR - but not straightforward. 
Some caveats here : 

1. the workaround we did will no longer be applicable since we are moving to core v2 (see Deya's comment for possible solution - https://github.com/Azure/azure-sdk-for-js/pull/16606#discussion_r678713604 )
2. the conversion of the rows is not that easy - i tried debugging (see current PR)
3. I don't see other values like boolean, int and float being returned - wondering if that's a bug in the core or the swagger type conversion - bcz i can see these values in the raw response in Fiddler.
4. Thinking if this effort will be any use -> instead if I move to core v2 and then debug. Should I try debugging on top of this PR after the other issue with this PR resolves? - https://github.com/Azure/azure-sdk-for-js/pull/16606