### PR TITLE
[Schema Registry Avro] Move the shim file to types

### DIFF
--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -260,7 +260,6 @@ $PackageExclusions = @{
   '@azure/core-asynciterator-polyfill'  = 'Docs CI fails https://github.com/Azure/azure-sdk-for-js/issues/16675';
   '@azure/arm-keyvault'                 = 'Docs CI fails https://github.com/Azure/azure-sdk-for-js/issues/16988';
   '@azure/arm-sql'                      = 'Docs CI fails https://github.com/Azure/azure-sdk-for-js/issues/16989';
-  '@azure/schema-registry-avro'         = 'Docs CI fails https://github.com/Azure/azure-sdk-for-js/issues/17550';
 }
 
 function Update-javascript-DocsMsPackages($DocsRepoLocation, $DocsMetadata) {

--- a/sdk/schemaregistry/schema-registry-avro/package.json
+++ b/sdk/schemaregistry/schema-registry-avro/package.json
@@ -8,7 +8,7 @@
   "browser": {
     "./dist-esm/src/utils/buffer.js": "./dist-esm/src/utils/buffer.browser.js"
   },
-  "types": "schema-registry-avro.shims.d.ts",
+  "types": "types/schema-registry-avro.shims.d.ts",
   "scripts": {
     "audit": "node ../../../common/scripts/rush-audit.js && rimraf node_modules package-lock.json && npm i --package-lock-only 2>&1 && npm audit",
     "build:browser": "tsc -p . && cross-env ONLY_BROWSER=true rollup -c 2>&1",
@@ -17,7 +17,7 @@
     "build:test": "tsc -p . && rollup -c rollup.test.config.js 2>&1",
     "build": "npm run clean && tsc -p . && rollup -c 2>&1 && api-extractor run --local",
     "check-format": "prettier --list-different --config ../../../.prettierrc.json --ignore-path ../../../.prettierignore \"src/**/*.ts\" \"test/**/*.ts\" \"samples-dev/**/*.ts\" \"*.{js,json}\"",
-    "clean": "rimraf dist dist-* temp types *.tgz *.log",
+    "clean": "rimraf dist dist-* temp \"types/!(schema-registry-avro.shims.d.ts)\" *.tgz *.log",
     "execute:samples": "dev-tool samples run samples-dev",
     "extract-api": "tsc -p . && api-extractor run --local",
     "format": "prettier --write --config ../../../.prettierrc.json --ignore-path ../../../.prettierignore \"src/**/*.ts\" \"test/**/*.ts\" \"samples-dev/**/*.ts\" \"*.{js,json}\"",
@@ -39,7 +39,7 @@
     "dist/",
     "dist-esm/src/",
     "types/schema-registry-avro.d.ts",
-    "schema-registry-avro.shims.d.ts",
+    "types/schema-registry-avro.shims.d.ts",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/schemaregistry/schema-registry-avro/types/schema-registry-avro.shims.d.ts
+++ b/sdk/schemaregistry/schema-registry-avro/types/schema-registry-avro.shims.d.ts
@@ -5,4 +5,4 @@ declare global {
   interface Blob {}
 }
 
-export * from "./types/schema-registry-avro";
+export * from "./schema-registry-avro";


### PR DESCRIPTION
Issue: https://github.com/Azure/azure-sdk-for-js/issues/17550

> @deyaaeldeen -- The docs system requires that the types .d.ts file be inside a folder. Example here: https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/schemaregistry/schema-registry/package.json#L9
> Putting the types file inside a folder should unblock this part of the docs build.

This PR addresses this issue by moving the shim file to the `types` directory.