### PR TITLE
[core] - return early if span is not recording

### DIFF
--- a/sdk/core/core-http/src/policies/tracingPolicy.ts
+++ b/sdk/core/core-http/src/policies/tracingPolicy.ts
@@ -89,7 +89,7 @@ export class TracingPolicy extends BaseRequestPolicy {
       // If the span is not recording, don't do any more work.
       if (!span.isRecording()) {
         span.end();
-        return;
+        return undefined;
       }
 
       const namespaceFromContext = request.tracingContext?.getValue(Symbol.for("az.namespace"));
@@ -122,7 +122,7 @@ export class TracingPolicy extends BaseRequestPolicy {
       return span;
     } catch (error) {
       logger.warning(`Skipping creating a tracing span due to an error: ${error.message}`);
-      return;
+      return undefined;
     }
   }
 

--- a/sdk/core/core-http/src/policies/tracingPolicy.ts
+++ b/sdk/core/core-http/src/policies/tracingPolicy.ts
@@ -86,6 +86,12 @@ export class TracingPolicy extends BaseRequestPolicy {
         }
       });
 
+      // If the span is not recording, don't do any more work.
+      if (!span.isRecording()) {
+        span.end();
+        return;
+      }
+
       const namespaceFromContext = request.tracingContext?.getValue(Symbol.for("az.namespace"));
 
       if (typeof namespaceFromContext === "string") {
@@ -116,7 +122,7 @@ export class TracingPolicy extends BaseRequestPolicy {
       return span;
     } catch (error) {
       logger.warning(`Skipping creating a tracing span due to an error: ${error.message}`);
-      return undefined;
+      return;
     }
   }
 

--- a/sdk/core/core-http/test/policies/tracingPolicyTests.ts
+++ b/sdk/core/core-http/test/policies/tracingPolicyTests.ts
@@ -336,6 +336,7 @@ describe("tracingPolicy", function() {
   it("will not set headers if span is a NoOpSpan", async () => {
     mockTracerProvider.disable();
     const request = new WebResource();
+    request.tracingContext = setSpan(context.active(), ROOT_SPAN);
 
     const policy = tracingPolicy().create(mockPolicy, new RequestPolicyOptions());
     await policy.sendRequest(request);
@@ -377,6 +378,7 @@ describe("tracingPolicy", function() {
     const errorTracer = new MockTracer("", "", TraceFlags.SAMPLED, "");
     mockTracerProvider.setTracer(errorTracer);
     const errorSpan = new MockSpan("", "", TraceFlags.SAMPLED, "");
+    sinon.stub(errorSpan, "end").throws(new Error("Test Error"));
     sinon.stub(errorTracer, "startSpan").returns(errorSpan);
 
     const request = new WebResource();

--- a/sdk/core/core-rest-pipeline/src/policies/tracingPolicy.ts
+++ b/sdk/core/core-rest-pipeline/src/policies/tracingPolicy.ts
@@ -88,6 +88,12 @@ function tryCreateSpan(request: PipelineRequest, userAgent?: string): Span | und
       tracingOptions: { ...request.tracingOptions, spanOptions: createSpanOptions }
     });
 
+    // If the span is not recording, don't do any more work.
+    if (!span.isRecording()) {
+      span.end();
+      return;
+    }
+
     const namespaceFromContext = request.tracingOptions?.tracingContext?.getValue(
       Symbol.for("az.namespace")
     );

--- a/sdk/core/core-rest-pipeline/src/policies/tracingPolicy.ts
+++ b/sdk/core/core-rest-pipeline/src/policies/tracingPolicy.ts
@@ -91,7 +91,7 @@ function tryCreateSpan(request: PipelineRequest, userAgent?: string): Span | und
     // If the span is not recording, don't do any more work.
     if (!span.isRecording()) {
       span.end();
-      return;
+      return undefined;
     }
 
     const namespaceFromContext = request.tracingOptions?.tracingContext?.getValue(
@@ -126,7 +126,7 @@ function tryCreateSpan(request: PipelineRequest, userAgent?: string): Span | und
     return span;
   } catch (error) {
     logger.warning(`Skipping creating a tracing span due to an error: ${error.message}`);
-    return;
+    return undefined;
   }
 }
 

--- a/sdk/core/core-rest-pipeline/src/policies/tracingPolicy.ts
+++ b/sdk/core/core-rest-pipeline/src/policies/tracingPolicy.ts
@@ -126,7 +126,7 @@ function tryCreateSpan(request: PipelineRequest, userAgent?: string): Span | und
     return span;
   } catch (error) {
     logger.warning(`Skipping creating a tracing span due to an error: ${error.message}`);
-    return undefined;
+    return;
   }
 }
 

--- a/sdk/core/core-rest-pipeline/test/tracingPolicy.spec.ts
+++ b/sdk/core/core-rest-pipeline/test/tracingPolicy.spec.ts
@@ -437,6 +437,7 @@ describe("tracingPolicy", function() {
     const errorTracer = new MockTracer("", "", TraceFlags.SAMPLED, "");
     mockTracerProvider.setTracer(errorTracer);
     const errorSpan = new MockSpan("", "", TraceFlags.SAMPLED, "");
+    sinon.stub(errorSpan, "end").throws(new Error("Test Error"));
     sinon.stub(errorTracer, "startSpan").returns(errorSpan);
 
     const request = createPipelineRequest({


### PR DESCRIPTION
## What

- If a span is not recording, return early and avoid doing any more work
- Update some missed test setup

## Why

When tracing is either not configured or the newly created span is not sampled this information would get dropped from both 
telemetry and request headers (since the serialized span context will not be valid).

We can return early in that case. It'll have several benefits:
1. Less instances of the Span#context / Span#spanContext rename issues (since we won't get there)
2. We can avoid some processing overhead, although for a non recording span it is probably (but not surely) very lightweight anyway.

## Callouts

Being able to avoid creating the span (and the URIBuilder overhead) is currently not possible for multiple reasons:
1. The OTel API does not provide a way to check whether tracing is globally configured https://github.com/open-telemetry/opentelemetry-js-api/issues/118 nor will that be supported in the future
2. Checking the current parent span is not an option either - due to sampling logic it's possible that the parent span is not recording but this span will be

So this is about as good as we can get for now.

Skipping CHANGELOG because the overall behavior should not change from a client's perspective.

Resolves #16580 