### PR TITLE
[Cosmos] Adds changelog entry for bulk bugfix

### DIFF
--- a/sdk/cosmosdb/cosmos/CHANGELOG.md
+++ b/sdk/cosmosdb/cosmos/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Adds TransactionalBatch to items `container.items.batch(operations)`
 
+### Bugs Fixed
+
+- Fixed bulk requests which had operations without partitionKey specified.
+
 ## 3.12.3 (2021-07-23)
 
 ### Bugs Fixed


### PR DESCRIPTION
we fixed an issue in bulk for operations missing partitionKeys at the top level when implementing transactional batch, this adds it to the changelog