### PR TITLE
Do not fail cleanup tags when a package is published for the first time

### DIFF
--- a/eng/scripts/cleanup-npm-next-tag.ps1
+++ b/eng/scripts/cleanup-npm-next-tag.ps1
@@ -31,8 +31,8 @@ $npmVersionInfo = GetNpmTagVersions -packageName $packageName
 if ($npmVersionInfo -eq $null)
 {
   # Version info object should not be null even if package is not present in npm
-  Write-Error "Failed to get version info from NPM registry."
-  exit 1
+  Write-Error "Failed to get version info from NPM registry. Package is probably published for the first time."
+  exit 0
 }
 $nextVersion = [AzureEngSemanticVersion]::ParseVersionString($npmVersionInfo.next)
 $latestVersion = [AzureEngSemanticVersion]::ParseVersionString($packageVersion) 


### PR DESCRIPTION
Cleanup tag script is failing when a new package is getting published for the first time. We should ignore npm errors in getting tags  and continue docs publishing step.