### PR TITLE
[KeyVault] - Increase timeout for KeyVault certificates and secrets

### DIFF
--- a/eng/tools/dependency-testing/templates/package.json
+++ b/eng/tools/dependency-testing/templates/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "build": "tsc -p .",
     "integration-test:browser": "karma start --single-run",
-    "integration-test:node": "nyc mocha -r esm --require source-map-support/register --reporter mocha-multi-reporter.js --timeout 250000 --full-trace 'dist/**/*.js' --exit",
+    "integration-test:node": "nyc mocha -r esm --require source-map-support/register --reporter mocha-multi-reporter.js --timeout 350000 --full-trace 'dist/**/*.js' --exit",
     "integration-test": "npm run integration-test:node && npm run integration-test:browser"
   },
   "repository": {

--- a/sdk/keyvault/keyvault-certificates/karma.conf.js
+++ b/sdk/keyvault/keyvault-certificates/karma.conf.js
@@ -96,7 +96,7 @@ module.exports = function(config) {
     singleRun: false,
     concurrency: 1,
 
-    browserNoActivityTimeout: 250000,
+    browserNoActivityTimeout: 350000,
     browserDisconnectTimeout: 10000,
     browserDisconnectTolerance: 3,
     browserConsoleLogOptions: {
@@ -108,7 +108,7 @@ module.exports = function(config) {
       mocha: {
         // change Karma's debug.html to the mocha web reporter
         reporter: "html",
-        timeout: "250000"
+        timeout: "350000"
       }
     }
   });

--- a/sdk/keyvault/keyvault-certificates/package.json
+++ b/sdk/keyvault/keyvault-certificates/package.json
@@ -52,7 +52,7 @@
     "extract-api": "tsc -p . && api-extractor run --local",
     "format": "prettier --write --config ../../../.prettierrc.json --ignore-path ../../../.prettierignore \"src/**/*.ts\" \"samples/*.ts\" \"test/**/*.ts\" \"samples-dev/**/*.ts\" \"*.{js,json}\"",
     "integration-test:browser": "karma start --single-run",
-    "integration-test:node": "nyc mocha -r esm --require source-map-support/register --reporter ../../../common/tools/mocha-multi-reporter.js --timeout 300000 --full-trace \"dist-esm/**/*.spec.js\"",
+    "integration-test:node": "nyc mocha -r esm --require source-map-support/register --reporter ../../../common/tools/mocha-multi-reporter.js --timeout 350000 --full-trace \"dist-esm/**/*.spec.js\"",
     "integration-test:node:no-timeout": "nyc mocha -r esm --require source-map-support/register --reporter ../../../common/tools/mocha-multi-reporter.js --no-timeouts --full-trace \"dist-esm/**/*.spec.js\"",
     "integration-test": "npm run integration-test:node && npm run integration-test:browser",
     "lint:fix": "eslint package.json api-extractor.json src test --ext .ts --fix --fix-type [problem,suggestion]",

--- a/sdk/keyvault/keyvault-certificates/test/public/CRUD.spec.ts
+++ b/sdk/keyvault/keyvault-certificates/test/public/CRUD.spec.ts
@@ -65,7 +65,6 @@ describe("Certificates client - create, read, update and delete", () => {
       certificateName,
       "Unexpected name in result from beginCreateCertificate()."
     );
-    await testClient.flushCertificate(certificateName);
   });
 
   it("can abort creating a certificate", async function(this: Context) {
@@ -137,7 +136,6 @@ describe("Certificates client - create, read, update and delete", () => {
       "value",
       "Expect attribute 'tags' to be updated."
     );
-    await testClient.flushCertificate(certificateName);
   });
 
   it("can disable a certificate", async function(this: Context) {
@@ -159,8 +157,6 @@ describe("Certificates client - create, read, update and delete", () => {
 
     result = await client.getCertificate(certificateName);
     assert.equal(result.properties.enabled, false);
-
-    await testClient.flushCertificate(certificateName);
   });
 
   it("can disable a certificate version", async function(this: Context) {
@@ -184,8 +180,6 @@ describe("Certificates client - create, read, update and delete", () => {
 
     result = await client.getCertificateVersion(certificateName, version);
     assert.equal(result.properties.enabled, false);
-
-    await testClient.flushCertificate(certificateName);
   });
 
   // On playback mode, the tests happen too fast for the timeout to work
@@ -223,7 +217,6 @@ describe("Certificates client - create, read, update and delete", () => {
       certificateName,
       "Unexpected certificate name in result from beginCreateCertificate()."
     );
-    await testClient.flushCertificate(certificateName);
   });
 
   it("can get a certificate's secret in PKCS 12 format", async function(this: Context) {
@@ -271,8 +264,6 @@ describe("Certificates client - create, read, update and delete", () => {
         .join("")
         .replace(/\n/g, "")
     );
-
-    await testClient.flushCertificate(certificateName);
   });
 
   it("can get a certificate's secret in PEM format", async function(this: Context) {
@@ -307,8 +298,6 @@ describe("Certificates client - create, read, update and delete", () => {
 
     // The PEM encoded public certificate should be the same as the Base64 encoded CER
     assert.equal(base64CER, base64PublicCertificate);
-
-    await testClient.flushCertificate(certificateName);
   });
 
   // On playback mode, the tests happen too fast for the timeout to work
@@ -340,7 +329,6 @@ describe("Certificates client - create, read, update and delete", () => {
       certificateName,
       "Unexpected certificate name in result from beginCreateCertificate()."
     );
-    await testClient.flushCertificate(certificateName);
   });
 
   it("can get a certificate (Non Existing)", async function(this: Context) {
@@ -382,7 +370,6 @@ describe("Certificates client - create, read, update and delete", () => {
     }
 
     await poller.pollUntilDone();
-    await testClient.purgeCertificate(certificateName);
   });
 
   // On playback mode, the tests happen too fast for the timeout to work
@@ -436,8 +423,6 @@ describe("Certificates client - create, read, update and delete", () => {
         certificateName,
         "Unexpected certificate name in result from pollUntilDone()."
       );
-
-      await testClient.purgeCertificate(certificateName);
     });
 
     it("using getDeletedCertificate", async function(this: Context) {
@@ -460,8 +445,6 @@ describe("Certificates client - create, read, update and delete", () => {
         certificateName,
         "Unexpected certificate name in result from getDeletedCertificate()."
       );
-
-      await testClient.purgeCertificate(certificateName);
     });
 
     it("can not get a certificate that never existed", async function(this: Context) {
@@ -543,8 +526,6 @@ describe("Certificates client - create, read, update and delete", () => {
       error = e;
     }
     assert.equal(error.message, "Issuer not found");
-
-    await testClient.flushCertificate(certificateName);
   });
 
   it("can update a certificate's policy", async function(this: Context) {
@@ -565,8 +546,6 @@ describe("Certificates client - create, read, update and delete", () => {
     });
     const updated = await client.getCertificate(certificateName);
     assert.equal(updated.policy!.subject, "cn=MyOtherCert");
-
-    await testClient.flushCertificate(certificateName);
   });
 
   it("can read, cancel and delete a certificate's operation", async function(this: Context) {
@@ -601,8 +580,6 @@ describe("Certificates client - create, read, update and delete", () => {
       error = e;
     }
     assert.equal(error.message, `Pending certificate not found: ${certificateName}`);
-
-    await testClient.flushCertificate(certificateName);
   });
 
   it("can set, read and delete a certificate's contacts", async function() {

--- a/sdk/keyvault/keyvault-certificates/test/public/list.spec.ts
+++ b/sdk/keyvault/keyvault-certificates/test/public/list.spec.ts
@@ -87,10 +87,6 @@ describe("Certificates client - list certificates in various ways", () => {
     }
 
     assert.equal(found, 2, "Unexpected number of certificates found by listCertificates.");
-
-    for (const name of certificateNames) {
-      await testClient.flushCertificate(name);
-    }
   });
 
   it("can list deleted certificates", async function(this: Context) {
@@ -145,9 +141,6 @@ describe("Certificates client - list certificates in various ways", () => {
       }
     }
     assert.equal(found, 2, "Unexpected number of certificates found by listCertificates.");
-    for (const name of certificateNames) {
-      await testClient.flushCertificate(name);
-    }
   });
 
   if (isNode && !isPlaybackMode()) {
@@ -242,7 +235,6 @@ describe("Certificates client - list certificates in various ways", () => {
     versions.sort(comp);
 
     expect(results).to.deep.equal(versions);
-    await testClient.flushCertificate(certificateName);
   });
 
   // On playback mode, the tests happen too fast for the timeout to work - in browsers only

--- a/sdk/keyvault/keyvault-certificates/test/public/lro.create.spec.ts
+++ b/sdk/keyvault/keyvault-certificates/test/public/lro.create.spec.ts
@@ -52,8 +52,6 @@ describe("Certificates client - LRO - create", () => {
 
     // The final certificate can also be obtained this way:
     assert.equal(poller.getOperationState().result!.name, certificateName);
-
-    await testClient.flushCertificate(certificateName);
   });
 
   it("can resume from a stopped poller", async function(this: Context) {
@@ -92,7 +90,5 @@ describe("Certificates client - LRO - create", () => {
     const createdCertificate: KeyVaultCertificate = await resumePoller.pollUntilDone();
     assert.equal(createdCertificate.name, certificateName);
     assert.ok(resumePoller.getOperationState().isCompleted);
-
-    await testClient.flushCertificate(certificateName);
   });
 });

--- a/sdk/keyvault/keyvault-certificates/test/public/lro.delete.spec.ts
+++ b/sdk/keyvault/keyvault-certificates/test/public/lro.delete.spec.ts
@@ -58,8 +58,6 @@ describe("Certificates client - lro - delete", () => {
 
     // The final deleted certificate can also be obtained this way:
     assert.equal(poller.getOperationState().result!.name, certificateName);
-
-    await testClient.purgeCertificate(certificateName);
   });
 
   it("can resume from a stopped poller", async function(this: Context) {
@@ -100,7 +98,5 @@ describe("Certificates client - lro - delete", () => {
     // Retrieving it without the poller
     deletedCertificate = await client.getDeletedCertificate(certificateName);
     assert.equal(deletedCertificate.name, certificateName);
-
-    await testClient.purgeCertificate(certificateName);
   });
 });

--- a/sdk/keyvault/keyvault-certificates/test/public/lro.operation.spec.ts
+++ b/sdk/keyvault/keyvault-certificates/test/public/lro.operation.spec.ts
@@ -61,8 +61,6 @@ describe("Certificates client - LRO - certificate operation", () => {
 
     // The final certificate operation can also be obtained this way:
     assert.equal(poller.getOperationState().certificateOperation!.status, "completed");
-
-    await testClient.flushCertificate(certificateName);
   });
 
   it("can resume from a stopped poller", async function(this: Context) {
@@ -94,7 +92,5 @@ describe("Certificates client - LRO - certificate operation", () => {
     const operation: CertificateOperation = resumePoller.getOperationState().certificateOperation!;
     assert.equal(operation.status, "completed");
     assert.ok(resumePoller.getOperationState().isCompleted);
-
-    await testClient.flushCertificate(certificateName);
   });
 });

--- a/sdk/keyvault/keyvault-certificates/test/public/mergeAndImport.spec.ts
+++ b/sdk/keyvault/keyvault-certificates/test/public/mergeAndImport.spec.ts
@@ -60,10 +60,6 @@ describe("Certificates client - merge and import certificates", () => {
     const buffer = base64ToUint8Array(base64EncodedCertificate);
 
     await client.importCertificate(certificateNames[1], buffer);
-
-    for (const name of certificateNames) {
-      await testClient.flushCertificate(name);
-    }
   });
 
   it("can import a certificate from a certificate's base64 secret value", async function(this: Context) {
@@ -88,10 +84,6 @@ describe("Certificates client - merge and import certificates", () => {
         contentType: "application/x-pem-file"
       }
     });
-
-    for (const name of certificateNames) {
-      await testClient.flushCertificate(name);
-    }
   });
 
   // The signed certificate will never be the same, so we can't play it back.
@@ -139,7 +131,5 @@ ${base64Csr}
       .join("");
 
     await client.mergeCertificate(certificateName, [Buffer.from(base64Crt)]);
-
-    await testClient.flushCertificate(certificateName);
   });
 });

--- a/sdk/keyvault/keyvault-certificates/test/public/recoverBackupRestore.spec.ts
+++ b/sdk/keyvault/keyvault-certificates/test/public/recoverBackupRestore.spec.ts
@@ -63,7 +63,6 @@ describe("Certificates client - restore certificates and recover backups", () =>
       certificateName,
       "Unexpected certificate name in result from getCertificate()."
     );
-    await testClient.flushCertificate(certificateName);
   });
 
   it("can recover a deleted certificate (non existing)", async function(this: Context) {
@@ -111,7 +110,6 @@ describe("Certificates client - restore certificates and recover backups", () =>
       const restoredCertificate = await restorePoller.pollUntilDone();
 
       assert.equal(restoredCertificate.name, certificateName);
-      await testClient.flushCertificate(certificateName);
     });
   }
 
@@ -151,7 +149,6 @@ describe("Certificates client - restore certificates and recover backups", () =>
       );
       await createPoller.pollUntilDone();
       const backup = await client.backupCertificate(certificateName);
-      await testClient.flushCertificate(certificateName);
 
       await assertThrowsAbortError(async () => {
         await client.restoreCertificateBackup(backup!, { requestOptions: { timeout: 1 } });

--- a/sdk/keyvault/keyvault-secrets/package.json
+++ b/sdk/keyvault/keyvault-secrets/package.json
@@ -52,7 +52,7 @@
     "extract-api": "tsc -p . && api-extractor run --local",
     "format": "prettier --write --config ../../../.prettierrc.json --ignore-path ../../../.prettierignore \"src/**/*.ts\" \"test/**/*.ts\" \"samples-dev/**/*.ts\" \"*.{js,json}\"",
     "integration-test:browser": "karma start --single-run",
-    "integration-test:node": "nyc mocha -r esm --require source-map-support/register --reporter ../../../common/tools/mocha-multi-reporter.js --timeout 250000 --full-trace \"dist-esm/**/*.spec.js\"",
+    "integration-test:node": "nyc mocha -r esm --require source-map-support/register --reporter ../../../common/tools/mocha-multi-reporter.js --timeout 350000 --full-trace \"dist-esm/**/*.spec.js\"",
     "integration-test:node:no-timeout": "nyc mocha -r esm --require source-map-support/register --reporter ../../../common/tools/mocha-multi-reporter.js --no-timeouts --full-trace \"dist-esm/**/*.spec.js\"",
     "integration-test": "npm run integration-test:node && npm run integration-test:browser",
     "lint:fix": "eslint package.json api-extractor.json src test --ext .ts --fix --fix-type [problem,suggestion]",

--- a/sdk/keyvault/keyvault-secrets/test/internal/challengeBasedAuthenticationPolicy.spec.ts
+++ b/sdk/keyvault/keyvault-secrets/test/internal/challengeBasedAuthenticationPolicy.spec.ts
@@ -95,9 +95,6 @@ describe("Challenge based authentication tests", () => {
     for (const name of secretNames) {
       await client.setSecret(name, "value");
     }
-    for (const name of secretNames) {
-      await testClient.flushSecret(name);
-    }
 
     // The challenge should have been written to the cache exactly ONCE.
     assert.equal(spy.getCalls().length, 1);

--- a/sdk/keyvault/keyvault-secrets/test/public/CRUD.spec.ts
+++ b/sdk/keyvault/keyvault-secrets/test/public/CRUD.spec.ts
@@ -42,7 +42,6 @@ describe("Secret client - create, read, update and delete operations", () => {
     const result = await client.setSecret(secretName, secretValue);
     assert.equal(result.name, secretName, "Unexpected secret name in result from setSecret().");
     assert.equal(result.value, secretValue, "Unexpected secret value in result from setSecret().");
-    await testClient.flushSecret(secretName);
   });
 
   // If this test is not skipped in the browser's playback, no other test will be played back.
@@ -103,7 +102,6 @@ describe("Secret client - create, read, update and delete operations", () => {
       emptySecretValue,
       "Unexpected secret value in result from setSecret()."
     );
-    await testClient.flushSecret(secretName);
   });
 
   it("can set a secret with attributes", async function(this: Context) {
@@ -119,7 +117,6 @@ describe("Secret client - create, read, update and delete operations", () => {
       updated!.properties.expiresOn!.getDate(),
       "Expect attribute 'expiresOn' to be defined."
     );
-    await testClient.flushSecret(secretName);
   });
 
   it("can update a secret", async function(this: Context) {
@@ -140,7 +137,6 @@ describe("Secret client - create, read, update and delete operations", () => {
       expiryDate.getDate(),
       "Expect attribute 'expiresOn' to be updated."
     );
-    await testClient.flushSecret(secretName);
   });
 
   // On playback mode, the tests happen too fast for the timeout to work
@@ -181,7 +177,6 @@ describe("Secret client - create, read, update and delete operations", () => {
       expiryDate.getDate(),
       "Expect attribute 'expiresOn' to be updated."
     );
-    await testClient.flushSecret(secretName);
   });
 
   it("can get a secret", async function(this: Context) {
@@ -192,7 +187,6 @@ describe("Secret client - create, read, update and delete operations", () => {
     const result = await client.getSecret(secretName);
     assert.equal(result.name, secretName, "Unexpected secret name in result from setSecret().");
     assert.equal(result.value, secretValue, "Unexpected secret value in result from setSecret().");
-    await testClient.flushSecret(secretName);
   });
 
   // On playback mode, the tests happen too fast for the timeout to work
@@ -233,7 +227,6 @@ describe("Secret client - create, read, update and delete operations", () => {
       "Operation get is not allowed on a disabled secret.",
       "Unexpected error after trying to get a disabled secret"
     );
-    await testClient.flushSecret(secretName);
   });
 
   it("can retrieve the latest version of a secret value", async function(this: Context) {
@@ -246,7 +239,6 @@ describe("Secret client - create, read, update and delete operations", () => {
 
     assert.equal(result.name, secretName, "Unexpected secret name in result from setSecret().");
     assert.equal(result.value, secretValue, "Unexpected secret value in result from setSecret().");
-    await testClient.flushSecret(secretName);
   });
 
   it("can get a secret (Non Existing)", async function(this: Context) {
@@ -299,7 +291,6 @@ describe("Secret client - create, read, update and delete operations", () => {
         throw e;
       }
     }
-    await testClient.purgeSecret(secretName);
   });
 
   // On playback mode, the tests happen too fast for the timeout to work
@@ -358,7 +349,6 @@ describe("Secret client - create, read, update and delete operations", () => {
 
     const getResult = await client.getDeletedSecret(secretName);
     assert.equal(getResult.name, secretName, "Unexpected secret name in result from getSecret().");
-    await testClient.purgeSecret(secretName);
   });
 
   it("can get a deleted secret (Non Existing)", async function(this: Context) {

--- a/sdk/keyvault/keyvault-secrets/test/public/list.spec.ts
+++ b/sdk/keyvault/keyvault-secrets/test/public/list.spec.ts
@@ -77,10 +77,6 @@ describe("Secret client - list secrets in various ways", () => {
     }
 
     assert.equal(found, 2, "Unexpected number of secrets found by getSecrets.");
-
-    for (const name of secretNames) {
-      await testClient.flushSecret(name);
-    }
   });
 
   // On playback mode, the tests happen too fast for the timeout to work
@@ -115,10 +111,6 @@ describe("Secret client - list secrets in various ways", () => {
     }
 
     assert.equal(found, 2, "Unexpected number of secrets found by getDeletedSecrets.");
-
-    for (const name of secretNames) {
-      await testClient.purgeSecret(name);
-    }
   });
 
   // On playback mode, the tests happen too fast for the timeout to work
@@ -162,7 +154,6 @@ describe("Secret client - list secrets in various ways", () => {
     versions.sort(comp);
 
     expect(results).to.deep.equal(versions);
-    await testClient.flushSecret(secretName);
   });
 
   // On playback mode, the tests happen too fast for the timeout to work
@@ -209,9 +200,6 @@ describe("Secret client - list secrets in various ways", () => {
       }
     }
     assert.equal(found, 2, "Unexpected number of secrets found by getSecrets.");
-    for (const name of secretNames) {
-      await testClient.flushSecret(name);
-    }
   });
 
   it("can list deleted secrets by page", async function(this: Context) {
@@ -236,9 +224,6 @@ describe("Secret client - list secrets in various ways", () => {
       }
     }
     assert.equal(found, 2, "Unexpected number of secrets found by getDeletedSecrets.");
-    for (const name of secretNames) {
-      await testClient.purgeSecret(name);
-    }
   });
 
   it("can retrieve all versions of a secret by page", async function(this: Context) {
@@ -271,7 +256,6 @@ describe("Secret client - list secrets in various ways", () => {
     versions.sort(comp);
 
     expect(results).to.deep.equal(versions);
-    await testClient.flushSecret(secretName);
   });
 
   it("can list secret versions by page (non existing)", async function(this: Context) {

--- a/sdk/keyvault/keyvault-secrets/test/public/lro.delete.spec.ts
+++ b/sdk/keyvault/keyvault-secrets/test/public/lro.delete.spec.ts
@@ -50,8 +50,6 @@ describe("Secrets client - Long Running Operations - delete", () => {
 
     // The final secret can also be obtained this way:
     assert.equal(poller.getOperationState().result!.name, secretName);
-
-    await testClient.purgeSecret(secretName);
   });
 
   it("can resume from a stopped poller", async function(this: Context) {
@@ -83,8 +81,6 @@ describe("Secrets client - Long Running Operations - delete", () => {
     const deletedSecret: DeletedSecret = await resumePoller.pollUntilDone();
     assert.equal(deletedSecret.name, secretName);
     assert.ok(resumePoller.getOperationState().isCompleted);
-
-    await testClient.purgeSecret(secretName);
   });
 
   // On playback mode, the tests happen too fast for the timeout to work

--- a/sdk/keyvault/keyvault-secrets/test/public/lro.recover.spec.ts
+++ b/sdk/keyvault/keyvault-secrets/test/public/lro.recover.spec.ts
@@ -54,8 +54,6 @@ describe("Secrets client - Long Running Operations - recoverDelete", () => {
 
     // The final secret can also be obtained this way:
     assert.equal(poller.getOperationState().result!.name, secretName);
-
-    await testClient.flushSecret(secretName);
   });
 
   it("can resume from a stopped poller", async function(this: Context) {
@@ -92,8 +90,6 @@ describe("Secrets client - Long Running Operations - recoverDelete", () => {
     const secretProperties: SecretProperties = await resumePoller.pollUntilDone();
     assert.equal(secretProperties.name, secretName);
     assert.ok(resumePoller.getOperationState().isCompleted);
-
-    await testClient.flushSecret(secretName);
   });
 
   // On playback mode, the tests happen too fast for the timeout to work

--- a/sdk/keyvault/keyvault-secrets/test/public/recoverBackupRestore.spec.ts
+++ b/sdk/keyvault/keyvault-secrets/test/public/recoverBackupRestore.spec.ts
@@ -60,7 +60,6 @@ describe("Secret client - restore secrets and recover backups", () => {
       secretName,
       "Unexpected secret name in result from getSecret()."
     );
-    await testClient.flushSecret(secretName);
   });
 
   it("can recover a deleted secret (non existing)", async function(this: Context) {
@@ -117,7 +116,6 @@ describe("Secret client - restore secrets and recover backups", () => {
       result!.length > 0,
       `Unexpected length (${result!.length}) of buffer from backupSecret()`
     );
-    await testClient.flushSecret(secretName);
   });
 
   it("can backup a secret (non existing)", async function(this: Context) {


### PR DESCRIPTION
## What

- Bump the timeout of integration tests for KV Secrets and Certificates
- Bump the timeout of min/max testing to work around #16731 
- Delete extra cleanup methods 

## Why

Due to an ongoing performance regression on the service side our tests have been timing out. The performance has gotten better but after talking to the service team it sounds like the recommendation is to avoid waiting on deletes / purges if you
are latency sensitive. 

However, not all our tests are just cleaning up, there are valid tests that exercise cleaning / purging certificates so bumping the 
timeout a bit feels appropriate. This works fine for tests except that min/max testing uses a hardcoded number for test timeouts
so need to update that as well (or add timeouts everywhere in our code). Since certificates and secrets _already_ has the longest
timeout period bumping it in min/max seems appropriate until #16731 is resolved.