### PR TITLE
Update ms-rest-js dependency to allow use of latest ms-rest-nodeauth with loganalytics

### DIFF
--- a/sdk/operationalinsights/loganalytics/package.json
+++ b/sdk/operationalinsights/loganalytics/package.json
@@ -2,9 +2,9 @@
   "name": "@azure/loganalytics",
   "author": "Microsoft Corporation",
   "description": "LogAnalyticsClient Library with typescript type definitions for node.js and browser.",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "dependencies": {
-    "@azure/ms-rest-js": "^1.1.0",
+    "@azure/ms-rest-js": "^2.4.0",
     "tslib": "^1.9.3"
   },
   "keywords": [

--- a/sdk/operationalinsights/loganalytics/src/logAnalyticsClientContext.ts
+++ b/sdk/operationalinsights/loganalytics/src/logAnalyticsClientContext.ts
@@ -12,7 +12,7 @@ import * as msRest from "@azure/ms-rest-js";
 import * as Models from "./models";
 
 const packageName = "@azure/loganalytics";
-const packageVersion = "0.1.0";
+const packageVersion = "0.3.0";
 
 export class LogAnalyticsClientContext extends msRest.ServiceClient {
   credentials: msRest.ServiceClientCredentials;


### PR DESCRIPTION
Credentials from the latest version of `@azure/ms-rest-nodeauth` will only work with the auto generated packages that depend on v2 and higher of `@azure/ms-rest-js`. This is the root cause for #16811

We have seen this issue in many of the mgmt plane packages as well. There, we regenerated the package use the latest v4 code generator and released a major version update.

But this package will be soon deprecated in favor of the new Monitor Query package and has been on ice since 2 years.

Therefore, to fix the issue with the minimum changes, I am only updating the dependency in this PR

I have chosen `^2.4.0` as that is the min version required if anyone wants to use the credentials from `@azure/identity`, use the adapter from `@azure/ms-rest-js` to create ServiceClientCredentials and then use this package.