### PR TITLE
[credscan] suppress fake test token  communication-common README

### DIFF
--- a/eng/CredScanSuppression.json
+++ b/eng/CredScanSuppression.json
@@ -44,7 +44,8 @@
         "liilef#$DdRGSa_ewkjh",
         "kt#_gahr!@aGERDXA",
         "goose",
-        "_password"
+        "_password",
+        "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjM2MDB9.adM-ddBZZlQ1WlN3pdPBOF5G4Wh9iZpxNP_fSvpF4cWs"
       ],
       "_justification": "Secret used by test code, it is fake."
     },


### PR DESCRIPTION
in file sdk/communication/communication-common/README.md

The decoded jwt token doesn't contain any secrets:

```js
{"header": {"alg":"HS256","typ":"JWT"}, "payload": {"exp":3600}}
```

I had considered using `"<user token>"` or similar in the README samples but
still prefer the fake test token as customer can understand easily what is
expected in the code sample:

https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/communication/communication-common/README.md#create-a-credential-with-a-static-token