### PR TITLE
Bump devcontainer docker image version to 1-linux

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
 # See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.145.0/containers/codespaces-linux/.devcontainer/base.Dockerfile
 
-FROM mcr.microsoft.com/vscode/devcontainers/universal:0-linux
+FROM mcr.microsoft.com/vscode/devcontainers/universal:1-linux
 
 RUN npm install -g "@microsoft/rush"


### PR DESCRIPTION
to have more recent versions of development tools.