### PR TITLE
[Tables] Infer EDM types for properties with no Type metadata

### DIFF
--- a/sdk/tables/data-tables/recordings/browsers/tableclient_sasconnectionstring_createentity_getentity_and_delete/recording_should_createentity_with_primitive_int_and_float_without_automatic_type_conversion.json
+++ b/sdk/tables/data-tables/recordings/browsers/tableclient_sasconnectionstring_createentity_getentity_and_delete/recording_should_createentity_with_primitive_int_and_float_without_automatic_type_conversion.json
@@ -1,0 +1,71 @@
+{
+ "recordings": [
+  {
+   "method": "POST",
+   "url": "https://fakeaccount.table.core.windows.net/tableClientTestSASConnectionStringbrowser",
+   "query": {},
+   "requestBody": "{\"PartitionKey\":\"P8_browser\",\"RowKey\":\"R8\",\"integerNumber\":3,\"floatingPointNumber\":3.14}",
+   "status": 204,
+   "response": "",
+   "responseHeaders": {
+    "cache-control": "no-cache",
+    "content-length": "0",
+    "dataserviceid": "https://fakeaccount.table.core.windows.net/tableClientTestSASConnectionStringbrowser(PartitionKey='P8_browser',RowKey='R8')",
+    "date": "Tue, 03 Aug 2021 22:50:25 GMT",
+    "etag": "W/\"datetime'2021-08-03T22%3A50%3A25.2507633Z'\"",
+    "location": "https://fakeaccount.table.core.windows.net/tableClientTestSASConnectionStringbrowser(PartitionKey='P8_browser',RowKey='R8')",
+    "preference-applied": "return-no-content",
+    "server": "Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0",
+    "x-content-type-options": "nosniff",
+    "x-ms-client-request-id": "d4799ad4-15cf-4d4a-9e5f-02440ef5ed87",
+    "x-ms-request-id": "e1f3e793-2002-00e9-57b9-887db9000000",
+    "x-ms-version": "2019-02-02"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://fakeaccount.table.core.windows.net/tableClientTestSASConnectionStringbrowser(PartitionKey='P8_browser',RowKey='R8')",
+   "query": {},
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"odata.metadata\":\"https://fakeaccount.table.core.windows.net/$metadata#tableClientTestSASConnectionStringbrowser/@Element\",\"odata.etag\":\"W/\\\"datetime'2021-08-03T22%3A50%3A25.2507633Z'\\\"\",\"PartitionKey\":\"P8_browser\",\"RowKey\":\"R8\",\"Timestamp\":\"2021-08-03T22:50:25.2507633Z\",\"integerNumber\":3,\"floatingPointNumber\":3.14}",
+   "responseHeaders": {
+    "access-control-allow-origin": "*",
+    "access-control-expose-headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,X-Content-Type-Options,Cache-Control,ETag,Content-Type,Content-Length,Date,Transfer-Encoding",
+    "cache-control": "no-cache",
+    "content-type": "application/json;odata=minimalmetadata;streaming=true;charset=utf-8",
+    "date": "Tue, 03 Aug 2021 22:50:25 GMT",
+    "etag": "W/\"datetime'2021-08-03T22%3A50%3A25.2507633Z'\"",
+    "server": "Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-ms-client-request-id": "22009e02-8cec-4995-825d-3e4b8b88e1cc",
+    "x-ms-request-id": "e1f3e7a0-2002-00e9-64b9-887db9000000",
+    "x-ms-version": "2019-02-02"
+   }
+  },
+  {
+   "method": "DELETE",
+   "url": "https://fakeaccount.table.core.windows.net/tableClientTestSASConnectionStringbrowser(PartitionKey='P8_browser',RowKey='R8')",
+   "query": {},
+   "requestBody": null,
+   "status": 204,
+   "response": "",
+   "responseHeaders": {
+    "cache-control": "no-cache",
+    "content-length": "0",
+    "date": "Tue, 03 Aug 2021 22:50:25 GMT",
+    "server": "Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0",
+    "x-content-type-options": "nosniff",
+    "x-ms-client-request-id": "474848e4-0b56-46ee-b183-3d8ebb2ab425",
+    "x-ms-request-id": "e1f3e7aa-2002-00e9-6eb9-887db9000000",
+    "x-ms-version": "2019-02-02"
+   }
+  }
+ ],
+ "uniqueTestInfo": {
+  "uniqueName": {},
+  "newDate": {}
+ },
+ "hash": "77344ad3ea3146abc55572a420c25082"
+}

--- a/sdk/tables/data-tables/recordings/browsers/tableclient_tokencredential_createentity_getentity_and_delete/recording_should_createentity_with_primitive_int_and_float_without_automatic_type_conversion.json
+++ b/sdk/tables/data-tables/recordings/browsers/tableclient_tokencredential_createentity_getentity_and_delete/recording_should_createentity_with_primitive_int_and_float_without_automatic_type_conversion.json
@@ -1,0 +1,95 @@
+{
+ "recordings": [
+  {
+   "method": "POST",
+   "url": "https://login.microsoftonline.com/88888888-8888-8888-8888-888888888888/oauth2/v2.0/token",
+   "query": {},
+   "requestBody": "response_type=token&grant_type=client_credentials&client_id=azure_client_id&client_secret=azure_client_secret&scope=https%3A%2F%2Fsanitized%2F",
+   "status": 200,
+   "response": "{\"token_type\":\"Bearer\",\"expires_in\":86399,\"ext_expires_in\":86399,\"access_token\":\"access_token\"}",
+   "responseHeaders": {
+    "cache-control": "no-store, no-cache",
+    "content-length": "1318",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Tue, 03 Aug 2021 22:50:24 GMT",
+    "expires": "-1",
+    "nel": "{\"report_to\":\"network-errors\",\"max_age\":86400,\"success_fraction\":0.001,\"failure_fraction\":1.0}",
+    "p3p": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\"",
+    "pragma": "no-cache",
+    "referrer-policy": "strict-origin-when-cross-origin",
+    "report-to": "{\"group\":\"network-errors\",\"max_age\":86400,\"endpoints\":[{\"url\":\"https://identity.nel.measure.office.net/api/report?catId=GW+estsfd+wst\"}]}",
+    "strict-transport-security": "max-age=31536000; includeSubDomains",
+    "x-content-type-options": "nosniff",
+    "x-ms-ests-server": "2.1.11898.12 - EUS ProdSlices",
+    "x-ms-request-id": "955b325c-e862-455b-8b32-0a7e09e02301"
+   }
+  },
+  {
+   "method": "POST",
+   "url": "https://fakeaccount.table.core.windows.net/tableClientTestTokenCredentialbrowser",
+   "query": {},
+   "requestBody": "{\"PartitionKey\":\"P8_browser\",\"RowKey\":\"R8\",\"integerNumber\":3,\"floatingPointNumber\":3.14}",
+   "status": 204,
+   "response": "",
+   "responseHeaders": {
+    "cache-control": "no-cache",
+    "content-length": "0",
+    "dataserviceid": "https://fakeaccount.table.core.windows.net/tableClientTestTokenCredentialbrowser(PartitionKey='P8_browser',RowKey='R8')",
+    "date": "Tue, 03 Aug 2021 22:50:24 GMT",
+    "etag": "W/\"datetime'2021-08-03T22%3A50%3A24.9995814Z'\"",
+    "location": "https://fakeaccount.table.core.windows.net/tableClientTestTokenCredentialbrowser(PartitionKey='P8_browser',RowKey='R8')",
+    "preference-applied": "return-no-content",
+    "server": "Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0",
+    "x-content-type-options": "nosniff",
+    "x-ms-client-request-id": "7642fd5f-591f-4a98-a5c2-ef661952a4db",
+    "x-ms-request-id": "e1f3e73b-2002-00e9-04b9-887db9000000",
+    "x-ms-version": "2019-02-02"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://fakeaccount.table.core.windows.net/tableClientTestTokenCredentialbrowser(PartitionKey='P8_browser',RowKey='R8')",
+   "query": {},
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"odata.metadata\":\"https://fakeaccount.table.core.windows.net/$metadata#tableClientTestTokenCredentialbrowser/@Element\",\"odata.etag\":\"W/\\\"datetime'2021-08-03T22%3A50%3A24.9995814Z'\\\"\",\"PartitionKey\":\"P8_browser\",\"RowKey\":\"R8\",\"Timestamp\":\"2021-08-03T22:50:24.9995814Z\",\"integerNumber\":3,\"floatingPointNumber\":3.14}",
+   "responseHeaders": {
+    "access-control-allow-origin": "*",
+    "access-control-expose-headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,X-Content-Type-Options,Cache-Control,ETag,Content-Type,Content-Length,Date,Transfer-Encoding",
+    "cache-control": "no-cache",
+    "content-type": "application/json;odata=minimalmetadata;streaming=true;charset=utf-8",
+    "date": "Tue, 03 Aug 2021 22:50:24 GMT",
+    "etag": "W/\"datetime'2021-08-03T22%3A50%3A24.9995814Z'\"",
+    "server": "Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-ms-client-request-id": "0fec9d92-a622-44a4-be6c-3ed424e118b6",
+    "x-ms-request-id": "e1f3e74d-2002-00e9-16b9-887db9000000",
+    "x-ms-version": "2019-02-02"
+   }
+  },
+  {
+   "method": "DELETE",
+   "url": "https://fakeaccount.table.core.windows.net/tableClientTestTokenCredentialbrowser(PartitionKey='P8_browser',RowKey='R8')",
+   "query": {},
+   "requestBody": null,
+   "status": 204,
+   "response": "",
+   "responseHeaders": {
+    "cache-control": "no-cache",
+    "content-length": "0",
+    "date": "Tue, 03 Aug 2021 22:50:24 GMT",
+    "server": "Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0",
+    "x-content-type-options": "nosniff",
+    "x-ms-client-request-id": "d3e1b749-09cb-4ce6-9f97-1200ca42a388",
+    "x-ms-request-id": "e1f3e759-2002-00e9-22b9-887db9000000",
+    "x-ms-version": "2019-02-02"
+   }
+  }
+ ],
+ "uniqueTestInfo": {
+  "uniqueName": {},
+  "newDate": {}
+ },
+ "hash": "77344ad3ea3146abc55572a420c25082"
+}

--- a/sdk/tables/data-tables/recordings/node/tableclient_sasconnectionstring_createentity_getentity_and_delete/recording_should_createentity_with_primitive_int_and_float_without_automatic_type_conversion.js
+++ b/sdk/tables/data-tables/recordings/node/tableclient_sasconnectionstring_createentity_getentity_and_delete/recording_should_createentity_with_primitive_int_and_float_without_automatic_type_conversion.js
@@ -1,0 +1,87 @@
+let nock = require('nock');
+
+module.exports.hash = "c41cb05d53f4e5bc9937bb8c5efb5ae6";
+
+module.exports.testInfo = {"uniqueName":{},"newDate":{}}
+
+nock('https://fakeaccount.table.core.windows.net:443', {"encodedQueryParams":true})
+  .post('/tableClientTestSASConnectionStringnode', {"PartitionKey":"P8_node","RowKey":"R8","integerNumber":3,"floatingPointNumber":3.14})
+  .query(true)
+  .reply(204, "", [
+  'Cache-Control',
+  'no-cache',
+  'Content-Length',
+  '0',
+  'ETag',
+  `W/"datetime'2021-08-03T22%3A50%3A12.3279187Z'"`,
+  'Location',
+  "https://fakeaccount.table.core.windows.net/tableClientTestSASConnectionStringnode(PartitionKey='P8_node',RowKey='R8')",
+  'Server',
+  'Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '5cd55e24-b002-0124-1cb9-885ea4000000',
+  'x-ms-client-request-id',
+  '20c74c18-1240-4b36-9743-8114752d68ef',
+  'x-ms-version',
+  '2019-02-02',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Preference-Applied',
+  'return-no-content',
+  'DataServiceId',
+  "https://fakeaccount.table.core.windows.net/tableClientTestSASConnectionStringnode(PartitionKey='P8_node',RowKey='R8')",
+  'Date',
+  'Tue, 03 Aug 2021 22:50:11 GMT'
+]);
+
+nock('https://fakeaccount.table.core.windows.net:443', {"encodedQueryParams":true})
+  .get(`/tableClientTestSASConnectionStringnode(PartitionKey='P8_node',RowKey='R8')`)
+  .query(true)
+  .reply(200, {"odata.metadata":"https://fakeaccount.table.core.windows.net/$metadata#tableClientTestSASConnectionStringnode/@Element","odata.etag":"W/\"datetime'2021-08-03T22%3A50%3A12.3279187Z'\"","PartitionKey":"P8_node","RowKey":"R8","Timestamp":"2021-08-03T22:50:12.3279187Z","integerNumber":3,"floatingPointNumber":3.14}, [
+  'Cache-Control',
+  'no-cache',
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json;odata=minimalmetadata;streaming=true;charset=utf-8',
+  'ETag',
+  `W/"datetime'2021-08-03T22%3A50%3A12.3279187Z'"`,
+  'Server',
+  'Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '5cd55e31-b002-0124-28b9-885ea4000000',
+  'x-ms-client-request-id',
+  '8fc8118a-284e-4d5d-af82-6971719a2120',
+  'x-ms-version',
+  '2019-02-02',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Access-Control-Expose-Headers',
+  'x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,X-Content-Type-Options,Cache-Control,ETag,Content-Type,Content-Length,Date,Transfer-Encoding',
+  'Access-Control-Allow-Origin',
+  '*',
+  'Date',
+  'Tue, 03 Aug 2021 22:50:11 GMT'
+]);
+
+nock('https://fakeaccount.table.core.windows.net:443', {"encodedQueryParams":true})
+  .delete(`/tableClientTestSASConnectionStringnode(PartitionKey='P8_node',RowKey='R8')`)
+  .query(true)
+  .reply(204, "", [
+  'Cache-Control',
+  'no-cache',
+  'Content-Length',
+  '0',
+  'Server',
+  'Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '5cd55e3b-b002-0124-32b9-885ea4000000',
+  'x-ms-client-request-id',
+  'a585fd59-0a23-4969-8dc3-938f281200de',
+  'x-ms-version',
+  '2019-02-02',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Date',
+  'Tue, 03 Aug 2021 22:50:11 GMT'
+]);

--- a/sdk/tables/data-tables/recordings/node/tableclient_tokencredential_createentity_getentity_and_delete/recording_should_createentity_with_primitive_int_and_float_without_automatic_type_conversion.js
+++ b/sdk/tables/data-tables/recordings/node/tableclient_tokencredential_createentity_getentity_and_delete/recording_should_createentity_with_primitive_int_and_float_without_automatic_type_conversion.js
@@ -1,0 +1,190 @@
+let nock = require('nock');
+
+module.exports.hash = "c41cb05d53f4e5bc9937bb8c5efb5ae6";
+
+module.exports.testInfo = {"uniqueName":{},"newDate":{}}
+
+nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
+  .get('/common/discovery/instance')
+  .query(true)
+  .reply(200, {"tenant_discovery_endpoint":"https://login.microsoftonline.com/88888888-8888-8888-8888-888888888888/v2.0/.well-known/openid-configuration","api-version":"1.1","metadata":[{"preferred_network":"login.microsoftonline.com","preferred_cache":"login.windows.net","aliases":["login.microsoftonline.com","login.windows.net","login.microsoft.com","sts.windows.net"]},{"preferred_network":"login.partner.microsoftonline.cn","preferred_cache":"login.partner.microsoftonline.cn","aliases":["login.partner.microsoftonline.cn","login.chinacloudapi.cn"]},{"preferred_network":"login.microsoftonline.de","preferred_cache":"login.microsoftonline.de","aliases":["login.microsoftonline.de"]},{"preferred_network":"login.microsoftonline.us","preferred_cache":"login.microsoftonline.us","aliases":["login.microsoftonline.us","login.usgovcloudapi.net"]},{"preferred_network":"login-us.microsoftonline.com","preferred_cache":"login-us.microsoftonline.com","aliases":["login-us.microsoftonline.com"]}]}, [
+  'Cache-Control',
+  'max-age=86400, private',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Access-Control-Allow-Origin',
+  '*',
+  'Access-Control-Allow-Methods',
+  'GET, OPTIONS',
+  'P3P',
+  'CP="DSP CUR OTPi IND OTRi ONL FIN"',
+  'x-ms-request-id',
+  'ed51638e-efb0-4bf1-b07b-97a08f564d01',
+  'x-ms-ests-server',
+  '2.1.11898.12 - NCUS ProdSlices',
+  'Set-Cookie',
+  'fpc=Aq_hibls2SJEk10Fq6pUV13JVDEwAQAAACO_m9gOAAAA; expires=Thu, 02-Sep-2021 22:50:11 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'Set-Cookie',
+  'esctx=AQABAAAAAAD--DLA3VO7QrddgJg7WevrBaGmPQLIIl4y-Xxst4vjBvz9ptffF_A87R226EFfjgCVDt_zYoLW0P6MzfuVVH69OeYiaP0NrfLzkrjTmy6znHQT3j5boaEmMtTBn4M1AyqrEiVj9L5VqhuJZJXVp2uCiEGEz50aXPTo5mC5xP_nZUQKvnikgjhGdMt92WmjVSIgAA; domain=.login.microsoftonline.com; path=/; secure; HttpOnly; SameSite=None',
+  'Set-Cookie',
+  'x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly',
+  'Set-Cookie',
+  'stsservicecookie=estsfd; path=/; secure; samesite=none; httponly',
+  'Date',
+  'Tue, 03 Aug 2021 22:50:11 GMT',
+  'Content-Length',
+  '980'
+]);
+
+nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
+  .get('/88888888-8888-8888-8888-888888888888/v2.0/.well-known/openid-configuration')
+  .reply(200, {"token_endpoint":"https://login.microsoftonline.com/88888888-8888-8888-8888-888888888888/oauth2/v2.0/token","token_endpoint_auth_methods_supported":["client_secret_post","private_key_jwt","client_secret_basic"],"jwks_uri":"https://login.microsoftonline.com/88888888-8888-8888-8888-888888888888/discovery/v2.0/keys","response_modes_supported":["query","fragment","form_post"],"subject_types_supported":["pairwise"],"id_token_signing_alg_values_supported":["RS256"],"response_types_supported":["code","id_token","code id_token","id_token token"],"scopes_supported":["openid","profile","email","offline_access"],"issuer":"https://login.microsoftonline.com/88888888-8888-8888-8888-888888888888/v2.0","request_uri_parameter_supported":false,"userinfo_endpoint":"https://graph.microsoft.com/oidc/userinfo","authorization_endpoint":"https://login.microsoftonline.com/88888888-8888-8888-8888-888888888888/oauth2/v2.0/authorize","device_authorization_endpoint":"https://login.microsoftonline.com/88888888-8888-8888-8888-888888888888/oauth2/v2.0/devicecode","http_logout_supported":true,"frontchannel_logout_supported":true,"end_session_endpoint":"https://login.microsoftonline.com/88888888-8888-8888-8888-888888888888/oauth2/v2.0/logout","claims_supported":["sub","iss","cloud_instance_name","cloud_instance_host_name","cloud_graph_host_name","msgraph_host","aud","exp","iat","auth_time","acr","nonce","preferred_username","name","tid","ver","at_hash","c_hash","email"],"kerberos_endpoint":"https://login.microsoftonline.com/88888888-8888-8888-8888-888888888888/kerberos","tenant_region_scope":"WW","cloud_instance_name":"microsoftonline.com","cloud_graph_host_name":"graph.windows.net","msgraph_host":"graph.microsoft.com","rbac_url":"https://pas.windows.net"}, [
+  'Cache-Control',
+  'max-age=86400, private',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Access-Control-Allow-Origin',
+  '*',
+  'Access-Control-Allow-Methods',
+  'GET, OPTIONS',
+  'P3P',
+  'CP="DSP CUR OTPi IND OTRi ONL FIN"',
+  'x-ms-request-id',
+  '86dfa25d-0226-4611-9eba-3d9b4b9c2e01',
+  'x-ms-ests-server',
+  '2.1.11898.12 - SCUS ProdSlices',
+  'Set-Cookie',
+  'fpc=Aq_hibls2SJEk10Fq6pUV13JVDEwAQAAACO_m9gOAAAA; expires=Thu, 02-Sep-2021 22:50:11 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'Set-Cookie',
+  'esctx=AQABAAAAAAD--DLA3VO7QrddgJg7WevrIIb_0SVoMUvd0tguX7mkLVjKy5osrOFyX4H_Yvi3TjRJlDNAzsaDLtT_GEJnLNe5t5esEKUODd9n38cpiaOHIgmKGxdw3JudeOQPEPB85yFhADa35OXwB8Wgg-BvZ7VSftL4npz_addCTA9Bl3irBjUVO-m5Ri2hX8lfENs7jZMgAA; domain=.login.microsoftonline.com; path=/; secure; HttpOnly; SameSite=None',
+  'Set-Cookie',
+  'x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly',
+  'Set-Cookie',
+  'stsservicecookie=estsfd; path=/; secure; samesite=none; httponly',
+  'Date',
+  'Tue, 03 Aug 2021 22:50:11 GMT',
+  'Content-Length',
+  '1753'
+]);
+
+nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
+  .post('/88888888-8888-8888-8888-888888888888/oauth2/v2.0/token', "client_id=azure_client_id&scope=https%3A%2F%2Fsanitized%2F&grant_type=client_credentials&x-client-SKU=msal.js.node&x-client-VER=1.2.0&x-client-OS=linux&x-client-CPU=x64&x-ms-lib-capability=retry-after, h429&x-client-current-telemetry=2|771,0|,&x-client-last-telemetry=2|0|||0,0&client-request-id=6dcb06f3-d6eb-411c-ab52-924f30bfeef8&client_secret=azure_client_secret")
+  .reply(200, {"token_type":"Bearer","expires_in":86399,"ext_expires_in":86399,"access_token":"access_token"}, [
+  'Cache-Control',
+  'no-store, no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'P3P',
+  'CP="DSP CUR OTPi IND OTRi ONL FIN"',
+  'x-ms-request-id',
+  '1834072a-4391-4ded-a2a2-5452a4523801',
+  'x-ms-ests-server',
+  '2.1.11898.12 - SCUS ProdSlices',
+  'x-ms-clitelem',
+  '1,0,0,,',
+  'Set-Cookie',
+  'fpc=Aq_hibls2SJEk10Fq6pUV13JVDEwAgAAACO_m9gOAAAA; expires=Thu, 02-Sep-2021 22:50:11 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'Set-Cookie',
+  'x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly',
+  'Set-Cookie',
+  'stsservicecookie=estsfd; path=/; secure; samesite=none; httponly',
+  'Date',
+  'Tue, 03 Aug 2021 22:50:11 GMT',
+  'Content-Length',
+  '1318'
+]);
+
+nock('https://fakeaccount.table.core.windows.net:443', {"encodedQueryParams":true})
+  .post('/tableClientTestTokenCredentialnode', {"PartitionKey":"P8_node","RowKey":"R8","integerNumber":3,"floatingPointNumber":3.14})
+  .reply(204, "", [
+  'Cache-Control',
+  'no-cache',
+  'Content-Length',
+  '0',
+  'ETag',
+  `W/"datetime'2021-08-03T22%3A50%3A12.0747374Z'"`,
+  'Location',
+  "https://fakeaccount.table.core.windows.net/tableClientTestTokenCredentialnode(PartitionKey='P8_node',RowKey='R8')",
+  'Server',
+  'Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '5cd55dd6-b002-0124-52b9-885ea4000000',
+  'x-ms-client-request-id',
+  'c888effb-fd77-45e6-b21c-eb40fa9ae853',
+  'x-ms-version',
+  '2019-02-02',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Preference-Applied',
+  'return-no-content',
+  'DataServiceId',
+  "https://fakeaccount.table.core.windows.net/tableClientTestTokenCredentialnode(PartitionKey='P8_node',RowKey='R8')",
+  'Date',
+  'Tue, 03 Aug 2021 22:50:11 GMT'
+]);
+
+nock('https://fakeaccount.table.core.windows.net:443', {"encodedQueryParams":true})
+  .get(`/tableClientTestTokenCredentialnode(PartitionKey='P8_node',RowKey='R8')`)
+  .reply(200, {"odata.metadata":"https://fakeaccount.table.core.windows.net/$metadata#tableClientTestTokenCredentialnode/@Element","odata.etag":"W/\"datetime'2021-08-03T22%3A50%3A12.0747374Z'\"","PartitionKey":"P8_node","RowKey":"R8","Timestamp":"2021-08-03T22:50:12.0747374Z","integerNumber":3,"floatingPointNumber":3.14}, [
+  'Cache-Control',
+  'no-cache',
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json;odata=minimalmetadata;streaming=true;charset=utf-8',
+  'ETag',
+  `W/"datetime'2021-08-03T22%3A50%3A12.0747374Z'"`,
+  'Server',
+  'Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '5cd55de8-b002-0124-63b9-885ea4000000',
+  'x-ms-client-request-id',
+  '73b1d7c7-1cc4-42a8-9b11-2546e05f30a0',
+  'x-ms-version',
+  '2019-02-02',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Access-Control-Expose-Headers',
+  'x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,X-Content-Type-Options,Cache-Control,ETag,Content-Type,Content-Length,Date,Transfer-Encoding',
+  'Access-Control-Allow-Origin',
+  '*',
+  'Date',
+  'Tue, 03 Aug 2021 22:50:11 GMT'
+]);
+
+nock('https://fakeaccount.table.core.windows.net:443', {"encodedQueryParams":true})
+  .delete(`/tableClientTestTokenCredentialnode(PartitionKey='P8_node',RowKey='R8')`)
+  .reply(204, "", [
+  'Cache-Control',
+  'no-cache',
+  'Content-Length',
+  '0',
+  'Server',
+  'Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '5cd55df4-b002-0124-6fb9-885ea4000000',
+  'x-ms-client-request-id',
+  '97042237-0417-4c9d-8f33-0286f49269de',
+  'x-ms-version',
+  '2019-02-02',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Date',
+  'Tue, 03 Aug 2021 22:50:11 GMT'
+]);

--- a/sdk/tables/data-tables/src/serialization.ts
+++ b/sdk/tables/data-tables/src/serialization.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 import { base64Encode, base64Decode } from "./utils/bufferSerializer";
-import { Edm, EdmTypes, SignedIdentifier } from "./models";
+import { Edm as EdmModel, EdmTypes, SignedIdentifier } from "./models";
 import { truncatedISO8061Date } from "./utils/truncateISO8061Date";
 import { SignedIdentifier as GeneratedSignedIdentifier } from "./generated/models";
 
@@ -145,7 +145,7 @@ export function deserialize<T extends object = Record<string, any>>(
       if (`${key}@odata.type` in obj) {
         const type = (obj as any)[`${key}@odata.type`];
         typedValue = getTypedObject(value, type, disableTypeConversion);
-      } else if(["number", "string"].includes(typeof value)) {
+      } else if (["number", "string"].includes(typeof value)) {
         // The service, doesn't return type metadata for number or strings
         // if automatic type conversion is disabled we'll infer the EDM object
         typedValue = inferTypedObject(key, value, disableTypeConversion);
@@ -157,9 +157,13 @@ export function deserialize<T extends object = Record<string, any>>(
   return deserialized;
 }
 
-function inferTypedObject(propertyName: string, value: number | string, disableTypeConversion: boolean) {
+function inferTypedObject(
+  propertyName: string,
+  value: number | string,
+  disableTypeConversion: boolean
+) {
   // Use value as is when typeConversion is enabled
-  if(!disableTypeConversion) {
+  if (!disableTypeConversion) {
     return value;
   }
 
@@ -174,20 +178,20 @@ function inferTypedObject(propertyName: string, value: number | string, disableT
 /**
  * Returns the number when typeConversion is enabled or the EDM object with the correct number format Double or Int32 if disabled
  */
-function getTypedNumber(value: number): Edm<"Double"> | Edm<"Int32"> | number {
-  const isDecimal = value % 1 != 0;
+function getTypedNumber(value: number): EdmModel<"Double"> | EdmModel<"Int32"> | number {
+  const isDecimal = value % 1 !== 0;
   if (isDecimal) {
-    return  { value, type: "Double" };
+    return { value, type: "Double" };
   } else {
     return { value, type: "Int32" };
   }
 }
 
 /**
- * Returns the string when typeConversion is enabled or the EDM<"String"> object if disabled
+ * Returns the string when typeConversion is enabled or the EDM\<\"String\"\> object if disabled
  */
-function getTypedString(value: string): Edm<"String"> | string {
- return {value, type: "String"};
+function getTypedString(value: string): EdmModel<"String"> | string {
+  return { value, type: "String" };
 }
 
 export function deserializeObjectsArray<T extends object>(

--- a/sdk/tables/data-tables/src/serialization.ts
+++ b/sdk/tables/data-tables/src/serialization.ts
@@ -145,7 +145,7 @@ export function deserialize<T extends object = Record<string, any>>(
       if (`${key}@odata.type` in obj) {
         const type = (obj as any)[`${key}@odata.type`];
         typedValue = getTypedObject(value, type, disableTypeConversion);
-      } else if (disableTypeConversion  && ["number", "string"].includes(typeof value)) {
+      } else if (disableTypeConversion && ["number", "string"].includes(typeof value)) {
         // The service, doesn't return type metadata for number or strings
         // if automatic type conversion is disabled we'll infer the EDM object
         typedValue = inferTypedObject(key, value);
@@ -157,10 +157,7 @@ export function deserialize<T extends object = Record<string, any>>(
   return deserialized;
 }
 
-function inferTypedObject(
-  propertyName: string,
-  value: number | string
-) {
+function inferTypedObject(propertyName: string, value: number | string) {
   // We need to skip service metadata fields such as partitionKey and rowKey and use the same value returned by the service
   if (propertyCaseMap.has(propertyName)) {
     return value;

--- a/sdk/tables/data-tables/test/internal/serialization.spec.ts
+++ b/sdk/tables/data-tables/test/internal/serialization.spec.ts
@@ -194,6 +194,82 @@ describe("Deserializer", () => {
     assert.strictEqual(deserialized.int64ObjProp.type, "Int64");
   });
 
+  it("should return an EDM object for Int32 when disableTypeConversion is true", () => {
+    const intValue = 123;
+    const deserialized = deserialize(
+      {
+        intValue: intValue
+      },
+      true
+    );
+    assert.strictEqual(deserialized.intValue.value, intValue);
+    assert.strictEqual(deserialized.intValue.type, "Int32");
+  });
+
+  it("should return an EDM object for String when disableTypeConversion is true", () => {
+    // JavaScript number primitive drops the decimal places if they are zero. JSON parser has no way to
+    // preserve zero decimals during parsing so 123.00 is interpreted as an integer
+    const stringValue = "foo";
+    const deserialized = deserialize(
+      {
+        stringValue
+      },
+      true
+    );
+    assert.strictEqual(deserialized.stringValue.value, stringValue);
+    assert.strictEqual(deserialized.stringValue.type, "String");
+  });
+
+  it("should return an EDM object for Int32 when decimals are zero and disableTypeConversion is true", () => {
+    // JavaScript number primitive drops the decimal places if they are zero. JSON parser has no way to
+    // preserve zero decimals during parsing so 123.00 is interpreted as an integer
+    const doubleValue = 123.0;
+    const deserialized = deserialize(
+      {
+        intValue: doubleValue
+      },
+      true
+    );
+    assert.strictEqual(deserialized.intValue.value, doubleValue);
+    assert.strictEqual(deserialized.intValue.type, "Int32");
+  });
+
+  it("should return an EDM object for Double when disableTypeConversion is true", () => {
+    // JavaScript number primitive drops the decimal places if they are zero. JSON parser has no way to
+    // preserve zero decimals during parsing so 123.00 is interpreted as an integer
+    const doubleValue = 123.01;
+    const deserialized = deserialize(
+      {
+        intValue: doubleValue
+      },
+      true
+    );
+    assert.strictEqual(deserialized.intValue.value, doubleValue);
+    assert.strictEqual(deserialized.intValue.type, "Double");
+  });
+
+  it("should return a number disableTypeConversion is false", () => {
+    const intValue = 123;
+    const deserialized = deserialize(
+      {
+        intValue: intValue
+      },
+      false
+    );
+    assert.strictEqual(deserialized.intValue, intValue);
+  });
+
+  it("should return a number when disableTypeConversion is false", () => {
+    const decimalValue = 123.0;
+    const deserialized = deserialize(
+      {
+        intValue: decimalValue
+      },
+      false
+    );
+    assert.strictEqual(deserialized.intValue, decimalValue);
+  });
+
   it("should deserialize a Date value", () => {
     const dateValue = new Date();
     const deserialized = deserialize({

--- a/sdk/tables/data-tables/test/public/tableclient.spec.ts
+++ b/sdk/tables/data-tables/test/public/tableclient.spec.ts
@@ -399,6 +399,32 @@ authModes.forEach((authMode) => {
         assert.equal(result.integerNumber, 3);
         assert.equal(result.floatingPointNumber, 3.14);
       });
+
+      it("should createEntity with primitive int and float without automatic type conversion", async () => {
+        type TestType = { integerNumber: number; floatingPointNumber: number };
+        const testEntity: TableEntity<TestType> = {
+          partitionKey: `P8_${suffix}`,
+          rowKey: "R8",
+          integerNumber: 3,
+          floatingPointNumber: 3.14
+        };
+        let createResult: FullOperationResponse | undefined;
+        let deleteResult: FullOperationResponse | undefined;
+        await client.createEntity(testEntity, { onResponse: (res) => (createResult = res) });
+        const result = await client.getEntity(testEntity.partitionKey, testEntity.rowKey, {
+          disableTypeConversion: true
+        });
+        await client.deleteEntity(testEntity.partitionKey, testEntity.rowKey, {
+          onResponse: (res) => (deleteResult = res)
+        });
+
+        assert.equal(deleteResult?.status, 204);
+        assert.equal(createResult?.status, 204);
+        assert.equal(result.partitionKey, testEntity.partitionKey);
+        assert.equal(result.rowKey, testEntity.rowKey);
+        assert.deepEqual(result.integerNumber, { value: 3, type: "Int32" });
+        assert.deepEqual(result.floatingPointNumber, { value: 3.14, type: "Double" });
+      });
     });
   });
 });


### PR DESCRIPTION
**Context:**
When querying the Tables service we have an option to disable automatic type conversion. This means that we would give users an object similar to what the service sends us. For example, an object with a Date property will be received like this, with an `@odata.type` metadata property

```json
{
   "PartitionKey": "1",
   "RowKey": "1",
   "dateValue": "2020-09-17T00:00:00.111Z",
   "dateValie@odata.type": "Edm.DateTime"
}
```

The SDK's automatic type conversion would use the metadata to give users a primitive Date type so the user would get the following object

```javascript
{
   partitionKey: "1",
   rowKey: "1",
   dateValue: new Date("2020-09-17T00:00:00.111Z")
}
```

If `disableTypeConversion` is true in the list or get operations the sdk returns the Edm object instead of a primitive type

```javascript
{
   partitionKey: "1",
   rowKey: "1",
   dateValue: {value: "2020-09-17T00:00:00.111Z", type: "DateTime"}
}
```

**Problem**
There are 3 types when the service never sends `@odata.type` metadata and just the value, these are int32, double, and string. Before this PR we would return the value instead of the EDM object since no @odata.type property was found. This causes an inconsistent experience.

**Fix**
When `disableTypeConversion` is true, return an EDM object instead of the value by inferring the EDM type, in the case of the string is straightforward. In the case of int32 and decimal, JavaScript treats both as `number` so we need to inspect the value looking for decimal places to decide whether to use `Edm.Int32` or `Edm.Decimal`.


**Note:**
There is a limitation with this approach, and it is that JavaScript drops decimals if they are `0` for example, `1.00` would be represented as `1`. With these changes, such cases would always have an Edm type of `Int32`