### PR TITLE
[core] - Ignore spanOptions in core-tracing tests

### DIFF
--- a/sdk/core/core-tracing/test/interfaces.spec.ts
+++ b/sdk/core/core-tracing/test/interfaces.spec.ts
@@ -52,13 +52,13 @@ describe("interface compatibility", () => {
 
     const t: Required<Omit<
       coreAuthTracingOptions,
-      keyof Required<coreTracing.OperationTracingOptions>
+      keyof Required<coreTracing.OperationTracingOptions> | "spanOptions"
     >> = {};
     assert.ok(t, "core-tracing and core-auth should have the same properties");
 
     const t2: Required<Omit<
       coreTracing.OperationTracingOptions,
-      keyof Required<coreAuthTracingOptions>
+      keyof Required<coreAuthTracingOptions> | "spanOptions"
     >> = {};
     assert.ok(t2, "core-tracing and core-auth should have the same properties");
 


### PR DESCRIPTION
We have a few tests that ensure core-tracing remains compatible with core-auth's OperationTracingOptions.

Since `spanOptions` is now effectively deprecated we can safely ignore that as well, but we need to specifically ignore
it in our test because of the versioning mismatch in nightly builds.

Fixes the nightly build (see https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1067749)