### PR TITLE
[Schema Registry] Rename getSchemaId to getSchemaProperties

### DIFF
--- a/sdk/schemaregistry/schema-registry-avro/src/schemaRegistryAvroSerializer.ts
+++ b/sdk/schemaregistry/schema-registry-avro/src/schemaRegistryAvroSerializer.ts
@@ -197,7 +197,7 @@ export class SchemaRegistryAvroSerializer {
     if (this.autoRegisterSchemas) {
       id = (await this.registry.registerSchema(description)).id;
     } else {
-      const response = await this.registry.getSchemaId(description);
+      const response = await this.registry.getSchemaProperties(description);
       if (!response) {
         throw new Error(
           `Schema '${description.name}' not found in registry group '${description.groupName}', or not found to have matching content.`

--- a/sdk/schemaregistry/schema-registry-avro/test/schemaRegistryAvroSerializer.spec.ts
+++ b/sdk/schemaregistry/schema-registry-avro/test/schemaRegistryAvroSerializer.spec.ts
@@ -10,7 +10,7 @@ import { ClientSecretCredential } from "@azure/identity";
 
 import {
   GetSchemaOptions,
-  GetSchemaIdOptions,
+  GetSchemaPropertiesOptions,
   RegisterSchemaOptions,
   Schema,
   SchemaDescription,
@@ -144,7 +144,7 @@ describe("SchemaRegistryAvroSerializer", function() {
     serializer = await createTestSerializer(false);
     assert.deepStrictEqual(await serializer.deserialize(buffer), testValue);
 
-    // throw away serializer again and cover getSchemaId instead of registerSchema
+    // throw away serializer again and cover getSchemaProperties instead of registerSchema
     serializer = await createTestSerializer(false);
     assert.deepStrictEqual(await serializer.serialize(testValue, testSchema), buffer);
   });
@@ -207,7 +207,7 @@ function createTestRegistry(neverLive = false): SchemaRegistry {
   const mapByContent = new Map<string, Schema>();
   let idCounter = 0;
 
-  return { registerSchema, getSchemaId, getSchema };
+  return { registerSchema, getSchemaProperties, getSchema };
 
   async function registerSchema(
     schema: SchemaDescription,
@@ -236,9 +236,9 @@ function createTestRegistry(neverLive = false): SchemaRegistry {
     }
   }
 
-  async function getSchemaId(
+  async function getSchemaProperties(
     schema: SchemaDescription,
-    _options?: GetSchemaIdOptions
+    _options?: GetSchemaPropertiesOptions
   ): Promise<SchemaProperties | undefined> {
     return mapByContent.get(schema.content);
   }

--- a/sdk/schemaregistry/schema-registry/review/schema-registry.api.md
+++ b/sdk/schemaregistry/schema-registry/review/schema-registry.api.md
@@ -9,11 +9,11 @@ import { OperationOptions } from '@azure/core-client';
 import { TokenCredential } from '@azure/core-auth';
 
 // @public
-export interface GetSchemaIdOptions extends OperationOptions {
+export interface GetSchemaOptions extends OperationOptions {
 }
 
 // @public
-export interface GetSchemaOptions extends OperationOptions {
+export interface GetSchemaPropertiesOptions extends OperationOptions {
 }
 
 // @public
@@ -48,7 +48,7 @@ export interface SchemaProperties {
 // @public
 export interface SchemaRegistry {
     getSchema(id: string, options?: GetSchemaOptions): Promise<Schema | undefined>;
-    getSchemaId(schema: SchemaDescription, options?: GetSchemaIdOptions): Promise<SchemaProperties | undefined>;
+    getSchemaProperties(schema: SchemaDescription, options?: GetSchemaPropertiesOptions): Promise<SchemaProperties | undefined>;
     registerSchema(schema: SchemaDescription, options?: RegisterSchemaOptions): Promise<SchemaProperties>;
 }
 
@@ -57,7 +57,7 @@ export class SchemaRegistryClient implements SchemaRegistry {
     constructor(endpoint: string, credential: TokenCredential, options?: SchemaRegistryClientOptions);
     readonly endpoint: string;
     getSchema(id: string, options?: GetSchemaOptions): Promise<Schema | undefined>;
-    getSchemaId(schema: SchemaDescription, options?: GetSchemaIdOptions): Promise<SchemaProperties | undefined>;
+    getSchemaProperties(schema: SchemaDescription, options?: GetSchemaPropertiesOptions): Promise<SchemaProperties | undefined>;
     registerSchema(schema: SchemaDescription, options?: RegisterSchemaOptions): Promise<SchemaProperties>;
     }
 

--- a/sdk/schemaregistry/schema-registry/samples-dev/schemaRegistrySample.ts
+++ b/sdk/schemaregistry/schema-registry/samples-dev/schemaRegistrySample.ts
@@ -51,7 +51,7 @@ export async function main() {
 
   // Get ID for existing schema by its description.
   // Note that this would throw if it had not been previously registered.
-  const found = await client.getSchemaId(schemaDescription);
+  const found = await client.getSchemaProperties(schemaDescription);
   if (found) {
     console.log(`Got schema ID=${found.id}`);
   }

--- a/sdk/schemaregistry/schema-registry/samples/v1/typescript/src/schemaRegistrySample.ts
+++ b/sdk/schemaregistry/schema-registry/samples/v1/typescript/src/schemaRegistrySample.ts
@@ -51,7 +51,7 @@ export async function main() {
 
   // Get ID for existing schema by its description.
   // Note that this would throw if it had not been previously registered.
-  const found = await client.getSchemaId(schemaDescription);
+  const found = await client.getSchemaProperties(schemaDescription);
   if (found) {
     console.log(`Got schema ID=${found.id}`);
   }

--- a/sdk/schemaregistry/schema-registry/src/models.ts
+++ b/sdk/schemaregistry/schema-registry/src/models.ts
@@ -59,9 +59,9 @@ export interface SchemaRegistryClientOptions extends CommonClientOptions {}
 export interface RegisterSchemaOptions extends OperationOptions {}
 
 /**
- * Options for SchemaRegistryClient.getSchemaId.
+ * Options for SchemaRegistryClient.getSchemaProperties.
  */
-export interface GetSchemaIdOptions extends OperationOptions {}
+export interface GetSchemaPropertiesOptions extends OperationOptions {}
 
 /**
  * Options to configure SchemaRegistryClient.getSchema.
@@ -97,9 +97,9 @@ export interface SchemaRegistry {
    * @param schema - Schema to match.
    * @returns Matched schema's ID or undefined if no matching schema was found.
    */
-  getSchemaId(
+  getSchemaProperties(
     schema: SchemaDescription,
-    options?: GetSchemaIdOptions
+    options?: GetSchemaPropertiesOptions
   ): Promise<SchemaProperties | undefined>;
 
   /**

--- a/sdk/schemaregistry/schema-registry/src/schemaRegistryClient.ts
+++ b/sdk/schemaregistry/schema-registry/src/schemaRegistryClient.ts
@@ -11,7 +11,7 @@ import { convertSchemaIdResponse, convertSchemaResponse } from "./conversions";
 
 import {
   GetSchemaOptions,
-  GetSchemaIdOptions,
+  GetSchemaPropertiesOptions,
   SchemaDescription,
   SchemaRegistryClientOptions,
   SchemaRegistry,
@@ -104,9 +104,9 @@ export class SchemaRegistryClient implements SchemaRegistry {
    * @param schema - Schema to match.
    * @returns Matched schema's ID or undefined if no matching schema was found.
    */
-  async getSchemaId(
+  async getSchemaProperties(
     schema: SchemaDescription,
-    options?: GetSchemaIdOptions
+    options?: GetSchemaPropertiesOptions
   ): Promise<SchemaProperties | undefined> {
     const cached = this.schemaToIdMap.get(schema);
     if (cached !== undefined) {

--- a/sdk/schemaregistry/schema-registry/test/schemaRegistry.spec.ts
+++ b/sdk/schemaregistry/schema-registry/test/schemaRegistry.spec.ts
@@ -96,25 +96,28 @@ describe("SchemaRegistryClient", function() {
   });
 
   it("fails to get schema ID when given invalid args", async () => {
-    await assert.isRejected(client.getSchemaId({ ...schema, name: null! }), /null/);
-    await assert.isRejected(client.getSchemaId({ ...schema, groupName: null! }), /null/);
-    await assert.isRejected(client.getSchemaId({ ...schema, content: null! }), /null/);
-    await assert.isRejected(client.getSchemaId({ ...schema, serializationType: null! }), /null/);
+    await assert.isRejected(client.getSchemaProperties({ ...schema, name: null! }), /null/);
+    await assert.isRejected(client.getSchemaProperties({ ...schema, groupName: null! }), /null/);
+    await assert.isRejected(client.getSchemaProperties({ ...schema, content: null! }), /null/);
     await assert.isRejected(
-      client.getSchemaId({ ...schema, serializationType: "not-valid" }),
+      client.getSchemaProperties({ ...schema, serializationType: null! }),
+      /null/
+    );
+    await assert.isRejected(
+      client.getSchemaProperties({ ...schema, serializationType: "not-valid" }),
       /not-valid/
     );
   });
 
   it("fails to get schema ID when no matching schema exists", async () => {
-    assert.isUndefined(await client.getSchemaId({ ...schema, name: "never-registered" }));
+    assert.isUndefined(await client.getSchemaProperties({ ...schema, name: "never-registered" }));
   });
 
   it("gets schema ID", async () => {
     const registered = await client.registerSchema(schema, options);
     assertIsValidSchemaId(registered);
 
-    const found = await client.getSchemaId(schema, options);
+    const found = await client.getSchemaProperties(schema, options);
     assertIsValidSchemaId(found);
 
     // NOTE: IDs may differ here as we could get a different version with same content.
@@ -149,7 +152,7 @@ describe("SchemaRegistryClient", function() {
     assertIsValidSchemaId(foundSchema);
     assert.equal(foundSchema.content, schema.content);
 
-    const foundId = await client.getSchemaId(schema, {
+    const foundId = await client.getSchemaProperties(schema, {
       onResponse: () => {
         assert.fail("Unexpected call to the service");
       }
@@ -187,7 +190,7 @@ describe("SchemaRegistryClient", function() {
 
     firstCall = false;
     // first call sends a request to the service and then cache the response
-    const foundIdFirstCall = await client.getSchemaId(schema, {
+    const foundIdFirstCall = await client.getSchemaProperties(schema, {
       onResponse: () => {
         firstCall = true;
       }
@@ -197,7 +200,7 @@ describe("SchemaRegistryClient", function() {
     assert.equal(foundIdFirstCall?.id, registered.id);
 
     // second call returns the result from the cache
-    const foundIdSecondCall = await client.getSchemaId(schema, {
+    const foundIdSecondCall = await client.getSchemaProperties(schema, {
       onResponse: () => {
         assert.fail("Unexpected call to the service");
       }
@@ -232,7 +235,7 @@ describe("SchemaRegistryClient", function() {
     assert.equal(foundSchema.content, schema2.content);
 
     let ran = false;
-    const foundId = await client.getSchemaId(
+    const foundId = await client.getSchemaProperties(
       {
         // content that comes from the service does not have whitespaces
         content: foundSchema.content,


### PR DESCRIPTION
According to what the crew and the service team agreed on since `getSchemaId` returns the schema version and the serialization type in addition to the ID.