### PR TITLE
[core-paging] make the page link type generic

### DIFF
--- a/sdk/core/core-paging/review/core-paging.api.md
+++ b/sdk/core/core-paging/review/core-paging.api.md
@@ -5,7 +5,7 @@
 ```ts
 
 // @public
-export function getPagedAsyncIterator<TElement, TPage = TElement[], TPageSettings = PageSettings>(pagedResult: PagedResult<TPage, TPageSettings>): PagedAsyncIterableIterator<TElement, TPage, TPageSettings>;
+export function getPagedAsyncIterator<TElement, TPage = TElement[], TLink = string, TPageSettings = PageSettings>(pagedResult: PagedResult<TPage, TLink, TPageSettings>): PagedAsyncIterableIterator<TElement, TPage, TPageSettings>;
 
 // @public
 export interface PagedAsyncIterableIterator<T, PageT = T[], PageSettingsT = PageSettings> {
@@ -15,12 +15,12 @@ export interface PagedAsyncIterableIterator<T, PageT = T[], PageSettingsT = Page
 }
 
 // @public
-export interface PagedResult<TPage, TPageSettings = PageSettings> {
+export interface PagedResult<TPage, TLink = string, TPageSettings = PageSettings> {
     byPage?: (settings?: TPageSettings) => AsyncIterableIterator<TPage>;
-    firstPageLink: string;
-    getPage: (pageLink: string, maxPageSize?: number) => Promise<{
+    firstPageLink: TLink;
+    getPage: (pageLink: TLink, maxPageSize?: number) => Promise<{
         page: TPage;
-        nextPageLink?: string;
+        nextPageLink?: TLink;
     }>;
 }
 

--- a/sdk/core/core-paging/review/core-paging.api.md
+++ b/sdk/core/core-paging/review/core-paging.api.md
@@ -5,7 +5,7 @@
 ```ts
 
 // @public
-export function getPagedAsyncIterator<TElement, TPage = TElement[], TLink = string, TPageSettings = PageSettings>(pagedResult: PagedResult<TPage, TLink, TPageSettings>): PagedAsyncIterableIterator<TElement, TPage, TPageSettings>;
+export function getPagedAsyncIterator<TElement, TPage = TElement[], TPageSettings = PageSettings, TLink = string>(pagedResult: PagedResult<TPage, TPageSettings, TLink>): PagedAsyncIterableIterator<TElement, TPage, TPageSettings>;
 
 // @public
 export interface PagedAsyncIterableIterator<T, PageT = T[], PageSettingsT = PageSettings> {
@@ -15,7 +15,7 @@ export interface PagedAsyncIterableIterator<T, PageT = T[], PageSettingsT = Page
 }
 
 // @public
-export interface PagedResult<TPage, TLink = string, TPageSettings = PageSettings> {
+export interface PagedResult<TPage, TPageSettings = PageSettings, TLink = string> {
     byPage?: (settings?: TPageSettings) => AsyncIterableIterator<TPage>;
     firstPageLink: TLink;
     getPage: (pageLink: TLink, maxPageSize?: number) => Promise<{

--- a/sdk/core/core-paging/src/getPagedAsyncIterator.ts
+++ b/sdk/core/core-paging/src/getPagedAsyncIterator.ts
@@ -13,10 +13,10 @@ import { PagedAsyncIterableIterator, PageSettings, PagedResult } from "./models"
 export function getPagedAsyncIterator<
   TElement,
   TPage = TElement[],
-  TLink = string,
-  TPageSettings = PageSettings
+  TPageSettings = PageSettings,
+  TLink = string
 >(
-  pagedResult: PagedResult<TPage, TLink, TPageSettings>
+  pagedResult: PagedResult<TPage, TPageSettings, TLink>
 ): PagedAsyncIterableIterator<TElement, TPage, TPageSettings> {
   const iter = getItemAsyncIterator<TElement, TPage, TLink, TPageSettings>(pagedResult);
   return {
@@ -30,7 +30,7 @@ export function getPagedAsyncIterator<
       pagedResult?.byPage ??
       ((settings?: PageSettings) => {
         return getPageAsyncIterator(
-          pagedResult as PagedResult<TPage, TLink, PageSettings>,
+          pagedResult as PagedResult<TPage, PageSettings, TLink>,
           settings?.maxPageSize
         );
       })
@@ -38,7 +38,7 @@ export function getPagedAsyncIterator<
 }
 
 async function* getItemAsyncIterator<TElement, TPage, TLink, TPageSettings>(
-  pagedResult: PagedResult<TPage, TLink, TPageSettings>,
+  pagedResult: PagedResult<TPage, TPageSettings, TLink>,
   maxPageSize?: number
 ): AsyncIterableIterator<TElement> {
   const pages = getPageAsyncIterator(pagedResult, maxPageSize);
@@ -59,7 +59,7 @@ async function* getItemAsyncIterator<TElement, TPage, TLink, TPageSettings>(
 }
 
 async function* getPageAsyncIterator<TPage, TLink, TPageSettings>(
-  pagedResult: PagedResult<TPage, TLink, TPageSettings>,
+  pagedResult: PagedResult<TPage, TPageSettings, TLink>,
   maxPageSize?: number
 ): AsyncIterableIterator<TPage> {
   let response = await pagedResult.getPage(pagedResult.firstPageLink, maxPageSize);

--- a/sdk/core/core-paging/src/getPagedAsyncIterator.ts
+++ b/sdk/core/core-paging/src/getPagedAsyncIterator.ts
@@ -10,10 +10,15 @@ import { PagedAsyncIterableIterator, PageSettings, PagedResult } from "./models"
  * @param pagedResult - an object that specifies how to get pages.
  * @returns a paged async iterator that iterates over results.
  */
-export function getPagedAsyncIterator<TElement, TPage = TElement[], TPageSettings = PageSettings>(
-  pagedResult: PagedResult<TPage, TPageSettings>
+export function getPagedAsyncIterator<
+  TElement,
+  TPage = TElement[],
+  TLink = string,
+  TPageSettings = PageSettings
+>(
+  pagedResult: PagedResult<TPage, TLink, TPageSettings>
 ): PagedAsyncIterableIterator<TElement, TPage, TPageSettings> {
-  const iter = getItemAsyncIterator<TElement, TPage, TPageSettings>(pagedResult);
+  const iter = getItemAsyncIterator<TElement, TPage, TLink, TPageSettings>(pagedResult);
   return {
     next() {
       return iter.next();
@@ -25,15 +30,15 @@ export function getPagedAsyncIterator<TElement, TPage = TElement[], TPageSetting
       pagedResult?.byPage ??
       ((settings?: PageSettings) => {
         return getPageAsyncIterator(
-          pagedResult as PagedResult<TPage, PageSettings>,
+          pagedResult as PagedResult<TPage, TLink, PageSettings>,
           settings?.maxPageSize
         );
       })
   };
 }
 
-async function* getItemAsyncIterator<TElement, TPage, TPageSettings>(
-  pagedResult: PagedResult<TPage, TPageSettings>,
+async function* getItemAsyncIterator<TElement, TPage, TLink, TPageSettings>(
+  pagedResult: PagedResult<TPage, TLink, TPageSettings>,
   maxPageSize?: number
 ): AsyncIterableIterator<TElement> {
   const pages = getPageAsyncIterator(pagedResult, maxPageSize);
@@ -53,8 +58,8 @@ async function* getItemAsyncIterator<TElement, TPage, TPageSettings>(
   }
 }
 
-async function* getPageAsyncIterator<TPage, TPageSettings>(
-  pagedResult: PagedResult<TPage, TPageSettings>,
+async function* getPageAsyncIterator<TPage, TLink, TPageSettings>(
+  pagedResult: PagedResult<TPage, TLink, TPageSettings>,
   maxPageSize?: number
 ): AsyncIterableIterator<TPage> {
   let response = await pagedResult.getPage(pagedResult.firstPageLink, maxPageSize);

--- a/sdk/core/core-paging/src/models.ts
+++ b/sdk/core/core-paging/src/models.ts
@@ -35,7 +35,7 @@ export interface PagedAsyncIterableIterator<T, PageT = T[], PageSettingsT = Page
 /**
  * An interface that describes how to communicate with the service.
  */
-export interface PagedResult<TPage, TLink = string, TPageSettings = PageSettings> {
+export interface PagedResult<TPage, TPageSettings = PageSettings, TLink = string> {
   /**
    * Link to the first page of results.
    */

--- a/sdk/core/core-paging/src/models.ts
+++ b/sdk/core/core-paging/src/models.ts
@@ -35,18 +35,18 @@ export interface PagedAsyncIterableIterator<T, PageT = T[], PageSettingsT = Page
 /**
  * An interface that describes how to communicate with the service.
  */
-export interface PagedResult<TPage, TPageSettings = PageSettings> {
+export interface PagedResult<TPage, TLink = string, TPageSettings = PageSettings> {
   /**
    * Link to the first page of results.
    */
-  firstPageLink: string;
+  firstPageLink: TLink;
   /**
    * A method that returns a page of results.
    */
   getPage: (
-    pageLink: string,
+    pageLink: TLink,
     maxPageSize?: number
-  ) => Promise<{ page: TPage; nextPageLink?: string }>;
+  ) => Promise<{ page: TPage; nextPageLink?: TLink }>;
   /**
    * a function to implement the `byPage` method on the paged async iterator. The default is
    * one that sets the `maxPageSizeParam` from `settings.maxPageSize`.

--- a/sdk/core/core-paging/test/getPagedAsyncIterator.spec.ts
+++ b/sdk/core/core-paging/test/getPagedAsyncIterator.spec.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 
 import { assert } from "chai";
-import { getPagedAsyncIterator, PagedResult } from "../src";
+import { getPagedAsyncIterator, PagedResult, PageSettings } from "../src";
 
 function buildIterator<T>(input: T) {
   return getPagedAsyncIterator({
@@ -47,7 +47,7 @@ describe("getPagedAsyncIterator", function() {
 
   it("should return an iterator over multiple pages (collections)", async function() {
     const collection = Array.from(Array(10), (_, i) => i + 1);
-    const pagedResult: PagedResult<number[], number> = {
+    const pagedResult: PagedResult<number[], PageSettings, number> = {
       firstPageLink: 0,
       async getPage(pageLink, maxPageSize) {
         const top = maxPageSize || 5;
@@ -82,7 +82,7 @@ describe("getPagedAsyncIterator", function() {
   it("should return an iterator over multiple pages (non-collections)", async function() {
     const maxPageSize = 5;
     const collection = Array.from(Array(10), (_, i) => i + 1);
-    const pagedResult: PagedResult<Record<string, unknown>, number> = {
+    const pagedResult: PagedResult<Record<string, unknown>, PageSettings, number> = {
       firstPageLink: 0,
       async getPage(pageLink, maxPageSize) {
         const top = maxPageSize || 5;
@@ -98,9 +98,12 @@ describe("getPagedAsyncIterator", function() {
         }
       }
     };
-    const iterator = getPagedAsyncIterator<Record<string, any>, Record<string, any>, number>(
-      pagedResult
-    );
+    const iterator = getPagedAsyncIterator<
+      Record<string, any>,
+      Record<string, any>,
+      PageSettings,
+      number
+    >(pagedResult);
     let receivedItems = []; // they're pages too
     let pagesCount = 0;
     for await (const val of iterator) {


### PR DESCRIPTION
some services use continuation tokens to point to pages which do not have to be strings, so this PR makes the link type a generic with a default to a string.