### PR TITLE
[schema-regitry-avro] deserialize supports Blob

### DIFF
--- a/sdk/schemaregistry/schema-registry-avro/package.json
+++ b/sdk/schemaregistry/schema-registry-avro/package.json
@@ -5,8 +5,10 @@
   "sdk-type": "client",
   "main": "dist/index.js",
   "module": "dist-esm/src/index.js",
-  "browser": {},
-  "types": "types/schema-registry-avro.d.ts",
+  "browser": {
+    "./dist-esm/src/utils/buffer.js": "./dist-esm/src/utils/buffer.browser.js"
+  },
+  "types": "schema-registry-avro.shims.d.ts",
   "scripts": {
     "audit": "node ../../../common/scripts/rush-audit.js && rimraf node_modules package-lock.json && npm i --package-lock-only 2>&1 && npm audit",
     "build:browser": "tsc -p . && cross-env ONLY_BROWSER=true rollup -c 2>&1",
@@ -37,6 +39,7 @@
     "dist/",
     "dist-esm/src/",
     "types/schema-registry-avro.d.ts",
+    "schema-registry-avro.shims.d.ts",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/schemaregistry/schema-registry-avro/review/schema-registry-avro.api.md
+++ b/sdk/schemaregistry/schema-registry-avro/review/schema-registry-avro.api.md
@@ -9,7 +9,7 @@ import { SchemaRegistry } from '@azure/schema-registry';
 // @public
 export class SchemaRegistryAvroSerializer {
     constructor(client: SchemaRegistry, groupName: string, options?: SchemaRegistryAvroSerializerOptions);
-    deserialize(buffer: Buffer): Promise<unknown>;
+    deserialize(input: Buffer | Blob | Uint8Array): Promise<unknown>;
     serialize(value: unknown, schema: string): Promise<Buffer>;
 }
 

--- a/sdk/schemaregistry/schema-registry-avro/schema-registry-avro.shims.d.ts
+++ b/sdk/schemaregistry/schema-registry-avro/schema-registry-avro.shims.d.ts
@@ -5,4 +5,4 @@ declare global {
   interface Blob {}
 }
 
-export * from "./types/latest/schema-registry-avro";
+export * from "./types/schema-registry-avro";

--- a/sdk/schemaregistry/schema-registry-avro/schema-registry-avro.shims.d.ts
+++ b/sdk/schemaregistry/schema-registry-avro/schema-registry-avro.shims.d.ts
@@ -1,0 +1,8 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+declare global {
+  interface Blob {}
+}
+
+export * from "./types/latest/schema-registry-avro";

--- a/sdk/schemaregistry/schema-registry-avro/src/schemaRegistryAvroSerializer.ts
+++ b/sdk/schemaregistry/schema-registry-avro/src/schemaRegistryAvroSerializer.ts
@@ -133,7 +133,7 @@ export class SchemaRegistryAvroSerializer {
    */
   async deserialize(input: Buffer | Blob | Uint8Array): Promise<unknown> {
     const arr8 = await toUint8Array(input);
-    const buffer = Buffer.from(arr8);
+    const buffer = Buffer.isBuffer(arr8) ? arr8 : Buffer.from(arr8);
     if (buffer.length < PAYLOAD_OFFSET) {
       throw new RangeError("Buffer is too small to have the correct format.");
     }

--- a/sdk/schemaregistry/schema-registry-avro/src/schemaRegistryAvroSerializer.ts
+++ b/sdk/schemaregistry/schema-registry-avro/src/schemaRegistryAvroSerializer.ts
@@ -3,6 +3,7 @@
 
 import { SchemaRegistry } from "@azure/schema-registry";
 import * as avro from "avsc";
+import { toUint8Array } from "./utils/buffer";
 
 // REVIEW: This should go in to a shared doc somewhere that all of the different
 //         language serializer's docs can reference.
@@ -130,7 +131,9 @@ export class SchemaRegistryAvroSerializer {
    * @param buffer - The buffer with the serialized value.
    * @returns The deserialized value.
    */
-  async deserialize(buffer: Buffer): Promise<unknown> {
+  async deserialize(input: Buffer | Blob | Uint8Array): Promise<unknown> {
+    const arr8 = await toUint8Array(input);
+    const buffer = Buffer.from(arr8);
     if (buffer.length < PAYLOAD_OFFSET) {
       throw new RangeError("Buffer is too small to have the correct format.");
     }

--- a/sdk/schemaregistry/schema-registry-avro/src/utils/buffer.browser.ts
+++ b/sdk/schemaregistry/schema-registry-avro/src/utils/buffer.browser.ts
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+async function blobToArrayBuffer(blob: Blob): Promise<ArrayBuffer> {
+  if ("arrayBuffer" in blob) {
+    return blob.arrayBuffer();
+  }
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result as ArrayBuffer);
+    reader.onerror = () => reject;
+    reader.readAsArrayBuffer(blob);
+  });
+}
+
+/**
+ * @param input - Input to `deserialize`.
+ * @returns Promise which completes with the input data as a Uint8Array.
+ */
+export async function toUint8Array(input: Uint8Array | Buffer | Blob): Promise<Uint8Array> {
+  // If this is not a Uint8Array, assume it's a blob and retrieve an ArrayBuffer from the blob.
+  if ((input as any).byteLength === undefined) {
+    return new Uint8Array(await blobToArrayBuffer(input as Blob));
+  }
+  return input as Uint8Array;
+}

--- a/sdk/schemaregistry/schema-registry-avro/src/utils/buffer.ts
+++ b/sdk/schemaregistry/schema-registry-avro/src/utils/buffer.ts
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+/**
+ * @param input - Input to `deserialize`.
+ * @returns Promise which completes with the input data as a Uint8Array.
+ */
+export async function toUint8Array(input: Uint8Array | Buffer | Blob): Promise<Uint8Array> {
+  if ((input as any).byteLength === undefined) {
+    throw TypeError("Blob is unsupported in node.");
+  }
+  return input as Uint8Array;
+}

--- a/sdk/schemaregistry/schema-registry-avro/tsconfig.json
+++ b/sdk/schemaregistry/schema-registry-avro/tsconfig.json
@@ -5,7 +5,8 @@
     "declarationDir": "./types",
     "paths": {
       "@azure/schema-registry-avro": ["./src/index"]
-    }
+    },
+    "lib": ["dom"]
   },
   "include": ["src/**/*.ts", "test/**/*.ts", "samples-dev/**/*.ts"]
 }


### PR DESCRIPTION
`deserialize` took only `Buffer` as input before and this PR makes it also support browser's `Blob` and `Uint8Array`.