### PR TITLE
[KeyVault] - Regenerate KeyVault Admin using 7.3-preview

### DIFF
--- a/sdk/keyvault/keyvault-admin/CHANGELOG.md
+++ b/sdk/keyvault/keyvault-admin/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Features Added
 
+- Updated the service version to default to 7.3-preview.
+
 ### Breaking Changes
 
 ### Bugs Fixed

--- a/sdk/keyvault/keyvault-admin/review/keyvault-admin.api.md
+++ b/sdk/keyvault/keyvault-admin/review/keyvault-admin.api.md
@@ -207,7 +207,7 @@ export enum KnownKeyVaultRoleScope {
 }
 
 // @public
-export const LATEST_API_VERSION = "7.2";
+export const LATEST_API_VERSION = "7.3-preview";
 
 // @public
 export interface ListRoleAssignmentsOptions extends OperationOptions {
@@ -240,7 +240,7 @@ export interface SetRoleDefinitionOptions extends OperationOptions {
 }
 
 // @public
-export type SUPPORTED_API_VERSIONS = "7.2";
+export type SUPPORTED_API_VERSIONS = "7.2" | "7.3-preview";
 
 
 // (No @packageDocumentation comment for this package)

--- a/sdk/keyvault/keyvault-admin/review/keyvault-admin.api.md
+++ b/sdk/keyvault/keyvault-admin/review/keyvault-admin.api.md
@@ -169,12 +169,15 @@ export enum KnownKeyVaultDataAction {
     DecryptHsmKey = "Microsoft.KeyVault/managedHsm/keys/decrypt/action",
     DeleteHsmKey = "Microsoft.KeyVault/managedHsm/keys/delete",
     DeleteRoleAssignment = "Microsoft.KeyVault/managedHsm/roleAssignments/delete/action",
+    DeleteRoleDefinition = "Microsoft.KeyVault/managedHsm/roleDefinitions/delete/action",
     DownloadHsmSecurityDomain = "Microsoft.KeyVault/managedHsm/securitydomain/download/action",
+    DownloadHsmSecurityDomainStatus = "Microsoft.KeyVault/managedHsm/securitydomain/download/read",
     EncryptHsmKey = "Microsoft.KeyVault/managedHsm/keys/encrypt/action",
     ExportHsmKey = "Microsoft.KeyVault/managedHsm/keys/export/action",
     GetRoleAssignment = "Microsoft.KeyVault/managedHsm/roleAssignments/read/action",
     ImportHsmKey = "Microsoft.KeyVault/managedHsm/keys/import/action",
     PurgeDeletedHsmKey = "Microsoft.KeyVault/managedHsm/keys/deletedKeys/delete",
+    RandomNumbersGenerate = "Microsoft.KeyVault/managedHsm/rng/action",
     ReadDeletedHsmKey = "Microsoft.KeyVault/managedHsm/keys/deletedKeys/read/action",
     ReadHsmBackupStatus = "Microsoft.KeyVault/managedHsm/backup/status/action",
     ReadHsmKey = "Microsoft.KeyVault/managedHsm/keys/read/action",
@@ -183,6 +186,7 @@ export enum KnownKeyVaultDataAction {
     ReadHsmSecurityDomainTransferKey = "Microsoft.KeyVault/managedHsm/securitydomain/transferkey/read",
     ReadRoleDefinition = "Microsoft.KeyVault/managedHsm/roleDefinitions/read/action",
     RecoverDeletedHsmKey = "Microsoft.KeyVault/managedHsm/keys/deletedKeys/recover/action",
+    ReleaseKey = "Microsoft.KeyVault/managedHsm/keys/release/action",
     RestoreHsmKeys = "Microsoft.KeyVault/managedHsm/keys/restore/action",
     SignHsmKey = "Microsoft.KeyVault/managedHsm/keys/sign/action",
     StartHsmBackup = "Microsoft.KeyVault/managedHsm/backup/start/action",
@@ -192,7 +196,8 @@ export enum KnownKeyVaultDataAction {
     VerifyHsmKey = "Microsoft.KeyVault/managedHsm/keys/verify/action",
     WrapHsmKey = "Microsoft.KeyVault/managedHsm/keys/wrap/action",
     WriteHsmKey = "Microsoft.KeyVault/managedHsm/keys/write/action",
-    WriteRoleAssignment = "Microsoft.KeyVault/managedHsm/roleAssignments/write/action"
+    WriteRoleAssignment = "Microsoft.KeyVault/managedHsm/roleAssignments/write/action",
+    WriteRoleDefinition = "Microsoft.KeyVault/managedHsm/roleDefinitions/write/action"
 }
 
 // @public

--- a/sdk/keyvault/keyvault-admin/src/accessControlModels.ts
+++ b/sdk/keyvault/keyvault-admin/src/accessControlModels.ts
@@ -5,10 +5,12 @@ import { CommonClientOptions, OperationOptions } from "@azure/core-client";
 import { SUPPORTED_API_VERSIONS } from "./constants";
 import {
   DataAction as KeyVaultDataAction,
-  RoleScope as KeyVaultRoleScope
+  RoleScope as KeyVaultRoleScope,
+  KnownDataAction as KnownKeyVaultDataAction,
+  KnownRoleScope as KnownKeyVaultRoleScope
 } from "./generated/index";
 
-export { KeyVaultDataAction, KeyVaultRoleScope };
+export { KeyVaultDataAction, KeyVaultRoleScope, KnownKeyVaultDataAction, KnownKeyVaultRoleScope };
 
 /**
  * The optional parameters accepted by the Key Vault's AccessControlClient
@@ -18,76 +20,6 @@ export interface AccessControlClientOptions extends CommonClientOptions {
    * The accepted versions of the Key Vault's service API.
    */
   serviceVersion?: SUPPORTED_API_VERSIONS;
-}
-
-/** Known values of {@link DataAction} that the service accepts. */
-export enum KnownKeyVaultDataAction {
-  /** Read HSM key metadata. */
-  ReadHsmKey = "Microsoft.KeyVault/managedHsm/keys/read/action",
-  /** Update an HSM key. */
-  WriteHsmKey = "Microsoft.KeyVault/managedHsm/keys/write/action",
-  /** Read deleted HSM key. */
-  ReadDeletedHsmKey = "Microsoft.KeyVault/managedHsm/keys/deletedKeys/read/action",
-  /** Recover deleted HSM key. */
-  RecoverDeletedHsmKey = "Microsoft.KeyVault/managedHsm/keys/deletedKeys/recover/action",
-  /** Backup HSM keys. */
-  BackupHsmKeys = "Microsoft.KeyVault/managedHsm/keys/backup/action",
-  /** Restore HSM keys. */
-  RestoreHsmKeys = "Microsoft.KeyVault/managedHsm/keys/restore/action",
-  /** Delete role assignment. */
-  DeleteRoleAssignment = "Microsoft.KeyVault/managedHsm/roleAssignments/delete/action",
-  /** Get role assignment. */
-  GetRoleAssignment = "Microsoft.KeyVault/managedHsm/roleAssignments/read/action",
-  /** Create or update role assignment. */
-  WriteRoleAssignment = "Microsoft.KeyVault/managedHsm/roleAssignments/write/action",
-  /** Get role definition. */
-  ReadRoleDefinition = "Microsoft.KeyVault/managedHsm/roleDefinitions/read/action",
-  /** Encrypt using an HSM key. */
-  EncryptHsmKey = "Microsoft.KeyVault/managedHsm/keys/encrypt/action",
-  /** Decrypt using an HSM key. */
-  DecryptHsmKey = "Microsoft.KeyVault/managedHsm/keys/decrypt/action",
-  /** Wrap using an HSM key. */
-  WrapHsmKey = "Microsoft.KeyVault/managedHsm/keys/wrap/action",
-  /** Unwrap using an HSM key. */
-  UnwrapHsmKey = "Microsoft.KeyVault/managedHsm/keys/unwrap/action",
-  /** Sign using an HSM key. */
-  SignHsmKey = "Microsoft.KeyVault/managedHsm/keys/sign/action",
-  /** Verify using an HSM key. */
-  VerifyHsmKey = "Microsoft.KeyVault/managedHsm/keys/verify/action",
-  /** Create an HSM key. */
-  CreateHsmKey = "Microsoft.KeyVault/managedHsm/keys/create",
-  /** Delete an HSM key. */
-  DeleteHsmKey = "Microsoft.KeyVault/managedHsm/keys/delete",
-  /** Export an HSM key. */
-  ExportHsmKey = "Microsoft.KeyVault/managedHsm/keys/export/action",
-  /** Import an HSM key. */
-  ImportHsmKey = "Microsoft.KeyVault/managedHsm/keys/import/action",
-  /** Purge a deleted HSM key. */
-  PurgeDeletedHsmKey = "Microsoft.KeyVault/managedHsm/keys/deletedKeys/delete",
-  /** Download an HSM security domain. */
-  DownloadHsmSecurityDomain = "Microsoft.KeyVault/managedHsm/securitydomain/download/action",
-  /** Upload an HSM security domain. */
-  UploadHsmSecurityDomain = "Microsoft.KeyVault/managedHsm/securitydomain/upload/action",
-  /** Check the status of the HSM security domain exchange file. */
-  ReadHsmSecurityDomainStatus = "Microsoft.KeyVault/managedHsm/securitydomain/upload/read",
-  /** Download an HSM security domain transfer key. */
-  ReadHsmSecurityDomainTransferKey = "Microsoft.KeyVault/managedHsm/securitydomain/transferkey/read",
-  /** Start an HSM backup. */
-  StartHsmBackup = "Microsoft.KeyVault/managedHsm/backup/start/action",
-  /** Start an HSM restore. */
-  StartHsmRestore = "Microsoft.KeyVault/managedHsm/restore/start/action",
-  /** Read an HSM backup status. */
-  ReadHsmBackupStatus = "Microsoft.KeyVault/managedHsm/backup/status/action",
-  /** Read an HSM restore status. */
-  ReadHsmRestoreStatus = "Microsoft.KeyVault/managedHsm/restore/status/action"
-}
-
-/** Known values of {@link RoleScope} that the service accepts. */
-export enum KnownKeyVaultRoleScope {
-  /** Global scope */
-  Global = "/",
-  /** Keys scope */
-  Keys = "/keys"
 }
 
 /**

--- a/sdk/keyvault/keyvault-admin/src/constants.ts
+++ b/sdk/keyvault/keyvault-admin/src/constants.ts
@@ -9,12 +9,12 @@ export const SDK_VERSION: string = "4.2.0-beta.2";
 /**
  * The latest supported Key Vault service API version.
  */
-export const LATEST_API_VERSION = "7.2";
+export const LATEST_API_VERSION = "7.3-preview";
 
 /**
  * Supported API versions
  */
-export type SUPPORTED_API_VERSIONS = "7.2";
+export type SUPPORTED_API_VERSIONS = "7.2" | "7.3-preview";
 
 /**
  * Authentication scopes

--- a/sdk/keyvault/keyvault-admin/src/generated/keyVaultClient.ts
+++ b/sdk/keyvault/keyvault-admin/src/generated/keyVaultClient.ts
@@ -14,7 +14,7 @@ import * as Mappers from "./models/mappers";
 import { KeyVaultClientContext } from "./keyVaultClientContext";
 import {
   KeyVaultClientOptionalParams,
-  ApiVersion72,
+  ApiVersion73Preview,
   KeyVaultClientFullBackupOptionalParams,
   KeyVaultClientFullBackupResponse,
   KeyVaultClientFullBackupStatusOptionalParams,
@@ -34,7 +34,7 @@ export class KeyVaultClient extends KeyVaultClientContext {
    * @param options The parameter options
    */
   constructor(
-    apiVersion: ApiVersion72,
+    apiVersion: ApiVersion73Preview,
     options?: KeyVaultClientOptionalParams
   ) {
     super(apiVersion, options);

--- a/sdk/keyvault/keyvault-admin/src/generated/keyVaultClientContext.ts
+++ b/sdk/keyvault/keyvault-admin/src/generated/keyVaultClientContext.ts
@@ -7,12 +7,12 @@
  */
 
 import * as coreClient from "@azure/core-client";
-import { ApiVersion72, KeyVaultClientOptionalParams } from "./models";
+import { ApiVersion73Preview, KeyVaultClientOptionalParams } from "./models";
 
 export const packageVersion = "4.2.0-beta.2";
 
 export class KeyVaultClientContext extends coreClient.ServiceClient {
-  apiVersion: ApiVersion72;
+  apiVersion: ApiVersion73Preview;
 
   /**
    * Initializes a new instance of the KeyVaultClientContext class.
@@ -20,7 +20,7 @@ export class KeyVaultClientContext extends coreClient.ServiceClient {
    * @param options The parameter options
    */
   constructor(
-    apiVersion: ApiVersion72,
+    apiVersion: ApiVersion73Preview,
     options?: KeyVaultClientOptionalParams
   ) {
     if (apiVersion === undefined) {
@@ -35,7 +35,7 @@ export class KeyVaultClientContext extends coreClient.ServiceClient {
       requestContentType: "application/json; charset=utf-8"
     };
 
-    const packageDetails = `azsdk-js-keyvault-admin/${packageVersion}`;
+    const packageDetails = `azsdk-js-keyvault-admin/4.2.0-beta.2`;
     const userAgentPrefix =
       options.userAgentOptions && options.userAgentOptions.userAgentPrefix
         ? `${options.userAgentOptions.userAgentPrefix} ${packageDetails}`

--- a/sdk/keyvault/keyvault-admin/src/generated/models/index.ts
+++ b/sdk/keyvault/keyvault-admin/src/generated/models/index.ts
@@ -184,7 +184,6 @@ export interface FullBackupOperation {
 }
 
 export interface RestoreOperationParameters {
-  /** SAS token parameter object containing Azure storage resourceUri and token */
   sasTokenParameters: SASTokenParameter;
   /** The Folder name of the blob where the previous successful full backup was stored */
   folderToRestore: string;
@@ -207,7 +206,6 @@ export interface RestoreOperation {
 }
 
 export interface SelectiveKeyRestoreOperationParameters {
-  /** SAS token parameter object containing Azure storage resourceUri and token */
   sasTokenParameters: SASTokenParameter;
   /** The Folder name of the blob where the previous successful full backup was stored */
   folder: string;
@@ -265,23 +263,23 @@ export interface KeyVaultClientSelectiveKeyRestoreOperationHeaders {
   azureAsyncOperation?: string;
 }
 
-/** Known values of {@link ApiVersion72} that the service accepts. */
-export const enum KnownApiVersion72 {
-  /** Api Version '7.2' */
-  Seven2 = "7.2"
+/** Known values of {@link ApiVersion73Preview} that the service accepts. */
+export enum KnownApiVersion73Preview {
+  /** Api Version '7.3-preview' */
+  Seven3Preview = "7.3-preview"
 }
 
 /**
- * Defines values for ApiVersion72. \
- * {@link KnownApiVersion72} can be used interchangeably with ApiVersion72,
+ * Defines values for ApiVersion73Preview. \
+ * {@link KnownApiVersion73Preview} can be used interchangeably with ApiVersion73Preview,
  *  this enum contains the known values that the service supports.
  * ### Known values supported by the service
- * **7.2**: Api Version '7.2'
+ * **7.3-preview**: Api Version '7.3-preview'
  */
-export type ApiVersion72 = string;
+export type ApiVersion73Preview = string;
 
 /** Known values of {@link RoleType} that the service accepts. */
-export const enum KnownRoleType {
+export enum KnownRoleType {
   /** Built in role. */
   BuiltInRole = "AKVBuiltInRole",
   /** Custom role. */
@@ -299,7 +297,7 @@ export const enum KnownRoleType {
 export type RoleType = string;
 
 /** Known values of {@link DataAction} that the service accepts. */
-export const enum KnownDataAction {
+export enum KnownDataAction {
   /** Read HSM key metadata. */
   ReadHsmKey = "Microsoft.KeyVault/managedHsm/keys/read/action",
   /** Update an HSM key. */
@@ -320,6 +318,10 @@ export const enum KnownDataAction {
   WriteRoleAssignment = "Microsoft.KeyVault/managedHsm/roleAssignments/write/action",
   /** Get role definition. */
   ReadRoleDefinition = "Microsoft.KeyVault/managedHsm/roleDefinitions/read/action",
+  /** Create or update role definition. */
+  WriteRoleDefinition = "Microsoft.KeyVault/managedHsm/roleDefinitions/write/action",
+  /** Delete role definition. */
+  DeleteRoleDefinition = "Microsoft.KeyVault/managedHsm/roleDefinitions/delete/action",
   /** Encrypt using an HSM key. */
   EncryptHsmKey = "Microsoft.KeyVault/managedHsm/keys/encrypt/action",
   /** Decrypt using an HSM key. */
@@ -338,12 +340,16 @@ export const enum KnownDataAction {
   DeleteHsmKey = "Microsoft.KeyVault/managedHsm/keys/delete",
   /** Export an HSM key. */
   ExportHsmKey = "Microsoft.KeyVault/managedHsm/keys/export/action",
+  /** Release an HSM key using Secure Key Release. */
+  ReleaseKey = "Microsoft.KeyVault/managedHsm/keys/release/action",
   /** Import an HSM key. */
   ImportHsmKey = "Microsoft.KeyVault/managedHsm/keys/import/action",
   /** Purge a deleted HSM key. */
   PurgeDeletedHsmKey = "Microsoft.KeyVault/managedHsm/keys/deletedKeys/delete",
   /** Download an HSM security domain. */
   DownloadHsmSecurityDomain = "Microsoft.KeyVault/managedHsm/securitydomain/download/action",
+  /** Check status of HSM security domain download. */
+  DownloadHsmSecurityDomainStatus = "Microsoft.KeyVault/managedHsm/securitydomain/download/read",
   /** Upload an HSM security domain. */
   UploadHsmSecurityDomain = "Microsoft.KeyVault/managedHsm/securitydomain/upload/action",
   /** Check the status of the HSM security domain exchange file. */
@@ -357,7 +363,9 @@ export const enum KnownDataAction {
   /** Read an HSM backup status. */
   ReadHsmBackupStatus = "Microsoft.KeyVault/managedHsm/backup/status/action",
   /** Read an HSM restore status. */
-  ReadHsmRestoreStatus = "Microsoft.KeyVault/managedHsm/restore/status/action"
+  ReadHsmRestoreStatus = "Microsoft.KeyVault/managedHsm/restore/status/action",
+  /** Generate random numbers. */
+  RandomNumbersGenerate = "Microsoft.KeyVault/managedHsm/rng/action"
 }
 
 /**
@@ -375,6 +383,8 @@ export const enum KnownDataAction {
  * **Microsoft.KeyVault\/managedHsm\/roleAssignments\/read\/action**: Get role assignment. \
  * **Microsoft.KeyVault\/managedHsm\/roleAssignments\/write\/action**: Create or update role assignment. \
  * **Microsoft.KeyVault\/managedHsm\/roleDefinitions\/read\/action**: Get role definition. \
+ * **Microsoft.KeyVault\/managedHsm\/roleDefinitions\/write\/action**: Create or update role definition. \
+ * **Microsoft.KeyVault\/managedHsm\/roleDefinitions\/delete\/action**: Delete role definition. \
  * **Microsoft.KeyVault\/managedHsm\/keys\/encrypt\/action**: Encrypt using an HSM key. \
  * **Microsoft.KeyVault\/managedHsm\/keys\/decrypt\/action**: Decrypt using an HSM key. \
  * **Microsoft.KeyVault\/managedHsm\/keys\/wrap\/action**: Wrap using an HSM key. \
@@ -384,21 +394,24 @@ export const enum KnownDataAction {
  * **Microsoft.KeyVault\/managedHsm\/keys\/create**: Create an HSM key. \
  * **Microsoft.KeyVault\/managedHsm\/keys\/delete**: Delete an HSM key. \
  * **Microsoft.KeyVault\/managedHsm\/keys\/export\/action**: Export an HSM key. \
+ * **Microsoft.KeyVault\/managedHsm\/keys\/release\/action**: Release an HSM key using Secure Key Release. \
  * **Microsoft.KeyVault\/managedHsm\/keys\/import\/action**: Import an HSM key. \
  * **Microsoft.KeyVault\/managedHsm\/keys\/deletedKeys\/delete**: Purge a deleted HSM key. \
  * **Microsoft.KeyVault\/managedHsm\/securitydomain\/download\/action**: Download an HSM security domain. \
+ * **Microsoft.KeyVault\/managedHsm\/securitydomain\/download\/read**: Check status of HSM security domain download. \
  * **Microsoft.KeyVault\/managedHsm\/securitydomain\/upload\/action**: Upload an HSM security domain. \
  * **Microsoft.KeyVault\/managedHsm\/securitydomain\/upload\/read**: Check the status of the HSM security domain exchange file. \
  * **Microsoft.KeyVault\/managedHsm\/securitydomain\/transferkey\/read**: Download an HSM security domain transfer key. \
  * **Microsoft.KeyVault\/managedHsm\/backup\/start\/action**: Start an HSM backup. \
  * **Microsoft.KeyVault\/managedHsm\/restore\/start\/action**: Start an HSM restore. \
  * **Microsoft.KeyVault\/managedHsm\/backup\/status\/action**: Read an HSM backup status. \
- * **Microsoft.KeyVault\/managedHsm\/restore\/status\/action**: Read an HSM restore status.
+ * **Microsoft.KeyVault\/managedHsm\/restore\/status\/action**: Read an HSM restore status. \
+ * **Microsoft.KeyVault\/managedHsm\/rng\/action**: Generate random numbers.
  */
 export type DataAction = string;
 
 /** Known values of {@link RoleScope} that the service accepts. */
-export const enum KnownRoleScope {
+export enum KnownRoleScope {
   /** Global scope */
   Global = "/",
   /** Keys scope */
@@ -416,7 +429,7 @@ export const enum KnownRoleScope {
 export type RoleScope = string;
 
 /** Known values of {@link RoleDefinitionType} that the service accepts. */
-export const enum KnownRoleDefinitionType {
+export enum KnownRoleDefinitionType {
   MicrosoftAuthorizationRoleDefinitions = "Microsoft.Authorization/roleDefinitions"
 }
 

--- a/sdk/keyvault/keyvault-admin/swagger/README.md
+++ b/sdk/keyvault/keyvault-admin/swagger/README.md
@@ -11,8 +11,8 @@ generate-metadata: false
 add-credentials: false
 license-header: MICROSOFT_MIT_NO_VERSION
 input-file:
-  - https://raw.githubusercontent.com/Azure/azure-rest-api-specs/1e2c9f3ec93078da8078389941531359e274f32a/specification/keyvault/data-plane/Microsoft.KeyVault/stable/7.2/rbac.json
-  - https://raw.githubusercontent.com/Azure/azure-rest-api-specs/1e2c9f3ec93078da8078389941531359e274f32a/specification/keyvault/data-plane/Microsoft.KeyVault/stable/7.2/backuprestore.json
+  - https://raw.githubusercontent.com/Azure/azure-rest-api-specs/7a42f16c75e5005c59b75fe7f0888c1103294d43/specification/keyvault/data-plane/Microsoft.KeyVault/preview/7.3-preview/rbac.json
+  - https://raw.githubusercontent.com/Azure/azure-rest-api-specs/7a42f16c75e5005c59b75fe7f0888c1103294d43/specification/keyvault/data-plane/Microsoft.KeyVault/preview/7.3-preview/backuprestore.json
 output-folder: ../
 source-code-folder-path: ./src/generated
 package-version: 4.2.0-beta.2

--- a/sdk/keyvault/keyvault-admin/test/internal/serviceVersionParameter.spec.ts
+++ b/sdk/keyvault/keyvault-admin/test/internal/serviceVersionParameter.spec.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import * as assert from "assert";
+import { assert } from "chai";
 import { createSandbox, SinonSandbox, SinonSpy } from "sinon";
 import { KeyVaultAccessControlClient, KeyVaultBackupClient } from "../../src";
 import { LATEST_API_VERSION } from "../../src/constants";
@@ -16,7 +16,7 @@ import { env } from "@azure/test-utils-recorder";
 import { URL } from "url";
 
 // Adding this to the source would change the public API.
-type ApIVersions = "7.2";
+type ApiVersions = "7.2" | "7.3-preview";
 
 const baseUrl = "https://managed_hsm.managedhsm.azure.net/";
 
@@ -77,7 +77,7 @@ describe("The keyvault-admin clients should set the serviceVersion", () => {
     it("it should allow us to specify an API version from a specific set of versions", async function() {
       const serviceVersion = "7.2";
       const client = new KeyVaultAccessControlClient(baseUrl, credential, {
-        serviceVersion: serviceVersion as ApIVersions,
+        serviceVersion: serviceVersion as ApiVersions,
         httpClient: mockHttpClient
       });
       await client.listRoleDefinitions("/").next();
@@ -85,7 +85,7 @@ describe("The keyvault-admin clients should set the serviceVersion", () => {
       assert.ok(spy.called);
       const calls = spy.getCalls();
       const params = new URL(calls[0].args[0].url);
-      assert.equal(params.searchParams.get("api-version"), LATEST_API_VERSION);
+      assert.equal(params.searchParams.get("api-version"), serviceVersion);
     });
   });
 
@@ -110,7 +110,7 @@ describe("The keyvault-admin clients should set the serviceVersion", () => {
     it("it should allow us to specify an API version from a specific set of versions", async function() {
       const serviceVersion = "7.2";
       const client = new KeyVaultBackupClient(baseUrl, credential, {
-        serviceVersion: serviceVersion as ApIVersions,
+        serviceVersion: serviceVersion as ApiVersions,
         httpClient: mockHttpClient
       });
       await client.beginBackup("secretName", "value");

--- a/sdk/keyvault/keyvault-certificates/test/internal/serviceVersionParameter.spec.ts
+++ b/sdk/keyvault/keyvault-certificates/test/internal/serviceVersionParameter.spec.ts
@@ -58,13 +58,13 @@ describe("The Certificates client should set the serviceVersion", () => {
   });
 
   // Adding this to the source would change the public API.
-  type ApIVersions = "7.0" | "7.1" | "7.2";
+  type ApiVersions = "7.0" | "7.1" | "7.2";
 
   it("it should allow us to specify an API version from a specific set of versions", async function() {
-    const versions: ApIVersions[] = ["7.0", "7.1", "7.2"];
+    const versions: ApiVersions[] = ["7.0", "7.1", "7.2"];
     for (const serviceVersion in versions) {
       const client = new CertificateClient(keyVaultUrl, credential, {
-        serviceVersion: serviceVersion as ApIVersions,
+        serviceVersion: serviceVersion as ApiVersions,
         httpClient: mockHttpClient
       });
       await client.getCertificate("certificateName");

--- a/sdk/keyvault/keyvault-secrets/test/internal/serviceVersionParameter.spec.ts
+++ b/sdk/keyvault/keyvault-secrets/test/internal/serviceVersionParameter.spec.ts
@@ -58,13 +58,13 @@ describe("The Secrets client should set the serviceVersion", () => {
   });
 
   // Adding this to the source would change the public API.
-  type ApIVersions = "7.0" | "7.1" | "7.2";
+  type ApiVersions = "7.0" | "7.1" | "7.2";
 
   it("it should allow us to specify an API version from a specific set of versions", async function() {
-    const versions: ApIVersions[] = ["7.0", "7.1", "7.2"];
+    const versions: ApiVersions[] = ["7.0", "7.1", "7.2"];
     for (const serviceVersion in versions) {
       const client = new SecretClient(keyVaultUrl, credential, {
-        serviceVersion: serviceVersion as ApIVersions,
+        serviceVersion: serviceVersion as ApiVersions,
         httpClient: mockHttpClient
       });
       await client.setSecret("secretName", "value");


### PR DESCRIPTION
## What

- Regenerate KeyVault Admin using 7.3-preview
- Remove the duplicated enums in accessControlModels

## Why

- In order to add support to the latest data actions for RBAC
- Now that generated code is not a `const enum` we can just re-export it directly instead of copying code

Resolves #16563 