### PR TITLE
Fix agent-string in packages migrated to use core v2

### DIFF
--- a/sdk/eventgrid/eventgrid/package.json
+++ b/sdk/eventgrid/eventgrid/package.json
@@ -50,8 +50,8 @@
         "prefix": "package-version"
       },
       {
-        "path": "src/constants.ts",
-        "prefix": "SDK_VERSION"
+        "path": "src/generated/generatedClientContext.ts",
+        "prefix": "packageDetails"
       }
     ]
   },

--- a/sdk/eventgrid/eventgrid/src/constants.ts
+++ b/sdk/eventgrid/eventgrid/src/constants.ts
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-export const SDK_VERSION: string = "4.4.1";
 export const DEFAULT_API_VERSION = "2018-01-01";
 export const DEFAULT_EVENTGRID_SCOPE = "https://eventgrid.azure.net/.default";

--- a/sdk/eventgrid/eventgrid/src/eventGridClient.ts
+++ b/sdk/eventgrid/eventgrid/src/eventGridClient.ts
@@ -5,7 +5,7 @@ import { isTokenCredential, KeyCredential, SASCredential } from "@azure/core-aut
 import { OperationOptions, CommonClientOptions } from "@azure/core-client";
 
 import { eventGridCredentialPolicy } from "./eventGridAuthenticationPolicy";
-import { SDK_VERSION, DEFAULT_EVENTGRID_SCOPE } from "./constants";
+import { DEFAULT_EVENTGRID_SCOPE } from "./constants";
 import {
   SendCloudEventInput,
   SendEventGridEventInput,
@@ -109,20 +109,7 @@ export class EventGridPublisherClient<T extends InputSchema> {
     this.endpointUrl = endpointUrl;
     this.inputSchema = inputSchema;
 
-    const libInfo = `azsdk-js-eventgrid/${SDK_VERSION}`;
-    const pipelineOptions = { ...options };
-
-    if (!pipelineOptions.userAgentOptions) {
-      pipelineOptions.userAgentOptions = {};
-    }
-
-    if (pipelineOptions.userAgentOptions.userAgentPrefix) {
-      pipelineOptions.userAgentOptions.userAgentPrefix = `${pipelineOptions.userAgentOptions.userAgentPrefix} ${libInfo}`;
-    } else {
-      pipelineOptions.userAgentOptions.userAgentPrefix = libInfo;
-    }
-
-    this.client = new GeneratedClient(pipelineOptions);
+    this.client = new GeneratedClient(options);
 
     const authPolicy = isTokenCredential(credential)
       ? bearerTokenAuthenticationPolicy({ credential, scopes: DEFAULT_EVENTGRID_SCOPE })

--- a/sdk/keyvault/keyvault-admin/package.json
+++ b/sdk/keyvault/keyvault-admin/package.json
@@ -78,6 +78,10 @@
         "prefix": "packageDetails"
       },
       {
+        "path": "src/constants.ts",
+        "prefix": "SDK_VERSION"
+      },
+      {
         "path": "swagger/README.md",
         "prefix": "package-version"
       }

--- a/sdk/keyvault/keyvault-admin/package.json
+++ b/sdk/keyvault/keyvault-admin/package.json
@@ -75,11 +75,7 @@
     "constantPaths": [
       {
         "path": "src/generated/keyVaultClientContext.ts",
-        "prefix": "packageVersion"
-      },
-      {
-        "path": "src/constants.ts",
-        "prefix": "SDK_VERSION"
+        "prefix": "packageDetails"
       },
       {
         "path": "swagger/README.md",

--- a/sdk/keyvault/keyvault-admin/src/accessControlClient.ts
+++ b/sdk/keyvault/keyvault-admin/src/accessControlClient.ts
@@ -26,7 +26,7 @@ import {
   DeleteRoleDefinitionOptions
 } from "./accessControlModels";
 
-import { SDK_VERSION, LATEST_API_VERSION, authenticationScopes } from "./constants";
+import { LATEST_API_VERSION, authenticationScopes } from "./constants";
 import { mappings } from "./mappings";
 import { logger } from "./log";
 import { v4 as v4uuid } from "uuid";
@@ -75,17 +75,6 @@ export class KeyVaultAccessControlClient {
     options: AccessControlClientOptions = {}
   ) {
     this.vaultUrl = vaultUrl;
-
-    const libInfo = `azsdk-js-keyvault-admin/${SDK_VERSION}`;
-
-    const userAgentOptions = options.userAgentOptions;
-
-    options.userAgentOptions = {
-      userAgentPrefix:
-        userAgentOptions && userAgentOptions.userAgentPrefix
-          ? `${userAgentOptions.userAgentPrefix} ${libInfo}`
-          : libInfo
-    };
 
     const serviceVersion = options.serviceVersion || LATEST_API_VERSION;
 

--- a/sdk/keyvault/keyvault-admin/src/backupClient.ts
+++ b/sdk/keyvault/keyvault-admin/src/backupClient.ts
@@ -13,7 +13,7 @@ import {
   KeyVaultRestoreResult,
   KeyVaultSelectiveKeyRestoreResult
 } from "./backupClientModels";
-import { LATEST_API_VERSION, SDK_VERSION, authenticationScopes } from "./constants";
+import { LATEST_API_VERSION, authenticationScopes } from "./constants";
 import { logger } from "./log";
 import { KeyVaultBackupPoller } from "./lro/backup/poller";
 import { KeyVaultRestorePoller } from "./lro/restore/poller";
@@ -75,17 +75,6 @@ export class KeyVaultBackupClient {
     options: KeyVaultBackupClientOptions = {}
   ) {
     this.vaultUrl = vaultUrl;
-
-    const libInfo = `azsdk-js-keyvault-admin/${SDK_VERSION}`;
-
-    const userAgentOptions = options.userAgentOptions;
-
-    options.userAgentOptions = {
-      userAgentPrefix:
-        userAgentOptions && userAgentOptions.userAgentPrefix
-          ? `${userAgentOptions.userAgentPrefix} ${libInfo}`
-          : libInfo
-    };
 
     const apiVersion = options.serviceVersion || LATEST_API_VERSION;
 

--- a/sdk/keyvault/keyvault-admin/src/constants.ts
+++ b/sdk/keyvault/keyvault-admin/src/constants.ts
@@ -2,6 +2,11 @@
 // Licensed under the MIT license.
 
 /**
+ * Current version of the Key Vault Admin SDK.
+ */
+export const SDK_VERSION: string = "4.1.0-beta.2";
+
+/**
  * The latest supported Key Vault service API version.
  */
 export const LATEST_API_VERSION = "7.2";

--- a/sdk/keyvault/keyvault-admin/src/constants.ts
+++ b/sdk/keyvault/keyvault-admin/src/constants.ts
@@ -2,11 +2,6 @@
 // Licensed under the MIT license.
 
 /**
- * Current version of the Key Vault Admin SDK.
- */
-export const SDK_VERSION: string = "4.1.0-beta.2";
-
-/**
  * The latest supported Key Vault service API version.
  */
 export const LATEST_API_VERSION = "7.2";

--- a/sdk/remoterendering/mixed-reality-remote-rendering/package.json
+++ b/sdk/remoterendering/mixed-reality-remote-rendering/package.json
@@ -12,12 +12,12 @@
   "//metadata": {
     "constantPaths": [
       {
-        "path": "src/generated/generatedClientContext.ts",
-        "prefix": "packageVersion"
+        "path": "swagger/README.md",
+        "prefix": "package-version"
       },
       {
-        "path": "src/constants.ts",
-        "prefix": "SDK_VERSION"
+        "path": "src/generated/generatedClientContext.ts",
+        "prefix": "packageDetails"
       }
     ]
   },

--- a/sdk/schemaregistry/schema-registry/package.json
+++ b/sdk/schemaregistry/schema-registry/package.json
@@ -43,7 +43,7 @@
     "constantPaths": [
       {
         "path": "src/generated/generatedSchemaRegistryClientContext.ts",
-        "prefix": "packageVersion"
+        "prefix": "packageDetails"
       },
       {
         "path": "swagger/README.md",

--- a/sdk/textanalytics/ai-text-analytics/package.json
+++ b/sdk/textanalytics/ai-text-analytics/package.json
@@ -32,11 +32,11 @@
     "constantPaths": [
       {
         "path": "src/generated/generatedClientContext.ts",
-        "prefix": "packageVersion"
+        "prefix": "packageDetails"
       },
       {
-        "path": "src/constants.ts",
-        "prefix": "SDK_VERSION"
+        "path": "swagger/README.md",
+        "prefix": "package-version"
       }
     ]
   },

--- a/sdk/textanalytics/ai-text-analytics/src/constants.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/constants.ts
@@ -1,7 +1,0 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT license.
-
-/**
- * @internal
- */
-export const SDK_VERSION: string = "5.1.1";

--- a/sdk/textanalytics/ai-text-analytics/src/textAnalyticsClient.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/textAnalyticsClient.ts
@@ -7,7 +7,6 @@ import {
   bearerTokenAuthenticationPolicy
 } from "@azure/core-rest-pipeline";
 import { TokenCredential, KeyCredential, isTokenCredential } from "@azure/core-auth";
-import { SDK_VERSION } from "./constants";
 import { GeneratedClient } from "./generated/generatedClient";
 import { logger } from "./logger";
 import {
@@ -372,16 +371,6 @@ export class TextAnalyticsClient {
     const { defaultCountryHint = "us", defaultLanguage = "en", ...pipelineOptions } = options;
     this.defaultCountryHint = defaultCountryHint;
     this.defaultLanguage = defaultLanguage;
-
-    const libInfo = `azsdk-js-ai-textanalytics/${SDK_VERSION}`;
-    if (!pipelineOptions.userAgentOptions) {
-      pipelineOptions.userAgentOptions = {};
-    }
-    if (pipelineOptions.userAgentOptions.userAgentPrefix) {
-      pipelineOptions.userAgentOptions.userAgentPrefix = `${pipelineOptions.userAgentOptions.userAgentPrefix} ${libInfo}`;
-    } else {
-      pipelineOptions.userAgentOptions.userAgentPrefix = libInfo;
-    }
 
     const internalPipelineOptions: InternalPipelineOptions = {
       ...pipelineOptions,

--- a/sdk/web-pubsub/web-pubsub/package.json
+++ b/sdk/web-pubsub/web-pubsub/package.json
@@ -41,6 +41,18 @@
     "README.md",
     "LICENSE"
   ],
+  "//metadata": {
+    "constantPaths": [
+      {
+        "path": "src/generated/generatedClientContext.ts",
+        "prefix": "packageDetails"
+      },
+      {
+        "path": "swagger/README.md",
+        "prefix": "package-version"
+      }
+    ]
+  },
   "browser": {
     "./dist-esm/src/util/url.js": "./dist-esm/src/util/url.browser.js"
   },


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-sdk-for-js/issues/16623

@ramya-rao-a noticed in https://github.com/Azure/azure-sdk-for-js/pull/15777#discussion_r653112105 that we could end up with duplicate versions in the agent-string header in our requests in packages that migrated to use core v2 because the code generator became smarter and now generates code that handles that for us. I noticed the same thing happening in attestation as well in https://github.com/Azure/azure-sdk-for-js/pull/16619#discussion_r678591391.

This PR fixes this issue for all data-plane packages that migrated to use core v2.

Note that 
- I intentionally left out tables because it needs to be regenerated with a later version of the code generator first so that it gets the auto-generated handling of the agent-string. I created https://github.com/Azure/azure-sdk-for-js/issues/16627 for tracking.
- I did not delete `SDK_VERSION` in kv-admin because it is exported!