### PR TITLE
[Batch] Include types in shipped package

### DIFF
--- a/sdk/batch/batch/package.json
+++ b/sdk/batch/batch/package.json
@@ -21,7 +21,7 @@
   "license": "MIT",
   "main": "./dist/batch.js",
   "module": "./esm/batchServiceClient.js",
-  "types": "./esm/batchServiceClient.d.ts",
+  "types": "./types/src/batchServiceClient.d.ts",
   "devDependencies": {
     "@rollup/plugin-commonjs": "^20.0.0",
     "@rollup/plugin-json": "^4.1.0",
@@ -76,18 +76,11 @@
     "url": "https://github.com/Azure/azure-sdk-for-js/issues"
   },
   "files": [
-    "dist/**/*.js",
-    "dist/**/*.js.map",
-    "dist/**/*.d.ts",
-    "dist/**/*.d.ts.map",
-    "esm/**/*.js",
-    "esm/**/*.js.map",
-    "esm/**/*.d.ts",
-    "esm/**/*.d.ts.map",
-    "src/**/*.ts",
+    "dist/",
+    "dist-esm/src/",
+    "types/src/",
     "README.md",
-    "rollup.config.js",
-    "tsconfig.json"
+    "LICENSE"
   ],
   "scripts": {
     "audit": "node ../../../common/scripts/rush-audit.js && rimraf node_modules package-lock.json && npm i --package-lock-only 2>&1 && npm audit",


### PR DESCRIPTION
The location of the type declarations changed after batch updated their tsconfig.json file. This PR uses the new location in package.json's files list and types entry. Fixes https://github.com/Azure/azure-sdk-for-js/issues/16809