### PR TITLE
Increment version after release of core-http

### DIFF
--- a/sdk/core/core-http/CHANGELOG.md
+++ b/sdk/core/core-http/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Release History
 
+## 2.2.1 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
+
 ## 2.2.0 (2021-09-02)
 
 ### Bugs Fixed

--- a/sdk/core/core-http/package.json
+++ b/sdk/core/core-http/package.json
@@ -2,7 +2,7 @@
   "name": "@azure/core-http",
   "sdk-type": "client",
   "author": "Microsoft Corporation",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Isomorphic client Runtime for Typescript/node.js/browser javascript client libraries generated using AutoRest",
   "tags": [
     "isomorphic",

--- a/sdk/core/core-http/src/util/constants.ts
+++ b/sdk/core/core-http/src/util/constants.ts
@@ -5,7 +5,7 @@ export const Constants = {
   /**
    * The core-http version
    */
-  coreHttpVersion: "2.2.0",
+  coreHttpVersion: "2.2.1",
 
   /**
    * Specifies HTTP.


### PR DESCRIPTION
Unfortunately the [automation build](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1077922&view=logs&j=e48a6a5a-3932-594b-dbbd-1adab0f233bc&t=3f58f8b2-03ca-5a9d-677f-c6fa3fac06c6) failed 
due to an error in the Update samples step. 

I manually ran the command `node ./eng/tools/versioning/increment.js --artifact-name azure-core-http --repo-root .` 