### PR TITLE
[stress testing] Improve dockerfile and ARM template for service bus

### DIFF
--- a/sdk/servicebus/service-bus/test/stress/Dockerfile
+++ b/sdk/servicebus/service-bus/test/stress/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:12-alpine
-RUN mkdir -p /app/src
-ADD ./app/src/*.ts /app/src
+RUN mkdir -p /app/src/
+ADD ./app/src/*.ts /app/src/
 ADD ./app/package.json /app/package.json
 ADD ./app/tsconfig.json /app/tsconfig.json
 WORKDIR /app

--- a/sdk/servicebus/service-bus/test/stress/test-resources.bicep
+++ b/sdk/servicebus/service-bus/test/stress/test-resources.bicep
@@ -1,0 +1,40 @@
+@description('The base resource name.')
+param baseName string = resourceGroup().name
+
+@description('The client OID to grant access to test resources.')
+param testApplicationOid string
+
+var apiVersion = '2017-04-01'
+var location = resourceGroup().location
+var authorizationRuleName_var = '${baseName}/RootManageSharedAccessKey'
+
+resource servicebus 'Microsoft.ServiceBus/namespaces@2018-01-01-preview' = {
+  name: baseName
+  location: location
+  sku: {
+    name: 'Standard'
+    tier: 'Standard'
+  }
+  properties: {
+    zoneRedundant: false
+  }
+}
+
+resource authorizationRuleName 'Microsoft.ServiceBus/namespaces/AuthorizationRules@2015-08-01' = {
+  name: authorizationRuleName_var
+  location: location
+  properties: {
+    rights: [
+      'Listen'
+      'Manage'
+      'Send'
+    ]
+  }
+  dependsOn: [
+    servicebus
+  ]
+}
+
+output SERVICEBUS_CONNECTION_STRING string = listKeys(resourceId('Microsoft.ServiceBus/namespaces/authorizationRules', baseName, 'RootManageSharedAccessKey'), apiVersion).primaryConnectionString
+output SERVICEBUS_ENDPOINT string = replace(servicebus.properties.serviceBusEndpoint, ':443/', '')
+output testApplicationOid string = testApplicationOid

--- a/sdk/servicebus/service-bus/test/stress/test-resources.json
+++ b/sdk/servicebus/service-bus/test/stress/test-resources.json
@@ -1,6 +1,13 @@
 {
   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "bicep",
+      "version": "0.4.63.48766",
+      "templateHash": "5601553675190796841"
+    }
+  },
   "parameters": {
     "baseName": {
       "type": "string",
@@ -16,11 +23,11 @@
       }
     }
   },
+  "functions": [],
   "variables": {
     "apiVersion": "2017-04-01",
     "location": "[resourceGroup().location]",
-    "authorizationRuleName": "[concat(parameters('baseName'), '/RootManageSharedAccessKey')]",
-    "serviceBusDataOwnerRoleId": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/090c5cfd-751d-490a-894a-3ce6f1109419')]"
+    "authorizationRuleName_var": "[format('{0}/RootManageSharedAccessKey', parameters('baseName'))]"
   },
   "resources": [
     {
@@ -39,72 +46,18 @@
     {
       "type": "Microsoft.ServiceBus/namespaces/AuthorizationRules",
       "apiVersion": "2015-08-01",
-      "name": "[variables('authorizationRuleName')]",
+      "name": "[variables('authorizationRuleName_var')]",
       "location": "[variables('location')]",
-      "dependsOn": [
-        "[resourceId('Microsoft.ServiceBus/namespaces', parameters('baseName'))]"
-      ],
       "properties": {
         "rights": [
           "Listen",
           "Manage",
           "Send"
         ]
-      }
-    },
-    {
-      "type": "Microsoft.Authorization/roleAssignments",
-      "apiVersion": "2018-01-01-preview",
-      "name": "[guid(concat('dataOwnerRoleId', parameters('baseName')))]",
+      },
       "dependsOn": [
         "[resourceId('Microsoft.ServiceBus/namespaces', parameters('baseName'))]"
-      ],
-      "properties": {
-        "roleDefinitionId": "[variables('serviceBusDataOwnerRoleId')]",
-        "principalId": "[parameters('testApplicationOid')]"
-      }
-    },
-    {
-      "type": "Microsoft.ServiceBus/namespaces/queues",
-      "apiVersion": "2017-04-01",
-      "name": "[concat(parameters('baseName'), '/testQueue')]",
-      "dependsOn": [
-        "[resourceId('Microsoft.ServiceBus/namespaces', parameters('baseName'))]"
-      ],
-      "properties": {
-        "lockDuration": "PT5M",
-        "maxSizeInMegabytes": "1024",
-        "requiresDuplicateDetection": "false",
-        "requiresSession": "false",
-        "defaultMessageTimeToLive": "P10675199DT2H48M5.4775807S",
-        "deadLetteringOnMessageExpiration": "false",
-        "duplicateDetectionHistoryTimeWindow": "PT10M",
-        "maxDeliveryCount": "10",
-        "autoDeleteOnIdle": "P10675199DT2H48M5.4775807S",
-        "enablePartitioning": "false",
-        "enableExpress": "false"
-      }
-    },
-    {
-      "type": "Microsoft.ServiceBus/namespaces/queues",
-      "apiVersion": "2017-04-01",
-      "name": "[concat(parameters('baseName'), '/testQueueWithSessions')]",
-      "dependsOn": [
-        "[resourceId('Microsoft.ServiceBus/namespaces', parameters('baseName'))]"
-      ],
-      "properties": {
-        "lockDuration": "PT5M",
-        "maxSizeInMegabytes": "1024",
-        "requiresDuplicateDetection": "false",
-        "requiresSession": "true",
-        "defaultMessageTimeToLive": "P10675199DT2H48M5.4775807S",
-        "deadLetteringOnMessageExpiration": "false",
-        "duplicateDetectionHistoryTimeWindow": "PT10M",
-        "maxDeliveryCount": "10",
-        "autoDeleteOnIdle": "P10675199DT2H48M5.4775807S",
-        "enablePartitioning": "false",
-        "enableExpress": "false"
-      }
+      ]
     }
   ],
   "outputs": {
@@ -116,13 +69,9 @@
       "type": "string",
       "value": "[replace(reference(resourceId('Microsoft.ServiceBus/namespaces', parameters('baseName'))).serviceBusEndpoint, ':443/', '')]"
     },
-    "QUEUE_NAME": {
+    "testApplicationOid": {
       "type": "string",
-      "value": "testQueue"
-    },
-    "QUEUE_NAME_WITH_SESSIONS": {
-      "type": "string",
-      "value": "testQueueWithSessions"
+      "value": "[parameters('testApplicationOid')]"
     }
   }
 }


### PR DESCRIPTION
This fixes the Dockerfile directory/ADD syntax to work with more versions of docker (it was failing in the pipeline due to no trailing slash). It also simplifies the ARM template to remove unnecessary resources that were copied from the parent template in the root service-bus directory, as well as migrates the template to be generated from a bicep file.