### PR TITLE
[Recorder] Releasing recorder to public - not setting private anymore

### DIFF
--- a/sdk/test-utils/recorder/package.json
+++ b/sdk/test-utils/recorder/package.json
@@ -61,7 +61,6 @@
   },
   "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/test-utils/recorder/",
   "sideEffects": false,
-  "private": true,
   "dependencies": {
     "@azure/core-http": "^2.0.0",
     "@azure/core-tracing": "1.0.0-preview.13",


### PR DESCRIPTION
As the title says..

This is required for publishing the package.