### PR TITLE
[Recorder] Fix encode method for special characters - `~`

### DIFF
--- a/sdk/core/core-rest-pipeline/src/defaultHttpClient.browser.ts
+++ b/sdk/core/core-rest-pipeline/src/defaultHttpClient.browser.ts
@@ -9,6 +9,6 @@ import { createXhrHttpClient } from "./xhrHttpClient";
  * Create the correct HttpClient for the current environment.
  */
 export function createDefaultHttpClient(): HttpClient {
-  const isFetch = typeof window.fetch !== "undefined";
+  const isFetch = typeof self.fetch !== "undefined";
   return isFetch ? createFetchHttpClient() : createXhrHttpClient();
 }

--- a/sdk/core/core-rest-pipeline/src/defaultHttpClient.browser.ts
+++ b/sdk/core/core-rest-pipeline/src/defaultHttpClient.browser.ts
@@ -2,11 +2,13 @@
 // Licensed under the MIT license.
 
 import { HttpClient } from "./interfaces";
+import { createFetchHttpClient } from "./fetchHttpClient";
 import { createXhrHttpClient } from "./xhrHttpClient";
 
 /**
  * Create the correct HttpClient for the current environment.
  */
 export function createDefaultHttpClient(): HttpClient {
-  return createXhrHttpClient();
+  const isFetch = typeof window.fetch !== "undefined";
+  return isFetch ? createFetchHttpClient() : createXhrHttpClient();
 }

--- a/sdk/test-utils/recorder/test/testProxyTests.spec.ts
+++ b/sdk/test-utils/recorder/test/testProxyTests.spec.ts
@@ -74,12 +74,12 @@ import { getTestServerUrl, makeRequestAndVerifyResponse, setTestMode } from "./u
         await makeRequestAndVerifyResponse(
           client,
           {
-            path: `/sample_response`,
+            path: `/post_sample_response`,
             body,
-            method: "GET",
+            method: "POST",
             headers: [{ headerName: "Content-Type", value: "text/plain" }],
           },
-          { val: "abc" }
+          { val: "post_abc" }
         );
       });
 
@@ -95,12 +95,12 @@ import { getTestServerUrl, makeRequestAndVerifyResponse, setTestMode } from "./u
         await makeRequestAndVerifyResponse(
           client,
           {
-            path: `/sample_response`,
+            path: `/post_sample_response`,
             body: "body",
-            method: "GET",
+            method: "POST",
             headers: [{ headerName: "Content-Type", value: "text/plain" }, testHeader],
           },
-          { val: "abc" }
+          { val: "post_abc" }
         );
       });
     });

--- a/sdk/test-utils/recorder/test/utils/server.ts
+++ b/sdk/test-utils/recorder/test/utils/server.ts
@@ -19,6 +19,10 @@ app.get("/sample_response", (_, res) => {
   res.send({ val: "abc" });
 });
 
+app.post("/post_sample_response", (_, res) => {
+  res.send({ val: "post_abc" });
+});
+
 app.get(`/sample_response/:secret_info`, (_, res) => {
   res.send({ val: "I am the answer!" });
 });


### PR DESCRIPTION
@joheredi reached out with a problem where the playback was failing upon rerecording a certain test.

Discussed this with @sadasant who has originally implemented the encoding/decoding parts.
The reason being the generated recording was not replaced as per the replaceable variables provided.
The reason being the secret had `~` character, and encodeRFC3986 method doesn't encode the character.
RFC 3986 standard does not encode the character, but the recordings have that encoded, so adding a new method `encodeSpecialCharacters` in the recorder to encode ~ character to allow the replacements to happen smoothly.

In case we find such characters in future, they should be added to the list in `encodeSpecialCharacters` method that is being added in this PR.