### PR TITLE
Prepare for an initial release of Azure Remote Rendering beta package

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -119,7 +119,7 @@
 /sdk/cognitiveservices/cognitiveservices-qnamaker/ @bingisbestest @nerajput1607
 
 # PRLabel: %MixedReality
-/sdk/mixedreality/ @craigtreasure 
+/sdk/mixedreality/ @craigktreasure 
 
 # PRLabel: %RemoteRendering
 /sdk/remoterendering/ @MalcolmTyrrell
@@ -130,8 +130,8 @@
 # API review files
 /sdk/**/review/*api.md @bterlson @xirzec @chradek
 
-# Management Plane
 
+# Management Plane
 # PRLabel: %Mgmt
 /sdk/advisor/arm-advisor @qiaozha @dw511214992
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -118,7 +118,7 @@
 /sdk/cognitiveservices/cognitiveservices-qnamaker-runtime/ @bingisbestest @nerajput1607
 /sdk/cognitiveservices/cognitiveservices-qnamaker/ @bingisbestest @nerajput1607
 
-# PRLabel: %MixedReality
+# PRLabel: %Mixed Reality
 /sdk/mixedreality/ @craigktreasure 
 
 # PRLabel: %RemoteRendering

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -118,6 +118,12 @@
 /sdk/cognitiveservices/cognitiveservices-qnamaker-runtime/ @bingisbestest @nerajput1607
 /sdk/cognitiveservices/cognitiveservices-qnamaker/ @bingisbestest @nerajput1607
 
+# PRLabel: %MixedReality
+/sdk/mixedreality/ @craigtreasure 
+
+# PRLabel: %RemoteRendering
+/sdk/remoterendering/ @MalcolmTyrrell
+
 # Smoke Tests
 /common/smoke-test/ @ramya-rao-a @chradek @jonathandturner @sadasant @jeremymeng @southpolesteve
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -121,7 +121,7 @@
 # PRLabel: %Mixed Reality
 /sdk/mixedreality/ @craigktreasure 
 
-# PRLabel: %RemoteRendering
+# PRLabel: %Remote Rendering
 /sdk/remoterendering/ @MalcolmTyrrell
 
 # Smoke Tests

--- a/sdk/remoterendering/mixed-reality-remote-rendering/CHANGELOG.md
+++ b/sdk/remoterendering/mixed-reality-remote-rendering/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Release History
 
-## 1.0.0-beta.1 (Unreleased)
+## 1.0.0-beta.1 (2021-09-20)
 
 - Initial release.

--- a/sdk/remoterendering/mixed-reality-remote-rendering/CHANGELOG.md
+++ b/sdk/remoterendering/mixed-reality-remote-rendering/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Release History
 
-## 1.0.0-beta.1 (2021-09-20)
+## 1.0.0-beta.1 (2021-09-21)
 
 - Initial release.


### PR DESCRIPTION
We haven't push an initial package for JS until now. We were waiting to push it at the same time as Python, but that has been delayed yet again, so let's just push this out, since we just pushed packages for Java and .net.