### PR TITLE
Skip all non arm packages when packing packages from feature/v4

### DIFF
--- a/.scripts/common.ts
+++ b/.scripts/common.ts
@@ -107,8 +107,8 @@ function isPackageFolderPath(folderPath: string, packagesToIgnore: string[]): bo
   const packageJsonFilePath: string = joinPath(folderPath, "package.json");
   if (fileExistsSync(packageJsonFilePath)) {
     const packageJson: PackageJson = readPackageJsonFileSync(packageJsonFilePath);
-    // Skip all perf framework projects from gulp pack
-    if (packageJson?.name?.startsWith("@azure-tests/")) {
+    // Skip all packages other than track1 arm packages by gulp script in feature/v4 branch
+    if (!packageJson?.name?.startsWith("@azure/arm-")) {
       return false;
     }
     result = !contains(packagesToIgnore, packageJson.name!);


### PR DESCRIPTION
@azure/graph package got released accidentally from feature/v4 branch. This shouldn't have been released from feature/v4. We have setup a new pipeline for track1 dataplane packages so gulp script should not consider any track1 packages when running on feature/v4 branch to avoid this issue in future due to version conflict on main and feature/v4 branch.