### PR TITLE
[Schema Registry] No longer return an undefined and throw instead

### DIFF
--- a/sdk/schemaregistry/schema-registry/CHANGELOG.md
+++ b/sdk/schemaregistry/schema-registry/CHANGELOG.md
@@ -10,6 +10,7 @@
 - renames `SchemaId` to `SchemaProperties`
 - renames `getSchemaById` to `getSchema`
 - renames `GetSchemaByIdOptions` to `GetSchemaOptions`
+- `getSchema` and `getSchemaProperties` no longer return `undefined` if the schema was not registered
 
 ### Bugs Fixed
 

--- a/sdk/schemaregistry/schema-registry/review/schema-registry.api.md
+++ b/sdk/schemaregistry/schema-registry/review/schema-registry.api.md
@@ -56,15 +56,14 @@ export interface SchemaRegistry {
 export class SchemaRegistryClient implements SchemaRegistry {
     constructor(endpoint: string, credential: TokenCredential, options?: SchemaRegistryClientOptions);
     readonly endpoint: string;
-    getSchema(id: string, options?: GetSchemaOptions): Promise<Schema | undefined>;
-    getSchemaProperties(schema: SchemaDescription, options?: GetSchemaPropertiesOptions): Promise<SchemaProperties | undefined>;
+    getSchema(id: string, options?: GetSchemaOptions): Promise<Schema>;
+    getSchemaProperties(schema: SchemaDescription, options?: GetSchemaPropertiesOptions): Promise<SchemaProperties>;
     registerSchema(schema: SchemaDescription, options?: RegisterSchemaOptions): Promise<SchemaProperties>;
-    }
+}
 
 // @public
 export interface SchemaRegistryClientOptions extends CommonClientOptions {
 }
-
 
 // (No @packageDocumentation comment for this package)
 

--- a/sdk/schemaregistry/schema-registry/test/schemaRegistry.spec.ts
+++ b/sdk/schemaregistry/schema-registry/test/schemaRegistry.spec.ts
@@ -110,7 +110,7 @@ describe("SchemaRegistryClient", function() {
   });
 
   it("fails to get schema ID when no matching schema exists", async () => {
-    assert.isUndefined(await client.getSchemaProperties({ ...schema, name: "never-registered" }));
+    assert.isRejected(client.getSchemaProperties({ ...schema, name: "never-registered" }));
   });
 
   it("gets schema ID", async () => {
@@ -128,7 +128,7 @@ describe("SchemaRegistryClient", function() {
   });
 
   it("fails to get schema when no schema exists with given ID", async () => {
-    assert.isUndefined(await client.getSchema("ffffffffffffffffffffffffffffffff"));
+    assert.isRejected(client.getSchema("ffffffffffffffffffffffffffffffff"));
   });
 
   it("gets schema by ID", async () => {


### PR DESCRIPTION
Related issue: https://github.com/Azure/azure-sdk-for-js/issues/17697

Let's throw instead of returning an undefined in `getSchema` and `getSchemaProperties`, since the [avro package will throw anyway](https://github.com/Azure/azure-sdk-for-js/blob/aced21f84bf4ac6c735b01a44e56022e096cc18e/sdk/schemaregistry/schema-registry-avro/src/schemaRegistryAvroSerializer.ts#L167-L170) and to be consistent with other languages.