### PR TITLE
[Text Analytics] bump core-paging dep version

### DIFF
--- a/common/config/rush/common-versions.json
+++ b/common/config/rush/common-versions.json
@@ -41,6 +41,9 @@
    * This design avoids unnecessary churn in this file.
    */
   "allowedAlternativeVersions": {
+    // Text Analytics uses this version and it is not released yet. I am making an exception
+    // for it here and it should be removed once core-paging 1.2.0 is released.
+    "@azure/core-paging": ["^1.2.0"],
     // "^12.6.0" is required for eventhubs-checkpointstore-blob to use the latest GA version
     // when there is a new beta version which is being maintained in the repo.
     // Remove "^12.6.0" when the storage-blob releases a stable version.

--- a/sdk/textanalytics/ai-text-analytics/package.json
+++ b/sdk/textanalytics/ai-text-analytics/package.json
@@ -94,7 +94,7 @@
     "@azure/core-client": "^1.0.0",
     "@azure/core-rest-pipeline": "^1.1.0",
     "@azure/core-lro": "^2.2.0",
-    "@azure/core-paging": "^1.1.1",
+    "@azure/core-paging": "^1.2.0",
     "@azure/core-tracing": "1.0.0-preview.13",
     "@azure/logger": "^1.0.0",
     "tslib": "^2.2.0"


### PR DESCRIPTION
min/max testing is failing for text analytics because of not using the correct core-paging version there. Since it is a release week and core-paging@1.2 was not released yet, I am coding it as an exception for now and then will merge https://github.com/Azure/azure-sdk-for-js/pull/16856 next week.