### PR TITLE
[Identity] Hotfix 1.5.2 - Updated the user agent

### DIFF
--- a/sdk/identity/identity/src/client/identityClient.ts
+++ b/sdk/identity/identity/src/client/identityClient.ts
@@ -77,7 +77,7 @@ export class IdentityClient extends ServiceClient implements INetworkModule {
   public authorityHost: string;
 
   constructor(options?: TokenCredentialOptions) {
-    const packageDetails = `azsdk-js-identity/1.5.0`;
+    const packageDetails = `azsdk-js-identity/1.5.2`;
     const userAgentPrefix = options?.userAgentOptions?.userAgentPrefix
       ? `${options.userAgentOptions.userAgentPrefix} ${packageDetails}`
       : `${packageDetails}`;


### PR DESCRIPTION
I’m too used to the automated checks :) we missed the user agent update on 1.5.1. I’m making sure we don’t miss this for 1.5.2