### PR TITLE
[Text Analytics] Regenerate using v3.2-preview.2 swagger

### DIFF
--- a/sdk/textanalytics/ai-text-analytics/src/generated/generatedClientContext.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/generated/generatedClientContext.ts
@@ -52,6 +52,6 @@ export class GeneratedClientContext extends coreClient.ServiceClient {
     this.endpoint = endpoint;
 
     // Assigning values to Constant parameters
-    this.apiVersion = options.apiVersion || "v3.2-preview.1";
+    this.apiVersion = options.apiVersion || "v3.2-preview.2";
   }
 }

--- a/sdk/textanalytics/ai-text-analytics/src/generated/models/index.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/generated/models/index.ts
@@ -124,6 +124,7 @@ export interface CustomEntitiesTask {
 export interface CustomEntitiesTaskParameters {
   projectName?: string;
   deploymentName?: string;
+  loggingOptOut?: boolean;
   stringIndexType?: StringIndexType;
 }
 
@@ -134,6 +135,7 @@ export interface CustomSingleClassificationTask {
 export interface CustomSingleClassificationTaskParameters {
   projectName?: string;
   deploymentName?: string;
+  loggingOptOut?: boolean;
 }
 
 export interface CustomMultiClassificationTask {
@@ -143,6 +145,7 @@ export interface CustomMultiClassificationTask {
 export interface CustomMultiClassificationTaskParameters {
   projectName?: string;
   deploymentName?: string;
+  loggingOptOut?: boolean;
 }
 
 export interface ErrorResponse {

--- a/sdk/textanalytics/ai-text-analytics/src/generated/models/index.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/generated/models/index.ts
@@ -47,6 +47,9 @@ export interface JobManifestTasks {
   entityLinkingTasks?: EntityLinkingTask[];
   sentimentAnalysisTasks?: SentimentAnalysisTask[];
   extractiveSummarizationTasks?: ExtractiveSummarizationTask[];
+  customEntityRecognitionTasks?: CustomEntitiesTask[];
+  customSingleClassificationTasks?: CustomSingleClassificationTask[];
+  customMultiClassificationTasks?: CustomMultiClassificationTask[];
 }
 
 export interface EntitiesTask {
@@ -114,6 +117,34 @@ export interface ExtractiveSummarizationTaskParameters {
   sortBy?: ExtractiveSummarizationTaskParametersSortBy;
 }
 
+export interface CustomEntitiesTask {
+  parameters?: CustomEntitiesTaskParameters;
+}
+
+export interface CustomEntitiesTaskParameters {
+  projectName?: string;
+  deploymentName?: string;
+  stringIndexType?: StringIndexType;
+}
+
+export interface CustomSingleClassificationTask {
+  parameters?: CustomSingleClassificationTaskParameters;
+}
+
+export interface CustomSingleClassificationTaskParameters {
+  projectName?: string;
+  deploymentName?: string;
+}
+
+export interface CustomMultiClassificationTask {
+  parameters?: CustomMultiClassificationTaskParameters;
+}
+
+export interface CustomMultiClassificationTaskParameters {
+  projectName?: string;
+  deploymentName?: string;
+}
+
 export interface ErrorResponse {
   /** Document Error. */
   error: TextAnalyticsError;
@@ -172,6 +203,9 @@ export interface TasksStateTasks {
   entityLinkingTasks?: TasksStateTasksEntityLinkingTasksItem[];
   sentimentAnalysisTasks?: TasksStateTasksSentimentAnalysisTasksItem[];
   extractiveSummarizationTasks?: TasksStateTasksExtractiveSummarizationTasksItem[];
+  customEntityRecognitionTasks?: TasksStateTasksCustomEntityRecognitionTasksItem[];
+  customSingleClassificationTasks?: TasksStateTasksCustomSingleClassificationTasksItem[];
+  customMultiClassificationTasks?: TasksStateTasksCustomMultiClassificationTasksItem[];
 }
 
 export interface TaskState {
@@ -501,6 +535,85 @@ export interface ExtractedSummarySentence {
   length: number;
 }
 
+export interface CustomEntitiesTaskResult {
+  results?: CustomEntitiesResult;
+}
+
+export interface CustomEntitiesResult {
+  /** Response by document */
+  documents: DocumentEntities[];
+  /** Errors by document id. */
+  errors: DocumentError[];
+  /** if includeStatistics=true was specified in the request this field will contain information about the request payload. */
+  statistics?: TextDocumentBatchStatistics;
+  /** This field indicates the project name for the model. */
+  projectName: string;
+  /** This field indicates the deployment name for the model. */
+  deploymentName: string;
+}
+
+export interface CustomSingleClassificationTaskResult {
+  results?: CustomSingleClassificationResult;
+}
+
+export interface CustomSingleClassificationResult {
+  /** Response by document */
+  documents: SingleClassificationDocument[];
+  /** Errors by document id. */
+  errors: DocumentError[];
+  /** if includeStatistics=true was specified in the request this field will contain information about the request payload. */
+  statistics?: TextDocumentBatchStatistics;
+  /** This field indicates the project name for the model. */
+  projectName: string;
+  /** This field indicates the deployment name for the model. */
+  deploymentName: string;
+}
+
+export interface SingleClassificationDocument {
+  /** Unique, non-empty document identifier. */
+  id: string;
+  classification: ClassificationResult;
+  /** Warnings encountered while processing document. */
+  warnings: TextAnalyticsWarning[];
+  /** if showStats=true was specified in the request this field will contain information about the document payload. */
+  statistics?: TextDocumentStatistics;
+}
+
+export interface ClassificationResult {
+  /** Classification type. */
+  category: string;
+  /** Confidence score between 0 and 1 of the recognized classification. */
+  confidenceScore: number;
+}
+
+export interface CustomMultiClassificationTaskResult {
+  results?: CustomMultiClassificationResult;
+}
+
+export interface CustomMultiClassificationResult {
+  /** Response by document */
+  documents: MultiClassificationDocument[];
+  /** Errors by document id. */
+  errors: DocumentError[];
+  /** if includeStatistics=true was specified in the request this field will contain information about the request payload. */
+  statistics?: TextDocumentBatchStatistics;
+  /** This field indicates the project name for the model. */
+  projectName: string;
+  /** This field indicates the deployment name for the model. */
+  deploymentName: string;
+}
+
+export interface MultiClassificationDocument {
+  /** Unique, non-empty document identifier. */
+  id: string;
+  /** Recognized classification results in the document. */
+  classifications: ClassificationResult[];
+  /** Warnings encountered while processing document. */
+  warnings: TextAnalyticsWarning[];
+  /** if showStats=true was specified in the request this field will contain information about the document payload. */
+  statistics?: TextDocumentStatistics;
+}
+
 export interface AnalyzeJobErrorsAndStatistics {
   errors?: TextAnalyticsError[];
   /** if includeStatistics=true was specified in the request this field will contain information about the request payload. */
@@ -670,6 +783,15 @@ export type TasksStateTasksSentimentAnalysisTasksItem = TaskState &
 
 export type TasksStateTasksExtractiveSummarizationTasksItem = TaskState &
   ExtractiveSummarizationTaskResult & {};
+
+export type TasksStateTasksCustomEntityRecognitionTasksItem = TaskState &
+  CustomEntitiesTaskResult & {};
+
+export type TasksStateTasksCustomSingleClassificationTasksItem = TaskState &
+  CustomSingleClassificationTaskResult & {};
+
+export type TasksStateTasksCustomMultiClassificationTasksItem = TaskState &
+  CustomMultiClassificationTaskResult & {};
 
 export type HealthcareEntity = HealthcareEntityProperties &
   HealthcareLinkingProperties & {};

--- a/sdk/textanalytics/ai-text-analytics/src/generated/models/mappers.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/generated/models/mappers.ts
@@ -182,6 +182,42 @@ export const JobManifestTasks: coreClient.CompositeMapper = {
             }
           }
         }
+      },
+      customEntityRecognitionTasks: {
+        serializedName: "customEntityRecognitionTasks",
+        type: {
+          name: "Sequence",
+          element: {
+            type: {
+              name: "Composite",
+              className: "CustomEntitiesTask"
+            }
+          }
+        }
+      },
+      customSingleClassificationTasks: {
+        serializedName: "customSingleClassificationTasks",
+        type: {
+          name: "Sequence",
+          element: {
+            type: {
+              name: "Composite",
+              className: "CustomSingleClassificationTask"
+            }
+          }
+        }
+      },
+      customMultiClassificationTasks: {
+        serializedName: "customMultiClassificationTasks",
+        type: {
+          name: "Sequence",
+          element: {
+            type: {
+              name: "Composite",
+              className: "CustomMultiClassificationTask"
+            }
+          }
+        }
       }
     }
   }
@@ -216,6 +252,7 @@ export const EntitiesTaskParameters: coreClient.CompositeMapper = {
         }
       },
       loggingOptOut: {
+        defaultValue: false,
         serializedName: "loggingOptOut",
         type: {
           name: "Boolean"
@@ -326,6 +363,7 @@ export const KeyPhrasesTaskParameters: coreClient.CompositeMapper = {
         }
       },
       loggingOptOut: {
+        defaultValue: false,
         serializedName: "loggingOptOut",
         type: {
           name: "Boolean"
@@ -364,6 +402,7 @@ export const EntityLinkingTaskParameters: coreClient.CompositeMapper = {
         }
       },
       loggingOptOut: {
+        defaultValue: false,
         serializedName: "loggingOptOut",
         type: {
           name: "Boolean"
@@ -408,12 +447,14 @@ export const SentimentAnalysisTaskParameters: coreClient.CompositeMapper = {
         }
       },
       loggingOptOut: {
+        defaultValue: false,
         serializedName: "loggingOptOut",
         type: {
           name: "Boolean"
         }
       },
       opinionMining: {
+        defaultValue: false,
         serializedName: "opinionMining",
         type: {
           name: "Boolean"
@@ -458,7 +499,7 @@ export const ExtractiveSummarizationTaskParameters: coreClient.CompositeMapper =
         }
       },
       loggingOptOut: {
-        defaultValue: true,
+        defaultValue: false,
         serializedName: "loggingOptOut",
         type: {
           name: "Boolean"
@@ -480,6 +521,123 @@ export const ExtractiveSummarizationTaskParameters: coreClient.CompositeMapper =
       sortBy: {
         defaultValue: "Offset",
         serializedName: "sortBy",
+        type: {
+          name: "String"
+        }
+      }
+    }
+  }
+};
+
+export const CustomEntitiesTask: coreClient.CompositeMapper = {
+  type: {
+    name: "Composite",
+    className: "CustomEntitiesTask",
+    modelProperties: {
+      parameters: {
+        serializedName: "parameters",
+        type: {
+          name: "Composite",
+          className: "CustomEntitiesTaskParameters"
+        }
+      }
+    }
+  }
+};
+
+export const CustomEntitiesTaskParameters: coreClient.CompositeMapper = {
+  type: {
+    name: "Composite",
+    className: "CustomEntitiesTaskParameters",
+    modelProperties: {
+      projectName: {
+        serializedName: "projectName",
+        type: {
+          name: "String"
+        }
+      },
+      deploymentName: {
+        serializedName: "deploymentName",
+        type: {
+          name: "String"
+        }
+      },
+      stringIndexType: {
+        serializedName: "stringIndexType",
+        type: {
+          name: "String"
+        }
+      }
+    }
+  }
+};
+
+export const CustomSingleClassificationTask: coreClient.CompositeMapper = {
+  type: {
+    name: "Composite",
+    className: "CustomSingleClassificationTask",
+    modelProperties: {
+      parameters: {
+        serializedName: "parameters",
+        type: {
+          name: "Composite",
+          className: "CustomSingleClassificationTaskParameters"
+        }
+      }
+    }
+  }
+};
+
+export const CustomSingleClassificationTaskParameters: coreClient.CompositeMapper = {
+  type: {
+    name: "Composite",
+    className: "CustomSingleClassificationTaskParameters",
+    modelProperties: {
+      projectName: {
+        serializedName: "projectName",
+        type: {
+          name: "String"
+        }
+      },
+      deploymentName: {
+        serializedName: "deploymentName",
+        type: {
+          name: "String"
+        }
+      }
+    }
+  }
+};
+
+export const CustomMultiClassificationTask: coreClient.CompositeMapper = {
+  type: {
+    name: "Composite",
+    className: "CustomMultiClassificationTask",
+    modelProperties: {
+      parameters: {
+        serializedName: "parameters",
+        type: {
+          name: "Composite",
+          className: "CustomMultiClassificationTaskParameters"
+        }
+      }
+    }
+  }
+};
+
+export const CustomMultiClassificationTaskParameters: coreClient.CompositeMapper = {
+  type: {
+    name: "Composite",
+    className: "CustomMultiClassificationTaskParameters",
+    modelProperties: {
+      projectName: {
+        serializedName: "projectName",
+        type: {
+          name: "String"
+        }
+      },
+      deploymentName: {
+        serializedName: "deploymentName",
         type: {
           name: "String"
         }
@@ -779,6 +937,42 @@ export const TasksStateTasks: coreClient.CompositeMapper = {
             type: {
               name: "Composite",
               className: "TasksStateTasksExtractiveSummarizationTasksItem"
+            }
+          }
+        }
+      },
+      customEntityRecognitionTasks: {
+        serializedName: "customEntityRecognitionTasks",
+        type: {
+          name: "Sequence",
+          element: {
+            type: {
+              name: "Composite",
+              className: "TasksStateTasksCustomEntityRecognitionTasksItem"
+            }
+          }
+        }
+      },
+      customSingleClassificationTasks: {
+        serializedName: "customSingleClassificationTasks",
+        type: {
+          name: "Sequence",
+          element: {
+            type: {
+              name: "Composite",
+              className: "TasksStateTasksCustomSingleClassificationTasksItem"
+            }
+          }
+        }
+      },
+      customMultiClassificationTasks: {
+        serializedName: "customMultiClassificationTasks",
+        type: {
+          name: "Sequence",
+          element: {
+            type: {
+              name: "Composite",
+              className: "TasksStateTasksCustomMultiClassificationTasksItem"
             }
           }
         }
@@ -2072,6 +2266,337 @@ export const ExtractedSummarySentence: coreClient.CompositeMapper = {
   }
 };
 
+export const CustomEntitiesTaskResult: coreClient.CompositeMapper = {
+  type: {
+    name: "Composite",
+    className: "CustomEntitiesTaskResult",
+    modelProperties: {
+      results: {
+        serializedName: "results",
+        type: {
+          name: "Composite",
+          className: "CustomEntitiesResult"
+        }
+      }
+    }
+  }
+};
+
+export const CustomEntitiesResult: coreClient.CompositeMapper = {
+  type: {
+    name: "Composite",
+    className: "CustomEntitiesResult",
+    modelProperties: {
+      documents: {
+        serializedName: "documents",
+        required: true,
+        type: {
+          name: "Sequence",
+          element: {
+            type: {
+              name: "Composite",
+              className: "DocumentEntities"
+            }
+          }
+        }
+      },
+      errors: {
+        serializedName: "errors",
+        required: true,
+        type: {
+          name: "Sequence",
+          element: {
+            type: {
+              name: "Composite",
+              className: "DocumentError"
+            }
+          }
+        }
+      },
+      statistics: {
+        serializedName: "statistics",
+        type: {
+          name: "Composite",
+          className: "TextDocumentBatchStatistics"
+        }
+      },
+      projectName: {
+        serializedName: "projectName",
+        required: true,
+        type: {
+          name: "String"
+        }
+      },
+      deploymentName: {
+        serializedName: "deploymentName",
+        required: true,
+        type: {
+          name: "String"
+        }
+      }
+    }
+  }
+};
+
+export const CustomSingleClassificationTaskResult: coreClient.CompositeMapper = {
+  type: {
+    name: "Composite",
+    className: "CustomSingleClassificationTaskResult",
+    modelProperties: {
+      results: {
+        serializedName: "results",
+        type: {
+          name: "Composite",
+          className: "CustomSingleClassificationResult"
+        }
+      }
+    }
+  }
+};
+
+export const CustomSingleClassificationResult: coreClient.CompositeMapper = {
+  type: {
+    name: "Composite",
+    className: "CustomSingleClassificationResult",
+    modelProperties: {
+      documents: {
+        serializedName: "documents",
+        required: true,
+        type: {
+          name: "Sequence",
+          element: {
+            type: {
+              name: "Composite",
+              className: "SingleClassificationDocument"
+            }
+          }
+        }
+      },
+      errors: {
+        serializedName: "errors",
+        required: true,
+        type: {
+          name: "Sequence",
+          element: {
+            type: {
+              name: "Composite",
+              className: "DocumentError"
+            }
+          }
+        }
+      },
+      statistics: {
+        serializedName: "statistics",
+        type: {
+          name: "Composite",
+          className: "TextDocumentBatchStatistics"
+        }
+      },
+      projectName: {
+        serializedName: "projectName",
+        required: true,
+        type: {
+          name: "String"
+        }
+      },
+      deploymentName: {
+        serializedName: "deploymentName",
+        required: true,
+        type: {
+          name: "String"
+        }
+      }
+    }
+  }
+};
+
+export const SingleClassificationDocument: coreClient.CompositeMapper = {
+  type: {
+    name: "Composite",
+    className: "SingleClassificationDocument",
+    modelProperties: {
+      id: {
+        serializedName: "id",
+        required: true,
+        type: {
+          name: "String"
+        }
+      },
+      classification: {
+        serializedName: "classification",
+        type: {
+          name: "Composite",
+          className: "ClassificationResult"
+        }
+      },
+      warnings: {
+        serializedName: "warnings",
+        required: true,
+        type: {
+          name: "Sequence",
+          element: {
+            type: {
+              name: "Composite",
+              className: "TextAnalyticsWarning"
+            }
+          }
+        }
+      },
+      statistics: {
+        serializedName: "statistics",
+        type: {
+          name: "Composite",
+          className: "TextDocumentStatistics"
+        }
+      }
+    }
+  }
+};
+
+export const ClassificationResult: coreClient.CompositeMapper = {
+  type: {
+    name: "Composite",
+    className: "ClassificationResult",
+    modelProperties: {
+      category: {
+        serializedName: "category",
+        required: true,
+        type: {
+          name: "String"
+        }
+      },
+      confidenceScore: {
+        serializedName: "confidenceScore",
+        required: true,
+        type: {
+          name: "Number"
+        }
+      }
+    }
+  }
+};
+
+export const CustomMultiClassificationTaskResult: coreClient.CompositeMapper = {
+  type: {
+    name: "Composite",
+    className: "CustomMultiClassificationTaskResult",
+    modelProperties: {
+      results: {
+        serializedName: "results",
+        type: {
+          name: "Composite",
+          className: "CustomMultiClassificationResult"
+        }
+      }
+    }
+  }
+};
+
+export const CustomMultiClassificationResult: coreClient.CompositeMapper = {
+  type: {
+    name: "Composite",
+    className: "CustomMultiClassificationResult",
+    modelProperties: {
+      documents: {
+        serializedName: "documents",
+        required: true,
+        type: {
+          name: "Sequence",
+          element: {
+            type: {
+              name: "Composite",
+              className: "MultiClassificationDocument"
+            }
+          }
+        }
+      },
+      errors: {
+        serializedName: "errors",
+        required: true,
+        type: {
+          name: "Sequence",
+          element: {
+            type: {
+              name: "Composite",
+              className: "DocumentError"
+            }
+          }
+        }
+      },
+      statistics: {
+        serializedName: "statistics",
+        type: {
+          name: "Composite",
+          className: "TextDocumentBatchStatistics"
+        }
+      },
+      projectName: {
+        serializedName: "projectName",
+        required: true,
+        type: {
+          name: "String"
+        }
+      },
+      deploymentName: {
+        serializedName: "deploymentName",
+        required: true,
+        type: {
+          name: "String"
+        }
+      }
+    }
+  }
+};
+
+export const MultiClassificationDocument: coreClient.CompositeMapper = {
+  type: {
+    name: "Composite",
+    className: "MultiClassificationDocument",
+    modelProperties: {
+      id: {
+        serializedName: "id",
+        required: true,
+        type: {
+          name: "String"
+        }
+      },
+      classifications: {
+        serializedName: "classifications",
+        required: true,
+        type: {
+          name: "Sequence",
+          element: {
+            type: {
+              name: "Composite",
+              className: "ClassificationResult"
+            }
+          }
+        }
+      },
+      warnings: {
+        serializedName: "warnings",
+        required: true,
+        type: {
+          name: "Sequence",
+          element: {
+            type: {
+              name: "Composite",
+              className: "TextAnalyticsWarning"
+            }
+          }
+        }
+      },
+      statistics: {
+        serializedName: "statistics",
+        type: {
+          name: "Composite",
+          className: "TextDocumentStatistics"
+        }
+      }
+    }
+  }
+};
+
 export const AnalyzeJobErrorsAndStatistics: coreClient.CompositeMapper = {
   type: {
     name: "Composite",
@@ -2732,6 +3257,39 @@ export const TasksStateTasksExtractiveSummarizationTasksItem: coreClient.Composi
     modelProperties: {
       ...TaskState.type.modelProperties,
       ...ExtractiveSummarizationTaskResult.type.modelProperties
+    }
+  }
+};
+
+export const TasksStateTasksCustomEntityRecognitionTasksItem: coreClient.CompositeMapper = {
+  type: {
+    name: "Composite",
+    className: "TasksStateTasksCustomEntityRecognitionTasksItem",
+    modelProperties: {
+      ...TaskState.type.modelProperties,
+      ...CustomEntitiesTaskResult.type.modelProperties
+    }
+  }
+};
+
+export const TasksStateTasksCustomSingleClassificationTasksItem: coreClient.CompositeMapper = {
+  type: {
+    name: "Composite",
+    className: "TasksStateTasksCustomSingleClassificationTasksItem",
+    modelProperties: {
+      ...TaskState.type.modelProperties,
+      ...CustomSingleClassificationTaskResult.type.modelProperties
+    }
+  }
+};
+
+export const TasksStateTasksCustomMultiClassificationTasksItem: coreClient.CompositeMapper = {
+  type: {
+    name: "Composite",
+    className: "TasksStateTasksCustomMultiClassificationTasksItem",
+    modelProperties: {
+      ...TaskState.type.modelProperties,
+      ...CustomMultiClassificationTaskResult.type.modelProperties
     }
   }
 };

--- a/sdk/textanalytics/ai-text-analytics/src/generated/models/mappers.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/generated/models/mappers.ts
@@ -562,6 +562,13 @@ export const CustomEntitiesTaskParameters: coreClient.CompositeMapper = {
           name: "String"
         }
       },
+      loggingOptOut: {
+        defaultValue: false,
+        serializedName: "loggingOptOut",
+        type: {
+          name: "Boolean"
+        }
+      },
       stringIndexType: {
         serializedName: "stringIndexType",
         type: {
@@ -604,6 +611,13 @@ export const CustomSingleClassificationTaskParameters: coreClient.CompositeMappe
         type: {
           name: "String"
         }
+      },
+      loggingOptOut: {
+        defaultValue: false,
+        serializedName: "loggingOptOut",
+        type: {
+          name: "Boolean"
+        }
       }
     }
   }
@@ -640,6 +654,13 @@ export const CustomMultiClassificationTaskParameters: coreClient.CompositeMapper
         serializedName: "deploymentName",
         type: {
           name: "String"
+        }
+      },
+      loggingOptOut: {
+        defaultValue: false,
+        serializedName: "loggingOptOut",
+        type: {
+          name: "Boolean"
         }
       }
     }

--- a/sdk/textanalytics/ai-text-analytics/src/generated/models/parameters.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/generated/models/parameters.ts
@@ -61,7 +61,7 @@ export const endpoint: OperationURLParameter = {
 export const apiVersion: OperationURLParameter = {
   parameterPath: "apiVersion",
   mapper: {
-    defaultValue: "v3.2-preview.1",
+    defaultValue: "v3.2-preview.2",
     isConstant: true,
     serializedName: "ApiVersion",
     type: {
@@ -110,6 +110,7 @@ export const top: OperationQueryParameter = {
 export const skip: OperationQueryParameter = {
   parameterPath: ["options", "skip"],
   mapper: {
+    defaultValue: 0,
     constraints: {
       InclusiveMinimum: 0
     },

--- a/sdk/textanalytics/ai-text-analytics/swagger/README.md
+++ b/sdk/textanalytics/ai-text-analytics/swagger/README.md
@@ -12,7 +12,7 @@ generate-metadata: false
 license-header: MICROSOFT_MIT_NO_VERSION
 output-folder: ../
 source-code-folder-path: ./src/generated
-input-file: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/d89b288853959fde45622730995d5c403f332164/specification/cognitiveservices/data-plane/TextAnalytics/preview/v3.2-preview.2/TextAnalytics.json
+input-file: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/c46283d507bc79eddc6b5f89f6663ee907bd30de/specification/cognitiveservices/data-plane/TextAnalytics/preview/v3.2-preview.2/TextAnalytics.json
 add-credentials: false
 package-version: 5.2.0-beta.2
 v3: true

--- a/sdk/textanalytics/ai-text-analytics/swagger/README.md
+++ b/sdk/textanalytics/ai-text-analytics/swagger/README.md
@@ -12,7 +12,7 @@ generate-metadata: false
 license-header: MICROSOFT_MIT_NO_VERSION
 output-folder: ../
 source-code-folder-path: ./src/generated
-input-file: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/d758c4205d331c552cafbb755ed02673b9fa5e22/specification/cognitiveservices/data-plane/TextAnalytics/preview/v3.2-preview.1/TextAnalytics.json
+input-file: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/d89b288853959fde45622730995d5c403f332164/specification/cognitiveservices/data-plane/TextAnalytics/preview/v3.2-preview.2/TextAnalytics.json
 add-credentials: false
 package-version: 5.2.0-beta.2
 v3: true


### PR DESCRIPTION
Regeneration using the swagger in https://github.com/Azure/azure-rest-api-specs/pull/15736#pullrequestreview-735691760. I noticed that the `LoggingOptOut` parameter is missing and I left a comment about this in the swagger PR.

Please note that I created a feature branch and this PR targets it, so please ignore the CI failures.