### PR TITLE
Add authorization header when allowInsecureConnection

### DIFF
--- a/sdk/core/core-rest-pipeline/CHANGELOG.md
+++ b/sdk/core/core-rest-pipeline/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Release History
 
+## 1.3.1 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
+
+- Allow `bearerTokenAuthenticationPolicy` to add authorization header on `http` endpoints when `allowInsecureConnection` option is set to true. [PR #17517](https://github.com/Azure/azure-sdk-for-js/pull/17517)
+
 ## 1.3.0 (2021-09-02)
 
 ### Bugs Fixed

--- a/sdk/core/core-rest-pipeline/CHANGELOG.md
+++ b/sdk/core/core-rest-pipeline/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### Other Changes
 
-- Allow `bearerTokenAuthenticationPolicy` to add authorization header on `http` endpoints when `allowInsecureConnection` option is set to true. [PR #17517](https://github.com/Azure/azure-sdk-for-js/pull/17517)
+- Added support for the `PipelineRequest` and `PipelineOptions` property `allowInsecureConnection` in the `bearerTokenAuthenticationPolicy`. If the `bearerTokenAuthenticationPolicy` encounters requests with the `allowInsecureConnection` property set to true, this policy will be allowed to authenticate against insecure authority hosts using the `http` endpoint. [PR #17517](https://github.com/Azure/azure-sdk-for-js/pull/17517)
 
 ## 1.3.0 (2021-09-02)
 

--- a/sdk/core/core-rest-pipeline/package.json
+++ b/sdk/core/core-rest-pipeline/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/core-rest-pipeline",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Isomorphic client library for making HTTP requests in node.js and browser.",
   "sdk-type": "client",
   "main": "dist/index.js",

--- a/sdk/core/core-rest-pipeline/src/constants.ts
+++ b/sdk/core/core-rest-pipeline/src/constants.ts
@@ -1,4 +1,4 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-export const SDK_VERSION: string = "1.3.0";
+export const SDK_VERSION: string = "1.3.1";

--- a/sdk/core/core-rest-pipeline/src/policies/bearerTokenAuthenticationPolicy.ts
+++ b/sdk/core/core-rest-pipeline/src/policies/bearerTokenAuthenticationPolicy.ts
@@ -155,7 +155,7 @@ export function bearerTokenAuthenticationPolicy(
      * - Retrieve a token with the challenge information, then re-send the request.
      */
     async sendRequest(request: PipelineRequest, next: SendRequest): Promise<PipelineResponse> {
-      if (!request.url.toLowerCase().startsWith("https://")) {
+      if (!request.allowInsecureConnection && !request.url.toLowerCase().startsWith("https://")) {
         throw new Error(
           "Bearer token authentication is not permitted for non-TLS protected (non-https) URLs."
         );

--- a/sdk/core/core-rest-pipeline/test/bearerTokenAuthenticationPolicy.spec.ts
+++ b/sdk/core/core-rest-pipeline/test/bearerTokenAuthenticationPolicy.spec.ts
@@ -58,6 +58,41 @@ describe("BearerTokenAuthenticationPolicy", function() {
     assert.strictEqual(request.headers.get("Authorization"), `Bearer ${mockToken}`);
   });
 
+  it("correctly adds an Authentication header with the Bearer token when using allowInsecureConnection", async function() {
+    const mockToken = "token";
+    const tokenScopes = ["scope1", "scope2"];
+    const fakeGetToken = sinon.fake.returns(
+      Promise.resolve({ token: mockToken, expiresOn: new Date() })
+    );
+    const mockCredential: TokenCredential = {
+      getToken: fakeGetToken
+    };
+
+    const request = createPipelineRequest({
+      url: "http://example.com",
+      allowInsecureConnection: true
+    });
+    const successResponse: PipelineResponse = {
+      headers: createHttpHeaders(),
+      request,
+      status: 200
+    };
+    const next = sinon.stub<Parameters<SendRequest>, ReturnType<SendRequest>>();
+    next.resolves(successResponse);
+
+    const bearerTokenAuthPolicy = createBearerTokenPolicy(tokenScopes, mockCredential);
+    await bearerTokenAuthPolicy.sendRequest(request, next);
+
+    assert(
+      fakeGetToken.calledWith(tokenScopes, {
+        abortSignal: undefined,
+        tracingOptions: undefined
+      }),
+      "fakeGetToken called incorrectly."
+    );
+    assert.strictEqual(request.headers.get("Authorization"), `Bearer ${mockToken}`);
+  });
+
   it("refreshes the token on initial request", async () => {
     const expiresOn = Date.now() + 1000 * 60; // One minute later.
     const credential = new MockRefreshAzureCredential(expiresOn);


### PR DESCRIPTION
We have a guard in `bearerTokenAuthenticationPolicy` to make sure that the authorization header is not added when the endpoint is not `https`.

However we have a `PipelineRequestOptions` property that users can set to allow insecure connections. If this is not set core-rest-pipeline would refuse to send the request, however, if this option is true, the request is allowed.

`bearerTokenAuthenticationPolicy` doesn't take this option into account, this PR allows adding the authorization header when the option is set to true.

This problem surfaced when updating the CodeGen dependency on core-rest-pipeline as it runs against a local http server instance

Note: Python seems to have a similar check ([link](https://github.com/Azure/azure-sdk-for-python/blob/d27b0f6a49afa85d99994f052188d192a10c5f02/sdk/containerregistry/azure-containerregistry/azure/containerregistry/_helpers.py#L94))