### PR TITLE
[Cosmos] Bump core-rest-pipeline version

### DIFF
--- a/sdk/cosmosdb/cosmos/CHANGELOG.md
+++ b/sdk/cosmosdb/cosmos/CHANGELOG.md
@@ -1,14 +1,10 @@
 # Release History
 
-## 3.14.1 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
+## 3.14.1 (2021-09-02)
 
 ### Bugs Fixed
 
-### Other Changes
+- Fix @azure/core-rest-pipeline version for AAD auth.
 
 ## 3.14.0 (2021-09-01)
 

--- a/sdk/cosmosdb/cosmos/package.json
+++ b/sdk/cosmosdb/cosmos/package.json
@@ -86,7 +86,7 @@
   },
   "dependencies": {
     "@azure/core-auth": "^1.3.0",
-    "@azure/core-rest-pipeline": "^1.1.0",
+    "@azure/core-rest-pipeline": "^1.2.0",
     "debug": "^4.1.1",
     "fast-json-stable-stringify": "^2.1.0",
     "jsbi": "^3.1.3",


### PR DESCRIPTION
I'm unsure how this went through with ^1.1.0 when it's missing challengeCallbacks, I had bumped it but incidentally must have checked in an old package.json