### PR TITLE
Remove references to specific Node.js versions in readmes

### DIFF
--- a/sdk/applicationinsights/applicationinsights-query/README.md
+++ b/sdk/applicationinsights/applicationinsights-query/README.md
@@ -4,8 +4,10 @@ This package contains an isomorphic SDK for ApplicationInsightsDataClient.
 
 ### Currently supported environments
 
-- Node.js version 6.x.x or higher
-- Browser JavaScript
+- [LTS versions of Node.js](https://nodejs.org/about/releases/)
+- Latest versions of Safari, Chrome, Edge, and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### How to Install
 

--- a/sdk/eventhub/mock-hub/samples/typescript/readme.md
+++ b/sdk/eventhub/mock-hub/samples/typescript/readme.md
@@ -4,7 +4,7 @@ This sample shows how to use the Azure Mock Hub utility.
 
 ## Prerequisites
 
-The samples are compatible with Node.js >= 8.0.0.
+The samples are compatible with all [LTS versions of Node.js](https://nodejs.org/about/releases/).
 
 You'll also need to generate a pfx certificate chain that the mock service
 will use to enforce TLS.

--- a/sdk/operationalinsights/loganalytics/README.md
+++ b/sdk/operationalinsights/loganalytics/README.md
@@ -4,8 +4,10 @@ This package contains an isomorphic SDK for LogAnalyticsClient.
 
 ### Currently supported environments
 
-- Node.js version 6.x.x or higher
-- Browser JavaScript
+- [LTS versions of Node.js](https://nodejs.org/about/releases/)
+- Latest versions of Safari, Chrome, Edge, and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### How to Install
 

--- a/sdk/servicefabric/servicefabric/README.md
+++ b/sdk/servicefabric/servicefabric/README.md
@@ -4,8 +4,10 @@ This package contains an isomorphic SDK for ServiceFabricClient.
 
 ### Currently supported environments
 
-- Node.js version 6.x.x or higher
-- Browser JavaScript
+- [LTS versions of Node.js](https://nodejs.org/about/releases/)
+- Latest versions of Safari, Chrome, Edge, and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### How to Install
 

--- a/sdk/template/template/README-EXAMPLE.md
+++ b/sdk/template/template/README-EXAMPLE.md
@@ -18,6 +18,13 @@ Use the client library for App Configuration to:
 
 ## Getting started
 
+### Currently supported environments
+
+- [LTS versions of Node.js](https://nodejs.org/about/releases/)
+- Latest versions of Safari, Chrome, Edge, and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
+
 ### Install the package
 
 ```bash
@@ -26,8 +33,8 @@ npm install @azure/app-configuration
 
 ### Prerequisites
 
-- You must have an [Azure Subscription](https://azure.microsoft.com) and an [App Configuration](https://docs.microsoft.com/azure/azure-app-configuration/) resource to use this package.
-- Node.js version 8.x.x or higher
+- An [Azure Subscription](https://azure.microsoft.com)
+- An [App Configuration](https://docs.microsoft.com/azure/azure-app-configuration/) resource.
 
 ### Create an App Configuration resource
 


### PR DESCRIPTION
Now that we have a support policy around Node.js versions, issues were logged as part of a sweep of all the documentation to ensure we don't mentioned specific Node.js versions and instead point to the support policy. This PR does the needful for a handful of packages. Similar changes are needed for some arm packages that will be managed by the mgmt plane team. Another issue for Track 1 cognitive services is #17603 which will be handled separately

Fixes #17632
Fixes #17650
Fixes #17663
Fixes #17668
Fixes #17678