### PR TITLE
[core] fix incorrect caching of proxy agents

### DIFF
--- a/sdk/core/core-http/test/defaultHttpClientTests.node.ts
+++ b/sdk/core/core-http/test/defaultHttpClientTests.node.ts
@@ -353,6 +353,48 @@ describe("defaultHttpClient (node)", function() {
       download.notified.should.be.true;
     });
   });
+
+  it.only("should use cached agent for requests with the same proxy settings", async function() {
+    const request1 = new WebResource("/url");
+    request1.proxySettings = { host: "host1", port: 8001, username: "user1", password: "pass123" };
+    const request2 = new WebResource("/url");
+    request2.proxySettings = { host: "host1", port: 8001, username: "user1", password: "pass123" };
+    const client = new DefaultHttpClient();
+
+    const requestInit1: Partial<RequestInit & { agent?: any }> = await client.prepareRequest(request1);
+    const requestInit2: Partial<RequestInit & { agent?: any }> = await client.prepareRequest(request2);
+    assert.deepStrictEqual(requestInit1.agent, requestInit2.agent);
+  })
+
+  it.only("should use different agents for requests with different proxy settings", async function() {
+    const request1 = new WebResource("/url");
+    request1.proxySettings = { host: "host1", port: 8001, username: "user1", password: "pass123" };
+    const request2 = new WebResource("/url");
+    request2.proxySettings = { host: "host2", port: 8002, username: "user2", password: "p@55wOrd" };
+    const client = new DefaultHttpClient();
+
+    const requestInit1: Partial<RequestInit & { agent?: any }> = await client.prepareRequest(request1);
+    const requestInit2: Partial<RequestInit & { agent?: any }> = await client.prepareRequest(request2);
+    assert.notStrictEqual(requestInit1.agent, requestInit2.agent);
+    assert.notEqual(requestInit1.agent.proxyOptions.host, requestInit2.agent.proxyOptions.host);
+    assert.notEqual(requestInit1.agent.proxyOptions.port, requestInit2.agent.proxyOptions.port);
+    assert.notEqual(requestInit1.agent.proxyOptions.username, requestInit2.agent.proxyOptions.username);
+    assert.notEqual(requestInit1.agent.proxyOptions.password, requestInit2.agent.proxyOptions.password);
+  })
+
+  it.only("should use different agents for requests with different proxy settings of same url but different credentials", async function() {
+    const request1 = new WebResource("/url");
+    request1.proxySettings = { host: "host1", port: 8001, username: "user1", password: "pass123" };
+    const request2 = new WebResource("/url");
+    request2.proxySettings = { host: "host1", port: 8001 };
+    const client = new DefaultHttpClient();
+
+    const requestInit1: Partial<RequestInit & { agent?: any }> = await client.prepareRequest(request1);
+    const requestInit2: Partial<RequestInit & { agent?: any }> = await client.prepareRequest(request2);
+    assert.notStrictEqual(requestInit1.agent, requestInit2.agent);
+    assert.notEqual(requestInit1.agent.proxyOptions.username, requestInit2.agent.proxyOptions.username);
+    assert.notEqual(requestInit1.agent.proxyOptions.password, requestInit2.agent.proxyOptions.password);
+  })
 });
 
 describe("ReportTransform", function() {

--- a/sdk/core/core-http/test/defaultHttpClientTests.node.ts
+++ b/sdk/core/core-http/test/defaultHttpClientTests.node.ts
@@ -354,47 +354,64 @@ describe("defaultHttpClient (node)", function() {
     });
   });
 
-  it.only("should use cached agent for requests with the same proxy settings", async function() {
+  it("should use cached agent for requests with the same proxy settings", async function() {
+    const proxySettings = { host: "host1", port: 8001, username: "user1", password: "pass123" };
     const request1 = new WebResource("/url");
-    request1.proxySettings = { host: "host1", port: 8001, username: "user1", password: "pass123" };
+    request1.proxySettings = proxySettings;
     const request2 = new WebResource("/url");
-    request2.proxySettings = { host: "host1", port: 8001, username: "user1", password: "pass123" };
+    request2.proxySettings = proxySettings;
     const client = new DefaultHttpClient();
 
-    const requestInit1: Partial<RequestInit & { agent?: any }> = await client.prepareRequest(request1);
-    const requestInit2: Partial<RequestInit & { agent?: any }> = await client.prepareRequest(request2);
+    const requestInit1: Partial<RequestInit & { agent?: any }> = await client.prepareRequest(
+      request1
+    );
+    const requestInit2: Partial<RequestInit & { agent?: any }> = await client.prepareRequest(
+      request2
+    );
     assert.deepStrictEqual(requestInit1.agent, requestInit2.agent);
-  })
+  });
 
-  it.only("should use different agents for requests with different proxy settings", async function() {
+  it("should use different agents for requests with different proxy settings", async function() {
     const request1 = new WebResource("/url");
     request1.proxySettings = { host: "host1", port: 8001, username: "user1", password: "pass123" };
     const request2 = new WebResource("/url");
     request2.proxySettings = { host: "host2", port: 8002, username: "user2", password: "p@55wOrd" };
     const client = new DefaultHttpClient();
 
-    const requestInit1: Partial<RequestInit & { agent?: any }> = await client.prepareRequest(request1);
-    const requestInit2: Partial<RequestInit & { agent?: any }> = await client.prepareRequest(request2);
+    const requestInit1: Partial<RequestInit & { agent?: any }> = await client.prepareRequest(
+      request1
+    );
+    const requestInit2: Partial<RequestInit & { agent?: any }> = await client.prepareRequest(
+      request2
+    );
     assert.notStrictEqual(requestInit1.agent, requestInit2.agent);
     assert.notEqual(requestInit1.agent.proxyOptions.host, requestInit2.agent.proxyOptions.host);
     assert.notEqual(requestInit1.agent.proxyOptions.port, requestInit2.agent.proxyOptions.port);
-    assert.notEqual(requestInit1.agent.proxyOptions.username, requestInit2.agent.proxyOptions.username);
-    assert.notEqual(requestInit1.agent.proxyOptions.password, requestInit2.agent.proxyOptions.password);
-  })
+    assert.notEqual(
+      requestInit1.agent.proxyOptions.proxyAuth,
+      requestInit2.agent.proxyOptions.proxyAuth
+    );
+  });
 
-  it.only("should use different agents for requests with different proxy settings of same url but different credentials", async function() {
+  it("should use different agents for requests with different proxy settings of same url but different credentials", async function() {
     const request1 = new WebResource("/url");
     request1.proxySettings = { host: "host1", port: 8001, username: "user1", password: "pass123" };
     const request2 = new WebResource("/url");
     request2.proxySettings = { host: "host1", port: 8001 };
     const client = new DefaultHttpClient();
 
-    const requestInit1: Partial<RequestInit & { agent?: any }> = await client.prepareRequest(request1);
-    const requestInit2: Partial<RequestInit & { agent?: any }> = await client.prepareRequest(request2);
+    const requestInit1: Partial<RequestInit & { agent?: any }> = await client.prepareRequest(
+      request1
+    );
+    const requestInit2: Partial<RequestInit & { agent?: any }> = await client.prepareRequest(
+      request2
+    );
     assert.notStrictEqual(requestInit1.agent, requestInit2.agent);
-    assert.notEqual(requestInit1.agent.proxyOptions.username, requestInit2.agent.proxyOptions.username);
-    assert.notEqual(requestInit1.agent.proxyOptions.password, requestInit2.agent.proxyOptions.password);
-  })
+    assert.notEqual(
+      requestInit1.agent.proxyOptions.proxyAuth,
+      requestInit2.agent.proxyOptions.proxyAuth
+    );
+  });
 });
 
 describe("ReportTransform", function() {


### PR DESCRIPTION
The problem is that we only ever create one proxy agent and cache it, despite that different requests
could have different proxy settings.  This PR fixes the issue by using a cache of a map of <string, AgentCache>, 
with the string representation of proxy settings as the key.

Issue #16418 