### PR TITLE
[storage] -  Remove unnecessarily extending CommonOptions 

### DIFF
--- a/sdk/storage/storage-blob/review/storage-blob.api.md
+++ b/sdk/storage/storage-blob/review/storage-blob.api.md
@@ -352,8 +352,7 @@ export type BlobBatchDeleteBlobsResponse = BlobBatchSubmitBatchResponse;
 export type BlobBatchSetBlobsAccessTierResponse = BlobBatchSubmitBatchResponse;
 
 // @public
-export interface BlobBatchSubmitBatchOptionalParams extends ServiceSubmitBatchOptionalParamsModel, CommonOptions {
-    abortSignal?: AbortSignalLike;
+export interface BlobBatchSubmitBatchOptionalParams extends ServiceSubmitBatchOptionalParamsModel {
 }
 
 // @public

--- a/sdk/storage/storage-blob/src/BlobBatchClient.ts
+++ b/sdk/storage/storage-blob/src/BlobBatchClient.ts
@@ -11,14 +11,12 @@ import { ParsedBatchResponse } from "./BatchResponse";
 import { BatchResponseParser } from "./BatchResponseParser";
 import { utf8ByteLength } from "./BatchUtils";
 import { BlobBatch } from "./BlobBatch";
-import { AbortSignalLike } from "@azure/abort-controller";
 import { SpanStatusCode } from "@azure/core-tracing";
 import { convertTracingToRequestOptionsBase, createSpan } from "./utils/tracing";
 import { HttpResponse, TokenCredential } from "@azure/core-http";
 import { Service, Container } from "./generated/src/operations";
 import { StorageSharedKeyCredential } from "./credentials/StorageSharedKeyCredential";
 import { AnonymousCredential } from "./credentials/AnonymousCredential";
-import { CommonOptions } from "./StorageClient";
 import { BlobDeleteOptions, BlobClient, BlobSetTierOptions } from "./Clients";
 import { StorageClientContext } from "./generated/src/storageClientContext";
 import { Pipeline, StoragePipelineOptions, newPipeline } from "./Pipeline";
@@ -27,15 +25,7 @@ import { getURLPath } from "./utils/utils.common";
 /**
  * Options to configure the Service - Submit Batch Optional Params.
  */
-export interface BlobBatchSubmitBatchOptionalParams
-  extends ServiceSubmitBatchOptionalParamsModel,
-    CommonOptions {
-  /**
-   * An implementation of the `AbortSignalLike` interface to signal the request to cancel the operation.
-   * For example, use the &commat;azure/abort-controller to create an `AbortSignal`.
-   */
-  abortSignal?: AbortSignalLike;
-}
+export interface BlobBatchSubmitBatchOptionalParams extends ServiceSubmitBatchOptionalParamsModel {}
 
 /**
  * Contains response data for blob batch operations.


### PR DESCRIPTION
## What

- change BlobBatchSubmitBatchOptionalParams to no longer extend CommonOptions
- remove the declaration of `abortSignal` in BlobBatchSubmitBatchOptionalParams

## Why

BlobBatchSubmitBatchOptionalParams already extends coreHttp.OperationOptions indirectly through ServiceSubmitBatchOptionalParams and does not need to pull tracingOptions from CommonOptions anymore. It also doesn't need to re-declare abortSignal as it gets that from OperationOptions as well.

So nothing changes, but we also know that enums which come in from tracingOptions are compatible but not identical, so when extending both TS will throw an error if core-tracing versions are different. See #15285

This change resolves the above in the only known case of this in our repo, cleans up the unnecessary duplication, and does not change the public API.