### PR TITLE
[core-client] Fix Serializer issue where File didn't count as a Blob

### DIFF
--- a/sdk/core/core-client/CHANGELOG.md
+++ b/sdk/core/core-client/CHANGELOG.md
@@ -1,10 +1,14 @@
 # Release History
 
-## 1.3.0 (Unreleased)
+## 1.3.0 (2021-08-04)
 
 ### Features Added
 
 - Updated to use version 1.0.0-preview.13 of `@azure/core-tracing`.
+
+### Key Bugs Fixed
+
+- Fixed an issue where APIs that accepted a Blob didn't work with File objects. See [#16754](https://github.com/Azure/azure-sdk-for-js/issues/16754) for more details.
 
 ## 1.2.2 (2021-07-13)
 

--- a/sdk/core/core-client/src/serializer.ts
+++ b/sdk/core/core-client/src/serializer.ts
@@ -433,7 +433,8 @@ function serializeBasicTypes(typeName: string, objectName: string, value: any): 
         typeof value.pipe !== "function" &&
         !(value instanceof ArrayBuffer) &&
         !ArrayBuffer.isView(value) &&
-        !(value?.constructor?.name === "Blob")
+        // File objects count as a type of Blob, so we want to use instanceof explicitly
+        !((typeof Blob === "function" || typeof Blob === "object") && value instanceof Blob)
       ) {
         throw new Error(
           `${objectName} must be a string, Blob, ArrayBuffer, ArrayBufferView, or NodeJS.ReadableStream.`

--- a/sdk/core/core-client/test/browser/serializer.spec.ts
+++ b/sdk/core/core-client/test/browser/serializer.spec.ts
@@ -1,0 +1,28 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { assert } from "chai";
+import { createSerializer, Mapper } from "../../src";
+
+describe("Serializer (browser specific)", function() {
+  describe("serialize", function() {
+    it("Should accept File objects as Blobs", function() {
+      const file = new File(
+        ["In ancient times, cats were worshiped as gods. They have never forgotten this."],
+        "cats.txt",
+        { type: "text/plain" }
+      );
+
+      const serializer = createSerializer();
+
+      const mapper: Mapper = {
+        type: { name: "Stream" },
+        required: true,
+        serializedName: "File"
+      };
+
+      const result = serializer.serialize(mapper, file);
+      assert.strictEqual(result, file, "Expect file streams to be left intact");
+    });
+  });
+});

--- a/sdk/core/core-rest-pipeline/CHANGELOG.md
+++ b/sdk/core/core-rest-pipeline/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.2.0 (Unreleased)
+## 1.2.0 (2021-08-04)
 
 ### Features Added
 


### PR DESCRIPTION
At some point during the creation of core-client we changed the validation logic for Blobs in a way that was not inclusive of `File` objects, which should be treated as Blobs in the browser.

This PR restores the previous detection we were doing in `core-http` (that is confirmed working) and adds a test to prevent regression.

Fixes #16754