### PR TITLE
[INTERNAL] Refactors: Bumps API version to 2020-07-15

### DIFF
--- a/sdk/cosmosdb/cosmos/src/common/constants.ts
+++ b/sdk/cosmosdb/cosmos/src/common/constants.ts
@@ -176,7 +176,7 @@ export const Constants = {
   ThrottleRetryCount: "x-ms-throttle-retry-count",
   ThrottleRetryWaitTimeInMs: "x-ms-throttle-retry-wait-time-ms",
 
-  CurrentVersion: "2018-12-31",
+  CurrentVersion: "2020-07-15",
 
   SDKName: "azure-cosmos-js",
   SDKVersion: "REPLACE_SDK_VERSION",


### PR DESCRIPTION
This change introduces code to change the internal cosmosdb api version used to 2020-07-15. This change adds support for subpartitioning container operations.