### PR TITLE
[Identity] Arc MSI fix

### DIFF
--- a/sdk/identity/identity/CHANGELOG.md
+++ b/sdk/identity/identity/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.5.2 (2021-09-01)
 
-- Fixed a bug introduced on 1.5.1 that caused the `ManagedIdentityCredential` to fail authenticating in Arc environments.
+- Fixed a bug introduced on 1.5.0 that caused the `ManagedIdentityCredential` to fail authenticating in Arc environments. Since our new core disables unsafe requests by default, we had to change the security settings for the first request of the Arc MSI, which retrieves the file path where the authentication value is stored since this request generally happens through an HTTP endpoint.
 
 ## 1.5.1 (2021-08-12)
 

--- a/sdk/identity/identity/CHANGELOG.md
+++ b/sdk/identity/identity/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Release History
 
-## 1.5.2 (Unreleased)
+## 1.5.2 (2021-09-01)
 
+- Fixed a bug introduced on 1.5.1 that caused the `ManagedIdentityCredential` to fail authenticating in Arc environments.
 
 ## 1.5.1 (2021-08-12)
 

--- a/sdk/identity/identity/src/credentials/managedIdentityCredential/arcMsi.ts
+++ b/sdk/identity/identity/src/credentials/managedIdentityCredential/arcMsi.ts
@@ -96,6 +96,7 @@ export const arcMsi: MSI = {
     }
 
     const requestOptions = {
+      allowInsecureConnection: true,
       disableJsonStringifyOnBody: true,
       deserializationMapper: undefined,
       abortSignal: getTokenOptions.abortSignal,

--- a/sdk/identity/identity/test/internal/node/managedIdentityCredential.spec.ts
+++ b/sdk/identity/identity/test/internal/node/managedIdentityCredential.spec.ts
@@ -312,8 +312,8 @@ describe("ManagedIdentityCredential", function() {
   it("sends an authorization request correctly in an Azure Arc environment", async () => {
     // Trigger Azure Arc behavior by setting environment variables
 
-    process.env.IMDS_ENDPOINT = "https://endpoint";
-    process.env.IDENTITY_ENDPOINT = "https://endpoint";
+    process.env.IMDS_ENDPOINT = "http://endpoint";
+    process.env.IDENTITY_ENDPOINT = "http://endpoint";
 
     // eslint-disable-next-line @typescript-eslint/no-require-imports
     const mockFs = require("mock-fs");
@@ -327,7 +327,7 @@ describe("ManagedIdentityCredential", function() {
     const authDetails = await sendCredentialRequests({
       scopes: ["https://service/.default"],
       credential: new ManagedIdentityCredential(),
-      secureResponses: [
+      insecureResponses: [
         {
           response: createResponse(401, "", {
             "www-authenticate": `we don't pay much attention about this format=${filePath}`
@@ -346,26 +346,26 @@ describe("ManagedIdentityCredential", function() {
     });
 
     // File request
-    const validationRequest = authDetails.secureRequestOptions[0];
+    const validationRequest = authDetails.insecureRequestOptions[0];
     let query = qs.parse(validationRequest.path!.split("?")[1]);
 
     assert.equal(validationRequest.method, "GET");
     assert.equal(decodeURIComponent(query.resource as string), "https://service");
 
     assert.ok(
-      `https://${validationRequest.hostname}`.startsWith(process.env.IDENTITY_ENDPOINT),
+      `http://${validationRequest.hostname}`.startsWith(process.env.IDENTITY_ENDPOINT),
       "URL does not start with expected host and path"
     );
 
     // Authorization request, which comes after getting the file path, for now at least.
-    const authRequest = authDetails.secureRequestOptions[1];
+    const authRequest = authDetails.insecureRequestOptions[1];
     query = qs.parse(validationRequest.path!.split("?")[1]);
 
     assert.equal(authRequest.method, "GET");
     assert.equal(decodeURIComponent(query.resource as string), "https://service");
 
     assert.ok(
-      `https://${validationRequest.hostname}`.startsWith(process.env.IDENTITY_ENDPOINT),
+      `http://${validationRequest.hostname}`.startsWith(process.env.IDENTITY_ENDPOINT),
       "URL does not start with expected host and path"
     );
 


### PR DESCRIPTION
The first request of the Arc MSI, which retrieves the file path where the basic authentication value is, generally happens through HTTP endpoints, so `allowInsecureConnection` should be set to true.