### PR TITLE
[KeyVault] - Porting changelog entries and updating versions after release

### DIFF
--- a/sdk/keyvault/keyvault-admin/CHANGELOG.md
+++ b/sdk/keyvault/keyvault-admin/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 4.1.0-beta.2 (Unreleased)
+## 4.2.0-beta.1 (Unreleased)
 
 ### Features Added
 
@@ -9,6 +9,14 @@
 ### Bugs Fixed
 
 ### Other Changes
+
+## 4.1.0 (2021-07-29)
+
+### New Features
+
+- Support for Node.js 8 and IE 11 has been dropped. Please see our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
+- Changed TS compilation target to ES2017 to produce smaller bundles and use more native platform features.
+- Updated our internal core package dependencies to their latest versions to add support for Opentelemetry 1.0.0, which is compatible with the latest versions of our other client libraries.
 
 ## 4.1.0-beta.1 (2021-07-07)
 

--- a/sdk/keyvault/keyvault-admin/package.json
+++ b/sdk/keyvault/keyvault-admin/package.json
@@ -2,7 +2,7 @@
   "name": "@azure/keyvault-admin",
   "sdk-type": "client",
   "author": "Microsoft Corporation",
-  "version": "4.1.0-beta.2",
+  "version": "4.2.0-beta.1",
   "license": "MIT",
   "description": "Isomorphic client library for Azure KeyVault's administrative functions.",
   "homepage": "https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/keyvault/keyvault-admin/README.md",

--- a/sdk/keyvault/keyvault-admin/src/constants.ts
+++ b/sdk/keyvault/keyvault-admin/src/constants.ts
@@ -4,7 +4,7 @@
 /**
  * Current version of the Key Vault Admin SDK.
  */
-export const SDK_VERSION: string = "4.1.0-beta.2";
+export const SDK_VERSION: string = "4.2.0-beta.1";
 
 /**
  * The latest supported Key Vault service API version.

--- a/sdk/keyvault/keyvault-admin/src/generated/keyVaultClientContext.ts
+++ b/sdk/keyvault/keyvault-admin/src/generated/keyVaultClientContext.ts
@@ -35,7 +35,7 @@ export class KeyVaultClientContext extends coreClient.ServiceClient {
       requestContentType: "application/json; charset=utf-8"
     };
 
-    const packageDetails = `azsdk-js-keyvault-admin/4.1.0-beta.1`;
+    const packageDetails = `azsdk-js-keyvault-admin/4.2.0-beta.1`;
     const userAgentPrefix =
       options.userAgentOptions && options.userAgentOptions.userAgentPrefix
         ? `${options.userAgentOptions.userAgentPrefix} ${packageDetails}`

--- a/sdk/keyvault/keyvault-admin/src/generated/keyVaultClientContext.ts
+++ b/sdk/keyvault/keyvault-admin/src/generated/keyVaultClientContext.ts
@@ -9,7 +9,7 @@
 import * as coreClient from "@azure/core-client";
 import { ApiVersion72, KeyVaultClientOptionalParams } from "./models";
 
-export const packageVersion = "4.1.0-beta.2";
+export const packageVersion = "4.2.0-beta.1";
 
 export class KeyVaultClientContext extends coreClient.ServiceClient {
   apiVersion: ApiVersion72;

--- a/sdk/keyvault/keyvault-admin/swagger/README.md
+++ b/sdk/keyvault/keyvault-admin/swagger/README.md
@@ -15,7 +15,7 @@ input-file:
   - https://raw.githubusercontent.com/Azure/azure-rest-api-specs/1e2c9f3ec93078da8078389941531359e274f32a/specification/keyvault/data-plane/Microsoft.KeyVault/stable/7.2/backuprestore.json
 output-folder: ../
 source-code-folder-path: ./src/generated
-package-version: 4.1.0-beta.2
+package-version: 4.2.0-beta.1
 ```
 
 ### Hide LROs

--- a/sdk/keyvault/keyvault-keys/CHANGELOG.md
+++ b/sdk/keyvault/keyvault-keys/CHANGELOG.md
@@ -1,18 +1,28 @@
 # Release History
 
-## 4.3.0-beta.2 (Unreleased)
+## 4.4.0-beta.1 (Unreleased)
 
 ### Features Added
 
 - Added support for Secure key Release from a Managed HSM.
   - Added `KeyClient.releaseKey` to release a key from a Managed HSM.
   - Added `exportable` and `releasePolicy` to `KeyVaultKey.properties`, `createKeyOptions`, and `importKeyOptions` in order to specify whether the key is exportable and the associated release policy.
+- Added support for `KeyClient.getRandomBytes` which, when connected to a managed HSM, can be used to generate a byte array of a given length with random values.
+- Updated the service version to 7.3-preview.
 
 ### Breaking Changes
 
 ### Bugs Fixed
 
 ### Other Changes
+
+## 4.3.0 (2021-07-29)
+
+### New Features
+
+- Support for Node.js 8 and IE 11 has been dropped. Please see our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
+- Changed TS compilation target to ES2017 to produce smaller bundles and use more native platform features.
+- Updated our internal core package dependencies to their latest versions to add support for Opentelemetry 1.0.0, which is compatible with the latest versions of our other client libraries.
 
 ## 4.3.0-beta.1 (2021-07-07)
 

--- a/sdk/keyvault/keyvault-keys/package.json
+++ b/sdk/keyvault/keyvault-keys/package.json
@@ -2,7 +2,7 @@
   "name": "@azure/keyvault-keys",
   "sdk-type": "client",
   "author": "Microsoft Corporation",
-  "version": "4.3.0-beta.2",
+  "version": "4.4.0-beta.1",
   "license": "MIT",
   "description": "Isomorphic client library for Azure KeyVault's keys.",
   "homepage": "https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/keyvault/keyvault-keys/README.md",

--- a/sdk/keyvault/keyvault-keys/src/constants.ts
+++ b/sdk/keyvault/keyvault-keys/src/constants.ts
@@ -1,4 +1,4 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-export const SDK_VERSION: string = "4.3.0-beta.2";
+export const SDK_VERSION: string = "4.4.0-beta.1";

--- a/sdk/keyvault/keyvault-keys/src/generated/keyVaultClientContext.ts
+++ b/sdk/keyvault/keyvault-keys/src/generated/keyVaultClientContext.ts
@@ -10,7 +10,7 @@ import * as coreHttp from "@azure/core-http";
 import { ApiVersion73Preview, KeyVaultClientOptionalParams } from "./models";
 
 const packageName = "@azure/keyvault-keys";
-export const packageVersion = "4.3.0-beta.2";
+export const packageVersion = "4.4.0-beta.1";
 
 export class KeyVaultClientContext extends coreHttp.ServiceClient {
   apiVersion: ApiVersion73Preview;


### PR DESCRIPTION
We released @azure/keyvault-admin@4.1.0 and @azure/keyvault-keys@4.3.0 off of a hotfix branch because we already had
betas out for the next release. 

So what this PR does is port over all the CHANGELOG entries from the hotfix branch as well as update the version numbers to reflect the new betas.