### PR TITLE
[service-bus] update long running stress test to use single sender

### DIFF
--- a/sdk/servicebus/service-bus/test/stress/app/src/scenarioLongRunning.ts
+++ b/sdk/servicebus/service-bus/test/stress/app/src/scenarioLongRunning.ts
@@ -46,7 +46,6 @@ async function sendMessagesForever(
       } catch (err) {
         console.log(`Sending message failed: `, err);
         stressTest.trackError("send", err as Error);
-        sender = undefined;
       }
     },
     1000,


### PR DESCRIPTION
Fixes #16887 

Our long running stress test had an issue where a memory leak would occur when sending to a namespace that existed when the client was created but was then deleted. This was because any time the sender encountered an error, a new sender was created to send future messages.

This update simply causes the send messages loop to always use a single sender, even if an error occurs. I'm not sure what the motivation was around creating a new sender anytime an error was encountered while sending messages...though I'd argue that if our sender can't come back online after a transient issue, we should detect that in our stress tests rather than ditch the sender right away.

I ran the test locally before and after this change and with this change the garbage collector is able to reclaim memory.