### PR TITLE
[KeyVault] - Regenerate secrets and certificates using 7.3-preview

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -571,6 +571,20 @@ packages:
       node: '>=12.0.0'
     resolution:
       integrity: sha512-x1AWJ2IxsVZkZ/REsuQxAqt1/LkDxKEgIAozH1x5WpuhyWvVRGyG3TxyTRB0dljc54+vWcXiThnPV1+g254Fxg==
+  /@azure/keyvault-certificates/4.3.0:
+    dependencies:
+      '@azure/abort-controller': 1.0.4
+      '@azure/core-http': 2.1.0
+      '@azure/core-lro': 2.2.0
+      '@azure/core-paging': 1.1.3
+      '@azure/core-tracing': 1.0.0-preview.13
+      '@azure/logger': 1.0.2
+      tslib: 2.3.1
+    dev: false
+    engines:
+      node: '>=12.0.0'
+    resolution:
+      integrity: sha512-wCceKxgorRupYqx8jmWkyCiBmEfOo3VXONYp4eyDhXt/MfaYf0YF5O829Ft6EFQLf6D9CQMc2maZgCMOajaeOA==
   /@azure/keyvault-keys/4.3.0:
     dependencies:
       '@azure/abort-controller': 1.0.4
@@ -585,6 +599,20 @@ packages:
       node: '>=8.0.0'
     resolution:
       integrity: sha512-OEosl0/rE/mKD5Ji9KaQN7UH+yQnV5MS0MRhGqQIiJrG+qAvAla0MYudJzv3XvBlplpGk0+MVgyL9H3KX/UAwQ==
+  /@azure/keyvault-secrets/4.3.0:
+    dependencies:
+      '@azure/abort-controller': 1.0.4
+      '@azure/core-http': 2.1.0
+      '@azure/core-lro': 2.2.0
+      '@azure/core-paging': 1.1.3
+      '@azure/core-tracing': 1.0.0-preview.13
+      '@azure/logger': 1.0.2
+      tslib: 2.3.1
+    dev: false
+    engines:
+      node: '>=12.0.0'
+    resolution:
+      integrity: sha512-bhdAr2Yjx+XpgfkClOufpTxcnKqDIwyOSKrbI9mJ2q5wQNb7Z1WPnPnIhjdsw1on/NRXzMaarYFNkf/MdS73FA==
   /@azure/logger-js/1.3.2:
     dependencies:
       tslib: 1.14.1
@@ -8533,6 +8561,7 @@ packages:
   file:projects/app-configuration.tgz:
     dependencies:
       '@azure/core-tracing': 1.0.0-preview.13
+      '@azure/keyvault-secrets': 4.3.0
       '@microsoft/api-extractor': 7.7.11
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-inject': 4.0.2_rollup@1.32.1
@@ -8580,7 +8609,7 @@ packages:
     dev: false
     name: '@rush-temp/app-configuration'
     resolution:
-      integrity: sha512-g4sZpBcubzg/mDgUtVc/eaQFqC0zeSFKcOZnly3IE2HgNJtt17ogJcI2ksSWpEFzcR3y6UblCgV2EXGYKvARYQ==
+      integrity: sha512-oCqsV43+ok9Ll0axfYs1+p6vwshPxKRkCyj5wYQyQekzW77YnfjR2SM8rTTCWb8BqUP95f4Z9jF4OFyeFp+2kg==
       tarball: file:projects/app-configuration.tgz
     version: 0.0.0
   file:projects/arm-appservice.tgz:
@@ -10722,6 +10751,7 @@ packages:
   file:projects/keyvault-certificates.tgz:
     dependencies:
       '@azure/core-tracing': 1.0.0-preview.13
+      '@azure/keyvault-secrets': 4.3.0
       '@microsoft/api-extractor': 7.7.11
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-json': 4.1.0_rollup@1.32.1
@@ -10771,7 +10801,7 @@ packages:
     dev: false
     name: '@rush-temp/keyvault-certificates'
     resolution:
-      integrity: sha512-RwdfeP0b8V6tk60hcseS9MmjKE7X6SmpvdPbPX7SIR2/RyN5B+usxZZ2NqNJeeevFck6V6BxYIBOWA/egnzMWQ==
+      integrity: sha512-AShnhzBFj1alNMcW6RZ1GvulVp4qktPxCw/fU/8vUNxbQegr8wQ+IgH3bJpOXB6/Re7F8N9Z2j7a9kdeeY3Rsw==
       tarball: file:projects/keyvault-certificates.tgz
     version: 0.0.0
   file:projects/keyvault-common.tgz:
@@ -11268,6 +11298,7 @@ packages:
   file:projects/perf-keyvault-certificates.tgz:
     dependencies:
       '@azure/identity': 2.0.0-beta.5
+      '@azure/keyvault-certificates': 4.3.0
       '@types/uuid': 8.3.1
       dotenv: 8.6.0
       eslint: 7.32.0
@@ -11280,7 +11311,7 @@ packages:
     dev: false
     name: '@rush-temp/perf-keyvault-certificates'
     resolution:
-      integrity: sha512-Lu5DMEEQaLKxeYQUA3vi9NsM2eezMgulBxsE/1H1/CcQ19Stsa8ZSocg/VXR2leUez9TMMAt3BEFe0SUMq43Zg==
+      integrity: sha512-zR46XVGRQbnv8ZsjvS/jv3gV208KjO2skSb3AUN+NHOTgqEjc1n7apyQ2I1SctiXa6Pb+E6B1bYbfFfpb+G12A==
       tarball: file:projects/perf-keyvault-certificates.tgz
     version: 0.0.0
   file:projects/perf-keyvault-keys.tgz:
@@ -11304,6 +11335,7 @@ packages:
   file:projects/perf-keyvault-secrets.tgz:
     dependencies:
       '@azure/identity': 2.0.0-beta.5
+      '@azure/keyvault-secrets': 4.3.0
       '@types/uuid': 8.3.1
       dotenv: 8.6.0
       eslint: 7.32.0
@@ -11316,7 +11348,7 @@ packages:
     dev: false
     name: '@rush-temp/perf-keyvault-secrets'
     resolution:
-      integrity: sha512-eNh/HrvUzTrZcgP2kjh13CFLWbWSVd73jjU5fupTSOdU8kk5xmDvjG5tKdwhXi9BGu5YV8qUz7cMJsFNrPLkdQ==
+      integrity: sha512-Y38lxfva8r/NoJ4JT8Qu62/bainC9NLzc8NnUeWtMVNXDuAxPcEtpnlhgNzWSD77sufnr/5pqwQ2QXSZqDPWtA==
       tarball: file:projects/perf-keyvault-secrets.tgz
     version: 0.0.0
   file:projects/perf-search-documents.tgz:

--- a/sdk/keyvault/keyvault-admin/CHANGELOG.md
+++ b/sdk/keyvault/keyvault-admin/CHANGELOG.md
@@ -4,13 +4,13 @@
 
 ### Features Added
 
-- Updated the service version to default to 7.3-preview.
-
 ### Breaking Changes
 
 ### Bugs Fixed
 
 ### Other Changes
+
+- Updated the latest service version to 7.3.
 
 ## 4.2.0-beta.1 (2021-08-10)
 

--- a/sdk/keyvault/keyvault-certificates/CHANGELOG.md
+++ b/sdk/keyvault/keyvault-certificates/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 4.3.1 (Unreleased)
+## 4.4.0-beta.1 (Unreleased)
 
 ### Features Added
 
@@ -9,6 +9,8 @@
 ### Bugs Fixed
 
 ### Other Changes
+
+- Updated the latest service version to 7.3.
 
 ## 4.3.0 (2021-07-29)
 

--- a/sdk/keyvault/keyvault-certificates/package.json
+++ b/sdk/keyvault/keyvault-certificates/package.json
@@ -2,7 +2,7 @@
   "name": "@azure/keyvault-certificates",
   "sdk-type": "client",
   "author": "Microsoft Corporation",
-  "version": "4.3.1",
+  "version": "4.4.0-beta.1",
   "license": "MIT",
   "description": "Isomorphic client library for Azure KeyVault's certificates.",
   "homepage": "https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/keyvault/keyvault-certificates/README.md",

--- a/sdk/keyvault/keyvault-certificates/review/keyvault-certificates.api.md
+++ b/sdk/keyvault/keyvault-certificates/review/keyvault-certificates.api.md
@@ -351,7 +351,7 @@ export interface KeyVaultCertificateWithPolicy extends KeyVaultCertificate {
 }
 
 // @public
-export const enum KnownCertificateKeyCurveNames {
+export enum KnownCertificateKeyCurveNames {
     P256 = "P-256",
     P256K = "P-256K",
     P384 = "P-384",
@@ -359,7 +359,7 @@ export const enum KnownCertificateKeyCurveNames {
 }
 
 // @public
-export const enum KnownCertificateKeyTypes {
+export enum KnownCertificateKeyTypes {
     EC = "EC",
     ECHSM = "EC-HSM",
     Oct = "oct",

--- a/sdk/keyvault/keyvault-certificates/src/certificatesModels.ts
+++ b/sdk/keyvault/keyvault-certificates/src/certificatesModels.ts
@@ -813,3 +813,91 @@ export type RequireAtLeastOne<T> = {
  * which are: emailAddress, name or phone.
  */
 export type CertificateContact = RequireAtLeastOne<CertificateContactAll> | undefined;
+
+/** Known values of {@link CertificateKeyCurveName} that the service accepts. */
+export enum KnownCertificateKeyCurveNames {
+  /**
+   * P-256 Key Curve.
+   */
+  P256 = "P-256",
+  /**
+   * P-384 Key Curve.
+   */
+  P384 = "P-384",
+  /**
+   * P-521 Key Curve.
+   */
+  P521 = "P-521",
+  /**
+   * P-256K Key Curve.
+   */
+  P256K = "P-256K"
+}
+
+/** Known values of {@link CertificateKeyType} that the service accepts. */
+export enum KnownCertificateKeyTypes {
+  /**
+   * EC Key Type.
+   */
+  EC = "EC",
+  /**
+   * EC-HSM Key Type.
+   */
+  ECHSM = "EC-HSM",
+  /**
+   * RSA Key Type.
+   */
+  RSA = "RSA",
+  /**
+   * RSA-HSM Key Type.
+   */
+  RSAHSM = "RSA-HSM",
+  /**
+   * oct Key Type
+   */
+  Oct = "oct",
+  /**
+   * oct-HSM Key Type
+   */
+  OctHSM = "oct-HSM"
+}
+
+/** Known values of {@link KeyUsageType} that the service accepts. */
+export const enum KnownKeyUsageTypes {
+  /**
+   * DigitalSignature Usage Type.
+   */
+  DigitalSignature = "digitalSignature",
+  /**
+   * NonRepudiation Usage Type.
+   */
+  NonRepudiation = "nonRepudiation",
+  /**
+   * KeyEncipherment Usage Type.
+   */
+  KeyEncipherment = "keyEncipherment",
+  /**
+   * DataEncipherment Usage Type.
+   */
+  DataEncipherment = "dataEncipherment",
+  /**
+   * KeyAgreement Usage Type.
+   */
+  KeyAgreement = "keyAgreement",
+  /**
+   * KeyCertSign Usage Type.
+   */
+  KeyCertSign = "keyCertSign",
+  /**
+   * CRLSign Usage Type.
+   */
+  CRLSign = "cRLSign",
+  /**
+   * EncipherOnly Usage Type.
+   */
+  EncipherOnly = "encipherOnly",
+  /**
+   * DecipherOnly Usage Type.
+   */
+  DecipherOnly = "decipherOnly"
+}

--- a/sdk/keyvault/keyvault-certificates/src/constants.ts
+++ b/sdk/keyvault/keyvault-certificates/src/constants.ts
@@ -1,4 +1,4 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-export const SDK_VERSION: string = "4.3.1";
+export const SDK_VERSION: string = "4.4.0-beta.1";

--- a/sdk/keyvault/keyvault-certificates/src/generated/keyVaultClient.ts
+++ b/sdk/keyvault/keyvault-certificates/src/generated/keyVaultClient.ts
@@ -12,7 +12,7 @@ import * as Mappers from "./models/mappers";
 import { KeyVaultClientContext } from "./keyVaultClientContext";
 import {
   KeyVaultClientOptionalParams,
-  ApiVersion72,
+  ApiVersion73Preview,
   KeyVaultClientGetCertificatesOptionalParams,
   KeyVaultClientGetCertificatesResponse,
   KeyVaultClientDeleteCertificateResponse,
@@ -69,7 +69,7 @@ export class KeyVaultClient extends KeyVaultClientContext {
    * @param options The parameter options
    */
   constructor(
-    apiVersion: ApiVersion72,
+    apiVersion: ApiVersion73Preview,
     options?: KeyVaultClientOptionalParams
   ) {
     super(apiVersion, options);
@@ -321,10 +321,10 @@ export class KeyVaultClient extends KeyVaultClientContext {
   }
 
   /**
-   * Imports an existing valid certificate, containing a private key, into Azure Key Vault. The
-   * certificate to be imported can be in either PFX or PEM format. If the certificate is in PEM format
-   * the PEM file must contain the key as well as x509 certificates. This operation requires the
-   * certificates/import permission.
+   * Imports an existing valid certificate, containing a private key, into Azure Key Vault. This
+   * operation requires the certificates/import permission. The certificate to be imported can be in
+   * either PFX or PEM format. If the certificate is in PEM format the PEM file must contain the key as
+   * well as x509 certificates. Key Vault will only accept a key in PKCS#8 format.
    * @param vaultBaseUrl The vault name, for example https://myvault.vault.azure.net.
    * @param certificateName The name of the certificate.
    * @param base64EncodedCertificate Base64 encoded representation of the certificate object to import.

--- a/sdk/keyvault/keyvault-certificates/src/generated/keyVaultClientContext.ts
+++ b/sdk/keyvault/keyvault-certificates/src/generated/keyVaultClientContext.ts
@@ -7,14 +7,14 @@
  */
 
 import * as coreHttp from "@azure/core-http";
-import { ApiVersion72, KeyVaultClientOptionalParams } from "./models";
+import { ApiVersion73Preview, KeyVaultClientOptionalParams } from "./models";
 
 const packageName = "@azure/keyvault-certificates";
 export const packageVersion = "4.3.1";
 
 /** @hidden */
 export class KeyVaultClientContext extends coreHttp.ServiceClient {
-  apiVersion: ApiVersion72;
+  apiVersion: ApiVersion73Preview;
 
   /**
    * Initializes a new instance of the KeyVaultClientContext class.
@@ -22,7 +22,7 @@ export class KeyVaultClientContext extends coreHttp.ServiceClient {
    * @param options The parameter options
    */
   constructor(
-    apiVersion: ApiVersion72,
+    apiVersion: ApiVersion73Preview,
     options?: KeyVaultClientOptionalParams
   ) {
     if (apiVersion === undefined) {

--- a/sdk/keyvault/keyvault-certificates/src/generated/keyVaultClientContext.ts
+++ b/sdk/keyvault/keyvault-certificates/src/generated/keyVaultClientContext.ts
@@ -10,7 +10,7 @@ import * as coreHttp from "@azure/core-http";
 import { ApiVersion73Preview, KeyVaultClientOptionalParams } from "./models";
 
 const packageName = "@azure/keyvault-certificates";
-export const packageVersion = "4.3.1";
+export const packageVersion = "4.4.0-beta.1";
 
 /** @hidden */
 export class KeyVaultClientContext extends coreHttp.ServiceClient {

--- a/sdk/keyvault/keyvault-certificates/src/generated/models/index.ts
+++ b/sdk/keyvault/keyvault-certificates/src/generated/models/index.ts
@@ -111,7 +111,7 @@ export interface CertificateBundle {
   readonly policy?: CertificatePolicy;
   /** CER contents of x509 certificate. */
   cer?: Uint8Array;
-  /** The content type of the secret. */
+  /** The content type of the secret. eg. 'application/x-pem-file' or 'application/x-pkcs12', */
   contentType?: string;
   /** The certificate attributes. */
   attributes?: CertificateAttributes;
@@ -142,7 +142,7 @@ export interface CertificatePolicy {
 
 /** Properties of the key pair backing a certificate. */
 export interface KeyProperties {
-  /** Not supported in this version. Indicates if the private key can be exported. */
+  /** Indicates if the private key can be exported. */
   exportable?: boolean;
   /** The type of key pair to be used for the certificate. */
   keyType?: JsonWebKeyType;
@@ -503,20 +503,20 @@ export type DeletedCertificateBundle = CertificateBundle & {
   readonly deletedDate?: Date;
 };
 
-/** Known values of {@link ApiVersion72} that the service accepts. */
-export const enum KnownApiVersion72 {
-  /** Api Version '7.2' */
-  Seven2 = "7.2"
+/** Known values of {@link ApiVersion73Preview} that the service accepts. */
+export const enum KnownApiVersion73Preview {
+  /** Api Version '7.3-preview' */
+  Seven3Preview = "7.3-preview"
 }
 
 /**
- * Defines values for ApiVersion72. \
- * {@link KnownApiVersion72} can be used interchangeably with ApiVersion72,
+ * Defines values for ApiVersion73Preview. \
+ * {@link KnownApiVersion73Preview} can be used interchangeably with ApiVersion73Preview,
  *  this enum contains the known values that the service supports.
  * ### Know values supported by the service
- * **7.2**: Api Version '7.2'
+ * **7.3-preview**: Api Version '7.3-preview'
  */
-export type ApiVersion72 = string;
+export type ApiVersion73Preview = string;
 
 /** Known values of {@link DeletionRecoveryLevel} that the service accepts. */
 export const enum KnownDeletionRecoveryLevel {
@@ -553,29 +553,11 @@ export type DeletionRecoveryLevel = string;
 
 /** Known values of {@link JsonWebKeyType} that the service accepts. */
 export const enum KnownJsonWebKeyType {
-  /**
-   * EC Key Type.
-   */
   EC = "EC",
-  /**
-   * EC-HSM Key Type.
-   */
   ECHSM = "EC-HSM",
-  /**
-   * RSA Key Type.
-   */
   RSA = "RSA",
-  /**
-   * RSA-HSM Key Type.
-   */
   RSAHSM = "RSA-HSM",
-  /**
-   * oct Key Type
-   */
   Oct = "oct",
-  /**
-   * oct-HSM Key Type
-   */
   OctHSM = "oct-HSM"
 }
 
@@ -595,21 +577,9 @@ export type JsonWebKeyType = string;
 
 /** Known values of {@link JsonWebKeyCurveName} that the service accepts. */
 export const enum KnownJsonWebKeyCurveName {
-  /**
-   * P-256 Key Curve.
-   */
   P256 = "P-256",
-  /**
-   * P-384 Key Curve.
-   */
   P384 = "P-384",
-  /**
-   * P-521 Key Curve.
-   */
   P521 = "P-521",
-  /**
-   * P-256K Key Curve.
-   */
   P256K = "P-256K"
 }
 
@@ -627,41 +597,14 @@ export type JsonWebKeyCurveName = string;
 
 /** Known values of {@link KeyUsageType} that the service accepts. */
 export const enum KnownKeyUsageType {
-  /**
-   * DigitalSignature Usage Type.
-   */
   DigitalSignature = "digitalSignature",
-  /**
-   * NonRepudiation Usage Type.
-   */
   NonRepudiation = "nonRepudiation",
-  /**
-   * KeyEncipherment Usage Type.
-   */
   KeyEncipherment = "keyEncipherment",
-  /**
-   * DataEncipherment Usage Type.
-   */
   DataEncipherment = "dataEncipherment",
-  /**
-   * KeyAgreement Usage Type.
-   */
   KeyAgreement = "keyAgreement",
-  /**
-   * KeyCertSign Usage Type.
-   */
   KeyCertSign = "keyCertSign",
-  /**
-   * CRLSign Usage Type.
-   */
   CRLSign = "cRLSign",
-  /**
-   * EncipherOnly Usage Type.
-   */
   EncipherOnly = "encipherOnly",
-  /**
-   * DecipherOnly Usage Type.
-   */
   DecipherOnly = "decipherOnly"
 }
 

--- a/sdk/keyvault/keyvault-certificates/src/index.ts
+++ b/sdk/keyvault/keyvault-certificates/src/index.ts
@@ -80,7 +80,10 @@ import {
   CertificateClientOptions,
   LATEST_API_VERSION,
   CancelCertificateOperationOptions,
-  ImportCertificatePolicy
+  ImportCertificatePolicy,
+  KnownCertificateKeyCurveNames,
+  KnownCertificateKeyTypes,
+  KnownKeyUsageTypes
 } from "./certificatesModels";
 
 import {
@@ -98,12 +101,9 @@ import {
   ActionType,
   DeletionRecoveryLevel,
   JsonWebKeyType as CertificateKeyType,
-  KnownJsonWebKeyType as KnownCertificateKeyTypes,
   JsonWebKeyCurveName as CertificateKeyCurveName,
-  KnownJsonWebKeyCurveName as KnownCertificateKeyCurveNames,
   KnownDeletionRecoveryLevel as KnownDeletionRecoveryLevels,
-  KeyUsageType,
-  KnownKeyUsageType as KnownKeyUsageTypes
+  KeyUsageType
 } from "./generated/models";
 import { KeyVaultClient } from "./generated/keyVaultClient";
 import { SDK_VERSION } from "./constants";

--- a/sdk/keyvault/keyvault-certificates/swagger/README.md
+++ b/sdk/keyvault/keyvault-certificates/swagger/README.md
@@ -18,5 +18,5 @@ input-file: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/7a42f16
 output-folder: ../
 source-code-folder-path: ./src/generated
 hide-clients: true
-package-version: 4.3.1
+package-version: 4.4.0-beta.1
 ```

--- a/sdk/keyvault/keyvault-certificates/swagger/README.md
+++ b/sdk/keyvault/keyvault-certificates/swagger/README.md
@@ -14,7 +14,7 @@ azure-arm: false
 generate-metadata: false
 add-credentials: false
 license-header: MICROSOFT_MIT_NO_VERSION
-input-file: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/1e2c9f3ec93078da8078389941531359e274f32a/specification/keyvault/data-plane/Microsoft.KeyVault/stable/7.2/certificates.json
+input-file: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/7a42f16c75e5005c59b75fe7f0888c1103294d43/specification/keyvault/data-plane/Microsoft.KeyVault/preview/7.3-preview/certificates.json
 output-folder: ../
 source-code-folder-path: ./src/generated
 hide-clients: true

--- a/sdk/keyvault/keyvault-secrets/CHANGELOG.md
+++ b/sdk/keyvault/keyvault-secrets/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 4.3.1 (Unreleased)
+## 4.4.0-beta.1 (Unreleased)
 
 ### Features Added
 
@@ -9,6 +9,8 @@
 ### Bugs Fixed
 
 ### Other Changes
+
+- Updated the latest service version to 7.3.
 
 ## 4.3.0 (2021-07-29)
 

--- a/sdk/keyvault/keyvault-secrets/package.json
+++ b/sdk/keyvault/keyvault-secrets/package.json
@@ -2,7 +2,7 @@
   "name": "@azure/keyvault-secrets",
   "sdk-type": "client",
   "author": "Microsoft Corporation",
-  "version": "4.3.1",
+  "version": "4.4.0-beta.1",
   "license": "MIT",
   "description": "Isomorphic client library for Azure KeyVault's secrets.",
   "homepage": "https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/keyvault/keyvault-secrets/README.md",

--- a/sdk/keyvault/keyvault-secrets/src/constants.ts
+++ b/sdk/keyvault/keyvault-secrets/src/constants.ts
@@ -1,4 +1,4 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-export const SDK_VERSION: string = "4.3.1";
+export const SDK_VERSION: string = "4.4.0-beta.1";

--- a/sdk/keyvault/keyvault-secrets/src/generated/keyVaultClient.ts
+++ b/sdk/keyvault/keyvault-secrets/src/generated/keyVaultClient.ts
@@ -12,7 +12,7 @@ import * as Mappers from "./models/mappers";
 import { KeyVaultClientContext } from "./keyVaultClientContext";
 import {
   KeyVaultClientOptionalParams,
-  ApiVersion72Preview,
+  ApiVersion73Preview,
   KeyVaultClientSetSecretOptionalParams,
   KeyVaultClientSetSecretResponse,
   KeyVaultClientDeleteSecretResponse,
@@ -45,7 +45,7 @@ export class KeyVaultClient extends KeyVaultClientContext {
    * @param options The parameter options
    */
   constructor(
-    apiVersion: ApiVersion72Preview,
+    apiVersion: ApiVersion73Preview,
     options?: KeyVaultClientOptionalParams
   ) {
     super(apiVersion, options);

--- a/sdk/keyvault/keyvault-secrets/src/generated/keyVaultClientContext.ts
+++ b/sdk/keyvault/keyvault-secrets/src/generated/keyVaultClientContext.ts
@@ -7,21 +7,24 @@
  */
 
 import * as coreHttp from "@azure/core-http";
-import { ApiVersion72Preview, KeyVaultClientOptionalParams } from "./models";
+import { ApiVersion73Preview, KeyVaultClientOptionalParams } from "./models";
 
 const packageName = "@azure/keyvault-secrets";
 export const packageVersion = "4.3.1";
 
 /** @hidden */
 export class KeyVaultClientContext extends coreHttp.ServiceClient {
-  apiVersion: ApiVersion72Preview;
+  apiVersion: ApiVersion73Preview;
 
   /**
    * Initializes a new instance of the KeyVaultClientContext class.
    * @param apiVersion Api Version
    * @param options The parameter options
    */
-  constructor(apiVersion: ApiVersion72Preview, options?: KeyVaultClientOptionalParams) {
+  constructor(
+    apiVersion: ApiVersion73Preview,
+    options?: KeyVaultClientOptionalParams
+  ) {
     if (apiVersion === undefined) {
       throw new Error("'apiVersion' cannot be null");
     }

--- a/sdk/keyvault/keyvault-secrets/src/generated/keyVaultClientContext.ts
+++ b/sdk/keyvault/keyvault-secrets/src/generated/keyVaultClientContext.ts
@@ -10,7 +10,7 @@ import * as coreHttp from "@azure/core-http";
 import { ApiVersion73Preview, KeyVaultClientOptionalParams } from "./models";
 
 const packageName = "@azure/keyvault-secrets";
-export const packageVersion = "4.3.1";
+export const packageVersion = "4.4.0-beta.1";
 
 /** @hidden */
 export class KeyVaultClientContext extends coreHttp.ServiceClient {

--- a/sdk/keyvault/keyvault-secrets/src/generated/models/index.ts
+++ b/sdk/keyvault/keyvault-secrets/src/generated/models/index.ts
@@ -70,7 +70,7 @@ export interface KeyVaultError {
    * The key vault server error.
    * NOTE: This property will not be serialized. It can only be populated by the server.
    */
-  readonly error?: ErrorModel;
+  readonly error?: ErrorModel | null;
 }
 
 /** The key vault server error. */
@@ -89,7 +89,7 @@ export interface ErrorModel {
    * The key vault server error.
    * NOTE: This property will not be serialized. It can only be populated by the server.
    */
-  readonly innerError?: ErrorModel;
+  readonly innerError?: ErrorModel | null;
 }
 
 /** The secret update parameters. */
@@ -214,20 +214,20 @@ export type DeletedSecretItem = SecretItem & {
   readonly deletedDate?: Date;
 };
 
-/** Known values of {@link ApiVersion72Preview} that the service accepts. */
-export const enum KnownApiVersion72Preview {
-  /** Api Version '7.2-preview' */
-  Seven2Preview = "7.2-preview"
+/** Known values of {@link ApiVersion73Preview} that the service accepts. */
+export const enum KnownApiVersion73Preview {
+  /** Api Version '7.3-preview' */
+  Seven3Preview = "7.3-preview"
 }
 
 /**
- * Defines values for ApiVersion72Preview. \
- * {@link KnownApiVersion72Preview} can be used interchangeably with ApiVersion72Preview,
+ * Defines values for ApiVersion73Preview. \
+ * {@link KnownApiVersion73Preview} can be used interchangeably with ApiVersion73Preview,
  *  this enum contains the known values that the service supports.
  * ### Know values supported by the service
- * **7.2-preview**: Api Version '7.2-preview'
+ * **7.3-preview**: Api Version '7.3-preview'
  */
-export type ApiVersion72Preview = string;
+export type ApiVersion73Preview = string;
 
 /** Known values of {@link DeletionRecoveryLevel} that the service accepts. */
 export const enum KnownDeletionRecoveryLevel {

--- a/sdk/keyvault/keyvault-secrets/swagger/README.md
+++ b/sdk/keyvault/keyvault-secrets/swagger/README.md
@@ -18,5 +18,5 @@ input-file: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/7a42f16
 output-folder: ../
 source-code-folder-path: ./src/generated
 hide-clients: true
-package-version: 4.3.1
+package-version: 4.4.0-beta.1
 ```

--- a/sdk/keyvault/keyvault-secrets/swagger/README.md
+++ b/sdk/keyvault/keyvault-secrets/swagger/README.md
@@ -14,7 +14,7 @@ azure-arm: false
 generate-metadata: false
 add-credentials: false
 license-header: MICROSOFT_MIT_NO_VERSION
-input-file: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/1e2c9f3ec93078da8078389941531359e274f32a/specification/keyvault/data-plane/Microsoft.KeyVault/stable/7.2/secrets.json
+input-file: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/7a42f16c75e5005c59b75fe7f0888c1103294d43/specification/keyvault/data-plane/Microsoft.KeyVault/preview/7.3-preview/secrets.json
 output-folder: ../
 source-code-folder-path: ./src/generated
 hide-clients: true


### PR DESCRIPTION
## What

- Regenerate certificates and secrets against the 7.3-preview swagger
- Update certificate and secrets package versions to beta of next minor

## Why

Although there are no changes in these packages, we should still offer support and default to the latest swagger version which 
will be 7.3. 

Since we'll be GAing in October, it makes sense to have a beta in September.