### PR TITLE
[core] - Remove SpanOptions from the public API

### DIFF
--- a/common/tools/dev-tool/package.json
+++ b/common/tools/dev-tool/package.json
@@ -26,6 +26,7 @@
     "unit-test:node": "mocha --require ts-node/register test/**/*.spec.ts",
     "unit-test:browser": "echo skipped",
     "build:samples": "echo Skipped.",
+    "test": "echo Skipped.",
     "docs": "typedoc --excludePrivate --excludeNotExported --excludeExternals --stripInternal --mode file --out ./dist/docs ./src"
   },
   "repository": "github:Azure/azure-sdk-for-js",

--- a/sdk/core/core-auth/review/core-auth.api.md
+++ b/sdk/core/core-auth/review/core-auth.api.md
@@ -79,21 +79,6 @@ export interface SASCredential {
 }
 
 // @public
-export interface SpanAttributes {
-    [attributeKey: string]: SpanAttributeValue | undefined;
-}
-
-// @public
-export type SpanAttributeValue = string | number | boolean | Array<null | undefined | string> | Array<null | undefined | number> | Array<null | undefined | boolean>;
-
-// @public
-export interface SpanContext {
-    spanId: string;
-    traceFlags: number;
-    traceId: string;
-}
-
-// @public
 export interface TokenCredential {
     getToken(scopes: string | string[], options?: GetTokenOptions): Promise<AccessToken | null>;
 }

--- a/sdk/core/core-auth/review/core-auth.api.md
+++ b/sdk/core/core-auth/review/core-auth.api.md
@@ -49,7 +49,6 @@ export interface GetTokenOptions {
     };
     tenantId?: string;
     tracingOptions?: {
-        spanOptions?: SpanOptions;
         tracingContext?: Context;
     };
 }
@@ -92,11 +91,6 @@ export interface SpanContext {
     spanId: string;
     traceFlags: number;
     traceId: string;
-}
-
-// @public
-export interface SpanOptions {
-    attributes?: SpanAttributes;
 }
 
 // @public

--- a/sdk/core/core-auth/src/index.ts
+++ b/sdk/core/core-auth/src/index.ts
@@ -16,4 +16,4 @@ export {
   isTokenCredential
 } from "./tokenCredential";
 
-export { SpanContext, SpanOptions, SpanAttributes, Context, SpanAttributeValue } from "./tracing";
+export { SpanContext, SpanAttributes, Context, SpanAttributeValue } from "./tracing";

--- a/sdk/core/core-auth/src/index.ts
+++ b/sdk/core/core-auth/src/index.ts
@@ -16,4 +16,4 @@ export {
   isTokenCredential
 } from "./tokenCredential";
 
-export { SpanContext, SpanAttributes, Context, SpanAttributeValue } from "./tracing";
+export { Context } from "./tracing";

--- a/sdk/core/core-auth/src/tokenCredential.ts
+++ b/sdk/core/core-auth/src/tokenCredential.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 
 import { AbortSignalLike } from "@azure/abort-controller";
-import { Context, SpanOptions } from "./tracing";
+import { Context } from "./tracing";
 
 /**
  * Represents a credential capable of providing an authentication token.
@@ -42,11 +42,6 @@ export interface GetTokenOptions {
    * Options used when tracing is enabled.
    */
   tracingOptions?: {
-    /**
-     * OpenTelemetry SpanOptions used to create a span when tracing is enabled.
-     */
-    spanOptions?: SpanOptions;
-
     /**
      * OpenTelemetry context
      */

--- a/sdk/core/core-auth/src/tracing.ts
+++ b/sdk/core/core-auth/src/tracing.ts
@@ -5,46 +5,6 @@
 // found in the `@azure/core-tracing` package.
 
 /**
- * Attributes for a Span.
- */
-export interface SpanAttributes {
-  /**
-   * Span attributes.
-   */
-  [attributeKey: string]: SpanAttributeValue | undefined;
-}
-/**
- * Attribute values may be any non-nullish primitive value except an object.
- *
- * null or undefined attribute values are invalid and will result in undefined behavior.
- */
-export declare type SpanAttributeValue =
-  | string
-  | number
-  | boolean
-  | Array<null | undefined | string>
-  | Array<null | undefined | number>
-  | Array<null | undefined | boolean>;
-
-/**
- * A light interface that tries to be structurally compatible with OpenTelemetry.
- */
-export declare interface SpanContext {
-  /**
-   * UUID of a trace.
-   */
-  traceId: string;
-  /**
-   * UUID of a Span.
-   */
-  spanId: string;
-  /**
-   * https://www.w3.org/TR/trace-context/#trace-flags
-   */
-  traceFlags: number;
-}
-
-/**
  * An interface structurally compatible with OpenTelemetry.
  */
 export interface Context {

--- a/sdk/core/core-auth/src/tracing.ts
+++ b/sdk/core/core-auth/src/tracing.ts
@@ -27,16 +27,6 @@ export declare type SpanAttributeValue =
   | Array<null | undefined | boolean>;
 
 /**
- * An interface that enables manual propagation of Spans.
- */
-export interface SpanOptions {
-  /**
-   * Attributes to set on the Span
-   */
-  attributes?: SpanAttributes;
-}
-
-/**
  * A light interface that tries to be structurally compatible with OpenTelemetry.
  */
 export declare interface SpanContext {

--- a/sdk/core/core-http/review/core-http.api.md
+++ b/sdk/core/core-http/review/core-http.api.md
@@ -613,7 +613,6 @@ export interface RequestOptionsBase {
     onUploadProgress?: (progress: TransferProgressEvent) => void;
     serializerOptions?: SerializerOptions;
     shouldDeserialize?: boolean | ((response: HttpOperationResponse) => boolean);
-    spanOptions?: SpanOptions;
     timeout?: number;
     tracingContext?: Context;
 }
@@ -975,7 +974,6 @@ export interface WebResourceLike {
     };
     requestId: string;
     shouldDeserialize?: boolean | ((response: HttpOperationResponse) => boolean);
-    spanOptions?: SpanOptions;
     // @deprecated (undocumented)
     streamResponseBody?: boolean;
     streamResponseStatusCodes?: Set<number>;

--- a/sdk/core/core-http/src/operationOptions.ts
+++ b/sdk/core/core-http/src/operationOptions.ts
@@ -68,7 +68,7 @@ export function operationOptionsToRequestOptionsBase<T extends OperationOptions>
 
   if (tracingOptions) {
     result.tracingContext = tracingOptions.tracingContext;
-    // Backwards compatibility
+    // By passing spanOptions if they exist at runtime, we're backwards compatible with @azure/core-tracing@preview.13 and earlier.
     result.spanOptions = (tracingOptions as any)?.spanOptions;
   }
 

--- a/sdk/core/core-http/src/operationOptions.ts
+++ b/sdk/core/core-http/src/operationOptions.ts
@@ -68,10 +68,9 @@ export function operationOptionsToRequestOptionsBase<T extends OperationOptions>
 
   if (tracingOptions) {
     result.tracingContext = tracingOptions.tracingContext;
+    // Backwards compatibility
+    result.spanOptions = (tracingOptions as any)?.spanOptions;
   }
-
-  // Backwards compatibility
-  result.spanOptions = (tracingOptions as any)?.spanOptions;
 
   return result;
 }

--- a/sdk/core/core-http/src/operationOptions.ts
+++ b/sdk/core/core-http/src/operationOptions.ts
@@ -67,9 +67,11 @@ export function operationOptionsToRequestOptionsBase<T extends OperationOptions>
   }
 
   if (tracingOptions) {
-    result.spanOptions = tracingOptions.spanOptions;
     result.tracingContext = tracingOptions.tracingContext;
   }
+
+  // Backwards compatibility
+  result.spanOptions = (tracingOptions as any)?.spanOptions;
 
   return result;
 }

--- a/sdk/core/core-http/src/policies/bearerTokenAuthenticationPolicy.ts
+++ b/sdk/core/core-http/src/policies/bearerTokenAuthenticationPolicy.ts
@@ -249,7 +249,6 @@ export function bearerTokenAuthenticationPolicy(
       const { token } = await getToken({
         abortSignal: webResource.abortSignal,
         tracingOptions: {
-          spanOptions: webResource.spanOptions,
           tracingContext: webResource.tracingContext
         }
       });

--- a/sdk/core/core-http/src/policies/tracingPolicy.ts
+++ b/sdk/core/core-http/src/policies/tracingPolicy.ts
@@ -94,6 +94,12 @@ export class TracingPolicy extends BaseRequestPolicy {
         span.setAttribute("http.user_agent", this.userAgent);
       }
 
+      const namespaceFromContext = request.tracingContext?.getValue(Symbol.for("az.namespace"));
+
+      if (typeof namespaceFromContext === "string") {
+        span.setAttribute("az.namespace", namespaceFromContext);
+      }
+
       // set headers
       const spanContext = span.spanContext();
       const traceParentHeader = getTraceParentHeader(spanContext);

--- a/sdk/core/core-http/src/policies/tracingPolicy.ts
+++ b/sdk/core/core-http/src/policies/tracingPolicy.ts
@@ -77,7 +77,7 @@ export class TracingPolicy extends BaseRequestPolicy {
       const { span } = createSpan(path, {
         tracingOptions: {
           spanOptions: {
-            ...request.spanOptions,
+            ...(request as any).spanOptions,
             kind: SpanKind.CLIENT
           },
           tracingContext: request.tracingContext

--- a/sdk/core/core-http/src/policies/tracingPolicy.ts
+++ b/sdk/core/core-http/src/policies/tracingPolicy.ts
@@ -74,6 +74,8 @@ export class TracingPolicy extends BaseRequestPolicy {
     try {
       const path = URLBuilder.parse(request.url).getPath() || "/";
 
+      // Passing spanOptions as part of tracingOptions to maintain compatibility with the previous version of core-tracing.
+      // We can pass this as a separate parameter once we upgrade to the latest core-tracing.
       const { span } = createSpan(path, {
         tracingOptions: {
           spanOptions: {

--- a/sdk/core/core-http/src/serviceClient.ts
+++ b/sdk/core/core-http/src/serviceClient.ts
@@ -492,7 +492,7 @@ export class ServiceClient {
         }
 
         if (options.spanOptions) {
-          httpRequest.spanOptions = options.spanOptions;
+          (httpRequest as any).spanOptions = options.spanOptions;
         }
 
         if (options.tracingContext) {

--- a/sdk/core/core-http/src/serviceClient.ts
+++ b/sdk/core/core-http/src/serviceClient.ts
@@ -492,6 +492,7 @@ export class ServiceClient {
         }
 
         if (options.spanOptions) {
+          // By passing spanOptions if they exist at runtime, we're backwards compatible with @azure/core-tracing@preview.13 and earlier.
           (httpRequest as any).spanOptions = options.spanOptions;
         }
 

--- a/sdk/core/core-http/src/webResource.ts
+++ b/sdk/core/core-http/src/webResource.ts
@@ -127,11 +127,6 @@ export interface WebResourceLike {
   onDownloadProgress?: (progress: TransferProgressEvent) => void;
 
   /**
-   * Tracing: Options used to create a span when tracing is enabled.
-   */
-  spanOptions?: SpanOptions;
-
-  /**
    * Tracing: Context used when creating spans.
    */
   tracingContext?: Context;
@@ -699,11 +694,6 @@ export interface RequestOptionsBase {
    * HttpOperationResponse should be deserialized.
    */
   shouldDeserialize?: boolean | ((response: HttpOperationResponse) => boolean);
-
-  /**
-   * Tracing: Options used to create a span when tracing is enabled.
-   */
-  spanOptions?: SpanOptions;
 
   /**
    * Tracing: Context used when creating spans.

--- a/sdk/core/core-http/test/policies/tracingPolicyTests.ts
+++ b/sdk/core/core-http/test/policies/tracingPolicyTests.ts
@@ -35,11 +35,14 @@ class MockSpan implements Span {
     private traceId: string,
     private spanId: string,
     private flags: TraceFlags,
-    private state: string
-  ) {}
+    private state: string,
+    options?: SpanOptions
+  ) {
+    this._attributes = options?.attributes || {};
+  }
 
   addEvent(): this {
-    throw new Error("Not implemented.");
+    throw new Error("Method not implemented.");
   }
 
   isRecording(): boolean {
@@ -47,11 +50,11 @@ class MockSpan implements Span {
   }
 
   recordException(): void {
-    throw new Error("Not implemented.");
+    throw new Error("Method not implemented.");
   }
 
   updateName(): this {
-    throw new Error("Not implemented.");
+    throw new Error("Method not implemented.");
   }
 
   didEnd(): boolean {
@@ -72,7 +75,9 @@ class MockSpan implements Span {
   }
 
   setAttributes(attributes: SpanAttributes): this {
-    this._attributes = attributes;
+    for (const key in attributes) {
+      this.setAttribute(key, attributes[key]!);
+    }
     return this;
   }
 
@@ -89,15 +94,15 @@ class MockSpan implements Span {
     const state = this.state;
 
     const traceState = {
-      set(_key: string, _value: string): TraceState {
-        // Nothing to do here.
+      set(): TraceState {
+        /* empty */
         return traceState;
       },
-      unset(_key: string): TraceState {
-        // Nothing to do here.
+      unset(): TraceState {
+        /* empty */
         return traceState;
       },
-      get(_key: string): string | undefined {
+      get(): string | undefined {
         return;
       },
       serialize() {
@@ -137,9 +142,9 @@ class MockTracer implements Tracer {
     return this._startSpanCalled;
   }
 
-  startSpan(_name: string, _options?: SpanOptions): MockSpan {
+  startSpan(_name: string, options?: SpanOptions): MockSpan {
     this._startSpanCalled = true;
-    const span = new MockSpan(this.traceId, this.spanId, this.flags, this.state);
+    const span = new MockSpan(this.traceId, this.spanId, this.flags, this.state, options);
     this.spans.push(span);
     return span;
   }
@@ -189,7 +194,7 @@ describe("tracingPolicy", function() {
     mockTracerProvider.disable();
   });
 
-  it("will not create a span if spanOptions are missing", async () => {
+  it("will not create a span if tracingContext is missing", async () => {
     const mockTracer = new MockTracer();
     const request = new WebResource();
     const policy = tracingPolicy().create(mockPolicy, new RequestPolicyOptions());
@@ -198,7 +203,7 @@ describe("tracingPolicy", function() {
     assert.isFalse(mockTracer.startSpanCalled());
   });
 
-  it("will create a span and correctly set trace headers if spanOptions are available", async () => {
+  it("will create a span and correctly set trace headers if tracingContext is available", async () => {
     const mockTraceId = "11111111111111111111111111111111";
     const mockSpanId = "2222222222222222";
     const mockTracer = new MockTracer(mockTraceId, mockSpanId, TraceFlags.SAMPLED);
@@ -224,7 +229,7 @@ describe("tracingPolicy", function() {
     assert.notExists(request.headers.get("tracestate"));
   });
 
-  it("will create a span and correctly set trace headers if spanOptions are available (no TraceOptions)", async () => {
+  it("will create a span and correctly set trace headers if tracingContext is available (no TraceOptions)", async () => {
     const mockTraceId = "11111111111111111111111111111111";
     const mockSpanId = "2222222222222222";
     // leave out the TraceOptions
@@ -253,7 +258,7 @@ describe("tracingPolicy", function() {
     assert.notExists(request.headers.get("tracestate"));
   });
 
-  it("will create a span and correctly set trace headers if spanOptions are available (TraceState)", async () => {
+  it("will create a span and correctly set trace headers if tracingContext is available (TraceState)", async () => {
     const mockTraceId = "11111111111111111111111111111111";
     const mockSpanId = "2222222222222222";
     const mockTraceState = "foo=bar";
@@ -381,5 +386,46 @@ describe("tracingPolicy", function() {
 
     const response = await policy.sendRequest(request);
     assert.equal(response.status, 200);
+  });
+
+  it("will give priority to context's az.namespace over spanOptions", async () => {
+    const mockTracer = new MockTracer();
+    mockTracerProvider.setTracer(mockTracer);
+
+    const request = new WebResource();
+    request.spanOptions = {
+      attributes: { "az.namespace": "value_from_span_options" }
+    };
+    request.tracingContext = setSpan(context.active(), ROOT_SPAN).setValue(
+      Symbol.for("az.namespace"),
+      "value_from_context"
+    );
+
+    const policy = tracingPolicy().create(mockPolicy, new RequestPolicyOptions());
+    await policy.sendRequest(request);
+
+    assert.isTrue(mockTracer.startSpanCalled());
+    assert.lengthOf(mockTracer.getStartedSpans(), 1);
+    const span = mockTracer.getStartedSpans()[0];
+    assert.equal(span.getAttribute("az.namespace"), "value_from_context");
+  });
+
+  it("will use spanOptions if context does not have az.namespace", async () => {
+    const mockTracer = new MockTracer();
+    mockTracerProvider.setTracer(mockTracer);
+
+    const request = new WebResource();
+    request.spanOptions = {
+      attributes: { "az.namespace": "value_from_span_options" }
+    };
+    request.tracingContext = setSpan(context.active(), ROOT_SPAN);
+
+    const policy = tracingPolicy().create(mockPolicy, new RequestPolicyOptions());
+    await policy.sendRequest(request);
+
+    assert.isTrue(mockTracer.startSpanCalled());
+    assert.lengthOf(mockTracer.getStartedSpans(), 1);
+    const span = mockTracer.getStartedSpans()[0];
+    assert.equal(span.getAttribute("az.namespace"), "value_from_span_options");
   });
 });

--- a/sdk/core/core-rest-pipeline/src/policies/tracingPolicy.ts
+++ b/sdk/core/core-rest-pipeline/src/policies/tracingPolicy.ts
@@ -7,7 +7,8 @@ import {
   createSpanFunction,
   SpanStatusCode,
   isSpanContextValid,
-  Span
+  Span,
+  SpanOptions
 } from "@azure/core-tracing";
 import { SpanKind } from "@azure/core-tracing";
 import { PipelineResponse, PipelineRequest, SendRequest } from "../interfaces";
@@ -75,10 +76,12 @@ export function tracingPolicy(options: TracingPolicyOptions = {}): PipelinePolic
 function tryCreateSpan(request: PipelineRequest, userAgent?: string): Span | undefined {
   try {
     // create a new span
-    const tracingOptions: OperationTracingOptions = {
+    // Backwards compatible with existing APIs that carried metadata about a span in spanOptions
+    // TODO: test this
+    const tracingOptions: OperationTracingOptions & { spanOptions?: SpanOptions } = {
       ...request.tracingOptions,
       spanOptions: {
-        ...request.tracingOptions?.spanOptions,
+        ...(request.tracingOptions as any)?.spanOptions,
         kind: SpanKind.CLIENT
       }
     };

--- a/sdk/core/core-rest-pipeline/src/policies/tracingPolicy.ts
+++ b/sdk/core/core-rest-pipeline/src/policies/tracingPolicy.ts
@@ -83,11 +83,11 @@ function tryCreateSpan(request: PipelineRequest, userAgent?: string): Span | und
     const url = new URL(request.url);
     const path = url.pathname || "/";
 
-    const { span } = createSpan(
-      path,
-      { tracingOptions: request.tracingOptions },
-      createSpanOptions
-    );
+    // Passing spanOptions as part of tracingOptions to maintain compatibility with the previous version of core-tracing.
+    // We can pass this as a separate parameter once we upgrade to the latest core-tracing.
+    const { span } = createSpan(path, {
+      tracingOptions: { ...request.tracingOptions, spanOptions: createSpanOptions }
+    });
 
     span.setAttributes({
       "http.method": request.method,

--- a/sdk/core/core-rest-pipeline/test/tracingPolicy.spec.ts
+++ b/sdk/core/core-rest-pipeline/test/tracingPolicy.spec.ts
@@ -20,7 +20,8 @@ import {
   SpanStatus,
   SpanStatusCode,
   SpanAttributes,
-  SpanAttributeValue
+  SpanAttributeValue,
+  SpanOptions
 } from "@azure/core-tracing";
 import { TracerProvider, Tracer, Span, trace } from "@opentelemetry/api";
 
@@ -35,8 +36,11 @@ class MockSpan implements Span {
     private traceId: string,
     private spanId: string,
     private flags: TraceFlags,
-    private state: string
-  ) {}
+    private state: string,
+    options?: SpanOptions
+  ) {
+    this._attributes = options?.attributes || {};
+  }
 
   addEvent(): this {
     throw new Error("Method not implemented.");
@@ -72,7 +76,9 @@ class MockSpan implements Span {
   }
 
   setAttributes(attributes: SpanAttributes): this {
-    this._attributes = attributes;
+    for (const key in attributes) {
+      this.setAttribute(key, attributes[key]!);
+    }
     return this;
   }
 
@@ -137,9 +143,9 @@ class MockTracer implements Tracer {
     return this._startSpanCalled;
   }
 
-  startSpan(): MockSpan {
+  startSpan(_name: string, options?: SpanOptions): MockSpan {
     this._startSpanCalled = true;
-    const span = new MockSpan(this.traceId, this.spanId, this.flags, this.state);
+    const span = new MockSpan(this.traceId, this.spanId, this.flags, this.state, options);
     this.spans.push(span);
     return span;
   }
@@ -179,7 +185,7 @@ describe("tracingPolicy", function() {
     mockTracerProvider.disable();
   });
 
-  it("will not create a span if spanOptions are missing", async () => {
+  it("will not create a span if tracingContext is missing", async () => {
     const mockTracer = new MockTracer();
     const request = createPipelineRequest({
       url: "https://bing.com"
@@ -197,7 +203,7 @@ describe("tracingPolicy", function() {
     assert.isFalse(mockTracer.startSpanCalled());
   });
 
-  it("will create a span and correctly set trace headers if spanOptions are available", async () => {
+  it("will create a span and correctly set trace headers if tracingContext is available", async () => {
     const mockTraceId = "11111111111111111111111111111111";
     const mockSpanId = "2222222222222222";
     const mockTracer = new MockTracer(mockTraceId, mockSpanId, TraceFlags.SAMPLED);
@@ -235,7 +241,7 @@ describe("tracingPolicy", function() {
     assert.notExists(request.headers.get("tracestate"));
   });
 
-  it("will create a span and correctly set trace headers if spanOptions are available (no TraceOptions)", async () => {
+  it("will create a span and correctly set trace headers if tracingContext is available (no TraceOptions)", async () => {
     const mockTraceId = "11111111111111111111111111111111";
     const mockSpanId = "2222222222222222";
     // leave out the TraceOptions
@@ -274,7 +280,7 @@ describe("tracingPolicy", function() {
     assert.notExists(request.headers.get("tracestate"));
   });
 
-  it("will create a span and correctly set trace headers if spanOptions are available (TraceState)", async () => {
+  it("will create a span and correctly set trace headers tracingContext is available (TraceState)", async () => {
     const mockTraceId = "11111111111111111111111111111111";
     const mockSpanId = "2222222222222222";
     const mockTraceState = "foo=bar";
@@ -451,5 +457,98 @@ describe("tracingPolicy", function() {
     // Does not throw
     const result = await policy.sendRequest(request, next);
     assert.equal(result, response);
+  });
+
+  it("will give priority to context's az.namespace over spanOptions", async () => {
+    const mockTraceId = "11111111111111111111111111111111";
+    const mockSpanId = "2222222222222222";
+    const mockTracer = new MockTracer(mockTraceId, mockSpanId, TraceFlags.SAMPLED);
+    mockTracerProvider.setTracer(mockTracer);
+
+    const request = createPipelineRequest({
+      url: "https://bing.com",
+      tracingOptions: {
+        tracingContext: setSpan(context.active(), ROOT_SPAN).setValue(
+          Symbol.for("az.namespace"),
+          "value_from_context"
+        )
+      }
+    });
+    Object.assign(request.tracingOptions, {
+      spanOptions: { attributes: { "az.namespace": "value_from_span_options" } }
+    });
+    const response: PipelineResponse = {
+      headers: createHttpHeaders(),
+      request: request,
+      status: 200
+    };
+    const policy = tracingPolicy();
+    const next = sinon.stub<Parameters<SendRequest>, ReturnType<SendRequest>>();
+    next.resolves(response);
+    await policy.sendRequest(request, next);
+
+    assert.isTrue(mockTracer.startSpanCalled());
+    assert.lengthOf(mockTracer.getStartedSpans(), 1);
+    const span = mockTracer.getStartedSpans()[0];
+    assert.equal(span.getAttribute("az.namespace"), "value_from_context");
+  });
+
+  it("will use spanOptions if context does not have namespace", async () => {
+    const mockTraceId = "11111111111111111111111111111111";
+    const mockSpanId = "2222222222222222";
+    const mockTracer = new MockTracer(mockTraceId, mockSpanId, TraceFlags.SAMPLED);
+    mockTracerProvider.setTracer(mockTracer);
+
+    const request = createPipelineRequest({
+      url: "https://bing.com",
+      tracingOptions: {
+        tracingContext: setSpan(context.active(), ROOT_SPAN)
+      }
+    });
+    Object.assign(request.tracingOptions, {
+      spanOptions: { attributes: { "az.namespace": "value_from_span_options" } }
+    });
+    const response: PipelineResponse = {
+      headers: createHttpHeaders(),
+      request: request,
+      status: 200
+    };
+    const policy = tracingPolicy();
+    const next = sinon.stub<Parameters<SendRequest>, ReturnType<SendRequest>>();
+    next.resolves(response);
+    await policy.sendRequest(request, next);
+
+    assert.isTrue(mockTracer.startSpanCalled());
+    assert.lengthOf(mockTracer.getStartedSpans(), 1);
+    const span = mockTracer.getStartedSpans()[0];
+    assert.equal(span.getAttribute("az.namespace"), "value_from_span_options");
+  });
+
+  it("is robust when spanOptions is undefined", async () => {
+    const mockTraceId = "11111111111111111111111111111111";
+    const mockSpanId = "2222222222222222";
+    const mockTracer = new MockTracer(mockTraceId, mockSpanId, TraceFlags.SAMPLED);
+    mockTracerProvider.setTracer(mockTracer);
+
+    const request = createPipelineRequest({
+      url: "https://bing.com",
+      tracingOptions: {
+        tracingContext: setSpan(context.active(), ROOT_SPAN)
+      }
+    });
+    const response: PipelineResponse = {
+      headers: createHttpHeaders(),
+      request: request,
+      status: 200
+    };
+    const policy = tracingPolicy();
+    const next = sinon.stub<Parameters<SendRequest>, ReturnType<SendRequest>>();
+    next.resolves(response);
+    await policy.sendRequest(request, next);
+
+    assert.isTrue(mockTracer.startSpanCalled());
+    assert.lengthOf(mockTracer.getStartedSpans(), 1);
+    const span = mockTracer.getStartedSpans()[0];
+    assert.notExists(span.getAttribute("az.namespace"));
   });
 });

--- a/sdk/core/core-tracing/CHANGELOG.md
+++ b/sdk/core/core-tracing/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 ### Breaking Changes
 
+- SpanOptions has been removed from OperationTracingOptions
+  - Customizing a newly created Span is only supported via passing `SpanOptions` to `createSpanFunction`
+
 ### Bugs Fixed
 
 ### Other Changes

--- a/sdk/core/core-tracing/CHANGELOG.md
+++ b/sdk/core/core-tracing/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Breaking Changes
 
-- SpanOptions has been removed from OperationTracingOptions
+- SpanOptions has been removed from OperationTracingOptions as it is internal and should not be exposed by client libraries.
   - Customizing a newly created Span is only supported via passing `SpanOptions` to `createSpanFunction`
 
 ### Bugs Fixed

--- a/sdk/core/core-tracing/package.json
+++ b/sdk/core/core-tracing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/core-tracing",
-  "version": "1.0.0-preview.14",
+  "version": "1.0.0-preview.13",
   "description": "Provides low-level interfaces and helper methods for tracing in Azure SDK",
   "sdk-type": "client",
   "main": "dist/index.js",

--- a/sdk/core/core-tracing/package.json
+++ b/sdk/core/core-tracing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/core-tracing",
-  "version": "1.0.0-preview.13",
+  "version": "1.0.0-preview.14",
   "description": "Provides low-level interfaces and helper methods for tracing in Azure SDK",
   "sdk-type": "client",
   "main": "dist/index.js",

--- a/sdk/core/core-tracing/review/core-tracing.api.md
+++ b/sdk/core/core-tracing/review/core-tracing.api.md
@@ -22,7 +22,8 @@ export interface ContextAPI {
 // @public
 export function createSpanFunction(args: CreateSpanFunctionArgs): <T extends {
     tracingOptions?: OperationTracingOptions | undefined;
-}>(operationName: string, operationOptions: T | undefined) => {
+    spanOptions?: SpanOptions | undefined;
+}>(operationName: string, operationOptions?: T | undefined) => {
     span: Span;
     updatedOptions: T;
 };
@@ -92,7 +93,6 @@ export interface Link {
 
 // @public
 export interface OperationTracingOptions {
-    spanOptions?: SpanOptions;
     tracingContext?: Context;
 }
 

--- a/sdk/core/core-tracing/review/core-tracing.api.md
+++ b/sdk/core/core-tracing/review/core-tracing.api.md
@@ -22,8 +22,7 @@ export interface ContextAPI {
 // @public
 export function createSpanFunction(args: CreateSpanFunctionArgs): <T extends {
     tracingOptions?: OperationTracingOptions | undefined;
-    spanOptions?: SpanOptions | undefined;
-}>(operationName: string, operationOptions?: T | undefined) => {
+}>(operationName: string, operationOptions?: T | undefined, startSpanOptions?: SpanOptions | undefined) => {
     span: Span;
     updatedOptions: T;
 };

--- a/sdk/core/core-tracing/src/createSpan.ts
+++ b/sdk/core/core-tracing/src/createSpan.ts
@@ -65,7 +65,7 @@ export function isTracingDisabled(): boolean {
 }
 
 /**
- * Maintains backwards compatibility with the previous `OperationTracingOptions` (@azure/core-tracing@preview.13 and earlier) which included `SpanOptions`
+ * Maintains backwards compatibility with the previous `OperationTracingOptions` (\@azure/core-tracing@preview.13 and earlier) which included `SpanOptions`
  */
 function disambiguateParameters<T extends { tracingOptions?: OperationTracingOptions }>(
   operationOptions: T,

--- a/sdk/core/core-tracing/src/createSpan.ts
+++ b/sdk/core/core-tracing/src/createSpan.ts
@@ -65,7 +65,8 @@ export function isTracingDisabled(): boolean {
 }
 
 /**
- * Maintains backwards compatibility with the previous `OperationTracingOptions` (\@azure/core-tracing@preview.13 and earlier) which included `SpanOptions`
+ * Maintains backwards compatibility with the previous `OperationTracingOptions` in core-tracing preview.13 and earlier
+ * which passed `spanOptions` as part of `tracingOptions`.
  */
 function disambiguateParameters<T extends { tracingOptions?: OperationTracingOptions }>(
   operationOptions: T,

--- a/sdk/core/core-tracing/src/createSpan.ts
+++ b/sdk/core/core-tracing/src/createSpan.ts
@@ -73,16 +73,12 @@ function disambiguateParameters<T extends { tracingOptions?: OperationTracingOpt
 ): [OperationTracingOptions, SpanOptions, T] {
   const { tracingOptions } = operationOptions;
 
-  // If startSpanOptions is provided, then we are using the new signature, 
+  // If startSpanOptions is provided, then we are using the new signature,
   // otherwise try to pluck it out of the tracingOptions.
   const spanOptions: SpanOptions = startSpanOptions || (tracingOptions as any)?.spanOptions || {};
-  spanOptions.kind ||= SpanKind.INTERNAL;
+  spanOptions.kind = spanOptions.kind || SpanKind.INTERNAL;
 
-  return [
-    tracingOptions || {},
-    spanOptions,
-    operationOptions
-  ];
+  return [tracingOptions || {}, spanOptions, operationOptions];
 }
 
 /**

--- a/sdk/core/core-tracing/src/createSpan.ts
+++ b/sdk/core/core-tracing/src/createSpan.ts
@@ -65,7 +65,7 @@ export function isTracingDisabled(): boolean {
 }
 
 /**
- * Maintains backwards compatibility with the previous `OperationTracingOptions` which included `SpanOptions`
+ * Maintains backwards compatibility with the previous `OperationTracingOptions` (@azure/core-tracing@preview.13 and earlier) which included `SpanOptions`
  */
 function disambiguateParameters<T extends { tracingOptions?: OperationTracingOptions }>(
   operationOptions: T,
@@ -123,7 +123,7 @@ function setNamespaceOnSpan(
     namespace
   );
 
-  // Here for backwards compatibility, but can be removed once we no longer use `spanOptions`
+  // Here for backwards compatibility, but can be removed once we no longer use `spanOptions` (every client and core library depends on a version higher than preview.13)
   const updatedSpanOptions = {
     ...spanOptions,
     attributes: {
@@ -160,7 +160,7 @@ export function createSpanFunction(args: CreateSpanFunctionArgs) {
    * @param operationOptions - The operation options containing the currently active tracing context when using manual span propagation.
    * @param startSpanOptions - The options to use when creating the span, and will be passed to the tracer.startSpan method.
    *
-   * @returns A span that can be used to create spans using the global tracer as well as updated options containing the currently active tracing context.
+   * @returns - A span from the global tracer provider, and an updatedOptions bag containing the new tracing context.
    *
    * Example usage:
    * ```ts

--- a/sdk/core/core-tracing/src/createSpan.ts
+++ b/sdk/core/core-tracing/src/createSpan.ts
@@ -103,17 +103,17 @@ export function createSpanFunction(args: CreateSpanFunctionArgs) {
     const { tracingOptions, spanOptions, otherOptions } = pluckOptions(operationOptions || {});
 
     const spanName = args.packagePrefix ? `${args.packagePrefix}.${operationName}` : operationName;
-    let context = tracingOptions?.tracingContext || otContext.active();
-    const span = startSpan(spanName, spanOptions, context);
+    let tracingContext = tracingOptions?.tracingContext || otContext.active();
+    const span = startSpan(spanName, spanOptions, tracingContext);
 
     if (args.namespace) {
       span.setAttribute("az.namespace", args.namespace);
-      context = context.setValue(Symbol.for("az.namespace"), args.namespace);
+      tracingContext = tracingContext.setValue(Symbol.for("az.namespace"), args.namespace);
     }
 
-    const newTracingOptions: Required<OperationTracingOptions> = {
+    const newTracingOptions: OperationTracingOptions = {
       ...tracingOptions,
-      tracingContext: setSpan(context, span)
+      tracingContext: setSpan(tracingContext, span)
     };
 
     const newOperationOptions = {

--- a/sdk/core/core-tracing/src/createSpan.ts
+++ b/sdk/core/core-tracing/src/createSpan.ts
@@ -8,7 +8,8 @@ import {
   setSpan,
   context as otContext,
   getTracer,
-  Context
+  Context,
+  SpanKind
 } from "./interfaces";
 import { trace, INVALID_SPAN_CONTEXT } from "@opentelemetry/api";
 
@@ -71,9 +72,15 @@ function disambiguateParameters<T extends { tracingOptions?: OperationTracingOpt
   startSpanOptions?: SpanOptions
 ): [OperationTracingOptions, SpanOptions, T] {
   const { tracingOptions } = operationOptions;
+
+  // If startSpanOptions is provided, then we are using the new signature, 
+  // otherwise try to pluck it out of the tracingOptions.
+  const spanOptions: SpanOptions = startSpanOptions || (tracingOptions as any)?.spanOptions || {};
+  spanOptions.kind ||= SpanKind.INTERNAL;
+
   return [
     tracingOptions || {},
-    startSpanOptions || (tracingOptions as any)?.spanOptions || {},
+    spanOptions,
     operationOptions
   ];
 }

--- a/sdk/core/core-tracing/src/createSpan.ts
+++ b/sdk/core/core-tracing/src/createSpan.ts
@@ -71,7 +71,7 @@ export function isTracingDisabled(): boolean {
 function disambiguateParameters<T extends { tracingOptions?: OperationTracingOptions }>(
   operationOptions: T,
   startSpanOptions?: SpanOptions
-): [OperationTracingOptions, SpanOptions, T] {
+): [OperationTracingOptions, SpanOptions] {
   const { tracingOptions } = operationOptions;
 
   // If startSpanOptions is provided, then we are using the new signature,
@@ -79,7 +79,7 @@ function disambiguateParameters<T extends { tracingOptions?: OperationTracingOpt
   const spanOptions: SpanOptions = startSpanOptions || (tracingOptions as any)?.spanOptions || {};
   spanOptions.kind = spanOptions.kind || SpanKind.INTERNAL;
 
-  return [tracingOptions || {}, spanOptions, operationOptions];
+  return [tracingOptions || {}, spanOptions];
 }
 
 /**
@@ -173,7 +173,7 @@ export function createSpanFunction(args: CreateSpanFunctionArgs) {
     operationOptions?: T,
     startSpanOptions?: SpanOptions
   ): { span: Span; updatedOptions: T } {
-    const [tracingOptions, spanOptions, otherOptions] = disambiguateParameters(
+    const [tracingOptions, spanOptions] = disambiguateParameters(
       operationOptions || ({} as T),
       startSpanOptions
     );
@@ -203,9 +203,9 @@ export function createSpanFunction(args: CreateSpanFunctionArgs) {
     };
 
     const newOperationOptions = {
-      ...otherOptions,
+      ...(operationOptions as T),
       tracingOptions: newTracingOptions
-    } as T & { tracingOptions: Required<OperationTracingOptions> };
+    };
 
     return {
       span,

--- a/sdk/core/core-tracing/src/interfaces.ts
+++ b/sdk/core/core-tracing/src/interfaces.ts
@@ -467,11 +467,6 @@ export interface SpanOptions {
  */
 export interface OperationTracingOptions {
   /**
-   * OpenTelemetry SpanOptions used to create a span when tracing is enabled.
-   */
-  spanOptions?: SpanOptions;
-
-  /**
    * OpenTelemetry context to use for created Spans.
    */
   tracingContext?: Context;

--- a/sdk/core/core-tracing/test/createSpan.spec.ts
+++ b/sdk/core/core-tracing/test/createSpan.spec.ts
@@ -29,11 +29,12 @@ describe("createSpan", () => {
     tracerProvider.disable();
   });
 
-  it("is backwards compatible at runtime", () => {
+  it("is backwards compatible at runtime with versions prior to preview.13", () => {
     const testSpan = tracerProvider.getTracer("test").startSpan("test");
     const someContext = setSpan(otContext.active(), testSpan);
 
-    // Ensure we are backwards compatible with { tracingOptions: { spanOptions } }
+    // Ensure we are backwards compatible with { tracingOptions: { spanOptions } } shape which was
+    // used prior to preview.13 for setting span options.
     const options = {
       tracingOptions: {
         tracingContext: someContext,

--- a/sdk/core/core-tracing/test/interfaces.spec.ts
+++ b/sdk/core/core-tracing/test/interfaces.spec.ts
@@ -47,24 +47,6 @@ describe("interface compatibility", () => {
 
   it("core-auth", () => {
     const coreTracingOptions: Required<coreTracing.OperationTracingOptions> = {
-      spanOptions: {
-        attributes: {
-          hello: "world"
-        },
-        kind: coreTracing.SpanKind.PRODUCER,
-        links: [
-          {
-            context: {
-              spanId: "spanId",
-              traceId: "traceId",
-              traceFlags: coreTracing.TraceFlags.NONE
-            },
-            attributes: {
-              hello2: "world2"
-            }
-          }
-        ]
-      },
       tracingContext: coreTracing.context.active()
     };
 

--- a/sdk/core/core-tracing/test/util/testSpan.ts
+++ b/sdk/core/core-tracing/test/util/testSpan.ts
@@ -10,7 +10,8 @@ import {
   SpanAttributes,
   SpanStatusCode,
   SpanAttributeValue,
-  Span
+  Span,
+  SpanOptions
 } from "../../src/interfaces";
 
 /**
@@ -68,21 +69,20 @@ export class TestSpan implements Span {
     parentTracer: Tracer,
     name: string,
     context: SpanContext,
-    kind: SpanKind,
     parentSpanId?: string,
-    startTime: TimeInput = Date.now()
+    options?: SpanOptions
   ) {
     this._tracer = parentTracer;
     this.name = name;
-    this.kind = kind;
-    this.startTime = startTime;
+    this.kind = options?.kind || SpanKind.INTERNAL;
+    this.startTime = options?.startTime || Date.now();
     this.parentSpanId = parentSpanId;
+    this.attributes = options?.attributes || {};
     this.status = {
       code: SpanStatusCode.OK
     };
     this.endCalled = false;
     this._context = context;
-    this.attributes = {};
   }
 
   /**

--- a/sdk/core/core-tracing/test/util/testTracer.ts
+++ b/sdk/core/core-tracing/test/util/testTracer.ts
@@ -4,7 +4,6 @@
 import { TestSpan } from "./testSpan";
 import {
   SpanContext,
-  SpanKind,
   SpanOptions,
   TraceFlags,
   Context as OTContext,
@@ -143,14 +142,7 @@ export class TestTracer implements Tracer {
       spanId: this.getNextSpanId(),
       traceFlags: TraceFlags.NONE
     };
-    const span = new TestSpan(
-      this,
-      name,
-      spanContext,
-      options?.kind || SpanKind.INTERNAL,
-      parentContext ? parentContext.spanId : undefined,
-      options?.startTime
-    );
+    const span = new TestSpan(this, name, spanContext, parentContext?.spanId, options);
     this.knownSpans.push(span);
     if (isRootSpan) {
       this.rootSpans.push(span);

--- a/sdk/eventhub/event-hubs/src/diagnostics/tracing.ts
+++ b/sdk/eventhub/event-hubs/src/diagnostics/tracing.ts
@@ -35,7 +35,7 @@ export function createEventHubSpan(
     tracingOptions: {
       ...operationOptions?.tracingOptions,
       spanOptions: {
-        ...operationOptions?.tracingOptions?.spanOptions,
+        ...(operationOptions?.tracingOptions as any)?.spanOptions,
         ...additionalSpanOptions
       }
     }

--- a/sdk/eventhub/event-hubs/src/diagnostics/tracing.ts
+++ b/sdk/eventhub/event-hubs/src/diagnostics/tracing.ts
@@ -35,6 +35,7 @@ export function createEventHubSpan(
     tracingOptions: {
       ...operationOptions?.tracingOptions,
       spanOptions: {
+        // By passing spanOptions if they exist at runtime, we're backwards compatible with @azure/core-tracing@preview.13 and earlier.
         ...(operationOptions?.tracingOptions as any)?.spanOptions,
         ...additionalSpanOptions
       }

--- a/sdk/identity/identity/src/client/identityClient.ts
+++ b/sdk/identity/identity/src/client/identityClient.ts
@@ -174,7 +174,7 @@ export class IdentityClient extends ServiceClient implements INetworkModule {
           Accept: "application/json",
           "Content-Type": "application/x-www-form-urlencoded"
         }),
-        tracingOptions: { ...updatedOptions?.tracingOptions }
+        tracingOptions: updatedOptions?.tracingOptions
       });
 
       const response = await this.sendTokenRequest(request, expiresOnParser);

--- a/sdk/identity/identity/src/client/identityClient.ts
+++ b/sdk/identity/identity/src/client/identityClient.ts
@@ -174,10 +174,7 @@ export class IdentityClient extends ServiceClient implements INetworkModule {
           Accept: "application/json",
           "Content-Type": "application/x-www-form-urlencoded"
         }),
-        tracingOptions: {
-          spanOptions: updatedOptions?.tracingOptions?.spanOptions,
-          tracingContext: updatedOptions?.tracingOptions?.tracingContext
-        }
+        tracingOptions: { ...updatedOptions?.tracingOptions }
       });
 
       const response = await this.sendTokenRequest(request, expiresOnParser);

--- a/sdk/identity/identity/src/credentials/clientSecretCredential.browser.ts
+++ b/sdk/identity/identity/src/credentials/clientSecretCredential.browser.ts
@@ -89,7 +89,7 @@ export class ClientSecretCredential implements TokenCredential {
           "Content-Type": "application/x-www-form-urlencoded"
         }),
         abortSignal: options && options.abortSignal,
-        tracingOptions: newOptions.tracingOptions
+        tracingOptions: newOptions?.tracingOptions
       });
 
       const tokenResponse = await this.identityClient.sendTokenRequest(request);

--- a/sdk/identity/identity/src/credentials/clientSecretCredential.browser.ts
+++ b/sdk/identity/identity/src/credentials/clientSecretCredential.browser.ts
@@ -89,10 +89,7 @@ export class ClientSecretCredential implements TokenCredential {
           "Content-Type": "application/x-www-form-urlencoded"
         }),
         abortSignal: options && options.abortSignal,
-        tracingOptions: {
-          spanOptions: newOptions.tracingOptions && newOptions.tracingOptions.spanOptions,
-          tracingContext: newOptions.tracingOptions && newOptions.tracingOptions.tracingContext
-        }
+        tracingOptions: { ...newOptions.tracingOptions }
       });
 
       const tokenResponse = await this.identityClient.sendTokenRequest(request);

--- a/sdk/identity/identity/src/credentials/clientSecretCredential.browser.ts
+++ b/sdk/identity/identity/src/credentials/clientSecretCredential.browser.ts
@@ -89,7 +89,7 @@ export class ClientSecretCredential implements TokenCredential {
           "Content-Type": "application/x-www-form-urlencoded"
         }),
         abortSignal: options && options.abortSignal,
-        tracingOptions: { ...newOptions.tracingOptions }
+        tracingOptions: newOptions.tracingOptions
       });
 
       const tokenResponse = await this.identityClient.sendTokenRequest(request);

--- a/sdk/identity/identity/src/credentials/managedIdentityCredential/arcMsi.ts
+++ b/sdk/identity/identity/src/credentials/managedIdentityCredential/arcMsi.ts
@@ -107,7 +107,6 @@ export const arcMsi: MSI = {
       disableJsonStringifyOnBody: true,
       deserializationMapper: undefined,
       abortSignal: getTokenOptions.abortSignal,
-      spanOptions: getTokenOptions.tracingOptions && getTokenOptions.tracingOptions.spanOptions,
       ...prepareRequestOptions(resource)
     };
 

--- a/sdk/identity/identity/src/credentials/managedIdentityCredential/imdsMsi.ts
+++ b/sdk/identity/identity/src/credentials/managedIdentityCredential/imdsMsi.ts
@@ -91,7 +91,7 @@ export const imdsMsi: MSI = {
       requestOptions.headers.delete("Metadata");
     }
 
-    requestOptions.tracingOptions = { ...options.tracingOptions };
+    requestOptions.tracingOptions = options.tracingOptions;
 
     try {
       // Create a request with a timeout since we expect that

--- a/sdk/identity/identity/src/credentials/managedIdentityCredential/imdsMsi.ts
+++ b/sdk/identity/identity/src/credentials/managedIdentityCredential/imdsMsi.ts
@@ -91,10 +91,7 @@ export const imdsMsi: MSI = {
       requestOptions.headers.delete("Metadata");
     }
 
-    requestOptions.tracingOptions = {
-      spanOptions: options.tracingOptions && options.tracingOptions.spanOptions,
-      tracingContext: options.tracingOptions && options.tracingOptions.tracingContext
-    };
+    requestOptions.tracingOptions = { ...options.tracingOptions };
 
     try {
       // Create a request with a timeout since we expect that

--- a/sdk/identity/identity/src/credentials/managedIdentityCredential/utils.ts
+++ b/sdk/identity/identity/src/credentials/managedIdentityCredential/utils.ts
@@ -36,7 +36,6 @@ export async function msiGenericGetToken(
 ): Promise<AccessToken | null> {
   const request = createPipelineRequest({
     abortSignal: getTokenOptions.abortSignal,
-    tracingOptions: { ...requestOptions.tracingOptions }, // TODO: why is this even necessary? we already splat out requestOptions
     ...requestOptions,
     allowInsecureConnection: true
   });

--- a/sdk/identity/identity/src/credentials/managedIdentityCredential/utils.ts
+++ b/sdk/identity/identity/src/credentials/managedIdentityCredential/utils.ts
@@ -36,11 +36,7 @@ export async function msiGenericGetToken(
 ): Promise<AccessToken | null> {
   const request = createPipelineRequest({
     abortSignal: getTokenOptions.abortSignal,
-    tracingOptions: {
-      spanOptions: getTokenOptions.tracingOptions && getTokenOptions.tracingOptions.spanOptions,
-      tracingContext:
-        getTokenOptions.tracingOptions && getTokenOptions.tracingOptions.tracingContext
-    },
+    tracingOptions: { ...requestOptions.tracingOptions }, // TODO: why is this even necessary? we already splat out requestOptions
     ...requestOptions,
     allowInsecureConnection: true
   });

--- a/sdk/identity/identity/src/credentials/usernamePasswordCredential.browser.ts
+++ b/sdk/identity/identity/src/credentials/usernamePasswordCredential.browser.ts
@@ -90,10 +90,7 @@ export class UsernamePasswordCredential implements TokenCredential {
           "Content-Type": "application/x-www-form-urlencoded"
         }),
         abortSignal: options && options.abortSignal,
-        tracingOptions: {
-          spanOptions: newOptions.tracingOptions && newOptions.tracingOptions.spanOptions,
-          tracingContext: newOptions.tracingOptions && newOptions.tracingOptions.tracingContext
-        }
+        tracingOptions: { ...newOptions.tracingOptions }
       });
 
       const tokenResponse = await this.identityClient.sendTokenRequest(webResource);

--- a/sdk/identity/identity/src/credentials/usernamePasswordCredential.browser.ts
+++ b/sdk/identity/identity/src/credentials/usernamePasswordCredential.browser.ts
@@ -90,7 +90,7 @@ export class UsernamePasswordCredential implements TokenCredential {
           "Content-Type": "application/x-www-form-urlencoded"
         }),
         abortSignal: options && options.abortSignal,
-        tracingOptions: { ...newOptions.tracingOptions }
+        tracingOptions: newOptions.tracingOptions
       });
 
       const tokenResponse = await this.identityClient.sendTokenRequest(webResource);

--- a/sdk/keyvault/keyvault-keys/test/internal/crypto.spec.ts
+++ b/sdk/keyvault/keyvault-keys/test/internal/crypto.spec.ts
@@ -6,6 +6,8 @@ import { Context } from "mocha";
 import chai, { assert } from "chai";
 import chaiAsPromised from "chai-as-promised";
 chai.use(chaiAsPromised);
+import chaiExclude from "chai-exclude";
+chai.use(chaiExclude);
 import sinon from "sinon";
 import { CryptographyClient, DecryptParameters, EncryptParameters, KeyVaultKey } from "../../src";
 import { RsaCryptographyProvider } from "../../src/cryptography/rsaCryptographyProvider";
@@ -145,7 +147,7 @@ describe("internal crypto tests", () => {
           { algorithm: "RSA1_5", plaintext: text },
           operationOptionsSinonMatcher({
             requestOptions: { timeout: 5 },
-            tracingOptions: { spanOptions: {} }
+            tracingOptions: {}
           })
         );
       });
@@ -163,7 +165,7 @@ describe("internal crypto tests", () => {
           { algorithm: "RSA1_5", plaintext: text },
           operationOptionsSinonMatcher({
             requestOptions: { timeout: 5 },
-            tracingOptions: { spanOptions: {} }
+            tracingOptions: {}
           })
         );
       });
@@ -179,7 +181,7 @@ describe("internal crypto tests", () => {
           { algorithm: "RSA1_5", ciphertext: text },
           operationOptionsSinonMatcher({
             requestOptions: { timeout: 5 },
-            tracingOptions: { spanOptions: {} }
+            tracingOptions: {}
           })
         );
       });
@@ -197,7 +199,7 @@ describe("internal crypto tests", () => {
           { algorithm: "RSA1_5", ciphertext: text },
           operationOptionsSinonMatcher({
             requestOptions: { timeout: 5 },
-            tracingOptions: { spanOptions: {} }
+            tracingOptions: {}
           })
         );
       });
@@ -427,7 +429,9 @@ function operationOptionsSinonMatcher<T extends OperationOptions>(
     assert.ok(actualOptions.tracingOptions?.tracingContext);
     delete actualOptions.tracingOptions?.tracingContext;
 
-    assert.deepEqual(expectedPropagatedOptions, actualOptions);
+    assert.deepEqualExcludingEvery(actualOptions, expectedPropagatedOptions, [
+      "spanOptions"
+    ] as any);
     return true;
   });
 }

--- a/sdk/servicebus/service-bus/src/diagnostics/tracing.ts
+++ b/sdk/servicebus/service-bus/src/diagnostics/tracing.ts
@@ -55,6 +55,7 @@ export function createServiceBusSpan(
     tracingOptions: {
       ...operationOptions?.tracingOptions,
       spanOptions: {
+        // By passing spanOptions if they exist at runtime, we're backwards compatible with @azure/core-tracing@preview.13 and earlier.
         ...(operationOptions?.tracingOptions as any)?.spanOptions,
         ...additionalSpanOptions
       }

--- a/sdk/servicebus/service-bus/src/diagnostics/tracing.ts
+++ b/sdk/servicebus/service-bus/src/diagnostics/tracing.ts
@@ -55,7 +55,7 @@ export function createServiceBusSpan(
     tracingOptions: {
       ...operationOptions?.tracingOptions,
       spanOptions: {
-        ...operationOptions?.tracingOptions?.spanOptions,
+        ...(operationOptions?.tracingOptions as any)?.spanOptions,
         ...additionalSpanOptions
       }
     }

--- a/sdk/servicebus/service-bus/src/util/atomXmlHelper.ts
+++ b/sdk/servicebus/service-bus/src/util/atomXmlHelper.ts
@@ -59,6 +59,7 @@ export async function executeAtomXmlOperation(
     onUploadProgress: operationOptions.requestOptions?.onUploadProgress,
     onDownloadProgress: operationOptions.requestOptions?.onDownloadProgress,
     abortSignal: operationOptions.abortSignal,
+    // By passing spanOptions if they exist at runtime, we're backwards compatible with @azure/core-tracing@preview.13 and earlier.
     spanOptions: (operationOptions.tracingOptions as any)?.spanOptions,
     tracingContext: operationOptions.tracingOptions?.tracingContext,
     disableJsonStringifyOnBody: true

--- a/sdk/servicebus/service-bus/src/util/atomXmlHelper.ts
+++ b/sdk/servicebus/service-bus/src/util/atomXmlHelper.ts
@@ -59,7 +59,7 @@ export async function executeAtomXmlOperation(
     onUploadProgress: operationOptions.requestOptions?.onUploadProgress,
     onDownloadProgress: operationOptions.requestOptions?.onDownloadProgress,
     abortSignal: operationOptions.abortSignal,
-    spanOptions: operationOptions.tracingOptions?.spanOptions,
+    spanOptions: (operationOptions.tracingOptions as any)?.spanOptions,
     tracingContext: operationOptions.tracingOptions?.tracingContext,
     disableJsonStringifyOnBody: true
   };

--- a/sdk/storage/storage-blob/src/utils/tracing.ts
+++ b/sdk/storage/storage-blob/src/utils/tracing.ts
@@ -22,8 +22,10 @@ export const createSpan = createSpanFunction({
  */
 export function convertTracingToRequestOptionsBase(
   options?: OperationOptions
-): Pick<RequestOptionsBase, "tracingContext"> {
+): Pick<RequestOptionsBase, "spanOptions" | "tracingContext"> {
   return {
+    // By passing spanOptions if they exist at runtime, we're backwards compatible with @azure/core-tracing@preview.13 and earlier.
+    spanOptions: (options?.tracingOptions as any)?.spanOptions,
     tracingContext: options?.tracingOptions?.tracingContext
   };
 }

--- a/sdk/storage/storage-blob/src/utils/tracing.ts
+++ b/sdk/storage/storage-blob/src/utils/tracing.ts
@@ -22,10 +22,8 @@ export const createSpan = createSpanFunction({
  */
 export function convertTracingToRequestOptionsBase(
   options?: OperationOptions
-): Pick<RequestOptionsBase, "spanOptions" | "tracingContext"> {
+): Pick<RequestOptionsBase, "tracingContext"> {
   return {
-    // Maintain backwards compatibility
-    spanOptions: (options?.tracingOptions as any)?.spanOptions,
     tracingContext: options?.tracingOptions?.tracingContext
   };
 }

--- a/sdk/storage/storage-blob/src/utils/tracing.ts
+++ b/sdk/storage/storage-blob/src/utils/tracing.ts
@@ -24,7 +24,8 @@ export function convertTracingToRequestOptionsBase(
   options?: OperationOptions
 ): Pick<RequestOptionsBase, "spanOptions" | "tracingContext"> {
   return {
-    spanOptions: options?.tracingOptions?.spanOptions,
+    // Maintain backwards compatibility
+    spanOptions: (options?.tracingOptions as any)?.spanOptions,
     tracingContext: options?.tracingOptions?.tracingContext
   };
 }

--- a/sdk/storage/storage-file-datalake/src/utils/tracing.ts
+++ b/sdk/storage/storage-file-datalake/src/utils/tracing.ts
@@ -22,8 +22,10 @@ export const createSpan = createSpanFunction({
  */
 export function convertTracingToRequestOptionsBase(
   options?: OperationOptions
-): Pick<RequestOptionsBase, "tracingContext"> {
+): Pick<RequestOptionsBase, "spanOptions" | "tracingContext"> {
   return {
+    // By passing spanOptions if they exist at runtime, we're backwards compatible with @azure/core-tracing@preview.13 and earlier.
+    spanOptions: (options?.tracingOptions as any)?.spanOptions,
     tracingContext: options?.tracingOptions?.tracingContext
   };
 }

--- a/sdk/storage/storage-file-datalake/src/utils/tracing.ts
+++ b/sdk/storage/storage-file-datalake/src/utils/tracing.ts
@@ -22,9 +22,8 @@ export const createSpan = createSpanFunction({
  */
 export function convertTracingToRequestOptionsBase(
   options?: OperationOptions
-): Pick<RequestOptionsBase, "spanOptions" | "tracingContext"> {
+): Pick<RequestOptionsBase, "tracingContext"> {
   return {
-    spanOptions: (options?.tracingOptions as any)?.spanOptions,
     tracingContext: options?.tracingOptions?.tracingContext
   };
 }

--- a/sdk/storage/storage-file-datalake/src/utils/tracing.ts
+++ b/sdk/storage/storage-file-datalake/src/utils/tracing.ts
@@ -24,7 +24,7 @@ export function convertTracingToRequestOptionsBase(
   options?: OperationOptions
 ): Pick<RequestOptionsBase, "spanOptions" | "tracingContext"> {
   return {
-    spanOptions: options?.tracingOptions?.spanOptions,
+    spanOptions: (options?.tracingOptions as any)?.spanOptions,
     tracingContext: options?.tracingOptions?.tracingContext
   };
 }

--- a/sdk/storage/storage-file-share/src/utils/tracing.ts
+++ b/sdk/storage/storage-file-share/src/utils/tracing.ts
@@ -22,7 +22,7 @@ export const createSpan = createSpanFunction({
  */
 export function convertTracingToRequestOptionsBase(
   options?: OperationOptions
-): Pick<RequestOptionsBase, "tracingContext" | "spanOptions"> {
+): Pick<RequestOptionsBase, "spanOptions" | "tracingContext"> {
   return {
     // By passing spanOptions if they exist at runtime, we're backwards compatible with @azure/core-tracing@preview.13 and earlier.
     spanOptions: (options?.tracingOptions as any)?.spanOptions,

--- a/sdk/storage/storage-file-share/src/utils/tracing.ts
+++ b/sdk/storage/storage-file-share/src/utils/tracing.ts
@@ -22,9 +22,8 @@ export const createSpan = createSpanFunction({
  */
 export function convertTracingToRequestOptionsBase(
   options?: OperationOptions
-): Pick<RequestOptionsBase, "spanOptions" | "tracingContext"> {
+): Pick<RequestOptionsBase, "tracingContext"> {
   return {
-    spanOptions: (options?.tracingOptions as any)?.spanOptions,
     tracingContext: options?.tracingOptions?.tracingContext
   };
 }

--- a/sdk/storage/storage-file-share/src/utils/tracing.ts
+++ b/sdk/storage/storage-file-share/src/utils/tracing.ts
@@ -24,7 +24,7 @@ export function convertTracingToRequestOptionsBase(
   options?: OperationOptions
 ): Pick<RequestOptionsBase, "spanOptions" | "tracingContext"> {
   return {
-    spanOptions: options?.tracingOptions?.spanOptions,
+    spanOptions: (options?.tracingOptions as any)?.spanOptions,
     tracingContext: options?.tracingOptions?.tracingContext
   };
 }

--- a/sdk/storage/storage-file-share/src/utils/tracing.ts
+++ b/sdk/storage/storage-file-share/src/utils/tracing.ts
@@ -22,8 +22,10 @@ export const createSpan = createSpanFunction({
  */
 export function convertTracingToRequestOptionsBase(
   options?: OperationOptions
-): Pick<RequestOptionsBase, "tracingContext"> {
+): Pick<RequestOptionsBase, "tracingContext" | "spanOptions"> {
   return {
+    // By passing spanOptions if they exist at runtime, we're backwards compatible with @azure/core-tracing@preview.13 and earlier.
+    spanOptions: (options?.tracingOptions as any)?.spanOptions,
     tracingContext: options?.tracingOptions?.tracingContext
   };
 }

--- a/sdk/storage/storage-queue/src/utils/tracing.ts
+++ b/sdk/storage/storage-queue/src/utils/tracing.ts
@@ -22,8 +22,10 @@ export const createSpan = createSpanFunction({
  */
 export function convertTracingToRequestOptionsBase(
   options?: OperationOptions
-): Pick<RequestOptionsBase, "tracingContext"> {
+): Pick<RequestOptionsBase, "spanOptions" | "tracingContext"> {
   return {
+    // By passing spanOptions if they exist at runtime, we're backwards compatible with @azure/core-tracing@preview.13 and earlier.
+    spanOptions: (options?.tracingOptions as any)?.spanOptions,
     tracingContext: options?.tracingOptions?.tracingContext
   };
 }

--- a/sdk/storage/storage-queue/src/utils/tracing.ts
+++ b/sdk/storage/storage-queue/src/utils/tracing.ts
@@ -22,9 +22,8 @@ export const createSpan = createSpanFunction({
  */
 export function convertTracingToRequestOptionsBase(
   options?: OperationOptions
-): Pick<RequestOptionsBase, "spanOptions" | "tracingContext"> {
+): Pick<RequestOptionsBase, "tracingContext"> {
   return {
-    spanOptions: (options?.tracingOptions as any)?.spanOptions,
     tracingContext: options?.tracingOptions?.tracingContext
   };
 }

--- a/sdk/storage/storage-queue/src/utils/tracing.ts
+++ b/sdk/storage/storage-queue/src/utils/tracing.ts
@@ -24,7 +24,7 @@ export function convertTracingToRequestOptionsBase(
   options?: OperationOptions
 ): Pick<RequestOptionsBase, "spanOptions" | "tracingContext"> {
   return {
-    spanOptions: options?.tracingOptions?.spanOptions,
+    spanOptions: (options?.tracingOptions as any)?.spanOptions,
     tracingContext: options?.tracingOptions?.tracingContext
   };
 }

--- a/sdk/test-utils/test-utils/src/tracing/testSpan.ts
+++ b/sdk/test-utils/test-utils/src/tracing/testSpan.ts
@@ -70,7 +70,8 @@ export class TestSpan implements Span {
     context: SpanContext,
     kind: SpanKind,
     parentSpanId?: string,
-    startTime: TimeInput = Date.now()
+    startTime: TimeInput = Date.now(),
+    attributes: SpanAttributes = {}
   ) {
     this._tracer = parentTracer;
     this.name = name;
@@ -82,7 +83,7 @@ export class TestSpan implements Span {
     };
     this.endCalled = false;
     this._context = context;
-    this.attributes = {};
+    this.attributes = attributes;
   }
 
   /**

--- a/sdk/test-utils/test-utils/src/tracing/testTracer.ts
+++ b/sdk/test-utils/test-utils/src/tracing/testTracer.ts
@@ -149,7 +149,8 @@ export class TestTracer implements Tracer {
       spanContext,
       options?.kind || SpanKind.INTERNAL,
       parentContext ? parentContext.spanId : undefined,
-      options?.startTime
+      options?.startTime,
+      options?.attributes
     );
     this.knownSpans.push(span);
     if (isRootSpan) {


### PR DESCRIPTION
## What

- Removes spanOptions from OperationTracingOptions
- Prepares client package for compatibility with both existing and future core-tracing code by adding runtime casts / checks where spanOptions are concerned
- Adds `az.namespace` as an attribute on the current context, ensuring that it is available for tracing policies
- Adds spanOptions as a parameter to `createSpan` allowing customization of a newly created span
- Prepare tracingPolicies for backwards and forwards compatibility at runtime by using spanOptions as well as spanContext to determine the value of az.namespace to set on spans.

## Why

spanContext originally existed to be able to shepherd attributes around in order to add them to any child spans. Specifically, we
need to add the az.namespace to the outgoing request span. Now that `tracingContext` is available as both a bag of values as 
well as a container for parenting info, we no longer need spanOptions.

Actually, spanOptions grew to add enums and other elements that caused us pain in the past. See #15285 as an example.

Finally, providing spanOptions as a publicly available option bag means that we are providing ways for consumers to customize
our own spans. We don't need that, as we own the spans we create.

But what we still need to provide is a way for our own libraries to customize the spans they produce. By moving spanOptions off
of OperationTracingOptions and into a separate parameter in createSpan we can support this.

## Callouts

I tested compatibility here in multiple ways:

1. I changed core-tracing's version to preview.13 so that all libraries will run tests against the new package
2. I then changed it _back_ to 14, so that all libraries will run tests against the old pacakge
3. I packed preview.13 with new bits and installed published packages for a few libraries and manually tested a few scenarios

I also realize this doesn't remove everything we want to. We'll get there, but for now let's keep spanOptions out of the client 
libraries' public API as progress towards stability.

Resolves #15285 
Resolves #16726 