### PR TITLE
fix check-node-versions command

### DIFF
--- a/common/tools/dev-tool/src/commands/samples/checkNodeVersions.ts
+++ b/common/tools/dev-tool/src/commands/samples/checkNodeVersions.ts
@@ -269,7 +269,12 @@ export const commandInfo = makeCommandInfo(
 
 export default leafCommand(commandInfo, async (options) => {
   const nodeVersions = [
-    ...new Set(options["node-versions"]?.split(",").concat(options["node-version"]))
+    ...new Set(
+      options["node-versions"]
+        ?.split(",")
+        .concat(options["node-version"])
+        .filter((ver) => ver !== "" && parseInt(ver) !== NaN)
+    )
   ];
   const dockerContextDirectory: string =
     options["context-directory-path"] === ""


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-sdk-for-js/issues/16657

The default value for `--node-version` is the empty string so if the caller did not provide it, they will end up with an empty string in the list of node versions to test and because no such docker image exists, the command will fail. This PR fixes this issue by filtering out empty strings and non-numerical inputs.