### PR TITLE
[REST Paging] Allow setting different `itemName` and `nextLinkName`

### DIFF
--- a/sdk/core/core-client-paging-rest/review/core-client-paging.api.md
+++ b/sdk/core/core-client-paging-rest/review/core-client-paging.api.md
@@ -12,8 +12,8 @@ export { PagedAsyncIterableIterator }
 
 // @public
 export interface PaginateOptions {
-    itemName?: string;
-    nextLinkName?: string | null;
+    itemName?: string | string[];
+    nextLinkName?: string[] | string | null;
 }
 
 // @public

--- a/sdk/core/core-client-paging-rest/review/core-client-paging.api.md
+++ b/sdk/core/core-client-paging-rest/review/core-client-paging.api.md
@@ -12,8 +12,8 @@ export { PagedAsyncIterableIterator }
 
 // @public
 export interface PaginateOptions {
-    itemName?: string | string[];
-    nextLinkName?: string[] | string | null;
+    itemNames?: string[];
+    nextLinkNames?: string[] | null;
 }
 
 // @public

--- a/sdk/core/core-client-paging-rest/src/paginate.ts
+++ b/sdk/core/core-client-paging-rest/src/paginate.ts
@@ -48,14 +48,15 @@ export function paginateResponse<TElement>(
   options: PaginateOptions = {}
 ): PagedAsyncIterableIterator<TElement> {
   let firstRun = true;
+  const { itemName, nextLinkName } = getPaginationProperties(initialResponse, options);
   const pagedResult: PagedResult<TElement[]> = {
     firstPageLink: "",
     async getPage(pageLink: string) {
       const result = firstRun ? initialResponse : await client.pathUnchecked(pageLink).get();
       firstRun = false;
       checkPagingRequest(result);
-      const nextLink = getNextLink(result.body, options);
-      const values = getElements<TElement>(result.body, options);
+      const nextLink = getNextLink(result.body, nextLinkName);
+      const values = getElements<TElement>(result.body, itemName);
       return {
         page: values,
         // According to x-ms-pageable is the nextLinkNames is set to null we should only
@@ -81,31 +82,58 @@ function checkPagingRequest(response: PathUncheckedResponse): void {
 }
 
 /**
- * Gets for the value of nextLink in the body. If a custom nextLinkNames was provided, it will be used instead of default
+ * Extracts the itemName and nextLinkName from the initial response to use them for pagination
  */
-function getNextLink(body: unknown, paginateOptions: PaginateOptions = {}): string | undefined {
+function getPaginationProperties(initialResponse: HttpResponse, options: PaginateOptions = {}) {
   // Build a set with the passed custom nextLinkNames
-  const nextLinkNames = new Set(paginateOptions.nextLinkNames ?? DEFAULT_NEXTLINK);
+  const nextLinkNames = new Set(options.nextLinkNames ?? DEFAULT_NEXTLINK);
   // Add the default nextLinkName if it doesn't exist yet
   nextLinkNames.add(DEFAULT_NEXTLINK);
 
-  let nextLink: string | undefined;
+  // Build a set with the passed custom set of itemNames
+  const itemNames = new Set(options.itemNames ?? DEFAULT_VALUES);
+  // Add the default itemName if it doesn't exist yet
+  itemNames.add(DEFAULT_VALUES);
 
-  // Loop through the known nextLink names to find it in the body.
-  for (const nextLinkName of nextLinkNames) {
-    nextLink = (body as Record<string, unknown>)[nextLinkName] as string;
+  let nextLinkName: string | undefined;
+  let itemName: string | undefined;
+
+  for (const name of nextLinkNames) {
+    const nextLink = (initialResponse.body as Record<string, unknown>)[name] as string;
     if (nextLink) {
+      nextLinkName = name;
       break;
     }
   }
 
-  if (typeof nextLink !== "string" && typeof nextLink !== "undefined") {
+  for (const name of itemNames) {
+    const item = (initialResponse.body as Record<string, unknown>)[name] as string;
+    if (item) {
+      itemName = name;
+      break;
+    }
+  }
+
+  if (!itemName) {
     throw new Error(
-      `Couldn't paginate response\nBody should contain a property named ${[...nextLinkNames].join(
-        " or "
-      )} which points to the next page.`
+      `Couldn't paginate response\n Body doesn't contain an array property with name: ${[
+        ...itemNames,
+      ].join(" OR ")}`
     );
   }
+
+  return { itemName, nextLinkName };
+}
+
+/**
+ * Gets for the value of nextLink in the body. If a custom nextLinkNames was provided, it will be used instead of default
+ */
+function getNextLink(body: unknown, nextLinkName?: string): string | undefined {
+  // It is possible to get an undefined for nextLinkName, in the scenario where the initial response contains the last page.
+  const nextLink =
+    nextLinkName === undefined
+      ? undefined
+      : ((body as Record<string, unknown>)[nextLinkName] as string);
 
   return nextLink;
 }
@@ -114,27 +142,12 @@ function getNextLink(body: unknown, paginateOptions: PaginateOptions = {}): stri
  * Gets the elements of the current request in the body. By default it will look in the `value` property unless
  * a different value for itemNames has been provided as part of the options.
  */
-function getElements<T = unknown>(body: unknown, paginateOptions: PaginateOptions = {}): T[] {
-  // Build a set with the passed custom set of itemNames
-  const valueNames = new Set(paginateOptions.itemNames ?? DEFAULT_VALUES);
-  // Add the default itemName if it doesn't exist yet
-  valueNames.add(DEFAULT_VALUES);
-  let value: unknown;
+function getElements<T = unknown>(body: unknown, itemName: string): T[] {
+  const value = (body as Record<string, unknown>)[itemName];
 
-  // Loop through the known itemNames to find it in the body.
-  for (const valueName of valueNames) {
-    const currentValue = (body as Record<string, unknown>)[valueName];
-    if (Array.isArray(currentValue)) {
-      value = currentValue;
-      break;
-    }
-  }
-
-  if (!value) {
+  if (!Array.isArray(value)) {
     throw new Error(
-      `Couldn't paginate response\n Body doesn't contain an array property with name: ${[
-        ...valueNames,
-      ].join(" OR ")}`
+      `Couldn't paginate response\n Body doesn't contain an array property with name: ${itemName}`
     );
   }
 

--- a/sdk/core/core-client-paging-rest/src/paginate.ts
+++ b/sdk/core/core-client-paging-rest/src/paginate.ts
@@ -28,11 +28,11 @@ export interface PaginateOptions {
    * Note: if nextLinkName is set to `null` only the first page is returned, no additional
    * requests are made.
    */
-  nextLinkName?: string[] | string | null;
+  nextLinkNames?: string[] | null;
   /**
    * Indicates the name of the property in which the set of values is found. Default: `value`
    */
-  itemName?: string | string[];
+  itemNames?: string[];
 }
 
 /**
@@ -58,10 +58,10 @@ export function paginateResponse<TElement>(
       const values = getElements<TElement>(result.body, options);
       return {
         page: values,
-        // According to x-ms-pageable is the nextLinkName is set to null we should only
+        // According to x-ms-pageable is the nextLinkNames is set to null we should only
         // return the first page and skip any additional queries even if the initial response
         // contains a nextLink.
-        nextPageLink: options.nextLinkName === null ? undefined : nextLink,
+        nextPageLink: options.nextLinkNames === null ? undefined : nextLink,
       };
     },
   };
@@ -81,11 +81,11 @@ function checkPagingRequest(response: PathUncheckedResponse): void {
 }
 
 /**
- * Gets for the value of nextLink in the body. If a custom nextLinkName was provided, it will be used instead of default
+ * Gets for the value of nextLink in the body. If a custom nextLinkNames was provided, it will be used instead of default
  */
 function getNextLink(body: unknown, paginateOptions: PaginateOptions = {}): string | undefined {
-  // Build a set with the passed custom nextLinkName or array of names
-  let nextLinkNames = new Set(paginateOptions.nextLinkName ?? DEFAULT_NEXTLINK);
+  // Build a set with the passed custom nextLinkNames
+  const nextLinkNames = new Set(paginateOptions.nextLinkNames ?? DEFAULT_NEXTLINK);
   // Add the default nextLinkName if it doesn't exist yet
   nextLinkNames.add(DEFAULT_NEXTLINK);
 
@@ -112,16 +112,16 @@ function getNextLink(body: unknown, paginateOptions: PaginateOptions = {}): stri
 
 /**
  * Gets the elements of the current request in the body. By default it will look in the `value` property unless
- * a different value for itemName has been provided as part of the options.
+ * a different value for itemNames has been provided as part of the options.
  */
 function getElements<T = unknown>(body: unknown, paginateOptions: PaginateOptions = {}): T[] {
-  // Build a set with the passed custom itemName or array of names
-  let valueNames = new Set(paginateOptions.itemName ?? DEFAULT_VALUES);
+  // Build a set with the passed custom set of itemNames
+  const valueNames = new Set(paginateOptions.itemNames ?? DEFAULT_VALUES);
   // Add the default itemName if it doesn't exist yet
   valueNames.add(DEFAULT_VALUES);
   let value: unknown;
 
-  // Loop through the known itemNames names to find it in the body.
+  // Loop through the known itemNames to find it in the body.
   for (const valueName of valueNames) {
     const currentValue = (body as Record<string, unknown>)[valueName];
     if (Array.isArray(currentValue)) {

--- a/sdk/core/core-client-paging-rest/test/paginate.spec.ts
+++ b/sdk/core/core-client-paging-rest/test/paginate.spec.ts
@@ -59,19 +59,10 @@ export function paginate<TReturn extends PathUncheckedResponse>(
   client: Client,
   initialResponse: TReturn
 ): PagedAsyncIterableIterator<PaginateReturn<TReturn>, PaginateReturn<TReturn>[]> {
-  return paginateResponse<PaginateReturn<TReturn>>(client, initialResponse);
-}
-
-/**
- *  Paginate helper function defining a custom property to find the paged elements.
- */
-export function paginateCustom<TReturn extends PathUncheckedResponse>(
-  client: Client,
-  initialResponse: TReturn
-): PagedAsyncIterableIterator<PaginateReturn<TReturn>, PaginateReturn<TReturn>[]> {
-  // The generator would generate this based on the swagger so that our users don't need to specify the itemName
-  // when it can be taken from the swagger
-  return paginateResponse<PaginateReturn<TReturn>>(client, initialResponse, { itemName: "values" });
+  return paginateResponse<PaginateReturn<TReturn>>(client, initialResponse, {
+    itemName: ["value", "values"],
+    nextLinkName: ["nextLink", "continuationLink"],
+  });
 }
 
 describe("Paginate heleper", () => {
@@ -141,7 +132,7 @@ describe("Paginate heleper", () => {
     ]);
 
     const response: TestResponseValues = await client.pathUnchecked("/paging/single").get();
-    const items = paginateCustom(client, response);
+    const items = paginate(client, response);
     const result = [];
     for await (const item of items) {
       // We get a strong type for item :)
@@ -157,7 +148,10 @@ describe("Paginate heleper", () => {
     mockResponse(client, [
       {
         path: "/paging/firstResponseEmpty/1",
-        response: { status: 200, body: { value: [], nextLink: "/paging/firstResponseEmpty/2" } },
+        response: {
+          status: 200,
+          body: { value: [], continuationLink: "/paging/firstResponseEmpty/2" },
+        },
       },
       {
         path: "/paging/firstResponseEmpty/2",

--- a/sdk/core/core-client-paging-rest/test/paginate.spec.ts
+++ b/sdk/core/core-client-paging-rest/test/paginate.spec.ts
@@ -60,8 +60,8 @@ export function paginate<TReturn extends PathUncheckedResponse>(
   initialResponse: TReturn
 ): PagedAsyncIterableIterator<PaginateReturn<TReturn>, PaginateReturn<TReturn>[]> {
   return paginateResponse<PaginateReturn<TReturn>>(client, initialResponse, {
-    itemName: ["value", "values"],
-    nextLinkName: ["nextLink", "continuationLink"],
+    itemNames: ["value", "values"],
+    nextLinkNames: ["nextLink", "continuationLink"],
   });
 }
 
@@ -111,7 +111,7 @@ describe("Paginate heleper", () => {
     ]);
 
     const response: TestResponse = await client.pathUnchecked("/paging/nullnextlink").get();
-    const items = paginateResponse(client, response, { nextLinkName: null });
+    const items = paginateResponse(client, response, { nextLinkNames: null });
     const result = [];
 
     for await (const item of items) {


### PR DESCRIPTION
According to the Swagger `x-ms-pageable` extension, `itemName` and `nextLinkName` are the properties where a pageable response body contains the page and link to the next page respectively.

There are many swaggers that would use different names for these properties across the swagger. This change allows us to pass a set of "known" names that the paging helper can try in the response body to find the `page` and `nextLink`.

In the generator we'd generate a wrapping class that passes this to the `paginateResponse` function:

```typescript
export function paginate<TReturn extends PathUncheckedResponse>(
  client: Client,
  initialResponse: TReturn
): PagedAsyncIterableIterator<
  PaginateReturn<TReturn>,
  PaginateReturn<TReturn>[]
> {
  return paginateResponse<PaginateReturn<TReturn>>(client, initialResponse, {
    itemNames: ["value", "values", "indexes"],
    nextLinkNames: ["nextLink", "odata.nextLink"]
  });
}
```

**Note:**  This is a best-effort pagination helper. Since in RLCs we don't have any mappings at runtime, we can't link resources with a specific combination of `nextLink` + `itemName` so this helper provides no protection against scenarios where the response contains more than one of the properties listed as `itemName` and `nextLinkName` and it will use the first one found. If more specific logic is needed the SDK owner would need to write a custom pagination helper. 

This logic should address the vast majority of the swaggers already in the `azure-rest-api-specs` repo.