### PR TITLE
Suppress CredScan warnings for test proxy dev cert

### DIFF
--- a/eng/CredScanSuppression.json
+++ b/eng/CredScanSuppression.json
@@ -50,6 +50,7 @@
     },
     {
       "file": [
+        "eng/common/testproxy/dotnet-devcert.pfx",
         "sdk/identity/identity/test/azure-identity-chain-test.crt",
         "sdk/identity/identity/test/azure-identity-test.crt",
         "sdk/keyvault/keyvault-certificates/ca.key",


### PR DESCRIPTION
This suppresses a CredScan warning that comes from a non-secret devcert
necessary for using the new test proxy. (See related Python PR at
https://github.com/Azure/azure-sdk-for-python/pull/20324)