### PR TITLE
[Cosmos] Adds pipeline to requestContext for AAD auth reuse

### DIFF
--- a/sdk/cosmosdb/cosmos/review/cosmos.api.md
+++ b/sdk/cosmosdb/cosmos/review/cosmos.api.md
@@ -5,6 +5,7 @@
 ```ts
 
 import { AbortSignal } from 'node-abort-controller';
+import { Pipeline } from '@azure/core-rest-pipeline';
 import { TokenCredential } from '@azure/core-auth';
 
 // @public (undocumented)
@@ -1353,6 +1354,8 @@ export interface RequestContext {
     partitionKeyRangeId?: string;
     // (undocumented)
     path?: string;
+    // (undocumented)
+    pipeline?: Pipeline;
     // (undocumented)
     plugins: PluginConfig[];
     // (undocumented)

--- a/sdk/cosmosdb/cosmos/src/ClientContext.ts
+++ b/sdk/cosmosdb/cosmos/src/ClientContext.ts
@@ -52,7 +52,7 @@ export class ClientContext {
     this.connectionPolicy = cosmosClientOptions.connectionPolicy;
     this.sessionContainer = new SessionContainer();
     this.partitionKeyDefinitionCache = {};
-    this.pipeline;
+    this.pipeline = null;
     if (cosmosClientOptions.aadCredentials) {
       this.pipeline = createEmptyPipeline();
       const hrefEndpoint = sanitizeEndpoint(cosmosClientOptions.endpoint);

--- a/sdk/cosmosdb/cosmos/src/ClientContext.ts
+++ b/sdk/cosmosdb/cosmos/src/ClientContext.ts
@@ -2,6 +2,11 @@
 // Licensed under the MIT license.
 import { v4 } from "uuid";
 const uuid = v4;
+import {
+  bearerTokenAuthenticationPolicy,
+  createEmptyPipeline,
+  Pipeline
+} from "@azure/core-rest-pipeline";
 import { PartitionKeyRange } from "./client/Container/PartitionKeyRange";
 import { Resource } from "./client/Resource";
 import { Constants, HTTPMethod, OperationType, ResourceType } from "./common/constants";
@@ -24,6 +29,7 @@ import { request as executeRequest } from "./request/RequestHandler";
 import { SessionContainer } from "./session/sessionContainer";
 import { SessionContext } from "./session/SessionContext";
 import { BulkOptions } from "./utils/batch";
+import { sanitizeEndpoint } from "./utils/checkURL";
 
 /** @hidden */
 const log = logger("ClientContext");
@@ -37,7 +43,7 @@ const QueryJsonContentType = "application/query+json";
 export class ClientContext {
   private readonly sessionContainer: SessionContainer;
   private connectionPolicy: ConnectionPolicy;
-
+  private pipeline: Pipeline;
   public partitionKeyDefinitionCache: { [containerUrl: string]: any }; // TODO: PartitionKeyDefinitionCache
   public constructor(
     private cosmosClientOptions: CosmosClientOptions,
@@ -46,6 +52,18 @@ export class ClientContext {
     this.connectionPolicy = cosmosClientOptions.connectionPolicy;
     this.sessionContainer = new SessionContainer();
     this.partitionKeyDefinitionCache = {};
+    this.pipeline;
+    if (cosmosClientOptions.aadCredentials) {
+      this.pipeline = createEmptyPipeline();
+      const hrefEndpoint = sanitizeEndpoint(cosmosClientOptions.endpoint);
+      const scope = `${hrefEndpoint}/.default`;
+      this.pipeline.addPolicy(
+        bearerTokenAuthenticationPolicy({
+          credential: cosmosClientOptions.aadCredentials,
+          scopes: scope
+        })
+      );
+    }
   }
   /** @hidden */
   public async read<T>({
@@ -74,7 +92,8 @@ export class ClientContext {
         options,
         resourceType,
         plugins: this.cosmosClientOptions.plugins,
-        partitionKey
+        partitionKey,
+        pipeline: this.pipeline
       };
 
       request.headers = await this.buildHeaders(request);
@@ -130,7 +149,8 @@ export class ClientContext {
       options,
       body: query,
       plugins: this.cosmosClientOptions.plugins,
-      partitionKey
+      partitionKey,
+      pipeline: this.pipeline
     };
     const requestId = uuid();
     if (query !== undefined) {
@@ -182,7 +202,8 @@ export class ClientContext {
       resourceType,
       options,
       body: query,
-      plugins: this.cosmosClientOptions.plugins
+      plugins: this.cosmosClientOptions.plugins,
+      pipeline: this.pipeline
     };
 
     request.endpoint = await this.globalEndpointManager.resolveServiceEndpoint(
@@ -251,7 +272,8 @@ export class ClientContext {
         options,
         resourceId,
         plugins: this.cosmosClientOptions.plugins,
-        partitionKey
+        partitionKey,
+        pipeline: this.pipeline
       };
 
       request.headers = await this.buildHeaders(request);
@@ -303,7 +325,8 @@ export class ClientContext {
         body,
         options,
         plugins: this.cosmosClientOptions.plugins,
-        partitionKey
+        partitionKey,
+        pipeline: this.pipeline
       };
 
       request.headers = await this.buildHeaders(request);
@@ -391,7 +414,8 @@ export class ClientContext {
         resourceId,
         options,
         plugins: this.cosmosClientOptions.plugins,
-        partitionKey
+        partitionKey,
+        pipeline: this.pipeline
       };
 
       request.headers = await this.buildHeaders(request);
@@ -440,7 +464,8 @@ export class ClientContext {
         resourceId,
         options,
         plugins: this.cosmosClientOptions.plugins,
-        partitionKey
+        partitionKey,
+        pipeline: this.pipeline
       };
 
       request.headers = await this.buildHeaders(request);
@@ -493,7 +518,8 @@ export class ClientContext {
       resourceId: id,
       body: params,
       plugins: this.cosmosClientOptions.plugins,
-      partitionKey
+      partitionKey,
+      pipeline: this.pipeline
     };
 
     request.headers = await this.buildHeaders(request);
@@ -525,7 +551,8 @@ export class ClientContext {
       path: "",
       resourceType: ResourceType.none,
       options,
-      plugins: this.cosmosClientOptions.plugins
+      plugins: this.cosmosClientOptions.plugins,
+      pipeline: this.pipeline
     };
 
     request.headers = await this.buildHeaders(request);
@@ -579,7 +606,8 @@ export class ClientContext {
         resourceType: ResourceType.item,
         resourceId,
         plugins: this.cosmosClientOptions.plugins,
-        options
+        options,
+        pipeline: this.pipeline
       };
 
       request.headers = await this.buildHeaders(request);
@@ -630,7 +658,8 @@ export class ClientContext {
         resourceType: ResourceType.item,
         resourceId,
         plugins: this.cosmosClientOptions.plugins,
-        options
+        options,
+        pipeline: this.pipeline
       };
 
       request.headers = await this.buildHeaders(request);

--- a/sdk/cosmosdb/cosmos/src/request/RequestContext.ts
+++ b/sdk/cosmosdb/cosmos/src/request/RequestContext.ts
@@ -9,6 +9,7 @@ import { PluginConfig } from "../plugins/Plugin";
 import { CosmosHeaders } from "../queryExecutionContext/CosmosHeaders";
 import { FeedOptions } from "./FeedOptions";
 import { RequestOptions } from "./RequestOptions";
+import { Pipeline } from "@azure/core-rest-pipeline";
 
 /**
  * @hidden
@@ -31,4 +32,5 @@ export interface RequestContext {
   options: FeedOptions | RequestOptions;
   plugins: PluginConfig[];
   partitionKey?: PartitionKey;
+  pipeline?: Pipeline;
 }

--- a/sdk/cosmosdb/cosmos/src/request/RequestHandler.ts
+++ b/sdk/cosmosdb/cosmos/src/request/RequestHandler.ts
@@ -81,7 +81,11 @@ async function httpRequest(
   }
 
   try {
-    response = await httpsClient.sendRequest(pipelineRequest);
+    if (requestContext.pipeline) {
+      response = await requestContext.pipeline.sendRequest(httpsClient, pipelineRequest);
+    } else {
+      response = await httpsClient.sendRequest(pipelineRequest);
+    }
   } catch (error) {
     if (error.name === "AbortError") {
       // If the user passed signal caused the abort, cancel the timeout and rethrow the error

--- a/sdk/cosmosdb/cosmos/src/request/request.ts
+++ b/sdk/cosmosdb/cosmos/src/request/request.ts
@@ -191,8 +191,7 @@ export async function getHeaders({
     clientOptions.key ||
     clientOptions.resourceTokens ||
     clientOptions.tokenProvider ||
-    clientOptions.permissionFeed ||
-    clientOptions.aadCredentials
+    clientOptions.permissionFeed
   ) {
     await setAuthorizationHeader(clientOptions, verb, path, resourceId, resourceType, headers);
   }


### PR DESCRIPTION
Dev build to test for https://github.com/Azure/azure-sdk-for-js/issues/16971

Gives a credential object to core-rest-pipeline which handles token cycling and caching for us. We were mistakenly refetching the AAD token per-request