### PR TITLE
[Schema Registry] Export a known enum

### DIFF
--- a/sdk/schemaregistry/schema-registry/review/schema-registry.api.md
+++ b/sdk/schemaregistry/schema-registry/review/schema-registry.api.md
@@ -17,6 +17,11 @@ export interface GetSchemaIdOptions extends OperationOptions {
 }
 
 // @public
+export const enum KnownSerializationType {
+    Avro = "avro"
+}
+
+// @public
 export interface RegisterSchemaOptions extends OperationOptions {
 }
 
@@ -56,7 +61,7 @@ export class SchemaRegistryClient implements SchemaRegistry {
     getSchemaById(id: string, options?: GetSchemaByIdOptions): Promise<Schema | undefined>;
     getSchemaId(schema: SchemaDescription, options?: GetSchemaIdOptions): Promise<SchemaId | undefined>;
     registerSchema(schema: SchemaDescription, options?: RegisterSchemaOptions): Promise<SchemaId>;
-}
+    }
 
 // @public
 export interface SchemaRegistryClientOptions extends CommonClientOptions {

--- a/sdk/schemaregistry/schema-registry/src/index.ts
+++ b/sdk/schemaregistry/schema-registry/src/index.ts
@@ -3,3 +3,4 @@
 
 export * from "./models";
 export { SchemaRegistryClient } from "./schemaRegistryClient";
+export { KnownSerializationType } from "./generated";


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-sdk-for-js/issues/16528

Exports `KnownSerializationType` so customers can refer to known enum values in their code.