### PR TITLE
[event-hubs] fix IoT Connection string sample

### DIFF
--- a/sdk/eventhub/event-hubs/package.json
+++ b/sdk/eventhub/event-hubs/package.json
@@ -82,6 +82,9 @@
     ]
   },
   "//sampleConfiguration": {
+    "dependencyOverrides": {
+      "@azure/identity": "^1.5.1"
+    },
     "extraFiles": {
       "./samples-browser": [
         "browser"

--- a/sdk/eventhub/event-hubs/samples-dev/iothubConnectionString.ts
+++ b/sdk/eventhub/event-hubs/samples-dev/iothubConnectionString.ts
@@ -15,7 +15,7 @@
 import * as crypto from "crypto";
 import { Buffer } from "buffer";
 import { AmqpError, Connection, ReceiverEvents, parseConnectionString } from "rhea-promise";
-import rheaPromise from "rhea-promise";
+import * as rheaPromise from "rhea-promise";
 import { EventHubConsumerClient, earliestEventPosition } from "@azure/event-hubs";
 
 // Load the .env file if it exists

--- a/sdk/eventhub/event-hubs/samples/v5/javascript/package.json
+++ b/sdk/eventhub/event-hubs/samples/v5/javascript/package.json
@@ -27,8 +27,8 @@
   "dependencies": {
     "@azure/event-hubs": "latest",
     "dotenv": "latest",
-    "rhea-promise": "^2.0.0",
-    "@azure/identity": "2.0.0-beta.5",
+    "rhea-promise": "^2.1.0",
+    "@azure/identity": "^1.5.1",
     "ws": "^7.1.1",
     "https-proxy-agent": "^5.0.0"
   }

--- a/sdk/eventhub/event-hubs/samples/v5/typescript/package.json
+++ b/sdk/eventhub/event-hubs/samples/v5/typescript/package.json
@@ -31,12 +31,13 @@
   "dependencies": {
     "@azure/event-hubs": "latest",
     "dotenv": "latest",
-    "rhea-promise": "^2.0.0",
-    "@azure/identity": "2.0.0-beta.5",
+    "rhea-promise": "^2.1.0",
+    "@azure/identity": "^1.5.1",
     "ws": "^7.1.1",
     "https-proxy-agent": "^5.0.0"
   },
   "devDependencies": {
+    "@types/ws": "^7.2.4",
     "typescript": "~4.2.0",
     "rimraf": "latest"
   }

--- a/sdk/eventhub/event-hubs/samples/v5/typescript/src/iothubConnectionString.ts
+++ b/sdk/eventhub/event-hubs/samples/v5/typescript/src/iothubConnectionString.ts
@@ -15,7 +15,7 @@
 import * as crypto from "crypto";
 import { Buffer } from "buffer";
 import { AmqpError, Connection, ReceiverEvents, parseConnectionString } from "rhea-promise";
-import rheaPromise from "rhea-promise";
+import * as rheaPromise from "rhea-promise";
 import { EventHubConsumerClient, earliestEventPosition } from "@azure/event-hubs";
 
 // Load the .env file if it exists


### PR DESCRIPTION
Fixes #16666 

This PR fixes a couple issues found in the linked issue.
1. `@azure/identity` was set to an unreleased beta version. This has been updated to depend on the GA version of `@azure/identity`.
2. Updates `import rheaPromise from "rhea-promise"` to `import * as rheaPromise from "rhea-promise"`, which fixes the `rheaPromise is undefined` issue.
3. `@types/ws` is now included as a dev dependency.