### PR TITLE
Bump core-paging dependency version

### DIFF
--- a/sdk/anomalydetector/ai-anomaly-detector/package.json
+++ b/sdk/anomalydetector/ai-anomaly-detector/package.json
@@ -64,7 +64,7 @@
   "dependencies": {
     "@azure/core-http": "^2.0.0",
     "@azure/core-auth": "^1.3.0",
-    "@azure/core-paging": "^1.1.1",
+    "@azure/core-paging": "^1.2.0",
     "@azure/logger": "^1.0.0",
     "tslib": "^2.2.0",
     "@azure/core-tracing": "1.0.0-preview.13"

--- a/sdk/appconfiguration/app-configuration/package.json
+++ b/sdk/appconfiguration/app-configuration/package.json
@@ -89,7 +89,7 @@
     "@azure/abort-controller": "^1.0.0",
     "@azure/core-asynciterator-polyfill": "^1.0.0",
     "@azure/core-http": "^2.0.0",
-    "@azure/core-paging": "^1.1.1",
+    "@azure/core-paging": "^1.2.0",
     "@azure/core-tracing": "1.0.0-preview.13",
     "@azure/core-auth": "^1.3.0",
     "tslib": "^2.2.0"

--- a/sdk/communication/communication-chat/package.json
+++ b/sdk/communication/communication-chat/package.json
@@ -73,7 +73,7 @@
     "@azure/logger": "^1.0.0",
     "events": "^3.0.0",
     "tslib": "^2.2.0",
-    "@azure/core-paging": "^1.1.1"
+    "@azure/core-paging": "^1.2.0"
   },
   "devDependencies": {
     "@azure/communication-identity": "^1.0.0",

--- a/sdk/communication/communication-identity/package.json
+++ b/sdk/communication/communication-identity/package.json
@@ -78,7 +78,7 @@
     "@azure/core-auth": "^1.3.0",
     "@azure/core-http": "^2.0.0",
     "@azure/core-lro": "^2.2.0",
-    "@azure/core-paging": "^1.1.1",
+    "@azure/core-paging": "^1.2.0",
     "@azure/core-tracing": "1.0.0-preview.13",
     "@azure/logger": "^1.0.0",
     "events": "^3.0.0",

--- a/sdk/communication/communication-phone-numbers/package.json
+++ b/sdk/communication/communication-phone-numbers/package.json
@@ -66,7 +66,7 @@
     "@azure/core-auth": "^1.3.0",
     "@azure/core-http": "^2.0.0",
     "@azure/core-lro": "^2.2.0",
-    "@azure/core-paging": "^1.1.1",
+    "@azure/core-paging": "^1.2.0",
     "@azure/core-tracing": "1.0.0-preview.13",
     "@azure/logger": "^1.0.0",
     "events": "^3.0.0",

--- a/sdk/compute/arm-compute/package.json
+++ b/sdk/compute/arm-compute/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@azure/core-lro": "^2.2.0",
     "@azure/abort-controller": "^1.0.0",
-    "@azure/core-paging": "^1.1.1",
+    "@azure/core-paging": "^1.2.0",
     "@azure/core-client": "^1.0.0",
     "@azure/core-auth": "^1.3.0",
     "@azure/core-rest-pipeline": "^1.1.0",

--- a/sdk/containerregistry/container-registry/package.json
+++ b/sdk/containerregistry/container-registry/package.json
@@ -79,7 +79,7 @@
     "@azure/core-auth": "^1.3.0",
     "@azure/core-client": "^1.0.0",
     "@azure/core-rest-pipeline": "^1.1.0",
-    "@azure/core-paging": "^1.1.1",
+    "@azure/core-paging": "^1.2.0",
     "@azure/core-tracing": "1.0.0-preview.13",
     "@azure/logger": "^1.0.0",
     "tslib": "^2.2.0"

--- a/sdk/core/core-client-paging-rest/package.json
+++ b/sdk/core/core-client-paging-rest/package.json
@@ -58,7 +58,7 @@
   "sideEffects": false,
   "prettier": "@azure/eslint-plugin-azure-sdk/prettier.json",
   "dependencies": {
-    "@azure/core-paging": "^1.1.1",
+    "@azure/core-paging": "^1.2.0",
     "@azure/core-rest-pipeline": "^1.1.0",
     "@azure-rest/core-client": "1.0.0-beta.6",
     "tslib": "^2.2.0"

--- a/sdk/deviceupdate/iot-device-update/package.json
+++ b/sdk/deviceupdate/iot-device-update/package.json
@@ -6,7 +6,7 @@
   "version": "1.0.0-beta.2",
   "dependencies": {
     "@azure/core-http": "^2.0.0",
-    "@azure/core-paging": "^1.1.1",
+    "@azure/core-paging": "^1.2.0",
     "@azure/core-tracing": "1.0.0-preview.13",
     "tslib": "^2.2.0"
   },

--- a/sdk/digitaltwins/digital-twins-core/package.json
+++ b/sdk/digitaltwins/digital-twins-core/package.json
@@ -67,7 +67,7 @@
   },
   "dependencies": {
     "@azure/core-http": "^2.0.0",
-    "@azure/core-paging": "^1.1.1",
+    "@azure/core-paging": "^1.2.0",
     "@azure/core-tracing": "1.0.0-preview.13",
     "@azure/logger": "^1.0.0",
     "tslib": "^2.2.0"

--- a/sdk/features/arm-features/package.json
+++ b/sdk/features/arm-features/package.json
@@ -8,7 +8,7 @@
     "node": ">=12.0.0"
   },
   "dependencies": {
-    "@azure/core-paging": "^1.1.1",
+    "@azure/core-paging": "^1.2.0",
     "@azure/core-client": "^1.0.0",
     "@azure/core-auth": "^1.3.0",
     "@azure/core-rest-pipeline": "^1.1.0",

--- a/sdk/formrecognizer/ai-form-recognizer/package.json
+++ b/sdk/formrecognizer/ai-form-recognizer/package.json
@@ -84,7 +84,7 @@
   "dependencies": {
     "@azure/core-auth": "^1.3.0",
     "@azure/core-lro": "^2.2.0",
-    "@azure/core-paging": "^1.1.1",
+    "@azure/core-paging": "^1.2.0",
     "@azure/core-http": "^2.0.0",
     "@azure/core-tracing": "1.0.0-preview.13",
     "@azure/logger": "^1.0.0",

--- a/sdk/keyvault/keyvault-admin/package.json
+++ b/sdk/keyvault/keyvault-admin/package.json
@@ -108,7 +108,7 @@
     "@azure/core-client": "^1.0.0",
     "@azure/core-http": "^2.0.0",
     "@azure/core-lro": "^2.2.0",
-    "@azure/core-paging": "^1.1.1",
+    "@azure/core-paging": "^1.2.0",
     "@azure/core-rest-pipeline": "^1.1.0",
     "@azure/core-tracing": "1.0.0-preview.13",
     "@azure/logger": "^1.0.0",

--- a/sdk/keyvault/keyvault-certificates/package.json
+++ b/sdk/keyvault/keyvault-certificates/package.json
@@ -110,7 +110,7 @@
     "@azure/abort-controller": "^1.0.0",
     "@azure/core-http": "^2.0.0",
     "@azure/core-lro": "^2.2.0",
-    "@azure/core-paging": "^1.1.1",
+    "@azure/core-paging": "^1.2.0",
     "@azure/core-tracing": "1.0.0-preview.13",
     "@azure/logger": "^1.0.0",
     "tslib": "^2.2.0"

--- a/sdk/keyvault/keyvault-keys/package.json
+++ b/sdk/keyvault/keyvault-keys/package.json
@@ -106,7 +106,7 @@
     "@azure/abort-controller": "^1.0.0",
     "@azure/core-http": "^2.0.0",
     "@azure/core-lro": "^2.2.0",
-    "@azure/core-paging": "^1.1.1",
+    "@azure/core-paging": "^1.2.0",
     "@azure/core-tracing": "1.0.0-preview.13",
     "@azure/logger": "^1.0.0",
     "tslib": "^2.2.0"

--- a/sdk/keyvault/keyvault-secrets/package.json
+++ b/sdk/keyvault/keyvault-secrets/package.json
@@ -106,7 +106,7 @@
     "@azure/abort-controller": "^1.0.0",
     "@azure/core-http": "^2.0.0",
     "@azure/core-lro": "^2.2.0",
-    "@azure/core-paging": "^1.1.1",
+    "@azure/core-paging": "^1.2.0",
     "@azure/core-tracing": "1.0.0-preview.13",
     "@azure/logger": "^1.0.0",
     "tslib": "^2.2.0"

--- a/sdk/links/arm-links/package.json
+++ b/sdk/links/arm-links/package.json
@@ -8,7 +8,7 @@
     "node": ">=12.0.0"
   },
   "dependencies": {
-    "@azure/core-paging": "^1.1.1",
+    "@azure/core-paging": "^1.2.0",
     "@azure/core-client": "^1.0.0",
     "@azure/core-auth": "^1.3.0",
     "@azure/core-rest-pipeline": "^1.1.0",

--- a/sdk/locks/arm-locks/package.json
+++ b/sdk/locks/arm-locks/package.json
@@ -8,7 +8,7 @@
     "node": ">=12.0.0"
   },
   "dependencies": {
-    "@azure/core-paging": "^1.1.1",
+    "@azure/core-paging": "^1.2.0",
     "@azure/core-client": "^1.0.0",
     "@azure/core-auth": "^1.3.0",
     "@azure/core-rest-pipeline": "^1.1.0",

--- a/sdk/managedapplications/arm-managedapplications/package.json
+++ b/sdk/managedapplications/arm-managedapplications/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@azure/core-lro": "^2.2.0",
     "@azure/abort-controller": "^1.0.0",
-    "@azure/core-paging": "^1.1.1",
+    "@azure/core-paging": "^1.2.0",
     "@azure/core-client": "^1.0.0",
     "@azure/core-auth": "^1.3.0",
     "@azure/core-rest-pipeline": "^1.1.0",

--- a/sdk/metricsadvisor/ai-metrics-advisor/package.json
+++ b/sdk/metricsadvisor/ai-metrics-advisor/package.json
@@ -83,7 +83,7 @@
   "dependencies": {
     "@azure/core-auth": "^1.3.0",
     "@azure/core-lro": "^2.2.0",
-    "@azure/core-paging": "^1.1.1",
+    "@azure/core-paging": "^1.2.0",
     "@azure/core-http": "^2.0.0",
     "@azure/core-tracing": "1.0.0-preview.13",
     "@azure/logger": "^1.0.0",

--- a/sdk/network/arm-network/package.json
+++ b/sdk/network/arm-network/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@azure/core-lro": "^2.2.0",
     "@azure/abort-controller": "^1.0.0",
-    "@azure/core-paging": "^1.1.1",
+    "@azure/core-paging": "^1.2.0",
     "@azure/core-client": "^1.0.0",
     "@azure/core-auth": "^1.3.0",
     "@azure/core-rest-pipeline": "^1.1.0",

--- a/sdk/policy/arm-policy/package.json
+++ b/sdk/policy/arm-policy/package.json
@@ -8,7 +8,7 @@
     "node": ">=12.0.0"
   },
   "dependencies": {
-    "@azure/core-paging": "^1.1.1",
+    "@azure/core-paging": "^1.2.0",
     "@azure/core-client": "^1.0.0",
     "@azure/core-auth": "^1.3.0",
     "@azure/core-rest-pipeline": "^1.1.0",

--- a/sdk/quantum/quantum-jobs/package.json
+++ b/sdk/quantum/quantum-jobs/package.json
@@ -64,7 +64,7 @@
     "url": "https://github.com/Azure/azure-sdk-for-js/issues"
   },
   "dependencies": {
-    "@azure/core-paging": "^1.1.1",
+    "@azure/core-paging": "^1.2.0",
     "@azure/core-http": "^2.0.0",
     "@azure/core-tracing": "1.0.0-preview.13",
     "tslib": "^2.2.0"

--- a/sdk/remoterendering/mixed-reality-remote-rendering/package.json
+++ b/sdk/remoterendering/mixed-reality-remote-rendering/package.json
@@ -83,7 +83,7 @@
     "@azure/mixed-reality-authentication": "1.0.0-beta.1",
     "@azure/core-lro": "^2.2.0",
     "@azure/abort-controller": "^1.0.0",
-    "@azure/core-paging": "^1.1.1",
+    "@azure/core-paging": "^1.2.0",
     "@azure/core-util": "^1.0.0-beta.1"
   },
   "devDependencies": {

--- a/sdk/resources/arm-resources/package.json
+++ b/sdk/resources/arm-resources/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@azure/core-lro": "^2.2.0",
     "@azure/abort-controller": "^1.0.0",
-    "@azure/core-paging": "^1.1.1",
+    "@azure/core-paging": "^1.2.0",
     "@azure/core-client": "^1.0.0",
     "@azure/core-auth": "^1.3.0",
     "@azure/core-rest-pipeline": "^1.1.0",

--- a/sdk/search/search-documents/package.json
+++ b/sdk/search/search-documents/package.json
@@ -78,7 +78,7 @@
   "dependencies": {
     "@azure/core-auth": "^1.3.0",
     "@azure/core-http": "^2.0.0",
-    "@azure/core-paging": "^1.1.1",
+    "@azure/core-paging": "^1.2.0",
     "@azure/core-tracing": "1.0.0-preview.13",
     "@azure/logger": "^1.0.0",
     "tslib": "^2.2.0",

--- a/sdk/servicebus/service-bus/package.json
+++ b/sdk/servicebus/service-bus/package.json
@@ -115,7 +115,7 @@
     "@azure/core-asynciterator-polyfill": "^1.0.0",
     "@azure/core-http": "^2.0.0",
     "@azure/core-tracing": "1.0.0-preview.13",
-    "@azure/core-paging": "^1.1.1",
+    "@azure/core-paging": "^1.2.0",
     "@azure/core-auth": "^1.3.0",
     "@azure/logger": "^1.0.0",
     "@types/is-buffer": "^2.0.0",

--- a/sdk/storage/arm-storage/package.json
+++ b/sdk/storage/arm-storage/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@azure/core-lro": "^2.2.0",
     "@azure/abort-controller": "^1.0.0",
-    "@azure/core-paging": "^1.1.1",
+    "@azure/core-paging": "^1.2.0",
     "@azure/core-client": "^1.0.0",
     "@azure/core-auth": "^1.3.0",
     "@azure/core-rest-pipeline": "^1.1.0",

--- a/sdk/storage/storage-blob-changefeed/package.json
+++ b/sdk/storage/storage-blob-changefeed/package.json
@@ -98,7 +98,7 @@
     "@azure/abort-controller": "^1.0.0",
     "@azure/core-http": "^2.0.0",
     "@azure/core-lro": "^2.2.0",
-    "@azure/core-paging": "^1.1.1",
+    "@azure/core-paging": "^1.2.0",
     "@azure/core-tracing": "1.0.0-preview.13",
     "@azure/logger": "^1.0.0",
     "events": "^3.0.0",

--- a/sdk/storage/storage-blob/package.json
+++ b/sdk/storage/storage-blob/package.json
@@ -129,7 +129,7 @@
     "@azure/abort-controller": "^1.0.0",
     "@azure/core-http": "^2.0.0",
     "@azure/core-lro": "^2.2.0",
-    "@azure/core-paging": "^1.1.1",
+    "@azure/core-paging": "^1.2.0",
     "@azure/core-tracing": "1.0.0-preview.13",
     "@azure/logger": "^1.0.0",
     "events": "^3.0.0",

--- a/sdk/storage/storage-file-datalake/package.json
+++ b/sdk/storage/storage-file-datalake/package.json
@@ -108,7 +108,7 @@
   "dependencies": {
     "@azure/abort-controller": "^1.0.0",
     "@azure/core-http": "^2.0.0",
-    "@azure/core-paging": "^1.1.1",
+    "@azure/core-paging": "^1.2.0",
     "@azure/core-tracing": "1.0.0-preview.13",
     "@azure/logger": "^1.0.0",
     "@azure/storage-blob": "^12.8.0-beta.1",

--- a/sdk/storage/storage-file-share/package.json
+++ b/sdk/storage/storage-file-share/package.json
@@ -116,7 +116,7 @@
   "dependencies": {
     "@azure/abort-controller": "^1.0.0",
     "@azure/core-http": "^2.0.0",
-    "@azure/core-paging": "^1.1.1",
+    "@azure/core-paging": "^1.2.0",
     "@azure/core-tracing": "1.0.0-preview.13",
     "@azure/logger": "^1.0.0",
     "events": "^3.0.0",

--- a/sdk/storage/storage-internal-avro/package.json
+++ b/sdk/storage/storage-internal-avro/package.json
@@ -65,7 +65,7 @@
   },
   "dependencies": {
     "@azure/abort-controller": "^1.0.0",
-    "@azure/core-paging": "^1.1.1",
+    "@azure/core-paging": "^1.2.0",
     "tslib": "^2.2.0"
   },
   "devDependencies": {

--- a/sdk/storage/storage-queue/package.json
+++ b/sdk/storage/storage-queue/package.json
@@ -111,7 +111,7 @@
   "dependencies": {
     "@azure/abort-controller": "^1.0.0",
     "@azure/core-http": "^2.0.0",
-    "@azure/core-paging": "^1.1.1",
+    "@azure/core-paging": "^1.2.0",
     "@azure/core-tracing": "1.0.0-preview.13",
     "@azure/logger": "^1.0.0",
     "tslib": "^2.2.0"

--- a/sdk/synapse/synapse-artifacts/package.json
+++ b/sdk/synapse/synapse-artifacts/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "@azure/core-auth": "^1.3.0",
     "@azure/core-lro": "^2.2.0",
-    "@azure/core-paging": "^1.1.1",
+    "@azure/core-paging": "^1.2.0",
     "@azure/core-client": "^1.0.0",
     "@azure/core-tracing": "1.0.0-preview.13",
     "@azure/core-rest-pipeline": "^1.1.0",

--- a/sdk/synapse/synapse-managed-private-endpoints/package.json
+++ b/sdk/synapse/synapse-managed-private-endpoints/package.json
@@ -8,7 +8,7 @@
   "repository": "github:Azure/azure-sdk-for-js",
   "dependencies": {
     "@azure/core-auth": "^1.3.0",
-    "@azure/core-paging": "^1.1.1",
+    "@azure/core-paging": "^1.2.0",
     "@azure/core-client": "^1.0.0",
     "@azure/core-tracing": "1.0.0-preview.13",
     "tslib": "^2.2.0"

--- a/sdk/tables/data-tables/package.json
+++ b/sdk/tables/data-tables/package.json
@@ -80,7 +80,7 @@
     "@azure/core-auth": "^1.3.0",
     "@azure/core-client": "^1.0.0",
     "@azure/core-rest-pipeline": "^1.1.0",
-    "@azure/core-paging": "^1.1.1",
+    "@azure/core-paging": "^1.2.0",
     "@azure/core-xml": "^1.0.0",
     "@azure/logger": "^1.0.0",
     "@azure/core-tracing": "1.0.0-preview.13",

--- a/sdk/textanalytics/ai-text-analytics/package.json
+++ b/sdk/textanalytics/ai-text-analytics/package.json
@@ -94,7 +94,7 @@
     "@azure/core-client": "^1.0.0",
     "@azure/core-rest-pipeline": "^1.1.0",
     "@azure/core-lro": "^2.2.0",
-    "@azure/core-paging": "^1.1.1",
+    "@azure/core-paging": "^1.2.0",
     "@azure/core-tracing": "1.0.0-preview.13",
     "@azure/logger": "^1.0.0",
     "tslib": "^2.2.0"

--- a/sdk/web-pubsub/arm-webpubsub/package.json
+++ b/sdk/web-pubsub/arm-webpubsub/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@azure/core-lro": "^2.2.0",
     "@azure/abort-controller": "^1.0.0",
-    "@azure/core-paging": "^1.1.1",
+    "@azure/core-paging": "^1.2.0",
     "@azure/core-client": "^1.0.0",
     "@azure/core-auth": "^1.3.0",
     "@azure/core-rest-pipeline": "^1.1.0",


### PR DESCRIPTION
Text Analytics now uses features part of `@azure/core-paging@1.2.0` so I am bumping the dependency on it to be `^1.2.0` across our packages. I will merge this PR after the release week. 

Please note that `@azure/core-paging@1.2.0` is not released yet so please let me know if your package is planned to release oob this month and it depends on `@azure/core-paging` so we can make an exception.