### PR TITLE
Bubble up system error code for the retry policy to evaluate the actu…

### DIFF
--- a/sdk/core/core-rest-pipeline/src/nodeHttpClient.ts
+++ b/sdk/core/core-rest-pipeline/src/nodeHttpClient.ts
@@ -210,9 +210,12 @@ class NodeHttpClient implements HttpClient {
     return new Promise<http.IncomingMessage>((resolve, reject) => {
       const req = isInsecure ? http.request(options, resolve) : https.request(options, resolve);
 
-      req.once("error", (err) => {
-        reject(new RestError(err.message, { code: RestError.REQUEST_SEND_ERROR, request }));
+      req.once("error", (err: Error & { code?: string }) => {
+        reject(
+          new RestError(err.message, { code: err.code ?? RestError.REQUEST_SEND_ERROR, request })
+        );
       });
+
       abortController.signal.addEventListener("abort", () => {
         req.abort();
         reject(new AbortError("The operation was aborted."));


### PR DESCRIPTION
Try to extract the actual system error code for the retry policy to evaluate the actual code instead of always getting `REQUEST_SEND_ERROR`


When trying to locally reproduce #16951 (Tables), retrying seems to eventually produce a successful request so I expect this PR to also address #16951