### PR TITLE
Support custom pagination

### DIFF
--- a/sdk/core/core-client-paging-rest/review/core-client-paging.api.md
+++ b/sdk/core/core-client-paging-rest/review/core-client-paging.api.md
@@ -8,6 +8,12 @@ import { Client } from '@azure-rest/core-client';
 import { HttpResponse } from '@azure-rest/core-client';
 import { PagedAsyncIterableIterator } from '@azure/core-paging';
 
+// @public
+export type GetPage<TLink, TPage> = (pageLink: TLink, maxPageSize?: number) => Promise<{
+    page: TPage;
+    nextPageLink?: TLink;
+}>;
+
 export { PagedAsyncIterableIterator }
 
 // @public
@@ -18,6 +24,9 @@ export interface PaginateOptions {
 
 // @public
 export function paginateResponse<TElement>(client: Client, initialResponse: HttpResponse, options?: PaginateOptions): PagedAsyncIterableIterator<TElement>;
+
+// @public
+export function paginateResponse<TElement>(client: Client, initialResponse: HttpResponse, getPage: GetPage<string, TElement[]>): PagedAsyncIterableIterator<TElement>;
 
 
 ```

--- a/sdk/core/core-client-paging-rest/src/index.ts
+++ b/sdk/core/core-client-paging-rest/src/index.ts
@@ -6,5 +6,5 @@
  *
  * @packageDocumentation
  */
-export { paginateResponse, PaginateOptions } from "./paginate";
+export { paginateResponse, PaginateOptions, GetPage } from "./paginate";
 export { PagedAsyncIterableIterator } from "@azure/core-paging";


### PR DESCRIPTION
Allow rest users to define their own custom paging strategy.

For example if the nextlink is located in the headers:

```typescript
const response = await client.pathUnchecked("/paging/multiple").get();
let initial = true;
const items = paginate(client, response, async (pageLink: string) => {
  // Setup a custom paginate strategy, looking at the headers for nextLink
  if (initial) {
    initial = false;
    return {
      nextPageLink: response.headers.nextlink,
      page: response.body.fooValue,
    };
  } else {
    const result = await client.pathUnchecked(pageLink).get();
    return {
      page: result.body.fooValue,
      nextPageLink: result.headers.nextlink,
    };
  }
});
const result = [];
for await (const item of items) {
  result.push(item);
}

```