### PR TITLE
[Schema Registry & Event Hubs] Upgrade api-extractor to v7.18

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -471,7 +471,7 @@ packages:
       integrity: sha512-CxaMaEjwtsmIhWtjHyGimKO7RmES0YxPqGQ9+jKqGygNlhG5NYHktDaiQu6w7k3g+I51VaLXtVSt+BVFd6VWfQ==
   /@azure/identity/1.2.5_debug@4.3.2:
     dependencies:
-      '@azure/core-http': 1.2.3
+      '@azure/core-http': 1.2.6
       '@azure/core-tracing': 1.0.0-preview.9
       '@azure/logger': 1.0.2
       '@azure/msal-node': 1.0.0-beta.6_debug@4.3.2
@@ -2933,7 +2933,7 @@ packages:
       integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
   /debug/3.2.6:
     dependencies:
-      ms: 2.1.1
+      ms: 2.1.3
     deprecated: Debug versions >=3.2.0 <3.2.7 || >=4 <4.3.1 have a low-severity ReDos regression when used in a Node.js environment. It is recommended you upgrade to 3.2.7 or 4.3.1. (https://github.com/visionmedia/debug/issues/797)
     dev: false
     resolution:
@@ -10084,7 +10084,7 @@ packages:
   file:projects/event-hubs.tgz:
     dependencies:
       '@azure/core-tracing': 1.0.0-preview.13
-      '@microsoft/api-extractor': 7.7.11
+      '@microsoft/api-extractor': 7.18.7
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-inject': 4.0.2_rollup@1.32.1
       '@rollup/plugin-json': 4.1.0_rollup@1.32.1
@@ -10151,7 +10151,7 @@ packages:
     dev: false
     name: '@rush-temp/event-hubs'
     resolution:
-      integrity: sha512-volaAWwVVNlEe64e4BR3fwuCFcSpZu419shiGlQKibDEihFzuRIVbGAwj/jiW2/rb0wuxTlWCl5zcZLFAoyqFA==
+      integrity: sha512-fEaozFyATZzYhts6rZVjOawlHHX3R360pcrt4Zd+mT/69QOoIDEWTlPHL7DRBa5HvBzO/bwCXKz6dU7NUhREDg==
       tarball: file:projects/event-hubs.tgz
     version: 0.0.0
   file:projects/event-processor-host.tgz:
@@ -11475,7 +11475,7 @@ packages:
   file:projects/schema-registry-avro.tgz:
     dependencies:
       '@azure/core-tracing': 1.0.0-preview.13
-      '@microsoft/api-extractor': 7.7.11
+      '@microsoft/api-extractor': 7.18.7
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-inject': 4.0.2_rollup@1.32.1
       '@rollup/plugin-json': 4.1.0_rollup@1.32.1
@@ -11524,13 +11524,13 @@ packages:
     dev: false
     name: '@rush-temp/schema-registry-avro'
     resolution:
-      integrity: sha512-MDe5usam/CD907fdEN+tpwdoyKTNr+t1Sv/6T/NTTpXFHU50NkzQcud4bA4m8N2et6muH6jr71qT/KV5B6oItw==
+      integrity: sha512-2kk4+GZuXE74COL6SC0UFTKcKNsRm27+D1bCgI2PYwpXAblWQaws9fClYJVVI+3k4vH0AniKnOqtNB10CngUmQ==
       tarball: file:projects/schema-registry-avro.tgz
     version: 0.0.0
   file:projects/schema-registry.tgz:
     dependencies:
       '@azure/core-tracing': 1.0.0-preview.13
-      '@microsoft/api-extractor': 7.7.11
+      '@microsoft/api-extractor': 7.18.7
       '@types/chai': 4.2.21
       '@types/chai-as-promised': 7.1.4
       '@types/mocha': 7.0.2
@@ -11566,7 +11566,7 @@ packages:
     dev: false
     name: '@rush-temp/schema-registry'
     resolution:
-      integrity: sha512-Wa0ZNJ563uHSOi4xiKpFUhWOZc8yXbeXvHm4xvunwe48Ow2+1Yahgc1TOVjFh8mJt3NdmnD6ufgneunTviNNoA==
+      integrity: sha512-CFUPH7NJ1Zd+6QO+Ag+gQzuW9SZhLYxOelzOdL7fYSaDytiO3UdbyveTnhIMNjrXulfHtG+dSh8RHu/4RfP/GA==
       tarball: file:projects/schema-registry.tgz
     version: 0.0.0
   file:projects/search-documents.tgz:

--- a/sdk/eventhub/event-hubs/package.json
+++ b/sdk/eventhub/event-hubs/package.json
@@ -128,7 +128,7 @@
     "@azure/identity": "2.0.0-beta.6",
     "@azure/test-utils": "^1.0.0",
     "@azure/test-utils-perfstress": "^1.0.0",
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.7",
     "@rollup/plugin-commonjs": "11.0.2",
     "@rollup/plugin-inject": "^4.0.0",
     "@rollup/plugin-json": "^4.0.0",

--- a/sdk/eventhub/event-hubs/review/event-hubs.api.md
+++ b/sdk/eventhub/event-hubs/review/event-hubs.api.md
@@ -4,8 +4,11 @@
 
 ```ts
 
+/// <reference types="node" />
+
 import { AbortSignalLike } from '@azure/abort-controller';
 import { AmqpAnnotatedMessage } from '@azure/core-amqp';
+import { AzureLogger } from '@azure/logger';
 import { MessagingError } from '@azure/core-amqp';
 import { NamedKeyCredential } from '@azure/core-auth';
 import { OperationTracingOptions } from '@azure/core-tracing';
@@ -114,7 +117,7 @@ export class EventHubConsumerClient {
     getPartitionProperties(partitionId: string, options?: GetPartitionPropertiesOptions): Promise<PartitionProperties>;
     subscribe(handlers: SubscriptionEventHandlers, options?: SubscribeOptions): Subscription;
     subscribe(partitionId: string, handlers: SubscriptionEventHandlers, options?: SubscribeOptions): Subscription;
-    }
+}
 
 // @public
 export interface EventHubConsumerClientOptions extends EventHubClientOptions {
@@ -135,7 +138,7 @@ export class EventHubProducerClient {
     getPartitionProperties(partitionId: string, options?: GetPartitionPropertiesOptions): Promise<PartitionProperties>;
     sendBatch(batch: EventData[] | AmqpAnnotatedMessage[], options?: SendBatchOptions): Promise<void>;
     sendBatch(batch: EventDataBatch, options?: OperationOptions): Promise<void>;
-    }
+}
 
 // @public
 export interface EventHubProperties {
@@ -183,7 +186,7 @@ export interface LoadBalancingOptions {
 }
 
 // @public
-export const logger: import("@azure/logger").AzureLogger;
+export const logger: AzureLogger;
 
 export { MessagingError }
 
@@ -307,7 +310,6 @@ export interface TryAddOptions {
 export { WebSocketImpl }
 
 export { WebSocketOptions }
-
 
 // (No @packageDocumentation comment for this package)
 

--- a/sdk/schemaregistry/schema-registry-avro/package.json
+++ b/sdk/schemaregistry/schema-registry-avro/package.json
@@ -86,7 +86,7 @@
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
     "@azure/identity": "2.0.0-beta.6",
     "@azure-tools/test-recorder": "^1.0.0",
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.7",
     "@rollup/plugin-commonjs": "11.0.2",
     "@rollup/plugin-json": "^4.0.0",
     "@rollup/plugin-inject": "^4.0.0",

--- a/sdk/schemaregistry/schema-registry-avro/review/schema-registry-avro.api.md
+++ b/sdk/schemaregistry/schema-registry-avro/review/schema-registry-avro.api.md
@@ -4,6 +4,8 @@
 
 ```ts
 
+/// <reference types="node" />
+
 import { SchemaRegistry } from '@azure/schema-registry';
 
 // @public
@@ -17,7 +19,6 @@ export class SchemaRegistryAvroSerializer {
 export interface SchemaRegistryAvroSerializerOptions {
     autoRegisterSchemas?: boolean;
 }
-
 
 // (No @packageDocumentation comment for this package)
 

--- a/sdk/schemaregistry/schema-registry/package.json
+++ b/sdk/schemaregistry/schema-registry/package.json
@@ -92,7 +92,7 @@
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
     "@azure/identity": "2.0.0-beta.6",
     "@azure-tools/test-recorder": "^1.0.0",
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.7",
     "@types/chai": "^4.1.6",
     "@types/chai-as-promised": "^7.1.0",
     "@types/mocha": "^7.0.2",


### PR DESCRIPTION
https://github.com/Azure/azure-sdk-for-js/pull/17421#issuecomment-910923108 explains that we should start from the leaves when upgrading the api-extractor so this PR does so for schema registry and event hubs.