### PR TITLE
Remove sdk/*/readme from the docsettings omitted paths

### DIFF
--- a/eng/.docsettings.yml
+++ b/eng/.docsettings.yml
@@ -4,7 +4,6 @@ omitted_paths:
   - documentation/ServicePrincipal/*
   - eng/*
   - samples/*
-  - sdk/*/README.md
   - sdk/**/samples-*/*
   - sdk/**/samples/*
   - sdk/**/swagger/*


### PR DESCRIPTION
Looks it was I who added  `sdk/*README`  in #15146, but I cannot recall the reason.
Other entries were for cases that we genuinely did need to skip

Well, creating to this PR to see what breaks if I do remove it :)

Resolves #16869