### PR TITLE
Remove references to Node.js out-of-date version number from Readmes for Cognitive Services

### DIFF
--- a/sdk/cognitiveservices/arm-cognitiveservices/README.md
+++ b/sdk/cognitiveservices/arm-cognitiveservices/README.md
@@ -4,8 +4,8 @@ This package contains an isomorphic SDK (runs both in node.js and in browsers) f
 
 ### Currently supported environments
 
-- Node.js version 8.x.x or higher
-- Browser JavaScript
+- [Node.js](https://nodejs.org/) LTS version.
+- Browser JavaScript.
 
 ### Prerequisites
 

--- a/sdk/cognitiveservices/cognitiveservices-anomalydetector/README.md
+++ b/sdk/cognitiveservices/cognitiveservices-anomalydetector/README.md
@@ -4,8 +4,8 @@ This package contains an isomorphic SDK for AnomalyDetectorClient.
 
 ### Currently supported environments
 
-- Node.js version 6.x.x or higher
-- Browser JavaScript
+- [Node.js](https://nodejs.org/) LTS version.
+- Browser JavaScript.
 
 ### How to Install
 

--- a/sdk/cognitiveservices/cognitiveservices-autosuggest/README.md
+++ b/sdk/cognitiveservices/cognitiveservices-autosuggest/README.md
@@ -4,8 +4,8 @@ This package contains an isomorphic SDK for AutoSuggestClient.
 
 ### Currently supported environments
 
-- Node.js version 6.x.x or higher
-- Browser JavaScript
+- [Node.js](https://nodejs.org/) LTS version.
+- Browser JavaScript.
 
 ### How to Install
 

--- a/sdk/cognitiveservices/cognitiveservices-computervision/README.md
+++ b/sdk/cognitiveservices/cognitiveservices-computervision/README.md
@@ -4,8 +4,8 @@ This package contains an isomorphic SDK for ComputerVisionClient.
 
 ### Currently supported environments
 
-- Node.js version 6.x.x or higher
-- Browser JavaScript
+- [Node.js](https://nodejs.org/) LTS version.
+- Browser JavaScript.
 
 ### How to Install
 

--- a/sdk/cognitiveservices/cognitiveservices-contentmoderator/README.md
+++ b/sdk/cognitiveservices/cognitiveservices-contentmoderator/README.md
@@ -4,8 +4,8 @@ This package contains an isomorphic SDK for ContentModeratorClient.
 
 ### Currently supported environments
 
-- Node.js version 6.x.x or higher
-- Browser JavaScript
+- [Node.js](https://nodejs.org/) LTS version.
+- Browser JavaScript.
 
 ### How to Install
 

--- a/sdk/cognitiveservices/cognitiveservices-customimagesearch/README.md
+++ b/sdk/cognitiveservices/cognitiveservices-customimagesearch/README.md
@@ -4,8 +4,8 @@ This package contains an isomorphic SDK for CustomImageSearchClient.
 
 ### Currently supported environments
 
-- Node.js version 6.x.x or higher
-- Browser JavaScript
+- [Node.js](https://nodejs.org/) LTS version.
+- Browser JavaScript.
 
 ### How to Install
 

--- a/sdk/cognitiveservices/cognitiveservices-customsearch/README.md
+++ b/sdk/cognitiveservices/cognitiveservices-customsearch/README.md
@@ -4,8 +4,8 @@ This package contains an isomorphic SDK for CustomSearchClient.
 
 ### Currently supported environments
 
-- Node.js version 6.x.x or higher
-- Browser JavaScript
+- [Node.js](https://nodejs.org/) LTS version.
+- Browser JavaScript.
 
 ### How to Install
 

--- a/sdk/cognitiveservices/cognitiveservices-customvision-prediction/README.md
+++ b/sdk/cognitiveservices/cognitiveservices-customvision-prediction/README.md
@@ -4,8 +4,8 @@ This package contains an isomorphic SDK for PredictionAPIClient.
 
 ### Currently supported environments
 
-- Node.js version 6.x.x or higher
-- Browser JavaScript
+- [Node.js](https://nodejs.org/) LTS version.
+- Browser JavaScript.
 
 ### How to Install
 

--- a/sdk/cognitiveservices/cognitiveservices-customvision-training/README.md
+++ b/sdk/cognitiveservices/cognitiveservices-customvision-training/README.md
@@ -4,8 +4,8 @@ This package contains an isomorphic SDK for TrainingAPIClient.
 
 ### Currently supported environments
 
-- Node.js version 6.x.x or higher
-- Browser JavaScript
+- [Node.js](https://nodejs.org/) LTS version.
+- Browser JavaScript.
 
 ### How to Install
 

--- a/sdk/cognitiveservices/cognitiveservices-entitysearch/README.md
+++ b/sdk/cognitiveservices/cognitiveservices-entitysearch/README.md
@@ -4,8 +4,8 @@ This package contains an isomorphic SDK for EntitySearchClient.
 
 ### Currently supported environments
 
-- Node.js version 6.x.x or higher
-- Browser JavaScript
+- [Node.js](https://nodejs.org/) LTS version.
+- Browser JavaScript.
 
 ### How to Install
 

--- a/sdk/cognitiveservices/cognitiveservices-face/README.md
+++ b/sdk/cognitiveservices/cognitiveservices-face/README.md
@@ -4,8 +4,8 @@ This package contains an isomorphic SDK for FaceClient.
 
 ### Currently supported environments
 
-- Node.js version 6.x.x or higher
-- Browser JavaScript
+- [Node.js](https://nodejs.org/) LTS version.
+- Browser JavaScript.
 
 ### How to Install
 

--- a/sdk/cognitiveservices/cognitiveservices-formrecognizer/README.md
+++ b/sdk/cognitiveservices/cognitiveservices-formrecognizer/README.md
@@ -4,8 +4,8 @@ This package contains an isomorphic SDK for FormRecognizerClient.
 
 ### Currently supported environments
 
-- Node.js version 6.x.x or higher
-- Browser JavaScript
+- [Node.js](https://nodejs.org/) LTS version.
+- Browser JavaScript.
 
 ### How to Install
 

--- a/sdk/cognitiveservices/cognitiveservices-imagesearch/README.md
+++ b/sdk/cognitiveservices/cognitiveservices-imagesearch/README.md
@@ -4,8 +4,8 @@ This package contains an isomorphic SDK for ImageSearchClient.
 
 ### Currently supported environments
 
-- Node.js version 6.x.x or higher
-- Browser JavaScript
+- [Node.js](https://nodejs.org/) LTS version.
+- Browser JavaScript.
 
 ### How to Install
 

--- a/sdk/cognitiveservices/cognitiveservices-localsearch/README.md
+++ b/sdk/cognitiveservices/cognitiveservices-localsearch/README.md
@@ -4,8 +4,8 @@ This package contains an isomorphic SDK for LocalSearchClient.
 
 ### Currently supported environments
 
-- Node.js version 6.x.x or higher
-- Browser JavaScript
+- [Node.js](https://nodejs.org/) LTS version.
+- Browser JavaScript.
 
 ### How to Install
 

--- a/sdk/cognitiveservices/cognitiveservices-luis-authoring/README.md
+++ b/sdk/cognitiveservices/cognitiveservices-luis-authoring/README.md
@@ -9,8 +9,8 @@ Package version | LUIS Authoring API version
 
 ### Currently supported environments
 
-- Node.js version 6.x.x or higher
-- Browser JavaScript
+- [Node.js](https://nodejs.org/) LTS version.
+- Browser JavaScript.
 
 ### How to Install
 

--- a/sdk/cognitiveservices/cognitiveservices-luis-runtime/README.md
+++ b/sdk/cognitiveservices/cognitiveservices-luis-runtime/README.md
@@ -4,8 +4,8 @@ This package contains an isomorphic SDK for LUISRuntimeClient.
 
 ### Currently supported environments
 
-- Node.js version 6.x.x or higher
-- Browser JavaScript
+- [Node.js](https://nodejs.org/) LTS version.
+- Browser JavaScript.
 
 ### How to Install
 

--- a/sdk/cognitiveservices/cognitiveservices-newssearch/README.md
+++ b/sdk/cognitiveservices/cognitiveservices-newssearch/README.md
@@ -4,8 +4,8 @@ This package contains an isomorphic SDK for NewsSearchClient.
 
 ### Currently supported environments
 
-- Node.js version 6.x.x or higher
-- Browser JavaScript
+- [Node.js](https://nodejs.org/) LTS version.
+- Browser JavaScript.
 
 ### How to Install
 

--- a/sdk/cognitiveservices/cognitiveservices-personalizer/README.md
+++ b/sdk/cognitiveservices/cognitiveservices-personalizer/README.md
@@ -4,8 +4,8 @@ This package contains an isomorphic SDK for PersonalizerClient.
 
 ### Currently supported environments
 
-- Node.js version 6.x.x or higher
-- Browser JavaScript
+- [Node.js](https://nodejs.org/) LTS version.
+- Browser JavaScript.
 
 ### How to Install
 

--- a/sdk/cognitiveservices/cognitiveservices-qnamaker-runtime/README.md
+++ b/sdk/cognitiveservices/cognitiveservices-qnamaker-runtime/README.md
@@ -5,8 +5,8 @@ For editing and creating Knowledge Bases see @azure/cognitiveservices-qnamaker.
 
 ### Currently supported environments
 
-- Node.js version 6.x.x or higher
-- Browser JavaScript
+- [Node.js](https://nodejs.org/) LTS version.
+- Browser JavaScript.
 
 ### How to Install
 

--- a/sdk/cognitiveservices/cognitiveservices-qnamaker/README.md
+++ b/sdk/cognitiveservices/cognitiveservices-qnamaker/README.md
@@ -5,8 +5,8 @@ For interacting with QnAMaker such as training and asking questions please see @
 
 ### Currently supported environments
 
-- Node.js version 6.x.x or higher
-- Browser JavaScript
+- [Node.js](https://nodejs.org/) LTS version.
+- Browser JavaScript.
 
 ### How to Install
 

--- a/sdk/cognitiveservices/cognitiveservices-spellcheck/README.md
+++ b/sdk/cognitiveservices/cognitiveservices-spellcheck/README.md
@@ -4,8 +4,8 @@ This package contains an isomorphic SDK for SpellCheckClient.
 
 ### Currently supported environments
 
-- Node.js version 6.x.x or higher
-- Browser JavaScript
+- [Node.js](https://nodejs.org/) LTS version.
+- Browser JavaScript.
 
 ### How to Install
 

--- a/sdk/cognitiveservices/cognitiveservices-textanalytics/README.md
+++ b/sdk/cognitiveservices/cognitiveservices-textanalytics/README.md
@@ -4,8 +4,8 @@ This package contains an isomorphic SDK for TextAnalyticsClient.
 
 ### Currently supported environments
 
-- Node.js version 6.x.x or higher
-- Browser JavaScript
+- [Node.js](https://nodejs.org/) LTS version.
+- Browser JavaScript.
 
 ### How to Install
 

--- a/sdk/cognitiveservices/cognitiveservices-translatortext/README.md
+++ b/sdk/cognitiveservices/cognitiveservices-translatortext/README.md
@@ -4,8 +4,8 @@ This package contains an isomorphic SDK for TranslatorTextClient.
 
 ### Currently supported environments
 
-- Node.js version 6.x.x or higher
-- Browser JavaScript
+- [Node.js](https://nodejs.org/) LTS version.
+- Browser JavaScript.
 
 ### How to Install
 

--- a/sdk/cognitiveservices/cognitiveservices-videosearch/README.md
+++ b/sdk/cognitiveservices/cognitiveservices-videosearch/README.md
@@ -4,8 +4,8 @@ This package contains an isomorphic SDK for VideoSearchClient.
 
 ### Currently supported environments
 
-- Node.js version 6.x.x or higher
-- Browser JavaScript
+- [Node.js](https://nodejs.org/) LTS version.
+- Browser JavaScript.
 
 ### How to Install
 

--- a/sdk/cognitiveservices/cognitiveservices-visualsearch/README.md
+++ b/sdk/cognitiveservices/cognitiveservices-visualsearch/README.md
@@ -4,8 +4,8 @@ This package contains an isomorphic SDK for VisualSearchClient.
 
 ### Currently supported environments
 
-- Node.js version 6.x.x or higher
-- Browser JavaScript
+- [Node.js](https://nodejs.org/) LTS version.
+- Browser JavaScript.
 
 ### How to Install
 

--- a/sdk/cognitiveservices/cognitiveservices-websearch/README.md
+++ b/sdk/cognitiveservices/cognitiveservices-websearch/README.md
@@ -4,8 +4,8 @@ This package contains an isomorphic SDK for WebSearchClient.
 
 ### Currently supported environments
 
-- Node.js version 6.x.x or higher
-- Browser JavaScript
+- [Node.js](https://nodejs.org/) LTS version.
+- Browser JavaScript.
 
 ### How to Install
 


### PR DESCRIPTION
Fixes: https://github.com/Azure/azure-sdk-for-js/issues/17603

Manually updating the readmes to reference the LTS version of Node.js instead of a fixed number version.