### PR TITLE
Prepare for stg78 GA 

### DIFF
--- a/common/config/rush/common-versions.json
+++ b/common/config/rush/common-versions.json
@@ -47,11 +47,6 @@
     // Text Analytics uses this version and it is not released yet. I am making an exception
     // for it here and it should be removed once core-paging 1.2.0 is released.
     "@azure/core-paging": ["^1.2.0", ">=1.2.0-alpha <1.2.0-alphb"],
-    // "^12.6.0" is required for eventhubs-checkpointstore-blob to use the latest GA version
-    // when there is a new beta version which is being maintained in the repo.
-    // Remove "^12.6.0" when the storage-blob releases a stable version.
-    // Add a new entry in case a new version is being tested through the perf tests (Example: "12.2.0").
-    "@azure/storage-blob": ["^12.6.0"],
     "@azure/ms-rest-js": ["^2.0.0"],
     /**
      * For example, allow some projects to use an older TypeScript compiler

--- a/sdk/eventhub/eventhubs-checkpointstore-blob/package.json
+++ b/sdk/eventhub/eventhubs-checkpointstore-blob/package.json
@@ -62,7 +62,7 @@
     "@azure/abort-controller": "^1.0.0",
     "@azure/event-hubs": "^5.6.0",
     "@azure/logger": "^1.0.0",
-    "@azure/storage-blob": "^12.6.0",
+    "@azure/storage-blob": "^12.8.0",
     "events": "^3.0.0",
     "tslib": "^2.2.0"
   },

--- a/sdk/quantum/quantum-jobs/package.json
+++ b/sdk/quantum/quantum-jobs/package.json
@@ -69,7 +69,7 @@
     "tslib": "^2.2.0"
   },
   "devDependencies": {
-    "@azure/storage-blob": "^12.6.0",
+    "@azure/storage-blob": "^12.8.0",
     "@azure/dev-tool": "^1.0.0",
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
     "@azure/identity": "2.0.0-beta.6",

--- a/sdk/storage/perf-tests/storage-blob/package.json
+++ b/sdk/storage/perf-tests/storage-blob/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@azure/core-http": "^2.0.0",
     "@azure/core-rest-pipeline": "^1.1.0",
-    "@azure/storage-blob": "^12.8.0-beta.1",
+    "@azure/storage-blob": "^12.8.0",
     "@azure/test-utils-perfstress": "^1.0.0",
     "dotenv": "^8.2.0",
     "uuid": "^8.3.0"

--- a/sdk/storage/storage-blob-changefeed/package.json
+++ b/sdk/storage/storage-blob-changefeed/package.json
@@ -93,7 +93,7 @@
     ]
   },
   "dependencies": {
-    "@azure/storage-blob": "^12.8.0-beta.1",
+    "@azure/storage-blob": "^12.8.0",
     "@azure/abort-controller": "^1.0.0",
     "@azure/core-http": "^2.0.0",
     "@azure/core-lro": "^2.2.0",

--- a/sdk/storage/storage-blob/CHANGELOG.md
+++ b/sdk/storage/storage-blob/CHANGELOG.md
@@ -1,14 +1,10 @@
 # Release History
 
-## 12.8.0-beta.2 (Unreleased)
+## 12.8.0 (2021-09-10)
 
 ### Features Added
 
-### Breaking Changes
-
-### Bugs Fixed
-
-### Other Changes
+- Includes all features released in 12.8.0-beta.1.
 
 ## 12.8.0-beta.1 (2021-07-28)
 

--- a/sdk/storage/storage-blob/package.json
+++ b/sdk/storage/storage-blob/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@azure/storage-blob",
   "sdk-type": "client",
-  "version": "12.8.0-beta.2",
+  "version": "12.8.0",
   "description": "Microsoft Azure Storage SDK for JavaScript - Blob",
   "main": "./dist/index.js",
   "module": "./dist-esm/storage-blob/src/index.js",

--- a/sdk/storage/storage-blob/src/generated/src/storageClientContext.ts
+++ b/sdk/storage/storage-blob/src/generated/src/storageClientContext.ts
@@ -10,7 +10,7 @@ import * as coreHttp from "@azure/core-http";
 import { StorageClientOptionalParams } from "./models";
 
 const packageName = "azure-storage-blob";
-const packageVersion = "12.8.0-beta.2";
+const packageVersion = "12.8.0";
 
 export class StorageClientContext extends coreHttp.ServiceClient {
   url: string;

--- a/sdk/storage/storage-blob/src/utils/constants.ts
+++ b/sdk/storage/storage-blob/src/utils/constants.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-export const SDK_VERSION: string = "12.8.0-beta.2";
+export const SDK_VERSION: string = "12.8.0";
 export const SERVICE_VERSION: string = "2020-10-02";
 
 export const BLOCK_BLOB_MAX_UPLOAD_BLOB_BYTES: number = 256 * 1024 * 1024; // 256MB

--- a/sdk/storage/storage-blob/swagger/README.md
+++ b/sdk/storage/storage-blob/swagger/README.md
@@ -20,7 +20,7 @@ disable-async-iterators: true
 add-credentials: false
 use-extension:
   "@autorest/typescript": "6.0.0-dev.20210218.1"
-package-version: 12.8.0-beta.2
+package-version: 12.8.0
 ```
 
 ## Customizations for Track 2 Generator

--- a/sdk/storage/storage-file-datalake/CHANGELOG.md
+++ b/sdk/storage/storage-file-datalake/CHANGELOG.md
@@ -1,14 +1,10 @@
 # Release History
 
-## 12.7.0-beta.2 (Unreleased)
+## 12.7.0 (2021-09-10)
 
 ### Features Added
 
-### Breaking Changes
-
-### Bugs Fixed
-
-### Other Changes
+- Includes all features released in 12.7.0-beta.1.
 
 ## 12.7.0-beta.1 (2021-07-28)
 

--- a/sdk/storage/storage-file-datalake/package.json
+++ b/sdk/storage/storage-file-datalake/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/storage-file-datalake",
-  "version": "12.7.0-beta.2",
+  "version": "12.7.0",
   "description": "Microsoft Azure Storage SDK for JavaScript - DataLake",
   "sdk-type": "client",
   "main": "./dist/index.js",
@@ -110,7 +110,7 @@
     "@azure/core-paging": "^1.1.1",
     "@azure/core-tracing": "1.0.0-preview.13",
     "@azure/logger": "^1.0.0",
-    "@azure/storage-blob": "^12.8.0-beta.1",
+    "@azure/storage-blob": "^12.8.0",
     "events": "^3.0.0",
     "tslib": "^2.2.0"
   },

--- a/sdk/storage/storage-file-datalake/src/generated/src/storageClientContext.ts
+++ b/sdk/storage/storage-file-datalake/src/generated/src/storageClientContext.ts
@@ -10,7 +10,7 @@ import * as coreHttp from "@azure/core-http";
 import { StorageClientOptionalParams } from "./models";
 
 const packageName = "azure-storage-datalake";
-const packageVersion = "12.7.0-beta.2";
+const packageVersion = "12.7.0";
 
 export class StorageClientContext extends coreHttp.ServiceClient {
   url: string;

--- a/sdk/storage/storage-file-datalake/src/utils/constants.ts
+++ b/sdk/storage/storage-file-datalake/src/utils/constants.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-export const SDK_VERSION: string = "12.7.0-beta.2";
+export const SDK_VERSION: string = "12.7.0";
 export const SERVICE_VERSION: string = "2020-10-02";
 
 export const KB: number = 1024;

--- a/sdk/storage/storage-file-datalake/swagger/README.md
+++ b/sdk/storage/storage-file-datalake/swagger/README.md
@@ -20,7 +20,7 @@ disable-async-iterators: true
 add-credentials: false
 use-extension:
   "@autorest/typescript": "6.0.0-dev.20210223.1"
-package-version: 12.7.0-beta.2
+package-version: 12.7.0
 ```
 
 ## Customizations for Track 2 Generator

--- a/sdk/storage/storage-file-share/CHANGELOG.md
+++ b/sdk/storage/storage-file-share/CHANGELOG.md
@@ -1,14 +1,10 @@
 # Release History
 
-## 12.8.0-beta.2 (Unreleased)
+## 12.8.0 (2021-09-10)
 
 ### Features Added
 
-### Breaking Changes
-
-### Bugs Fixed
-
-### Other Changes
+- Includes all features released in 12.8.0-beta.1.
 
 ## 12.8.0-beta.1 (2021-07-28)
 

--- a/sdk/storage/storage-file-share/package.json
+++ b/sdk/storage/storage-file-share/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@azure/storage-file-share",
   "sdk-type": "client",
-  "version": "12.8.0-beta.2",
+  "version": "12.8.0",
   "description": "Microsoft Azure Storage SDK for JavaScript - File",
   "main": "./dist/index.js",
   "module": "./dist-esm/src/index.js",
@@ -122,7 +122,7 @@
     "tslib": "^2.2.0"
   },
   "devDependencies": {
-    "@azure/storage-blob": "^12.8.0-beta.1",
+    "@azure/storage-blob": "^12.8.0",
     "@azure/dev-tool": "^1.0.0",
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
     "@azure/test-utils": "^1.0.0",

--- a/sdk/storage/storage-file-share/src/generated/src/storageClientContext.ts
+++ b/sdk/storage/storage-file-share/src/generated/src/storageClientContext.ts
@@ -10,7 +10,7 @@ import * as coreHttp from "@azure/core-http";
 import { StorageClientOptionalParams } from "./models";
 
 const packageName = "azure-storage-file-share";
-const packageVersion = "12.8.0-beta.2";
+const packageVersion = "12.8.0";
 
 export class StorageClientContext extends coreHttp.ServiceClient {
   url: string;

--- a/sdk/storage/storage-file-share/src/utils/constants.ts
+++ b/sdk/storage/storage-file-share/src/utils/constants.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-export const SDK_VERSION: string = "12.8.0-beta.2";
+export const SDK_VERSION: string = "12.8.0";
 export const SERVICE_VERSION: string = "2020-10-02";
 
 export const FILE_MAX_SIZE_BYTES: number = 4 * 1024 * 1024 * 1024 * 1024; // 4TB

--- a/sdk/storage/storage-file-share/swagger/README.md
+++ b/sdk/storage/storage-file-share/swagger/README.md
@@ -20,7 +20,7 @@ disable-async-iterators: true
 add-credentials: false
 use-extension:
   "@autorest/typescript": "6.0.0-dev.20210218.1"
-package-version: 12.8.0-beta.2
+package-version: 12.8.0
 ```
 
 ## Customizations for Track 2 Generator

--- a/sdk/storage/storage-queue/CHANGELOG.md
+++ b/sdk/storage/storage-queue/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Release History
 
-## 12.7.0 (Unreleased)
+## 12.7.0 (2021-09-10)
 
 ### Features Added
 
+- Added support for service version 2020-10-02.
 - With the dropping of support for Node.js versions that are no longer in LTS, the dependency on `@types/node` has been updated to version 12. Read our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Breaking Changes

--- a/sdk/storage/storage-queue/src/generated/src/models/parameters.ts
+++ b/sdk/storage/storage-queue/src/generated/src/models/parameters.ts
@@ -100,7 +100,7 @@ export const timeoutInSeconds: OperationQueryParameter = {
 export const version: OperationParameter = {
   parameterPath: "version",
   mapper: {
-    defaultValue: "2020-08-04",
+    defaultValue: "2020-10-02",
     isConstant: true,
     serializedName: "x-ms-version",
     type: {

--- a/sdk/storage/storage-queue/src/generated/src/storageClientContext.ts
+++ b/sdk/storage/storage-queue/src/generated/src/storageClientContext.ts
@@ -10,7 +10,7 @@ import * as coreHttp from "@azure/core-http";
 import { StorageClientOptionalParams } from "./models";
 
 const packageName = "azure-storage-queue";
-const packageVersion = "12.6.0";
+const packageVersion = "12.7.0";
 
 export class StorageClientContext extends coreHttp.ServiceClient {
   url: string;
@@ -47,6 +47,6 @@ export class StorageClientContext extends coreHttp.ServiceClient {
     this.url = url;
 
     // Assigning values to Constant parameters
-    this.version = options.version || "2020-08-04";
+    this.version = options.version || "2020-10-02";
   }
 }

--- a/sdk/storage/storage-queue/src/utils/constants.ts
+++ b/sdk/storage/storage-queue/src/utils/constants.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 
 export const SDK_VERSION: string = "12.7.0";
-export const SERVICE_VERSION: string = "2020-08-04";
+export const SERVICE_VERSION: string = "2020-10-02";
 
 /**
  * The OAuth scope to use with Azure Storage.

--- a/sdk/storage/storage-queue/swagger/README.md
+++ b/sdk/storage/storage-queue/swagger/README.md
@@ -226,13 +226,13 @@ directive:
       $["x-ms-client-name"] = "queueAnalyticsLogging"
 ```
 
-### Update service version from "2018-03-28" to "2020-08-04"
+### Update service version from "2018-03-28" to "2020-10-02"
 
 ```yaml
 directive:
   - from: swagger-document
     where: $.parameters.ApiVersionParameter
-    transform: $.enum = [ "2020-08-04" ];
+    transform: $.enum = [ "2020-10-02" ];
 ```
 
 ### Rename AccessPolicy start -> startsOn


### PR DESCRIPTION
1. Upgrade storage packages versions.
2. Update API version for storage-queue to 2020-10-02