### PR TITLE
[service-bus] fix getMessageIterator docs

### DIFF
--- a/sdk/servicebus/service-bus/src/receivers/receiver.ts
+++ b/sdk/servicebus/service-bus/src/receivers/receiver.ts
@@ -73,10 +73,8 @@ export interface ServiceBusReceiver {
 
   /**
    * Returns an iterator that can be used to receive messages from Service Bus.
-   * If the iterator is not able to fetch a new message in over a minute, `undefined` will be returned.
    *
    * @param options - A set of options to control the receive operation.
-   * - `maxWaitTimeInMs`: The time to wait to receive the message in each iteration.
    * - `abortSignal`: The signal to use to abort the ongoing operation.
    *
    * @throws Error if the underlying connection, client or receiver is closed.


### PR DESCRIPTION
Fixes #16618

There are 2 issues with the existing docs for `getMessageIterator`:
1. > If the iterator is not able to fetch a new message in over a minute, `undefined` will be returned.

This isn't actually true. We only return actual messages. I believe this doc is a carry-over from when this was a preview feature. The `abortSignal` can be used to exit a `for...await` loop.

2. maxWaitTimeInMs is documented. This was a carry-over from when this feature was in preview and `undefined` was returned if no events were received within the `maxWaitTimeInMs` interval. Since we no longer return `undefined` for this scenario, we also stopped accepting `maxWaitTimeInMs`. Note: Technically, you could pass `maxWaitTimeInMs` and the code would honor it, but the behavior you see wouldn't change.