### PR TITLE
[Rest clients] Explicitly set pipeline policies

### DIFF
--- a/sdk/agrifood/agrifood-farming-rest/package.json
+++ b/sdk/agrifood/agrifood-farming-rest/package.json
@@ -85,8 +85,7 @@
   "dependencies": {
     "@azure/core-auth": "^1.3.0",
     "@azure-rest/core-client-paging": "1.0.0-beta.1",
-    "@azure-rest/core-client": "1.0.0-beta.6",
-    "@azure/core-rest-pipeline": "^1.1.0",
+    "@azure-rest/core-client": "1.0.0-beta.7",
     "@azure-rest/core-client-lro": "1.0.0-beta.1",
     "@azure/logger": "^1.0.0",
     "tslib": "^2.2.0"

--- a/sdk/confidentialledger/confidential-ledger-rest/package.json
+++ b/sdk/confidentialledger/confidential-ledger-rest/package.json
@@ -84,7 +84,7 @@
   "autoPublish": false,
   "dependencies": {
     "@azure/core-auth": "^1.3.0",
-    "@azure-rest/core-client": "1.0.0-beta.6",
+    "@azure-rest/core-client": "1.0.0-beta.7",
     "@azure/core-rest-pipeline": "^1.1.0",
     "@azure/logger": "^1.0.0",
     "tslib": "^2.2.0"

--- a/sdk/core/core-client-lro-rest/package.json
+++ b/sdk/core/core-client-lro-rest/package.json
@@ -58,7 +58,7 @@
   "prettier": "@azure/eslint-plugin-azure-sdk/prettier.json",
   "dependencies": {
     "@azure/core-lro": "^2.2.0",
-    "@azure-rest/core-client": "1.0.0-beta.6",
+    "@azure-rest/core-client": "1.0.0-beta.7",
     "tslib": "^2.2.0"
   },
   "devDependencies": {

--- a/sdk/core/core-client-paging-rest/package.json
+++ b/sdk/core/core-client-paging-rest/package.json
@@ -59,7 +59,7 @@
   "dependencies": {
     "@azure/core-paging": "^1.2.0",
     "@azure/core-rest-pipeline": "^1.1.0",
-    "@azure-rest/core-client": "1.0.0-beta.6",
+    "@azure-rest/core-client": "1.0.0-beta.7",
     "tslib": "^2.2.0"
   },
   "devDependencies": {

--- a/sdk/core/core-client-rest/CHANGELOG.md
+++ b/sdk/core/core-client-rest/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Other Changes
 
+- Create pipeline from scratch excluding tracingPolicy to decrease bundle size. [#17015](https://github.com/Azure/azure-sdk-for-js/pull/17015)
 - Allow number and boolean as input headers. [#17358](https://github.com/Azure/azure-sdk-for-js/pull/17358)
 
 ## 1.0.0-beta.6 (2021-08-05)

--- a/sdk/core/core-client-rest/CHANGELOG.md
+++ b/sdk/core/core-client-rest/CHANGELOG.md
@@ -1,18 +1,15 @@
 # Release History
 
-## 1.0.0-beta.7 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
-
-### Bugs Fixed
+## 1.0.0-beta.7 (2021-09-02)
 
 ### Other Changes
+
+- Allow number and boolean as input headers. [#17358](https://github.com/Azure/azure-sdk-for-js/pull/17358)
 
 ## 1.0.0-beta.6 (2021-08-05)
 
 ### Fixes
+
 - Fixed exported types [#15898](https://github.com/Azure/azure-sdk-for-js/pull/15898)
 
 ## 1.0.0-beta.5 (2021-06-24)

--- a/sdk/core/core-client-rest/package.json
+++ b/sdk/core/core-client-rest/package.json
@@ -59,7 +59,7 @@
   "dependencies": {
     "@azure/core-auth": "^1.3.0",
     "@azure/core-rest-pipeline": "^1.1.0",
-    "tslib": "^2.2.0"
+    "@azure/core-util": "^1.0.0-beta.1"
   },
   "devDependencies": {
     "@microsoft/api-extractor": "7.13.2",
@@ -91,6 +91,7 @@
     "sinon": "^9.0.2",
     "typescript": "~4.2.0",
     "util": "^0.12.1",
-    "typedoc": "0.15.2"
+    "typedoc": "0.15.2",
+    "tslib": "^2.2.0"
   }
 }

--- a/sdk/core/core-client-rest/package.json
+++ b/sdk/core/core-client-rest/package.json
@@ -59,7 +59,8 @@
   "dependencies": {
     "@azure/core-auth": "^1.3.0",
     "@azure/core-rest-pipeline": "^1.1.0",
-    "@azure/core-util": "^1.0.0-beta.1"
+    "@azure/core-util": "^1.0.0-beta.1",
+    "tslib": "^2.2.0"
   },
   "devDependencies": {
     "@microsoft/api-extractor": "7.13.2",
@@ -91,7 +92,6 @@
     "sinon": "^9.0.2",
     "typescript": "~4.2.0",
     "util": "^0.12.1",
-    "typedoc": "0.15.2",
-    "tslib": "^2.2.0"
+    "typedoc": "0.15.2"
   }
 }

--- a/sdk/core/core-client-rest/test/clientHelpers.spec.ts
+++ b/sdk/core/core-client-rest/test/clientHelpers.spec.ts
@@ -14,10 +14,6 @@ describe("clientHelpers", () => {
     const policies = pipeline.getOrderedPolicies();
 
     assert.isDefined(policies, "default pipeline should contain policies");
-    assert.isUndefined(
-      policies.find((p) => p.name === "exponentialRetryPolicy"),
-      "pipeline shouldn't have exponentialRetryPolicy"
-    );
 
     assert.isUndefined(
       policies.find((p) => p.name === bearerTokenAuthenticationPolicyName),
@@ -48,10 +44,6 @@ describe("clientHelpers", () => {
     const policies = pipeline.getOrderedPolicies();
 
     assert.isDefined(policies, "default pipeline should contain policies");
-    assert.isUndefined(
-      policies.find((p) => p.name === "exponentialRetryPolicy"),
-      "pipeline shouldn't have exponentialRetryPolicy"
-    );
 
     assert.isUndefined(
       policies.find((p) => p.name === bearerTokenAuthenticationPolicyName),
@@ -72,10 +64,6 @@ describe("clientHelpers", () => {
     const policies = pipeline.getOrderedPolicies();
 
     assert.isDefined(policies, "default pipeline should contain policies");
-    assert.isUndefined(
-      policies.find((p) => p.name === "exponentialRetryPolicy"),
-      "pipeline shouldn't have exponentialRetryPolicy"
-    );
 
     assert.isDefined(
       policies.find((p) => p.name === bearerTokenAuthenticationPolicyName),

--- a/sdk/core/core-rest-pipeline/CHANGELOG.md
+++ b/sdk/core/core-rest-pipeline/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.3.0 (2021-09-07)
+## 1.3.0 (2021-09-02)
 
 ### Bugs Fixed
 
@@ -9,6 +9,7 @@
 ### Other Changes
 
 - Allow `number`, `boolean` and `string` for input raw http headers. [PR #17358](https://github.com/Azure/azure-sdk-for-js/pull/17358)
+- Refactor `createPipelineFromOptions` to its own file to help tree shaking. [PR #17015](https://github.com/Azure/azure-sdk-for-js/pull/17015)
 
 ## 1.2.0 (2021-08-04)
 

--- a/sdk/core/core-rest-pipeline/src/createPipelineFromOptions.ts
+++ b/sdk/core/core-rest-pipeline/src/createPipelineFromOptions.ts
@@ -1,19 +1,60 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { InternalPipelineOptions, Pipeline, createEmptyPipeline } from "./pipeline";
+import { ProxySettings } from ".";
+import { Pipeline, createEmptyPipeline } from "./pipeline";
 import { decompressResponsePolicy } from "./policies/decompressResponsePolicy";
-import { exponentialRetryPolicy } from "./policies/exponentialRetryPolicy";
+import {
+  exponentialRetryPolicy,
+  ExponentialRetryPolicyOptions
+} from "./policies/exponentialRetryPolicy";
 import { formDataPolicy } from "./policies/formDataPolicy";
-import { logPolicy } from "./policies/logPolicy";
+import { logPolicy, LogPolicyOptions } from "./policies/logPolicy";
 import { proxyPolicy } from "./policies/proxyPolicy";
-import { redirectPolicy } from "./policies/redirectPolicy";
+import { redirectPolicy, RedirectPolicyOptions } from "./policies/redirectPolicy";
 import { setClientRequestIdPolicy } from "./policies/setClientRequestIdPolicy";
 import { systemErrorRetryPolicy } from "./policies/systemErrorRetryPolicy";
 import { throttlingRetryPolicy } from "./policies/throttlingRetryPolicy";
 import { tracingPolicy } from "./policies/tracingPolicy";
-import { userAgentPolicy } from "./policies/userAgentPolicy";
+import { userAgentPolicy, UserAgentPolicyOptions } from "./policies/userAgentPolicy";
 import { isNode } from "./util/helpers";
+
+/**
+ * Defines options that are used to configure the HTTP pipeline for
+ * an SDK client.
+ */
+export interface PipelineOptions {
+  /**
+   * Options that control how to retry failed requests.
+   */
+  retryOptions?: ExponentialRetryPolicyOptions;
+
+  /**
+   * Options to configure a proxy for outgoing requests.
+   */
+  proxyOptions?: ProxySettings;
+
+  /**
+   * Options for how redirect responses are handled.
+   */
+  redirectOptions?: RedirectPolicyOptions;
+
+  /**
+   * Options for adding user agent details to outgoing requests.
+   */
+  userAgentOptions?: UserAgentPolicyOptions;
+}
+
+/**
+ * Defines options that are used to configure internal options of
+ * the HTTP pipeline for an SDK client.
+ */
+export interface InternalPipelineOptions extends PipelineOptions {
+  /**
+   * Options to configure request/response logging.
+   */
+  loggingOptions?: LogPolicyOptions;
+}
 
 /**
  * Create a new pipeline with a default set of customizable policies.

--- a/sdk/core/core-rest-pipeline/src/createPipelineFromOptions.ts
+++ b/sdk/core/core-rest-pipeline/src/createPipelineFromOptions.ts
@@ -1,0 +1,38 @@
+import { InternalPipelineOptions, Pipeline, HttpPipeline } from "./pipeline";
+import { decompressResponsePolicy } from "./policies/decompressResponsePolicy";
+import { exponentialRetryPolicy } from "./policies/exponentialRetryPolicy";
+import { formDataPolicy } from "./policies/formDataPolicy";
+import { logPolicy } from "./policies/logPolicy";
+import { proxyPolicy } from "./policies/proxyPolicy";
+import { redirectPolicy } from "./policies/redirectPolicy";
+import { setClientRequestIdPolicy } from "./policies/setClientRequestIdPolicy";
+import { systemErrorRetryPolicy } from "./policies/systemErrorRetryPolicy";
+import { throttlingRetryPolicy } from "./policies/throttlingRetryPolicy";
+import { tracingPolicy } from "./policies/tracingPolicy";
+import { userAgentPolicy } from "./policies/userAgentPolicy";
+import { isNode } from "./util/helpers";
+
+/**
+ * Create a new pipeline with a default set of customizable policies.
+ * @param options - Options to configure a custom pipeline.
+ */
+export function createPipelineFromOptions(options: InternalPipelineOptions): Pipeline {
+  const pipeline = HttpPipeline.create();
+
+  if (isNode) {
+    pipeline.addPolicy(proxyPolicy(options.proxyOptions));
+    pipeline.addPolicy(decompressResponsePolicy());
+  }
+
+  pipeline.addPolicy(formDataPolicy());
+  pipeline.addPolicy(tracingPolicy(options.userAgentOptions));
+  pipeline.addPolicy(userAgentPolicy(options.userAgentOptions));
+  pipeline.addPolicy(setClientRequestIdPolicy());
+  pipeline.addPolicy(throttlingRetryPolicy(), { phase: "Retry" });
+  pipeline.addPolicy(systemErrorRetryPolicy(options.retryOptions), { phase: "Retry" });
+  pipeline.addPolicy(exponentialRetryPolicy(options.retryOptions), { phase: "Retry" });
+  pipeline.addPolicy(redirectPolicy(options.redirectOptions), { afterPhase: "Retry" });
+  pipeline.addPolicy(logPolicy(options.loggingOptions), { afterPhase: "Retry" });
+
+  return pipeline;
+}

--- a/sdk/core/core-rest-pipeline/src/createPipelineFromOptions.ts
+++ b/sdk/core/core-rest-pipeline/src/createPipelineFromOptions.ts
@@ -1,4 +1,4 @@
-import { InternalPipelineOptions, Pipeline, HttpPipeline } from "./pipeline";
+import { InternalPipelineOptions, Pipeline, createEmptyPipeline } from "./pipeline";
 import { decompressResponsePolicy } from "./policies/decompressResponsePolicy";
 import { exponentialRetryPolicy } from "./policies/exponentialRetryPolicy";
 import { formDataPolicy } from "./policies/formDataPolicy";
@@ -17,7 +17,7 @@ import { isNode } from "./util/helpers";
  * @param options - Options to configure a custom pipeline.
  */
 export function createPipelineFromOptions(options: InternalPipelineOptions): Pipeline {
-  const pipeline = HttpPipeline.create();
+  const pipeline = createEmptyPipeline();
 
   if (isNode) {
     pipeline.addPolicy(proxyPolicy(options.proxyOptions));

--- a/sdk/core/core-rest-pipeline/src/createPipelineFromOptions.ts
+++ b/sdk/core/core-rest-pipeline/src/createPipelineFromOptions.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
 import { InternalPipelineOptions, Pipeline, createEmptyPipeline } from "./pipeline";
 import { decompressResponsePolicy } from "./policies/decompressResponsePolicy";
 import { exponentialRetryPolicy } from "./policies/exponentialRetryPolicy";

--- a/sdk/core/core-rest-pipeline/src/index.ts
+++ b/sdk/core/core-rest-pipeline/src/index.ts
@@ -22,11 +22,13 @@ export {
   PipelinePhase,
   PipelinePolicy,
   Pipeline,
-  createEmptyPipeline,
+  createEmptyPipeline
+} from "./pipeline";
+export {
+  createPipelineFromOptions,
   InternalPipelineOptions,
   PipelineOptions
-} from "./pipeline";
-export { createPipelineFromOptions } from "./createPipelineFromOptions";
+} from "./createPipelineFromOptions";
 export { createDefaultHttpClient } from "./defaultHttpClient";
 export { createHttpHeaders } from "./httpHeaders";
 export { createPipelineRequest, PipelineRequestOptions } from "./pipelineRequest";

--- a/sdk/core/core-rest-pipeline/src/index.ts
+++ b/sdk/core/core-rest-pipeline/src/index.ts
@@ -24,9 +24,9 @@ export {
   Pipeline,
   createEmptyPipeline,
   InternalPipelineOptions,
-  PipelineOptions,
-  createPipelineFromOptions
+  PipelineOptions
 } from "./pipeline";
+export { createPipelineFromOptions } from "./createPipelineFromOptions";
 export { createDefaultHttpClient } from "./defaultHttpClient";
 export { createHttpHeaders } from "./httpHeaders";
 export { createPipelineRequest, PipelineRequestOptions } from "./pipelineRequest";

--- a/sdk/core/core-rest-pipeline/src/pipeline.ts
+++ b/sdk/core/core-rest-pipeline/src/pipeline.ts
@@ -1,17 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import {
-  PipelineRequest,
-  PipelineResponse,
-  HttpClient,
-  SendRequest,
-  ProxySettings
-} from "./interfaces";
-import { LogPolicyOptions } from "./policies/logPolicy";
-import { UserAgentPolicyOptions } from "./policies/userAgentPolicy";
-import { RedirectPolicyOptions } from "./policies/redirectPolicy";
-import { ExponentialRetryPolicyOptions } from "./policies/exponentialRetryPolicy";
+import { PipelineRequest, PipelineResponse, HttpClient, SendRequest } from "./interfaces";
 
 /**
  * Policies are executed in phases.
@@ -376,41 +366,4 @@ class HttpPipeline implements Pipeline {
  */
 export function createEmptyPipeline(): Pipeline {
   return HttpPipeline.create();
-}
-
-/**
- * Defines options that are used to configure the HTTP pipeline for
- * an SDK client.
- */
-export interface PipelineOptions {
-  /**
-   * Options that control how to retry failed requests.
-   */
-  retryOptions?: ExponentialRetryPolicyOptions;
-
-  /**
-   * Options to configure a proxy for outgoing requests.
-   */
-  proxyOptions?: ProxySettings;
-
-  /**
-   * Options for how redirect responses are handled.
-   */
-  redirectOptions?: RedirectPolicyOptions;
-
-  /**
-   * Options for adding user agent details to outgoing requests.
-   */
-  userAgentOptions?: UserAgentPolicyOptions;
-}
-
-/**
- * Defines options that are used to configure internal options of
- * the HTTP pipeline for an SDK client.
- */
-export interface InternalPipelineOptions extends PipelineOptions {
-  /**
-   * Options to configure request/response logging.
-   */
-  loggingOptions?: LogPolicyOptions;
 }

--- a/sdk/core/core-rest-pipeline/src/pipeline.ts
+++ b/sdk/core/core-rest-pipeline/src/pipeline.ts
@@ -118,7 +118,7 @@ interface PolicyGraphNode {
  * Do not export this class from the package.
  * @internal
  */
-export class HttpPipeline implements Pipeline {
+class HttpPipeline implements Pipeline {
   private _policies: PipelineDescriptor[] = [];
   private _orderedPolicies?: PipelinePolicy[];
 

--- a/sdk/documenttranslator/ai-document-translator-rest/package.json
+++ b/sdk/documenttranslator/ai-document-translator-rest/package.json
@@ -89,7 +89,7 @@
   "autoPublish": false,
   "dependencies": {
     "@azure/core-auth": "^1.3.0",
-    "@azure-rest/core-client": "1.0.0-beta.6",
+    "@azure-rest/core-client": "1.0.0-beta.7",
     "@azure/core-rest-pipeline": "^1.1.0",
     "@azure/logger": "^1.0.0",
     "tslib": "^2.2.0"

--- a/sdk/purview/purview-account-rest/package.json
+++ b/sdk/purview/purview-account-rest/package.json
@@ -84,7 +84,7 @@
   "dependencies": {
     "@azure-rest/core-client-paging": "1.0.0-beta.1",
     "@azure/core-auth": "^1.3.0",
-    "@azure-rest/core-client": "1.0.0-beta.6",
+    "@azure-rest/core-client": "1.0.0-beta.7",
     "@azure/core-rest-pipeline": "^1.1.0",
     "@azure/logger": "^1.0.0",
     "tslib": "^2.2.0"

--- a/sdk/purview/purview-catalog-rest/package.json
+++ b/sdk/purview/purview-catalog-rest/package.json
@@ -83,7 +83,7 @@
   "autoPublish": false,
   "dependencies": {
     "@azure/core-auth": "^1.3.0",
-    "@azure-rest/core-client": "1.0.0-beta.6",
+    "@azure-rest/core-client": "1.0.0-beta.7",
     "@azure/core-rest-pipeline": "^1.1.0",
     "@azure/logger": "^1.0.0",
     "tslib": "^2.2.0"

--- a/sdk/purview/purview-scanning-rest/package.json
+++ b/sdk/purview/purview-scanning-rest/package.json
@@ -83,7 +83,7 @@
   "autoPublish": false,
   "dependencies": {
     "@azure/core-auth": "^1.3.0",
-    "@azure-rest/core-client": "1.0.0-beta.6",
+    "@azure-rest/core-client": "1.0.0-beta.7",
     "@azure/core-rest-pipeline": "^1.1.0",
     "@azure/logger": "^1.0.0",
     "tslib": "^2.2.0"


### PR DESCRIPTION
We want more control on which pipelines to add in RestClients. Switching from `createPipelineFromOptions` to `createEmptyPipeline` and explicitly adding policies.

Initially, this PR removes tracing policy, Open for discussion on which policies to keep or remove.
