### PR TITLE
[core-lro] Check for string type before calling toLowerCase()

### DIFF
--- a/sdk/core/core-lro/CHANGELOG.md
+++ b/sdk/core/core-lro/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Check for string type before calling toLowerCase(). [PR #17573](https://github.com/Azure/azure-sdk-for-js/pull/17573)
+
 ### Other Changes
 
 ## 2.2.0 (2021-08-05)

--- a/sdk/core/core-lro/src/lroEngine/azureAsyncPolling.ts
+++ b/sdk/core/core-lro/src/lroEngine/azureAsyncPolling.ts
@@ -15,7 +15,7 @@ import { isUnexpectedPollingResponse } from "./requestUtils";
 
 function getResponseStatus(rawResponse: RawResponse): string {
   const { status } = (rawResponse.body as LroBody) ?? {};
-  return status?.toLowerCase() ?? "succeeded";
+  return typeof status === "string" ? status.toLowerCase() : "succeeded";
 }
 
 function isAzureAsyncPollingDone(rawResponse: RawResponse): boolean {

--- a/sdk/core/core-lro/src/lroEngine/bodyPolling.ts
+++ b/sdk/core/core-lro/src/lroEngine/bodyPolling.ts
@@ -14,7 +14,7 @@ import { isUnexpectedPollingResponse } from "./requestUtils";
 function getProvisioningState(rawResponse: RawResponse): string {
   const { properties, provisioningState } = (rawResponse.body as LroBody) ?? {};
   const state: string | undefined = properties?.provisioningState ?? provisioningState;
-  return state?.toLowerCase() ?? "succeeded";
+  return typeof state === "string" ? state.toLowerCase() : "succeeded";
 }
 
 export function isBodyPollingDone(rawResponse: RawResponse): boolean {

--- a/sdk/core/core-lro/test/utils/router/routesProcesses.ts
+++ b/sdk/core/core-lro/test/utils/router/routesProcesses.ts
@@ -389,7 +389,11 @@ export function nonretryerrorDeleteasyncRetry400(request: PipelineRequest): Pipe
 export function nonretryerrorDeleteasyncRetryFailedOperationResults400(
   request: PipelineRequest
 ): PipelineResponse {
-  return buildResponse(request, 400, `{ "message" : "Expected bad request message" }`);
+  return buildResponse(
+    request,
+    400,
+    `{ "message" : "Expected bad request message", "status": 200 }`
+  );
 }
 
 export function nonretryerrorPost400(request: PipelineRequest): PipelineResponse {


### PR DESCRIPTION
Currently, we are trying to call toLowerCase() on a response body.status. However, it is possible that the body has a status property that is not a string, and we crash.

This problem was surfaced when adding tests in the CodeGen 