### PR TITLE
[core-tracing] upgrade the api extractor version

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -9884,7 +9884,7 @@ packages:
     version: 0.0.0
   file:projects/core-tracing.tgz:
     dependencies:
-      '@microsoft/api-extractor': 7.7.11
+      '@microsoft/api-extractor': 7.13.2
       '@opentelemetry/api': 1.0.2
       '@opentelemetry/tracing': 0.22.0_@opentelemetry+api@1.0.2
       '@types/chai': 4.2.21
@@ -9919,7 +9919,7 @@ packages:
     dev: false
     name: '@rush-temp/core-tracing'
     resolution:
-      integrity: sha512-hjSwB3OLU9ukMINsZaZWCTbo94TiJjihe2mLVuIWmd5x1kT9gTL0n9JmcToqc0WKJ1s3Ek8CieRv51HqlEHzFw==
+      integrity: sha512-AW43H+9Zu/SnTYm6LuFW3fpbdygkhHOOQ1CArVUfKED76xVq8pn99yjGkZYIMxVvHPrLwIkkHP2XNECfvmnDtg==
       tarball: file:projects/core-tracing.tgz
     version: 0.0.0
   file:projects/core-util.tgz:

--- a/sdk/core/core-tracing/package.json
+++ b/sdk/core/core-tracing/package.json
@@ -64,7 +64,7 @@
     "@azure/core-auth": "^1.3.0",
     "@azure/dev-tool": "^1.0.0",
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "7.13.2",
     "@opentelemetry/tracing": "^0.22.0",
     "@types/chai": "^4.1.6",
     "@types/mocha": "^7.0.2",

--- a/sdk/core/core-tracing/review/core-tracing.api.md
+++ b/sdk/core/core-tracing/review/core-tracing.api.md
@@ -12,7 +12,9 @@ export interface Context {
 }
 
 // @public
-export const context: ContextAPI;
+const context_2: ContextAPI;
+
+export { context_2 as context }
 
 // @public
 export interface ContextAPI {


### PR DESCRIPTION
To work with re-exporting of OTel definitions that use recent TS features. 