### PR TITLE
[KeyVault] - Update getRandomBytes to return a model

### DIFF
--- a/sdk/keyvault/keyvault-keys/review/keyvault-keys.api.md
+++ b/sdk/keyvault/keyvault-keys/review/keyvault-keys.api.md
@@ -417,7 +417,7 @@ export interface PurgeDeletedKeyOptions extends coreHttp.OperationOptions {
 
 // @public
 export interface RandomBytes {
-    result: Uint8Array;
+    bytes: Uint8Array;
 }
 
 // @public

--- a/sdk/keyvault/keyvault-keys/review/keyvault-keys.api.md
+++ b/sdk/keyvault/keyvault-keys/review/keyvault-keys.api.md
@@ -226,7 +226,7 @@ export class KeyClient {
     createRsaKey(name: string, options?: CreateRsaKeyOptions): Promise<KeyVaultKey>;
     getDeletedKey(name: string, options?: GetDeletedKeyOptions): Promise<DeletedKey>;
     getKey(name: string, options?: GetKeyOptions): Promise<KeyVaultKey>;
-    getRandomBytes(count: number, options?: GetRandomBytesOptions): Promise<Uint8Array>;
+    getRandomBytes(count: number, options?: GetRandomBytesOptions): Promise<RandomBytes>;
     importKey(name: string, key: JsonWebKey, options?: ImportKeyOptions): Promise<KeyVaultKey>;
     listDeletedKeys(options?: ListDeletedKeysOptions): PagedAsyncIterableIterator<DeletedKey>;
     listPropertiesOfKeys(options?: ListPropertiesOfKeysOptions): PagedAsyncIterableIterator<KeyProperties>;
@@ -413,6 +413,11 @@ export { PollOperationState }
 
 // @public
 export interface PurgeDeletedKeyOptions extends coreHttp.OperationOptions {
+}
+
+// @public
+export interface RandomBytes {
+    result: Uint8Array;
 }
 
 // @public

--- a/sdk/keyvault/keyvault-keys/src/index.ts
+++ b/sdk/keyvault/keyvault-keys/src/index.ts
@@ -671,7 +671,7 @@ export class KeyClient {
    * Example usage:
    * ```ts
    * let client = new KeyClient(vaultUrl, credentials);
-   * let bytes = await client.getRandomBytes(10);
+   * let { iv: result } = await client.getRandomBytes(10);
    * ```
    * @param count - The number of bytes to generate between 1 and 128 inclusive.
    * @param options - The optional parameters.

--- a/sdk/keyvault/keyvault-keys/src/index.ts
+++ b/sdk/keyvault/keyvault-keys/src/index.ts
@@ -671,7 +671,7 @@ export class KeyClient {
    * Example usage:
    * ```ts
    * let client = new KeyClient(vaultUrl, credentials);
-   * let { iv: result } = await client.getRandomBytes(10);
+   * let { bytes } = await client.getRandomBytes(10);
    * ```
    * @param count - The number of bytes to generate between 1 and 128 inclusive.
    * @param options - The optional parameters.
@@ -679,7 +679,7 @@ export class KeyClient {
   public getRandomBytes(count: number, options: GetRandomBytesOptions = {}): Promise<RandomBytes> {
     return withTrace("getRandomBytes", options, async (updatedOptions) => {
       const response = await this.client.getRandomBytes(this.vaultUrl, count, updatedOptions);
-      return { result: response.value! };
+      return { bytes: response.value! };
     });
   }
 

--- a/sdk/keyvault/keyvault-keys/src/index.ts
+++ b/sdk/keyvault/keyvault-keys/src/index.ts
@@ -64,7 +64,8 @@ import {
   ReleaseKeyOptions,
   ReleaseKeyResult,
   KeyReleasePolicy,
-  KeyExportEncryptionAlgorithm
+  KeyExportEncryptionAlgorithm,
+  RandomBytes
 } from "./keysModels";
 
 import { CryptographyClient } from "./cryptographyClient";
@@ -142,6 +143,7 @@ export {
   GetDeletedKeyOptions,
   GetKeyOptions,
   GetRandomBytesOptions,
+  RandomBytes,
   ImportKeyOptions,
   JsonWebKey,
   KeyCurveName,
@@ -674,10 +676,10 @@ export class KeyClient {
    * @param count - The number of bytes to generate between 1 and 128 inclusive.
    * @param options - The optional parameters.
    */
-  public getRandomBytes(count: number, options: GetRandomBytesOptions = {}): Promise<Uint8Array> {
+  public getRandomBytes(count: number, options: GetRandomBytesOptions = {}): Promise<RandomBytes> {
     return withTrace("getRandomBytes", options, async (updatedOptions) => {
       const response = await this.client.getRandomBytes(this.vaultUrl, count, updatedOptions);
-      return response.value!;
+      return { result: response.value! };
     });
   }
 

--- a/sdk/keyvault/keyvault-keys/src/keysModels.ts
+++ b/sdk/keyvault/keyvault-keys/src/keysModels.ts
@@ -592,5 +592,5 @@ export type KeyExportEncryptionAlgorithm = string;
  */
 export interface RandomBytes {
   /** The random bytes returned by the service. */
-  result: Uint8Array;
+  bytes: Uint8Array;
 }

--- a/sdk/keyvault/keyvault-keys/src/keysModels.ts
+++ b/sdk/keyvault/keyvault-keys/src/keysModels.ts
@@ -553,17 +553,17 @@ export interface ReleaseKeyResult {
 export enum KnownKeyOperations {
   /** Key operation - encrypt */
   Encrypt = "encrypt",
-  /** Key operation - encrypt */
+  /** Key operation - decrypt */
   Decrypt = "decrypt",
-  /** Key operation - encrypt */
+  /** Key operation - sign */
   Sign = "sign",
-  /** Key operation - encrypt */
+  /** Key operation - verify */
   Verify = "verify",
-  /** Key operation - encrypt */
+  /** Key operation - wrapKey */
   WrapKey = "wrapKey",
-  /** Key operation - encrypt */
+  /** Key operation - unwrapKey */
   UnwrapKey = "unwrapKey",
-  /** Key operation - encrypt */
+  /** Key operation - import */
   Import = "import"
 }
 
@@ -586,3 +586,11 @@ export enum KnownKeyExportEncryptionAlgorithm {
  */
 export type KeyExportEncryptionAlgorithm = string;
 /* eslint-enable tsdoc/syntax */
+
+/**
+ * Result of the {@link KeyClient.getRandomBytes} operation.
+ */
+export interface RandomBytes {
+  /** The random bytes returned by the service. */
+  result: Uint8Array;
+}

--- a/sdk/keyvault/keyvault-keys/test/public/keyClient.hsm.spec.ts
+++ b/sdk/keyvault/keyvault-keys/test/public/keyClient.hsm.spec.ts
@@ -55,8 +55,8 @@ onVersions({ minVer: "7.2" }).describe(
     onVersions({ minVer: "7.3-preview" }).describe("getRandomBytes", () => {
       it("can return the required number of bytes", async () => {
         const randomBytes = await hsmClient.getRandomBytes(10);
-        assert.exists(randomBytes);
-        assert.equal(randomBytes!.length, 10);
+        assert.exists(randomBytes.result);
+        assert.equal(randomBytes.result.length, 10);
       });
 
       it("returns an error when bytes is out of range", async () => {

--- a/sdk/keyvault/keyvault-keys/test/public/keyClient.hsm.spec.ts
+++ b/sdk/keyvault/keyvault-keys/test/public/keyClient.hsm.spec.ts
@@ -54,9 +54,9 @@ onVersions({ minVer: "7.2" }).describe(
 
     onVersions({ minVer: "7.3-preview" }).describe("getRandomBytes", () => {
       it("can return the required number of bytes", async () => {
-        const randomBytes = await hsmClient.getRandomBytes(10);
-        assert.exists(randomBytes.result);
-        assert.equal(randomBytes.result.length, 10);
+        const result = await hsmClient.getRandomBytes(10);
+        assert.exists(result.bytes);
+        assert.equal(result.bytes.length, 10);
       });
 
       it("returns an error when bytes is out of range", async () => {


### PR DESCRIPTION
## What

- Update `getRandomBytes` to return a model instead of the raw bytes

## Why

This came up from an architecture feedback, where we are deviating from the guidelines by returning the raw bytes.
Returning the model instead conforms to our guidelines, is consistent with other operations, and is extensible.