### PR TITLE
[Identity] Update after Hotfix 1.5.2: Enabling insecure connection requests on the Arc MSI

### DIFF
--- a/sdk/identity/identity/CHANGELOG.md
+++ b/sdk/identity/identity/CHANGELOG.md
@@ -13,7 +13,7 @@
 ### Bugs Fixed
 
 - `ClientSecretCredential`, `ClientCertificateCredential` and `UsernamePasswordCredential` now throw if the required parameters are not provided (even in JavaScript).
-- **Included fix from v1.5.2:** Fixed a bug introduced on 1.5.0 that caused the `ManagedIdentityCredential` to fail authenticating in Arc environments. Since our new core disables unsafe requests by default, we had to change the security settings for the first request of the Arc MSI, which retrieves the file path where the authentication value is stored since this request generally happens through an HTTP endpoint.
+- Fixed a bug introduced on 2.0.0-beta.5 that caused the `ManagedIdentityCredential` to fail authenticating in Arc environments. Since our new core disables unsafe requests by default, we had to change the security settings for the first request of the Arc MSI, which retrieves the file path where the authentication value is stored since this request generally happens through an HTTP endpoint.
 
 ### Other Changes
 

--- a/sdk/identity/identity/CHANGELOG.md
+++ b/sdk/identity/identity/CHANGELOG.md
@@ -35,6 +35,10 @@
 
 - With this release, we've migrated from using `@azure/core-http` to `@azure/core-rest-pipeline` for the handling of HTTP requests. See [Azure Core v1 vs v2](https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/core/core-rest-pipeline/documentation/core2.md) for more on the difference and benefits of the move. This removes our dependency on `node-fetch` and along with it issues we have seen in using this dependency in specific environments like Kubernetes pods.
 
+## 1.5.2 (2021-09-01)
+
+- Fixed a bug introduced on 1.5.0 that caused the `ManagedIdentityCredential` to fail authenticating in Arc environments. Since our new core disables unsafe requests by default, we had to change the security settings for the first request of the Arc MSI, which retrieves the file path where the authentication value is stored since this request generally happens through an HTTP endpoint.
+
 ## 1.5.1 (2021-08-12)
 
 - Fixed how we verify the IMDS endpoint is available. Now, besides skipping the `Metadata` header, we skip the URL query. Both will ensure that all the known IMDS endpoints return as early as possible.

--- a/sdk/identity/identity/CHANGELOG.md
+++ b/sdk/identity/identity/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### Bugs Fixed
 
 - `ClientSecretCredential`, `ClientCertificateCredential` and `UsernamePasswordCredential` now throw if the required parameters are not provided (even in JavaScript).
+- **Included fix from v1.5.2:** Fixed a bug introduced on 1.5.0 that caused the `ManagedIdentityCredential` to fail authenticating in Arc environments. Since our new core disables unsafe requests by default, we had to change the security settings for the first request of the Arc MSI, which retrieves the file path where the authentication value is stored since this request generally happens through an HTTP endpoint.
 
 ### Other Changes
 

--- a/sdk/identity/identity/src/credentials/managedIdentityCredential/arcMsi.ts
+++ b/sdk/identity/identity/src/credentials/managedIdentityCredential/arcMsi.ts
@@ -107,7 +107,8 @@ export const arcMsi: MSI = {
       disableJsonStringifyOnBody: true,
       deserializationMapper: undefined,
       abortSignal: getTokenOptions.abortSignal,
-      ...prepareRequestOptions(resource)
+      ...prepareRequestOptions(resource),
+      allowInsecureConnection: true
     };
 
     const filePath = await filePathRequest(identityClient, requestOptions);

--- a/sdk/identity/identity/test/internal/node/managedIdentityCredential.spec.ts
+++ b/sdk/identity/identity/test/internal/node/managedIdentityCredential.spec.ts
@@ -372,8 +372,8 @@ describe("ManagedIdentityCredential", function() {
   it("sends an authorization request correctly in an Azure Arc environment", async function() {
     // Trigger Azure Arc behavior by setting environment variables
 
-    process.env.IMDS_ENDPOINT = "https://endpoint";
-    process.env.IDENTITY_ENDPOINT = "https://endpoint";
+    process.env.IMDS_ENDPOINT = "http://endpoint";
+    process.env.IDENTITY_ENDPOINT = "http://endpoint";
 
     // eslint-disable-next-line @typescript-eslint/no-invalid-this
     const testTitle = this.test?.title || `test-Date.time()`;
@@ -386,7 +386,7 @@ describe("ManagedIdentityCredential", function() {
       const authDetails = await sendCredentialRequests({
         scopes: ["https://service/.default"],
         credential: new ManagedIdentityCredential(),
-        secureResponses: [
+        insecureResponses: [
           createResponse(
             401,
             {},


### PR DESCRIPTION
This PR does the same as the hotfix PR: https://github.com/Azure/azure-sdk-for-js/pull/17362

Thinks look a bit different because the tests are a bit different from that version to this version, but the behavior is the same. If we undo the source fix but keep the test changes, the related test will fail.

Reviews appreciated 👍 