### PR TITLE
[EventGrid] Fix Test Compilation Errors

### DIFF
--- a/sdk/eventgrid/eventgrid/test/public/generateSharedAccessSignature.spec.ts
+++ b/sdk/eventgrid/eventgrid/test/public/generateSharedAccessSignature.spec.ts
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+/// <reference lib="dom"/>
+
 import { assert } from "chai";
 import { AzureKeyCredential, generateSharedAccessSignature } from "../../src";
 import { isNode } from "@azure/test-utils";


### PR DESCRIPTION
In #16700 we updated our tests to generate the key we used for testing
by doing a base64 conversion of a fixed string so we didn't have something that looked like a key embedded in source which was upsetting some static analysis tools.

This causes a build break in the min/max testing where `btoa` can't be found when building the test. Since we have the correct runtime behavior in the test to only call `btoa` when we are not in a node-context we simply reference the dom library to appease the compiler.