### PR TITLE
[KeyVault] - Extend Karma timeout for Key Vault Secrets

### DIFF
--- a/sdk/keyvault/keyvault-secrets/karma.conf.js
+++ b/sdk/keyvault/keyvault-secrets/karma.conf.js
@@ -96,7 +96,7 @@ module.exports = function(config) {
     singleRun: false,
     concurrency: 1,
 
-    browserNoActivityTimeout: 180000,
+    browserNoActivityTimeout: 350000,
     browserDisconnectTimeout: 10000,
     browserDisconnectTolerance: 3,
     browserConsoleLogOptions: {
@@ -108,7 +108,7 @@ module.exports = function(config) {
       mocha: {
         // change Karma's debug.html to the mocha web reporter
         reporter: "html",
-        timeout: "180000"
+        timeout: "350000"
       }
     }
   });


### PR DESCRIPTION
In abf3de05c9f7e99c7fc0cc1a45096abf0aaea1f7 we increased the timeouts for live tests in KV. I didn't update karma config for 
secrets (I did for certificates).

This PR just updates the browser tests' timeout as well 