### PR TITLE
Exclude packages failing daily docs.ms build

### DIFF
--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -256,6 +256,7 @@ function ValidatePackagesForDocs($packages) {
 $PackageExclusions = @{ 
   '@azure/identity-vscode' = 'Fails type2docfx execution https://github.com/Azure/azure-sdk-for-js/issues/16303';
   '@azure/identity-cache-persistence' = 'Fails typedoc2fx execution https://github.com/Azure/azure-sdk-for-js/issues/16310';
+  '@azure-rest/core-client-paging'    = 'Cannot find types/latest/core-client-paging-rest.d.ts https://github.com/Azure/azure-sdk-for-js/issues/16677';
 }
 
 function Update-javascript-DocsMsPackages($DocsRepoLocation, $DocsMetadata) {

--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -257,6 +257,7 @@ $PackageExclusions = @{
   '@azure/identity-vscode' = 'Fails type2docfx execution https://github.com/Azure/azure-sdk-for-js/issues/16303';
   '@azure/identity-cache-persistence' = 'Fails typedoc2fx execution https://github.com/Azure/azure-sdk-for-js/issues/16310';
   '@azure-rest/core-client-paging'    = 'Cannot find types/latest/core-client-paging-rest.d.ts https://github.com/Azure/azure-sdk-for-js/issues/16677';
+  '@azure/core-asynciterator-polyfill' = 'Docs CI fails https://github.com/Azure/azure-sdk-for-js/issues/16675'
 }
 
 function Update-javascript-DocsMsPackages($DocsRepoLocation, $DocsMetadata) {


### PR DESCRIPTION
Excluding these packages from being onboarded when they release to daily feed (and are onboarded in daily docs), ship a new version to preview, or ship a new version to GA. 

Existing entries will remain. This change only prevents new versions from updating the existing onboarding entries.