### PR TITLE
[storage-file-datalake][storage-blob] Allow storage-blob to accept Pipeline instances from other storage packages

### DIFF
--- a/sdk/storage/storage-blob/review/storage-blob.api.md
+++ b/sdk/storage/storage-blob/review/storage-blob.api.md
@@ -195,7 +195,7 @@ export type AppendBlobAppendBlockResponse = AppendBlobAppendBlockHeaders & {
 export class AppendBlobClient extends BlobClient {
     constructor(connectionString: string, containerName: string, blobName: string, options?: StoragePipelineOptions);
     constructor(url: string, credential: StorageSharedKeyCredential | AnonymousCredential | TokenCredential, options?: StoragePipelineOptions);
-    constructor(url: string, pipeline: Pipeline);
+    constructor(url: string, pipeline: PipelineLike);
     appendBlock(body: HttpRequestBody, contentLength: number, options?: AppendBlobAppendBlockOptions): Promise<AppendBlobAppendBlockResponse>;
     appendBlockFromURL(sourceURL: string, sourceOffset: number, count: number, options?: AppendBlobAppendBlockFromURLOptions): Promise<AppendBlobAppendBlockFromUrlResponse>;
     create(options?: AppendBlobCreateOptions): Promise<AppendBlobCreateResponse>;
@@ -336,7 +336,7 @@ export class BlobBatch {
 // @public
 export class BlobBatchClient {
     constructor(url: string, credential?: StorageSharedKeyCredential | AnonymousCredential | TokenCredential, options?: StoragePipelineOptions);
-    constructor(url: string, pipeline: Pipeline);
+    constructor(url: string, pipeline: PipelineLike);
     createBatch(): BlobBatch;
     deleteBlobs(urls: string[], credential: StorageSharedKeyCredential | AnonymousCredential | TokenCredential, options?: BlobDeleteOptions): Promise<BlobBatchDeleteBlobsResponse>;
     deleteBlobs(blobClients: BlobClient[], options?: BlobDeleteOptions): Promise<BlobBatchDeleteBlobsResponse>;
@@ -401,7 +401,7 @@ export interface BlobChangeLeaseOptions extends CommonOptions {
 export class BlobClient extends StorageClient {
     constructor(connectionString: string, containerName: string, blobName: string, options?: StoragePipelineOptions);
     constructor(url: string, credential?: StorageSharedKeyCredential | AnonymousCredential | TokenCredential, options?: StoragePipelineOptions);
-    constructor(url: string, pipeline: Pipeline);
+    constructor(url: string, pipeline: PipelineLike);
     abortCopyFromURL(copyId: string, options?: BlobAbortCopyFromURLOptions): Promise<BlobAbortCopyFromURLResponse>;
     beginCopyFromURL(copySource: string, options?: BlobBeginCopyFromURLOptions): Promise<PollerLike<PollOperationState<BlobBeginCopyFromURLResponse>, BlobBeginCopyFromURLResponse>>;
     get containerName(): string;
@@ -1118,7 +1118,7 @@ export interface BlobSASSignatureValues {
 // @public
 export class BlobServiceClient extends StorageClient {
     constructor(url: string, credential?: StorageSharedKeyCredential | AnonymousCredential | TokenCredential, options?: StoragePipelineOptions);
-    constructor(url: string, pipeline: Pipeline);
+    constructor(url: string, pipeline: PipelineLike);
     createContainer(containerName: string, options?: ContainerCreateOptions): Promise<{
         containerClient: ContainerClient;
         containerCreateResponse: ContainerCreateResponse;
@@ -1404,7 +1404,7 @@ export interface Block {
 export class BlockBlobClient extends BlobClient {
     constructor(connectionString: string, containerName: string, blobName: string, options?: StoragePipelineOptions);
     constructor(url: string, credential?: StorageSharedKeyCredential | AnonymousCredential | TokenCredential, options?: StoragePipelineOptions);
-    constructor(url: string, pipeline: Pipeline);
+    constructor(url: string, pipeline: PipelineLike);
     commitBlockList(blocks: string[], options?: BlockBlobCommitBlockListOptions): Promise<BlockBlobCommitBlockListResponse>;
     getBlockList(listType: BlockListType, options?: BlockBlobGetBlockListOptions): Promise<BlockBlobGetBlockListResponse>;
     query(query: string, options?: BlockBlobQueryOptions): Promise<BlobDownloadResponseModel>;
@@ -1739,7 +1739,7 @@ export interface ContainerChangeLeaseOptions extends CommonOptions {
 export class ContainerClient extends StorageClient {
     constructor(connectionString: string, containerName: string, options?: StoragePipelineOptions);
     constructor(url: string, credential?: StorageSharedKeyCredential | AnonymousCredential | TokenCredential, options?: StoragePipelineOptions);
-    constructor(url: string, pipeline: Pipeline);
+    constructor(url: string, pipeline: PipelineLike);
     get containerName(): string;
     create(options?: ContainerCreateOptions): Promise<ContainerCreateResponse>;
     createIfNotExists(options?: ContainerCreateOptions): Promise<ContainerCreateIfNotExistsResponse>;
@@ -2262,6 +2262,9 @@ export { HttpRequestBody }
 export { IHttpClient }
 
 // @public
+export function isPipelineLike(pipeline: unknown): pipeline is PipelineLike;
+
+// @public
 export interface Lease {
     date?: Date;
     errorCode?: string;
@@ -2499,7 +2502,7 @@ export type PageBlobClearPagesResponse = PageBlobClearPagesHeaders & {
 export class PageBlobClient extends BlobClient {
     constructor(connectionString: string, containerName: string, blobName: string, options?: StoragePipelineOptions);
     constructor(url: string, credential: StorageSharedKeyCredential | AnonymousCredential | TokenCredential, options?: StoragePipelineOptions);
-    constructor(url: string, pipeline: Pipeline);
+    constructor(url: string, pipeline: PipelineLike);
     clearPages(offset?: number, count?: number, options?: PageBlobClearPagesOptions): Promise<PageBlobClearPagesResponse>;
     create(size: number, options?: PageBlobCreateOptions): Promise<PageBlobCreateResponse>;
     createIfNotExists(size: number, options?: PageBlobCreateIfNotExistsOptions): Promise<PageBlobCreateIfNotExistsResponse>;
@@ -2790,8 +2793,15 @@ export interface ParsedBatchResponse {
 }
 
 // @public
-export class Pipeline {
+export class Pipeline implements PipelineLike {
     constructor(factories: RequestPolicyFactory[], options?: PipelineOptions);
+    readonly factories: RequestPolicyFactory[];
+    readonly options: PipelineOptions;
+    toServiceClientOptions(): ServiceClientOptions;
+}
+
+// @public
+export interface PipelineLike {
     readonly factories: RequestPolicyFactory[];
     readonly options: PipelineOptions;
     toServiceClientOptions(): ServiceClientOptions;

--- a/sdk/storage/storage-blob/src/BlobBatchClient.ts
+++ b/sdk/storage/storage-blob/src/BlobBatchClient.ts
@@ -21,7 +21,7 @@ import { AnonymousCredential } from "./credentials/AnonymousCredential";
 import { CommonOptions } from "./StorageClient";
 import { BlobDeleteOptions, BlobClient, BlobSetTierOptions } from "./Clients";
 import { StorageClientContext } from "./generated/src/storageClientContext";
-import { Pipeline, StoragePipelineOptions, newPipeline } from "./Pipeline";
+import { PipelineLike, StoragePipelineOptions, newPipeline, isPipelineLike } from "./Pipeline";
 import { getURLPath } from "./utils/utils.common";
 
 /**
@@ -94,18 +94,18 @@ export class BlobBatchClient {
    * @param pipeline - Call newPipeline() to create a default
    *                            pipeline, or provide a customized pipeline.
    */
-  constructor(url: string, pipeline: Pipeline);
+  constructor(url: string, pipeline: PipelineLike);
   constructor(
     url: string,
     credentialOrPipeline?:
       | StorageSharedKeyCredential
       | AnonymousCredential
       | TokenCredential
-      | Pipeline,
+      | PipelineLike,
     options?: StoragePipelineOptions
   ) {
-    let pipeline: Pipeline;
-    if (credentialOrPipeline instanceof Pipeline) {
+    let pipeline: PipelineLike;
+    if (isPipelineLike(credentialOrPipeline)) {
       pipeline = credentialOrPipeline;
     } else if (!credentialOrPipeline) {
       // no credential provided

--- a/sdk/storage/storage-blob/src/BlobServiceClient.ts
+++ b/sdk/storage/storage-blob/src/BlobServiceClient.ts
@@ -29,7 +29,7 @@ import {
   LeaseAccessConditions
 } from "./generatedModels";
 import { Container, Service } from "./generated/src/operations";
-import { newPipeline, StoragePipelineOptions, Pipeline } from "./Pipeline";
+import { newPipeline, StoragePipelineOptions, PipelineLike, isPipelineLike } from "./Pipeline";
 import {
   ContainerClient,
   ContainerCreateOptions,
@@ -477,18 +477,18 @@ export class BlobServiceClient extends StorageClient {
    * @param pipeline - Call newPipeline() to create a default
    *                            pipeline, or provide a customized pipeline.
    */
-  constructor(url: string, pipeline: Pipeline);
+  constructor(url: string, pipeline: PipelineLike);
   constructor(
     url: string,
     credentialOrPipeline?:
       | StorageSharedKeyCredential
       | AnonymousCredential
       | TokenCredential
-      | Pipeline,
+      | PipelineLike,
     options?: StoragePipelineOptions
   ) {
-    let pipeline: Pipeline;
-    if (credentialOrPipeline instanceof Pipeline) {
+    let pipeline: PipelineLike;
+    if (isPipelineLike(credentialOrPipeline)) {
       pipeline = credentialOrPipeline;
     } else if (
       (isNode && credentialOrPipeline instanceof StorageSharedKeyCredential) ||

--- a/sdk/storage/storage-blob/src/Clients.ts
+++ b/sdk/storage/storage-blob/src/Clients.ts
@@ -87,7 +87,7 @@ import {
   PageBlobGetPageRangesResponse,
   rangeResponseFromModel
 } from "./PageBlobRangeResponse";
-import { newPipeline, Pipeline, StoragePipelineOptions } from "./Pipeline";
+import { newPipeline, PipelineLike, isPipelineLike, StoragePipelineOptions } from "./Pipeline";
 import {
   BlobBeginCopyFromUrlPoller,
   BlobBeginCopyFromUrlPollState,
@@ -913,7 +913,7 @@ export class BlobClient extends StorageClient {
    * @param pipeline - Call newPipeline() to create a default
    *                            pipeline, or provide a customized pipeline.
    */
-  constructor(url: string, pipeline: Pipeline);
+  constructor(url: string, pipeline: PipelineLike);
   constructor(
     urlOrConnectionString: string,
     credentialOrPipelineOrContainerName?:
@@ -921,14 +921,14 @@ export class BlobClient extends StorageClient {
       | StorageSharedKeyCredential
       | AnonymousCredential
       | TokenCredential
-      | Pipeline,
+      | PipelineLike,
     blobNameOrOptions?: string | StoragePipelineOptions,
     options?: StoragePipelineOptions
   ) {
     options = options || {};
-    let pipeline: Pipeline;
+    let pipeline: PipelineLike;
     let url: string;
-    if (credentialOrPipelineOrContainerName instanceof Pipeline) {
+    if (isPipelineLike(credentialOrPipelineOrContainerName)) {
       // (url: string, pipeline: Pipeline)
       url = urlOrConnectionString;
       pipeline = credentialOrPipelineOrContainerName;
@@ -2566,7 +2566,7 @@ export class AppendBlobClient extends BlobClient {
    * @param pipeline - Call newPipeline() to create a default
    *                            pipeline, or provide a customized pipeline.
    */
-  constructor(url: string, pipeline: Pipeline);
+  constructor(url: string, pipeline: PipelineLike);
   constructor(
     urlOrConnectionString: string,
     credentialOrPipelineOrContainerName:
@@ -2574,16 +2574,16 @@ export class AppendBlobClient extends BlobClient {
       | StorageSharedKeyCredential
       | AnonymousCredential
       | TokenCredential
-      | Pipeline,
+      | PipelineLike,
     blobNameOrOptions?: string | StoragePipelineOptions,
     options?: StoragePipelineOptions
   ) {
     // In TypeScript we cannot simply pass all parameters to super() like below so have to duplicate the code instead.
     //   super(s, credentialOrPipelineOrContainerNameOrOptions, blobNameOrOptions, options);
-    let pipeline: Pipeline;
+    let pipeline: PipelineLike;
     let url: string;
     options = options || {};
-    if (credentialOrPipelineOrContainerName instanceof Pipeline) {
+    if (isPipelineLike(credentialOrPipelineOrContainerName)) {
       // (url: string, pipeline: Pipeline)
       url = urlOrConnectionString;
       pipeline = credentialOrPipelineOrContainerName;
@@ -3564,7 +3564,7 @@ export class BlockBlobClient extends BlobClient {
    * @param pipeline - Call newPipeline() to create a default
    *                            pipeline, or provide a customized pipeline.
    */
-  constructor(url: string, pipeline: Pipeline);
+  constructor(url: string, pipeline: PipelineLike);
   constructor(
     urlOrConnectionString: string,
     credentialOrPipelineOrContainerName?:
@@ -3572,16 +3572,16 @@ export class BlockBlobClient extends BlobClient {
       | StorageSharedKeyCredential
       | AnonymousCredential
       | TokenCredential
-      | Pipeline,
+      | PipelineLike,
     blobNameOrOptions?: string | StoragePipelineOptions,
     options?: StoragePipelineOptions
   ) {
     // In TypeScript we cannot simply pass all parameters to super() like below so have to duplicate the code instead.
     //   super(s, credentialOrPipelineOrContainerNameOrOptions, blobNameOrOptions, options);
-    let pipeline: Pipeline;
+    let pipeline: PipelineLike;
     let url: string;
     options = options || {};
-    if (credentialOrPipelineOrContainerName instanceof Pipeline) {
+    if (isPipelineLike(credentialOrPipelineOrContainerName)) {
       // (url: string, pipeline: Pipeline)
       url = urlOrConnectionString;
       pipeline = credentialOrPipelineOrContainerName;
@@ -4804,7 +4804,7 @@ export class PageBlobClient extends BlobClient {
    * @param pipeline - Call newPipeline() to create a default
    *                            pipeline, or provide a customized pipeline.
    */
-  constructor(url: string, pipeline: Pipeline);
+  constructor(url: string, pipeline: PipelineLike);
   constructor(
     urlOrConnectionString: string,
     credentialOrPipelineOrContainerName:
@@ -4812,16 +4812,16 @@ export class PageBlobClient extends BlobClient {
       | StorageSharedKeyCredential
       | AnonymousCredential
       | TokenCredential
-      | Pipeline,
+      | PipelineLike,
     blobNameOrOptions?: string | StoragePipelineOptions,
     options?: StoragePipelineOptions
   ) {
     // In TypeScript we cannot simply pass all parameters to super() like below so have to duplicate the code instead.
     //   super(s, credentialOrPipelineOrContainerNameOrOptions, blobNameOrOptions, options);
-    let pipeline: Pipeline;
+    let pipeline: PipelineLike;
     let url: string;
     options = options || {};
-    if (credentialOrPipelineOrContainerName instanceof Pipeline) {
+    if (isPipelineLike(credentialOrPipelineOrContainerName)) {
       // (url: string, pipeline: Pipeline)
       url = urlOrConnectionString;
       pipeline = credentialOrPipelineOrContainerName;

--- a/sdk/storage/storage-blob/src/ContainerClient.ts
+++ b/sdk/storage/storage-blob/src/ContainerClient.ts
@@ -43,7 +43,7 @@ import {
   ContainerRequestConditions,
   ModifiedAccessConditions
 } from "./models";
-import { newPipeline, Pipeline, StoragePipelineOptions } from "./Pipeline";
+import { isPipelineLike, newPipeline, PipelineLike, StoragePipelineOptions } from "./Pipeline";
 import { CommonOptions, StorageClient } from "./StorageClient";
 import { convertTracingToRequestOptionsBase, createSpan } from "./utils/tracing";
 import {
@@ -68,6 +68,7 @@ import {
   PageBlobClient
 } from "./Clients";
 import { BlobBatchClient } from "./BlobBatchClient";
+import { isCredential } from "./credentials/Credential";
 
 /**
  * Options to configure {@link ContainerClient.create} operation.
@@ -623,74 +624,19 @@ export class ContainerClient extends StorageClient {
    * @param pipeline - Call newPipeline() to create a default
    *                            pipeline, or provide a customized pipeline.
    */
-  constructor(url: string, pipeline: Pipeline);
+  constructor(url: string, pipeline: PipelineLike);
   constructor(
-    urlOrConnectionString: string,
-    credentialOrPipelineOrContainerName?:
-      | string
-      | StorageSharedKeyCredential
-      | AnonymousCredential
-      | TokenCredential
-      | Pipeline,
-    options?: StoragePipelineOptions
+    ...args:
+      | [connectionString: string, containerName: string, options?: StoragePipelineOptions]
+      | [
+          url: string,
+          credential?: (StorageSharedKeyCredential | AnonymousCredential | TokenCredential),
+          options?: StoragePipelineOptions
+        ]
+      | [url: string, pipeline: PipelineLike]
   ) {
-    let pipeline: Pipeline;
-    let url: string;
-    options = options || {};
-    if (credentialOrPipelineOrContainerName instanceof Pipeline) {
-      // (url: string, pipeline: Pipeline)
-      url = urlOrConnectionString;
-      pipeline = credentialOrPipelineOrContainerName;
-    } else if (
-      (isNode && credentialOrPipelineOrContainerName instanceof StorageSharedKeyCredential) ||
-      credentialOrPipelineOrContainerName instanceof AnonymousCredential ||
-      isTokenCredential(credentialOrPipelineOrContainerName)
-    ) {
-      // (url: string, credential?: StorageSharedKeyCredential | AnonymousCredential | TokenCredential, options?: StoragePipelineOptions)
-      url = urlOrConnectionString;
-      pipeline = newPipeline(credentialOrPipelineOrContainerName, options);
-    } else if (
-      !credentialOrPipelineOrContainerName &&
-      typeof credentialOrPipelineOrContainerName !== "string"
-    ) {
-      // (url: string, credential?: StorageSharedKeyCredential | AnonymousCredential | TokenCredential, options?: StoragePipelineOptions)
-      // The second parameter is undefined. Use anonymous credential.
-      url = urlOrConnectionString;
-      pipeline = newPipeline(new AnonymousCredential(), options);
-    } else if (
-      credentialOrPipelineOrContainerName &&
-      typeof credentialOrPipelineOrContainerName === "string"
-    ) {
-      // (connectionString: string, containerName: string, blobName: string, options?: StoragePipelineOptions)
-      const containerName = credentialOrPipelineOrContainerName;
+    const { pipeline, url } = disambiguateContainterClientParameters(args);
 
-      const extractedCreds = extractConnectionStringParts(urlOrConnectionString);
-      if (extractedCreds.kind === "AccountConnString") {
-        if (isNode) {
-          const sharedKeyCredential = new StorageSharedKeyCredential(
-            extractedCreds.accountName!,
-            extractedCreds.accountKey
-          );
-          url = appendToURLPath(extractedCreds.url, encodeURIComponent(containerName));
-          options.proxyOptions = getDefaultProxySettings(extractedCreds.proxyUri);
-          pipeline = newPipeline(sharedKeyCredential, options);
-        } else {
-          throw new Error("Account connection string is only supported in Node.js environment");
-        }
-      } else if (extractedCreds.kind === "SASConnString") {
-        url =
-          appendToURLPath(extractedCreds.url, encodeURIComponent(containerName)) +
-          "?" +
-          extractedCreds.accountSas;
-        pipeline = newPipeline(new AnonymousCredential(), options);
-      } else {
-        throw new Error(
-          "Connection string must be either an Account connection string or a SAS connection string"
-        );
-      }
-    } else {
-      throw new Error("Expecting non-empty strings for containerName parameter");
-    }
     super(url, pipeline);
     this._containerName = this.getContainerNameFromUrl();
     this.containerContext = new Container(this.storageClientContext);
@@ -1828,5 +1774,60 @@ export class ContainerClient extends StorageClient {
    */
   public getBlobBatchClient(): BlobBatchClient {
     return new BlobBatchClient(this.url, this.pipeline);
+  }
+}
+
+function disambiguateContainterClientParameters(
+  args:
+    | [connectionString: string, containerName: string, options?: StoragePipelineOptions]
+    | [
+        url: string,
+        credential?: (StorageSharedKeyCredential | AnonymousCredential | TokenCredential),
+        options?: StoragePipelineOptions
+      ]
+    | [url: string, pipeline: PipelineLike]
+): { url: string; pipeline: PipelineLike } {
+  const options = args[2] ?? {};
+  if (typeof args[1] == "string") {
+    // (connectionString: string, containerName: string, blobName: string, options?: StoragePipelineOptions)
+    const containerName = args[1];
+
+    const extractedCreds = extractConnectionStringParts(args[0]);
+    if (extractedCreds.kind === "AccountConnString") {
+      if (isNode) {
+        const sharedKeyCredential = new StorageSharedKeyCredential(
+          extractedCreds.accountName!,
+          extractedCreds.accountKey
+        );
+        const url = appendToURLPath(extractedCreds.url, encodeURIComponent(containerName));
+        options.proxyOptions = getDefaultProxySettings(extractedCreds.proxyUri);
+        const pipeline = newPipeline(sharedKeyCredential, options);
+        return { url, pipeline };
+      } else {
+        throw new Error("Account connection string is only supported in Node.js environment");
+      }
+    } else if (extractedCreds.kind === "SASConnString") {
+      const url =
+        appendToURLPath(extractedCreds.url, encodeURIComponent(containerName)) +
+        "?" +
+        extractedCreds.accountSas;
+      const pipeline = newPipeline(new AnonymousCredential(), options);
+      return { url, pipeline };
+    } else {
+      throw new Error(
+        "Connection string must be either an Account connection string or a SAS connection string"
+      );
+    }
+  } else if (isCredential(args[1]) || isTokenCredential(args[1]) || !args[1]) {
+    // (url: string, credential?: StorageSharedKeyCredential | AnonymousCredential | TokenCredential, options?: StoragePipelineOptions)
+    return {
+      url: args[0],
+      pipeline: newPipeline(args[1] ?? new AnonymousCredential(), options)
+    };
+  } else if (isPipelineLike(args[1])) {
+    // (url: string, pipeline: PipelineLike)
+    return { url: args[0], pipeline: args[1] };
+  } else {
+    throw new Error("Expecting non-empty strings for containerName parameter");
   }
 }

--- a/sdk/storage/storage-blob/src/Pipeline.ts
+++ b/sdk/storage/storage-blob/src/Pipeline.ts
@@ -69,6 +69,51 @@ export interface PipelineOptions {
 }
 
 /**
+ * An interface for the {@link Pipeline} class containing HTTP request policies.
+ * You can create a default Pipeline by calling {@link newPipeline}.
+ * Or you can create a Pipeline with your own policies by the constructor of Pipeline.
+ *
+ * Refer to {@link newPipeline} and provided policies before implementing your
+ * customized Pipeline.
+ */
+export interface PipelineLike {
+  /**
+   * A list of chained request policy factories.
+   */
+  readonly factories: RequestPolicyFactory[];
+  /**
+   * Configures pipeline logger and HTTP client.
+   */
+  readonly options: PipelineOptions;
+  /**
+   * Transfer Pipeline object to ServiceClientOptions object which is required by
+   * ServiceClient constructor.
+   *
+   * @returns The ServiceClientOptions object from this Pipeline.
+   */
+  toServiceClientOptions(): ServiceClientOptions;
+}
+
+/**
+ * A helper to decide if a given argument satisfies the Pipeline contract
+ * @param pipeline An argument that may be a Pipeline
+ * @returns true when the argument satisfies the Pipeline contract
+ */
+export function isPipelineLike(pipeline: unknown): pipeline is PipelineLike {
+  if (!pipeline || typeof pipeline !== "object") {
+    return false;
+  }
+
+  const castPipeline = pipeline as PipelineLike;
+
+  return (
+    Array.isArray(castPipeline.factories) &&
+    typeof castPipeline.options === "object" &&
+    typeof castPipeline.toServiceClientOptions === "function"
+  );
+}
+
+/**
  * A Pipeline class containing HTTP request policies.
  * You can create a default Pipeline by calling {@link newPipeline}.
  * Or you can create a Pipeline with your own policies by the constructor of Pipeline.
@@ -76,7 +121,7 @@ export interface PipelineOptions {
  * Refer to {@link newPipeline} and provided policies before implementing your
  * customized Pipeline.
  */
-export class Pipeline {
+export class Pipeline implements PipelineLike {
   /**
    * A list of chained request policy factories.
    */

--- a/sdk/storage/storage-blob/src/StorageClient.ts
+++ b/sdk/storage/storage-blob/src/StorageClient.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 
 import { StorageClientContext } from "./generated/src/storageClientContext";
-import { Pipeline } from "./Pipeline";
+import { PipelineLike } from "./Pipeline";
 import { escapeURLPath, getURLScheme, iEqual, getAccountNameFromUrl } from "./utils/utils.common";
 import { AnonymousCredential } from "./credentials/AnonymousCredential";
 import { StorageSharedKeyCredential } from "./credentials/StorageSharedKeyCredential";
@@ -34,7 +34,7 @@ export abstract class StorageClient {
    *
    * @internal
    */
-  protected readonly pipeline: Pipeline;
+  protected readonly pipeline: PipelineLike;
   /**
    * Such as AnonymousCredential, StorageSharedKeyCredential or any credential from the `@azure/identity` package to authenticate requests to the service. You can also provide an object that implements the TokenCredential interface. If not specified, AnonymousCredential is used.
    */
@@ -53,7 +53,7 @@ export abstract class StorageClient {
    * @param url - url to resource
    * @param pipeline - request policy pipeline.
    */
-  protected constructor(url: string, pipeline: Pipeline) {
+  protected constructor(url: string, pipeline: PipelineLike) {
     // URL should be encoded and only once, protocol layer shouldn't encode URL again
     this.url = escapeURLPath(url);
     this.accountName = getAccountNameFromUrl(url);

--- a/sdk/storage/storage-blob/src/credentials/Credential.ts
+++ b/sdk/storage/storage-blob/src/credentials/Credential.ts
@@ -32,19 +32,3 @@ export type CredentialPolicyCreator = (
   nextPolicy: RequestPolicy,
   options: RequestPolicyOptions
 ) => CredentialPolicy;
-
-/**
- * A helper to detect when a passed argument is a Credential subclass
- * @param credential Possibly a Credential type
- * @returns true if the argument is a Credential
- */
-export function isCredential(credential: unknown): credential is Credential {
-  if (!credential || typeof credential !== "object") {
-    return false;
-  }
-  const castCredential = credential as {
-    create: unknown;
-  };
-
-  return typeof castCredential.create === "function";
-}

--- a/sdk/storage/storage-blob/src/credentials/Credential.ts
+++ b/sdk/storage/storage-blob/src/credentials/Credential.ts
@@ -32,3 +32,19 @@ export type CredentialPolicyCreator = (
   nextPolicy: RequestPolicy,
   options: RequestPolicyOptions
 ) => CredentialPolicy;
+
+/**
+ * A helper to detect when a passed argument is a Credential subclass
+ * @param credential Possibly a Credential type
+ * @returns true if the argument is a Credential
+ */
+export function isCredential(credential: unknown): credential is Credential {
+  if (!credential || typeof credential !== "object") {
+    return false;
+  }
+  const castCredential = credential as {
+    create: unknown;
+  };
+
+  return typeof castCredential.create === "function";
+}

--- a/sdk/storage/storage-file-datalake/review/storage-file-datalake.api.md
+++ b/sdk/storage/storage-file-datalake/review/storage-file-datalake.api.md
@@ -27,7 +27,6 @@ import { LeaseOperationResponse } from '@azure/storage-blob';
 import { ModifiedAccessConditions as ModifiedAccessConditions_2 } from '@azure/storage-blob';
 import { OperationTracingOptions } from '@azure/core-tracing';
 import { PagedAsyncIterableIterator } from '@azure/core-paging';
-import { Pipeline as Pipeline_2 } from '@azure/storage-blob';
 import { ProxyOptions } from '@azure/core-http';
 import { Readable } from 'stream';
 import { RequestPolicy } from '@azure/core-http';
@@ -1809,7 +1808,7 @@ export interface PathUpdateHeaders {
 }
 
 // @public
-export class Pipeline extends Pipeline_2 {
+export class Pipeline {
     constructor(factories: RequestPolicyFactory[], options?: PipelineOptions);
     readonly factories: RequestPolicyFactory[];
     readonly options: PipelineOptions;

--- a/sdk/storage/storage-file-datalake/src/Pipeline.ts
+++ b/sdk/storage/storage-file-datalake/src/Pipeline.ts
@@ -34,7 +34,6 @@ import { logger } from "./log";
 import { StorageBrowserPolicyFactory } from "./StorageBrowserPolicyFactory";
 import { StorageRetryOptions, StorageRetryPolicyFactory } from "./StorageRetryPolicyFactory";
 import { TelemetryPolicyFactory } from "./TelemetryPolicyFactory";
-import { Pipeline as BlobPipeline } from "@azure/storage-blob";
 import {
   StorageDataLakeLoggingAllowedHeaderNames,
   StorageDataLakeLoggingAllowedQueryParameters,
@@ -79,7 +78,7 @@ export interface PipelineOptions {
  * Refer to {@link newPipeline} and provided policies before implementing your
  * customized Pipeline.
  */
-export class Pipeline extends BlobPipeline {
+export class Pipeline {
   /**
    * A list of chained request policy factories.
    */
@@ -96,7 +95,6 @@ export class Pipeline extends BlobPipeline {
    * @param options -
    */
   constructor(factories: RequestPolicyFactory[], options: PipelineOptions = {}) {
-    super(factories, options);
     this.factories = factories;
     // when options.httpClient is not specified, passing in a DefaultHttpClient instance to
     // avoid each client creating its own http client.

--- a/sdk/storage/storage-file-datalake/src/Pipeline.ts
+++ b/sdk/storage/storage-file-datalake/src/Pipeline.ts
@@ -41,9 +41,6 @@ import {
 } from "./utils/constants";
 import { getCachedDefaultHttpClient } from "./utils/cache";
 
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT license.
-
 // Export following interfaces and types for customers who want to implement their
 // own RequestPolicy or HTTPClient
 export {


### PR DESCRIPTION
Looking into the code for this, the subclass of `Pipeline` in `storage-file-datalake` simply repeats the same behavior in `storage-blob`'s `Pipeline` class: https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/storage/storage-blob/src/Pipeline.ts

This was apparently done to work around an `instanceof` check in `ContainerClient`. Since `instanceof` checks are strongly discouraged, I have altered `storage-blob` to take an interface instead.

If this is not desired, I believe that `storage-file-datalake` could import `storage-blob`'s Pipeline class instead of declaring its own.