### PR TITLE
Remove unused dependency on proxy-agent

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -121,7 +121,7 @@ packages:
   /@azure-rest/core-client-paging/1.0.0-beta.1:
     dependencies:
       '@azure-rest/core-client': 1.0.0-beta.6
-      '@azure/core-paging': 1.1.3
+      '@azure/core-paging': 1.2.0
       '@azure/core-rest-pipeline': 1.2.0
       tslib: 2.3.1
     dev: false
@@ -152,7 +152,7 @@ packages:
       '@azure/core-auth': 1.3.2
       '@azure/core-http': 1.2.6
       '@azure/core-lro': 1.0.5
-      '@azure/core-paging': 1.1.3
+      '@azure/core-paging': 1.2.0
       '@azure/core-tracing': 1.0.0-preview.11
       '@azure/logger': 1.0.2
       tslib: 2.3.1
@@ -166,7 +166,7 @@ packages:
       '@azure/core-auth': 1.3.2
       '@azure/core-http': 1.2.6
       '@azure/core-lro': 1.0.5
-      '@azure/core-paging': 1.1.3
+      '@azure/core-paging': 1.2.0
       '@azure/core-tracing': 1.0.0-preview.9
       '@azure/logger': 1.0.2
       '@opentelemetry/api': 0.10.2
@@ -183,7 +183,7 @@ packages:
       '@azure/core-auth': 1.3.2
       '@azure/core-client': 1.3.0
       '@azure/core-lro': 2.2.0
-      '@azure/core-paging': 1.1.3
+      '@azure/core-paging': 1.2.0
       '@azure/core-rest-pipeline': 1.2.0
       '@azure/core-tracing': 1.0.0-preview.12
       '@azure/logger': 1.0.2
@@ -235,7 +235,7 @@ packages:
       '@azure/core-auth': 1.3.2
       '@azure/core-http': 1.2.6
       '@azure/core-lro': 1.0.5
-      '@azure/core-paging': 1.1.3
+      '@azure/core-paging': 1.2.0
       '@azure/core-tracing': 1.0.0-preview.10
       '@azure/logger': 1.0.2
       '@opentelemetry/api': 0.10.2
@@ -374,14 +374,15 @@ packages:
       node: '>=12.0.0'
     resolution:
       integrity: sha512-TJo95eNT1dwYOPCb0m1C2zyxVlHuRRkKGeg9TKu8XMF2qh4v6c1weD63r9RVIrLdHdnSqS0n6PTXBpWoB8NqMw==
-  /@azure/core-paging/1.1.3:
+  /@azure/core-paging/1.2.0:
     dependencies:
       '@azure/core-asynciterator-polyfill': 1.0.0
+      tslib: 2.3.1
     dev: false
     engines:
-      node: '>=8.0.0'
+      node: '>=12.0.0'
     resolution:
-      integrity: sha512-his7Ah40ThEYORSpIAwuh6B8wkGwO/zG7gqVtmSE4WAJ46e36zUDXTKReUCLBDc6HmjjApQQxxcRFy5FruG79A==
+      integrity: sha512-ZX1bCjm/MjKPCN6kQD/9GJErYSoKA8YWp6YWoo5EIzcTWlSBLXu3gNaBTUl8usGl+UShiKo7b4Gdy1NSTIlpZg==
   /@azure/core-rest-pipeline/1.2.0:
     dependencies:
       '@azure/abort-controller': 1.0.4
@@ -420,7 +421,7 @@ packages:
       integrity: sha512-frF0pJc9HTmKncVokhBxCqipjbql02DThQ1ZJ9wLi7SDMLdPAFyDI5xZNzX5guLz+/DtPkY+SGK2li9FIXqshQ==
   /@azure/core-tracing/1.0.0-preview.12:
     dependencies:
-      '@opentelemetry/api': 1.0.2
+      '@opentelemetry/api': 1.0.3
       tslib: 2.3.1
     dev: false
     engines:
@@ -429,7 +430,7 @@ packages:
       integrity: sha512-nvo2Wc4EKZGN6eFu9n3U7OXmASmL8VxoPIH7xaD6OlQqi44bouF0YIi9ID5rEsKLiAU59IYx6M297nqWVMWPDg==
   /@azure/core-tracing/1.0.0-preview.13:
     dependencies:
-      '@opentelemetry/api': 1.0.2
+      '@opentelemetry/api': 1.0.3
       tslib: 2.3.1
     dev: false
     engines:
@@ -470,7 +471,7 @@ packages:
       integrity: sha512-CxaMaEjwtsmIhWtjHyGimKO7RmES0YxPqGQ9+jKqGygNlhG5NYHktDaiQu6w7k3g+I51VaLXtVSt+BVFd6VWfQ==
   /@azure/identity/1.2.5_debug@4.3.2:
     dependencies:
-      '@azure/core-http': 1.2.6
+      '@azure/core-http': 1.2.3
       '@azure/core-tracing': 1.0.0-preview.9
       '@azure/logger': 1.0.2
       '@azure/msal-node': 1.0.0-beta.6_debug@4.3.2
@@ -494,7 +495,7 @@ packages:
       debug: '*'
     resolution:
       integrity: sha512-Q71Buur3RMcg6lCnisLL8Im562DBw+ybzgm+YQj/FbAaI8ZNu/zl/5z1fE4k3Q9LSIzYrz6HLRzlhdSBXpydlQ==
-  /@azure/identity/1.5.1:
+  /@azure/identity/1.5.2:
     dependencies:
       '@azure/core-auth': 1.3.2
       '@azure/core-client': 1.3.0
@@ -518,8 +519,8 @@ packages:
     optionalDependencies:
       keytar: 7.7.0
     resolution:
-      integrity: sha512-ENYdcHT72PwEb+aiL2G6WIXxdm8mO0LNLZVPXaSRZYNsIshre72MF1H/rnJvcVGX9uVDVClSbNPxXwY5MJPLjw==
-  /@azure/identity/1.5.1_debug@4.3.2:
+      integrity: sha512-vqyeRbd2i0h9F4mqW5JbkP1xfabqKQ21l/81osKhpOQ2LtwaJW6nw4+0PsVYnxcbPHFCIZt6EWAk74a3OGYZJA==
+  /@azure/identity/1.5.2_debug@4.3.2:
     dependencies:
       '@azure/core-auth': 1.3.2
       '@azure/core-client': 1.3.0
@@ -545,7 +546,7 @@ packages:
     peerDependencies:
       debug: '*'
     resolution:
-      integrity: sha512-ENYdcHT72PwEb+aiL2G6WIXxdm8mO0LNLZVPXaSRZYNsIshre72MF1H/rnJvcVGX9uVDVClSbNPxXwY5MJPLjw==
+      integrity: sha512-vqyeRbd2i0h9F4mqW5JbkP1xfabqKQ21l/81osKhpOQ2LtwaJW6nw4+0PsVYnxcbPHFCIZt6EWAk74a3OGYZJA==
   /@azure/identity/2.0.0-beta.5:
     dependencies:
       '@azure/abort-controller': 1.0.4
@@ -576,7 +577,7 @@ packages:
       '@azure/abort-controller': 1.0.4
       '@azure/core-http': 2.1.0
       '@azure/core-lro': 2.2.0
-      '@azure/core-paging': 1.1.3
+      '@azure/core-paging': 1.2.0
       '@azure/core-tracing': 1.0.0-preview.13
       '@azure/logger': 1.0.2
       tslib: 2.3.1
@@ -590,7 +591,7 @@ packages:
       '@azure/abort-controller': 1.0.4
       '@azure/core-http': 2.1.0
       '@azure/core-lro': 2.2.0
-      '@azure/core-paging': 1.1.3
+      '@azure/core-paging': 1.2.0
       '@azure/core-tracing': 1.0.0-preview.13
       '@azure/logger': 1.0.2
       tslib: 2.3.1
@@ -604,7 +605,7 @@ packages:
       '@azure/abort-controller': 1.0.4
       '@azure/core-http': 2.1.0
       '@azure/core-lro': 2.2.0
-      '@azure/core-paging': 1.1.3
+      '@azure/core-paging': 1.2.0
       '@azure/core-tracing': 1.0.0-preview.13
       '@azure/logger': 1.0.2
       tslib: 2.3.1
@@ -630,11 +631,11 @@ packages:
   /@azure/monitor-opentelemetry-exporter/1.0.0-beta.4:
     dependencies:
       '@azure/core-http': 2.1.0
-      '@opentelemetry/api': 1.0.2
-      '@opentelemetry/core': 0.22.0_@opentelemetry+api@1.0.2
-      '@opentelemetry/resources': 0.22.0_@opentelemetry+api@1.0.2
+      '@opentelemetry/api': 1.0.3
+      '@opentelemetry/core': 0.22.0_@opentelemetry+api@1.0.3
+      '@opentelemetry/resources': 0.22.0_@opentelemetry+api@1.0.3
       '@opentelemetry/semantic-conventions': 0.22.0
-      '@opentelemetry/tracing': 0.22.0_@opentelemetry+api@1.0.2
+      '@opentelemetry/tracing': 0.22.0_@opentelemetry+api@1.0.3
       tslib: 2.3.1
     dev: false
     engines:
@@ -773,7 +774,7 @@ packages:
       '@azure/abort-controller': 1.0.4
       '@azure/core-http': 2.1.0
       '@azure/core-lro': 2.2.0
-      '@azure/core-paging': 1.1.3
+      '@azure/core-paging': 1.2.0
       '@azure/core-tracing': 1.0.0-preview.13
       '@azure/logger': 1.0.2
       events: 3.3.0
@@ -1165,9 +1166,9 @@ packages:
       node: '>=6.0'
     resolution:
       integrity: sha512-xB+w7ZDAu3YBzqH44rCmG9/RlrOmFuDPt/bpf17eJr8eZSrLt7nc7LnWdxM9Mmoj/YKMHpxRg28txu3TcpiL+g==
-  /@opentelemetry/api-metrics/0.22.0_@opentelemetry+api@1.0.2:
+  /@opentelemetry/api-metrics/0.22.0_@opentelemetry+api@1.0.3:
     dependencies:
-      '@opentelemetry/api': 1.0.2
+      '@opentelemetry/api': 1.0.3
     dev: false
     engines:
       node: '>=8.0.0'
@@ -1189,15 +1190,15 @@ packages:
       node: '>=8.0.0'
     resolution:
       integrity: sha512-iXKByCMfrlO5S6Oh97BuM56tM2cIBB0XsL/vWF/AtJrJEKx4MC/Xdu0xDsGXMGcNWpqF7ujMsjjnp0+UHBwnDQ==
-  /@opentelemetry/api/1.0.2:
+  /@opentelemetry/api/1.0.3:
     dev: false
     engines:
       node: '>=8.0.0'
     resolution:
-      integrity: sha512-DCF9oC89ao8/EJUqrp/beBlDR8Bp2R43jqtzayqCoomIvkwTuPfLcHdVhIGRR69GFlkykFjcDW+V92t0AS7Tww==
-  /@opentelemetry/context-async-hooks/0.22.0_@opentelemetry+api@1.0.2:
+      integrity: sha512-puWxACExDe9nxbBB3lOymQFrLYml2dVOrd7USiVRnSbgXE+KwBu+HxFvxrzfqsiSda9IWsXJG1ef7C1O2/GmKQ==
+  /@opentelemetry/context-async-hooks/0.22.0_@opentelemetry+api@1.0.3:
     dependencies:
-      '@opentelemetry/api': 1.0.2
+      '@opentelemetry/api': 1.0.3
     dev: false
     engines:
       node: '>=8.1.0'
@@ -1211,9 +1212,9 @@ packages:
       node: '>=8.0.0'
     resolution:
       integrity: sha512-hZNKjKOYsckoOEgBziGMnBcX0M7EtstnCmwz5jZUOUYwlZ+/xxX6z3jPu1XVO2Jivk0eLfuP9GP+vFD49CMetw==
-  /@opentelemetry/core/0.22.0_@opentelemetry+api@1.0.2:
+  /@opentelemetry/core/0.22.0_@opentelemetry+api@1.0.3:
     dependencies:
-      '@opentelemetry/api': 1.0.2
+      '@opentelemetry/api': 1.0.3
       '@opentelemetry/semantic-conventions': 0.22.0
       semver: 7.3.5
     dev: false
@@ -1223,11 +1224,11 @@ packages:
       '@opentelemetry/api': ^1.0.0
     resolution:
       integrity: sha512-x6JxuQ4rY2x39GEXJSqMgyf8XZPNNiZrGcCMhZSrtypq/WXlsJuxMNnUAl2hj2rpSGGukhhWn5cMpCmMJJz1hw==
-  /@opentelemetry/instrumentation-http/0.22.0_@opentelemetry+api@1.0.2:
+  /@opentelemetry/instrumentation-http/0.22.0_@opentelemetry+api@1.0.3:
     dependencies:
-      '@opentelemetry/api': 1.0.2
-      '@opentelemetry/core': 0.22.0_@opentelemetry+api@1.0.2
-      '@opentelemetry/instrumentation': 0.22.0_@opentelemetry+api@1.0.2
+      '@opentelemetry/api': 1.0.3
+      '@opentelemetry/core': 0.22.0_@opentelemetry+api@1.0.3
+      '@opentelemetry/instrumentation': 0.22.0_@opentelemetry+api@1.0.3
       '@opentelemetry/semantic-conventions': 0.22.0
       semver: 7.3.5
     dev: false
@@ -1237,10 +1238,10 @@ packages:
       '@opentelemetry/api': ^1.0.0
     resolution:
       integrity: sha512-vqM1hqgYtcO8Upq8pl4I+YW0bnodHlUSSKYuOH7m9Aujbi571pU3zFctpiU5pNhj9eLEJ/r7aOTV6O4hCxqOjQ==
-  /@opentelemetry/instrumentation/0.22.0_@opentelemetry+api@1.0.2:
+  /@opentelemetry/instrumentation/0.22.0_@opentelemetry+api@1.0.3:
     dependencies:
-      '@opentelemetry/api': 1.0.2
-      '@opentelemetry/api-metrics': 0.22.0_@opentelemetry+api@1.0.2
+      '@opentelemetry/api': 1.0.3
+      '@opentelemetry/api-metrics': 0.22.0_@opentelemetry+api@1.0.3
       require-in-the-middle: 5.1.0
       semver: 7.3.5
       shimmer: 1.2.1
@@ -1249,14 +1250,14 @@ packages:
       '@opentelemetry/api': ^1.0.0
     resolution:
       integrity: sha512-/NT3+mZO9Bll6UZPjqemrD2VhkI7wRrMto884+wKGK8LIC+EKlg5EKk9y9ym4Vtnlis8/hVxNrFSeaS29N2NLw==
-  /@opentelemetry/node/0.22.0_@opentelemetry+api@1.0.2:
+  /@opentelemetry/node/0.22.0_@opentelemetry+api@1.0.3:
     dependencies:
-      '@opentelemetry/api': 1.0.2
-      '@opentelemetry/context-async-hooks': 0.22.0_@opentelemetry+api@1.0.2
-      '@opentelemetry/core': 0.22.0_@opentelemetry+api@1.0.2
-      '@opentelemetry/propagator-b3': 0.22.0_@opentelemetry+api@1.0.2
-      '@opentelemetry/propagator-jaeger': 0.22.0_@opentelemetry+api@1.0.2
-      '@opentelemetry/tracing': 0.22.0_@opentelemetry+api@1.0.2
+      '@opentelemetry/api': 1.0.3
+      '@opentelemetry/context-async-hooks': 0.22.0_@opentelemetry+api@1.0.3
+      '@opentelemetry/core': 0.22.0_@opentelemetry+api@1.0.3
+      '@opentelemetry/propagator-b3': 0.22.0_@opentelemetry+api@1.0.3
+      '@opentelemetry/propagator-jaeger': 0.22.0_@opentelemetry+api@1.0.3
+      '@opentelemetry/tracing': 0.22.0_@opentelemetry+api@1.0.3
       semver: 7.3.5
     dev: false
     engines:
@@ -1265,10 +1266,10 @@ packages:
       '@opentelemetry/api': ^1.0.0
     resolution:
       integrity: sha512-+HhGbDruQ7cwejVOIYyxRa28uosnG8W95NiQZ6qE8PXXPsDSyGeftAPbtYpGit0H2f5hrVcMlwmWHeAo9xkSLA==
-  /@opentelemetry/propagator-b3/0.22.0_@opentelemetry+api@1.0.2:
+  /@opentelemetry/propagator-b3/0.22.0_@opentelemetry+api@1.0.3:
     dependencies:
-      '@opentelemetry/api': 1.0.2
-      '@opentelemetry/core': 0.22.0_@opentelemetry+api@1.0.2
+      '@opentelemetry/api': 1.0.3
+      '@opentelemetry/core': 0.22.0_@opentelemetry+api@1.0.3
     dev: false
     engines:
       node: '>=8.0.0'
@@ -1276,10 +1277,10 @@ packages:
       '@opentelemetry/api': ^1.0.0
     resolution:
       integrity: sha512-7UESJWUUmInXrlux9whSjoIMfpmajKbu2UBU/ux7TVkLTeaJwebLHoqDhuUTS4dbmvg3fnkpfmocyUgby16NwQ==
-  /@opentelemetry/propagator-jaeger/0.22.0_@opentelemetry+api@1.0.2:
+  /@opentelemetry/propagator-jaeger/0.22.0_@opentelemetry+api@1.0.3:
     dependencies:
-      '@opentelemetry/api': 1.0.2
-      '@opentelemetry/core': 0.22.0_@opentelemetry+api@1.0.2
+      '@opentelemetry/api': 1.0.3
+      '@opentelemetry/core': 0.22.0_@opentelemetry+api@1.0.3
     dev: false
     engines:
       node: '>=8.5.0'
@@ -1287,10 +1288,10 @@ packages:
       '@opentelemetry/api': ^1.0.0
     resolution:
       integrity: sha512-Xclq+eLfc0Zk1UAbY6clYjoCZqikk4SzvG8C/ODJ6LfDHnqMr/fKXaHHhh/DdHdi6d73o9S8ytblryc+CaTkrw==
-  /@opentelemetry/resources/0.22.0_@opentelemetry+api@1.0.2:
+  /@opentelemetry/resources/0.22.0_@opentelemetry+api@1.0.3:
     dependencies:
-      '@opentelemetry/api': 1.0.2
-      '@opentelemetry/core': 0.22.0_@opentelemetry+api@1.0.2
+      '@opentelemetry/api': 1.0.3
+      '@opentelemetry/core': 0.22.0_@opentelemetry+api@1.0.3
       '@opentelemetry/semantic-conventions': 0.22.0
     dev: false
     engines:
@@ -1305,11 +1306,11 @@ packages:
       node: '>=8.0.0'
     resolution:
       integrity: sha512-t4fKikazahwNKmwD+CE/icHyuZldWvNMupJhjxdk9T/KxHFx3zCGjHT3MKavwYP6abzgAAm5WwzD1oHlmj7dyg==
-  /@opentelemetry/tracing/0.22.0_@opentelemetry+api@1.0.2:
+  /@opentelemetry/tracing/0.22.0_@opentelemetry+api@1.0.3:
     dependencies:
-      '@opentelemetry/api': 1.0.2
-      '@opentelemetry/core': 0.22.0_@opentelemetry+api@1.0.2
-      '@opentelemetry/resources': 0.22.0_@opentelemetry+api@1.0.2
+      '@opentelemetry/api': 1.0.3
+      '@opentelemetry/core': 0.22.0_@opentelemetry+api@1.0.3
+      '@opentelemetry/resources': 0.22.0_@opentelemetry+api@1.0.3
       '@opentelemetry/semantic-conventions': 0.22.0
       lodash.merge: 4.6.2
     dev: false
@@ -1498,7 +1499,7 @@ packages:
   /@types/body-parser/1.19.1:
     dependencies:
       '@types/connect': 3.4.35
-      '@types/node': 12.20.21
+      '@types/node': 12.20.23
     dev: false
     resolution:
       integrity: sha512-a6bTJ21vFOGIkwM0kzh9Yr89ziVxq4vYH2fQ6N8AeipEzai/cFK6aGMArIkUeIdRIgpwQa+2bXiLuUJCpSf2Cg==
@@ -1524,7 +1525,7 @@ packages:
       integrity: sha512-bsjleuRKWmGqajMerkzox19aGbscQX5rmmvvXl3wlIp5gMG1HgkiwPxsN5p070fBDKTNSPgojVbuY1+HWMbFhg==
   /@types/connect/3.4.35:
     dependencies:
-      '@types/node': 12.20.21
+      '@types/node': 12.20.23
     dev: false
     resolution:
       integrity: sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==
@@ -1559,7 +1560,7 @@ packages:
       integrity: sha512-C6N5s2ZFtuZRj54k2/zyRhNDjJwwcViAM3Nbm8zjBpbqAdZ00mr0CFxvSKeO8Y/e03WVFLpQMdHYVfUd6SB+Hw==
   /@types/express-serve-static-core/4.17.24:
     dependencies:
-      '@types/node': 12.20.21
+      '@types/node': 12.20.23
       '@types/qs': 6.9.7
       '@types/range-parser': 1.2.4
     dev: false
@@ -1576,20 +1577,20 @@ packages:
       integrity: sha512-6bSZTPaTIACxn48l50SR+axgrqm6qXFIxrdAKaG6PaJk3+zuUr35hBlgT7vOmJcum+OEaIBLtHV/qloEAFITeA==
   /@types/fs-extra/8.1.2:
     dependencies:
-      '@types/node': 12.20.21
+      '@types/node': 12.20.23
     dev: false
     resolution:
       integrity: sha512-SvSrYXfWSc7R4eqnOzbQF4TZmfpNSM9FrSWLU3EUnWBuyZqNBOrv1B1JA3byUDPUl9z4Ab3jeZG2eDdySlgNMg==
   /@types/glob/7.1.4:
     dependencies:
       '@types/minimatch': 3.0.5
-      '@types/node': 12.20.21
+      '@types/node': 12.20.23
     dev: false
     resolution:
       integrity: sha512-w+LsMxKyYQm347Otw+IfBXOv9UWVjpHpCDdbBMt8Kz/xbvCYNjP+0qPh91Km3iKfSRLBB0P7fAMf0KHrPu+MyA==
   /@types/is-buffer/2.0.0:
     dependencies:
-      '@types/node': 12.20.21
+      '@types/node': 12.20.23
     dev: false
     resolution:
       integrity: sha512-0f7N/e3BAz32qDYvgB4d2cqv1DqUwvGxHkXsrucICn8la1Vb6Yl6Eg8mPScGwUiqHJeE7diXlzaK+QMA9m4Gxw==
@@ -1603,13 +1604,13 @@ packages:
       integrity: sha1-7ihweulOEdK4J7y+UnC86n8+ce4=
   /@types/jsonwebtoken/8.5.5:
     dependencies:
-      '@types/node': 12.20.21
+      '@types/node': 12.20.23
     dev: false
     resolution:
       integrity: sha512-OGqtHQ7N5/Ap/TUwO6IgHDuLiAoTmHhGpNvgkCm/F4N6pKzx/RBSfr2OXZSwC6vkfnsEdb6+7DNZVtiXiwdwFw==
   /@types/jws/3.2.4:
     dependencies:
-      '@types/node': 12.20.21
+      '@types/node': 12.20.23
     dev: false
     resolution:
       integrity: sha512-aqtH4dPw1wUjFZaeMD1ak/pf8iXlu/odFe+trJrvw0g1sTh93i+SCykg0Ek8C6B7rVK3oBORbfZAsKO7P10etg==
@@ -1623,7 +1624,7 @@ packages:
       integrity: sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w==
   /@types/md5/2.3.1:
     dependencies:
-      '@types/node': 12.20.21
+      '@types/node': 12.20.23
     dev: false
     resolution:
       integrity: sha512-OK3oe+ALIoPSo262lnhAYwpqFNXbiwH2a+0+Z5YBnkQEwWD8fk5+PIeRhYA48PzvX9I4SGNpWy+9bLj8qz92RQ==
@@ -1649,13 +1650,13 @@ packages:
       integrity: sha512-ZvO2tAcjmMi8V/5Z3JsyofMe3hasRcaw88cto5etSVMwVQfeivGAlEYmaQgceUSVYFofVjT+ioHsATjdWcFt1w==
   /@types/mock-fs/4.10.0:
     dependencies:
-      '@types/node': 12.20.21
+      '@types/node': 12.20.23
     dev: false
     resolution:
       integrity: sha512-FQ5alSzmHMmliqcL36JqIA4Yyn9jyJKvRSGV3mvPh108VFatX7naJDzSG4fnFQNZFq9dIx0Dzoe6ddflMB2Xkg==
   /@types/mock-require/2.0.0:
     dependencies:
-      '@types/node': 12.20.21
+      '@types/node': 12.20.23
     dev: false
     resolution:
       integrity: sha512-nOgjoE5bBiDeiA+z41i95makyHUSMWQMOPocP+J67Pqx/68HAXaeWN1NFtrAYYV6LrISIZZ8vKHm/a50k0f6Sg==
@@ -1669,7 +1670,7 @@ packages:
       integrity: sha512-DPxmjiDwubsNmguG5X4fEJ+XCyzWM3GXWsqQlvUcjJKa91IOoJUy51meDr0GkzK64qqNcq85ymLlyjoct9tInw==
   /@types/node-fetch/2.5.12:
     dependencies:
-      '@types/node': 12.20.21
+      '@types/node': 12.20.23
       form-data: 3.0.1
     dev: false
     resolution:
@@ -1678,10 +1679,10 @@ packages:
     dev: false
     resolution:
       integrity: sha512-pMCcqU2zT4TjqYFrWtYHKal7Sl30Ims6ulZ4UFXxI4xbtQqK/qqKwkDoBFCfooRqqmRu9vY3xaJRwxSh673aYg==
-  /@types/node/12.20.21:
+  /@types/node/12.20.23:
     dev: false
     resolution:
-      integrity: sha512-Qk7rOvV2A4vNgXNS88vEvbJE1NDFPCQ8AU+pNElrU2bA4yrRDef3fg3SUe+xkwyin3Bpg/Xh5JkNWTlsOcS2tA==
+      integrity: sha512-FW0q7NI8UnjbKrJK8NGr6QXY69ATw9IFe6ItIo5yozPwA9DU/xkhiPddctUVyrmFXvyFYerYgQak/qu200UBDw==
   /@types/node/8.10.66:
     dev: false
     resolution:
@@ -1704,7 +1705,7 @@ packages:
       integrity: sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==
   /@types/resolve/1.17.1:
     dependencies:
-      '@types/node': 12.20.21
+      '@types/node': 12.20.23
     dev: false
     resolution:
       integrity: sha512-yy7HuzQhj0dhGpD8RLXSZWEkLsV9ibvxvi6EiJ3bkqLAO1RGo0WbkWQiwpRlSFymTJRz0d3k5LM3kkx8ArDbLw==
@@ -1715,7 +1716,7 @@ packages:
   /@types/serve-static/1.13.10:
     dependencies:
       '@types/mime': 1.3.2
-      '@types/node': 12.20.21
+      '@types/node': 12.20.23
     dev: false
     resolution:
       integrity: sha512-nCkHGI4w7ZgAdNkrEu0bv+4xNV/XDqW+DydknebMOQwkpDGx8G+HTlj7R7ABI8i8nKxVw0wtKPi1D+lPOkh4YQ==
@@ -1731,7 +1732,7 @@ packages:
       integrity: sha512-E1dU4fzC9wN2QK2Cr1MLCfyHM8BoNnRFvuf45LYMPNDA+WqbNzC45S4UzPxvp1fFJ1rvSGU0bPvdd35VLmXG8g==
   /@types/stoppable/1.1.1:
     dependencies:
-      '@types/node': 12.20.21
+      '@types/node': 12.20.23
     dev: false
     resolution:
       integrity: sha512-b8N+fCADRIYYrGZOcmOR8ZNBOqhktWTB/bMUl5LvGtT201QKJZOOH5UsFyI3qtteM6ZAJbJqZoBcLqqxKIwjhw==
@@ -1741,13 +1742,13 @@ packages:
       integrity: sha512-Y0K95ThC3esLEYD6ZuqNek29lNX2EM1qxV8y2FTLUB0ff5wWrk7az+mLrnNFUnaXcgKye22+sFBRXOgpPILZNg==
   /@types/tunnel/0.0.1:
     dependencies:
-      '@types/node': 12.20.21
+      '@types/node': 12.20.23
     dev: false
     resolution:
       integrity: sha512-AOqu6bQu5MSWwYvehMXLukFHnupHrpZ8nvgae5Ggie9UwzDR1CCwoXgSSWNZJuyOlCdfdsWMA5F2LlmvyoTv8A==
   /@types/tunnel/0.0.3:
     dependencies:
-      '@types/node': 12.20.21
+      '@types/node': 12.20.23
     dev: false
     resolution:
       integrity: sha512-sOUTGn6h1SfQ+gbgqC364jLFBw2lnFqkgF3q0WovEHRLMrVD1sd5aufqi/aJObLekJO+Aq5z646U4Oxy6shXMA==
@@ -1761,19 +1762,19 @@ packages:
       integrity: sha512-Y2mHTRAbqfFkpjldbkHGY8JIzRN6XqYRliG8/24FcHm2D2PwW24fl5xMRTVGdrb7iMrwCaIEbLWerGIkXuFWVg==
   /@types/ws/7.4.7:
     dependencies:
-      '@types/node': 12.20.21
+      '@types/node': 12.20.23
     dev: false
     resolution:
       integrity: sha512-JQbbmxZTZehdc2iszGKs5oC3NFnjeay7mtAWrdt7qNtAVK0g19muApzAy4bm9byz79xa2ZnO/BOBC2R8RC5Lww==
   /@types/xml2js/0.4.9:
     dependencies:
-      '@types/node': 12.20.21
+      '@types/node': 12.20.23
     dev: false
     resolution:
       integrity: sha512-CHiCKIihl1pychwR2RNX5mAYmJDACgFVCMT5OArMaO3erzwXVcBqPcusr+Vl8yeeXukxZqtF8mZioqX+mpjjdw==
   /@types/yauzl/2.9.2:
     dependencies:
-      '@types/node': 12.20.21
+      '@types/node': 12.20.23
     dev: false
     optional: true
     resolution:
@@ -2040,13 +2041,15 @@ packages:
     dev: false
     resolution:
       integrity: sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=
-  /are-we-there-yet/1.1.5:
+  /are-we-there-yet/1.1.6:
     dependencies:
       delegates: 1.0.0
-      readable-stream: 2.3.7
+      readable-stream: 3.6.0
     dev: false
+    engines:
+      node: '>=10'
     resolution:
-      integrity: sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==
+      integrity: sha512-+1byPnimWdGcKFRS48zG73nxM08kamPFReUYvEmRXI3E8E4YhF4voMRDaGlfGD1UeRHEgs4NhQCE28KI8JVj1A==
   /arg/4.1.3:
     dev: false
     resolution:
@@ -2122,14 +2125,6 @@ packages:
     dev: false
     resolution:
       integrity: sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==
-  /ast-types/0.13.4:
-    dependencies:
-      tslib: 2.3.1
-    dev: false
-    engines:
-      node: '>=4'
-    resolution:
-      integrity: sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==
   /astral-regex/2.0.0:
     dev: false
     engines:
@@ -2171,12 +2166,12 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
-  /available-typed-arrays/1.0.4:
+  /available-typed-arrays/1.0.5:
     dev: false
     engines:
       node: '>= 0.4'
     resolution:
-      integrity: sha512-SA5mXJWrId1TaQjfxUYghbqQ/hYioKmLJvPJyDuYRtXXenFNMjj4hSSt1Cf1xsuXSXrtxrVC5Ot4eU6cOtBDdA==
+      integrity: sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==
   /avsc/5.7.3:
     dev: false
     engines:
@@ -2387,7 +2382,7 @@ packages:
     dependencies:
       caniuse-lite: 1.0.30001252
       colorette: 1.3.0
-      electron-to-chromium: 1.3.822
+      electron-to-chromium: 1.3.827
       escalade: 3.1.1
       node-releases: 1.1.75
     dev: false
@@ -2756,15 +2751,19 @@ packages:
     requiresBuild: true
     resolution:
       integrity: sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==
-  /core-js/3.16.4:
+  /core-js/3.17.1:
     dev: false
     requiresBuild: true
     resolution:
-      integrity: sha512-Tq4GVE6XCjE+hcyW6hPy0ofN3hwtLudz5ZRdrlCnsnD/xkm/PWQRudzYHiKgZKUcefV6Q57fhDHjZHJP5dpfSg==
+      integrity: sha512-C8i/FNpVN2Ti89QIJcFn9ZQmnM+HaAQr2OpE+ja3TRM9Q34FigsGlAVuwPGkIgydSVClo/1l1D1grP8LVt9IYA==
   /core-util-is/1.0.2:
     dev: false
     resolution:
       integrity: sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=
+  /core-util-is/1.0.3:
+    dev: false
+    resolution:
+      integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==
   /cors/2.8.5:
     dependencies:
       object-assign: 4.1.1
@@ -2850,12 +2849,6 @@ packages:
       node: '>=0.10'
     resolution:
       integrity: sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=
-  /data-uri-to-buffer/3.0.1:
-    dev: false
-    engines:
-      node: '>= 6'
-    resolution:
-      integrity: sha512-WboRycPNsVw3B3TL559F7kuBUM4d8CgMEvk6xEJlOp7OBPjt6G7z8WMWlD2rOFZLk6OYfFIUGsCOWzcQH9K2og==
   /date-format/2.1.0:
     dev: false
     engines:
@@ -2886,7 +2879,7 @@ packages:
       integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
   /debug/3.2.6:
     dependencies:
-      ms: 2.1.3
+      ms: 2.1.1
     deprecated: Debug versions >=3.2.0 <3.2.7 || >=4 <4.3.1 have a low-severity ReDos regression when used in a Node.js environment. It is recommended you upgrade to 3.2.7 or 4.3.1. (https://github.com/visionmedia/debug/issues/797)
     dev: false
     resolution:
@@ -2994,16 +2987,6 @@ packages:
       node: '>= 0.4'
     resolution:
       integrity: sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==
-  /degenerator/2.2.0:
-    dependencies:
-      ast-types: 0.13.4
-      escodegen: 1.14.3
-      esprima: 4.0.1
-    dev: false
-    engines:
-      node: '>= 6'
-    resolution:
-      integrity: sha512-aiQcQowF01RxFI4ZLFMpzyotbQonhNpBao6dkI8JPk5a+hmSjR5ErHp2CQySmQe8os3VBqLCIh87nDBgZXvsmg==
   /delay/4.4.1:
     dev: false
     engines:
@@ -3139,10 +3122,10 @@ packages:
     dev: false
     resolution:
       integrity: sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=
-  /electron-to-chromium/1.3.822:
+  /electron-to-chromium/1.3.827:
     dev: false
     resolution:
-      integrity: sha512-k7jG5oYYHxF4jx6PcqwHX3JVME/OjzolqOZiIogi9xtsfsmTjTdie4x88OakYFPEa8euciTgCCzvVNwvmjHb1Q==
+      integrity: sha512-ye+4uQOY/jbjRutMcE/EmOcNwUeo1qo9aKL2tPyb09cU3lmxNeyDF4RWiemmkknW+p29h7dyDqy02higTxc9/A==
   /emoji-regex/7.0.3:
     dev: false
     resolution:
@@ -3273,20 +3256,6 @@ packages:
       node: '>=10'
     resolution:
       integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==
-  /escodegen/1.14.3:
-    dependencies:
-      esprima: 4.0.1
-      estraverse: 4.3.0
-      esutils: 2.0.3
-      optionator: 0.8.3
-    dev: false
-    engines:
-      node: '>=4.0'
-    hasBin: true
-    optionalDependencies:
-      source-map: 0.6.1
-    resolution:
-      integrity: sha512-qFcX0XJkdg+PB3xjZZG/wKSuT1PnQWx57+TVSjIMmILd2yC/6ByYElPwJnslDsuWuSAp4AwJGumarAAmJch5Kw==
   /eslint-config-prettier/7.2.0_eslint@7.32.0:
     dependencies:
       eslint: 7.32.0
@@ -3682,7 +3651,7 @@ packages:
     dependencies:
       '@babel/core': 7.15.0
       '@babel/runtime': 7.15.3
-      core-js: 3.16.4
+      core-js: 3.17.1
       debug: 4.3.2
       glob-to-regexp: 0.4.1
       is-subset: 0.1.1
@@ -3713,12 +3682,6 @@ packages:
     dev: false
     resolution:
       integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==
-  /file-uri-to-path/2.0.0:
-    dev: false
-    engines:
-      node: '>= 6'
-    resolution:
-      integrity: sha512-hjPFI8oE/2iQPVe4gbrJ73Pp+Xfub2+WI2LlXDbsaJBwT5wuMh35WNWVYYTpnz895shtwfyutMFLFywpQAFdLg==
   /fill-range/7.0.1:
     dependencies:
       to-regex-range: 5.0.1
@@ -3955,15 +3918,6 @@ packages:
       - darwin
     resolution:
       integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
-  /ftp/0.3.10:
-    dependencies:
-      readable-stream: 1.1.14
-      xregexp: 2.0.0
-    dev: false
-    engines:
-      node: '>=0.8.0'
-    resolution:
-      integrity: sha1-kZfYYa2BQvPmPVqDv+TFn3MwiF0=
   /function-bind/1.1.1:
     dev: false
     resolution:
@@ -4027,19 +3981,6 @@ packages:
       node: '>=10'
     resolution:
       integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==
-  /get-uri/3.0.2:
-    dependencies:
-      '@tootallnate/once': 1.1.2
-      data-uri-to-buffer: 3.0.1
-      debug: 4.3.2
-      file-uri-to-path: 2.0.0
-      fs-extra: 8.1.0
-      ftp: 0.3.10
-    dev: false
-    engines:
-      node: '>= 6'
-    resolution:
-      integrity: sha512-+5s0SJbGoyiJTZZ2JTpFPLMPSch72KEqGOTvQsBqg0RBWvwhWUSYZFAtz3TPW0GXJuLBJPts1E241iHg+VRfhg==
   /getos/3.2.1:
     dependencies:
       async: 3.2.1
@@ -4471,10 +4412,6 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk=
-  /ip/1.1.5:
-    dev: false
-    resolution:
-      integrity: sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=
   /ipaddr.js/1.9.1:
     dev: false
     engines:
@@ -4682,9 +4619,9 @@ packages:
       node: '>= 0.4'
     resolution:
       integrity: sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==
-  /is-typed-array/1.1.7:
+  /is-typed-array/1.1.8:
     dependencies:
-      available-typed-arrays: 1.0.4
+      available-typed-arrays: 1.0.5
       call-bind: 1.0.2
       es-abstract: 1.18.5
       foreach: 2.0.5
@@ -4693,7 +4630,7 @@ packages:
     engines:
       node: '>= 0.4'
     resolution:
-      integrity: sha512-VxlpTBGknhQ3o7YiVjIhdLU6+oD8dPz/79vvvH4F+S/c8608UCVa9fgDpa1kZgFoUST2DCgacc70UszKgzKuvA==
+      integrity: sha512-HqH41TNZq2fgtGT8WHVFVJhBVGuY3AnP3Q36K8JKXUxSxRgk/d+7NjmwG2vo2mYmXK8UYZKu0qH8bVP5gEisjA==
   /is-typedarray/1.0.0:
     dev: false
     resolution:
@@ -5248,15 +5185,6 @@ packages:
       node: '> 0.8'
     resolution:
       integrity: sha1-eZllXoZGwX8In90YfRUNMyTVRRM=
-  /levn/0.3.0:
-    dependencies:
-      prelude-ls: 1.1.2
-      type-check: 0.3.2
-    dev: false
-    engines:
-      node: '>= 0.8.0'
-    resolution:
-      integrity: sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=
   /levn/0.4.1:
     dependencies:
       prelude-ls: 1.2.1
@@ -5402,12 +5330,6 @@ packages:
     dev: false
     resolution:
       integrity: sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==
-  /lru-cache/5.1.1:
-    dependencies:
-      yallist: 3.1.1
-    dev: false
-    resolution:
-      integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==
   /lru-cache/6.0.0:
     dependencies:
       yallist: 4.0.0
@@ -5734,12 +5656,6 @@ packages:
     dev: false
     resolution:
       integrity: sha512-AO81vsIO1k1sM4Zrd6Hu7regmJN1NSiAja10gc4bX3F0wd+9rQmcuHQaHVQCYIEC8iFXnE+mavh23GOt7wBgug==
-  /netmask/2.0.2:
-    dev: false
-    engines:
-      node: '>= 0.4.0'
-    resolution:
-      integrity: sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==
   /nice-try/1.0.5:
     dev: false
     resolution:
@@ -5765,12 +5681,12 @@ packages:
       node: '>= 10.13'
     resolution:
       integrity: sha512-QNb/j8kbFnKCiyqi9C5DD0jH/FubFGj5rt9NQFONXwQm3IPB0CULECg/eS3AU1KgZb/6SwUa4/DTRKhVxkGABw==
-  /node-abi/2.30.0:
+  /node-abi/2.30.1:
     dependencies:
       semver: 5.7.1
     dev: false
     resolution:
-      integrity: sha512-g6bZh3YCKQRdwuO/tSZZYJAw622SjsRfJ2X0Iy4sSOHZ34/sPPdVBn8fev2tj7njzLwuqPw9uMtGsGkO5kIQvg==
+      integrity: sha512-/2D0wOQPgaUWzVSVgRMx+trKJRC2UG4SUc4oCJoXx9Uxjtp0Vy3/kt7zcbxHF8+Z/pK3UloLWzBISg72brfy1w==
   /node-abort-controller/1.2.1:
     dev: false
     resolution:
@@ -5846,7 +5762,7 @@ packages:
       integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==
   /npmlog/4.1.2:
     dependencies:
-      are-we-there-yet: 1.1.5
+      are-we-there-yet: 1.1.6
       console-control-strings: 1.1.0
       gauge: 2.7.4
       set-blocking: 2.0.0
@@ -5985,19 +5901,6 @@ packages:
       node: '>=8'
     resolution:
       integrity: sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==
-  /optionator/0.8.3:
-    dependencies:
-      deep-is: 0.1.3
-      fast-levenshtein: 2.0.6
-      levn: 0.3.0
-      prelude-ls: 1.1.2
-      type-check: 0.3.2
-      word-wrap: 1.2.3
-    dev: false
-    engines:
-      node: '>= 0.8.0'
-    resolution:
-      integrity: sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==
   /optionator/0.9.1:
     dependencies:
       deep-is: 0.1.3
@@ -6069,32 +5972,6 @@ packages:
       node: '>=6'
     resolution:
       integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==
-  /pac-proxy-agent/4.1.0:
-    dependencies:
-      '@tootallnate/once': 1.1.2
-      agent-base: 6.0.2
-      debug: 4.3.2
-      get-uri: 3.0.2
-      http-proxy-agent: 4.0.1
-      https-proxy-agent: 5.0.0
-      pac-resolver: 4.2.0
-      raw-body: 2.4.1
-      socks-proxy-agent: 5.0.1
-    dev: false
-    engines:
-      node: '>= 6'
-    resolution:
-      integrity: sha512-ejNgYm2HTXSIYX9eFlkvqFp8hyJ374uDf0Zq5YUAifiSh1D6fo+iBivQZirGvVv8dCYUsLhmLBRhlAYvBKI5+Q==
-  /pac-resolver/4.2.0:
-    dependencies:
-      degenerator: 2.2.0
-      ip: 1.1.5
-      netmask: 2.0.2
-    dev: false
-    engines:
-      node: '>= 6'
-    resolution:
-      integrity: sha512-rPACZdUyuxT5Io/gFKUeeZFfE5T7ve7cAkE5TUZRRfuKP0u5Hocwe48X7ZEm6mYB+bTB0Qf+xlVlA/RM/i6RCQ==
   /package-hash/3.0.0:
     dependencies:
       graceful-fs: 4.2.8
@@ -6284,7 +6161,7 @@ packages:
       minimist: 1.2.5
       mkdirp-classic: 0.5.3
       napi-build-utils: 1.0.2
-      node-abi: 2.30.0
+      node-abi: 2.30.1
       npmlog: 4.1.2
       pump: 3.0.0
       rc: 1.2.8
@@ -6297,12 +6174,6 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-Z4vpywnK1lBg+zdPCVCsKq0xO66eEV9rWo2zrROGGiRS4JtueBOdlB1FnY8lcy7JsUud/Q3ijUxyWN26Ika0vQ==
-  /prelude-ls/1.1.2:
-    dev: false
-    engines:
-      node: '>= 0.8.0'
-    resolution:
-      integrity: sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=
   /prelude-ls/1.2.1:
     dev: false
     engines:
@@ -6374,21 +6245,6 @@ packages:
       node: '>= 0.10'
     resolution:
       integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==
-  /proxy-agent/4.0.1:
-    dependencies:
-      agent-base: 6.0.2
-      debug: 4.3.2
-      http-proxy-agent: 4.0.1
-      https-proxy-agent: 5.0.0
-      lru-cache: 5.1.1
-      pac-proxy-agent: 4.1.0
-      proxy-from-env: 1.1.0
-      socks-proxy-agent: 5.0.1
-    dev: false
-    engines:
-      node: '>=6'
-    resolution:
-      integrity: sha512-ODnQnW2jc/FUVwHHuaZEfN5otg/fMbvMxz9nMSUQfJ9JU7q2SZvSULSsjLloVgJOiv9yhc8GlNMKc4GkFmcVEA==
   /proxy-from-env/1.1.0:
     dev: false
     resolution:
@@ -6513,17 +6369,6 @@ packages:
       node: '>= 0.8'
     resolution:
       integrity: sha512-4Oz8DUIwdvoa5qMJelxipzi/iJIi40O5cGV1wNYp5hvZP8ZN0T+jiNkL0QepXs+EsQ9XJ8ipEDoiH70ySUJP3Q==
-  /raw-body/2.4.1:
-    dependencies:
-      bytes: 3.1.0
-      http-errors: 1.7.3
-      iconv-lite: 0.4.24
-      unpipe: 1.0.0
-    dev: false
-    engines:
-      node: '>= 0.8'
-    resolution:
-      integrity: sha512-9WmIKF6mkvA0SLmA2Knm9+qj89e+j1zqgyn8aXGd7+nAduPoqgI9lO57SAZNn/Byzo5P7JhXTyg9PzaJbH73bA==
   /rc/1.2.8:
     dependencies:
       deep-extend: 0.6.0
@@ -6562,18 +6407,9 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=
-  /readable-stream/1.1.14:
-    dependencies:
-      core-util-is: 1.0.2
-      inherits: 2.0.4
-      isarray: 0.0.1
-      string_decoder: 0.10.31
-    dev: false
-    resolution:
-      integrity: sha1-fPTFTvZI44EwhMY23SB54WbAgdk=
   /readable-stream/2.0.6:
     dependencies:
-      core-util-is: 1.0.2
+      core-util-is: 1.0.3
       inherits: 2.0.4
       isarray: 1.0.0
       process-nextick-args: 1.0.7
@@ -6584,7 +6420,7 @@ packages:
       integrity: sha1-j5A0HmilPMySh4jaz80Rs265t44=
   /readable-stream/2.3.7:
     dependencies:
-      core-util-is: 1.0.2
+      core-util-is: 1.0.3
       inherits: 2.0.4
       isarray: 1.0.0
       process-nextick-args: 2.0.1
@@ -6883,7 +6719,7 @@ packages:
   /rollup/1.32.1:
     dependencies:
       '@types/estree': 0.0.50
-      '@types/node': 12.20.21
+      '@types/node': 12.20.23
       acorn: 7.4.1
     dev: false
     hasBin: true
@@ -7098,13 +6934,6 @@ packages:
       node: '>=10'
     resolution:
       integrity: sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==
-  /smart-buffer/4.2.0:
-    dev: false
-    engines:
-      node: '>= 6.0.0'
-      npm: '>= 3.0.0'
-    resolution:
-      integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==
   /snap-shot-compare/3.0.0:
     dependencies:
       check-more-types: 2.24.0
@@ -7176,7 +7005,7 @@ packages:
     dependencies:
       '@types/cookie': 0.4.1
       '@types/cors': 2.8.12
-      '@types/node': 12.20.21
+      '@types/node': 12.20.23
       accepts: 1.3.7
       base64id: 2.0.0
       debug: 4.3.2
@@ -7188,26 +7017,6 @@ packages:
       node: '>=10.0.0'
     resolution:
       integrity: sha512-JubKZnTQ4Z8G4IZWtaAZSiRP3I/inpy8c/Bsx2jrwGrTbKeVU5xd6qkKMHpChYeM3dWZSO0QACiGK+obhBNwYw==
-  /socks-proxy-agent/5.0.1:
-    dependencies:
-      agent-base: 6.0.2
-      debug: 4.3.2
-      socks: 2.6.1
-    dev: false
-    engines:
-      node: '>= 6'
-    resolution:
-      integrity: sha512-vZdmnjb9a2Tz6WEQVIurybSwElwPxMZaIc7PzqbJTrezcKNznv6giT7J7tZDZ1BojVaa1jvO/UiUdhDVB0ACoQ==
-  /socks/2.6.1:
-    dependencies:
-      ip: 1.1.5
-      smart-buffer: 4.2.0
-    dev: false
-    engines:
-      node: '>= 10.13.0'
-      npm: '>= 3.0.0'
-    resolution:
-      integrity: sha512-kLQ9N5ucj8uIcxrDwjm0Jsqk06xdpBjGNQtpXy4Q8/QY2k+fY7nZH8CARy+hkbG+SGAovmzzuauCpBlb8FrnBA==
   /source-map-resolve/0.5.3:
     dependencies:
       atob: 2.1.2
@@ -7715,14 +7524,6 @@ packages:
     dev: false
     resolution:
       integrity: sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=
-  /type-check/0.3.2:
-    dependencies:
-      prelude-ls: 1.1.2
-    dev: false
-    engines:
-      node: '>= 0.8.0'
-    resolution:
-      integrity: sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=
   /type-check/0.4.0:
     dependencies:
       prelude-ls: 1.2.1
@@ -7896,9 +7697,9 @@ packages:
       inherits: 2.0.4
       is-arguments: 1.1.1
       is-generator-function: 1.0.10
-      is-typed-array: 1.1.7
+      is-typed-array: 1.1.8
       safe-buffer: 5.2.1
-      which-typed-array: 1.1.6
+      which-typed-array: 1.1.7
     dev: false
     resolution:
       integrity: sha512-bxZ9qtSlGUWSOy9Qa9Xgk11kSslpuZwaxCg4sNIDj6FLucDab2JxnHwyNTCpHMtK1MjoQiWQ6DiUMZYbSrO+Sw==
@@ -7997,19 +7798,19 @@ packages:
     dev: false
     resolution:
       integrity: sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=
-  /which-typed-array/1.1.6:
+  /which-typed-array/1.1.7:
     dependencies:
-      available-typed-arrays: 1.0.4
+      available-typed-arrays: 1.0.5
       call-bind: 1.0.2
       es-abstract: 1.18.5
       foreach: 2.0.5
       has-tostringtag: 1.0.0
-      is-typed-array: 1.1.7
+      is-typed-array: 1.1.8
     dev: false
     engines:
       node: '>= 0.4'
     resolution:
-      integrity: sha512-DdY984dGD5sQ7Tf+x1CkXzdg85b9uEel6nr4UkFg1LoE9OXv3uRuZhe5CoWdawhGACeFpEZXH8fFLQnDhbpm/Q==
+      integrity: sha512-vjxaB4nfDqwKI0ws7wZpxIlde1XrLX5uB0ZjpfshgmapJMD7jJWhZI+yToJTqaFByF0eNBcYxbjmCzoRP7CfEw==
   /which/1.3.1:
     dependencies:
       isexe: 2.0.0
@@ -8164,10 +7965,6 @@ packages:
       node: '>=0.4.0'
     resolution:
       integrity: sha512-jg+qkfS4K8E7965sqaUl8mRngXiKb3WZGfONgE18pr03FUQiuSV6G+Ej4tS55B+rIQSFEIw3phdVAQ4pPqNWfQ==
-  /xregexp/2.0.0:
-    dev: false
-    resolution:
-      integrity: sha1-UqY+VsoLhKfzpfPWGHLxJq16WUM=
   /y18n/4.0.3:
     dev: false
     resolution:
@@ -8182,10 +7979,6 @@ packages:
     dev: false
     resolution:
       integrity: sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=
-  /yallist/3.1.1:
-    dev: false
-    resolution:
-      integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==
   /yallist/4.0.0:
     dev: false
     resolution:
@@ -8277,7 +8070,7 @@ packages:
       '@microsoft/api-extractor': 7.7.11
       '@types/chai': 4.2.21
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.21
+      '@types/node': 12.20.23
       chai: 4.3.4
       cross-env: 7.0.3
       delay: 4.4.1
@@ -8312,13 +8105,12 @@ packages:
     version: 0.0.0
   file:projects/agrifood-farming.tgz:
     dependencies:
-      '@azure-rest/core-client': 1.0.0-beta.6
       '@azure-rest/core-client-paging': 1.0.0-beta.1
-      '@azure/identity': 1.5.1
+      '@azure/identity': 1.5.2
       '@microsoft/api-extractor': 7.13.2
       '@types/chai': 4.2.21
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.21
+      '@types/node': 12.20.23
       chai: 4.3.4
       cross-env: 7.0.3
       dotenv: 8.6.0
@@ -8351,7 +8143,7 @@ packages:
     dev: false
     name: '@rush-temp/agrifood-farming'
     resolution:
-      integrity: sha512-fI0ZnOU97ijUuuYLyfEmoblNdvsESeIFjLoqXElcFHbHpt3oY29P9TeOXZGkYPZWn0rqdS6ThSrwtm4whLGXhw==
+      integrity: sha512-cqKpvpFUi1vmXReL/3Kr/NFHD4h94JoyZFOQ1m+wfBVnwVOuv/43PvlE7u3zvnOf4dPqk+EvhWUWYNBrTPx/tw==
       tarball: file:projects/agrifood-farming.tgz
     version: 0.0.0
   file:projects/ai-anomaly-detector.tgz:
@@ -8365,7 +8157,7 @@ packages:
       '@rollup/plugin-replace': 2.4.2_rollup@1.32.1
       '@types/chai': 4.2.21
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.21
+      '@types/node': 12.20.23
       chai: 4.3.4
       cross-env: 7.0.3
       csv-parse: 4.16.2
@@ -8405,12 +8197,11 @@ packages:
     version: 0.0.0
   file:projects/ai-document-translator.tgz:
     dependencies:
-      '@azure-rest/core-client': 1.0.0-beta.6
-      '@azure/identity': 1.5.1
+      '@azure/identity': 1.5.2
       '@microsoft/api-extractor': 7.13.2
       '@types/chai': 4.2.21
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.21
+      '@types/node': 12.20.23
       chai: 4.3.4
       cross-env: 7.0.3
       dotenv: 8.6.0
@@ -8442,7 +8233,7 @@ packages:
     dev: false
     name: '@rush-temp/ai-document-translator'
     resolution:
-      integrity: sha512-IzEwMBXTUYe48UJSbAhbemKiVE6/y54KMHUucFE2JkGuqIBa2Ci4J6W4mrFMICX5yhweisFxOxWUF7X4P1wjHw==
+      integrity: sha512-RTnU8NxdkRVFfwo3U+Xeiq7/nhTYqqiMPhh61x4ff25/2pI9x3II0hGAJsMA1hTYKoItr8EDGrZWrVTFx7FRTA==
       tarball: file:projects/ai-document-translator.tgz
     version: 0.0.0
   file:projects/ai-form-recognizer.tgz:
@@ -8451,7 +8242,7 @@ packages:
       '@microsoft/api-extractor': 7.7.11
       '@types/chai': 4.2.21
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.21
+      '@types/node': 12.20.23
       '@types/sinon': 9.0.11
       chai: 4.3.4
       chai-as-promised: 7.1.1_chai@4.3.4
@@ -8491,11 +8282,11 @@ packages:
   file:projects/ai-metrics-advisor.tgz:
     dependencies:
       '@azure/core-tracing': 1.0.0-preview.13
-      '@azure/identity': 1.5.1
+      '@azure/identity': 1.5.2
       '@microsoft/api-extractor': 7.7.11
       '@types/chai': 4.2.21
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.21
+      '@types/node': 12.20.23
       '@types/sinon': 9.0.11
       chai: 4.3.4
       chai-as-promised: 7.1.1_chai@4.3.4
@@ -8540,7 +8331,7 @@ packages:
       '@types/chai': 4.2.21
       '@types/chai-as-promised': 7.1.4
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.21
+      '@types/node': 12.20.23
       '@types/sinon': 9.0.11
       chai: 4.3.4
       chai-as-promised: 7.1.1_chai@4.3.4
@@ -8592,7 +8383,7 @@ packages:
       '@rollup/plugin-replace': 2.4.2_rollup@1.32.1
       '@types/chai': 4.2.21
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.21
+      '@types/node': 12.20.23
       '@types/sinon': 9.0.11
       assert: 1.5.0
       chai: 4.3.4
@@ -8681,7 +8472,6 @@ packages:
       '@rollup/plugin-node-resolve': 8.4.0_rollup@1.32.1
       mkdirp: 1.0.4
       rollup: 1.32.1
-      rollup-plugin-node-resolve: 3.4.0
       rollup-plugin-sourcemaps: 0.4.2_rollup@1.32.1
       tslib: 2.3.1
       typescript: 4.2.4
@@ -8959,7 +8749,7 @@ packages:
       '@types/chai': 4.2.21
       '@types/chai-as-promised': 7.1.4
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.21
+      '@types/node': 12.20.23
       buffer: 6.0.3
       chai: 4.3.4
       chai-as-promised: 7.1.1_chai@4.3.4
@@ -9016,7 +8806,7 @@ packages:
       '@rollup/plugin-replace': 2.4.2_rollup@1.32.1
       '@types/chai': 4.2.21
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.21
+      '@types/node': 12.20.23
       '@types/sinon': 9.0.11
       '@types/uuid': 8.3.1
       assert: 1.5.0
@@ -9074,7 +8864,7 @@ packages:
       '@types/chai-as-promised': 7.1.4
       '@types/jwt-decode': 2.2.1
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.21
+      '@types/node': 12.20.23
       '@types/sinon': 9.0.11
       assert: 1.5.0
       chai: 4.3.4
@@ -9126,7 +8916,7 @@ packages:
       '@rollup/plugin-replace': 2.4.2_rollup@1.32.1
       '@types/chai': 4.2.21
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.21
+      '@types/node': 12.20.23
       '@types/sinon': 9.0.11
       assert: 1.5.0
       chai: 4.3.4
@@ -9180,7 +8970,7 @@ packages:
       '@rollup/plugin-replace': 2.4.2_rollup@1.32.1
       '@types/chai': 4.2.21
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.21
+      '@types/node': 12.20.23
       '@types/sinon': 9.0.11
       assert: 1.5.0
       chai: 4.3.4
@@ -9233,7 +9023,7 @@ packages:
       '@rollup/plugin-replace': 2.4.2_rollup@1.32.1
       '@types/chai': 4.2.21
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.21
+      '@types/node': 12.20.23
       '@types/sinon': 9.0.11
       assert: 1.5.0
       chai: 4.3.4
@@ -9286,7 +9076,7 @@ packages:
       '@rollup/plugin-replace': 2.4.2_rollup@1.32.1
       '@types/chai': 4.2.21
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.21
+      '@types/node': 12.20.23
       '@types/sinon': 9.0.11
       assert: 1.5.0
       chai: 4.3.4
@@ -9329,12 +9119,11 @@ packages:
     version: 0.0.0
   file:projects/confidential-ledger.tgz:
     dependencies:
-      '@azure-rest/core-client': 1.0.0-beta.6
-      '@azure/identity': 1.5.1
+      '@azure/identity': 1.5.2
       '@microsoft/api-extractor': 7.13.2
       '@types/chai': 4.2.21
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.21
+      '@types/node': 12.20.23
       chai: 4.3.4
       cross-env: 7.0.3
       dotenv: 8.6.0
@@ -9366,7 +9155,7 @@ packages:
     dev: false
     name: '@rush-temp/confidential-ledger'
     resolution:
-      integrity: sha512-45GvfLJPR9/2EHGurNlqEjXLpJPSA0TWViAhKkAG3e3jlZxFRIBVhJgmjZ4ges76gQfWjBh0hK7H4F6jnNcEWw==
+      integrity: sha512-lQYlLhA8jsiSwPsCRn0A+03cVkbIds7xTk4dqHv3dUeXmFoKYxUvPd6hBQfnVSMjrLZj6QMiViKnUS8/b5SUkA==
       tarball: file:projects/confidential-ledger.tgz
     version: 0.0.0
   file:projects/container-registry.tgz:
@@ -9376,7 +9165,7 @@ packages:
       '@types/chai': 4.2.21
       '@types/chai-as-promised': 7.1.4
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.21
+      '@types/node': 12.20.23
       chai: 4.3.4
       chai-as-promised: 7.1.1_chai@4.3.4
       cross-env: 7.0.3
@@ -9424,7 +9213,7 @@ packages:
       '@types/chai': 4.2.21
       '@types/debug': 4.1.7
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.21
+      '@types/node': 12.20.23
       '@types/sinon': 9.0.11
       '@types/ws': 7.4.7
       buffer: 6.0.3
@@ -9468,7 +9257,7 @@ packages:
     version: 0.0.0
   file:projects/core-asynciterator-polyfill.tgz:
     dependencies:
-      '@types/node': 12.20.21
+      '@types/node': 12.20.23
       eslint: 7.32.0
       prettier: 1.19.1
       typedoc: 0.15.2
@@ -9484,7 +9273,7 @@ packages:
       '@microsoft/api-extractor': 7.7.11
       '@types/chai': 4.2.21
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.21
+      '@types/node': 12.20.23
       chai: 4.3.4
       cross-env: 7.0.3
       downlevel-dts: 0.4.0
@@ -9511,7 +9300,7 @@ packages:
       '@microsoft/api-extractor': 7.7.11
       '@types/chai': 4.2.21
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.21
+      '@types/node': 12.20.23
       '@types/sinon': 9.0.11
       chai: 4.3.4
       cross-env: 7.0.3
@@ -9547,11 +9336,10 @@ packages:
     version: 0.0.0
   file:projects/core-client-lro.tgz:
     dependencies:
-      '@azure-rest/core-client': 1.0.0-beta.6
       '@microsoft/api-extractor': 7.13.2
       '@types/chai': 4.2.21
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.21
+      '@types/node': 12.20.23
       chai: 4.3.4
       cross-env: 7.0.3
       eslint: 7.32.0
@@ -9580,16 +9368,15 @@ packages:
     dev: false
     name: '@rush-temp/core-client-lro'
     resolution:
-      integrity: sha512-n7OJnwa3mZ4WMtwlX0t8UY0ZAPc877e+UfhsTLa5V+3Re0wkEvKUo1IvMedAgKPLag3MoTrRcxl3c3KXGXxGRA==
+      integrity: sha512-M4evzMVsUDQjqh47XEQtziCB+jT5OhhmOrmpzyI1yE/2vYMM3Bz0kZPBWGq9KZDcBmkFCNNHhjk4uY8oG/BWMA==
       tarball: file:projects/core-client-lro.tgz
     version: 0.0.0
   file:projects/core-client-paging.tgz:
     dependencies:
-      '@azure-rest/core-client': 1.0.0-beta.6
       '@microsoft/api-extractor': 7.13.2
       '@types/chai': 4.2.21
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.21
+      '@types/node': 12.20.23
       chai: 4.3.4
       cross-env: 7.0.3
       eslint: 7.32.0
@@ -9618,7 +9405,7 @@ packages:
     dev: false
     name: '@rush-temp/core-client-paging'
     resolution:
-      integrity: sha512-bsDMFvEcIAb5YzNyy2nbN/9r6iqMizurHzWN6bT+C4son4pDW7+ij6qMx/FKi9l+HiMhx8Ns6prqJypy8g30IQ==
+      integrity: sha512-jR9MSynY/6hjmMjyWjs+hFAAwk0VN2zJV0yBg0vH/9dv5ANOkjoAYfk54Vu3V0CHHQ7njmLScWqrFdqcRkqypw==
       tarball: file:projects/core-client-paging.tgz
     version: 0.0.0
   file:projects/core-client.tgz:
@@ -9626,7 +9413,7 @@ packages:
       '@microsoft/api-extractor': 7.13.2
       '@types/chai': 4.2.21
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.21
+      '@types/node': 12.20.23
       chai: 4.3.4
       cross-env: 7.0.3
       eslint: 7.32.0
@@ -9655,7 +9442,7 @@ packages:
     dev: false
     name: '@rush-temp/core-client'
     resolution:
-      integrity: sha512-A+GvNgdlwTt5h3ZbVfNlhfUSKtdo96ruE9aQ7Vvf83wsasti6gtLOQFPXPiLMvhvQoKg4eQ3iZU9TtNxW2RY+g==
+      integrity: sha512-VGDp4uzLU6NL5A31+vMbrE2BUlAtWssXoUiG5q21WDHo/5bdVv5Ksl+r9UzYxzgaEWDeNVr5KxfoBvZo7+xJAw==
       tarball: file:projects/core-client.tgz
     version: 0.0.0
   file:projects/core-crypto.tgz:
@@ -9666,7 +9453,7 @@ packages:
       '@rollup/plugin-replace': 2.4.2_rollup@1.32.1
       '@types/chai': 4.2.21
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.21
+      '@types/node': 12.20.23
       '@types/sinon': 9.0.11
       chai: 4.3.4
       cross-env: 7.0.3
@@ -9704,12 +9491,12 @@ packages:
       '@azure/core-tracing': 1.0.0-preview.13
       '@azure/logger-js': 1.3.2
       '@microsoft/api-extractor': 7.7.11
-      '@opentelemetry/api': 1.0.2
+      '@opentelemetry/api': 1.0.3
       '@types/chai': 4.2.21
       '@types/express': 4.17.13
       '@types/glob': 7.1.4
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.21
+      '@types/node': 12.20.23
       '@types/node-fetch': 2.5.12
       '@types/sinon': 9.0.11
       '@types/tough-cookie': 4.0.1
@@ -9768,7 +9555,7 @@ packages:
       '@microsoft/api-extractor': 7.7.11
       '@types/chai': 4.2.21
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.21
+      '@types/node': 12.20.23
       chai: 4.3.4
       cross-env: 7.0.3
       eslint: 7.32.0
@@ -9806,7 +9593,7 @@ packages:
       '@microsoft/api-extractor': 7.7.11
       '@types/chai': 4.2.21
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.21
+      '@types/node': 12.20.23
       chai: 4.3.4
       downlevel-dts: 0.4.0
       eslint: 7.32.0
@@ -9839,10 +9626,10 @@ packages:
     dependencies:
       '@azure/core-tracing': 1.0.0-preview.13
       '@microsoft/api-extractor': 7.7.11
-      '@opentelemetry/api': 1.0.2
+      '@opentelemetry/api': 1.0.3
       '@types/chai': 4.2.21
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.21
+      '@types/node': 12.20.23
       '@types/sinon': 9.0.11
       '@types/uuid': 8.3.1
       chai: 4.3.4
@@ -9885,11 +9672,11 @@ packages:
   file:projects/core-tracing.tgz:
     dependencies:
       '@microsoft/api-extractor': 7.7.11
-      '@opentelemetry/api': 1.0.2
-      '@opentelemetry/tracing': 0.22.0_@opentelemetry+api@1.0.2
+      '@opentelemetry/api': 1.0.3
+      '@opentelemetry/tracing': 0.22.0_@opentelemetry+api@1.0.3
       '@types/chai': 4.2.21
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.21
+      '@types/node': 12.20.23
       '@types/sinon': 9.0.11
       chai: 4.3.4
       cross-env: 7.0.3
@@ -9927,7 +9714,7 @@ packages:
       '@microsoft/api-extractor': 7.7.11
       '@types/chai': 4.2.21
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.21
+      '@types/node': 12.20.23
       '@types/sinon': 9.0.11
       chai: 4.3.4
       cross-env: 7.0.3
@@ -9966,7 +9753,7 @@ packages:
       '@microsoft/api-extractor': 7.7.11
       '@types/chai': 4.2.21
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.21
+      '@types/node': 12.20.23
       '@types/sinon': 9.0.11
       '@types/xml2js': 0.4.9
       chai: 4.3.4
@@ -10004,13 +9791,13 @@ packages:
     version: 0.0.0
   file:projects/cosmos.tgz:
     dependencies:
-      '@azure/identity': 1.5.1_debug@4.3.2
+      '@azure/identity': 1.5.2_debug@4.3.2
       '@microsoft/api-extractor': 7.7.11
       '@rollup/plugin-json': 4.1.0_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
       '@types/debug': 4.1.7
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.21
+      '@types/node': 12.20.23
       '@types/priorityqueuejs': 1.0.1
       '@types/semaphore': 1.1.1
       '@types/sinon': 9.0.11
@@ -10030,7 +9817,6 @@ packages:
       node-abort-controller: 1.2.1
       prettier: 1.19.1
       priorityqueuejs: 1.0.0
-      proxy-agent: 4.0.1
       requirejs: 2.3.6
       rimraf: 3.0.2
       rollup: 1.32.1
@@ -10048,7 +9834,7 @@ packages:
     dev: false
     name: '@rush-temp/cosmos'
     resolution:
-      integrity: sha512-Nfj3USkLkf7QCn7UuB/PrIEELRhpS9jJ7QWwpo0j6H6/eBa8KCf9368JVYh6I1k7VwFMedUIhEkQPosdjdL0pQ==
+      integrity: sha512-ajLbG/BUFLdxciEBH0Gm8oSxWJvIqJHRVrTJdxRKFbb6cC9MJBDJGfxcu0GheMWwdE2qOJqX7EHdK7hRW2qdqA==
       tarball: file:projects/cosmos.tgz
     version: 0.0.0
   file:projects/data-tables.tgz:
@@ -10063,7 +9849,7 @@ packages:
       '@rollup/plugin-replace': 2.4.2_rollup@1.32.1
       '@types/chai': 4.2.21
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.21
+      '@types/node': 12.20.23
       '@types/sinon': 9.0.11
       '@types/uuid': 8.3.1
       chai: 4.3.4
@@ -10117,7 +9903,7 @@ packages:
       '@types/fs-extra': 8.1.2
       '@types/minimist': 1.2.2
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.21
+      '@types/node': 12.20.23
       '@types/prettier': 2.0.2
       builtin-modules: 3.2.0
       chai: 4.3.4
@@ -10155,7 +9941,7 @@ packages:
       '@rollup/plugin-replace': 2.4.2_rollup@1.32.1
       '@types/chai': 4.2.21
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.21
+      '@types/node': 12.20.23
       '@types/sinon': 9.0.11
       '@types/uuid': 8.3.1
       chai: 4.3.4
@@ -10206,7 +9992,7 @@ packages:
       '@types/glob': 7.1.4
       '@types/json-schema': 7.0.9
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.21
+      '@types/node': 12.20.23
       '@typescript-eslint/eslint-plugin': 4.19.0_359354e87b989469ccdce12bde18eddc
       '@typescript-eslint/experimental-utils': 4.19.0_eslint@7.32.0+typescript@4.2.4
       '@typescript-eslint/parser': 4.19.0_eslint@7.32.0+typescript@4.2.4
@@ -10251,7 +10037,7 @@ packages:
       '@types/debug': 4.1.7
       '@types/long': 4.0.1
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.21
+      '@types/node': 12.20.23
       '@types/sinon': 9.0.11
       '@types/uuid': 8.3.1
       '@types/ws': 7.4.7
@@ -10323,7 +10109,7 @@ packages:
       '@types/chai-string': 1.4.2
       '@types/debug': 4.1.7
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.21
+      '@types/node': 12.20.23
       '@types/uuid': 8.3.1
       '@types/ws': 7.4.7
       async-lock: 1.3.0
@@ -10369,7 +10155,7 @@ packages:
       '@types/chai': 4.2.21
       '@types/chai-as-promised': 7.1.4
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.21
+      '@types/node': 12.20.23
       '@types/sinon': 9.0.11
       '@types/uuid': 8.3.1
       chai: 4.3.4
@@ -10428,7 +10214,7 @@ packages:
       '@types/chai-string': 1.4.2
       '@types/debug': 4.1.7
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.21
+      '@types/node': 12.20.23
       assert: 1.5.0
       chai: 4.3.4
       chai-as-promised: 7.1.1_chai@4.3.4
@@ -10487,7 +10273,7 @@ packages:
       '@types/chai-string': 1.4.2
       '@types/debug': 4.1.7
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.21
+      '@types/node': 12.20.23
       assert: 1.5.0
       chai: 4.3.4
       chai-as-promised: 7.1.1_chai@4.3.4
@@ -10538,7 +10324,7 @@ packages:
       '@microsoft/api-extractor': 7.7.11
       '@types/jws': 3.2.4
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.21
+      '@types/node': 12.20.23
       '@types/qs': 6.9.7
       '@types/sinon': 9.0.11
       assert: 1.5.0
@@ -10569,7 +10355,7 @@ packages:
       '@microsoft/api-extractor': 7.7.11
       '@types/jws': 3.2.4
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.21
+      '@types/node': 12.20.23
       '@types/qs': 6.9.7
       '@types/sinon': 9.0.11
       '@types/uuid': 8.3.1
@@ -10606,8 +10392,7 @@ packages:
       '@types/chai': 4.2.21
       '@types/jws': 3.2.4
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.21
-      '@types/qs': 6.9.7
+      '@types/node': 12.20.23
       '@types/sinon': 9.0.11
       '@types/stoppable': 1.1.1
       '@types/uuid': 8.3.1
@@ -10632,7 +10417,6 @@ packages:
       open: 7.4.2
       prettier: 1.19.1
       puppeteer: 10.2.0
-      qs: 6.10.1
       rimraf: 3.0.2
       rollup: 1.32.1
       sinon: 9.2.4
@@ -10652,7 +10436,7 @@ packages:
     dependencies:
       '@azure/core-tracing': 1.0.0-preview.13
       '@microsoft/api-extractor': 7.7.11
-      '@types/node': 12.20.21
+      '@types/node': 12.20.23
       '@types/uuid': 8.3.1
       cross-env: 7.0.3
       dotenv: 8.6.0
@@ -10684,7 +10468,7 @@ packages:
       '@rollup/plugin-replace': 2.4.2_rollup@1.32.1
       '@types/chai': 4.2.21
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.21
+      '@types/node': 12.20.23
       '@types/sinon': 9.0.11
       chai: 4.3.4
       cross-env: 7.0.3
@@ -10737,7 +10521,7 @@ packages:
       '@types/chai': 4.2.21
       '@types/chai-as-promised': 7.1.4
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.21
+      '@types/node': 12.20.23
       '@types/sinon': 9.0.11
       '@types/uuid': 8.3.1
       assert: 1.5.0
@@ -10781,7 +10565,7 @@ packages:
       '@rollup/plugin-replace': 2.4.2_rollup@1.32.1
       '@types/chai': 4.2.21
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.21
+      '@types/node': 12.20.23
       '@types/sinon': 9.0.11
       assert: 1.5.0
       chai: 4.3.4
@@ -10851,7 +10635,7 @@ packages:
       '@types/chai': 4.2.21
       '@types/chai-as-promised': 7.1.4
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.21
+      '@types/node': 12.20.23
       '@types/sinon': 9.0.11
       assert: 1.5.0
       chai: 4.3.4
@@ -10908,7 +10692,7 @@ packages:
       '@rollup/plugin-replace': 2.4.2_rollup@1.32.1
       '@types/chai': 4.2.21
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.21
+      '@types/node': 12.20.23
       '@types/sinon': 9.0.11
       assert: 1.5.0
       chai: 4.3.4
@@ -10957,7 +10741,7 @@ packages:
       '@microsoft/api-extractor': 7.7.11
       '@types/chai': 4.2.21
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.21
+      '@types/node': 12.20.23
       '@types/sinon': 9.0.11
       chai: 4.3.4
       cross-env: 7.0.3
@@ -11000,7 +10784,7 @@ packages:
       '@types/chai': 4.2.21
       '@types/chai-as-promised': 7.1.4
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.21
+      '@types/node': 12.20.23
       chai: 4.3.4
       chai-as-promised: 7.1.1_chai@4.3.4
       cross-env: 7.0.3
@@ -11039,12 +10823,12 @@ packages:
   file:projects/mixed-reality-remote-rendering.tgz:
     dependencies:
       '@azure/core-tracing': 1.0.0-preview.13
-      '@azure/identity': 1.5.1
+      '@azure/identity': 1.5.2
       '@microsoft/api-extractor': 7.7.11
       '@types/chai': 4.2.21
       '@types/chai-as-promised': 7.1.4
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.21
+      '@types/node': 12.20.23
       '@types/uuid': 8.3.1
       chai: 4.3.4
       chai-as-promised: 7.1.1_chai@4.3.4
@@ -11083,7 +10867,7 @@ packages:
     version: 0.0.0
   file:projects/mock-hub.tgz:
     dependencies:
-      '@types/node': 12.20.21
+      '@types/node': 12.20.23
       dotenv: 8.6.0
       eslint: 7.32.0
       prettier: 1.19.1
@@ -11100,16 +10884,16 @@ packages:
   file:projects/monitor-opentelemetry-exporter.tgz:
     dependencies:
       '@microsoft/api-extractor': 7.7.11
-      '@opentelemetry/api': 1.0.2
-      '@opentelemetry/core': 0.22.0_@opentelemetry+api@1.0.2
-      '@opentelemetry/instrumentation': 0.22.0_@opentelemetry+api@1.0.2
-      '@opentelemetry/instrumentation-http': 0.22.0_@opentelemetry+api@1.0.2
-      '@opentelemetry/node': 0.22.0_@opentelemetry+api@1.0.2
-      '@opentelemetry/resources': 0.22.0_@opentelemetry+api@1.0.2
+      '@opentelemetry/api': 1.0.3
+      '@opentelemetry/core': 0.22.0_@opentelemetry+api@1.0.3
+      '@opentelemetry/instrumentation': 0.22.0_@opentelemetry+api@1.0.3
+      '@opentelemetry/instrumentation-http': 0.22.0_@opentelemetry+api@1.0.3
+      '@opentelemetry/node': 0.22.0_@opentelemetry+api@1.0.3
+      '@opentelemetry/resources': 0.22.0_@opentelemetry+api@1.0.3
       '@opentelemetry/semantic-conventions': 0.22.0
-      '@opentelemetry/tracing': 0.22.0_@opentelemetry+api@1.0.2
+      '@opentelemetry/tracing': 0.22.0_@opentelemetry+api@1.0.3
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.21
+      '@types/node': 12.20.23
       dotenv: 8.6.0
       eslint: 7.32.0
       eslint-plugin-node: 11.1.0_eslint@7.32.0
@@ -11134,16 +10918,16 @@ packages:
   file:projects/monitor-query.tgz:
     dependencies:
       '@azure/core-tracing': 1.0.0-preview.13
-      '@azure/identity': 1.5.1
+      '@azure/identity': 1.5.2
       '@azure/monitor-opentelemetry-exporter': 1.0.0-beta.4
       '@microsoft/api-extractor': 7.7.11
-      '@opentelemetry/api': 1.0.2
-      '@opentelemetry/node': 0.22.0_@opentelemetry+api@1.0.2
-      '@opentelemetry/tracing': 0.22.0_@opentelemetry+api@1.0.2
+      '@opentelemetry/api': 1.0.3
+      '@opentelemetry/node': 0.22.0_@opentelemetry+api@1.0.3
+      '@opentelemetry/tracing': 0.22.0_@opentelemetry+api@1.0.3
       '@types/chai': 4.2.21
       '@types/chai-as-promised': 7.1.4
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.21
+      '@types/node': 12.20.23
       chai: 4.3.4
       chai-as-promised: 7.1.1_chai@4.3.4
       cross-env: 7.0.3
@@ -11185,7 +10969,7 @@ packages:
     dependencies:
       '@azure/ai-form-recognizer': 3.1.0-beta.3
       '@azure/identity': 2.0.0-beta.5
-      '@types/node': 12.20.21
+      '@types/node': 12.20.23
       dotenv: 8.6.0
       eslint: 7.32.0
       prettier: 1.19.1
@@ -11202,7 +10986,7 @@ packages:
   file:projects/perf-ai-metrics-advisor.tgz:
     dependencies:
       '@azure/ai-metrics-advisor': 1.0.0-beta.3
-      '@types/node': 12.20.21
+      '@types/node': 12.20.23
       dotenv: 8.6.0
       eslint: 7.32.0
       prettier: 1.19.1
@@ -11219,7 +11003,7 @@ packages:
   file:projects/perf-ai-text-analytics.tgz:
     dependencies:
       '@azure/ai-text-analytics': 5.1.0
-      '@types/node': 12.20.21
+      '@types/node': 12.20.23
       dotenv: 8.6.0
       eslint: 7.32.0
       prettier: 1.19.1
@@ -11235,7 +11019,7 @@ packages:
     version: 0.0.0
   file:projects/perf-app-configuration.tgz:
     dependencies:
-      '@types/node': 12.20.21
+      '@types/node': 12.20.23
       '@types/uuid': 8.3.1
       dotenv: 8.6.0
       eslint: 7.32.0
@@ -11269,7 +11053,7 @@ packages:
     version: 0.0.0
   file:projects/perf-data-tables.tgz:
     dependencies:
-      '@types/node': 12.20.21
+      '@types/node': 12.20.23
       '@types/uuid': 8.3.1
       dotenv: 8.6.0
       eslint: 7.32.0
@@ -11287,7 +11071,7 @@ packages:
     version: 0.0.0
   file:projects/perf-eventgrid.tgz:
     dependencies:
-      '@types/node': 12.20.21
+      '@types/node': 12.20.23
       dotenv: 8.6.0
       eslint: 7.32.0
       prettier: 1.19.1
@@ -11376,7 +11160,7 @@ packages:
   file:projects/perf-search-documents.tgz:
     dependencies:
       '@azure/identity': 2.0.0-beta.5
-      '@types/node': 12.20.21
+      '@types/node': 12.20.23
       dotenv: 8.6.0
       eslint: 7.32.0
       prettier: 1.19.1
@@ -11392,7 +11176,7 @@ packages:
     version: 0.0.0
   file:projects/perf-storage-blob.tgz:
     dependencies:
-      '@types/node': 12.20.21
+      '@types/node': 12.20.23
       '@types/node-fetch': 2.5.12
       '@types/uuid': 8.3.1
       dotenv: 8.6.0
@@ -11412,7 +11196,7 @@ packages:
     version: 0.0.0
   file:projects/perf-storage-file-datalake.tgz:
     dependencies:
-      '@types/node': 12.20.21
+      '@types/node': 12.20.23
       '@types/uuid': 8.3.1
       dotenv: 8.6.0
       eslint: 7.32.0
@@ -11430,7 +11214,7 @@ packages:
     version: 0.0.0
   file:projects/perf-storage-file-share.tgz:
     dependencies:
-      '@types/node': 12.20.21
+      '@types/node': 12.20.23
       '@types/uuid': 8.3.1
       dotenv: 8.6.0
       eslint: 7.32.0
@@ -11448,13 +11232,12 @@ packages:
     version: 0.0.0
   file:projects/purview-account.tgz:
     dependencies:
-      '@azure-rest/core-client': 1.0.0-beta.6
       '@azure-rest/core-client-paging': 1.0.0-beta.1
-      '@azure/identity': 1.5.1
+      '@azure/identity': 1.5.2
       '@microsoft/api-extractor': 7.13.2
       '@types/chai': 4.2.21
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.21
+      '@types/node': 12.20.23
       chai: 4.3.4
       cross-env: 7.0.3
       dotenv: 8.6.0
@@ -11487,17 +11270,16 @@ packages:
     dev: false
     name: '@rush-temp/purview-account'
     resolution:
-      integrity: sha512-if5JygVMi5EaFVhbOVYimljQS6RFD/AbV1lQe4zIJ2W/gMAzTTkb4zUwX3wUbTDuUE4Mzn6fnasa139O1luSsA==
+      integrity: sha512-tc6KFxfVCGUIwZjdgRZ80vPbwro2EwMEy4B3MQahsza/FZ4i3AHouoborKtNJg30pkTh1n2l7xOeaQJr/hQ7wg==
       tarball: file:projects/purview-account.tgz
     version: 0.0.0
   file:projects/purview-catalog.tgz:
     dependencies:
-      '@azure-rest/core-client': 1.0.0-beta.6
-      '@azure/identity': 1.5.1
+      '@azure/identity': 1.5.2
       '@microsoft/api-extractor': 7.13.2
       '@types/chai': 4.2.21
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.21
+      '@types/node': 12.20.23
       chai: 4.3.4
       cross-env: 7.0.3
       dotenv: 8.6.0
@@ -11530,17 +11312,16 @@ packages:
     dev: false
     name: '@rush-temp/purview-catalog'
     resolution:
-      integrity: sha512-A6d6LOn/IF/XQhtWl/O/PrdkXsIDLWDLypn2hTE5tZCIqgRXFXdnvL1JYnxMc4Ov+z5Tj0I6OCwBjRCw50uZ0g==
+      integrity: sha512-BpZ4lOcV2MTB83zU2HMD+uUDLS9RjPLFiZXEL0RfjELRDVYHW7Mzc8iHm4hh0z0KJ8LgJU6IicmaNvMP/X8LBA==
       tarball: file:projects/purview-catalog.tgz
     version: 0.0.0
   file:projects/purview-scanning.tgz:
     dependencies:
-      '@azure-rest/core-client': 1.0.0-beta.6
-      '@azure/identity': 1.5.1
+      '@azure/identity': 1.5.2
       '@microsoft/api-extractor': 7.13.2
       '@types/chai': 4.2.21
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.21
+      '@types/node': 12.20.23
       chai: 4.3.4
       cross-env: 7.0.3
       dotenv: 8.6.0
@@ -11573,7 +11354,7 @@ packages:
     dev: false
     name: '@rush-temp/purview-scanning'
     resolution:
-      integrity: sha512-U0BqvzNxYHfqTIpxFfs48K55AOgH9utGrS73zZVPI9dPSc4WywkLsuxQrzOou86FJ5B44Khjp8ae9pZPj672qw==
+      integrity: sha512-HX4JV2mB44SB0PkGp9I4CQ/Bu0yYtFOkwu5WHNn9sathdM9wxEbX+GXP/1e9Xh4EpGweOSDprabMN+IGzK+4Tw==
       tarball: file:projects/purview-scanning.tgz
     version: 0.0.0
   file:projects/quantum-jobs.tgz:
@@ -11588,7 +11369,7 @@ packages:
       '@rollup/plugin-replace': 2.4.2_rollup@1.32.1
       '@types/chai': 4.2.21
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.21
+      '@types/node': 12.20.23
       '@types/sinon': 9.0.11
       chai: 4.3.4
       cross-env: 7.0.3
@@ -11643,7 +11424,7 @@ packages:
       '@types/chai': 4.2.21
       '@types/chai-as-promised': 7.1.4
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.21
+      '@types/node': 12.20.23
       avsc: 5.7.3
       buffer: 6.0.3
       chai: 4.3.4
@@ -11692,7 +11473,7 @@ packages:
       '@types/chai': 4.2.21
       '@types/chai-as-promised': 7.1.4
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.21
+      '@types/node': 12.20.23
       chai: 4.3.4
       chai-as-promised: 7.1.1_chai@4.3.4
       cross-env: 7.0.3
@@ -11738,7 +11519,7 @@ packages:
       '@rollup/plugin-replace': 2.4.2_rollup@1.32.1
       '@types/chai': 4.2.21
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.21
+      '@types/node': 12.20.23
       '@types/sinon': 9.0.11
       chai: 4.3.4
       cross-env: 7.0.3
@@ -11798,7 +11579,7 @@ packages:
       '@types/is-buffer': 2.0.0
       '@types/long': 4.0.1
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.21
+      '@types/node': 12.20.23
       '@types/sinon': 9.0.11
       '@types/ws': 7.4.7
       assert: 1.5.0
@@ -11865,7 +11646,7 @@ packages:
       '@rollup/plugin-node-resolve': 8.4.0_rollup@1.32.1
       '@rollup/plugin-replace': 2.4.2_rollup@1.32.1
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.21
+      '@types/node': 12.20.23
       '@types/sinon': 9.0.11
       assert: 1.5.0
       cross-env: 7.0.3
@@ -11923,7 +11704,7 @@ packages:
       '@rollup/plugin-node-resolve': 8.4.0_rollup@1.32.1
       '@rollup/plugin-replace': 2.4.2_rollup@1.32.1
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.21
+      '@types/node': 12.20.23
       '@types/node-fetch': 2.5.12
       assert: 1.5.0
       cross-env: 7.0.3
@@ -11981,7 +11762,7 @@ packages:
       '@rollup/plugin-node-resolve': 8.4.0_rollup@1.32.1
       '@rollup/plugin-replace': 2.4.2_rollup@1.32.1
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.21
+      '@types/node': 12.20.23
       assert: 1.5.0
       cross-env: 7.0.3
       dotenv: 8.6.0
@@ -12037,7 +11818,7 @@ packages:
       '@rollup/plugin-node-resolve': 8.4.0_rollup@1.32.1
       '@rollup/plugin-replace': 2.4.2_rollup@1.32.1
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.21
+      '@types/node': 12.20.23
       assert: 1.5.0
       cross-env: 7.0.3
       dotenv: 8.6.0
@@ -12091,7 +11872,7 @@ packages:
       '@rollup/plugin-node-resolve': 8.4.0_rollup@1.32.1
       '@rollup/plugin-replace': 2.4.2_rollup@1.32.1
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.21
+      '@types/node': 12.20.23
       assert: 1.5.0
       dotenv: 8.6.0
       downlevel-dts: 0.4.0
@@ -12143,7 +11924,7 @@ packages:
       '@rollup/plugin-node-resolve': 8.4.0_rollup@1.32.1
       '@rollup/plugin-replace': 2.4.2_rollup@1.32.1
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.21
+      '@types/node': 12.20.23
       assert: 1.5.0
       cross-env: 7.0.3
       dotenv: 8.6.0
@@ -12195,7 +11976,7 @@ packages:
       '@types/chai': 4.2.21
       '@types/chai-as-promised': 7.1.4
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.21
+      '@types/node': 12.20.23
       '@types/sinon': 9.0.11
       chai: 4.3.4
       chai-as-promised: 7.1.1_chai@4.3.4
@@ -12242,7 +12023,7 @@ packages:
       '@types/chai': 4.2.21
       '@types/chai-as-promised': 7.1.4
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.21
+      '@types/node': 12.20.23
       '@types/sinon': 9.0.11
       chai: 4.3.4
       chai-as-promised: 7.1.1_chai@4.3.4
@@ -12394,7 +12175,7 @@ packages:
       '@types/chai': 4.2.21
       '@types/chai-as-promised': 7.1.4
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.21
+      '@types/node': 12.20.23
       chai: 4.3.4
       chai-as-promised: 7.1.1_chai@4.3.4
       cross-env: 7.0.3
@@ -12445,7 +12226,7 @@ packages:
       '@types/mock-fs': 4.10.0
       '@types/mock-require': 2.0.0
       '@types/nise': 1.4.0
-      '@types/node': 12.20.21
+      '@types/node': 12.20.23
       chai: 4.3.4
       dotenv: 8.6.0
       eslint: 7.32.0
@@ -12498,7 +12279,7 @@ packages:
       '@types/mock-fs': 4.10.0
       '@types/mock-require': 2.0.0
       '@types/nise': 1.4.0
-      '@types/node': 12.20.21
+      '@types/node': 12.20.23
       chai: 4.3.4
       dotenv: 8.6.0
       eslint: 7.32.0
@@ -12544,7 +12325,7 @@ packages:
   file:projects/test-utils-perfstress.tgz:
     dependencies:
       '@types/minimist': 1.2.2
-      '@types/node': 12.20.21
+      '@types/node': 12.20.23
       '@types/node-fetch': 2.5.12
       eslint: 7.32.0
       karma: 6.3.4
@@ -12567,10 +12348,10 @@ packages:
     dependencies:
       '@azure/core-tracing': 1.0.0-preview.13
       '@microsoft/api-extractor': 7.7.11
-      '@opentelemetry/api': 1.0.2
+      '@opentelemetry/api': 1.0.3
       '@types/chai': 4.2.21
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.21
+      '@types/node': 12.20.23
       '@types/sinon': 9.0.11
       chai: 4.3.4
       chai-as-promised: 7.1.1_chai@4.3.4
@@ -12605,7 +12386,7 @@ packages:
       '@types/mock-fs': 4.10.0
       '@types/mock-require': 2.0.0
       '@types/nise': 1.4.0
-      '@types/node': 12.20.21
+      '@types/node': 12.20.23
       '@types/uuid': 8.3.1
       chai: 4.3.4
       dotenv: 8.6.0
@@ -12652,7 +12433,7 @@ packages:
       '@types/chai': 4.2.21
       '@types/chai-as-promised': 7.1.4
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.21
+      '@types/node': 12.20.23
       azure-iothub: 1.14.3
       chai: 4.3.4
       chai-as-promised: 7.1.1_chai@4.3.4
@@ -12701,7 +12482,7 @@ packages:
       '@types/express-serve-static-core': 4.17.24
       '@types/jsonwebtoken': 8.5.5
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.21
+      '@types/node': 12.20.23
       '@types/sinon': 9.0.11
       assert: 1.5.0
       chai: 4.3.4
@@ -12748,7 +12529,7 @@ packages:
   file:projects/web-pubsub.tgz:
     dependencies:
       '@azure/core-tracing': 1.0.0-preview.13
-      '@azure/identity': 1.5.1
+      '@azure/identity': 1.5.2
       '@microsoft/api-extractor': 7.7.11
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-json': 4.1.0_rollup@1.32.1
@@ -12758,7 +12539,7 @@ packages:
       '@types/chai': 4.2.21
       '@types/jsonwebtoken': 8.5.5
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.21
+      '@types/node': 12.20.23
       '@types/sinon': 9.0.11
       chai: 4.3.4
       cross-env: 7.0.3

--- a/sdk/cosmosdb/cosmos/package.json
+++ b/sdk/cosmosdb/cosmos/package.json
@@ -121,7 +121,6 @@
     "mocha": "^7.1.1",
     "mocha-junit-reporter": "^1.18.0",
     "prettier": "^1.16.4",
-    "proxy-agent": "^4.0.1",
     "requirejs": "^2.3.5",
     "rimraf": "^3.0.0",
     "rollup": "^1.16.3",


### PR DESCRIPTION
#17106 requires us to update the version of proxy-agent being used in the cosmosdb package to the latest major version.

Found that this package is no longer being used. The [test case that did use it is now commented out](https://github.com/Azure/azure-sdk-for-js/blob/d3647f86a9f8e29f6376ef1e04015dd5e94d63a7/sdk/cosmosdb/cosmos/test/public/integration/proxy.spec.ts).

So, choosing to remove the dependency altogether.

When the cosmosdb team plans to add the test case back, they can test it with the latest version of proxy-agent and add that dependency back

Fixes https://github.com/Azure/azure-sdk-for-js/issues/17106

_Regarding the changes to the lock file:_
I tried running `rush update --recheck` to ensure proxy-agent gets removed from the lock file, but that did not work out. So, resorted to running `rush update --full` which causes the large number of updates to the lock file as we have been releasing core packages this week