### PR TITLE
[credscan] add placeholder for blob batch test secrets

### DIFF
--- a/eng/CredScanSuppression.json
+++ b/eng/CredScanSuppression.json
@@ -26,6 +26,10 @@
       "_justification": "Secret used by test code"
     },
     {
+      "placeholder": "SharedKey fakestorageaccount:pass123",
+      "_justification": "fake test secret placeholder used by storage blob (sdk/storage/storage-blob/test/utils/testutils.common.ts)"
+    },
+    {
       "placeholder": [
         "`$`{NPM_TOKEN`}",
         "azure_client_secret&scope=https%3A%2F%2Fsanitized%2F",

--- a/eng/CredScanSuppression.json
+++ b/eng/CredScanSuppression.json
@@ -2,35 +2,17 @@
   "tool": "Credential Scanner",
   "suppressions": [
     {
-      "placeholder": "efQ8O5wj+98pO9uoDas4uhlPwdp5GHCRs9N2Da2EC/g=",
-      "_justification": "Secret used by test code, it is fake."
-    },
-    {
-      "placeholder": "79f43c3b9c23fbdf293bdba80dab38ba194fc1da79187091b3d3760dad840bf8",
-      "_justification": "Secret used by test code, it is fake."
-    },
-    {
-      "placeholder": "AJ/qUoDtgLeA1A5ND2AS3uF7hsSe9O7imtXlkAj8VR4=",
-      "_justification": "Secret used by test code, it is fake."
-    },
-    {
-      "placeholder": "009fea5280ed80b780d40e4d0f6012dee17b86c49ef4eee29ad5e59008fc551e",
-      "_justification": "Secret used by test code, it is fake."
-    },
-    {
-      "placeholder": "1cb763e7c4b9a3c4811c4560af6827c2",
-      "_justification": "Secret used by test code"
-    },
-    {
       "hash": "5ETIzLYe9aa9Xx5512Uy6gJiCZ/CL2QzS3nDfN51nz8=",
       "_justification": "Secret used by test code"
     },
     {
-      "placeholder": "SharedKey fakestorageaccount:pass123",
-      "_justification": "fake test secret placeholder used by storage blob (sdk/storage/storage-blob/test/utils/testutils.common.ts)"
-    },
-    {
       "placeholder": [
+        "SharedKey fakestorageaccount:pass123",
+        "1cb763e7c4b9a3c4811c4560af6827c2",
+        "009fea5280ed80b780d40e4d0f6012dee17b86c49ef4eee29ad5e59008fc551e",
+        "AJ/qUoDtgLeA1A5ND2AS3uF7hsSe9O7imtXlkAj8VR4=",
+        "79f43c3b9c23fbdf293bdba80dab38ba194fc1da79187091b3d3760dad840bf8",
+        "efQ8O5wj+98pO9uoDas4uhlPwdp5GHCRs9N2Da2EC/g=",
         "`$`{NPM_TOKEN`}",
         "azure_client_secret&scope=https%3A%2F%2Fsanitized%2F",
         "azure_client_secret&scope=https%3A%2F%2Fattest.azure.net%2F.default",

--- a/sdk/storage/storage-blob/recordings/node/blobbatch/recording_deleteblobs_should_work_for_batch_delete.js
+++ b/sdk/storage/storage-blob/recordings/node/blobbatch/recording_deleteblobs_should_work_for_batch_delete.js
@@ -1,175 +1,176 @@
 let nock = require('nock');
 
-module.exports.testInfo = {"container":"container157135007048206827"}
+module.exports.hash = "23e4af99478a6bded62febf1a909d476";
+
+module.exports.testInfo = {"uniqueName":{"container":"container163164553243504643"},"newDate":{}}
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container157135007048206827')
+  .put('/container163164553243504643')
   .query(true)
-  .reply(201, "", [ 'Content-Length',
+  .reply(201, "", [
+  'Content-Length',
   '0',
   'Last-Modified',
-  'Thu, 17 Oct 2019 22:07:50 GMT',
+  'Tue, 14 Sep 2021 18:52:12 GMT',
   'ETag',
-  '"0x8D7534E7381C173"',
+  '"0x8D977B0C371FE36"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '1943d166-601e-004d-4137-8537e1000000',
+  'c3f0480d-301e-008f-5899-a93dc7000000',
   'x-ms-client-request-id',
-  '8b06612a-fe80-4f12-a7b3-9607efa670af',
+  '31dfb478-cefd-4b1e-8373-75e7c3ee2495',
   'x-ms-version',
-  '2019-02-02',
+  '2020-10-02',
   'Date',
-  'Thu, 17 Oct 2019 22:07:50 GMT',
-  'Connection',
-  'close' ]);
-
+  'Tue, 14 Sep 2021 18:52:12 GMT'
+]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container157135007048206827/blob0', "Hello World")
-  .reply(201, "", [ 'Content-Length',
-  '0',
-  'Content-MD5',
-  'sQqNsWTgdUEFt6mb5y4/5Q==',
-  'Last-Modified',
-  'Thu, 17 Oct 2019 22:07:50 GMT',
-  'ETag',
-  '"0x8D7534E738C6A42"',
-  'Server',
-  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
-  'x-ms-request-id',
-  'a3819e60-101e-00d1-6d37-859a87000000',
-  'x-ms-client-request-id',
-  '5a7b13e5-3f20-4200-89c2-ca7f54bffac5',
-  'x-ms-version',
-  '2019-02-02',
-  'x-ms-content-crc64',
-  'YeJLfssylmU=',
-  'x-ms-request-server-encrypted',
-  'true',
-  'Date',
-  'Thu, 17 Oct 2019 22:07:50 GMT',
-  'Connection',
-  'close' ]);
-
-
-nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container157135007048206827/blob1', "Hello World")
-  .reply(201, "", [ 'Content-Length',
+  .put('/container163164553243504643/blob0', "Hello World")
+  .reply(201, "", [
+  'Content-Length',
   '0',
   'Content-MD5',
   'sQqNsWTgdUEFt6mb5y4/5Q==',
   'Last-Modified',
-  'Thu, 17 Oct 2019 22:07:50 GMT',
+  'Tue, 14 Sep 2021 18:52:12 GMT',
   'ETag',
-  '"0x8D7534E73945AF6"',
+  '"0x8D977B0C37C67B3"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'a00d2322-f01e-00bb-0e37-8542af000000',
+  'c3f04843-301e-008f-0899-a93dc7000000',
   'x-ms-client-request-id',
-  '4431d38b-b95d-4fb7-878b-3e3b16f14610',
+  '3ff322e5-d2cd-462e-8741-e04a2eec58b6',
   'x-ms-version',
-  '2019-02-02',
+  '2020-10-02',
   'x-ms-content-crc64',
   'YeJLfssylmU=',
   'x-ms-request-server-encrypted',
   'true',
+  'x-ms-version-id',
+  '2021-09-14T18:52:12.7295411Z',
   'Date',
-  'Thu, 17 Oct 2019 22:07:49 GMT',
-  'Connection',
-  'close' ]);
-
+  'Tue, 14 Sep 2021 18:52:12 GMT'
+]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container157135007048206827/%C3%A5%20%C3%A4%20%C3%B6', "Hello World")
-  .reply(201, "", [ 'Content-Length',
+  .put('/container163164553243504643/blob1', "Hello World")
+  .reply(201, "", [
+  'Content-Length',
   '0',
   'Content-MD5',
   'sQqNsWTgdUEFt6mb5y4/5Q==',
   'Last-Modified',
-  'Thu, 17 Oct 2019 22:07:50 GMT',
+  'Tue, 14 Sep 2021 18:52:12 GMT',
   'ETag',
-  '"0x8D7534E739BAF45"',
+  '"0x8D977B0C38431CA"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '402aa0fe-501e-0024-6c37-850ead000000',
+  'c3f04863-301e-008f-2399-a93dc7000000',
   'x-ms-client-request-id',
-  'ac95c072-ab0a-4476-b2dd-e8728943dc8e',
+  'd706f4c4-38e6-4035-8205-eec2fb05d84c',
   'x-ms-version',
-  '2019-02-02',
+  '2020-10-02',
   'x-ms-content-crc64',
   'YeJLfssylmU=',
   'x-ms-request-server-encrypted',
   'true',
+  'x-ms-version-id',
+  '2021-09-14T18:52:12.7805898Z',
   'Date',
-  'Thu, 17 Oct 2019 22:07:49 GMT',
-  'Connection',
-  'close' ]);
-
+  'Tue, 14 Sep 2021 18:52:12 GMT'
+]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .post('/', "--batch_1e324473-c7ec-4c6c-9b47-645a57a99ba5\r\nContent-Type: application/http\r\nContent-Transfer-Encoding: binary\r\nContent-ID: 0\r\n\r\nDELETE /container157135007048206827/blob0 HTTP/1.1\r\nx-ms-date: Thu, 17 Oct 2019 22:07:50 GMT\r\nAuthorization: SharedKey fakestorageaccount:v8AC45Bjze7bUSVWdhO78h1WQlH+2kBFbG2v6XnAs60=\r\n\r\n--batch_1e324473-c7ec-4c6c-9b47-645a57a99ba5\r\nContent-Type: application/http\r\nContent-Transfer-Encoding: binary\r\nContent-ID: 1\r\n\r\nDELETE /container157135007048206827/blob1 HTTP/1.1\r\nx-ms-date: Thu, 17 Oct 2019 22:07:50 GMT\r\nAuthorization: SharedKey fakestorageaccount:S2wYSshnb3mAelCdFIGUeIbuRt6p5C4GSeo6JYOudWQ=\r\n\r\n--batch_1e324473-c7ec-4c6c-9b47-645a57a99ba5\r\nContent-Type: application/http\r\nContent-Transfer-Encoding: binary\r\nContent-ID: 2\r\n\r\nDELETE /container157135007048206827/%C3%A5%20%C3%A4%20%C3%B6 HTTP/1.1\r\nx-ms-date: Thu, 17 Oct 2019 22:07:50 GMT\r\nAuthorization: SharedKey fakestorageaccount:HU7PymO65lVLsnHsyg2Z80PIkbbJdckkEBUCHWyyT/8=\r\n\r\n--batch_1e324473-c7ec-4c6c-9b47-645a57a99ba5--\r\n")
+  .put('/container163164553243504643/%C3%A5%20%C3%A4%20%C3%B6', "Hello World")
+  .reply(201, "", [
+  'Content-Length',
+  '0',
+  'Content-MD5',
+  'sQqNsWTgdUEFt6mb5y4/5Q==',
+  'Last-Modified',
+  'Tue, 14 Sep 2021 18:52:12 GMT',
+  'ETag',
+  '"0x8D977B0C38BFBDC"',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  'c3f04882-301e-008f-3f99-a93dc7000000',
+  'x-ms-client-request-id',
+  '6e4510e7-9532-4d43-ac56-48b60a8b0c1c',
+  'x-ms-version',
+  '2020-10-02',
+  'x-ms-content-crc64',
+  'YeJLfssylmU=',
+  'x-ms-request-server-encrypted',
+  'true',
+  'x-ms-version-id',
+  '2021-09-14T18:52:12.8316380Z',
+  'Date',
+  'Tue, 14 Sep 2021 18:52:12 GMT'
+]);
+
+nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
+  .post('/', "--batch_f4e7306c-04db-4452-bfc7-8cd3b59521b1\r\nContent-Type: application/http\r\nContent-Transfer-Encoding: binary\r\nContent-ID: 0\r\n\r\nDELETE /container163164553243504643/blob0 HTTP/1.1\r\nAccept: application/xml\r\nx-ms-date: Tue, 14 Sep 2021 18:52:12 GMT\r\nAuthorization: SharedKey fakestorageaccount:pass123\r\n\r\n--batch_f4e7306c-04db-4452-bfc7-8cd3b59521b1\r\nContent-Type: application/http\r\nContent-Transfer-Encoding: binary\r\nContent-ID: 1\r\n\r\nDELETE /container163164553243504643/blob1 HTTP/1.1\r\nAccept: application/xml\r\nx-ms-date: Tue, 14 Sep 2021 18:52:12 GMT\r\nAuthorization: SharedKey fakestorageaccount:pass123\r\n\r\n--batch_f4e7306c-04db-4452-bfc7-8cd3b59521b1\r\nContent-Type: application/http\r\nContent-Transfer-Encoding: binary\r\nContent-ID: 2\r\n\r\nDELETE /container163164553243504643/%C3%A5%20%C3%A4%20%C3%B6 HTTP/1.1\r\nAccept: application/xml\r\nx-ms-date: Tue, 14 Sep 2021 18:52:12 GMT\r\nAuthorization: SharedKey fakestorageaccount:pass123\r\n\r\n--batch_f4e7306c-04db-4452-bfc7-8cd3b59521b1--\r\n")
   .query(true)
-  .reply(202, "--batchresponse_fbc39ce8-0efa-487a-8c73-135fff9a07fe\r\nContent-Type: application/http\r\nContent-ID: 0\r\n\r\nHTTP/1.1 202 Accepted\r\nx-ms-delete-type-permanent: true\r\nx-ms-request-id: 531d05e8-a01e-00a6-2d37-854f131e55e4\r\nx-ms-version: 2019-02-02\r\nServer: Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_fbc39ce8-0efa-487a-8c73-135fff9a07fe\r\nContent-Type: application/http\r\nContent-ID: 1\r\n\r\nHTTP/1.1 202 Accepted\r\nx-ms-delete-type-permanent: true\r\nx-ms-request-id: 531d05e8-a01e-00a6-2d37-854f131e55e8\r\nx-ms-version: 2019-02-02\r\nServer: Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_fbc39ce8-0efa-487a-8c73-135fff9a07fe\r\nContent-Type: application/http\r\nContent-ID: 2\r\n\r\nHTTP/1.1 202 Accepted\r\nx-ms-delete-type-permanent: true\r\nx-ms-request-id: 531d05e8-a01e-00a6-2d37-854f131e55e9\r\nx-ms-version: 2019-02-02\r\nServer: Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_fbc39ce8-0efa-487a-8c73-135fff9a07fe--", [ 'Transfer-Encoding',
+  .reply(202, "--batchresponse_ca5a9f6c-5883-443e-82b1-263d2e8791ec\r\nContent-Type: application/http\r\nContent-ID: 0\r\n\r\nHTTP/1.1 202 Accepted\r\nx-ms-delete-type-permanent: true\r\nx-ms-request-id: c3f048aa-301e-008f-6599-a93dc71e748d\r\nx-ms-version: 2020-10-02\r\nServer: Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_ca5a9f6c-5883-443e-82b1-263d2e8791ec\r\nContent-Type: application/http\r\nContent-ID: 1\r\n\r\nHTTP/1.1 202 Accepted\r\nx-ms-delete-type-permanent: true\r\nx-ms-request-id: c3f048aa-301e-008f-6599-a93dc71e748f\r\nx-ms-version: 2020-10-02\r\nServer: Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_ca5a9f6c-5883-443e-82b1-263d2e8791ec\r\nContent-Type: application/http\r\nContent-ID: 2\r\n\r\nHTTP/1.1 202 Accepted\r\nx-ms-delete-type-permanent: true\r\nx-ms-request-id: c3f048aa-301e-008f-6599-a93dc71e7490\r\nx-ms-version: 2020-10-02\r\nServer: Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_ca5a9f6c-5883-443e-82b1-263d2e8791ec--", [
+  'Transfer-Encoding',
   'chunked',
   'Content-Type',
-  'multipart/mixed; boundary=batchresponse_fbc39ce8-0efa-487a-8c73-135fff9a07fe',
+  'multipart/mixed; boundary=batchresponse_ca5a9f6c-5883-443e-82b1-263d2e8791ec',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '531d05e8-a01e-00a6-2d37-854f13000000',
+  'c3f048aa-301e-008f-6599-a93dc7000000',
   'x-ms-version',
-  '2019-02-02',
+  '2020-10-02',
   'x-ms-client-request-id',
-  '3245c0f9-157c-4b13-af2c-e771f6d5b347',
+  '80a3676b-b389-490f-983a-ddb439313003',
   'Date',
-  'Thu, 17 Oct 2019 22:07:50 GMT',
-  'Connection',
-  'close' ]);
-
+  'Tue, 14 Sep 2021 18:52:12 GMT'
+]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .get('/container157135007048206827')
+  .get('/container163164553243504643')
   .query(true)
-  .reply(200, "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults ServiceEndpoint=\"https://fakestorageaccount.blob.core.windows.net/\" ContainerName=\"container157135007048206827\"><MaxResults>1</MaxResults><Blobs /><NextMarker /></EnumerationResults>", [ 'Transfer-Encoding',
+  .reply(200, "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults ServiceEndpoint=\"https://fakestorageaccount.blob.core.windows.net/\" ContainerName=\"container163164553243504643\"><MaxResults>1</MaxResults><Blobs /><NextMarker /></EnumerationResults>", [
+  'Transfer-Encoding',
   'chunked',
   'Content-Type',
   'application/xml',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '5c01dcb5-001e-00cd-5537-85c8e7000000',
+  'c3f048e4-301e-008f-1b99-a93dc7000000',
   'x-ms-client-request-id',
-  'b1afbbc6-06c4-49e7-b4d0-6da22d25adba',
+  '33125b4d-0efa-4943-876c-86d671166b47',
   'x-ms-version',
-  '2019-02-02',
+  '2020-10-02',
   'Access-Control-Expose-Headers',
   'x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,Content-Type,Content-Length,Date,Transfer-Encoding',
   'Access-Control-Allow-Origin',
   '*',
   'Date',
-  'Thu, 17 Oct 2019 22:07:50 GMT',
-  'Connection',
-  'close' ]);
-
+  'Tue, 14 Sep 2021 18:52:12 GMT'
+]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .delete('/container157135007048206827')
+  .delete('/container163164553243504643')
   .query(true)
-  .reply(202, "", [ 'Content-Length',
+  .reply(202, "", [
+  'Content-Length',
   '0',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'ed70cb70-e01e-001e-0d37-8514d5000000',
+  'c3f0491e-301e-008f-5299-a93dc7000000',
   'x-ms-client-request-id',
-  '6792c2fb-f2dc-4c7a-a14f-835390c3ea58',
+  'e2e1a0aa-fbfb-4876-a5fb-8dcdd11af66e',
   'x-ms-version',
-  '2019-02-02',
+  '2020-10-02',
   'Date',
-  'Thu, 17 Oct 2019 22:07:51 GMT',
-  'Connection',
-  'close' ]);
-
+  'Tue, 14 Sep 2021 18:52:12 GMT'
+]);

--- a/sdk/storage/storage-blob/recordings/node/blobbatch/recording_setblobsaccesstier_should_work_for_batch_set_tier.js
+++ b/sdk/storage/storage-blob/recordings/node/blobbatch/recording_setblobsaccesstier_should_work_for_batch_set_tier.js
@@ -1,161 +1,168 @@
 let nock = require('nock');
 
-module.exports.testInfo = {"container":"container157135007166703757"}
+module.exports.hash = "80e55c6f7877b8f52a009693c776edca";
+
+module.exports.testInfo = {"uniqueName":{"container":"container163164553304207685"},"newDate":{}}
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container157135007166703757')
+  .put('/container163164553304207685')
   .query(true)
-  .reply(201, "", [ 'Content-Length',
+  .reply(201, "", [
+  'Content-Length',
   '0',
   'Last-Modified',
-  'Thu, 17 Oct 2019 22:07:51 GMT',
+  'Tue, 14 Sep 2021 18:52:13 GMT',
   'ETag',
-  '"0x8D7534E741DBC3F"',
+  '"0x8D977B0C3B0EB1E"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '73a93d46-501e-00d0-3137-85c55b000000',
+  'c3f04954-301e-008f-0399-a93dc7000000',
   'x-ms-client-request-id',
-  '71c819a0-06d3-4aac-91fd-31d388f82b32',
+  '3d2fce95-18b1-4713-9844-eb1e4a83ba70',
   'x-ms-version',
-  '2019-02-02',
+  '2020-10-02',
   'Date',
-  'Thu, 17 Oct 2019 22:07:51 GMT',
-  'Connection',
-  'close' ]);
-
+  'Tue, 14 Sep 2021 18:52:12 GMT'
+]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container157135007166703757/blob0', "Hello World")
-  .reply(201, "", [ 'Content-Length',
-  '0',
-  'Content-MD5',
-  'sQqNsWTgdUEFt6mb5y4/5Q==',
-  'Last-Modified',
-  'Thu, 17 Oct 2019 22:07:51 GMT',
-  'ETag',
-  '"0x8D7534E74247FF1"',
-  'Server',
-  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
-  'x-ms-request-id',
-  '5c01dd50-001e-00cd-6137-85c8e7000000',
-  'x-ms-client-request-id',
-  '6ca9143c-f60f-4222-9f92-d3d22fab60b0',
-  'x-ms-version',
-  '2019-02-02',
-  'x-ms-content-crc64',
-  'YeJLfssylmU=',
-  'x-ms-request-server-encrypted',
-  'true',
-  'Date',
-  'Thu, 17 Oct 2019 22:07:50 GMT',
-  'Connection',
-  'close' ]);
-
-
-nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container157135007166703757/blob1', "Hello World")
-  .reply(201, "", [ 'Content-Length',
+  .put('/container163164553304207685/blob0', "Hello World")
+  .reply(201, "", [
+  'Content-Length',
   '0',
   'Content-MD5',
   'sQqNsWTgdUEFt6mb5y4/5Q==',
   'Last-Modified',
-  'Thu, 17 Oct 2019 22:07:51 GMT',
+  'Tue, 14 Sep 2021 18:52:13 GMT',
   'ETag',
-  '"0x8D7534E742BAD2A"',
+  '"0x8D977B0C3B90A39"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'a794a574-b01e-002c-2837-8514a2000000',
+  'c3f04973-301e-008f-1f99-a93dc7000000',
   'x-ms-client-request-id',
-  'c04b1947-85f6-4a00-9305-d1340f5e5c79',
+  '2bd69e3b-f054-47f8-ae52-217d6cecce5c',
   'x-ms-version',
-  '2019-02-02',
+  '2020-10-02',
   'x-ms-content-crc64',
   'YeJLfssylmU=',
   'x-ms-request-server-encrypted',
   'true',
+  'x-ms-version-id',
+  '2021-09-14T18:52:13.1269177Z',
   'Date',
-  'Thu, 17 Oct 2019 22:07:51 GMT',
-  'Connection',
-  'close' ]);
-
+  'Tue, 14 Sep 2021 18:52:12 GMT'
+]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container157135007166703757/%C3%A5%20%C3%A4%20%C3%B6', "Hello World")
-  .reply(201, "", [ 'Content-Length',
+  .put('/container163164553304207685/blob1', "Hello World")
+  .reply(201, "", [
+  'Content-Length',
   '0',
   'Content-MD5',
   'sQqNsWTgdUEFt6mb5y4/5Q==',
   'Last-Modified',
-  'Thu, 17 Oct 2019 22:07:51 GMT',
+  'Tue, 14 Sep 2021 18:52:13 GMT',
   'ETag',
-  '"0x8D7534E74348861"',
+  '"0x8D977B0C3C0AD45"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '2e5b9e12-b01e-00d8-7d37-85df54000000',
+  'c3f0498c-301e-008f-3599-a93dc7000000',
   'x-ms-client-request-id',
-  '0a3c5de0-ce44-432c-856b-5bcafa0cd4b2',
+  '57a805cf-4602-4cc7-a2b8-e8e895ae41b7',
   'x-ms-version',
-  '2019-02-02',
+  '2020-10-02',
   'x-ms-content-crc64',
   'YeJLfssylmU=',
   'x-ms-request-server-encrypted',
   'true',
+  'x-ms-version-id',
+  '2021-09-14T18:52:13.1769669Z',
   'Date',
-  'Thu, 17 Oct 2019 22:07:51 GMT',
-  'Connection',
-  'close' ]);
-
+  'Tue, 14 Sep 2021 18:52:12 GMT'
+]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .post('/', "--batch_800eff24-1101-4863-9df1-3ae3e78da4c5\r\nContent-Type: application/http\r\nContent-Transfer-Encoding: binary\r\nContent-ID: 0\r\n\r\nPUT /container157135007166703757/blob0?comp=tier HTTP/1.1\r\nx-ms-access-tier: Cool\r\nx-ms-date: Thu, 17 Oct 2019 22:07:51 GMT\r\nAuthorization: SharedKey fakestorageaccount:JduYLUQSrfG9icq2l3NbRGe2UVhpOawfVCk2FxegHig=\r\n\r\n--batch_800eff24-1101-4863-9df1-3ae3e78da4c5\r\nContent-Type: application/http\r\nContent-Transfer-Encoding: binary\r\nContent-ID: 1\r\n\r\nPUT /container157135007166703757/blob1?comp=tier HTTP/1.1\r\nx-ms-access-tier: Cool\r\nx-ms-date: Thu, 17 Oct 2019 22:07:51 GMT\r\nAuthorization: SharedKey fakestorageaccount:h9lD8UTmYM3KFud7jUdLE282N4UshznlhV9dzNDaOyU=\r\n\r\n--batch_800eff24-1101-4863-9df1-3ae3e78da4c5\r\nContent-Type: application/http\r\nContent-Transfer-Encoding: binary\r\nContent-ID: 2\r\n\r\nPUT /container157135007166703757/%C3%A5%20%C3%A4%20%C3%B6?comp=tier HTTP/1.1\r\nx-ms-access-tier: Cool\r\nx-ms-date: Thu, 17 Oct 2019 22:07:51 GMT\r\nAuthorization: SharedKey fakestorageaccount:CvRjDFwHT7nHr5nN7sxjPdoPXK9X22yLLP0ZOQHyygs=\r\n\r\n--batch_800eff24-1101-4863-9df1-3ae3e78da4c5--\r\n")
+  .put('/container163164553304207685/%C3%A5%20%C3%A4%20%C3%B6', "Hello World")
+  .reply(201, "", [
+  'Content-Length',
+  '0',
+  'Content-MD5',
+  'sQqNsWTgdUEFt6mb5y4/5Q==',
+  'Last-Modified',
+  'Tue, 14 Sep 2021 18:52:13 GMT',
+  'ETag',
+  '"0x8D977B0C3C8EC9C"',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  'c3f0499e-301e-008f-4599-a93dc7000000',
+  'x-ms-client-request-id',
+  '794cd89b-bb40-4ae5-bc1d-a5546c1f416d',
+  'x-ms-version',
+  '2020-10-02',
+  'x-ms-content-crc64',
+  'YeJLfssylmU=',
+  'x-ms-request-server-encrypted',
+  'true',
+  'x-ms-version-id',
+  '2021-09-14T18:52:13.2310172Z',
+  'Date',
+  'Tue, 14 Sep 2021 18:52:12 GMT'
+]);
+
+nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
+  .post('/', "--batch_a489a1a2-4389-47dd-bfc8-584db3adb213\r\nContent-Type: application/http\r\nContent-Transfer-Encoding: binary\r\nContent-ID: 0\r\n\r\nPUT /container163164553304207685/blob0?comp=tier HTTP/1.1\r\nAccept: application/xml\r\nx-ms-access-tier: Cool\r\nx-ms-date: Tue, 14 Sep 2021 18:52:13 GMT\r\nAuthorization\
+>: SharedKey fakestorageaccount:pass123\r\n\r\n--batch_a489a1a2-4389-47dd-bfc8-584db3adb213\r\nContent-Type: application/http\r\nContent-Transfer-Encoding: binary\r\nContent-ID: 1\r\n\r\nPUT /container163164553304207685/blob1?comp=tier HTTP/1.1\r\nAccept: application/xml\r\nx-ms-access-tier: Cool\r\nx-ms-date: Tue, 14 Sep 2021 18:52:13 GMT\r\nAuthorization: SharedKey fakestorageaccount:pass123\r\n\r\n--batch_a489a1a2-4389-47dd-bfc8-584db3adb213\r\nContent-Type: application/http\r\nContent-Transfer-Encoding: binary\r\nContent-ID: 2\r\n\r\nPUT /container163164553304207685/%C3%A5%20%C3%A4%20%C3%B6?comp=tier HTTP/1.1\r\nAccept: application/xml\r\nx-ms-access-tier: Cool\r\nx-ms-date: Tue, 14 Sep 2021 18:52:13 GMT\r\nAuthorization: SharedKey fakestorageaccount:pass123\r\n\r\n--batch_a489a1a2-4389-47dd-bfc8-584db3adb213--\r\n")
   .query(true)
-  .reply(202, "--batchresponse_d1a69b61-2d1d-49f2-8d65-b2d9ca086d72\r\nContent-Type: application/http\r\nContent-ID: 0\r\n\r\nHTTP/1.1 200 OK\r\nx-ms-request-id: 87c4bd84-b01e-0061-2437-85db4e1eaa81\r\nx-ms-version: 2019-02-02\r\nServer: Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_d1a69b61-2d1d-49f2-8d65-b2d9ca086d72\r\nContent-Type: application/http\r\nContent-ID: 1\r\n\r\nHTTP/1.1 200 OK\r\nx-ms-request-id: 87c4bd84-b01e-0061-2437-85db4e1eaa86\r\nx-ms-version: 2019-02-02\r\nServer: Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_d1a69b61-2d1d-49f2-8d65-b2d9ca086d72\r\nContent-Type: application/http\r\nContent-ID: 2\r\n\r\nHTTP/1.1 200 OK\r\nx-ms-request-id: 87c4bd84-b01e-0061-2437-85db4e1eaa87\r\nx-ms-version: 2019-02-02\r\nServer: Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_d1a69b61-2d1d-49f2-8d65-b2d9ca086d72--", [ 'Transfer-Encoding',
+  .reply(202, "--batchresponse_1e3e1cd3-6550-468b-8640-7fc57c4e9542\r\nContent-Type: application/http\r\nContent-ID: 0\r\n\r\nHTTP/1.1 200 OK\r\nx-ms-request-id: c3f049b5-301e-008f-5b99-a93dc71e749b\r\nx-ms-version: 2020-10-02\r\nServer: Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_1e3e1cd3-6550-468b-8640-7fc57c4e9542\r\nContent-Type: application/http\r\nContent-ID: 1\r\n\r\nHTTP/1.1 200 OK\r\nx-ms-request-id: c3f049b5-301e-008f-5b99-a93dc71e749d\r\nx-ms-version: 2020-10-02\r\nServer: Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_1e3e1cd3-6550-468b-8640-7fc57c4e9542\r\nContent-Type: application/http\r\nContent-ID: 2\r\n\r\nHTTP/1.1 200 OK\r\nx-ms-request-id: c3f049b5-301e-008f-5b99-a93dc71e749e\r\nx-ms-version: 2020-10-02\r\nServer: Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_1e3e1cd3-6550-468b-8640-7fc57c4e9542--", [
+  'Transfer-Encoding',
   'chunked',
   'Content-Type',
-  'multipart/mixed; boundary=batchresponse_d1a69b61-2d1d-49f2-8d65-b2d9ca086d72',
+  'multipart/mixed; boundary=batchresponse_1e3e1cd3-6550-468b-8640-7fc57c4e9542',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '87c4bd84-b01e-0061-2437-85db4e000000',
+  'c3f049b5-301e-008f-5b99-a93dc7000000',
   'x-ms-version',
-  '2019-02-02',
+  '2020-10-02',
   'x-ms-client-request-id',
-  '94406769-e058-4753-bc36-f155391ac993',
+  'e0e27cab-f284-4df4-b096-f6d60d69e2ca',
   'Date',
-  'Thu, 17 Oct 2019 22:07:51 GMT',
-  'Connection',
-  'close' ]);
-
+  'Tue, 14 Sep 2021 18:52:12 GMT'
+]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .head('/container157135007166703757/blob0')
-  .reply(200, "", [ 'Content-Length',
+  .head('/container163164553304207685/blob0')
+  .reply(200, "", [
+  'Content-Length',
   '11',
   'Content-Type',
   'application/octet-stream',
   'Content-MD5',
   'sQqNsWTgdUEFt6mb5y4/5Q==',
   'Last-Modified',
-  'Thu, 17 Oct 2019 22:07:51 GMT',
+  'Tue, 14 Sep 2021 18:52:13 GMT',
   'Accept-Ranges',
   'bytes',
   'ETag',
-  '"0x8D7534E74247FF1"',
+  '"0x8D977B0C3B90A39"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'd63e9e46-b01e-00aa-0c37-85d81b000000',
+  'c3f049c3-301e-008f-6899-a93dc7000000',
   'x-ms-client-request-id',
-  'ff6a9376-f06b-4e8e-a91e-a0ffe8e2c414',
+  'de8514fd-dc61-48ff-8325-6ed56e7231d4',
   'x-ms-version',
-  '2019-02-02',
-  'x-ms-tag-count',
-  '0',
+  '2020-10-02',
+  'x-ms-version-id',
+  '2021-09-14T18:52:13.1269177Z',
+  'x-ms-is-current-version',
+  'true',
   'x-ms-creation-time',
-  'Thu, 17 Oct 2019 22:07:51 GMT',
+  'Tue, 14 Sep 2021 18:52:13 GMT',
   'x-ms-lease-status',
   'unlocked',
   'x-ms-lease-state',
@@ -167,43 +174,44 @@ nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParam
   'x-ms-access-tier',
   'Cool',
   'x-ms-access-tier-change-time',
-  'Thu, 17 Oct 2019 22:07:52 GMT',
+  'Tue, 14 Sep 2021 18:52:13 GMT',
   'Access-Control-Expose-Headers',
-  'x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,x-ms-tag-count,Content-Type,Last-Modified,ETag,x-ms-creation-time,Content-MD5,x-ms-lease-status,x-ms-lease-state,x-ms-blob-type,x-ms-server-encrypted,x-ms-access-tier,x-ms-access-tier-change-time,Accept-Ranges,Content-Length,Date,Transfer-Encoding',
+  'x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,x-ms-version-id,x-ms-is-current-version,Content-Type,Last-Modified,ETag,x-ms-creation-time,Content-MD5,x-ms-lease-status,x-ms-lease-state,x-ms-blob-type,x-ms-server-encrypted,x-ms-access-tier,x-ms-access-tier-change-time,Accept-Ranges,Content-Length,Date,Transfer-Encoding',
   'Access-Control-Allow-Origin',
   '*',
   'Date',
-  'Thu, 17 Oct 2019 22:07:51 GMT',
-  'Connection',
-  'close' ]);
-
+  'Tue, 14 Sep 2021 18:52:12 GMT'
+]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .head('/container157135007166703757/blob1')
-  .reply(200, "", [ 'Content-Length',
+  .head('/container163164553304207685/blob1')
+  .reply(200, "", [
+  'Content-Length',
   '11',
   'Content-Type',
   'application/octet-stream',
   'Content-MD5',
   'sQqNsWTgdUEFt6mb5y4/5Q==',
   'Last-Modified',
-  'Thu, 17 Oct 2019 22:07:51 GMT',
+  'Tue, 14 Sep 2021 18:52:13 GMT',
   'Accept-Ranges',
   'bytes',
   'ETag',
-  '"0x8D7534E742BAD2A"',
+  '"0x8D977B0C3C0AD45"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '4d01e8c4-201e-005c-0437-85ad55000000',
+  'c3f049d0-301e-008f-7599-a93dc7000000',
   'x-ms-client-request-id',
-  '4ca08b75-5f47-475e-8e64-3ade2a853076',
+  '39f1f1c9-217f-4395-aae1-5d5335338bfc',
   'x-ms-version',
-  '2019-02-02',
-  'x-ms-tag-count',
-  '0',
+  '2020-10-02',
+  'x-ms-version-id',
+  '2021-09-14T18:52:13.1769669Z',
+  'x-ms-is-current-version',
+  'true',
   'x-ms-creation-time',
-  'Thu, 17 Oct 2019 22:07:51 GMT',
+  'Tue, 14 Sep 2021 18:52:13 GMT',
   'x-ms-lease-status',
   'unlocked',
   'x-ms-lease-state',
@@ -215,43 +223,44 @@ nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParam
   'x-ms-access-tier',
   'Cool',
   'x-ms-access-tier-change-time',
-  'Thu, 17 Oct 2019 22:07:52 GMT',
+  'Tue, 14 Sep 2021 18:52:13 GMT',
   'Access-Control-Expose-Headers',
-  'x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,x-ms-tag-count,Content-Type,Last-Modified,ETag,x-ms-creation-time,Content-MD5,x-ms-lease-status,x-ms-lease-state,x-ms-blob-type,x-ms-server-encrypted,x-ms-access-tier,x-ms-access-tier-change-time,Accept-Ranges,Content-Length,Date,Transfer-Encoding',
+  'x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,x-ms-version-id,x-ms-is-current-version,Content-Type,Last-Modified,ETag,x-ms-creation-time,Content-MD5,x-ms-lease-status,x-ms-lease-state,x-ms-blob-type,x-ms-server-encrypted,x-ms-access-tier,x-ms-access-tier-change-time,Accept-Ranges,Content-Length,Date,Transfer-Encoding',
   'Access-Control-Allow-Origin',
   '*',
   'Date',
-  'Thu, 17 Oct 2019 22:07:52 GMT',
-  'Connection',
-  'close' ]);
-
+  'Tue, 14 Sep 2021 18:52:12 GMT'
+]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .head('/container157135007166703757/%C3%A5%20%C3%A4%20%C3%B6')
-  .reply(200, "", [ 'Content-Length',
+  .head('/container163164553304207685/%C3%A5%20%C3%A4%20%C3%B6')
+  .reply(200, "", [
+  'Content-Length',
   '11',
   'Content-Type',
   'application/octet-stream',
   'Content-MD5',
   'sQqNsWTgdUEFt6mb5y4/5Q==',
   'Last-Modified',
-  'Thu, 17 Oct 2019 22:07:51 GMT',
+  'Tue, 14 Sep 2021 18:52:13 GMT',
   'Accept-Ranges',
   'bytes',
   'ETag',
-  '"0x8D7534E74348861"',
+  '"0x8D977B0C3C8EC9C"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '73a93e81-501e-00d0-2f37-85c55b000000',
+  'c3f049e9-301e-008f-0b99-a93dc7000000',
   'x-ms-client-request-id',
-  '13f09def-6626-418b-9d3e-7d2be115d4bc',
+  'ea351fc9-51d2-4954-9854-a493d0690a10',
   'x-ms-version',
-  '2019-02-02',
-  'x-ms-tag-count',
-  '0',
+  '2020-10-02',
+  'x-ms-version-id',
+  '2021-09-14T18:52:13.2310172Z',
+  'x-ms-is-current-version',
+  'true',
   'x-ms-creation-time',
-  'Thu, 17 Oct 2019 22:07:51 GMT',
+  'Tue, 14 Sep 2021 18:52:13 GMT',
   'x-ms-lease-status',
   'unlocked',
   'x-ms-lease-state',
@@ -263,32 +272,29 @@ nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParam
   'x-ms-access-tier',
   'Cool',
   'x-ms-access-tier-change-time',
-  'Thu, 17 Oct 2019 22:07:52 GMT',
+  'Tue, 14 Sep 2021 18:52:13 GMT',
   'Access-Control-Expose-Headers',
-  'x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,x-ms-tag-count,Content-Type,Last-Modified,ETag,x-ms-creation-time,Content-MD5,x-ms-lease-status,x-ms-lease-state,x-ms-blob-type,x-ms-server-encrypted,x-ms-access-tier,x-ms-access-tier-change-time,Accept-Ranges,Content-Length,Date,Transfer-Encoding',
+  'x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,x-ms-version-id,x-ms-is-current-version,Content-Type,Last-Modified,ETag,x-ms-creation-time,Content-MD5,x-ms-lease-status,x-ms-lease-state,x-ms-blob-type,x-ms-server-encrypted,x-ms-access-tier,x-ms-access-tier-change-time,Accept-Ranges,Content-Length,Date,Transfer-Encoding',
   'Access-Control-Allow-Origin',
   '*',
   'Date',
-  'Thu, 17 Oct 2019 22:07:51 GMT',
-  'Connection',
-  'close' ]);
-
+  'Tue, 14 Sep 2021 18:52:12 GMT'
+]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .delete('/container157135007166703757')
+  .delete('/container163164553304207685')
   .query(true)
-  .reply(202, "", [ 'Content-Length',
+  .reply(202, "", [
+  'Content-Length',
   '0',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '8cdc2eb3-601e-005d-3237-85f289000000',
+  'c3f049f8-301e-008f-1a99-a93dc7000000',
   'x-ms-client-request-id',
-  '6fde0f56-56db-46ca-bb46-5b5b1413abed',
+  '73b868a3-2b6d-4250-ae69-f9d91d8c312a',
   'x-ms-version',
-  '2019-02-02',
+  '2020-10-02',
   'Date',
-  'Thu, 17 Oct 2019 22:07:51 GMT',
-  'Connection',
-  'close' ]);
-
+  'Tue, 14 Sep 2021 18:52:12 GMT'
+]);

--- a/sdk/storage/storage-blob/test/utils/testutils.common.ts
+++ b/sdk/storage/storage-blob/test/utils/testutils.common.ts
@@ -52,6 +52,11 @@ export const recorderEnvSetup: RecorderEnvironmentSetup = {
       recording.replace(
         new RegExp(env.ACCOUNT_SAS.match("(.*)&sig=(.*)")[2], "g"),
         `${mockAccountKey}`
+      ),
+    (recording: string): string =>
+      recording.replace(
+        /Authorization: SharedKey [^\\]+/g,
+        "Authorization: SharedKey fakestorageaccount:pass123"
       )
   ],
   // SAS token may contain sensitive information


### PR DESCRIPTION
The affected tests are still skipped due to dynamic GUIDs in blob batch requests
but this PR does the work to replace shared keys with a place holder which is
suppressed in credscan.