### PR TITLE
[Identity] OnBehalfOfCredential, credential-only approach

### DIFF
--- a/sdk/identity/identity/review/identity.api.md
+++ b/sdk/identity/identity/review/identity.api.md
@@ -250,6 +250,21 @@ export class ManagedIdentityCredential implements TokenCredential {
     }
 
 // @public
+export class OnBehalfOfCredential implements TokenCredential {
+    constructor(tenantId: string, clientId: string, clientSecret: string, options?: OnBehalfOfCredentialOptions);
+    // (undocumented)
+    getToken(_scopes: string | string[], _options?: GetTokenOptions): Promise<AccessToken>;
+    // (undocumented)
+    userAssertionContext(userAssertion: string, callback: () => Promise<void>): Promise<void>;
+}
+
+// @public (undocumented)
+export interface OnBehalfOfCredentialOptions extends TokenCredentialOptions, CredentialPersistenceOptions {
+    // (undocumented)
+    userAssertion?: string;
+}
+
+// @public
 export enum RegionalAuthority {
     AsiaEast = "eastasia",
     AsiaSouthEast = "southeastasia",

--- a/sdk/identity/identity/review/identity.api.md
+++ b/sdk/identity/identity/review/identity.api.md
@@ -253,9 +253,9 @@ export class ManagedIdentityCredential implements TokenCredential {
 export class OnBehalfOfCredential implements TokenCredential {
     constructor(tenantId: string, clientId: string, clientSecret: string, options?: OnBehalfOfCredentialOptions);
     // (undocumented)
-    getToken(_scopes: string | string[], _options?: GetTokenOptions): Promise<AccessToken>;
+    getToken(scopes: string | string[], options?: GetTokenOptions): Promise<AccessToken>;
     // (undocumented)
-    userAssertionContext(userAssertion: string, callback: () => Promise<void>): Promise<void>;
+    withContext<Callback extends () => ReturnType<Callback>>(userAssertion: string, callback: Callback): Promise<ReturnType<Callback>>;
 }
 
 // @public (undocumented)

--- a/sdk/identity/identity/src/credentials/onBehalfOfCredential.ts
+++ b/sdk/identity/identity/src/credentials/onBehalfOfCredential.ts
@@ -1,0 +1,113 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { AccessToken, TokenCredential, GetTokenOptions } from "@azure/core-auth";
+import { TokenCredentialOptions } from "../client/identityClient";
+import { MsalOnBehalfOf } from "../msal/nodeFlows/msalOnBehalfOf";
+import { credentialLogger } from "../util/logging";
+import { trace } from "../util/tracing";
+import { CredentialPersistenceOptions } from "./credentialPersistenceOptions";
+
+const logger = credentialLogger("OnBehalfOfCredential");
+
+export interface OnBehalfOfCredentialOptions
+  extends TokenCredentialOptions,
+    CredentialPersistenceOptions {
+  userAssertion?: string;
+}
+
+/**
+ * Example usage:
+ *
+ * ```ts
+ * const credential = new OnBehalfOfCredential();
+ * const client = new SecretClient("https://key-vault-name.vault.azure.net", credential);
+ *
+ * // Must be called within a userAssertionContext(), so the following lines will fail:
+ * // await credential.getToken() will fail.
+ * // await client.getSecret("secret-name"); will fail.
+ *
+ * // This will work:
+ * await credential.userAssertionContext("user-assertion", async () => {
+ *   for await (const page of client.listPropertiesOfSecrets().byPage({ maxPageSize: 2 })) {
+ *     for (const secretProperties of page) {
+ *       if (secretProperties.enabled) {
+ *         const secret = await client.getSecret(secretProperties.name);
+ *         console.log("secret: ", secret);
+ *       }
+ *     }
+ *   }
+ * });
+ *
+ * // Any calls outside of `userAssertionContext` will fail.
+ * // Attempts to set multiple parallel userAssertionContexts will fail.
+ * ```
+ */
+export class OnBehalfOfCredential implements TokenCredential {
+  private options: OnBehalfOfCredentialOptions;
+  private contextLock: boolean = false;
+
+  /**
+   * Creates an instance of the OnBehalfOfCredential.
+   *
+   * @param tenantId - The Azure Active Directory tenant (directory) ID.
+   * @param clientId - The client (application) ID of an App Registration in the tenant.
+   * @param clientSecret - A client secret that was generated for the App Registration.
+   * @param options - Options for configuring the client which makes the authentication request.
+   */
+  constructor(
+    private tenantId: string,
+    private clientId: string,
+    private clientSecret: string,
+    options: OnBehalfOfCredentialOptions = {}
+  ) {
+    this.options = options;
+  }
+
+  async userAssertionContext(userAssertion: string, callback: () => Promise<void>): Promise<void> {
+    if (this.contextLock) {
+      throw new Error("The userAssertionContext of this OnBehalfOfCredential is already in use.");
+    }
+    this.contextLock = true;
+
+    const msalFlow = new MsalOnBehalfOf({
+      ...this.options,
+      logger,
+      clientId: this.clientId,
+      tenantId: this.tenantId,
+      clientSecret: this.clientSecret,
+      userAssertion,
+      tokenCredentialOptions: this.options
+    });
+    const originalGetToken = this.getToken;
+
+    this.getToken = async (
+      scopes: string | string[],
+      options: GetTokenOptions = {}
+    ): Promise<AccessToken> => {
+      return trace("OnBehalfOfCredential.getToken", options, async (newOptions) => {
+        if (!msalFlow) {
+          throw new Error(
+            "OnBehalfOfCredential calls must be executed inside of a userAssertionContext call"
+          );
+        } else {
+          const arrayScopes = Array.isArray(scopes) ? scopes : [scopes];
+          return msalFlow.getToken(arrayScopes, newOptions);
+        }
+      });
+    };
+
+    try {
+      await callback();
+    } finally {
+      this.contextLock = false;
+      this.getToken = originalGetToken;
+    }
+  }
+
+  async getToken(_scopes: string | string[], _options: GetTokenOptions = {}): Promise<AccessToken> {
+    throw new Error(
+      "OnBehalfOfCredential calls must be executed inside of a userAssertionContext call"
+    );
+  }
+}

--- a/sdk/identity/identity/src/index.ts
+++ b/sdk/identity/identity/src/index.ts
@@ -24,6 +24,10 @@ export {
   EnvironmentCredential,
   EnvironmentCredentialOptions
 } from "./credentials/environmentCredential";
+export {
+  OnBehalfOfCredential,
+  OnBehalfOfCredentialOptions
+} from "./credentials/onBehalfOfCredential";
 export { ClientSecretCredential } from "./credentials/clientSecretCredential";
 export { ClientSecretCredentialOptions } from "./credentials/clientSecretCredentialOptions";
 export { ClientCertificateCredential } from "./credentials/clientCertificateCredential";

--- a/sdk/identity/identity/src/msal/nodeFlows/msalOnBehalfOf.ts
+++ b/sdk/identity/identity/src/msal/nodeFlows/msalOnBehalfOf.ts
@@ -1,0 +1,50 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { AccessToken } from "@azure/core-auth";
+
+import { CredentialFlowGetTokenOptions } from "../credentials";
+import { MsalNodeOptions, MsalNode } from "./nodeCommon";
+
+/**
+ * @internal
+ */
+export interface MsalOnBehalfOfOptions extends MsalNodeOptions {
+  clientSecret: string;
+  userAssertion?: string;
+}
+
+/**
+ * @internal
+ */
+export class MsalOnBehalfOf extends MsalNode {
+  private userAssertion: string;
+
+  constructor(options: MsalOnBehalfOfOptions) {
+    super(options);
+    if (!options.userAssertion) {
+      throw new Error("userAssertion is required");
+    }
+    this.userAssertion = options.userAssertion;
+    this.requiresConfidential = true;
+  }
+
+  protected async doGetToken(
+    scopes: string[],
+    options: CredentialFlowGetTokenOptions = {}
+  ): Promise<AccessToken> {
+    try {
+      const result = await this.confidentialApp!.acquireTokenOnBehalfOf({
+        scopes,
+        correlationId: options.correlationId,
+        authority: options.authority,
+        oboAssertion: this.userAssertion
+      });
+      // The Client Credential flow does not return an account,
+      // so each time getToken gets called, we will have to acquire a new token through the service.
+      return this.handleResult(scopes, this.clientId, result || undefined);
+    } catch (err) {
+      throw this.handleError(scopes, err, options);
+    }
+  }
+}


### PR DESCRIPTION
This PR is a way to approach the requirements for the OnBehalfOfCredential from a credential-only perspective.

While “swaping credentials” approach here: https://github.com/Azure/azure-sdk-for-js/pull/16924 is on the ambitious and generic side, this approach is on the most minimal, less obtrusive side. You can read more about the underlying problems and two solutions we’ve discussed (neither on this PR) going to this link: https://gist.github.com/sadasant/ece98248cb8cd2df5edd03ab92749f35

This PR allows:
- Keeping the MSAL clients per user-assertion.
- Avoiding problems with parallel requests with this credential.

If this PR seems favorable, it would need:
- Finishing documentation and tests.
- It will need a separate design change from .Net: extending the AccessToken type with a “refreshOn” property, to control our tokenCycler from the credentials directly.
- ⚠️ **Important:** To re-use the context, we will need to return an opaque “context” object from the context call and allow users to pass it through the `userAssertionContext` call in order to re-use that same context in the future.

The public API from this PR aims to be as closed as possible to .Net’s code. .Net’s code looks as follows:

```c#
var cred = new OnBehalfOfCredential(TenantId, ClientId, Secret);
var client = new Client(Uri, cred);

using (var _ = UserAssertionContext(CurrentUserContextToken)) {
  // do request in the context of CurrentUserContextToken
  return Ok(client.GetItem());
}
```

This code above declares the `OnBehalfCredential` with three of the four required values to authenticate, then uses a `UserAssertionContext` to alter the internals of the requests that take action within the `using` scope, specifying the last piece for the On-behalf-of authentication flow to finally succeed: the user assertion — which is contained in a class instance, to allow more things to be stored with it.

In this PR, I’m proposing an approach that would make things look as follow:

```ts
const credential = new OnBehalfOfCredential();
const client = new SecretClient("https://key-vault-name.vault.azure.net", credential);

// Must be called within a userAssertionContext(), so the following lines will fail:
// await credential.getToken() // will fail.
// await client.getSecret("secret-name"); // will fail.

// This will work:
await credential.userAssertionContext("current-user-context-token", async () => {
  await client.getSecret("secret-name"); // will succeed.
});

// Any calls outside of `userAssertionContext` will fail.
// Attempts to set multiple parallel userAssertionContexts will fail.
```

This approach works by replacing the credential’s getToken with a good getToken that can only work in the scope that executes the callback of `userAssertionContext`. Any call outside of that scope will fail. Any attempt to repeat a `userAssertionContext` while there’s one already running will fail. We give full control to the users and we prevent problems with parallelisms, we keep MSAL clients per user assertion, and we also automatically clean any caching once the user returns on their callback scope.

How does this look? Feedback appreciated.