### PR TITLE
[core-rest-pipeline] Remove empty changelog sections

### DIFF
--- a/sdk/core/core-rest-pipeline/CHANGELOG.md
+++ b/sdk/core/core-rest-pipeline/CHANGELOG.md
@@ -8,12 +8,6 @@
 - `tracingPolicy` will no longer inject invalid traceparent headers if an incorrect tracer implementation is used.
 - `proxyPolicy` now allows passing in a list of no-proxy patterns to override global ones loaded from NO_PROXY environment variable [PR #16414](https://github.com/Azure/azure-sdk-for-js/pull/16414)
 
-### Breaking Changes
-
-### Bugs Fixed
-
-### Other Changes
-
 ## 1.1.1 (2021-07-13)
 
 ### Key Bugs Fixed


### PR DESCRIPTION
Apparently the release pipeline now validates this:

##[error]The changelog entry has the following sections with no content (Bugs Fixed, Breaking Changes, Other Changes). Please ensure to either remove the empty sections or add content to the section.

