### PR TITLE
[Batch] Rollback the support for TokenCredential

### DIFF
--- a/sdk/batch/batch/README.md
+++ b/sdk/batch/batch/README.md
@@ -4,8 +4,10 @@ This package contains an isomorphic SDK for BatchServiceClient.
 
 ### Currently supported environments
 
-- Node.js version 6.x.x or higher
-- Browser JavaScript
+- [LTS versions of Node.js](https://nodejs.org/about/releases/)
+- Latest versions of Safari, Chrome, Edge, and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### How to Install
 
@@ -25,25 +27,7 @@ npm install @azure/ms-rest-nodeauth
 
 ##### Authentication
 
-1. Use `AzureCliCredentials` exported from `@azure/ms-rest-nodeauth`.
-   **Please make sure to install Azure CLI and login using `az login`.**
-
-```typescript
-import { BatchServiceClient } from "@azure/batch";
-import { AzureCliCredentials } from "@azure/ms-rest-nodeauth";
-
-const batchEndpoint = process.env["AZURE_BATCH_ENDPOINT"] || "";
-async function main(): Promise<void> {
-  try {
-    const creds = await AzureCliCredentials.create({ resource: "https://batch.core.windows.net/" });
-    const client = new BatchServiceClient(creds, batchEndpoint);
-  } catch (err) {
-    console.log(err);
-  }
-}
-```
-
-2. Use the `BatchSharedKeyCredentials` exported from `@azure/batch`.
+1. Use the `BatchSharedKeyCredentials` exported from `@azure/batch`.
 
 ```typescript
 import { BatchServiceClient, BatchSharedKeyCredentials } from "@azure/batch";
@@ -62,7 +46,7 @@ async function main(): Promise<void> {
 }
 ```
 
-3. Use the `MSIVmTokenCredentials` exported from `@azure/ms-rest-nodeauth`.
+2. Use the `MSIVmTokenCredentials` exported from `@azure/ms-rest-nodeauth`.
 
 ```typescript
 import { BatchServiceClient } from "@azure/batch";

--- a/sdk/batch/batch/README.md
+++ b/sdk/batch/batch/README.md
@@ -1,121 +1,127 @@
 ## Azure BatchServiceClient SDK for JavaScript
 
-This package contains an isomorphic SDK (runs both in Node.js and in browsers) for BatchServiceClient.
+This package contains an isomorphic SDK for BatchServiceClient.
 
 ### Currently supported environments
 
-- [LTS versions of Node.js](https://nodejs.org/about/releases/)
-- Latest versions of Safari, Chrome, Edge and Firefox.
+- Node.js version 6.x.x or higher
+- Browser JavaScript
 
-### Prerequisites
-
-You must have an [Azure subscription](https://azure.microsoft.com/free/).
-
-### How to install
-
-To use this SDK in your project, you will need to install two packages.
-
-- `@azure/batch` that contains the client.
-- `@azure/identity` that provides different mechanisms for the client to authenticate your requests using Azure Active Directory.
-
-Install both packages using the below command:
+### How to Install
 
 ```bash
-npm install --save @azure/batch @azure/identity
+npm install @azure/batch
 ```
-
-> **Note**: You may have used either `@azure/ms-rest-nodeauth` or `@azure/ms-rest-browserauth` in the past. These packages are in maintenance mode receiving critical bug fixes, but no new features.
-> If you are on a [Node.js that has LTS status](https://nodejs.org/about/releases/), or are writing a client side browser application, we strongly encourage you to upgrade to `@azure/identity` which uses the latest versions of Azure Active Directory and MSAL APIs and provides more authentication options.
 
 ### How to use
 
-- If you are writing a client side browser application,
-  - Follow the instructions in the section on Authenticating client side browser applications in [Azure Identity examples](https://aka.ms/azsdk/js/identity/examples) to register your application in the Microsoft identity platform and set the right permissions.
-  - Copy the client ID and tenant ID from the Overview section of your app registration in Azure portal and use it in the browser sample below.
-- If you are writing a server side application,
-  - [Select a credential from `@azure/identity` based on the authentication method of your choice](https://aka.ms/azsdk/js/identity/examples)
-  - Complete the set up steps required by the credential if any.
-  - Use the credential you picked in the place of `DefaultAzureCredential` in the Node.js sample below.
+#### nodejs - Authentication, client creation and list application as an example written in TypeScript.
 
-In the below samples, we pass the credential and the Azure subscription id to instantiate the client.
-Once the client is created, explore the operations on it either in your favorite editor or in our [API reference documentation](https://docs.microsoft.com/javascript/api) to get started.
+##### Install @azure/ms-rest-nodeauth
 
-#### nodejs - Authentication, client creation, and list application as an example written in JavaScript.
-
-##### Sample code
-
-```javascript
-const { DefaultAzureCredential } = require("@azure/identity");
-const { BatchServiceClient } = require("@azure/batch");
-const subscriptionId = process.env["AZURE_SUBSCRIPTION_ID"];
-
-// Use `DefaultAzureCredential` or any other credential of your choice based on https://aka.ms/azsdk/js/identity/examples
-// Please note that you can also use credentials from the `@azure/ms-rest-nodeauth` package instead.
-const creds = new DefaultAzureCredential();
-const client = new BatchServiceClient(creds, subscriptionId);
-const maxResults = 1;
-const timeout = 1;
-const clientRequestId = ec7b1657-199d-4d8a-bbb2-89a11a42e02a;
-const returnClientRequestId = true;
-const ocpDate = new Date().toUTCString();
-client.application.list(maxResults, timeout, clientRequestId, returnClientRequestId, ocpDate).then((result) => {
-  console.log("The result is:");
-  console.log(result);
-}).catch((err) => {
-  console.log("An error occurred:");
-  console.error(err);
-});
+```bash
+npm install @azure/ms-rest-nodeauth
 ```
 
-#### browser - Authentication, client creation, and list application as an example written in JavaScript.
+##### Authentication
 
-In browser applications, we recommend using the `InteractiveBrowserCredential` that interactively authenticates using the default system browser.
+1. Use `AzureCliCredentials` exported from `@azure/ms-rest-nodeauth`.
+   **Please make sure to install Azure CLI and login using `az login`.**
 
-- See [Single-page application: App registration guide](https://docs.microsoft.com/azure/active-directory/develop/scenario-spa-app-registration) to configure your app registration for the browser.
-- Note down the client Id from the previous step and use it in the browser sample below.
+```typescript
+import { BatchServiceClient } from "@azure/batch";
+import { AzureCliCredentials } from "@azure/ms-rest-nodeauth";
+
+const batchEndpoint = process.env["AZURE_BATCH_ENDPOINT"] || "";
+async function main(): Promise<void> {
+  try {
+    const creds = await AzureCliCredentials.create({ resource: "https://batch.core.windows.net/" });
+    const client = new BatchServiceClient(creds, batchEndpoint);
+  } catch (err) {
+    console.log(err);
+  }
+}
+```
+
+2. Use the `BatchSharedKeyCredentials` exported from `@azure/batch`.
+
+```typescript
+import { BatchServiceClient, BatchSharedKeyCredentials } from "@azure/batch";
+
+const batchAccountName = process.env["AZURE_BATCH_ACCOUNT_NAME"] || "";
+const batchAccountKey = process.env["AZURE_BATCH_ACCOUNT_KEY"] || "";
+const batchEndpoint = process.env["AZURE_BATCH_ENDPOINT"] || "";
+
+async function main(): Promise<void> {
+  try {
+    const creds = new BatchSharedKeyCredentials(batchAccountName, batchAccountKey);
+    const client = new BatchServiceClient(creds, batchEndpoint);
+  } catch (err) {
+    console.log(err);
+  }
+}
+```
+
+3. Use the `MSIVmTokenCredentials` exported from `@azure/ms-rest-nodeauth`.
+
+```typescript
+import { BatchServiceClient } from "@azure/batch";
+import { loginWithVmMSI } from "@azure/ms-rest-nodeauth";
+
+const batchEndpoint = process.env["AZURE_BATCH_ENDPOINT"] || "";
+
+async function main(): Promise<void> {
+  try {
+    const creds = await loginWithVmMSI({
+      resource: "https://batch.core.windows.net/"
+    });
+    const client = new BatchServiceClient(creds, batchEndpoint);
+  } catch (err) {
+    console.log(err);
+  }
+}
+```
 
 ##### Sample code
 
-- index.html
+```typescript
+import { BatchServiceClient, BatchServiceModels, BatchSharedKeyCredentials } from "@azure/batch";
 
-```html
-<!DOCTYPE html>
-<html lang="en">
-  <head>
-    <title>@azure/batch sample</title>
-    <script src="node_modules/@azure/ms-rest-azure-js/dist/msRestAzure.js"></script>
-    <script src="node_modules/@azure/identity/dist/index.js"></script>
-    <script src="node_modules/@azure/batch/dist/batch.js"></script>
-    <script type="text/javascript">
-      const subscriptionId = "<Subscription_Id>";
-      // Create credentials using the `@azure/identity` package.
-      // Please note that you can also use credentials from the `@azure/ms-rest-browserauth` package instead.
-      const credential = new InteractiveBrowserCredential(
-      {
-        clientId: "<client id for your Azure AD app>",
-        tenant: "<optional tenant for your organization>"
-      });
-      const client = new Azure.Batch.BatchServiceClient(creds, subscriptionId);
-      const maxResults = 1;
-      const timeout = 1;
-      const clientRequestId = ec7b1657-199d-4d8a-bbb2-89a11a42e02a;
-      const returnClientRequestId = true;
-      const ocpDate = new Date().toUTCString();
-      client.application.list(maxResults, timeout, clientRequestId, returnClientRequestId, ocpDate).then((result) => {
-        console.log("The result is:");
-        console.log(result);
-      }).catch((err) => {
-        console.log("An error occurred:");
-        console.error(err);
-      });
-    </script>
-  </head>
-  <body></body>
-</html>
+const batchAccountName = process.env["AZURE_BATCH_ACCOUNT_NAME"] || "";
+const batchAccountKey = process.env["AZURE_BATCH_ACCOUNT_KEY"] || "";
+const batchEndpoint = process.env["AZURE_BATCH_ENDPOINT"] || "";
+
+const creds = new BatchSharedKeyCredentials(batchAccountName, batchAccountKey);
+const client = new BatchServiceClient(creds, batchEndpoint);
+
+const options: BatchServiceModels.JobListOptionalParams = {
+  jobListOptions: { maxResults: 10 }
+};
+
+async function loop(res: BatchServiceModels.JobListResponse, nextLink?: string): Promise<void> {
+  if (nextLink !== undefined) {
+    const res1 = await client.job.listNext(nextLink);
+    if (res1.length) {
+      for (const item of res1) {
+        res.push(item);
+      }
+    }
+    return loop(res, res1.odatanextLink);
+  }
+  return Promise.resolve();
+}
+
+async function main(): Promise<void> {
+  const result = await client.job.list(options);
+  await loop(result, result.odatanextLink);
+  console.dir(result, { depth: null, colors: true });
+}
+
+main().catch((err) => console.log("An error occurred: ", err));
 ```
 
 ## Related projects
 
 - [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
 
-![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js/sdk/batch/batch/README.png)
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fsdk%2Fbatch%2Fbatch%2FREADME.png)

--- a/sdk/batch/batch/package.json
+++ b/sdk/batch/batch/package.json
@@ -2,9 +2,8 @@
   "name": "@azure/batch",
   "author": "Microsoft Corporation",
   "description": "BatchServiceClient Library with typescript type definitions for node.js and browser.",
-  "version": "9.0.0",
+  "version": "9.1.0",
   "dependencies": {
-    "@azure/core-auth": "^1.1.4",
     "@azure/ms-rest-azure-js": "^2.1.0",
     "@azure/ms-rest-js": "^2.2.0",
     "jssha": "^3.2.0",

--- a/sdk/batch/batch/package.json
+++ b/sdk/batch/batch/package.json
@@ -2,7 +2,7 @@
   "name": "@azure/batch",
   "author": "Microsoft Corporation",
   "description": "BatchServiceClient Library with typescript type definitions for node.js and browser.",
-  "version": "9.1.0",
+  "version": "10.0.0",
   "dependencies": {
     "@azure/ms-rest-azure-js": "^2.1.0",
     "@azure/ms-rest-js": "^2.2.0",

--- a/sdk/batch/batch/src/batchServiceClient.ts
+++ b/sdk/batch/batch/src/batchServiceClient.ts
@@ -29,12 +29,7 @@ class BatchServiceClient extends BatchServiceClientContext {
 
   /**
    * Initializes a new instance of the BatchServiceClient class.
-   * @param credentials Credentials needed for the client to connect to Azure. Credentials
-   * implementing the TokenCredential interface from the @azure/identity package are recommended. For
-   * more information about these credentials, see
-   * {@link https://www.npmjs.com/package/@azure/identity}. Credentials implementing the
-   * ServiceClientCredentials interface from the older packages @azure/ms-rest-nodeauth and
-   * @azure/ms-rest-browserauth are also supported.
+   * @param credentials Credentials needed for the client to connect to Azure.
    * @param batchUrl The base URL for all Azure Batch service requests.
    * @param [options] The parameter options
    */

--- a/sdk/batch/batch/src/batchServiceClient.ts
+++ b/sdk/batch/batch/src/batchServiceClient.ts
@@ -8,7 +8,6 @@
  */
 
 import * as msRest from "@azure/ms-rest-js";
-import { TokenCredential } from "@azure/core-auth";
 import * as msRestAzure from "@azure/ms-rest-azure-js";
 import * as Models from "./models";
 import * as Mappers from "./models/mappers";
@@ -40,7 +39,7 @@ class BatchServiceClient extends BatchServiceClientContext {
    * @param [options] The parameter options
    */
   constructor(
-    credentials: msRest.ServiceClientCredentials | TokenCredential,
+    credentials: msRest.ServiceClientCredentials,
     batchUrl: string,
     options?: msRestAzure.AzureServiceClientOptions
   ) {

--- a/sdk/batch/batch/src/batchServiceClientContext.ts
+++ b/sdk/batch/batch/src/batchServiceClientContext.ts
@@ -11,7 +11,7 @@ import * as msRest from "@azure/ms-rest-js";
 import * as msRestAzure from "@azure/ms-rest-azure-js";
 
 const packageName = "@azure/batch";
-const packageVersion = "9.1.0";
+const packageVersion = "10.0.0";
 
 export class BatchServiceClientContext extends msRestAzure.AzureServiceClient {
   credentials: msRest.ServiceClientCredentials;

--- a/sdk/batch/batch/src/batchServiceClientContext.ts
+++ b/sdk/batch/batch/src/batchServiceClientContext.ts
@@ -9,29 +9,23 @@
 
 import * as msRest from "@azure/ms-rest-js";
 import * as msRestAzure from "@azure/ms-rest-azure-js";
-import { TokenCredential } from "@azure/core-auth";
 
 const packageName = "@azure/batch";
-const packageVersion = "9.0.0";
+const packageVersion = "9.1.0";
 
 export class BatchServiceClientContext extends msRestAzure.AzureServiceClient {
-  credentials: msRest.ServiceClientCredentials | TokenCredential;
+  credentials: msRest.ServiceClientCredentials;
   apiVersion?: string;
   batchUrl: string;
 
   /**
    * Initializes a new instance of the BatchServiceClient class.
-   * @param credentials Credentials needed for the client to connect to Azure. Credentials
-   * implementing the TokenCredential interface from the @azure/identity package are recommended. For
-   * more information about these credentials, see
-   * {@link https://www.npmjs.com/package/@azure/identity}. Credentials implementing the
-   * ServiceClientCredentials interface from the older packages @azure/ms-rest-nodeauth and
-   * @azure/ms-rest-browserauth are also supported.
+   * @param credentials Credentials needed for the client to connect to Azure.
    * @param batchUrl The base URL for all Azure Batch service requests.
    * @param [options] The parameter options
    */
   constructor(
-    credentials: msRest.ServiceClientCredentials | TokenCredential,
+    credentials: msRest.ServiceClientCredentials,
     batchUrl: string,
     options?: msRestAzure.AzureServiceClientOptions
   ) {

--- a/sdk/batch/batch/test/utils/recordedClient.ts
+++ b/sdk/batch/batch/test/utils/recordedClient.ts
@@ -6,7 +6,7 @@
 // import { Context } from "mocha";
 
 // import { env, Recorder, record, RecorderEnvironmentSetup } from "@azure/test-utils-recorder";
-import { TokenCredential, ClientSecretCredential } from "@azure/identity";
+// import { TokenCredential, ClientSecretCredential } from "@azure/identity";
 
 import "./env";
 import { BatchServiceClient } from "../../src/batchServiceClient";
@@ -45,7 +45,7 @@ export function createClient(
   authMethod: AuthMethod,
   options?: AzureServiceClientOptions
 ): BatchServiceClient {
-  let credential: BatchSharedKeyCredentials | TokenCredential;
+  let credential: BatchSharedKeyCredentials;
   switch (authMethod) {
     case "APIKey": {
       credential = new BatchSharedKeyCredentials(
@@ -55,12 +55,13 @@ export function createClient(
       break;
     }
     case "AAD": {
-      credential = new ClientSecretCredential(
-        process.env.AZURE_TENANT_ID!,
-        process.env.AZURE_CLIENT_ID!,
-        process.env.AZURE_CLIENT_SECRET!
-      );
-      break;
+      throw new Error("AAD is not supported");
+      // credential = new ClientSecretCredential(
+      //   process.env.AZURE_TENANT_ID!,
+      //   process.env.AZURE_CLIENT_ID!,
+      //   process.env.AZURE_CLIENT_SECRET!
+      // );
+      // break;
     }
     case "DummyAPIKey": {
       credential = new BatchSharedKeyCredentials("whatever", "whatever");


### PR DESCRIPTION
Batch has been advertising using shared keys as their primary way of authentication in their docs. https://github.com/Azure/azure-sdk-for-js/pull/16679 added support for `TokenCredential` authentication but it turned out that batch is not compatible with the support for token credentials in `@azure/ms-rest-js` because the [latter assumes a scope that only works with management-plane libs](https://github.com/Azure/ms-rest-js/blob/702088850b339804fc7b178407d0c7e0117701ed/lib/credentials/azureIdentityTokenCredentialAdapter.ts#L22).

If we want to fix the support for AAD, we will have to add support for custom scopes in `@azure/ms-rest-js` so we can pass the batch scope `https://batch.core.windows.net//.default` to it and also update `azureTokenCredential` as follows:
```ts
azureTokenCredential.msalFlow.identityClient.authorityHost = "https://login.microsoftonline.com/<tenant id>";
azureTokenCredential.msalFlow.identityClient.baseUri = "https://login.microsoftonline.com/<tenant id>";
azureTokenCredential.msalFlow.tenantId = "<tenant id>";
```

Because of the hassle of doing the fix and the fact that AAD support was not advertisied in batch to begin with, we want to go ahead and revert the support for `TokenCredential` instead.