### PR TITLE
[smoke-tests] update pipeline to find samples that migrated to v2 workflow

### DIFF
--- a/common/smoke-test/Initialize-SmokeTests.ps1
+++ b/common/smoke-test/Initialize-SmokeTests.ps1
@@ -90,7 +90,7 @@ function Set-EnvironmentVariables {
 
 function New-DeployManifest {
   Write-Verbose "Detecting samples..."
-  $javascriptSamples = (Get-ChildItem -Path "$repoRoot/sdk/$ServiceDirectory/*/samples/javascript/" -Directory
+  $javascriptSamples = (Get-ChildItem -Path "$repoRoot/sdk/$ServiceDirectory/*/samples/**/javascript/" -Directory
     | Where-Object { Test-Path "$_/package.json" })
 
   $manifest = $javascriptSamples | ForEach-Object {


### PR DESCRIPTION
I was working on an issue where some service bus samples weren't being ran as part of the smoke test pipeline and found out that __most__ of our samples aren't being ran by the pipeline.

It looks like the script that detects samples isn't taking into account the new samples structure when we migrated to the v2 workflow, where the package major version number is part of the path to the sample.

This is in draft because I want to run the pipeline and am still figuring out what works/doesn't work.