### PR TITLE
[Identity] Test improvements

### DIFF
--- a/sdk/identity/identity/src/credentials/managedIdentityCredential/imdsMsi.ts
+++ b/sdk/identity/identity/src/credentials/managedIdentityCredential/imdsMsi.ts
@@ -2,7 +2,6 @@
 // Licensed under the MIT license.
 
 import qs from "qs";
-import path from "path";
 import { delay } from "@azure/core-util";
 import { AccessToken, GetTokenOptions } from "@azure/core-auth";
 import {
@@ -47,10 +46,7 @@ function prepareRequestOptions(resource?: string, clientId?: string): PipelineRe
   }
 
   const query = qs.stringify(queryParameters);
-  const url = path.posix.join(
-    process.env.AZURE_POD_IDENTITY_AUTHORITY_HOST ?? imdsHost,
-    imdsEndpointPath
-  );
+  const url = new URL(imdsEndpointPath, process.env.AZURE_POD_IDENTITY_AUTHORITY_HOST ?? imdsHost);
 
   return {
     url: `${url}?${query}`,

--- a/sdk/identity/identity/test/internal/node/managedIdentityCredential.spec.ts
+++ b/sdk/identity/identity/test/internal/node/managedIdentityCredential.spec.ts
@@ -240,7 +240,7 @@ describe("ManagedIdentityCredential", function() {
   });
 
   it("IMDS MSI works even if the AZURE_POD_IDENTITY_AUTHORITY_HOST ends with a slash", async function() {
-    process.env.AZURE_POD_IDENTITY_AUTHORITY_HOST = "http://169.254.169.254/";
+    process.env.AZURE_POD_IDENTITY_AUTHORITY_HOST = "http://10.0.0.1/";
 
     const authDetails = await sendCredentialRequests({
       scopes: ["https://service/.default"],
@@ -257,12 +257,12 @@ describe("ManagedIdentityCredential", function() {
     const imdsPingRequest = authDetails.requests[0];
     assert.equal(
       imdsPingRequest.url,
-      "http://169.254.169.254/metadata/identity/oauth2/token?resource=https%3A%2F%2Fservice&api-version=2018-02-01&client_id=client"
+      "http://10.0.0.1/metadata/identity/oauth2/token?resource=https%3A%2F%2Fservice&api-version=2018-02-01&client_id=client"
     );
   });
 
   it("IMDS MSI works even if the AZURE_POD_IDENTITY_AUTHORITY_HOST doesn't end with a slash", async function() {
-    process.env.AZURE_POD_IDENTITY_AUTHORITY_HOST = "http://169.254.169.254";
+    process.env.AZURE_POD_IDENTITY_AUTHORITY_HOST = "http://10.0.0.1";
 
     const authDetails = await sendCredentialRequests({
       scopes: ["https://service/.default"],
@@ -277,9 +277,10 @@ describe("ManagedIdentityCredential", function() {
 
     // The first request is the IMDS ping.
     const imdsPingRequest = authDetails.requests[0];
+
     assert.equal(
       imdsPingRequest.url,
-      "http://169.254.169.254/metadata/identity/oauth2/token?resource=https%3A%2F%2Fservice&api-version=2018-02-01&client_id=client"
+      "http://10.0.0.1/metadata/identity/oauth2/token?resource=https%3A%2F%2Fservice&api-version=2018-02-01&client_id=client"
     );
   });
 


### PR DESCRIPTION
`path.posix.join` changes `https://` to `https:/`. That happens to be automatically fixed by our core, so the tests didn’t break before. This PR ensures we always send a reasonable URL to the core.

We also test with a non-default environment, to make sure the tests don’t accidentally use the default values.

Thanks to @chlowell for the feedback!