### PR TITLE
[schema-registry-avro] Prepare release

### DIFF
--- a/sdk/schemaregistry/schema-registry-avro/CHANGELOG.md
+++ b/sdk/schemaregistry/schema-registry-avro/CHANGELOG.md
@@ -1,7 +1,10 @@
 # Release History
 
-## 1.0.0-beta.2 (Unreleased)
+## 1.0.0-beta.2 (2021-08-17)
 
+### Features Added
+
+- Depends on @azure/schema-registry@1.0.0-beta.2 which supports client-level caching.
 
 ## 1.0.0-beta.1 (2020-09-08)
 


### PR DESCRIPTION
So we release today. I did not know that it depends on a hard coded version for `azure/schema-registry` so we will need to make a release even though nothing else changed.