### PR TITLE
[Attestation] Fix a duplication issue in user-agent string

### DIFF
--- a/sdk/attestation/attestation/package.json
+++ b/sdk/attestation/attestation/package.json
@@ -17,8 +17,12 @@
   "//metadata": {
     "constantPaths": [
       {
-        "path": "src/constants.ts",
-        "prefix": "SDK_VERSION"
+        "path": "src/generated/generatedClientContext.ts",
+        "prefix": "packageVersion"
+      },
+      {
+        "path": "swagger/README.md",
+        "prefix": "package-version"
       }
     ]
   },

--- a/sdk/attestation/attestation/src/attestationAdministrationClient.ts
+++ b/sdk/attestation/attestation/src/attestationAdministrationClient.ts
@@ -3,7 +3,6 @@
 
 import { SpanStatusCode } from "@azure/core-tracing";
 
-import { SDK_VERSION } from "./constants";
 import { GeneratedClient } from "./generated/generatedClient";
 
 import { logger } from "./logger";
@@ -101,17 +100,6 @@ export class AttestationAdministrationClient {
     credentials: TokenCredential,
     options: AttestationAdministrationClientOptions = {}
   ) {
-    // The below code helps us set a proper User-Agent header on all requests
-    const libInfo = `azsdk-js-api-security-attestation/${SDK_VERSION}`;
-    if (!options.userAgentOptions) {
-      options.userAgentOptions = {};
-    }
-    if (options.userAgentOptions.userAgentPrefix) {
-      options.userAgentOptions.userAgentPrefix = `${options.userAgentOptions.userAgentPrefix} ${libInfo}`;
-    } else {
-      options.userAgentOptions.userAgentPrefix = libInfo;
-    }
-
     this._validationOptions = options.validationOptions;
 
     const internalPipelineOptions: GeneratedClientOptionalParams = {

--- a/sdk/attestation/attestation/src/attestationClient.ts
+++ b/sdk/attestation/attestation/src/attestationClient.ts
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { SDK_VERSION } from "./constants";
 import { GeneratedClient } from "./generated/generatedClient";
 
 import { AttestationSigner, AttestationTokenValidationOptions, AttestationResult } from "./models";
@@ -163,17 +162,6 @@ export class AttestationClient {
    */
 
   constructor(endpoint: string, options: AttestationClientOptions = {}) {
-    // The below code helps us set a proper User-Agent header on all requests
-    const libInfo = `azsdk-js-api-security-attestation/${SDK_VERSION}`;
-    if (!options.userAgentOptions) {
-      options.userAgentOptions = {};
-    }
-    if (options.userAgentOptions.userAgentPrefix) {
-      options.userAgentOptions.userAgentPrefix = `${options.userAgentOptions.userAgentPrefix} ${libInfo}`;
-    } else {
-      options.userAgentOptions.userAgentPrefix = libInfo;
-    }
-
     let credentialScopes: string[] | undefined = undefined;
     if (options.credentials) {
       credentialScopes = ["https://attest.azure.net/.default"];

--- a/sdk/attestation/attestation/src/constants.ts
+++ b/sdk/attestation/attestation/src/constants.ts
@@ -1,4 +1,0 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT license.
-
-export const SDK_VERSION: string = "1.0.0-beta.5";

--- a/sdk/attestation/attestation/src/generated/generatedClientContext.ts
+++ b/sdk/attestation/attestation/src/generated/generatedClientContext.ts
@@ -31,7 +31,8 @@ export class GeneratedClientContext extends coreClient.ServiceClient {
       requestContentType: "application/json; charset=utf-8"
     };
 
-    const packageDetails = `azsdk-js-attestation/1.0.0-beta.2`;
+    const packageVersion = "1.0.0-beta.5";
+    const packageDetails = `azsdk-js-attestation/${packageVersion}`;
     const userAgentPrefix =
       options.userAgentOptions && options.userAgentOptions.userAgentPrefix
         ? `${options.userAgentOptions.userAgentPrefix} ${packageDetails}`


### PR DESCRIPTION
Related to https://github.com/Azure/azure-sdk-for-js/issues/16623 and https://github.com/Azure/autorest.typescript/issues/1125

The user-agent header attestation sends with their requests: "user-agent":"azsdk-js-api-security-attestation/1.0.0 azsdk-js-attestation/1.0.0 core-rest-pipeline/1.1.2 Node/v14.17.0 OS/(x64-Linux-5.10.16.3-microsoft-standard-WSL2)" and you can notice that attestation version comes up twice. 

This PR fixes this issue by 
- removing the logic to set the user agent in the clients constructor so that the user agent is only set in the auto-generated context class. 
- factoring out the version string in the context class to its own variable and add that to the constantsPath list in `package.json` so the post-release bot can update it.
- add the `package-version` variable in `swagger/README.md` to the constantsPath list in `package.json` so the post-release bot can update it.