### PR TITLE
[Text Analytics] Rename sortby to orderby

### DIFF
--- a/sdk/textanalytics/ai-text-analytics/review/ai-text-analytics.api.md
+++ b/sdk/textanalytics/ai-text-analytics/review/ai-text-analytics.api.md
@@ -395,7 +395,7 @@ export enum KnownInnerErrorCodeValue {
 }
 
 // @public
-export type KnownSummarySentencesSortBy = "Offset" | "Rank";
+export type KnownSummarySentencesOrderBy = "Offset" | "Rank";
 
 // @public
 export enum KnownWarningCode {

--- a/sdk/textanalytics/ai-text-analytics/src/index.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/index.ts
@@ -34,7 +34,7 @@ export {
   RecognizeLinkedEntitiesAction,
   AnalyzeSentimentAction,
   ExtractSummaryAction,
-  KnownSummarySentencesSortBy
+  KnownSummarySentencesSortBy as KnownSummarySentencesOrderBy
 } from "./textAnalyticsClient";
 export { TextAnalyticsOperationOptions } from "./textAnalyticsOperationOptions";
 export {


### PR DESCRIPTION
Because we use `orderBy` everywhere.