### PR TITLE
[KeyVault] - Add provisioner OID to initial MHSM admins

### DIFF
--- a/sdk/keyvault/test-resources.json
+++ b/sdk/keyvault/test-resources.json
@@ -18,9 +18,14 @@
     },
     "testApplicationOid": {
       "type": "string",
-      "defaultValue": "b3653439-8136-4cd5-aac3-2a9460871ca6",
       "metadata": {
         "description": "The client OID to grant access to test resources."
+      }
+    },
+    "provisionerApplicationOid": {
+      "type": "string",
+      "metadata": {
+        "description": "The provisioner OID to grant access to test resources."
       }
     },
     "location": {
@@ -185,7 +190,7 @@
         "publicNetworkAccess": "Enabled",
         "networkAcls": "[variables('networkAcls')]",
         "tenantId": "[parameters('tenantId')]",
-        "initialAdminObjectIds": ["[parameters('testApplicationOid')]"],
+        "initialAdminObjectIds": "[union(array(parameters('testApplicationOid')), array(parameters('provisionerApplicationOid')))]",
         "enablePurgeProtection": false,
         "enableSoftDelete": true,
         "softDeleteRetentionInDays": 7


### PR DESCRIPTION
Updated test-resources.json as necessary to support Azure/azure-sdk-tools#1983.