### PR TITLE
[Cosmos] remove deprecated @types/fast-json-stable-stringify dependency

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -9942,7 +9942,7 @@ packages:
     dev: false
     name: '@rush-temp/cosmos'
     resolution:
-      integrity: sha512-BsRi7P/t0dCE+meCvDsGmLSVADUF4kFlR0Gt8JJu3FoBvRnG2eyUG4oDnYg71frICUhgptWpHWoLC7pOqlZdZg==
+      integrity: sha512-ccjG0WDeeY6YNl3ls3WPXeotL6A77FlJRlru9NBbNfJCTQnmyfHpEc/8V08uaNiePCL78AG8z8SaXM/5hvUD1g==
       tarball: file:projects/cosmos.tgz
     version: 0.0.0
   file:projects/data-tables.tgz:

--- a/sdk/cosmosdb/cosmos/package.json
+++ b/sdk/cosmosdb/cosmos/package.json
@@ -89,7 +89,7 @@
     "@azure/core-auth": "^1.3.0",
     "@azure/core-rest-pipeline": "^1.1.0",
     "debug": "^4.1.1",
-    "fast-json-stable-stringify": "^2.0.0",
+    "fast-json-stable-stringify": "^2.1.0",
     "jsbi": "^3.1.3",
     "node-abort-controller": "^1.2.0",
     "priorityqueuejs": "^1.0.0",

--- a/sdk/cosmosdb/cosmos/package.json
+++ b/sdk/cosmosdb/cosmos/package.json
@@ -106,7 +106,6 @@
     "@rollup/plugin-json": "^4.0.0",
     "@rollup/plugin-multi-entry": "^3.0.0",
     "@types/debug": "^4.1.4",
-    "@types/fast-json-stable-stringify": "^2.0.0",
     "@types/mocha": "^7.0.2",
     "@types/node": "^12.0.0",
     "@types/priorityqueuejs": "^1.0.1",


### PR DESCRIPTION
as recommended by

```
 WARN  deprecated @types/fast-json-stable-stringify@2.1.0: This is a stub types definition. fast-json-stable-stringify provides its own type definitions, so you do not need this installed.
```