### PR TITLE
[ContainerRegistry][Test] Apply MatrixFilters.Pool for weekly only

### DIFF
--- a/sdk/containerregistry/container-registry/tests.yml
+++ b/sdk/containerregistry/container-registry/tests.yml
@@ -7,7 +7,6 @@ stages:
       ServiceDirectory: containerregistry
       MatrixFilters:
         - DependencyVersion=^$
-        - Pool=.*mms-ubuntu-2004.*
       SupportedClouds: 'Public,UsGov,China'
       EnvVars:
         AZURE_CLIENT_ID: $(aad-azure-sdk-test-client-id)

--- a/sdk/containerregistry/container-registry/tests.yml
+++ b/sdk/containerregistry/container-registry/tests.yml
@@ -7,7 +7,7 @@ stages:
       ServiceDirectory: containerregistry
       MatrixFilters:
         - DependencyVersion=^$
-        ${{ if contains(variables['Build.DefinitionName'], 'tests-weekly') }}:
+        - ${{ if contains(variables['Build.DefinitionName'], 'tests-weekly') }}:
           - Pool=.*mms-ubuntu-2004.*
       SupportedClouds: 'Public,UsGov,China'
       EnvVars:

--- a/sdk/containerregistry/container-registry/tests.yml
+++ b/sdk/containerregistry/container-registry/tests.yml
@@ -7,6 +7,8 @@ stages:
       ServiceDirectory: containerregistry
       MatrixFilters:
         - DependencyVersion=^$
+        ${{ if contains(variables['Build.DefinitionName'], 'tests-weekly') }}:
+          - Pool=.*mms-ubuntu-2004.*
       SupportedClouds: 'Public,UsGov,China'
       EnvVars:
         AZURE_CLIENT_ID: $(aad-azure-sdk-test-client-id)


### PR DESCRIPTION
It was added for testing purpose when creating weekly pipeline and applied to
nightly pipeline runs as well, which is not desired. This PR limits the filter to weekly
pipeline.