### PR TITLE
Bump pnpm version to 5.18.10

### DIFF
--- a/rush.json
+++ b/rush.json
@@ -23,7 +23,7 @@
    * Specify one of: "pnpmVersion", "npmVersion", or "yarnVersion".  See the Rush documentation
    * for details about these alternatives.
    */
-  "pnpmVersion": "5.15.0",
+  "pnpmVersion": "5.18.10",
   // "npmVersion": "4.5.0",
   // "yarnVersion": "1.9.4",
   /**


### PR DESCRIPTION
to have security fix for tar@6.1.0 (see https://github.com/pnpm/pnpm/releases/tag/v5.18.10 for details)