### PR TITLE
Enable nightly dev releases for iot-modelsrepository

### DIFF
--- a/rush.json
+++ b/rush.json
@@ -703,7 +703,8 @@
     },
     {
       "packageName": "@azure/iot-modelsrepository",
-      "projectFolder": "sdk/iot/iot-modelsrepository"
+      "projectFolder": "sdk/iot/iot-modelsrepository",
+      "versionPolicyName": "client"
     },
     {
       "packageName": "@azure-tests/perf-ai-form-recognizer",


### PR DESCRIPTION
https://dev.azure.com/azure-sdk/internal/_build?definitionId=2765&_a=summary has been failing to publish nightly dev packages for iot-modelsrepository due to a missing entry in rush.json file

Thanks to @praveenkuttappan for helping to root cause this