### PR TITLE
[Identity] Version changes after the releases

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -577,6 +577,56 @@ packages:
       node: '>=12.0.0'
     resolution:
       integrity: sha512-x1AWJ2IxsVZkZ/REsuQxAqt1/LkDxKEgIAozH1x5WpuhyWvVRGyG3TxyTRB0dljc54+vWcXiThnPV1+g254Fxg==
+  /@azure/identity/2.0.0-beta.6:
+    dependencies:
+      '@azure/abort-controller': 1.0.4
+      '@azure/core-auth': 1.3.2
+      '@azure/core-client': 1.3.0
+      '@azure/core-rest-pipeline': 1.3.0
+      '@azure/core-tracing': 1.0.0-preview.13
+      '@azure/core-util': 1.0.0-beta.1
+      '@azure/logger': 1.0.2
+      '@azure/msal-browser': 2.17.0
+      '@azure/msal-common': 4.5.1
+      '@azure/msal-node': 1.3.1
+      '@types/stoppable': 1.1.1
+      events: 3.3.0
+      jws: 4.0.0
+      open: 7.4.2
+      stoppable: 1.1.0
+      tslib: 2.3.1
+      uuid: 8.3.2
+    dev: false
+    engines:
+      node: '>=12.0.0'
+    resolution:
+      integrity: sha512-wtaAj11o7P1yJIhBDjP0W9nTUlhguJ711v7sEYR522ACOgfTuf5OMuVaF8HR/8Y57f4EFDGIj2Rqls2+VC6mCg==
+  /@azure/identity/2.0.0-beta.6_debug@4.3.2:
+    dependencies:
+      '@azure/abort-controller': 1.0.4
+      '@azure/core-auth': 1.3.2
+      '@azure/core-client': 1.3.0
+      '@azure/core-rest-pipeline': 1.3.0
+      '@azure/core-tracing': 1.0.0-preview.13
+      '@azure/core-util': 1.0.0-beta.1
+      '@azure/logger': 1.0.2
+      '@azure/msal-browser': 2.17.0
+      '@azure/msal-common': 4.5.1
+      '@azure/msal-node': 1.3.1_debug@4.3.2
+      '@types/stoppable': 1.1.1
+      events: 3.3.0
+      jws: 4.0.0
+      open: 7.4.2
+      stoppable: 1.1.0
+      tslib: 2.3.1
+      uuid: 8.3.2
+    dev: false
+    engines:
+      node: '>=12.0.0'
+    peerDependencies:
+      debug: '*'
+    resolution:
+      integrity: sha512-wtaAj11o7P1yJIhBDjP0W9nTUlhguJ711v7sEYR522ACOgfTuf5OMuVaF8HR/8Y57f4EFDGIj2Rqls2+VC6mCg==
   /@azure/keyvault-certificates/4.3.0:
     dependencies:
       '@azure/abort-controller': 1.0.4
@@ -780,6 +830,19 @@ packages:
     dev: false
     engines:
       node: 10 || 12 || 14 || 16
+    resolution:
+      integrity: sha512-c3bSdXUBpjUehx7mdI5iY+mwMF1mTz1qrVppH5LTD3SfbousRaFN9F2phAeaejVnCzbKzFPl4TTHxOJbkBVXHA==
+  /@azure/msal-node/1.3.1_debug@4.3.2:
+    dependencies:
+      '@azure/msal-common': 5.0.0
+      axios: 0.21.4_debug@4.3.2
+      jsonwebtoken: 8.5.1
+      uuid: 8.3.2
+    dev: false
+    engines:
+      node: 10 || 12 || 14 || 16
+    peerDependencies:
+      debug: '*'
     resolution:
       integrity: sha512-c3bSdXUBpjUehx7mdI5iY+mwMF1mTz1qrVppH5LTD3SfbousRaFN9F2phAeaejVnCzbKzFPl4TTHxOJbkBVXHA==
   /@babel/code-frame/7.12.11:
@@ -8288,6 +8351,7 @@ packages:
   file:projects/ai-anomaly-detector.tgz:
     dependencies:
       '@azure/core-tracing': 1.0.0-preview.13
+      '@azure/identity': 2.0.0-beta.6
       '@microsoft/api-extractor': 7.7.11
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-json': 4.1.0_rollup@1.32.1
@@ -8331,7 +8395,7 @@ packages:
     dev: false
     name: '@rush-temp/ai-anomaly-detector'
     resolution:
-      integrity: sha512-PMKbRx0Y1k+Uma23AFAqOggkqpcAo7QIDg5qVef24SrtJBA4LjUQukbCLMmtcL2Y8fhzBw/3WFmJQSq/GMfFUg==
+      integrity: sha512-8eiHwPfczMiT5YmtQc9kG/TZx5SqySlXAShKgCR1ILFNYndPrk6ngtkx6OmCFzhePZajVB1iQhMA2bXyF5X87A==
       tarball: file:projects/ai-anomaly-detector.tgz
     version: 0.0.0
   file:projects/ai-document-translator.tgz:
@@ -8378,6 +8442,7 @@ packages:
   file:projects/ai-form-recognizer.tgz:
     dependencies:
       '@azure/core-tracing': 1.0.0-preview.13
+      '@azure/identity': 2.0.0-beta.6
       '@microsoft/api-extractor': 7.7.11
       '@types/chai': 4.2.21
       '@types/mocha': 7.0.2
@@ -8415,7 +8480,7 @@ packages:
     dev: false
     name: '@rush-temp/ai-form-recognizer'
     resolution:
-      integrity: sha512-8mpClkUfSZIt1zJfQXdHizP6fpP0KtewY7RPCBxoHaS6fx8SK8htStAn78q20U4sl6frD/e/ip/ttsbwu1SEbA==
+      integrity: sha512-YvthO3IXaeYFhgEYtwpgosyRaBw1k6lRXJ1RZKardk2SuNeSKCaIusZS8pHvdb2uWbSYN7dzUIMPCBN1Dro1mA==
       tarball: file:projects/ai-form-recognizer.tgz
     version: 0.0.0
   file:projects/ai-metrics-advisor.tgz:
@@ -8466,6 +8531,7 @@ packages:
   file:projects/ai-text-analytics.tgz:
     dependencies:
       '@azure/core-tracing': 1.0.0-preview.13
+      '@azure/identity': 2.0.0-beta.6
       '@microsoft/api-extractor': 7.18.7
       '@types/chai': 4.2.21
       '@types/chai-as-promised': 7.1.4
@@ -8506,12 +8572,13 @@ packages:
     dev: false
     name: '@rush-temp/ai-text-analytics'
     resolution:
-      integrity: sha512-hRasIXf1uFNRB+8KPd+8PBWrr2UKyar+xdfhea1Dhnl679ycQZZUXP7jhsMFFkCniRzwhE2pwkqc98CBYlX35A==
+      integrity: sha512-ZxFZFGVS8QE7mgdOlzQBb8QoHd1lb+hed1Dp5KojWLWTKmOv7X4WxVPIDiVbIj8ebpPjAd4cHhua0frdwCiSig==
       tarball: file:projects/ai-text-analytics.tgz
     version: 0.0.0
   file:projects/app-configuration.tgz:
     dependencies:
       '@azure/core-tracing': 1.0.0-preview.13
+      '@azure/identity': 2.0.0-beta.6
       '@azure/keyvault-secrets': 4.3.0
       '@microsoft/api-extractor': 7.7.11
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
@@ -8560,7 +8627,7 @@ packages:
     dev: false
     name: '@rush-temp/app-configuration'
     resolution:
-      integrity: sha512-rfq90e76ju8sRaJJ0C1vKr18hPTjN2ITtZ21KaE5tjWwAmRnZ2WQLYgeaWJ5U5YLagyImFMmmRJDz6L5hVYA5w==
+      integrity: sha512-/U5KWOuiyI9hrAutHmMPodzoL6WOmKw0+XNTscQv6Wa80Nwz+sYN3MfqyTRLi0TRHdeRXPGptZ4NxXkUU9hB1g==
       tarball: file:projects/app-configuration.tgz
     version: 0.0.0
   file:projects/arm-appservice.tgz:
@@ -8940,6 +9007,7 @@ packages:
   file:projects/attestation.tgz:
     dependencies:
       '@azure/core-tracing': 1.0.0-preview.13
+      '@azure/identity': 2.0.0-beta.6
       '@microsoft/api-extractor': 7.7.11
       '@types/chai': 4.2.21
       '@types/chai-as-promised': 7.1.4
@@ -8985,7 +9053,7 @@ packages:
     dev: false
     name: '@rush-temp/attestation'
     resolution:
-      integrity: sha512-QNTLspl+nUVzTmEt0d7GEq+FZodMYQmqfMUk9CxT6N3MXJDiyFPloqsowp8/9cvmLCFgNbbFwtVMo32J9XdFIA==
+      integrity: sha512-MWwZlGPsxTbmfdj0axvPY0KVohkpCJZTd40tbKbMYtamWCOp1j/3Xx6XEOBdF9GGfezIpGtJSla5ERFd9Q2hbQ==
       tarball: file:projects/attestation.tgz
     version: 0.0.0
   file:projects/communication-chat.tgz:
@@ -9103,6 +9171,7 @@ packages:
   file:projects/communication-identity.tgz:
     dependencies:
       '@azure/core-tracing': 1.0.0-preview.13
+      '@azure/identity': 2.0.0-beta.6
       '@microsoft/api-extractor': 7.7.11
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-json': 4.1.0_rollup@1.32.1
@@ -9150,13 +9219,14 @@ packages:
     dev: false
     name: '@rush-temp/communication-identity'
     resolution:
-      integrity: sha512-yGo9dFpYLG4NlBcYUcgTVzjkPB5jhGQVP+VCir1ofGj/LwPZJIHYiJfrOGiyepxn9ZZYVELmMJSvSkwASkkBtg==
+      integrity: sha512-hN3srNgjmJdDIoAO1Su+GZsI1qh5b54PAmbyr3spfLMnzejf5ljcxCZWSHAO7gYwvGT+Av4CICtWtUuyFLaQHg==
       tarball: file:projects/communication-identity.tgz
     version: 0.0.0
   file:projects/communication-network-traversal.tgz:
     dependencies:
       '@azure/communication-identity': 1.0.0
       '@azure/core-tracing': 1.0.0-preview.13
+      '@azure/identity': 2.0.0-beta.6
       '@microsoft/api-extractor': 7.7.11
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-json': 4.1.0_rollup@1.32.1
@@ -9204,12 +9274,13 @@ packages:
     dev: false
     name: '@rush-temp/communication-network-traversal'
     resolution:
-      integrity: sha512-IaZgF78wrRmTbECUZFnv9bJzukGvbdY5t062yHd8R67XwxbIZuUFRZUu5GjXkS0rq4xWRfpeusRXfUsOX5xQ2A==
+      integrity: sha512-+ULxT3XN8qSsW68KcALoAriUSlCBTR7TU/qXsydwS+BfhMMG2voGPXEjRSKJc7PRMi1mR0Z7tWW4nFNy7EnuYg==
       tarball: file:projects/communication-network-traversal.tgz
     version: 0.0.0
   file:projects/communication-phone-numbers.tgz:
     dependencies:
       '@azure/core-tracing': 1.0.0-preview.13
+      '@azure/identity': 2.0.0-beta.6
       '@microsoft/api-extractor': 7.7.11
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-json': 4.1.0_rollup@1.32.1
@@ -9257,12 +9328,13 @@ packages:
     dev: false
     name: '@rush-temp/communication-phone-numbers'
     resolution:
-      integrity: sha512-mWYCJhDH+j4Z3fpnWSjMBzM3LkQ05p1eU/VcGM9KEGnqNmwPuwLjNgNwds//gVF9tCWRaWyrJdAl96SywJqi8g==
+      integrity: sha512-EpHIaOTq9RyLWOVSd9tPraMODTp7u10AlJbZHOsCrWbOhXm9eiJY2h4l7CI9yiQ0KSOJ+KG7sotMSdPh5Grzkw==
       tarball: file:projects/communication-phone-numbers.tgz
     version: 0.0.0
   file:projects/communication-sms.tgz:
     dependencies:
       '@azure/core-tracing': 1.0.0-preview.13
+      '@azure/identity': 2.0.0-beta.6
       '@microsoft/api-extractor': 7.7.11
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-json': 4.1.0_rollup@1.32.1
@@ -9309,7 +9381,7 @@ packages:
     dev: false
     name: '@rush-temp/communication-sms'
     resolution:
-      integrity: sha512-DqMrWo8w5sAh+oF+KLVFEMDY53GrTfoGVUEk6/yyIc71vF8tDOtLDaIAkkE7otWPCwjiTEJ0sLC1sH5nnXDg/A==
+      integrity: sha512-qN1zBX/BCstzeKeHn84XCJTeq/Cs3F+5/xu9fiXVxGnzaQBlZCuWSFTn8vSEKEuK4ZxQu9IXSD9pJmAOP5u6Qg==
       tarball: file:projects/communication-sms.tgz
     version: 0.0.0
   file:projects/confidential-ledger.tgz:
@@ -9356,6 +9428,7 @@ packages:
   file:projects/container-registry.tgz:
     dependencies:
       '@azure/core-tracing': 1.0.0-preview.13
+      '@azure/identity': 2.0.0-beta.6
       '@microsoft/api-extractor': 7.7.11
       '@types/chai': 4.2.21
       '@types/chai-as-promised': 7.1.4
@@ -9393,7 +9466,7 @@ packages:
     dev: false
     name: '@rush-temp/container-registry'
     resolution:
-      integrity: sha512-QW0HTlnp4PdfVUy2/VEsWqz19e/amM39pmBaP5QnWpnsvA4B9Ag4+ODV1Gs1+2I+Z6V3TFQ2OsxGvd/c4alQzQ==
+      integrity: sha512-x1+6Vq4/SBsQKlK+DOBTsie+XrqCviHhBTfolK4sxjuP6/0g78eUsUrfsWxBgjUSNgT/A04F6/7PAlecV7sh9Q==
       tarball: file:projects/container-registry.tgz
     version: 0.0.0
   file:projects/core-amqp.tgz:
@@ -10036,6 +10109,7 @@ packages:
   file:projects/data-tables.tgz:
     dependencies:
       '@azure/core-tracing': 1.0.0-preview.13
+      '@azure/identity': 2.0.0-beta.6
       '@microsoft/api-extractor': 7.7.11
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-inject': 4.0.2_rollup@1.32.1
@@ -10085,7 +10159,7 @@ packages:
     dev: false
     name: '@rush-temp/data-tables'
     resolution:
-      integrity: sha512-X4h5u9kxy6CgXCPHsI8uJKzdWy4AJ9usiUtWI05GOx2CsATtW/5ik4nnELoeawb1pANu1MV27OINTqYlvOyRDQ==
+      integrity: sha512-5lC14kRDR5gwBUEBKDcVadiXycIhD8S7vqwj2ZU48opjaXppInwQC/PfMG6LcU+r3ABnKb+C8nVOLoFScSb04A==
       tarball: file:projects/data-tables.tgz
     version: 0.0.0
   file:projects/dev-tool.tgz:
@@ -10129,6 +10203,7 @@ packages:
   file:projects/digital-twins-core.tgz:
     dependencies:
       '@azure/core-tracing': 1.0.0-preview.13
+      '@azure/identity': 2.0.0-beta.6
       '@microsoft/api-extractor': 7.7.11
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-json': 4.1.0_rollup@1.32.1
@@ -10177,7 +10252,7 @@ packages:
     dev: false
     name: '@rush-temp/digital-twins-core'
     resolution:
-      integrity: sha512-Jgnp5dQnW57aVbd2XHt6hO48rWI/7wX6twY6MSMoKjjrVIQbIU8a6B0jEhIBrj6g0I/HOfUpJYhwcklXNkSCGg==
+      integrity: sha512-sQ2dM4V47Cltcn560kx15C1QwQceO8PTBOsRnr5sqphKGbMQhnGp7/3DIFN3KrPuFPRG/pp+GXAdCeD+CNjNLg==
       tarball: file:projects/digital-twins-core.tgz
     version: 0.0.0
   file:projects/eslint-plugin-azure-sdk.tgz:
@@ -10219,6 +10294,7 @@ packages:
   file:projects/event-hubs.tgz:
     dependencies:
       '@azure/core-tracing': 1.0.0-preview.13
+      '@azure/identity': 2.0.0-beta.6_debug@4.3.2
       '@microsoft/api-extractor': 7.18.7
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-inject': 4.0.2_rollup@1.32.1
@@ -10286,7 +10362,7 @@ packages:
     dev: false
     name: '@rush-temp/event-hubs'
     resolution:
-      integrity: sha512-Qcg7rtWSOdoNX+sioODkCkgY/i5tghyT7//fIXGil2qIRyAL8DbHrQT1tsUgmZVLm1PbdDZ1BfGOv9gxJjZc1A==
+      integrity: sha512-Znp/pWCEiVRhPM+mk2OVq9n1+fbGl7kkvL9mkWWKuHIXsjQZB9hBAL7EclBtRsqDVABFj9tRos4SXkDvj/cUVQ==
       tarball: file:projects/event-hubs.tgz
     version: 0.0.0
   file:projects/event-processor-host.tgz:
@@ -10542,7 +10618,7 @@ packages:
     dev: false
     name: '@rush-temp/identity-cache-persistence'
     resolution:
-      integrity: sha512-MjEb8jVg9Mqsb0Wd5itSPOQjq7oEblXtK3Hoa3DCdP+L/a615xCViTBujZTtHyA3o77bHhGerOwDxZ7Dj6tyFA==
+      integrity: sha512-ETCkr+UfX8rXnhq6tZ/jSpZLJdcP/JiXhvq9cpDnVvxcAWyeJdGUhX3WUhOl4va4jD0HyUy5zjwAsrDvfHV1Wg==
       tarball: file:projects/identity-cache-persistence.tgz
     version: 0.0.0
   file:projects/identity-vscode.tgz:
@@ -10574,7 +10650,7 @@ packages:
     dev: false
     name: '@rush-temp/identity-vscode'
     resolution:
-      integrity: sha512-Hd72kbCQ7ii3aMTf/hvNszHSqtlPXQb/zfPrHYHlkbBAx0487zEG08yYsOvZwOAWQZeySQkJa+Sr8vaLyJ0U2A==
+      integrity: sha512-6DB5l5krRBSviDlAKWbX+EWsKUu3GTeDr1QleUWxM/Dz2LPI6sktK/DhGiG/DD5GO/vTScDenqhgtkMPge1lDw==
       tarball: file:projects/identity-vscode.tgz
     version: 0.0.0
   file:projects/identity.tgz:
@@ -10630,6 +10706,7 @@ packages:
   file:projects/iot-device-update.tgz:
     dependencies:
       '@azure/core-tracing': 1.0.0-preview.13
+      '@azure/identity': 2.0.0-beta.6
       '@microsoft/api-extractor': 7.7.11
       '@types/node': 12.20.24
       '@types/uuid': 8.3.1
@@ -10649,7 +10726,7 @@ packages:
     dev: false
     name: '@rush-temp/iot-device-update'
     resolution:
-      integrity: sha512-kL3fFp9QhcyAryY2/YEo5eH90SDFUv0GXYrd54cWb6pr6l7xqh6Jel4YLbVQ7mlJW7Ts3lYODVqBTFFjEX3mKw==
+      integrity: sha512-DOkGgC0zGQZGz5CArpHHsu/0v+XVKygrO/9dRJ8xM2ZKrYzn3xrrUDAjPeqJCvaSIc52FSn8hbb5dFLVSzYj1Q==
       tarball: file:projects/iot-device-update.tgz
     version: 0.0.0
   file:projects/iot-modelsrepository.tgz:
@@ -10745,7 +10822,7 @@ packages:
     dev: false
     name: '@rush-temp/keyvault-admin'
     resolution:
-      integrity: sha512-5VJOXIOhrGpxSiZVtgjMVEcUSWh1g8jYZouEgPQ4rpoW6z0RxiL8r+/11qgNILgGlf0FXj3PaN8brAT6fx0IGQ==
+      integrity: sha512-sPfcSpG2bj1ZQaEJjRvYdpImotADgwahBhf64pzotWETsYH2v6i79bqaYTEvjJWL8Se5TzXIbzL1PeMzY0V80Q==
       tarball: file:projects/keyvault-admin.tgz
     version: 0.0.0
   file:projects/keyvault-certificates.tgz:
@@ -10801,7 +10878,7 @@ packages:
     dev: false
     name: '@rush-temp/keyvault-certificates'
     resolution:
-      integrity: sha512-AShnhzBFj1alNMcW6RZ1GvulVp4qktPxCw/fU/8vUNxbQegr8wQ+IgH3bJpOXB6/Re7F8N9Z2j7a9kdeeY3Rsw==
+      integrity: sha512-CtrJZLopz0ZdjSJ67+mjEP0pVr+ahlmdqmuHm8BWe6nHv4Q0LIK8sC67jXUADi0ow3YveCf+4659w3R2RJGBuA==
       tarball: file:projects/keyvault-certificates.tgz
     version: 0.0.0
   file:projects/keyvault-common.tgz:
@@ -10873,7 +10950,7 @@ packages:
     dev: false
     name: '@rush-temp/keyvault-keys'
     resolution:
-      integrity: sha512-mbAG8Hc1TeiW9TO/0PmJEQR+lt1Ij2F6S4q1PBJWe1aVGpvV0gQxm7RPVlFxoo7m1aIOQ6ZAjsXo1HwUcvKMjg==
+      integrity: sha512-qyVgXM2CL95HxDi90zOKMHc49d3n43Fuih5xo8wyc88x+NW7ueGD5aC76ZmLivqT+OK/cr+wMYiM4VL5khN7HQ==
       tarball: file:projects/keyvault-keys.tgz
     version: 0.0.0
   file:projects/keyvault-secrets.tgz:
@@ -10928,7 +11005,7 @@ packages:
     dev: false
     name: '@rush-temp/keyvault-secrets'
     resolution:
-      integrity: sha512-Qeo8N9T/5tWS1rR7//fwnxUdVpT0tiyUEbnS3byJxxklysXjdqrzZhlGiIhdvRwgFIY3biLiYLDEIrIcFS9pOw==
+      integrity: sha512-ZllwmMvvKcvY7PRn5T9MKqYhzCRNsFJTKBJtAKCToOG94EMxL7nnbBUd0lNx82TEfoXMIoAsJnkOqRXL6ovECQ==
       tarball: file:projects/keyvault-secrets.tgz
     version: 0.0.0
   file:projects/logger.tgz:
@@ -11157,7 +11234,7 @@ packages:
     dev: false
     name: '@rush-temp/monitor-query'
     resolution:
-      integrity: sha512-wTWUYsAt7ut9FCaEDjKBqgcZnXvS7jRCafdZOHQCw7BY3cUTrNyRmmWmu/OYyJ7lB91pPYXhVeUzbN0fQq8AZQ==
+      integrity: sha512-pIaZvhGUj1JGFR945VFkaCNPoKaIMwhXIfz3XmdW55rJfRCmWm8x1ZHYmNjbepyWNK9C58Y1UCXv/P1n1LQqDg==
       tarball: file:projects/monitor-query.tgz
     version: 0.0.0
   file:projects/perf-ai-form-recognizer.tgz:
@@ -11198,6 +11275,7 @@ packages:
   file:projects/perf-ai-text-analytics.tgz:
     dependencies:
       '@azure/ai-text-analytics': 5.1.0
+      '@azure/identity': 2.0.0-beta.6
       '@types/node': 12.20.24
       dotenv: 8.6.0
       eslint: 7.32.0
@@ -11209,7 +11287,7 @@ packages:
     dev: false
     name: '@rush-temp/perf-ai-text-analytics'
     resolution:
-      integrity: sha512-LZzmvRGmoulKmr8ZD+tSXuqQB/VuzX2n76xaffPgbbQ7/bWQCUGFtw7aqyQ9IW9DZXJgEeEMR6lsTQAA9je5pQ==
+      integrity: sha512-OUvjOGcvUwZAvEh5wQyZoH/6hE7Q6F8hP6swetAbfENX5eeKfobS4oAGIwhr7foFLbSTwK3hIM4/N0HaiUVDpg==
       tarball: file:projects/perf-ai-text-analytics.tgz
     version: 0.0.0
   file:projects/perf-app-configuration.tgz:
@@ -11339,6 +11417,7 @@ packages:
     version: 0.0.0
   file:projects/perf-keyvault-keys.tgz:
     dependencies:
+      '@azure/identity': 2.0.0-beta.6
       '@azure/keyvault-keys': 4.3.0
       '@types/node': 12.20.24
       '@types/uuid': 8.3.1
@@ -11353,7 +11432,7 @@ packages:
     dev: false
     name: '@rush-temp/perf-keyvault-keys'
     resolution:
-      integrity: sha512-VbsYGGECoP28wT4erUUSzjxfNFb4u6ZHCKVjvFBwxsu2xazs10VuMT4Pd5eR0GuxTQbshYuX1OyEaWfwMxCQLg==
+      integrity: sha512-E70lXSAAAdU9JRCXksCGYaFr7bjsHdn1AP3zSB+HKyLQhhU1FxNL02tPnZLvylS7c+sC42nJTaaBqXIkWaQuKA==
       tarball: file:projects/perf-keyvault-keys.tgz
     version: 0.0.0
   file:projects/perf-keyvault-secrets.tgz:
@@ -11597,6 +11676,7 @@ packages:
   file:projects/quantum-jobs.tgz:
     dependencies:
       '@azure/core-tracing': 1.0.0-preview.13
+      '@azure/identity': 2.0.0-beta.6
       '@microsoft/api-extractor': 7.7.11
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-json': 4.1.0_rollup@1.32.1
@@ -11644,11 +11724,12 @@ packages:
     dev: false
     name: '@rush-temp/quantum-jobs'
     resolution:
-      integrity: sha512-xpM31y1ADL8pwAWv5U1y8KlGbGXkId5yNvWWV58UW7tsr1rIlPaT1reMvttm8nC1L8UUk/rEUxv0ASBq7uxWWg==
+      integrity: sha512-XVXR8wpPwC2WRY092LdqozMHD1gvgjrVSjDF0KKIKPyFUYOgu2O4dnPFZZuMyiEvw/I53IZ91v7ddx5RzgHtqg==
       tarball: file:projects/quantum-jobs.tgz
     version: 0.0.0
   file:projects/schema-registry-avro.tgz:
     dependencies:
+      '@azure/identity': 2.0.0-beta.6
       '@microsoft/api-extractor': 7.18.7
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-inject': 4.0.2_rollup@1.32.1
@@ -11692,12 +11773,13 @@ packages:
     dev: false
     name: '@rush-temp/schema-registry-avro'
     resolution:
-      integrity: sha512-KHHpFCOOwve5rTm9DOsslci6XlwyMvgwRl3VmUPrQ1Dx+RcMI/GuWmnPvrcRNC68rT5OVBvbhsUxTpalJR0Hyw==
+      integrity: sha512-HjDqcDAbRqLD2/+t/axLJZmLPbrB8hb9uuMIJkgyxd17AIurR/+Lnav4TS602wRdz0dh8z/P5g9C8UwisZzN3A==
       tarball: file:projects/schema-registry-avro.tgz
     version: 0.0.0
   file:projects/schema-registry.tgz:
     dependencies:
       '@azure/core-tracing': 1.0.0-preview.13
+      '@azure/identity': 2.0.0-beta.6
       '@microsoft/api-extractor': 7.18.7
       '@types/chai': 4.2.21
       '@types/chai-as-promised': 7.1.4
@@ -11734,7 +11816,7 @@ packages:
     dev: false
     name: '@rush-temp/schema-registry'
     resolution:
-      integrity: sha512-CFUPH7NJ1Zd+6QO+Ag+gQzuW9SZhLYxOelzOdL7fYSaDytiO3UdbyveTnhIMNjrXulfHtG+dSh8RHu/4RfP/GA==
+      integrity: sha512-3u6zoUWe+USz56Vcbc/CvVDy/roObzFCPl9ijWjt6bq94pPhgakJ4eKVlIFb5iytzPg6HVHcbt2kKMK6UN6OOg==
       tarball: file:projects/schema-registry.tgz
     version: 0.0.0
   file:projects/search-documents.tgz:
@@ -11794,6 +11876,7 @@ packages:
   file:projects/service-bus.tgz:
     dependencies:
       '@azure/core-tracing': 1.0.0-preview.13
+      '@azure/identity': 2.0.0-beta.6_debug@4.3.2
       '@microsoft/api-extractor': 7.7.11
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-inject': 4.0.2_rollup@1.32.1
@@ -11863,7 +11946,7 @@ packages:
     dev: false
     name: '@rush-temp/service-bus'
     resolution:
-      integrity: sha512-ODZRsh83LprTuHRaeo6molj1uvyQKEXxjB635RUbTM7VdBXGTP1crPWW9mNST0dhrogpXiilBWkyVEGGzAJfYw==
+      integrity: sha512-taRKsIxjmgo9TDFPIs0WoZdV8kXMUQrOAGHo0Xn0+4WCo2dtDWAjTRRznNIQ78QDljnqHOLRdMYtNCLxlysM4g==
       tarball: file:projects/service-bus.tgz
     version: 0.0.0
   file:projects/storage-blob-changefeed.tgz:
@@ -11926,6 +12009,7 @@ packages:
   file:projects/storage-blob.tgz:
     dependencies:
       '@azure/core-tracing': 1.0.0-preview.13
+      '@azure/identity': 2.0.0-beta.6
       '@microsoft/api-extractor': 7.7.11
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-json': 4.1.0_rollup@1.32.1
@@ -11978,12 +12062,13 @@ packages:
     dev: false
     name: '@rush-temp/storage-blob'
     resolution:
-      integrity: sha512-hi5zDW/BJQy2kNlghXIux/VlJiGF0MKVi1yGLK5jfi7PglSKHlu07Yb7g4LJVoe/f56A2skogvYydL1yuZGHZw==
+      integrity: sha512-oG2JiQptBvC9GwPPVrw2Mb7SmWBWG1H/S9Jwkdyuq3pRcRFBe12vvGwvYgI4v3uEvEu7oHaiS2VPVSwhvAXgAg==
       tarball: file:projects/storage-blob.tgz
     version: 0.0.0
   file:projects/storage-file-datalake.tgz:
     dependencies:
       '@azure/core-tracing': 1.0.0-preview.13
+      '@azure/identity': 2.0.0-beta.6
       '@microsoft/api-extractor': 7.7.11
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-json': 4.1.0_rollup@1.32.1
@@ -12035,7 +12120,7 @@ packages:
     dev: false
     name: '@rush-temp/storage-file-datalake'
     resolution:
-      integrity: sha512-eDolCyPFs5yZg9LctzQOxDu0goufUzmQhXU19SkBJAeG2G+h8LVdf8F9NWvkHi49aEoEiC/xFn8hJi4eIV+h4Q==
+      integrity: sha512-ZCFFMiB1Ot1bBuotstCNTDgAlXMyyXpJZgkpQ2qGnmKjUP2D/sSiq2WhoaNmIZzTLuZhsbJEL6Mu4zap2c2X8A==
       tarball: file:projects/storage-file-datalake.tgz
     version: 0.0.0
   file:projects/storage-file-share.tgz:
@@ -12147,6 +12232,7 @@ packages:
   file:projects/storage-queue.tgz:
     dependencies:
       '@azure/core-tracing': 1.0.0-preview.13
+      '@azure/identity': 2.0.0-beta.6
       '@microsoft/api-extractor': 7.7.11
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
@@ -12195,12 +12281,13 @@ packages:
     dev: false
     name: '@rush-temp/storage-queue'
     resolution:
-      integrity: sha512-JOp9DuRAXjx3jcRO9p/KA4GObBQ33NKH7lqqp2bi0JkR8LI/u3PJMOYFk1N0jTDGhHNik67+tZObGs5MN3nm7A==
+      integrity: sha512-P8fE8ianJFOaHSuwKFp4zXeYVNG8bA9dsRW8RkH9+Zarg3pSLPhHIM70pSCTJBmaI9lDSsanhJIHacK55/zhaw==
       tarball: file:projects/storage-queue.tgz
     version: 0.0.0
   file:projects/synapse-access-control.tgz:
     dependencies:
       '@azure/core-tracing': 1.0.0-preview.13
+      '@azure/identity': 2.0.0-beta.6
       '@microsoft/api-extractor': 7.7.11
       '@types/chai': 4.2.21
       '@types/chai-as-promised': 7.1.4
@@ -12242,12 +12329,13 @@ packages:
     dev: false
     name: '@rush-temp/synapse-access-control'
     resolution:
-      integrity: sha512-d+h9vtbraShuNGguka7y6hunfV+5RGfQfUAg/i+lF8fa6+EohAPwkvwIjOacV57FZOGj+3kEq9Xd8eiI1kR2yQ==
+      integrity: sha512-fXpynEKAT+081vxYyKEdqJk2XD4NNHix5UKR2gsKWlCNKerWh1vfMrfInOUUHCsyidVHpzWVMgaK4rcIskiUog==
       tarball: file:projects/synapse-access-control.tgz
     version: 0.0.0
   file:projects/synapse-artifacts.tgz:
     dependencies:
       '@azure/core-tracing': 1.0.0-preview.13
+      '@azure/identity': 2.0.0-beta.6
       '@microsoft/api-extractor': 7.7.11
       '@types/chai': 4.2.21
       '@types/chai-as-promised': 7.1.4
@@ -12289,12 +12377,13 @@ packages:
     dev: false
     name: '@rush-temp/synapse-artifacts'
     resolution:
-      integrity: sha512-qI+NhcSIYrsgofYRLe//aUH2QEArpJUtOSKh86+gUYjOhrnlZMAcyvQ/5OCe16l2Ljq0jexmZhYYVGZUVPqYQA==
+      integrity: sha512-cKJhR8vNTMPT1wzvBfZDQPWhP8/BXsqapXgO6DFd0ab4lHXm/t1bvRA4dhZVcerttsaOuqDwn/7suhy/kK2ntA==
       tarball: file:projects/synapse-artifacts.tgz
     version: 0.0.0
   file:projects/synapse-managed-private-endpoints.tgz:
     dependencies:
       '@azure/core-tracing': 1.0.0-preview.13
+      '@azure/identity': 2.0.0-beta.6
       '@microsoft/api-extractor': 7.7.11
       '@types/chai': 4.2.21
       '@types/chai-as-promised': 7.1.4
@@ -12331,7 +12420,7 @@ packages:
     dev: false
     name: '@rush-temp/synapse-managed-private-endpoints'
     resolution:
-      integrity: sha512-TKjMIigqql+UxGPJrm5kuMZxipcpI3ngLT/zX6zrtyJwLp5ZWP6yk8v5HEP4cMEsUfmFci/jQGnHn2yyFiM5bw==
+      integrity: sha512-HWoyPUk0hC/+xreznV9W8M/m3PHHO7EPDBgxHbsjroOuYYedMYtd6NO7RY2xWpsIGT0283awU7LpMGhrALxBzw==
       tarball: file:projects/synapse-managed-private-endpoints.tgz
     version: 0.0.0
   file:projects/synapse-monitoring.tgz:
@@ -12357,6 +12446,7 @@ packages:
   file:projects/synapse-spark.tgz:
     dependencies:
       '@azure/core-tracing': 1.0.0-preview.13
+      '@azure/identity': 2.0.0-beta.6
       '@microsoft/api-extractor': 7.7.11
       '@types/chai': 4.2.21
       '@types/chai-as-promised': 7.1.4
@@ -12393,7 +12483,7 @@ packages:
     dev: false
     name: '@rush-temp/synapse-spark'
     resolution:
-      integrity: sha512-y/4UcUJhMtjWwK6lCbdvnyuYGzEdRyPwcoruOdsLXd9NlDykuM3TSpDXalYPclU1q2Fl9Zj25vJLaZFyvwuX3g==
+      integrity: sha512-QZRJ/07S1hSuTRj4VyMM2nwC60FJ5O27eoaePeKPgUa7z4/i7vWpr7la8JSDXu+iYdZUG/2U2FCQuLRmMYoQYA==
       tarball: file:projects/synapse-spark.tgz
     version: 0.0.0
   file:projects/template.tgz:

--- a/sdk/identity/identity-cache-persistence/CHANGELOG.md
+++ b/sdk/identity/identity-cache-persistence/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Release History
 
+## 1.0.0-beta.3 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
+
 ## 1.0.0-beta.2 (2021-09-09)
 
 ### Bugs Fixed

--- a/sdk/identity/identity-cache-persistence/package.json
+++ b/sdk/identity/identity-cache-persistence/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/identity-cache-persistence",
-  "version": "1.0.0-beta.2",
+  "version": "1.0.0-beta.3",
   "sdk-type": "client",
   "description": "A secure, persistent token cache for Azure Identity credentials that uses the OS secret-management API",
   "main": "dist/index.js",
@@ -61,7 +61,7 @@
   "sideEffects": false,
   "dependencies": {
     "@azure/core-auth": "^1.3.0",
-    "@azure/identity": "^2.0.0-beta.6",
+    "@azure/identity": "^2.0.0-beta.7",
     "@azure/msal-node": "^1.3.0",
     "@azure/msal-node-extensions": "1.0.0-alpha.9",
     "keytar": "^7.6.0",

--- a/sdk/identity/identity-vscode/CHANGELOG.md
+++ b/sdk/identity/identity-vscode/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Release History
 
+## 1.0.0-beta.3 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
+ 
 ## 1.0.0-beta.2 (2021-09-09)
 
 ### Other Changes

--- a/sdk/identity/identity-vscode/package.json
+++ b/sdk/identity/identity-vscode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/identity-vscode",
-  "version": "1.0.0-beta.2",
+  "version": "1.0.0-beta.3",
   "sdk-type": "client",
   "description": "Use the Azure Account extension for Visual Studio Code to authenticate with Azure Identity",
   "main": "dist/index.js",
@@ -60,7 +60,7 @@
   "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/identity/identity-vscode/README.md",
   "sideEffects": false,
   "dependencies": {
-    "@azure/identity": "^2.0.0-beta.6",
+    "@azure/identity": "^2.0.0-beta.7",
     "keytar": "^7.6.0",
     "tslib": "^2.2.0"
   },

--- a/sdk/identity/identity/CHANGELOG.md
+++ b/sdk/identity/identity/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Release History
 
+## 2.0.0-beta.7 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
+
 ## 2.0.0-beta.6 (2021-09-09)
 
 ### Features Added

--- a/sdk/identity/identity/package.json
+++ b/sdk/identity/identity/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@azure/identity",
   "sdk-type": "client",
-  "version": "2.0.0-beta.6",
+  "version": "2.0.0-beta.7",
   "description": "Provides credential implementations for Azure SDK libraries that can authenticate with Azure Active Directory",
   "main": "dist/index.js",
   "module": "dist-esm/src/index.js",

--- a/sdk/identity/identity/src/client/identityClient.ts
+++ b/sdk/identity/identity/src/client/identityClient.ts
@@ -64,7 +64,7 @@ export class IdentityClient extends ServiceClient implements INetworkModule {
   private abortControllers: Map<string, AbortController[] | undefined>;
 
   constructor(options?: TokenCredentialOptions) {
-    const packageDetails = `azsdk-js-identity/2.0.0-beta.6`;
+    const packageDetails = `azsdk-js-identity/2.0.0-beta.7`;
     const userAgentPrefix = options?.userAgentOptions?.userAgentPrefix
       ? `${options.userAgentOptions.userAgentPrefix} ${packageDetails}`
       : `${packageDetails}`;

--- a/sdk/keyvault/keyvault-admin/package.json
+++ b/sdk/keyvault/keyvault-admin/package.json
@@ -120,7 +120,7 @@
     "@azure/core-util": "^1.0.0-beta.1",
     "@azure/dev-tool": "^1.0.0",
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
-    "@azure/identity": "2.0.0-beta.6",
+    "@azure/identity": "2.0.0-beta.7",
     "@azure/keyvault-keys": "^4.2.1",
     "@azure/test-utils": "^1.0.0",
     "@azure-tools/test-recorder": "^1.0.0",

--- a/sdk/keyvault/keyvault-certificates/package.json
+++ b/sdk/keyvault/keyvault-certificates/package.json
@@ -117,7 +117,7 @@
   "devDependencies": {
     "@azure/dev-tool": "^1.0.0",
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
-    "@azure/identity": "2.0.0-beta.6",
+    "@azure/identity": "2.0.0-beta.7",
     "@azure/keyvault-secrets": "^4.2.0",
     "@azure/test-utils": "^1.0.0",
     "@azure-tools/test-recorder": "^1.0.0",

--- a/sdk/keyvault/keyvault-keys/package.json
+++ b/sdk/keyvault/keyvault-keys/package.json
@@ -114,7 +114,7 @@
   "devDependencies": {
     "@azure/dev-tool": "^1.0.0",
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
-    "@azure/identity": "2.0.0-beta.6",
+    "@azure/identity": "2.0.0-beta.7",
     "@azure/test-utils": "^1.0.0",
     "@azure-tools/test-recorder": "^1.0.0",
     "@microsoft/api-extractor": "7.7.11",

--- a/sdk/keyvault/keyvault-secrets/package.json
+++ b/sdk/keyvault/keyvault-secrets/package.json
@@ -113,7 +113,7 @@
   "devDependencies": {
     "@azure/dev-tool": "^1.0.0",
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
-    "@azure/identity": "2.0.0-beta.6",
+    "@azure/identity": "2.0.0-beta.7",
     "@azure/test-utils": "^1.0.0",
     "@azure-tools/test-recorder": "^1.0.0",
     "@microsoft/api-extractor": "7.7.11",

--- a/sdk/monitor/monitor-query/package.json
+++ b/sdk/monitor/monitor-query/package.json
@@ -109,7 +109,7 @@
     "@azure/dev-tool": "^1.0.0",
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
     "@azure/abort-controller": "^1.0.0",
-    "@azure/identity": "^1.1.0",
+    "@azure/identity": "2.0.0-beta.7",
     "@azure/monitor-opentelemetry-exporter": "1.0.0-beta.4",
     "@azure-tools/test-recorder": "^1.0.0",
     "@microsoft/api-extractor": "7.7.11",


### PR DESCRIPTION
New PR, smaller than the big one I made: https://github.com/Azure/azure-sdk-for-js/pull/17580

This PR:
- Changes the Identity package versions to the next beta (meaning, from 1.0.0-beta.2 to 1.0.0-beta.3 and to 2.0.0-beta.6 t o 2.0.0-beta.7).
- Sets some packages to use 2.0.0-beta.7 of Identity. Namely: The Identity package, the Key Vault packages and the Monitor Query (I’ve asked @maorleger and @KarishmaGhiya for permission 😄).