### PR TITLE
[Identity] Hotfix 1.5.1: IMDS ping fixes

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -20,11 +20,6 @@ parameters:
   - name: Matrix
     type: object
     default:
-      Linux_Node8:
-        Pool: $(LinuxPool)
-        OSVmImage:
-        NodeTestVersion: "8.x"
-        TestType: "node"
       Windows_Node10:
         Pool: $(WindowsPool)
         OSVmImage:

--- a/sdk/identity/identity/CHANGELOG.md
+++ b/sdk/identity/identity/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Release History
 
-## 1.5.1 (Unreleased)
+## 1.5.1 (2021-08-12)
 
+- Fixed how we verify the IMDS endpoint is available. Now, besides skipping the `Metadata` header, we skip the URL query. Both will ensure that all the known IMDS endpoints return as early as possible.
+- Added support for the `AZURE_POD_IDENTITY_AUTHORITY_HOST` environment variable. If present, the IMDS endpoint initial verification will be skipped.
 
 ## 1.5.0 (2021-07-19)
 

--- a/sdk/identity/identity/README.md
+++ b/sdk/identity/identity/README.md
@@ -13,6 +13,7 @@ You can find examples for these various credentials in [Azure Identity Examples 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge, and Firefox.
   - Note: Among the different credentials exported in this library, `InteractiveBrowserCredential` is the only one that is supported in the browser.
+- See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Install the package
 
@@ -24,7 +25,6 @@ npm install --save @azure/identity
 
 ### Prerequisites
 
-- Node.js 8 LTS or higher.
 - An [Azure subscription](https://azure.microsoft.com/free/).
 - The [Azure CLI][azure_cli] can also be useful for authenticating in a development environment and managing account roles.
 

--- a/sdk/identity/identity/README.md
+++ b/sdk/identity/identity/README.md
@@ -11,6 +11,7 @@ You can find examples for these various credentials in [Azure Identity Examples 
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
+  - **Note:** If your application runs on Node.js v8 or lower and you cannot upgrade your Node.js version to latest stable version, then pin your `@azure/identity` dependency to version 1.1.0.
 - Latest versions of Safari, Chrome, Edge, and Firefox.
   - Note: Among the different credentials exported in this library, `InteractiveBrowserCredential` is the only one that is supported in the browser.
 - See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.

--- a/sdk/identity/identity/src/credentials/managedIdentityCredential/constants.ts
+++ b/sdk/identity/identity/src/credentials/managedIdentityCredential/constants.ts
@@ -3,7 +3,8 @@
 
 export const DefaultScopeSuffix = "/.default";
 
-export const imdsEndpoint = "http://169.254.169.254/metadata/identity/oauth2/token";
+export const imdsHost = "http://169.254.169.254";
+export const imdsEndpointPath = "/metadata/identity/oauth2/token";
 export const imdsApiVersion = "2018-02-01";
 export const azureArcAPIVersion = "2019-11-01";
 export const azureFabricVersion = "2019-07-01-preview";

--- a/sdk/identity/identity/src/credentials/managedIdentityCredential/imdsMsi.ts
+++ b/sdk/identity/identity/src/credentials/managedIdentityCredential/imdsMsi.ts
@@ -95,27 +95,19 @@ export const imdsMsi: MSI = {
       getTokenOptions
     );
 
-    const requestOptions = prepareRequestOptions(resource, clientId, {
-      skipMetadataHeader: true,
-      skipQuery: true
-    });
-
-    // This will always be populated, but let's make TypeScript happy
-    if (requestOptions.headers) {
-      // Remove the Metadata header to invoke a request error from
-      // IMDS endpoint
-      requestOptions.headers.delete("Metadata");
-    }
-
-    requestOptions.tracingOptions = {
-      spanOptions: options.tracingOptions && options.tracingOptions.spanOptions,
-      tracingContext: options.tracingOptions && options.tracingOptions.tracingContext
-    };
-
     try {
       // Create a request with a timeout since we expect that
       // not having a "Metadata" header should cause an error to be
       // returned quickly from the endpoint, proving its availability.
+      // Later we found that skipping the query parameters is also necessary in some cases.
+      const requestOptions = prepareRequestOptions(resource, clientId, {
+        skipMetadataHeader: true,
+        skipQuery: true
+      });
+      requestOptions.tracingOptions = {
+        spanOptions: options.tracingOptions && options.tracingOptions.spanOptions,
+        tracingContext: options.tracingOptions && options.tracingOptions.tracingContext
+      };
       const request = createPipelineRequest(requestOptions);
 
       request.timeout = options.requestOptions?.timeout ?? 300;


### PR DESCRIPTION
This PR is intended to release Identity hotfix 1.5.1, which:

- Fixes how we verify the IMDS endpoint is available. Now, besides skipping the `Metadata` header, we skip the URL query. Both will ensure that all the known IMDS endpoints return as early as possible.
- Adds support for the `AZURE_POD_IDENTITY_AUTHORITY_HOST` environment variable. If present, the IMDS endpoint initial verification will be skipped.

It took us a while to figure out why sometimes IMDS pings couldn’t be fulfilled on time. While it was under our assumptions that requests to the IMDS endpoint would immediately fail if they were sent without a `Metadata` header, turns out that this is not the case: Some IMDS endpoints, like the one used by the Pod Identity service, won’t necessarily fail if this header is missing. More generally, these endpoints will fail if both this header and the query parameters are missing.

The environment variable seems like a reasonable plus to include.

Feedback always appreciated!