### PR TITLE
[core] - core-tracing compatibility matrix and README updates

### DIFF
--- a/sdk/core/core-tracing/README.md
+++ b/sdk/core/core-tracing/README.md
@@ -41,18 +41,7 @@ Some incompatibility between the two libraries is due to mismatches between the 
 | 1.0.0-preview.12 | ^2.1.4               | ^1.0.0        |
 | 1.0.0-preview.13 | ^2.1.4               | ^1.0.0        |
 
-#### Troubleshooting guide
-
-Errors such as `span.spanContext is not a function` or `span.context is not a function` are likely due to a mismatch of OpenTelemetry versions between two libraries.
-
-Please ensure that all Azure client libraries are using a compatible version of OpenTelemetry. If you are using `applicationinsights` please ensure that you are using the same version of OpenTelemetry as the Azure client libraries.
-
-> Ideally you'd want to use OpenTelemetry 1.0.0 or higher.
-
-If you are using `npm` you may run `npm ls @opentelemetry/api` to see the version of OpenTelemetry you are using and which client libraries are using it.
-For `yarn` users, `yarn why @opentelemetry/api` will show you the version of OpenTelemetry you are using and which client libraries are using it.
-
-You may then upgrade client libraries as needed to ensure compatibility. Things should work as expected when the above command returns a version of OpenTelemetry that is >= 1.0.0.
+Please see the [troubleshooting](#troubleshooting) section for additional information about handling compatibility errors.
 
 ## Examples
 
@@ -88,6 +77,19 @@ You can build and run the tests locally by executing `rushx test`. Explore the `
 ## Troubleshooting
 
 If you run into issues while using this library, please feel free to [file an issue](https://github.com/Azure/azure-sdk-for-js/issues/new).
+
+### OpenTelemetry Compatibility Errors
+
+Errors such as `span.spanContext is not a function` or `span.context is not a function` are likely due to a mismatch of OpenTelemetry versions between two libraries.
+
+To resolve this, please ensure that all Azure client libraries are using a compatible version of OpenTelemetry as per the [compatibility matrix](#compatibility-matrix). If you are using `applicationinsights` please ensure that you are using the same version of OpenTelemetry as the Azure client libraries.
+
+> Ideally you'd want to use OpenTelemetry 1.0.0 or higher.
+
+If you are using `npm` you may run `npm ls @opentelemetry/api` to see the version of OpenTelemetry you are using and which client libraries are using it.
+For `yarn` users, `yarn why @opentelemetry/api` will show you the version of OpenTelemetry you are using and which client libraries are using it.
+
+You may then upgrade client libraries as needed to ensure compatibility. Things should work as expected when the above command returns a version of OpenTelemetry that is >= 1.0.0.
 
 ## Contributing
 

--- a/sdk/core/core-tracing/README.md
+++ b/sdk/core/core-tracing/README.md
@@ -16,7 +16,7 @@ npm install @azure/core-tracing
 
 The `@azure/core-tracing` package supports enabling tracing for Azure SDK packages, using an [OpenTelemetry](https://opentelemetry.io/) `Tracer`.
 
-By default, all libraries log with a `NoOpTracer` that takes no action. To change this, you have to set a global tracer provider following the instructions in the [OpenTelemetry getting started guide](https://opentelemetry.io/docs/js/getting_started/nodejs).
+By default, all libraries log with a `NoOpTracer` that takes no action. To enable tracing, you will need to set a global tracer provider following the instructions in the [OpenTelemetry getting started guide](https://opentelemetry.io/docs/js/getting_started/nodejs).
 
 ### Span Propagation
 

--- a/sdk/core/core-tracing/README.md
+++ b/sdk/core/core-tracing/README.md
@@ -30,7 +30,7 @@ Most Azure SDKs and Microsoft's [Application Insights](https://www.npmjs.com/pac
 
 As OpenTelemetry iterated on their API towards their 1.0 GA release, our libraries were updated to match.
 
-Some incompatibility between the libraries is due to mismatches between the OpenTelemetry versions used in either `@azure/core-tracing` or `applicationinsights` when the two are used side-by-side. For folks who are using both an Azure Client Library and Application Insights in the same application, we recommend using the same version of OpenTelemetry for both libraries by upgrading to their latest versions.
+Some incompatibility between the libraries is due to mismatches between the OpenTelemetry versions used in either `@azure/core-tracing` or `applicationinsights` when the two are used side-by-side. For folks who are using both an Azure Client Library (and transitively, `@azure/core-tracing`) and Application Insights in the same application, we recommend using the same version of OpenTelemetry for both libraries by upgrading to their latest versions.
 
 > Please note that we do not foresee any future compatibility concerns now that OpenTelemetry 1.0.0 has been released and the API considered stable.
 

--- a/sdk/core/core-tracing/README.md
+++ b/sdk/core/core-tracing/README.md
@@ -16,13 +16,13 @@ npm install @azure/core-tracing
 
 The `@azure/core-tracing` package supports enabling tracing for Azure SDK packages, using an [OpenTelemetry](https://opentelemetry.io/) `Tracer`.
 
-By default, all libraries log with a `NoOpTracer` that takes no action. To enable tracing, you will need to set a global tracer provider following the instructions in the [OpenTelemetry getting started guide](https://opentelemetry.io/docs/js/getting_started/nodejs) or [the Enabling Tracing using OpenTelemetry example](#enabling-tracing-using-opentelemetry) below.
+By default, all libraries log with a `NoOpTracer` that takes no action. To enable tracing, you will need to set a global tracer provider following the instructions in the [OpenTelemetry getting started guide](https://opentelemetry.io/docs/js/getting_started/nodejs) or the [Enabling Tracing using OpenTelemetry example](#enabling-tracing-using-opentelemetry) below.
 
 ### Span Propagation
 
 Core Tracing supports both automatic and manual span propagation. Automatic propagation is handled using OpenTelemetry's API and will work well in most scenarios when run in `Node.js`.
 
-For customers who require manual propagation, or to provide context propagation in the browser, all client library operations accept an optional options collection where a tracingContext can be passed in and used as the currently active context. Please see [the manual propagation example below](#manual-span-propagation-using-opentelemetry) for more details.
+For customers who require manual propagation, or to provide context propagation in the browser, all client library operations accept an optional options collection where a tracingContext can be passed in and used as the currently active context. Please see the [Manual Span Propagation example](#manual-span-propagation-using-opentelemetry) below for more details.
 
 ### OpenTelemetry Compatibility
 

--- a/sdk/core/core-tracing/README.md
+++ b/sdk/core/core-tracing/README.md
@@ -26,20 +26,25 @@ For customers who require manual propagation, all client library operations acce
 
 ### OpenTelemetry Compatibility
 
-Both the Azure SDK and Microsoft's [Application Insights](https://www.npmjs.com/package/applicationinsights) use OpenTelemetry to provide tracing. As OpenTelemetry iterated on their API towards their 1.0 GA release, both libraries were updated to match.
+Both the Azure SDK and Microsoft's [Application Insights](https://www.npmjs.com/package/applicationinsights) use [OpenTelemetry](https://opentelemetry.io/) to support tracing. Specifically, we depend on the [@opentelemetry/api](https://www.npmjs.com/package/@opentelemetry/api) npm package.
 
-Some incompatibility between the two libraries is due to mismatches between the OpenTelemetry versions used in either `@azure/core-tracing` or `applicationinsights` when the two are used side-by-side. For folks who are using both libraries in the same application, we recommend using the same version of OpenTelemetry for both libraries.
+As OpenTelemetry iterated on their API towards their 1.0 GA release, both libraries were updated to match.
+
+Some incompatibility between the two libraries is due to mismatches between the OpenTelemetry versions used in either `@azure/core-tracing` or `applicationinsights` when the two are used side-by-side. For folks who are using both libraries in the same application, we recommend using the same version of OpenTelemetry for both libraries by upgrading to their latest versions.
 
 > Please note that we do not foresee any future compatibility concerns now that OpenTelemetry 1.0.0 has been released and the API considered stable.
 
 #### Compatibility Matrix
 
-| Core Tracing     | Application Insights | OpenTelemetry |
-| ---------------- | -------------------- | ------------- |
-| 1.0.0-preview.10 |                      | 0.10.2        |
-| 1.0.0-preview.11 |                      | 1.0.0-rc.0    |
-| 1.0.0-preview.12 | ^2.1.4               | ^1.0.0        |
-| 1.0.0-preview.13 | ^2.1.4               | ^1.0.0        |
+| Core Tracing     | Application Insights | @opentelemetry/api |
+| ---------------- | -------------------- | ------------------ |
+| 1.0.0-preview.10 |                      | 0.10.2             |
+| 1.0.0-preview.11 | 2.1.0                | 1.0.0-rc.0         |
+| 1.0.0-preview.11 | 2.1.1                | 1.0.0-rc.0         |
+| 1.0.0-preview.11 | 2.1.2                | 1.0.0-rc.0         |
+| 1.0.0-preview.11 | 2.1.3                | 1.0.0-rc.0         |
+| 1.0.0-preview.12 | ^2.1.4               | ^1.0.0             |
+| 1.0.0-preview.13 | ^2.1.4               | ^1.0.0             |
 
 Please see the [troubleshooting](#troubleshooting) section for additional information about handling compatibility errors.
 

--- a/sdk/core/core-tracing/README.md
+++ b/sdk/core/core-tracing/README.md
@@ -28,7 +28,7 @@ For customers who require manual propagation, all client library operations acce
 
 Both the Azure SDK and Microsoft's [Application Insights](https://www.npmjs.com/package/applicationinsights) use OpenTelemetry to provide tracing. As OpenTelemetry iterated on their API towards their 1.0 GA release, both libraries were updated to match.
 
-Some incompatibility between the two libraries is due to mismatches between the versions used in the two libraries when the two are used side-by-side. For folks who are using both libraries in the same application, we recommend using the same version of OpenTelemetry for both libraries.
+Some incompatibility between the two libraries is due to mismatches between the OpenTelemetry versions used in either `@azure/core-tracing` or `applicationinsights` when the two are used side-by-side. For folks who are using both libraries in the same application, we recommend using the same version of OpenTelemetry for both libraries.
 
 > Please note that we do not foresee any future compatibility concerns now that OpenTelemetry 1.0.0 has been released and the API considered stable.
 

--- a/sdk/core/core-tracing/README.md
+++ b/sdk/core/core-tracing/README.md
@@ -16,17 +16,17 @@ npm install @azure/core-tracing
 
 The `@azure/core-tracing` package supports enabling tracing for Azure SDK packages, using an [OpenTelemetry](https://opentelemetry.io/) `Tracer`.
 
-By default, all libraries log with a `NoOpTracer` that takes no action.
-To change this, you have to set a global tracer provider following the instructions in the [OpenTelemetry getting started guide](https://opentelemetry.io/docs/js/getting_started/nodejs).
+By default, all libraries log with a `NoOpTracer` that takes no action. To change this, you have to set a global tracer provider following the instructions in the [OpenTelemetry getting started guide](https://opentelemetry.io/docs/js/getting_started/nodejs).
 
 ### Span Propagation
 
 Core Tracing supports both automatic and manual span propagation. Automatic propagation is handled using OpenTelemetry's API and will work well in most scenarios.
+
 For customers who require manual propagation, all client library operations accept a `tracingContext` option under `tracingOptions` which allows you to manually pass the current context to the Azure SDK client library.
 
 ### OpenTelemetry Compatibility
 
-Both the `@azure/core-tracing` and Microsoft's [Application Insights](https://www.npmjs.com/package/applicationinsights) use OpenTelemetry to provide tracing. As OpenTelemetry iterated on their API towards their 1.0 GA release, both libraries were updated to match.
+Both the Azure SDK and Microsoft's [Application Insights](https://www.npmjs.com/package/applicationinsights) use OpenTelemetry to provide tracing. As OpenTelemetry iterated on their API towards their 1.0 GA release, both libraries were updated to match.
 
 Some incompatibility between the two libraries is due to mismatches between the versions used in the two libraries when the two are used side-by-side. For folks who are using both libraries in the same application, we recommend using the same version of OpenTelemetry for both libraries.
 
@@ -86,8 +86,8 @@ To resolve this, please ensure that all Azure client libraries are using a compa
 
 > Ideally you'd want to use OpenTelemetry 1.0.0 or higher.
 
-If you are using `npm` you may run `npm ls @opentelemetry/api` to see the version of OpenTelemetry you are using and which client libraries are using it.
-For `yarn` users, `yarn why @opentelemetry/api` will show you the version of OpenTelemetry you are using and which client libraries are using it.
+- If you are using `npm` you may run `npm ls @opentelemetry/api` to see the version of OpenTelemetry you are using and which client libraries are using it.
+- For `yarn` users, `yarn why @opentelemetry/api` will show you the version of OpenTelemetry you are using and which client libraries are using it.
 
 You may then upgrade client libraries as needed to ensure compatibility. Things should work as expected when the above command returns a version of OpenTelemetry that is >= 1.0.0.
 

--- a/sdk/core/core-tracing/README.md
+++ b/sdk/core/core-tracing/README.md
@@ -20,9 +20,9 @@ By default, all libraries log with a `NoOpTracer` that takes no action. To enabl
 
 ### Span Propagation
 
-Core Tracing supports both automatic and manual span propagation. Automatic propagation is handled using OpenTelemetry's API and will work well in most scenarios.
+Core Tracing supports both automatic and manual span propagation. Automatic propagation is handled using OpenTelemetry's API and will work well in most scenarios when run in `Node.js`.
 
-For customers who require manual propagation, all client library operations accept a `tracingContext` option under `tracingOptions` which allows you to manually pass the current context to the Azure SDK client library.
+For customers who require manual propagation, or to provide context propagation in the browser, all client library operations accept a `tracingContext` option under `tracingOptions` which allows you to manually pass the current context to the Azure SDK client library.
 
 ### OpenTelemetry Compatibility
 

--- a/sdk/core/core-tracing/README.md
+++ b/sdk/core/core-tracing/README.md
@@ -17,39 +17,63 @@ npm install @azure/core-tracing
 The `@azure/core-tracing` package supports enabling tracing for Azure SDK packages, using an [OpenTelemetry](https://opentelemetry.io/) `Tracer`.
 
 By default, all libraries log with a `NoOpTracer` that takes no action.
-To change this, you have to use `setTracer` to set a new default `Tracer`.
+To change this, you have to set a global tracer provider following the instructions in the [OpenTelemetry getting started guide](https://opentelemetry.io/docs/js/getting_started/nodejs).
+
+### Span Propagation
+
+Core Tracing supports both automatic and manual span propagation. Automatic propagation is handled using OpenTelemetry's API and will work well in most scenarios.
+For customers who require manual propagation, all client library operations accept a `tracingContext` option under `tracingOptions` which allows you to manually pass the current context to the Azure SDK client library.
+
+### OpenTelemetry Compatibility
+
+Both the `@azure/core-tracing` and Microsoft's [Application Insights](https://www.npmjs.com/package/applicationinsights) use OpenTelemetry to provide tracing. As OpenTelemetry iterated on their API towards their 1.0 GA release, both libraries were updated to match.
+
+Some incompatibility between the two libraries is due to mismatches between the versions used in the two libraries when the two are used side-by-side. For folks who are using both libraries in the same application, we recommend using the same version of OpenTelemetry for both libraries.
+
+> Please note that we do not foresee any future compatibility concerns now that OpenTelemetry 1.0.0 has been released and the API considered stable.
+
+#### Compatibility Matrix
+
+| Core Tracing     | Application Insights | OpenTelemetry |
+| ---------------- | -------------------- | ------------- |
+| 1.0.0-preview.10 |                      | 0.10.2        |
+| 1.0.0-preview.11 |                      | 1.0.0-rc.0    |
+| 1.0.0-preview.12 | ^2.1.4               | ^1.0.0        |
+| 1.0.0-preview.13 | ^2.1.4               | ^1.0.0        |
+
+#### Troubleshooting guide
+
+Errors such as `span.spanContext is not a function` or `span.context is not a function` are likely due to a mismatch of OpenTelemetry versions between two libraries.
+
+Please ensure that all Azure client libraries are using a compatible version of OpenTelemetry. If you are using `applicationinsights` please ensure that you are using the same version of OpenTelemetry as the Azure client libraries.
+
+> Ideally you'd want to use OpenTelemetry 1.0.0 or higher.
+
+If you are using `npm` you may run `npm ls @opentelemetry/api` to see the version of OpenTelemetry you are using and which client libraries are using it.
+For `yarn` users, `yarn why @opentelemetry/api` will show you the version of OpenTelemetry you are using and which client libraries are using it.
+
+You may then upgrade client libraries as needed to ensure compatibility. Things should work as expected when the above command returns a version of OpenTelemetry that is >= 1.0.0.
 
 ## Examples
 
-### Example 1 - Setting an OpenTelemetry Tracer
+### Example 1 - Enabling tracing using OpenTelemetry
 
-```js
+```ts
 const opentelemetry = require("@opentelemetry/api");
-const { BasicTracer, SimpleSpanProcessor } = require("@opentelemetry/tracing");
-const { ZipkinExporter } = require("@opentelemetry/exporter-zipkin");
-const { setTracer } = require("@azure/core-tracing");
+const { SimpleSpanProcessor, ConsoleSpanExporter } = require("@opentelemetry/tracing");
 
-const exporter = new ZipkinExporter({
-  serviceName: "azure-tracing-sample"
-});
-const tracer = new BasicTracer();
-tracer.addSpanProcessor(new SimpleSpanProcessor(exporter));
+const provider = new NodeTracerProvider();
+provider.addSpanProcessor(new SimpleSpanProcessor(new ConsoleSpanExporter()));
+provider.register();
 
-setTracer(tracer);
-
-const rootSpan = tracer.startSpan("root");
-const context = opentelemetry.setSpan(opentelemetry.context.active(), rootSpan);
-
-// Call some client library methods and pass rootSpan via tracingOptions.
-
-rootSpan.end();
-exporter.shutdown();
+// Call some client library methods using automatic span propagation.
 ```
 
-### Example 2 - Passing current Context to library operations
+### Example 2 - Manual Span Propagation using OpenTelemetry
 
-```js
-// Given a BlobClient from @azure/storage-blob
+```ts
+// Given a BlobClient from @azure/storage-blob, a given context, and a global tracer provider as per the previous example.
+// The context is passed to the client library as a tracingContext option.
 const result = await blobClient.download(undefined, undefined, {
   tracingOptions: {
     tracingContext: context


### PR DESCRIPTION
## What

- Update the core-tracing README's examples
- Add a Compatibility matrix section in core-tracing
- Add a troubleshooting section for Span#context -> Span#spanContext rename

## Why

- The samples are outdated as we no longer require `setTracer` to enable tracing and support automatic span propagation where possible
- We've been seeing more and more issues with compatibility between core-tracing, OpenTelemetry, and applicationinsights and it was suggested by one of our customers to add a compatibility matrix to aid in resolving such issues
- FInally, Span#context -> Span#spanContext rename was particularly painful as it's used in TracingPolicy - a perfect storm of changes put us in a position where this error might keep coming up. 

I should note that even without any changes on our side, the above rename would cause errors for anyone who has pulled in OpenTelemetry >= 0.20 (including 1.0) as previous versions of core-http would still try to access Span#context (which has been renamed)

Partially resolves #16936 
Resolves #17369