### PR TITLE
[Schema Registry] bump versions

### DIFF
--- a/sdk/schemaregistry/schema-registry-avro/package.json
+++ b/sdk/schemaregistry/schema-registry-avro/package.json
@@ -70,7 +70,7 @@
     }
   },
   "dependencies": {
-    "@azure/schema-registry": "1.0.0-beta.2",
+    "@azure/schema-registry": "1.0.0-beta.3",
     "@azure/core-http": "^2.0.0",
     "@azure/core-tracing": "1.0.0-preview.13",
     "@azure/logger": "^1.0.0",

--- a/sdk/schemaregistry/schema-registry/CHANGELOG.md
+++ b/sdk/schemaregistry/schema-registry/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Release History
 
+## 1.0.0-beta.3 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
+
 ## 1.0.0-beta.2 (2021-08-17)
 
 ### Features Added

--- a/sdk/schemaregistry/schema-registry/package.json
+++ b/sdk/schemaregistry/schema-registry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/schema-registry",
-  "version": "1.0.0-beta.2",
+  "version": "1.0.0-beta.3",
   "description": "Schema Registry Library with typescript type definitions for node.js and browser.",
   "sdk-type": "client",
   "main": "dist/index.js",

--- a/sdk/schemaregistry/schema-registry/samples/v1/javascript/README.md
+++ b/sdk/schemaregistry/schema-registry/samples/v1/javascript/README.md
@@ -8,7 +8,7 @@ These sample programs show how to use the JavaScript client libraries for Azure 
 
 ## Prerequisites
 
-The sample programs are compatible with Node.js >=12.0.0.
+The sample programs are compatible with [LTS versions of Node.js](https://nodejs.org/about/releases/).
 
 You need [an Azure subscription][freesub] and the following Azure resources to run these sample programs:
 

--- a/sdk/schemaregistry/schema-registry/samples/v1/javascript/package.json
+++ b/sdk/schemaregistry/schema-registry/samples/v1/javascript/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "version": "1.0.0",
   "description": "Azure Schema Registry client library samples for JavaScript",
-  "engine": {
+  "engines": {
     "node": ">=12.0.0"
   },
   "repository": {
@@ -25,6 +25,6 @@
   "dependencies": {
     "@azure/schema-registry": "next",
     "dotenv": "latest",
-    "@azure/identity": "2.0.0-beta.3"
+    "@azure/identity": "2.0.0-beta.4"
   }
 }

--- a/sdk/schemaregistry/schema-registry/samples/v1/typescript/README.md
+++ b/sdk/schemaregistry/schema-registry/samples/v1/typescript/README.md
@@ -8,7 +8,7 @@ These sample programs show how to use the TypeScript client libraries for Azure 
 
 ## Prerequisites
 
-The sample programs are compatible with Node.js >=12.0.0.
+The sample programs are compatible with [LTS versions of Node.js](https://nodejs.org/about/releases/).
 
 Before running the samples in Node, they must be compiled to JavaScript using the TypeScript compiler. For more information on TypeScript, see the [TypeScript documentation][typescript]. Install the TypeScript compiler using:
 

--- a/sdk/schemaregistry/schema-registry/samples/v1/typescript/package.json
+++ b/sdk/schemaregistry/schema-registry/samples/v1/typescript/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "version": "1.0.0",
   "description": "Azure Schema Registry client library samples for TypeScript",
-  "engine": {
+  "engines": {
     "node": ">=12.0.0"
   },
   "scripts": {

--- a/sdk/schemaregistry/schema-registry/src/generated/generatedSchemaRegistryClientContext.ts
+++ b/sdk/schemaregistry/schema-registry/src/generated/generatedSchemaRegistryClientContext.ts
@@ -35,7 +35,7 @@ export class GeneratedSchemaRegistryClientContext extends coreClient.ServiceClie
       requestContentType: "application/json; charset=utf-8"
     };
 
-    const packageDetails = `azsdk-js-schema-registry/1.0.0-beta.2`;
+    const packageDetails = `azsdk-js-schema-registry/1.0.0-beta.3`;
     const userAgentPrefix =
       options.userAgentOptions && options.userAgentOptions.userAgentPrefix
         ? `${options.userAgentOptions.userAgentPrefix} ${packageDetails}`

--- a/sdk/schemaregistry/schema-registry/swagger/README.md
+++ b/sdk/schemaregistry/schema-registry/swagger/README.md
@@ -10,7 +10,7 @@ https://github.com/Azure/azure-rest-api-specs/pull/10220 is merged.
 ```yaml
 v3: true
 package-name: "@azure/schema-registry"
-package-version: 1.0.0-beta.2
+package-version: 1.0.0-beta.3
 title: GeneratedSchemaRegistryClient
 description: Generated Schema Registry Client
 generate-metadata: false


### PR DESCRIPTION
After we made a release for beta.2 yesterday. The release pipeline failed to run the post release bot for some reason: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1052303&view=results

However, it ran fine for the avro package here: https://github.com/Azure/azure-sdk-for-js/pull/16961

cc @praveenkuttappan 