### PR TITLE
[Cred Scan] Generate fake key instead of putting directly in the test file

### DIFF
--- a/sdk/eventgrid/eventgrid/test/public/generateSharedAccessSignature.spec.ts
+++ b/sdk/eventgrid/eventgrid/test/public/generateSharedAccessSignature.spec.ts
@@ -3,12 +3,14 @@
 
 import { assert } from "chai";
 import { AzureKeyCredential, generateSharedAccessSignature } from "../../src";
+import { isNode } from "@azure/test-utils";
 
-describe("generateSharedAccessSignature", function() {
+describe("generateSharedAccessSignature", function () {
   it("generates the correct signiture", async () => {
     // This is not a real key, it's the base64 encoding of "this is not a real EventGrid key", which happens to be the same
     // number of bytes as an actual EventGrid Access Key.
-    const key = Buffer.from("this is not a real EventGrid key").toString("base64");
+    const keyAsString = "this is not a real EventGrid key";
+    const key = isNode ? Buffer.from(keyAsString).toString("base64") : btoa(keyAsString);
     const topicUrl = "https://eg-topic.westus-2.eventgrid.azure.net/api/events";
 
     const sig = await generateSharedAccessSignature(

--- a/sdk/eventgrid/eventgrid/test/public/generateSharedAccessSignature.spec.ts
+++ b/sdk/eventgrid/eventgrid/test/public/generateSharedAccessSignature.spec.ts
@@ -4,11 +4,11 @@
 import { assert } from "chai";
 import { AzureKeyCredential, generateSharedAccessSignature } from "../../src";
 
-describe("generateSharedAccessSignature", function() {
+describe("generateSharedAccessSignature", function () {
   it("generates the correct signiture", async () => {
     // This is not a real key, it's the base64 encoding of "this is not a real EventGrid key", which happens to be the same
     // number of bytes as an actual EventGrid Access Key.
-    const key = "dGhpcyBpcyBub3QgYSByZWFsIEV2ZW50R3JpZCBrZXk=";
+    const key = Buffer.from("this is not a real EventGrid key").toString('base64');
     const topicUrl = "https://eg-topic.westus-2.eventgrid.azure.net/api/events";
 
     const sig = await generateSharedAccessSignature(

--- a/sdk/eventgrid/eventgrid/test/public/generateSharedAccessSignature.spec.ts
+++ b/sdk/eventgrid/eventgrid/test/public/generateSharedAccessSignature.spec.ts
@@ -5,7 +5,7 @@ import { assert } from "chai";
 import { AzureKeyCredential, generateSharedAccessSignature } from "../../src";
 import { isNode } from "@azure/test-utils";
 
-describe("generateSharedAccessSignature", function () {
+describe("generateSharedAccessSignature", function() {
   it("generates the correct signiture", async () => {
     // This is not a real key, it's the base64 encoding of "this is not a real EventGrid key", which happens to be the same
     // number of bytes as an actual EventGrid Access Key.

--- a/sdk/eventgrid/eventgrid/test/public/generateSharedAccessSignature.spec.ts
+++ b/sdk/eventgrid/eventgrid/test/public/generateSharedAccessSignature.spec.ts
@@ -4,11 +4,11 @@
 import { assert } from "chai";
 import { AzureKeyCredential, generateSharedAccessSignature } from "../../src";
 
-describe("generateSharedAccessSignature", function () {
+describe("generateSharedAccessSignature", function() {
   it("generates the correct signiture", async () => {
     // This is not a real key, it's the base64 encoding of "this is not a real EventGrid key", which happens to be the same
     // number of bytes as an actual EventGrid Access Key.
-    const key = Buffer.from("this is not a real EventGrid key").toString('base64');
+    const key = Buffer.from("this is not a real EventGrid key").toString("base64");
     const topicUrl = "https://eg-topic.westus-2.eventgrid.azure.net/api/events";
 
     const sig = await generateSharedAccessSignature(


### PR DESCRIPTION
This would help reduce the noise in the cred scan report by striking off one complaint from the list of complaints.

https://dev.azure.com/azure-sdk/internal/_build?definitionId=1394&_a=summary

