### PR TITLE
[Text Analytics] Make project and deployment names required

### DIFF
--- a/sdk/textanalytics/ai-text-analytics/review/ai-text-analytics.api.md
+++ b/sdk/textanalytics/ai-text-analytics/review/ai-text-analytics.api.md
@@ -248,8 +248,8 @@ export interface CustomRecongizeEntitiesActionSuccessResult extends TextAnalytic
 // @public
 export interface CustomTextAnalyticsAction {
     actionName?: string;
-    deploymentName?: string;
-    projectName?: string;
+    deploymentName: string;
+    projectName: string;
 }
 
 // @public

--- a/sdk/textanalytics/ai-text-analytics/src/generated/models/index.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/generated/models/index.ts
@@ -122,8 +122,8 @@ export interface CustomEntitiesTask {
 }
 
 export interface CustomEntitiesTaskParameters {
-  projectName?: string;
-  deploymentName?: string;
+  projectName: string;
+  deploymentName: string;
   loggingOptOut?: boolean;
   stringIndexType?: StringIndexType;
 }
@@ -133,8 +133,8 @@ export interface CustomSingleClassificationTask {
 }
 
 export interface CustomSingleClassificationTaskParameters {
-  projectName?: string;
-  deploymentName?: string;
+  projectName: string;
+  deploymentName: string;
   loggingOptOut?: boolean;
 }
 
@@ -143,8 +143,8 @@ export interface CustomMultiClassificationTask {
 }
 
 export interface CustomMultiClassificationTaskParameters {
-  projectName?: string;
-  deploymentName?: string;
+  projectName: string;
+  deploymentName: string;
   loggingOptOut?: boolean;
 }
 

--- a/sdk/textanalytics/ai-text-analytics/src/generated/models/mappers.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/generated/models/mappers.ts
@@ -552,12 +552,14 @@ export const CustomEntitiesTaskParameters: coreClient.CompositeMapper = {
     modelProperties: {
       projectName: {
         serializedName: "projectName",
+        required: true,
         type: {
           name: "String"
         }
       },
       deploymentName: {
         serializedName: "deploymentName",
+        required: true,
         type: {
           name: "String"
         }
@@ -602,12 +604,14 @@ export const CustomSingleClassificationTaskParameters: coreClient.CompositeMappe
     modelProperties: {
       projectName: {
         serializedName: "projectName",
+        required: true,
         type: {
           name: "String"
         }
       },
       deploymentName: {
         serializedName: "deploymentName",
+        required: true,
         type: {
           name: "String"
         }
@@ -646,12 +650,14 @@ export const CustomMultiClassificationTaskParameters: coreClient.CompositeMapper
     modelProperties: {
       projectName: {
         serializedName: "projectName",
+        required: true,
         type: {
           name: "String"
         }
       },
       deploymentName: {
         serializedName: "deploymentName",
+        required: true,
         type: {
           name: "String"
         }

--- a/sdk/textanalytics/ai-text-analytics/src/textAnalyticsAction.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/textAnalyticsAction.ts
@@ -24,12 +24,12 @@ export interface CustomTextAnalyticsAction {
    * The project name for the text analytics model used by this operation on this
    * batch of input documents.
    */
-  projectName?: string;
+  projectName: string;
   /**
    * The deployment name for the text analytics model used by this operation on this
    * batch of input documents.
    */
-  deploymentName?: string;
+  deploymentName: string;
   /**
    * The preferred name for this action.
    */

--- a/sdk/textanalytics/ai-text-analytics/swagger/README.md
+++ b/sdk/textanalytics/ai-text-analytics/swagger/README.md
@@ -12,7 +12,7 @@ generate-metadata: false
 license-header: MICROSOFT_MIT_NO_VERSION
 output-folder: ../
 source-code-folder-path: ./src/generated
-input-file: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/c46283d507bc79eddc6b5f89f6663ee907bd30de/specification/cognitiveservices/data-plane/TextAnalytics/preview/v3.2-preview.2/TextAnalytics.json
+input-file: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/5efb2eca2fc3d94f27015f5d3176786c7497f946/specification/cognitiveservices/data-plane/TextAnalytics/preview/v3.2-preview.2/TextAnalytics.json
 add-credentials: false
 package-version: 5.2.0-beta.2
 v3: true


### PR DESCRIPTION
After regenerating with latest version of the swagger in https://github.com/Azure/azure-rest-api-specs/pull/15736