### PR TITLE
[monitor-query] fix what is publicly exported and make only one copy of function

### DIFF
--- a/sdk/monitor/monitor-query/review/monitor-query.api.md
+++ b/sdk/monitor/monitor-query/review/monitor-query.api.md
@@ -10,7 +10,24 @@ import { PagedAsyncIterableIterator } from '@azure/core-paging';
 import { TokenCredential } from '@azure/core-auth';
 
 // @public
+export class AggregateBatchError extends Error {
+    constructor(errors: ErrorInfo[]);
+    // (undocumented)
+    errors: BatchError[];
+}
+
+// @public
 export type AggregationType = "None" | "Average" | "Count" | "Minimum" | "Maximum" | "Total";
+
+// @public
+export class BatchError extends Error implements ErrorInfo {
+    constructor(errorInfo: ErrorInfo);
+    additionalProperties?: Record<string, unknown>;
+    code: string;
+    details?: ErrorDetail[];
+    innerError?: ErrorInfo;
+    message: string;
+}
 
 // @public
 export const Durations: {

--- a/sdk/monitor/monitor-query/src/index.ts
+++ b/sdk/monitor/monitor-query/src/index.ts
@@ -16,7 +16,9 @@ export {
   LogsTable,
   LogsColumn,
   LogsQueryResultStatus,
-  ErrorInfo
+  ErrorInfo,
+  BatchError,
+  AggregateBatchError
 } from "./models/publicLogsModels";
 export {
   MetricsQueryClient,

--- a/sdk/monitor/monitor-query/src/internal/modelConverters.ts
+++ b/sdk/monitor/monitor-query/src/internal/modelConverters.ts
@@ -39,7 +39,8 @@ import {
   MetricNamespace,
   Metric,
   MetricDefinition,
-  TimeSeriesElement
+  TimeSeriesElement,
+  createMetricsQueryResult
 } from "../models/publicMetricsModels";
 import { FullOperationResponse } from "@azure/core-client";
 import {
@@ -262,13 +263,10 @@ export function convertResponseForMetrics(
   // eslint-disable-next-line @typescript-eslint/no-unused-vars -- eslint doesn't recognize that the extracted variables are prefixed with '_' and are purposefully unused.
   const { resourceregion, value: _ignoredValue, interval, timespan, ...rest } = generatedResponse;
 
-  const obj: MetricsQueryResult = {
+  const obj: Omit<MetricsQueryResult, "getMetricByName"> = {
     ...rest,
     metrics,
-    timespan: convertIntervalToTimeIntervalObject(timespan),
-    getMetricByName(metricName) {
-      return this.metrics.find((it) => it.name === metricName);
-    }
+    timespan: convertIntervalToTimeIntervalObject(timespan)
   };
 
   if (resourceregion) {
@@ -278,7 +276,7 @@ export function convertResponseForMetrics(
     obj.granularity = interval;
   }
 
-  return obj;
+  return createMetricsQueryResult(obj);
 }
 
 /**

--- a/sdk/monitor/monitor-query/src/logsQueryClient.ts
+++ b/sdk/monitor/monitor-query/src/logsQueryClient.ts
@@ -138,7 +138,7 @@ export class LogsQueryClient {
       }
     }
     if (options?.throwOnAnyFailure && result.status !== "Success") {
-      throw result.error;
+      throw new BatchError(result.error as ErrorInfo);
     }
     return result;
   }

--- a/sdk/monitor/monitor-query/src/models/publicLogsModels.ts
+++ b/sdk/monitor/monitor-query/src/models/publicLogsModels.ts
@@ -66,7 +66,7 @@ export interface ErrorInfo extends Error {
   additionalProperties?: Record<string, unknown>;
 }
 
-/** Batch Error class */
+/** Batch Error class for errors returned in logs query API */
 export class BatchError extends Error implements ErrorInfo {
   /** A machine readable error code. */
   code: string;
@@ -89,7 +89,7 @@ export class BatchError extends Error implements ErrorInfo {
     this.additionalProperties = errorInfo.additionalProperties;
   }
 }
-/** AggregateBatchError class */
+/** AggregateBatchError type for errors returned in logs query batch API*/
 export class AggregateBatchError extends Error {
   errors: BatchError[];
   constructor(errors: ErrorInfo[]) {

--- a/sdk/monitor/monitor-query/src/models/publicLogsModels.ts
+++ b/sdk/monitor/monitor-query/src/models/publicLogsModels.ts
@@ -66,6 +66,7 @@ export interface ErrorInfo extends Error {
   additionalProperties?: Record<string, unknown>;
 }
 
+/** Batch Error class */
 export class BatchError extends Error implements ErrorInfo {
   /** A machine readable error code. */
   code: string;
@@ -88,6 +89,7 @@ export class BatchError extends Error implements ErrorInfo {
     this.additionalProperties = errorInfo.additionalProperties;
   }
 }
+/** AggregateBatchError class */
 export class AggregateBatchError extends Error {
   errors: BatchError[];
   constructor(errors: ErrorInfo[]) {

--- a/sdk/monitor/monitor-query/src/models/publicLogsModels.ts
+++ b/sdk/monitor/monitor-query/src/models/publicLogsModels.ts
@@ -66,7 +66,7 @@ export interface ErrorInfo extends Error {
   additionalProperties?: Record<string, unknown>;
 }
 
-/** Batch Error class for errors returned in logs query API */
+/** Batch Error class for type of each error item in the {@link AggregateBatchError} list returned in logs query batch API */
 export class BatchError extends Error implements ErrorInfo {
   /** A machine readable error code. */
   code: string;

--- a/sdk/monitor/monitor-query/src/models/publicMetricsModels.ts
+++ b/sdk/monitor/monitor-query/src/models/publicMetricsModels.ts
@@ -115,7 +115,7 @@ export interface MetricsQueryResult {
   getMetricByName(metricName: string): Metric | undefined;
 }
 
-export function getMetricByName(this: MetricsQueryResult, metricName: string) {
+export function getMetricByName(this: MetricsQueryResult, metricName: string): Metric | undefined {
   return this.metrics.find((it) => it.name === metricName);
 }
 

--- a/sdk/monitor/monitor-query/src/models/publicMetricsModels.ts
+++ b/sdk/monitor/monitor-query/src/models/publicMetricsModels.ts
@@ -119,10 +119,10 @@ export function getMetricByName(this: MetricsQueryResult, metricName: string): M
   return this.metrics.find((it) => it.name === metricName);
 }
 
-export function createMetricsQueryResult({
-  ...params
-}: Omit<MetricsQueryResult, "getMetricByName">): MetricsQueryResult {
-  return { ...params, getMetricByName };
+export function createMetricsQueryResult(
+  metricsQueryResultData: Omit<MetricsQueryResult, "getMetricByName">
+): MetricsQueryResult {
+  return { ...metricsQueryResultData, getMetricByName };
 }
 
 /**

--- a/sdk/monitor/monitor-query/src/models/publicMetricsModels.ts
+++ b/sdk/monitor/monitor-query/src/models/publicMetricsModels.ts
@@ -115,6 +115,16 @@ export interface MetricsQueryResult {
   getMetricByName(metricName: string): Metric | undefined;
 }
 
+export function getMetricByName(this: MetricsQueryResult, metricName: string) {
+  return this.metrics.find((it) => it.name === metricName);
+}
+
+export function createMetricsQueryResult({
+  ...params
+}: Omit<MetricsQueryResult, "getMetricByName">): MetricsQueryResult {
+  return { ...params, getMetricByName };
+}
+
 /**
  * Options used when getting metric definitions.
  */


### PR DESCRIPTION
- Make error types publicly exported
- make only one copy of function - "getMetricByName" in the interface