### PR TITLE
[stress testing] Update stress-test-addons chart version

### DIFF
--- a/sdk/servicebus/service-bus/test/stress/Chart.lock
+++ b/sdk/servicebus/service-bus/test/stress/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: stress-test-addons
   repository: https://stresstestcharts.blob.core.windows.net/helm/
-  version: 0.1.4
-digest: sha256:c463bfc41e22ce2d3e6ae19279297b3727fa1d76866fbcbd93dd4744c7b768bd
-generated: "2021-08-10T12:27:43.5070631-04:00"
+  version: 0.1.6
+digest: sha256:b97697ef5f303eec43e9a94fca8e312d20b8aed71318250499344aeca9880d31
+generated: "2021-08-16T13:00:30.1011459-04:00"

--- a/sdk/servicebus/service-bus/test/stress/Chart.yaml
+++ b/sdk/servicebus/service-bus/test/stress/Chart.yaml
@@ -9,5 +9,5 @@ annotations:
 
 dependencies:
 - name: stress-test-addons
-  version: 0.1.4
+  version: 0.1.6
   repository: https://stresstestcharts.blob.core.windows.net/helm/


### PR DESCRIPTION
Bumping the [stress-test-addons](https://github.com/Azure/azure-sdk-tools/tree/main/tools/stress-cluster/cluster/kubernetes/stress-test-addons) chart version dependency:

- Uses correct ISO8601 format `DeleteAfter` tags for resource groups
- Does not print resource deployments to stdout (in case of secrets in ARM template)