### PR TITLE
[schema-registry-avro] serialize into JS's standard Uint8Array instead of Buffer

### DIFF
--- a/sdk/schemaregistry/schema-registry-avro/review/schema-registry-avro.api.md
+++ b/sdk/schemaregistry/schema-registry-avro/review/schema-registry-avro.api.md
@@ -12,7 +12,7 @@ import { SchemaRegistry } from '@azure/schema-registry';
 export class SchemaRegistryAvroSerializer {
     constructor(client: SchemaRegistry, groupName: string, options?: SchemaRegistryAvroSerializerOptions);
     deserialize(input: Buffer | Blob | Uint8Array): Promise<unknown>;
-    serialize(value: unknown, schema: string): Promise<Buffer>;
+    serialize(value: unknown, schema: string): Promise<Uint8Array>;
 }
 
 // @public

--- a/sdk/schemaregistry/schema-registry-avro/src/schemaRegistryAvroSerializer.ts
+++ b/sdk/schemaregistry/schema-registry-avro/src/schemaRegistryAvroSerializer.ts
@@ -113,7 +113,7 @@ export class SchemaRegistryAvroSerializer {
    * @param schema - The Avro schema to use.
    * @returns A new buffer with the serialized value
    */
-  async serialize(value: unknown, schema: string): Promise<Buffer> {
+  async serialize(value: unknown, schema: string): Promise<Uint8Array> {
     const entry = await this.getSchemaByContent(schema);
     const payload = entry.type.toBuffer(value);
     const buffer = Buffer.alloc(PAYLOAD_OFFSET + payload.length);

--- a/sdk/schemaregistry/schema-registry-avro/src/schemaRegistryAvroSerializer.ts
+++ b/sdk/schemaregistry/schema-registry-avro/src/schemaRegistryAvroSerializer.ts
@@ -121,7 +121,11 @@ export class SchemaRegistryAvroSerializer {
     buffer.writeUInt32BE(FORMAT_INDICATOR, 0);
     buffer.write(entry.id, SCHEMA_ID_OFFSET, SCHEMA_ID_LENGTH, "utf-8");
     payload.copy(buffer, PAYLOAD_OFFSET);
-    return buffer;
+    return new Uint8Array(
+      buffer.buffer,
+      buffer.byteOffset,
+      buffer.byteLength / Uint8Array.BYTES_PER_ELEMENT
+    );
   }
 
   // REVIEW: signature. See serialize and s/serialize into/deserialize from/.

--- a/sdk/schemaregistry/schema-registry-avro/test/schemaRegistryAvroSerializer.spec.ts
+++ b/sdk/schemaregistry/schema-registry-avro/test/schemaRegistryAvroSerializer.spec.ts
@@ -71,6 +71,7 @@ describe("SchemaRegistryAvroSerializer", function() {
     const schemaId = await registerTestSchema(registry);
     const serializer = await createTestSerializer(false, registry);
     const arr = await serializer.serialize(testValue, testSchema);
+    assert.isUndefined((arr as Buffer).readBigInt64BE);
     const buffer = Buffer.from(arr);
     assert.strictEqual(0x0, buffer.readUInt32BE(0));
     assert.strictEqual(schemaId, buffer.toString("utf-8", 4, 36));

--- a/sdk/schemaregistry/schema-registry-avro/test/schemaRegistryAvroSerializer.spec.ts
+++ b/sdk/schemaregistry/schema-registry-avro/test/schemaRegistryAvroSerializer.spec.ts
@@ -70,7 +70,8 @@ describe("SchemaRegistryAvroSerializer", function() {
     const registry = createTestRegistry();
     const schemaId = await registerTestSchema(registry);
     const serializer = await createTestSerializer(false, registry);
-    const buffer = await serializer.serialize(testValue, testSchema);
+    const arr = await serializer.serialize(testValue, testSchema);
+    const buffer = Buffer.from(arr);
     assert.strictEqual(0x0, buffer.readUInt32BE(0));
     assert.strictEqual(schemaId, buffer.toString("utf-8", 4, 36));
     const payload = buffer.slice(36);


### PR DESCRIPTION
`serialize` currently returns a `Buffer` which is a NodeJS only thing. This PR changes this return type to `Uint8Array` instead because it is a standard JS type that will work anywhere. Note that under the hood we return a buffer because this package depends on `avsc` which is a NodeJS only package so we have to work with buffers internally anyway. However, we use the `Uint8Array` for the type here so that we are ready to jump to a Buffer-less avro implementation should one be available in the future and to be able to work with other JS platforms.

There is still a question on whether we should add extra serialize methods for other types as well but I will leave that to concrete customer asks for now.