### PR TITLE
Update samples after a package release

### DIFF
--- a/eng/pipelines/templates/stages/archetype-js-release.yml
+++ b/eng/pipelines/templates/stages/archetype-js-release.yml
@@ -181,11 +181,17 @@ stages:
                 name: azsdk-pool-mms-ubuntu-2004-general
                 vmImage: MMSUbuntu20.04
 
+              variables:
+                - template: /eng/pipelines/templates/variables/globals.yml
+
               strategy:
                 runOnce:
                   deploy:
                     steps:
                       - checkout: self
+
+                      - template: /eng/pipelines/templates/steps/common.yml
+
                       - bash: |
                           npm install
                         workingDirectory: ./eng/tools/versioning
@@ -195,12 +201,22 @@ stages:
                           node ./eng/tools/versioning/increment.js --artifact-name ${{ artifact.name }} --repo-root .
                         displayName: Increment package version
 
+                      - bash: |
+                          node common/scripts/install-run-rush.js install
+                        displayName: "Install dependencies"
+
+                      - bash: |
+                          npm install -g ./common/tools/dev-tool
+                          npm install ./eng/tools/eng-package-utils
+                          node ./eng/tools/eng-package-utils/update-samples.js ${{ artifact.name }}
+                        displayName: Update samples
+
                       - template: /eng/common/pipelines/templates/steps/create-pull-request.yml
                         parameters:
                           RepoName: azure-sdk-for-js
-                          PRBranchName: increment-package-version-${{ parameters.ServiceDirectory }}-$(Build.BuildId)
-                          CommitMsg: "Increment package version after release of ${{ artifact.name }}"
-                          PRTitle: "Increment version for ${{ parameters.ServiceDirectory }} releases"
+                          PRBranchName: post-release-automation-${{ parameters.ServiceDirectory }}-$(Build.BuildId)
+                          CommitMsg: "Post release automated changes for ${{ artifact.name }}"
+                          PRTitle: "Post release automated changes for ${{ parameters.ServiceDirectory }} releases"
                           PRLabels: "auto-merge"
                           CloseAfterOpenForTesting: '${{ parameters.TestPipeline }}'
 

--- a/eng/tools/eng-package-utils/update-samples.js
+++ b/eng/tools/eng-package-utils/update-samples.js
@@ -1,0 +1,45 @@
+const path = require("path");
+const process = require("process");
+const { spawnSync } = require("child_process");
+const { getRushSpec } = require("./index");
+
+
+const parseArgs = () => {
+  if (process.argv.some((a) => ["-h", "--help"].includes(a.toLowerCase())) || process.argv.length < 3) {
+    console.error("Usage: node update-samples.js <artifact-name>");
+    console.error("Example: node update-samples.js azure-storage-blob");
+  }
+
+  const [scriptPath, artifactName] = process.argv.slice(1);
+  const baseDir = path.resolve(`${path.dirname(scriptPath)}/../../..`);
+  return [baseDir, artifactName];
+};
+
+
+const spawnNode = (cwd, ...args) => {
+  console.log(`Executing: "dev-tool ${args.join(" ")}" in ${cwd}\n\n`);
+  const proc = spawnSync("dev-tool", args, { cwd, shell: true, stdio: "inherit" });
+  console.log(`\n\process exited with code ${proc.status}`);
+  if (proc.status !== 0) {
+    process.exitCode = proc.status || 1;
+  }
+  return proc.status
+};
+
+async function main(repoRoot, artifactName) {
+  var rushSpec = await getRushSpec(repoRoot);
+  //Find project root directory using information in rush.json
+  const targetPackage = rushSpec.projects.find(
+    (packageSpec) => packageSpec.packageName.replace("@", "").replace("/", "-") == artifactName
+  );
+
+  if (!targetPackage) {
+    console.error(`Package is not found in rush.json for artifact ${artifactName}`);
+    return;
+  }
+  console.log(`Running samples update for package ${targetPackage.packageName}`);
+  spawnNode(targetPackage.projectFolder, "samples publish --force");
+};
+
+const [repoRoot, artifactName] = parseArgs();
+main(repoRoot, artifactName);


### PR DESCRIPTION
Update samples after package release so samples are refreshed using latest code. This will be later used by samples publishing automation.