### PR TITLE
[Identity] README: Identity can be used with more than Azure SDKs

### DIFF
--- a/sdk/identity/identity/README.md
+++ b/sdk/identity/identity/README.md
@@ -1,6 +1,6 @@
 ## Azure Identity client library for JavaScript
 
-The Azure Identity library provides Azure Active Directory token authentication support across the Azure SDK. It provides a set of [TokenCredential](https://docs.microsoft.com/javascript/api/@azure/core-auth/tokencredential) implementations which can be used to construct Azure SDK clients which support AAD token authentication.
+The Azure Identity library provides [Azure Active Directory (AAD)](https://azure.microsoft.com/en-us/services/active-directory/) token authentication through a set of convenient [TokenCredentials](https://docs.microsoft.com/javascript/api/@azure/core-auth/tokencredential). It enables Azure SDK clients to authenticate with Azure AAD, while also allowing other JavaScript and TypeScript applications to authenticate with AAD work and school accounts, Microsoft personal accounts (MSA), and other Identity providers through the [Azure AD B2C](https://azure.microsoft.com/en-us/services/active-directory/external-identities/b2c/) service.
 
 You can find examples for these various credentials in the [Azure Identity Examples Page](https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/identity/identity/samples/AzureIdentityExamples.md)
 

--- a/sdk/identity/identity/README.md
+++ b/sdk/identity/identity/README.md
@@ -1,6 +1,6 @@
 ## Azure Identity client library for JavaScript
 
-The Azure Identity library provides [Azure Active Directory (AAD)](https://azure.microsoft.com/en-us/services/active-directory/) token authentication through a set of convenient [TokenCredentials](https://docs.microsoft.com/javascript/api/@azure/core-auth/tokencredential). It enables Azure SDK clients to authenticate with Azure AAD, while also allowing other JavaScript and TypeScript applications to authenticate with AAD work and school accounts, Microsoft personal accounts (MSA), and other Identity providers through the [Azure AD B2C](https://azure.microsoft.com/en-us/services/active-directory/external-identities/b2c/) service.
+The Azure Identity library provides [Azure Active Directory (AAD)](https://azure.microsoft.com/services/active-directory/) token authentication through a set of convenient [TokenCredentials](https://docs.microsoft.com/javascript/api/@azure/core-auth/tokencredential). It enables Azure SDK clients to authenticate with Azure AAD, while also allowing other JavaScript and TypeScript applications to authenticate with AAD work and school accounts, Microsoft personal accounts (MSA), and other Identity providers through the [Azure AD B2C](https://azure.microsoft.com/services/active-directory/external-identities/b2c/) service.
 
 You can find examples for these various credentials in the [Azure Identity Examples Page](https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/identity/identity/samples/AzureIdentityExamples.md)
 

--- a/sdk/identity/identity/README.md
+++ b/sdk/identity/identity/README.md
@@ -1,6 +1,6 @@
 ## Azure Identity client library for JavaScript
 
-The Azure Identity library provides [Azure Active Directory (AAD)](https://azure.microsoft.com/services/active-directory/) token authentication through a set of convenient [TokenCredentials](https://docs.microsoft.com/javascript/api/@azure/core-auth/tokencredential). It enables Azure SDK clients to authenticate with Azure AAD, while also allowing other JavaScript and TypeScript applications to authenticate with AAD work and school accounts, Microsoft personal accounts (MSA), and other Identity providers through the [Azure AD B2C](https://azure.microsoft.com/services/active-directory/external-identities/b2c/) service.
+The Azure Identity library provides [Azure Active Directory (AAD)](https://docs.microsoft.com/azure/active-directory/fundamentals/active-directory-whatis) token authentication through a set of convenient [TokenCredential](https://docs.microsoft.com/javascript/api/@azure/core-auth/tokencredential) implementations. It enables Azure SDK clients to authenticate with AAD, while also allowing other JavaScript and TypeScript apps to authenticate with AAD work and school accounts, Microsoft personal accounts (MSA), and other Identity providers through the [AAD B2C](https://docs.microsoft.com/azure/active-directory-b2c/overview) service.
 
 You can find examples for these various credentials in the [Azure Identity Examples Page](https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/identity/identity/samples/AzureIdentityExamples.md)
 


### PR DESCRIPTION
Nikitha Udaykumar pointed out to us that, since the `@azure/identity` package can be used for more than Azure SDKs, we should be a bit more open with our introductory definition in the README.

What do you think about the definition I’m proposing here?

If this looks correct, I can make issues in the other languages before moving this out of draft.