### PR TITLE
[Identity] Fix broken link

### DIFF
--- a/sdk/identity/identity/samples/manual/README.md
+++ b/sdk/identity/identity/samples/manual/README.md
@@ -4,7 +4,7 @@ This is a manual sample to test the `AuthorizationCodeCredential` class.
 
 Steps to run this sample:
 
-1. Set up your environment with [these instructions](https://github.com/sadasant/azure-sdk-for-js/blob/identity/fix15188/CONTRIBUTING.md#setting-up-your-environment)
+1. Set up your environment with [these instructions](https://github.com/azure/azure-sdk-for-js/blob/main/CONTRIBUTING.md#setting-up-your-environment).
 
 2. Build the Identity package with dependencies.
 


### PR DESCRIPTION
In this PR I’m fixing a broken link. It pointed to a feature branch, and it correctly routed to it while we were developing the feature, but after merging an deleting that branch, the link is now broken! (reasonably so). Let’s clean it up!

Thank you, @jeremymeng for letting me know about this.