### PR TITLE
[Identity] Added suport for AZURE_MANAGED_IDENTITY_CLIENT_ID

### DIFF
--- a/sdk/identity/identity/CHANGELOG.md
+++ b/sdk/identity/identity/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Features Added
 
+- The `ManagedIdentityCredential` now suppports specifying the Client ID through the `AZURE_MANAGED_IDENTITY_CLIENT_ID` environment variable.
+
 ### Breaking Changes
 
 ### Bugs Fixed

--- a/sdk/identity/identity/src/credentials/managedIdentityCredential/index.ts
+++ b/sdk/identity/identity/src/credentials/managedIdentityCredential/index.ts
@@ -35,12 +35,16 @@ export class ManagedIdentityCredential implements TokenCredential {
    * Creates an instance of ManagedIdentityCredential with the client ID of a
    * user-assigned identity, or app registration (when working with AKS pod-identity).
    *
+   * If the `clientId` is not specified, the `AZURE_MANAGED_IDENTITY_CLIENT_ID` environment variable will be used.
+   *
    * @param clientId - The client ID of the user-assigned identity, or app registration (when working with AKS pod-identity).
    * @param options - Options for configuring the client which makes the access token request.
    */
   constructor(clientId: string, options?: TokenCredentialOptions);
   /**
-   * Creates an instance of ManagedIdentityCredential
+   * Creates an instance of ManagedIdentityCredential.
+   *
+   * If the `clientId` is not specified, the `AZURE_MANAGED_IDENTITY_CLIENT_ID` environment variable will be used.
    *
    * @param options - Options for configuring the client which makes the access token request.
    */
@@ -58,6 +62,9 @@ export class ManagedIdentityCredential implements TokenCredential {
       this.clientId = clientIdOrOptions;
       this.identityClient = new IdentityClient(options);
     } else {
+      if (process.env.AZURE_MANAGED_IDENTITY_CLIENT_ID) {
+        this.clientId = process.env.AZURE_MANAGED_IDENTITY_CLIENT_ID;
+      }
       // options only constructor
       this.identityClient = new IdentityClient(clientIdOrOptions);
     }


### PR DESCRIPTION
This PR makes it so the ManagedIdentityCredential can receive the Client ID from the environment variables.

This design has not been approved yet.

Fixes #8436