### PR TITLE
[App Config] Skip live testing for byPage to avoid throttling in the CI

### DIFF
--- a/sdk/appconfiguration/app-configuration/test/public/index.spec.ts
+++ b/sdk/appconfiguration/app-configuration/test/public/index.spec.ts
@@ -19,12 +19,12 @@ describe("AppConfigurationClient", () => {
   let client: AppConfigurationClient;
   let recorder: Recorder;
 
-  beforeEach(function (this: Context) {
+  beforeEach(function(this: Context) {
     recorder = startRecorder(this);
     client = createAppConfigurationClientForTests() || this.skip();
   });
 
-  afterEach(async function (this: Context) {
+  afterEach(async function(this: Context) {
     await recorder.stop();
   });
 
@@ -723,7 +723,7 @@ describe("AppConfigurationClient", () => {
       assert.ok(foundMyExactSettingToo);
     });
 
-    it("list with multiple pages", async function () {
+    it("list with multiple pages", async function() {
       // This occasionally hits 429 error (throttling) since we are making 100s of requests in the test to create, get and delete keys.
       // To avoid hitting the service with too many requests, skipping the test in live.
       // More details at https://github.com/Azure/azure-sdk-for-js/issues/16743

--- a/sdk/appconfiguration/app-configuration/test/public/index.spec.ts
+++ b/sdk/appconfiguration/app-configuration/test/public/index.spec.ts
@@ -724,8 +724,10 @@ describe("AppConfigurationClient", () => {
     });
 
     it("list with multiple pages", async function() {
-      // This occasionally hits 429 error (throttling).
+      // This occasionally hits 429 error (throttling) since we are making 100s of requests in the test to create, get and delete keys.
       // To avoid hitting the service with too many requests, skipping the test in live.
+      // More details at https://github.com/Azure/azure-sdk-for-js/issues/16743
+      //
       // Remove the following line if you want to hit the live service.
       if (isLiveMode()) this.skip();
 

--- a/sdk/appconfiguration/app-configuration/test/public/index.spec.ts
+++ b/sdk/appconfiguration/app-configuration/test/public/index.spec.ts
@@ -12,7 +12,7 @@ import {
   startRecorder
 } from "./utils/testHelpers";
 import { AppConfigurationClient, ConfigurationSetting, ConfigurationSettingParam } from "../../src";
-import { Recorder, delay } from "@azure/test-utils-recorder";
+import { Recorder, delay, isLiveMode } from "@azure/test-utils-recorder";
 import { Context } from "mocha";
 
 describe("AppConfigurationClient", () => {
@@ -723,7 +723,12 @@ describe("AppConfigurationClient", () => {
       assert.ok(foundMyExactSettingToo);
     });
 
-    it("list with multiple pages", async () => {
+    it("list with multiple pages", async function() {
+      // This occasionally hits 429 error (throttling).
+      // To avoid hitting the service with too many requests, skipping the test in live.
+      // Remove the following line if you want to hit the live service.
+      if (isLiveMode()) this.skip();
+
       const key = recorder.getUniqueName("listMultiplePagesOfResults");
 
       // this number is arbitrarily chosen to match the size of a page + 1

--- a/sdk/appconfiguration/app-configuration/test/public/index.spec.ts
+++ b/sdk/appconfiguration/app-configuration/test/public/index.spec.ts
@@ -19,12 +19,12 @@ describe("AppConfigurationClient", () => {
   let client: AppConfigurationClient;
   let recorder: Recorder;
 
-  beforeEach(function(this: Context) {
+  beforeEach(function (this: Context) {
     recorder = startRecorder(this);
     client = createAppConfigurationClientForTests() || this.skip();
   });
 
-  afterEach(async function(this: Context) {
+  afterEach(async function (this: Context) {
     await recorder.stop();
   });
 
@@ -723,12 +723,13 @@ describe("AppConfigurationClient", () => {
       assert.ok(foundMyExactSettingToo);
     });
 
-    it("list with multiple pages", async function() {
+    it("list with multiple pages", async function () {
       // This occasionally hits 429 error (throttling) since we are making 100s of requests in the test to create, get and delete keys.
       // To avoid hitting the service with too many requests, skipping the test in live.
       // More details at https://github.com/Azure/azure-sdk-for-js/issues/16743
       //
       // Remove the following line if you want to hit the live service.
+      // eslint-disable-next-line @typescript-eslint/no-invalid-this
       if (isLiveMode()) this.skip();
 
       const key = recorder.getUniqueName("listMultiplePagesOfResults");


### PR DESCRIPTION
## Issue https://github.com/Azure/azure-sdk-for-js/issues/16743

This test occasionally hits 429 error (throttling) since we are making 100s of requests in the test to create, get and delete keys.
To avoid hitting the service with too many requests, skipping the test in live.
More details at https://github.com/Azure/azure-sdk-for-js/issues/16743

Remove the following line if you want to hit the live service.
      `if (isLiveMode()) this.skip();`

Fixes #16743