### PR TITLE
rush update --full 8/26/2021

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -1453,7 +1453,7 @@ packages:
   /@types/body-parser/1.19.1:
     dependencies:
       '@types/connect': 3.4.35
-      '@types/node': 12.20.20
+      '@types/node': 12.20.21
     dev: false
     resolution:
       integrity: sha512-a6bTJ21vFOGIkwM0kzh9Yr89ziVxq4vYH2fQ6N8AeipEzai/cFK6aGMArIkUeIdRIgpwQa+2bXiLuUJCpSf2Cg==
@@ -1479,7 +1479,7 @@ packages:
       integrity: sha512-bsjleuRKWmGqajMerkzox19aGbscQX5rmmvvXl3wlIp5gMG1HgkiwPxsN5p070fBDKTNSPgojVbuY1+HWMbFhg==
   /@types/connect/3.4.35:
     dependencies:
-      '@types/node': 12.20.20
+      '@types/node': 12.20.21
     dev: false
     resolution:
       integrity: sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==
@@ -1514,7 +1514,7 @@ packages:
       integrity: sha512-C6N5s2ZFtuZRj54k2/zyRhNDjJwwcViAM3Nbm8zjBpbqAdZ00mr0CFxvSKeO8Y/e03WVFLpQMdHYVfUd6SB+Hw==
   /@types/express-serve-static-core/4.17.24:
     dependencies:
-      '@types/node': 12.20.20
+      '@types/node': 12.20.21
       '@types/qs': 6.9.7
       '@types/range-parser': 1.2.4
     dev: false
@@ -1531,20 +1531,20 @@ packages:
       integrity: sha512-6bSZTPaTIACxn48l50SR+axgrqm6qXFIxrdAKaG6PaJk3+zuUr35hBlgT7vOmJcum+OEaIBLtHV/qloEAFITeA==
   /@types/fs-extra/8.1.2:
     dependencies:
-      '@types/node': 12.20.20
+      '@types/node': 12.20.21
     dev: false
     resolution:
       integrity: sha512-SvSrYXfWSc7R4eqnOzbQF4TZmfpNSM9FrSWLU3EUnWBuyZqNBOrv1B1JA3byUDPUl9z4Ab3jeZG2eDdySlgNMg==
   /@types/glob/7.1.4:
     dependencies:
       '@types/minimatch': 3.0.5
-      '@types/node': 12.20.20
+      '@types/node': 12.20.21
     dev: false
     resolution:
       integrity: sha512-w+LsMxKyYQm347Otw+IfBXOv9UWVjpHpCDdbBMt8Kz/xbvCYNjP+0qPh91Km3iKfSRLBB0P7fAMf0KHrPu+MyA==
   /@types/is-buffer/2.0.0:
     dependencies:
-      '@types/node': 12.20.20
+      '@types/node': 12.20.21
     dev: false
     resolution:
       integrity: sha512-0f7N/e3BAz32qDYvgB4d2cqv1DqUwvGxHkXsrucICn8la1Vb6Yl6Eg8mPScGwUiqHJeE7diXlzaK+QMA9m4Gxw==
@@ -1558,13 +1558,13 @@ packages:
       integrity: sha1-7ihweulOEdK4J7y+UnC86n8+ce4=
   /@types/jsonwebtoken/8.5.5:
     dependencies:
-      '@types/node': 12.20.20
+      '@types/node': 12.20.21
     dev: false
     resolution:
       integrity: sha512-OGqtHQ7N5/Ap/TUwO6IgHDuLiAoTmHhGpNvgkCm/F4N6pKzx/RBSfr2OXZSwC6vkfnsEdb6+7DNZVtiXiwdwFw==
   /@types/jws/3.2.4:
     dependencies:
-      '@types/node': 12.20.20
+      '@types/node': 12.20.21
     dev: false
     resolution:
       integrity: sha512-aqtH4dPw1wUjFZaeMD1ak/pf8iXlu/odFe+trJrvw0g1sTh93i+SCykg0Ek8C6B7rVK3oBORbfZAsKO7P10etg==
@@ -1578,7 +1578,7 @@ packages:
       integrity: sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w==
   /@types/md5/2.3.1:
     dependencies:
-      '@types/node': 12.20.20
+      '@types/node': 12.20.21
     dev: false
     resolution:
       integrity: sha512-OK3oe+ALIoPSo262lnhAYwpqFNXbiwH2a+0+Z5YBnkQEwWD8fk5+PIeRhYA48PzvX9I4SGNpWy+9bLj8qz92RQ==
@@ -1604,13 +1604,13 @@ packages:
       integrity: sha512-ZvO2tAcjmMi8V/5Z3JsyofMe3hasRcaw88cto5etSVMwVQfeivGAlEYmaQgceUSVYFofVjT+ioHsATjdWcFt1w==
   /@types/mock-fs/4.10.0:
     dependencies:
-      '@types/node': 12.20.20
+      '@types/node': 12.20.21
     dev: false
     resolution:
       integrity: sha512-FQ5alSzmHMmliqcL36JqIA4Yyn9jyJKvRSGV3mvPh108VFatX7naJDzSG4fnFQNZFq9dIx0Dzoe6ddflMB2Xkg==
   /@types/mock-require/2.0.0:
     dependencies:
-      '@types/node': 12.20.20
+      '@types/node': 12.20.21
     dev: false
     resolution:
       integrity: sha512-nOgjoE5bBiDeiA+z41i95makyHUSMWQMOPocP+J67Pqx/68HAXaeWN1NFtrAYYV6LrISIZZ8vKHm/a50k0f6Sg==
@@ -1624,7 +1624,7 @@ packages:
       integrity: sha512-DPxmjiDwubsNmguG5X4fEJ+XCyzWM3GXWsqQlvUcjJKa91IOoJUy51meDr0GkzK64qqNcq85ymLlyjoct9tInw==
   /@types/node-fetch/2.5.12:
     dependencies:
-      '@types/node': 12.20.20
+      '@types/node': 12.20.21
       form-data: 3.0.1
     dev: false
     resolution:
@@ -1633,10 +1633,10 @@ packages:
     dev: false
     resolution:
       integrity: sha512-pMCcqU2zT4TjqYFrWtYHKal7Sl30Ims6ulZ4UFXxI4xbtQqK/qqKwkDoBFCfooRqqmRu9vY3xaJRwxSh673aYg==
-  /@types/node/12.20.20:
+  /@types/node/12.20.21:
     dev: false
     resolution:
-      integrity: sha512-kqmxiJg4AT7rsSPIhO6eoBIx9mNwwpeH42yjtgQh6X2ANSpLpvToMXv+LMFdfxpwG1FZXZ41OGZMiUAtbBLEvg==
+      integrity: sha512-Qk7rOvV2A4vNgXNS88vEvbJE1NDFPCQ8AU+pNElrU2bA4yrRDef3fg3SUe+xkwyin3Bpg/Xh5JkNWTlsOcS2tA==
   /@types/node/8.10.66:
     dev: false
     resolution:
@@ -1663,7 +1663,7 @@ packages:
       integrity: sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==
   /@types/resolve/1.17.1:
     dependencies:
-      '@types/node': 12.20.20
+      '@types/node': 12.20.21
     dev: false
     resolution:
       integrity: sha512-yy7HuzQhj0dhGpD8RLXSZWEkLsV9ibvxvi6EiJ3bkqLAO1RGo0WbkWQiwpRlSFymTJRz0d3k5LM3kkx8ArDbLw==
@@ -1674,7 +1674,7 @@ packages:
   /@types/serve-static/1.13.10:
     dependencies:
       '@types/mime': 1.3.2
-      '@types/node': 12.20.20
+      '@types/node': 12.20.21
     dev: false
     resolution:
       integrity: sha512-nCkHGI4w7ZgAdNkrEu0bv+4xNV/XDqW+DydknebMOQwkpDGx8G+HTlj7R7ABI8i8nKxVw0wtKPi1D+lPOkh4YQ==
@@ -1690,7 +1690,7 @@ packages:
       integrity: sha512-E1dU4fzC9wN2QK2Cr1MLCfyHM8BoNnRFvuf45LYMPNDA+WqbNzC45S4UzPxvp1fFJ1rvSGU0bPvdd35VLmXG8g==
   /@types/stoppable/1.1.1:
     dependencies:
-      '@types/node': 12.20.20
+      '@types/node': 12.20.21
     dev: false
     resolution:
       integrity: sha512-b8N+fCADRIYYrGZOcmOR8ZNBOqhktWTB/bMUl5LvGtT201QKJZOOH5UsFyI3qtteM6ZAJbJqZoBcLqqxKIwjhw==
@@ -1700,7 +1700,7 @@ packages:
       integrity: sha512-Y0K95ThC3esLEYD6ZuqNek29lNX2EM1qxV8y2FTLUB0ff5wWrk7az+mLrnNFUnaXcgKye22+sFBRXOgpPILZNg==
   /@types/tunnel/0.0.1:
     dependencies:
-      '@types/node': 12.20.20
+      '@types/node': 12.20.21
     dev: false
     resolution:
       integrity: sha512-AOqu6bQu5MSWwYvehMXLukFHnupHrpZ8nvgae5Ggie9UwzDR1CCwoXgSSWNZJuyOlCdfdsWMA5F2LlmvyoTv8A==
@@ -1714,19 +1714,19 @@ packages:
       integrity: sha512-Y2mHTRAbqfFkpjldbkHGY8JIzRN6XqYRliG8/24FcHm2D2PwW24fl5xMRTVGdrb7iMrwCaIEbLWerGIkXuFWVg==
   /@types/ws/7.4.7:
     dependencies:
-      '@types/node': 12.20.20
+      '@types/node': 12.20.21
     dev: false
     resolution:
       integrity: sha512-JQbbmxZTZehdc2iszGKs5oC3NFnjeay7mtAWrdt7qNtAVK0g19muApzAy4bm9byz79xa2ZnO/BOBC2R8RC5Lww==
   /@types/xml2js/0.4.9:
     dependencies:
-      '@types/node': 12.20.20
+      '@types/node': 12.20.21
     dev: false
     resolution:
       integrity: sha512-CHiCKIihl1pychwR2RNX5mAYmJDACgFVCMT5OArMaO3erzwXVcBqPcusr+Vl8yeeXukxZqtF8mZioqX+mpjjdw==
   /@types/yauzl/2.9.2:
     dependencies:
-      '@types/node': 12.20.20
+      '@types/node': 12.20.21
     dev: false
     optional: true
     resolution:
@@ -2338,9 +2338,9 @@ packages:
       integrity: sha1-rrGvKN5sDXpqLOQK22j/GEIq8x8=
   /browserslist/4.16.8:
     dependencies:
-      caniuse-lite: 1.0.30001251
+      caniuse-lite: 1.0.30001252
       colorette: 1.3.0
-      electron-to-chromium: 1.3.817
+      electron-to-chromium: 1.3.819
       escalade: 3.1.1
       node-releases: 1.1.75
     dev: false
@@ -2416,10 +2416,10 @@ packages:
       node: '>=6'
     resolution:
       integrity: sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
-  /caniuse-lite/1.0.30001251:
+  /caniuse-lite/1.0.30001252:
     dev: false
     resolution:
-      integrity: sha512-HOe1r+9VkU4TFmnU70z+r7OLmtR+/chB1rdcJUeQlAinjEeb0cKL20tlAtOagNZhbrtLnCvV19B4FmF1rgzl6A==
+      integrity: sha512-I56jhWDGMtdILQORdusxBOH+Nl/KgQSdDmpJezYddnAkVOmnoU8zwjTV9xAjMIYxr0iPreEAVylCGcmHCjfaOw==
   /caseless/0.12.0:
     dev: false
     resolution:
@@ -3085,10 +3085,10 @@ packages:
     dev: false
     resolution:
       integrity: sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=
-  /electron-to-chromium/1.3.817:
+  /electron-to-chromium/1.3.819:
     dev: false
     resolution:
-      integrity: sha512-Vw0Faepf2Id9Kf2e97M/c99qf168xg86JLKDxivvlpBQ9KDtjSeX0v+TiuSE25PqeQfTz+NJs375b64ca3XOIQ==
+      integrity: sha512-vH3jJLd+tMwrQcYlZJUSjUMlq2JacHuIKl4rT0ZEAdY1Lxk95dBg+rc69ahIPGdKPPWgaN4wjt2f0BopFF3wjQ==
   /emoji-regex/7.0.3:
     dev: false
     resolution:
@@ -3568,7 +3568,7 @@ packages:
       integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==
   /extract-zip/2.0.1:
     dependencies:
-      debug: 4.3.2
+      debug: 4.3.1
       get-stream: 5.2.0
       yauzl: 2.10.0
     dev: false
@@ -6830,7 +6830,7 @@ packages:
   /rollup/1.32.1:
     dependencies:
       '@types/estree': 0.0.50
-      '@types/node': 12.20.20
+      '@types/node': 12.20.21
       acorn: 7.4.1
     dev: false
     hasBin: true
@@ -7123,7 +7123,7 @@ packages:
     dependencies:
       '@types/cookie': 0.4.1
       '@types/cors': 2.8.12
-      '@types/node': 12.20.20
+      '@types/node': 12.20.21
       accepts: 1.3.7
       base64id: 2.0.0
       debug: 4.3.2
@@ -8230,7 +8230,7 @@ packages:
       '@microsoft/api-extractor': 7.7.11
       '@types/chai': 4.2.21
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.20
+      '@types/node': 12.20.21
       chai: 4.3.4
       cross-env: 7.0.3
       delay: 4.4.1
@@ -8271,7 +8271,7 @@ packages:
       '@microsoft/api-extractor': 7.13.2
       '@types/chai': 4.2.21
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.20
+      '@types/node': 12.20.21
       chai: 4.3.4
       cross-env: 7.0.3
       dotenv: 8.6.0
@@ -8318,7 +8318,7 @@ packages:
       '@rollup/plugin-replace': 2.4.2_rollup@1.32.1
       '@types/chai': 4.2.21
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.20
+      '@types/node': 12.20.21
       chai: 4.3.4
       cross-env: 7.0.3
       csv-parse: 4.16.0
@@ -8363,7 +8363,7 @@ packages:
       '@microsoft/api-extractor': 7.13.2
       '@types/chai': 4.2.21
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.20
+      '@types/node': 12.20.21
       chai: 4.3.4
       cross-env: 7.0.3
       dotenv: 8.6.0
@@ -8404,7 +8404,7 @@ packages:
       '@microsoft/api-extractor': 7.7.11
       '@types/chai': 4.2.21
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.20
+      '@types/node': 12.20.21
       '@types/sinon': 9.0.11
       chai: 4.3.4
       chai-as-promised: 7.1.1_chai@4.3.4
@@ -8448,7 +8448,7 @@ packages:
       '@microsoft/api-extractor': 7.7.11
       '@types/chai': 4.2.21
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.20
+      '@types/node': 12.20.21
       '@types/sinon': 9.0.11
       chai: 4.3.4
       chai-as-promised: 7.1.1_chai@4.3.4
@@ -8493,7 +8493,7 @@ packages:
       '@types/chai': 4.2.21
       '@types/chai-as-promised': 7.1.4
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.20
+      '@types/node': 12.20.21
       '@types/sinon': 9.0.11
       chai: 4.3.4
       chai-as-promised: 7.1.1_chai@4.3.4
@@ -8544,7 +8544,7 @@ packages:
       '@rollup/plugin-replace': 2.4.2_rollup@1.32.1
       '@types/chai': 4.2.21
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.20
+      '@types/node': 12.20.21
       '@types/sinon': 9.0.11
       assert: 1.5.0
       chai: 4.3.4
@@ -8892,7 +8892,7 @@ packages:
       '@types/chai': 4.2.21
       '@types/chai-as-promised': 7.1.4
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.20
+      '@types/node': 12.20.21
       buffer: 5.7.1
       chai: 4.3.4
       chai-as-promised: 7.1.1_chai@4.3.4
@@ -8949,7 +8949,7 @@ packages:
       '@rollup/plugin-replace': 2.4.2_rollup@1.32.1
       '@types/chai': 4.2.21
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.20
+      '@types/node': 12.20.21
       '@types/sinon': 9.0.11
       '@types/uuid': 8.3.1
       assert: 1.5.0
@@ -9007,7 +9007,7 @@ packages:
       '@types/chai-as-promised': 7.1.4
       '@types/jwt-decode': 2.2.1
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.20
+      '@types/node': 12.20.21
       '@types/sinon': 9.0.11
       assert: 1.5.0
       chai: 4.3.4
@@ -9059,7 +9059,7 @@ packages:
       '@rollup/plugin-replace': 2.4.2_rollup@1.32.1
       '@types/chai': 4.2.21
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.20
+      '@types/node': 12.20.21
       '@types/sinon': 9.0.11
       assert: 1.5.0
       chai: 4.3.4
@@ -9113,7 +9113,7 @@ packages:
       '@rollup/plugin-replace': 2.4.2_rollup@1.32.1
       '@types/chai': 4.2.21
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.20
+      '@types/node': 12.20.21
       '@types/sinon': 9.0.11
       assert: 1.5.0
       chai: 4.3.4
@@ -9166,7 +9166,7 @@ packages:
       '@rollup/plugin-replace': 2.4.2_rollup@1.32.1
       '@types/chai': 4.2.21
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.20
+      '@types/node': 12.20.21
       '@types/sinon': 9.0.11
       assert: 1.5.0
       chai: 4.3.4
@@ -9219,7 +9219,7 @@ packages:
       '@rollup/plugin-replace': 2.4.2_rollup@1.32.1
       '@types/chai': 4.2.21
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.20
+      '@types/node': 12.20.21
       '@types/sinon': 9.0.11
       assert: 1.5.0
       chai: 4.3.4
@@ -9267,7 +9267,7 @@ packages:
       '@microsoft/api-extractor': 7.13.2
       '@types/chai': 4.2.21
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.20
+      '@types/node': 12.20.21
       chai: 4.3.4
       cross-env: 7.0.3
       dotenv: 8.6.0
@@ -9309,7 +9309,7 @@ packages:
       '@types/chai': 4.2.21
       '@types/chai-as-promised': 7.1.4
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.20
+      '@types/node': 12.20.21
       chai: 4.3.4
       chai-as-promised: 7.1.1_chai@4.3.4
       cross-env: 7.0.3
@@ -9357,7 +9357,7 @@ packages:
       '@types/chai': 4.2.21
       '@types/debug': 4.1.7
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.20
+      '@types/node': 12.20.21
       '@types/sinon': 9.0.11
       '@types/ws': 7.4.7
       buffer: 5.7.1
@@ -9401,7 +9401,7 @@ packages:
     version: 0.0.0
   file:projects/core-asynciterator-polyfill.tgz:
     dependencies:
-      '@types/node': 12.20.20
+      '@types/node': 12.20.21
       eslint: 7.32.0
       prettier: 1.19.1
       typedoc: 0.15.2
@@ -9417,7 +9417,7 @@ packages:
       '@microsoft/api-extractor': 7.7.11
       '@types/chai': 4.2.21
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.20
+      '@types/node': 12.20.21
       chai: 4.3.4
       cross-env: 7.0.3
       downlevel-dts: 0.4.0
@@ -9444,7 +9444,7 @@ packages:
       '@microsoft/api-extractor': 7.7.11
       '@types/chai': 4.2.21
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.20
+      '@types/node': 12.20.21
       '@types/sinon': 9.0.11
       chai: 4.3.4
       cross-env: 7.0.3
@@ -9484,7 +9484,7 @@ packages:
       '@microsoft/api-extractor': 7.13.2
       '@types/chai': 4.2.21
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.20
+      '@types/node': 12.20.21
       chai: 4.3.4
       cross-env: 7.0.3
       eslint: 7.32.0
@@ -9522,7 +9522,7 @@ packages:
       '@microsoft/api-extractor': 7.13.2
       '@types/chai': 4.2.21
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.20
+      '@types/node': 12.20.21
       chai: 4.3.4
       cross-env: 7.0.3
       eslint: 7.32.0
@@ -9559,7 +9559,7 @@ packages:
       '@microsoft/api-extractor': 7.13.2
       '@types/chai': 4.2.21
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.20
+      '@types/node': 12.20.21
       chai: 4.3.4
       cross-env: 7.0.3
       eslint: 7.32.0
@@ -9599,7 +9599,7 @@ packages:
       '@rollup/plugin-replace': 2.4.2_rollup@1.32.1
       '@types/chai': 4.2.21
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.20
+      '@types/node': 12.20.21
       '@types/sinon': 9.0.11
       chai: 4.3.4
       cross-env: 7.0.3
@@ -9642,7 +9642,7 @@ packages:
       '@types/express': 4.17.13
       '@types/glob': 7.1.4
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.20
+      '@types/node': 12.20.21
       '@types/node-fetch': 2.5.12
       '@types/sinon': 9.0.11
       '@types/tough-cookie': 4.0.1
@@ -9701,7 +9701,7 @@ packages:
       '@microsoft/api-extractor': 7.7.11
       '@types/chai': 4.2.21
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.20
+      '@types/node': 12.20.21
       chai: 4.3.4
       cross-env: 7.0.3
       eslint: 7.32.0
@@ -9739,7 +9739,7 @@ packages:
       '@microsoft/api-extractor': 7.7.11
       '@types/chai': 4.2.21
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.20
+      '@types/node': 12.20.21
       chai: 4.3.4
       downlevel-dts: 0.4.0
       eslint: 7.32.0
@@ -9775,7 +9775,7 @@ packages:
       '@opentelemetry/api': 1.0.2
       '@types/chai': 4.2.21
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.20
+      '@types/node': 12.20.21
       '@types/sinon': 9.0.11
       '@types/uuid': 8.3.1
       chai: 4.3.4
@@ -9822,7 +9822,7 @@ packages:
       '@opentelemetry/tracing': 0.22.0_@opentelemetry+api@1.0.2
       '@types/chai': 4.2.21
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.20
+      '@types/node': 12.20.21
       '@types/sinon': 9.0.11
       chai: 4.3.4
       cross-env: 7.0.3
@@ -9860,7 +9860,7 @@ packages:
       '@microsoft/api-extractor': 7.7.11
       '@types/chai': 4.2.21
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.20
+      '@types/node': 12.20.21
       '@types/sinon': 9.0.11
       chai: 4.3.4
       cross-env: 7.0.3
@@ -9899,7 +9899,7 @@ packages:
       '@microsoft/api-extractor': 7.7.11
       '@types/chai': 4.2.21
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.20
+      '@types/node': 12.20.21
       '@types/sinon': 9.0.11
       '@types/xml2js': 0.4.9
       chai: 4.3.4
@@ -9943,7 +9943,7 @@ packages:
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
       '@types/debug': 4.1.7
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.20
+      '@types/node': 12.20.21
       '@types/priorityqueuejs': 1.0.1
       '@types/semaphore': 1.1.1
       '@types/sinon': 9.0.11
@@ -9997,7 +9997,7 @@ packages:
       '@rollup/plugin-replace': 2.4.2_rollup@1.32.1
       '@types/chai': 4.2.21
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.20
+      '@types/node': 12.20.21
       '@types/sinon': 9.0.11
       '@types/uuid': 8.3.1
       chai: 4.3.4
@@ -10051,7 +10051,7 @@ packages:
       '@types/fs-extra': 8.1.2
       '@types/minimist': 1.2.2
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.20
+      '@types/node': 12.20.21
       '@types/prettier': 2.0.2
       builtin-modules: 3.2.0
       chai: 4.3.4
@@ -10089,7 +10089,7 @@ packages:
       '@rollup/plugin-replace': 2.4.2_rollup@1.32.1
       '@types/chai': 4.2.21
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.20
+      '@types/node': 12.20.21
       '@types/sinon': 9.0.11
       '@types/uuid': 8.3.1
       chai: 4.3.4
@@ -10140,7 +10140,7 @@ packages:
       '@types/glob': 7.1.4
       '@types/json-schema': 7.0.9
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.20
+      '@types/node': 12.20.21
       '@typescript-eslint/eslint-plugin': 4.19.0_359354e87b989469ccdce12bde18eddc
       '@typescript-eslint/experimental-utils': 4.19.0_eslint@7.32.0+typescript@4.2.4
       '@typescript-eslint/parser': 4.19.0_eslint@7.32.0+typescript@4.2.4
@@ -10185,7 +10185,7 @@ packages:
       '@types/debug': 4.1.7
       '@types/long': 4.0.1
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.20
+      '@types/node': 12.20.21
       '@types/sinon': 9.0.11
       '@types/uuid': 8.3.1
       '@types/ws': 7.4.7
@@ -10257,7 +10257,7 @@ packages:
       '@types/chai-string': 1.4.2
       '@types/debug': 4.1.7
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.20
+      '@types/node': 12.20.21
       '@types/uuid': 8.3.1
       '@types/ws': 7.4.7
       async-lock: 1.3.0
@@ -10303,7 +10303,7 @@ packages:
       '@types/chai': 4.2.21
       '@types/chai-as-promised': 7.1.4
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.20
+      '@types/node': 12.20.21
       '@types/sinon': 9.0.11
       '@types/uuid': 8.3.1
       chai: 4.3.4
@@ -10362,7 +10362,7 @@ packages:
       '@types/chai-string': 1.4.2
       '@types/debug': 4.1.7
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.20
+      '@types/node': 12.20.21
       assert: 1.5.0
       chai: 4.3.4
       chai-as-promised: 7.1.1_chai@4.3.4
@@ -10421,7 +10421,7 @@ packages:
       '@types/chai-string': 1.4.2
       '@types/debug': 4.1.7
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.20
+      '@types/node': 12.20.21
       assert: 1.5.0
       chai: 4.3.4
       chai-as-promised: 7.1.1_chai@4.3.4
@@ -10472,7 +10472,7 @@ packages:
       '@microsoft/api-extractor': 7.7.11
       '@types/jws': 3.2.4
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.20
+      '@types/node': 12.20.21
       '@types/qs': 6.9.7
       '@types/sinon': 9.0.11
       assert: 1.5.0
@@ -10504,7 +10504,7 @@ packages:
       '@microsoft/api-extractor': 7.7.11
       '@types/jws': 3.2.4
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.20
+      '@types/node': 12.20.21
       '@types/qs': 6.9.7
       '@types/sinon': 9.0.11
       '@types/uuid': 8.3.1
@@ -10542,7 +10542,7 @@ packages:
       '@types/chai': 4.2.21
       '@types/jws': 3.2.4
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.20
+      '@types/node': 12.20.21
       '@types/qs': 6.9.7
       '@types/sinon': 9.0.11
       '@types/stoppable': 1.1.1
@@ -10588,7 +10588,7 @@ packages:
     dependencies:
       '@azure/core-tracing': 1.0.0-preview.13
       '@microsoft/api-extractor': 7.7.11
-      '@types/node': 12.20.20
+      '@types/node': 12.20.21
       '@types/uuid': 8.3.1
       cross-env: 7.0.3
       dotenv: 8.6.0
@@ -10620,7 +10620,7 @@ packages:
       '@rollup/plugin-replace': 2.4.2_rollup@1.32.1
       '@types/chai': 4.2.21
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.20
+      '@types/node': 12.20.21
       '@types/sinon': 9.0.11
       chai: 4.3.4
       cross-env: 7.0.3
@@ -10673,7 +10673,7 @@ packages:
       '@types/chai': 4.2.21
       '@types/chai-as-promised': 7.1.4
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.20
+      '@types/node': 12.20.21
       '@types/sinon': 9.0.11
       '@types/uuid': 8.3.1
       assert: 1.5.0
@@ -10716,7 +10716,7 @@ packages:
       '@rollup/plugin-replace': 2.4.2_rollup@1.32.1
       '@types/chai': 4.2.21
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.20
+      '@types/node': 12.20.21
       '@types/query-string': 6.2.0
       '@types/sinon': 9.0.11
       assert: 1.5.0
@@ -10788,7 +10788,7 @@ packages:
       '@types/chai': 4.2.21
       '@types/chai-as-promised': 7.1.4
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.20
+      '@types/node': 12.20.21
       '@types/query-string': 6.2.0
       '@types/sinon': 9.0.11
       assert: 1.5.0
@@ -10847,7 +10847,7 @@ packages:
       '@rollup/plugin-replace': 2.4.2_rollup@1.32.1
       '@types/chai': 4.2.21
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.20
+      '@types/node': 12.20.21
       '@types/query-string': 6.2.0
       '@types/sinon': 9.0.11
       assert: 1.5.0
@@ -10898,7 +10898,7 @@ packages:
       '@microsoft/api-extractor': 7.7.11
       '@types/chai': 4.2.21
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.20
+      '@types/node': 12.20.21
       '@types/sinon': 9.0.11
       chai: 4.3.4
       cross-env: 7.0.3
@@ -10941,7 +10941,7 @@ packages:
       '@types/chai': 4.2.21
       '@types/chai-as-promised': 7.1.4
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.20
+      '@types/node': 12.20.21
       chai: 4.3.4
       chai-as-promised: 7.1.1_chai@4.3.4
       cross-env: 7.0.3
@@ -10985,7 +10985,7 @@ packages:
       '@types/chai': 4.2.21
       '@types/chai-as-promised': 7.1.4
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.20
+      '@types/node': 12.20.21
       '@types/uuid': 8.3.1
       chai: 4.3.4
       chai-as-promised: 7.1.1_chai@4.3.4
@@ -11024,7 +11024,7 @@ packages:
     version: 0.0.0
   file:projects/mock-hub.tgz:
     dependencies:
-      '@types/node': 12.20.20
+      '@types/node': 12.20.21
       dotenv: 8.6.0
       eslint: 7.32.0
       prettier: 1.19.1
@@ -11050,7 +11050,7 @@ packages:
       '@opentelemetry/semantic-conventions': 0.22.0
       '@opentelemetry/tracing': 0.22.0_@opentelemetry+api@1.0.2
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.20
+      '@types/node': 12.20.21
       dotenv: 8.6.0
       eslint: 7.32.0
       eslint-plugin-node: 11.1.0_eslint@7.32.0
@@ -11083,7 +11083,7 @@ packages:
       '@types/chai': 4.2.21
       '@types/chai-as-promised': 7.1.4
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.20
+      '@types/node': 12.20.21
       chai: 4.3.4
       chai-as-promised: 7.1.1_chai@4.3.4
       cross-env: 7.0.3
@@ -11125,7 +11125,7 @@ packages:
     dependencies:
       '@azure/ai-form-recognizer': 3.1.0-beta.3
       '@azure/identity': 2.0.0-beta.5
-      '@types/node': 12.20.20
+      '@types/node': 12.20.21
       dotenv: 8.6.0
       eslint: 7.32.0
       prettier: 1.19.1
@@ -11142,7 +11142,7 @@ packages:
   file:projects/perf-ai-metrics-advisor.tgz:
     dependencies:
       '@azure/ai-metrics-advisor': 1.0.0-beta.3
-      '@types/node': 12.20.20
+      '@types/node': 12.20.21
       dotenv: 8.6.0
       eslint: 7.32.0
       prettier: 1.19.1
@@ -11159,7 +11159,7 @@ packages:
   file:projects/perf-ai-text-analytics.tgz:
     dependencies:
       '@azure/ai-text-analytics': 5.1.0
-      '@types/node': 12.20.20
+      '@types/node': 12.20.21
       dotenv: 8.6.0
       eslint: 7.32.0
       prettier: 1.19.1
@@ -11175,7 +11175,7 @@ packages:
     version: 0.0.0
   file:projects/perf-app-configuration.tgz:
     dependencies:
-      '@types/node': 12.20.20
+      '@types/node': 12.20.21
       '@types/uuid': 8.3.1
       dotenv: 8.6.0
       eslint: 7.32.0
@@ -11209,7 +11209,7 @@ packages:
     version: 0.0.0
   file:projects/perf-data-tables.tgz:
     dependencies:
-      '@types/node': 12.20.20
+      '@types/node': 12.20.21
       '@types/uuid': 8.3.1
       dotenv: 8.6.0
       eslint: 7.32.0
@@ -11227,7 +11227,7 @@ packages:
     version: 0.0.0
   file:projects/perf-eventgrid.tgz:
     dependencies:
-      '@types/node': 12.20.20
+      '@types/node': 12.20.21
       dotenv: 8.6.0
       eslint: 7.32.0
       prettier: 1.19.1
@@ -11314,7 +11314,7 @@ packages:
   file:projects/perf-search-documents.tgz:
     dependencies:
       '@azure/identity': 2.0.0-beta.5
-      '@types/node': 12.20.20
+      '@types/node': 12.20.21
       dotenv: 8.6.0
       eslint: 7.32.0
       prettier: 1.19.1
@@ -11330,7 +11330,7 @@ packages:
     version: 0.0.0
   file:projects/perf-storage-blob.tgz:
     dependencies:
-      '@types/node': 12.20.20
+      '@types/node': 12.20.21
       '@types/node-fetch': 2.5.12
       '@types/uuid': 8.3.1
       dotenv: 8.6.0
@@ -11350,7 +11350,7 @@ packages:
     version: 0.0.0
   file:projects/perf-storage-file-datalake.tgz:
     dependencies:
-      '@types/node': 12.20.20
+      '@types/node': 12.20.21
       '@types/uuid': 8.3.1
       dotenv: 8.6.0
       eslint: 7.32.0
@@ -11368,7 +11368,7 @@ packages:
     version: 0.0.0
   file:projects/perf-storage-file-share.tgz:
     dependencies:
-      '@types/node': 12.20.20
+      '@types/node': 12.20.21
       '@types/uuid': 8.3.1
       dotenv: 8.6.0
       eslint: 7.32.0
@@ -11392,7 +11392,7 @@ packages:
       '@microsoft/api-extractor': 7.13.2
       '@types/chai': 4.2.21
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.20
+      '@types/node': 12.20.21
       chai: 4.3.4
       cross-env: 7.0.3
       dotenv: 8.6.0
@@ -11435,7 +11435,7 @@ packages:
       '@microsoft/api-extractor': 7.13.2
       '@types/chai': 4.2.21
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.20
+      '@types/node': 12.20.21
       chai: 4.3.4
       cross-env: 7.0.3
       dotenv: 8.6.0
@@ -11478,7 +11478,7 @@ packages:
       '@microsoft/api-extractor': 7.13.2
       '@types/chai': 4.2.21
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.20
+      '@types/node': 12.20.21
       chai: 4.3.4
       cross-env: 7.0.3
       dotenv: 8.6.0
@@ -11526,7 +11526,7 @@ packages:
       '@rollup/plugin-replace': 2.4.2_rollup@1.32.1
       '@types/chai': 4.2.21
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.20
+      '@types/node': 12.20.21
       '@types/sinon': 9.0.11
       chai: 4.3.4
       cross-env: 7.0.3
@@ -11581,7 +11581,7 @@ packages:
       '@types/chai': 4.2.21
       '@types/chai-as-promised': 7.1.4
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.20
+      '@types/node': 12.20.21
       avsc: 5.7.3
       buffer: 5.7.1
       chai: 4.3.4
@@ -11630,7 +11630,7 @@ packages:
       '@types/chai': 4.2.21
       '@types/chai-as-promised': 7.1.4
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.20
+      '@types/node': 12.20.21
       chai: 4.3.4
       chai-as-promised: 7.1.1_chai@4.3.4
       cross-env: 7.0.3
@@ -11676,7 +11676,7 @@ packages:
       '@rollup/plugin-replace': 2.4.2_rollup@1.32.1
       '@types/chai': 4.2.21
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.20
+      '@types/node': 12.20.21
       '@types/sinon': 9.0.11
       chai: 4.3.4
       cross-env: 7.0.3
@@ -11736,7 +11736,7 @@ packages:
       '@types/is-buffer': 2.0.0
       '@types/long': 4.0.1
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.20
+      '@types/node': 12.20.21
       '@types/sinon': 9.0.11
       '@types/ws': 7.4.7
       assert: 1.5.0
@@ -11803,7 +11803,7 @@ packages:
       '@rollup/plugin-node-resolve': 8.4.0_rollup@1.32.1
       '@rollup/plugin-replace': 2.4.2_rollup@1.32.1
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.20
+      '@types/node': 12.20.21
       '@types/sinon': 9.0.11
       assert: 1.5.0
       cross-env: 7.0.3
@@ -11861,7 +11861,7 @@ packages:
       '@rollup/plugin-node-resolve': 8.4.0_rollup@1.32.1
       '@rollup/plugin-replace': 2.4.2_rollup@1.32.1
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.20
+      '@types/node': 12.20.21
       '@types/node-fetch': 2.5.12
       assert: 1.5.0
       cross-env: 7.0.3
@@ -11919,7 +11919,7 @@ packages:
       '@rollup/plugin-node-resolve': 8.4.0_rollup@1.32.1
       '@rollup/plugin-replace': 2.4.2_rollup@1.32.1
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.20
+      '@types/node': 12.20.21
       '@types/query-string': 6.2.0
       assert: 1.5.0
       cross-env: 7.0.3
@@ -11977,7 +11977,7 @@ packages:
       '@rollup/plugin-node-resolve': 8.4.0_rollup@1.32.1
       '@rollup/plugin-replace': 2.4.2_rollup@1.32.1
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.20
+      '@types/node': 12.20.21
       assert: 1.5.0
       cross-env: 7.0.3
       dotenv: 8.6.0
@@ -12031,7 +12031,7 @@ packages:
       '@rollup/plugin-node-resolve': 8.4.0_rollup@1.32.1
       '@rollup/plugin-replace': 2.4.2_rollup@1.32.1
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.20
+      '@types/node': 12.20.21
       assert: 1.5.0
       dotenv: 8.6.0
       downlevel-dts: 0.4.0
@@ -12083,7 +12083,7 @@ packages:
       '@rollup/plugin-node-resolve': 8.4.0_rollup@1.32.1
       '@rollup/plugin-replace': 2.4.2_rollup@1.32.1
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.20
+      '@types/node': 12.20.21
       assert: 1.5.0
       cross-env: 7.0.3
       dotenv: 8.6.0
@@ -12135,7 +12135,7 @@ packages:
       '@types/chai': 4.2.21
       '@types/chai-as-promised': 7.1.4
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.20
+      '@types/node': 12.20.21
       '@types/sinon': 9.0.11
       chai: 4.3.4
       chai-as-promised: 7.1.1_chai@4.3.4
@@ -12182,7 +12182,7 @@ packages:
       '@types/chai': 4.2.21
       '@types/chai-as-promised': 7.1.4
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.20
+      '@types/node': 12.20.21
       '@types/sinon': 9.0.11
       chai: 4.3.4
       chai-as-promised: 7.1.1_chai@4.3.4
@@ -12334,7 +12334,7 @@ packages:
       '@types/chai': 4.2.21
       '@types/chai-as-promised': 7.1.4
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.20
+      '@types/node': 12.20.21
       chai: 4.3.4
       chai-as-promised: 7.1.1_chai@4.3.4
       cross-env: 7.0.3
@@ -12386,7 +12386,7 @@ packages:
       '@types/mock-fs': 4.10.0
       '@types/mock-require': 2.0.0
       '@types/nise': 1.4.0
-      '@types/node': 12.20.20
+      '@types/node': 12.20.21
       chai: 4.3.4
       dotenv: 8.6.0
       eslint: 7.32.0
@@ -12432,7 +12432,7 @@ packages:
   file:projects/test-utils-perfstress.tgz:
     dependencies:
       '@types/minimist': 1.2.2
-      '@types/node': 12.20.20
+      '@types/node': 12.20.21
       '@types/node-fetch': 2.5.12
       eslint: 7.32.0
       karma: 6.3.4
@@ -12458,7 +12458,7 @@ packages:
       '@opentelemetry/api': 1.0.2
       '@types/chai': 4.2.21
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.20
+      '@types/node': 12.20.21
       '@types/sinon': 9.0.11
       chai: 4.3.4
       chai-as-promised: 7.1.1_chai@4.3.4
@@ -12487,7 +12487,7 @@ packages:
       '@types/chai': 4.2.21
       '@types/chai-as-promised': 7.1.4
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.20
+      '@types/node': 12.20.21
       azure-iothub: 1.14.3
       chai: 4.3.4
       chai-as-promised: 7.1.1_chai@4.3.4
@@ -12536,7 +12536,7 @@ packages:
       '@types/express-serve-static-core': 4.17.24
       '@types/jsonwebtoken': 8.5.5
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.20
+      '@types/node': 12.20.21
       '@types/query-string': 6.2.0
       '@types/sinon': 9.0.11
       assert: 1.5.0
@@ -12595,7 +12595,7 @@ packages:
       '@types/chai': 4.2.21
       '@types/jsonwebtoken': 8.5.5
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.20
+      '@types/node': 12.20.21
       '@types/query-string': 6.2.0
       '@types/sinon': 9.0.11
       chai: 4.3.4


### PR DESCRIPTION
I was trying to remove some of the unused dependencies in our packages and this invariably will change the lock file. Found that `@types/node` v12 had a patch update in the past 24 hours that caused much noise to my updates. So, creating this PR with just `rush update --full` so that my future PRs can have less noise

Please note that the automated weekly PR that does this was already run yesterday and merged