### PR TITLE
[event-hubs] fix flaky consumer tests

### DIFF
--- a/sdk/eventhub/event-hubs/test/public/eventHubConsumerClient.spec.ts
+++ b/sdk/eventhub/event-hubs/test/public/eventHubConsumerClient.spec.ts
@@ -429,9 +429,8 @@ describe("EventHubConsumerClient", () => {
         )
       );
 
-      const subscription = clients[0].subscribe("0", tester, {
-        startPosition: latestEventPosition
-      });
+      const startPosition = await getStartingPositionsForTests(clients[0]);
+      const subscription = clients[0].subscribe("0", tester, { startPosition });
 
       subscriptions.push(subscription);
 
@@ -461,9 +460,8 @@ describe("EventHubConsumerClient", () => {
         )
       );
 
-      const subscription = clients[0].subscribe(tester, {
-        startPosition: latestEventPosition
-      });
+      const startPosition = await getStartingPositionsForTests(clients[0]);
+      const subscription = clients[0].subscribe(tester, { startPosition });
 
       await tester.runTestAndPoll(producerClient);
       subscriptions.push(subscription);
@@ -500,10 +498,9 @@ describe("EventHubConsumerClient", () => {
         )
       );
 
+      const startPosition = await getStartingPositionsForTests(clients[0]);
       for (const partitionId of await partitionIds) {
-        const subscription = clients[0].subscribe(partitionId, tester, {
-          startPosition: latestEventPosition
-        });
+        const subscription = clients[0].subscribe(partitionId, tester, { startPosition });
         subscriptions.push(subscription);
       }
 
@@ -542,12 +539,11 @@ describe("EventHubConsumerClient", () => {
           // also uses the BalancedLoadBalancingStrategy
         )
       );
+      const startPosition = await getStartingPositionsForTests(clients[0]);
 
       const tester = new ReceivedMessagesTester(partitionIds, true);
 
-      const subscriber1 = clients[0].subscribe(tester, {
-        startPosition: latestEventPosition
-      });
+      const subscriber1 = clients[0].subscribe(tester, { startPosition });
       subscriptions.push(subscriber1);
 
       clients.push(
@@ -560,9 +556,7 @@ describe("EventHubConsumerClient", () => {
         )
       );
 
-      const subscriber2 = clients[1].subscribe(tester, {
-        startPosition: latestEventPosition
-      });
+      const subscriber2 = clients[1].subscribe(tester, { startPosition });
       subscriptions.push(subscriber2);
 
       await tester.runTestAndPoll(producerClient);
@@ -610,9 +604,8 @@ describe("EventHubConsumerClient", () => {
 
       const tester = new ReceivedMessagesTester(partitionIds, true);
 
-      const subscriber1 = clients[0].subscribe(tester, {
-        startPosition: latestEventPosition
-      });
+      const startPosition = await getStartingPositionsForTests(clients[0]);
+      const subscriber1 = clients[0].subscribe(tester, { startPosition });
       subscriptions.push(subscriber1);
 
       clients.push(
@@ -630,9 +623,7 @@ describe("EventHubConsumerClient", () => {
         )
       );
 
-      const subscriber2 = clients[1].subscribe(tester, {
-        startPosition: latestEventPosition
-      });
+      const subscriber2 = clients[1].subscribe(tester, { startPosition });
       subscriptions.push(subscriber2);
 
       await tester.runTestAndPoll(producerClient);


### PR DESCRIPTION
Fixes #16797

Most of our tests have been updated to use a `startPosition` that equals the last enqueued sequence number for each partition. This is preferred over using `latestEventPosition` since any flakiness with the consumer before a message is received can cause the tests to time out.

`latestEventPosition` will receive any events that the event hub receives _after_ the consumer establishes a receiver link, so if the producer ends up sending an event prior to that link being established, our tests can fail as they'll never see the event round-tripped.

This PR updates a few more tests to use the last enqueued sequence number instead of the `latestEventPosition`, since none of the tests are specifically testing that `latestEventPosition` works.