### PR TITLE
Rewrite typo libraies -> libraries in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Management libraries enable you to provision and manage Azure resources via the 
 
 Newer versions of these libraries follow the [Azure SDK Design Guidelines for TypeScript](https://azure.github.io/azure-sdk/typescript_introduction.html). These new versions provide a number of core capabilities that are shared amongst all Azure SDKs, including the intuitive Azure Identity library, an HTTP Pipeline with custom policies, error-handling, distributed tracing, and much more. A few helpful resources to get started with these are:
 
-- [List of management libraies that follow the new guidelines](https://azure.github.io/azure-sdk/releases/latest/mgmt/js.html)
+- [List of management libraries that follow the new guidelines](https://azure.github.io/azure-sdk/releases/latest/mgmt/js.html)
 - [Documentation and code samples](https://aka.ms/azsdk/js/mgmt).
 - [Migration guide](https://github.com/Azure/azure-sdk-for-js/blob/main/documentation/MIGRATION-guide-for-next-generation-management-libraries.md) that shows how to transition from older versions of libraries.
 


### PR DESCRIPTION
In the main README.md, there was a small typo 8). 