### PR TITLE
[Identity] Sending the IMDS ping without a query

### DIFF
--- a/sdk/identity/identity/src/credentials/managedIdentityCredential/imdsMsi.ts
+++ b/sdk/identity/identity/src/credentials/managedIdentityCredential/imdsMsi.ts
@@ -94,15 +94,15 @@ export const imdsMsi: MSI = {
     clientId?: string,
     getTokenOptions?: GetTokenOptions
   ): Promise<boolean> {
-    const { span, updatedOptions: options } = createSpan(
-      "ManagedIdentityCredential-pingImdsEndpoint",
-      getTokenOptions
-    );
-
     // if the PodIdenityEndpoint environment variable was set no need to probe the endpoint, it can be assumed to exist
     if (process.env.AZURE_POD_IDENTITY_AUTHORITY_HOST) {
       return true;
     }
+
+    const { span, updatedOptions: options } = createSpan(
+      "ManagedIdentityCredential-pingImdsEndpoint",
+      getTokenOptions
+    );
 
     // Ping request.
     const requestOptions = prepareRequestOptions(resource, clientId, {

--- a/sdk/identity/identity/test/internal/node/managedIdentityCredential.spec.ts
+++ b/sdk/identity/identity/test/internal/node/managedIdentityCredential.spec.ts
@@ -68,7 +68,7 @@ describe("ManagedIdentityCredential", function() {
 
     // The first request is the IMDS ping.
     const imdsPingRequest = authDetails.requests[0];
-    assert.notOk(imdsPingRequest.headers.Metadata);
+    assert.notOk(imdsPingRequest.headers.metadata);
     assert.equal(
       imdsPingRequest.url,
       new URL(

--- a/sdk/identity/identity/test/internal/node/managedIdentityCredential.spec.ts
+++ b/sdk/identity/identity/test/internal/node/managedIdentityCredential.spec.ts
@@ -68,6 +68,7 @@ describe("ManagedIdentityCredential", function() {
 
     // The first request is the IMDS ping.
     const imdsPingRequest = authDetails.requests[0];
+    assert.notOk(imdsPingRequest.headers.Metadata);
     assert.equal(
       imdsPingRequest.url,
       new URL(
@@ -79,8 +80,9 @@ describe("ManagedIdentityCredential", function() {
     // The second one tries to authenticate against IMDS once we know the endpoint is available.
     const authRequest = authDetails.requests[1];
 
-    const query = new URLSearchParams(authRequest.url.split("?")[1]);
+    assert.ok(authRequest.headers.metadata);
 
+    const query = new URLSearchParams(authRequest.url.split("?")[1]);
     assert.equal(authRequest.method, "GET");
     assert.equal(query.get("client_id"), "client");
     assert.equal(decodeURIComponent(query.get("resource")!), "https://service");

--- a/sdk/identity/identity/test/internal/node/managedIdentityCredential.spec.ts
+++ b/sdk/identity/identity/test/internal/node/managedIdentityCredential.spec.ts
@@ -9,7 +9,8 @@ import { RestError } from "@azure/core-rest-pipeline";
 import { ManagedIdentityCredential } from "../../../src";
 import {
   imdsHost,
-  imdsApiVersion
+  imdsApiVersion,
+  imdsEndpointPath
 } from "../../../src/credentials/managedIdentityCredential/constants";
 import {
   imdsMsi,
@@ -66,6 +67,15 @@ describe("ManagedIdentityCredential", function() {
     });
 
     // The first request is the IMDS ping.
+    const imdsPingRequest = authDetails.requests[0];
+    assert.equal(
+      imdsPingRequest.url,
+      new URL(
+        imdsEndpointPath,
+        process.env.AZURE_POD_IDENTITY_AUTHORITY_HOST ?? imdsHost
+      ).toString()
+    );
+
     // The second one tries to authenticate against IMDS once we know the endpoint is available.
     const authRequest = authDetails.requests[1];
 
@@ -253,10 +263,9 @@ describe("ManagedIdentityCredential", function() {
       ]
     });
 
-    // The first request is the IMDS ping.
-    const imdsPingRequest = authDetails.requests[0];
+    const authorizationRequest = authDetails.requests[0];
     assert.equal(
-      imdsPingRequest.url,
+      authorizationRequest.url,
       "http://10.0.0.1/metadata/identity/oauth2/token?resource=https%3A%2F%2Fservice&api-version=2018-02-01&client_id=client"
     );
   });
@@ -275,11 +284,9 @@ describe("ManagedIdentityCredential", function() {
       ]
     });
 
-    // The first request is the IMDS ping.
-    const imdsPingRequest = authDetails.requests[0];
-
+    const authorizationRequest = authDetails.requests[0];
     assert.equal(
-      imdsPingRequest.url,
+      authorizationRequest.url,
       "http://10.0.0.1/metadata/identity/oauth2/token?resource=https%3A%2F%2Fservice&api-version=2018-02-01&client_id=client"
     );
   });


### PR DESCRIPTION
Pod Identity does not automatically disable authentication requests if they have the Metadata endpoint missing. This is causing the ping request to fail sometimes, since the IMDS endpoint in those cases is taking longer than the 300 milliseconds timeout we’ve configured.

TODO:
- Hotfix.
- Changelog entry.