### PR TITLE
[core-rest-pipeline] Enforce HTTPS at `bearerTokenPolicy`

### DIFF
--- a/sdk/core/core-rest-pipeline/CHANGELOG.md
+++ b/sdk/core/core-rest-pipeline/CHANGELOG.md
@@ -10,8 +10,6 @@
 
 ### Other Changes
 
-- Added support for the `PipelineRequest` and `PipelineOptions` property `allowInsecureConnection` in the `bearerTokenAuthenticationPolicy`. If the `bearerTokenAuthenticationPolicy` encounters requests with the `allowInsecureConnection` property set to true, this policy will be allowed to authenticate against insecure authority hosts using the `http` endpoint. [PR #17517](https://github.com/Azure/azure-sdk-for-js/pull/17517)
-
 ## 1.3.0 (2021-09-02)
 
 ### Bugs Fixed

--- a/sdk/core/core-rest-pipeline/src/policies/bearerTokenAuthenticationPolicy.ts
+++ b/sdk/core/core-rest-pipeline/src/policies/bearerTokenAuthenticationPolicy.ts
@@ -155,7 +155,7 @@ export function bearerTokenAuthenticationPolicy(
      * - Retrieve a token with the challenge information, then re-send the request.
      */
     async sendRequest(request: PipelineRequest, next: SendRequest): Promise<PipelineResponse> {
-      if (!request.allowInsecureConnection && !request.url.toLowerCase().startsWith("https://")) {
+      if (!request.url.toLowerCase().startsWith("https://")) {
         throw new Error(
           "Bearer token authentication is not permitted for non-TLS protected (non-https) URLs."
         );

--- a/sdk/core/core-rest-pipeline/test/bearerTokenAuthenticationPolicy.spec.ts
+++ b/sdk/core/core-rest-pipeline/test/bearerTokenAuthenticationPolicy.spec.ts
@@ -58,41 +58,6 @@ describe("BearerTokenAuthenticationPolicy", function() {
     assert.strictEqual(request.headers.get("Authorization"), `Bearer ${mockToken}`);
   });
 
-  it("correctly adds an Authentication header with the Bearer token when using allowInsecureConnection", async function() {
-    const mockToken = "token";
-    const tokenScopes = ["scope1", "scope2"];
-    const fakeGetToken = sinon.fake.returns(
-      Promise.resolve({ token: mockToken, expiresOn: new Date() })
-    );
-    const mockCredential: TokenCredential = {
-      getToken: fakeGetToken
-    };
-
-    const request = createPipelineRequest({
-      url: "http://example.com",
-      allowInsecureConnection: true
-    });
-    const successResponse: PipelineResponse = {
-      headers: createHttpHeaders(),
-      request,
-      status: 200
-    };
-    const next = sinon.stub<Parameters<SendRequest>, ReturnType<SendRequest>>();
-    next.resolves(successResponse);
-
-    const bearerTokenAuthPolicy = createBearerTokenPolicy(tokenScopes, mockCredential);
-    await bearerTokenAuthPolicy.sendRequest(request, next);
-
-    assert(
-      fakeGetToken.calledWith(tokenScopes, {
-        abortSignal: undefined,
-        tracingOptions: undefined
-      }),
-      "fakeGetToken called incorrectly."
-    );
-    assert.strictEqual(request.headers.get("Authorization"), `Bearer ${mockToken}`);
-  });
-
   it("refreshes the token on initial request", async () => {
     const expiresOn = Date.now() + 1000 * 60; // One minute later.
     const credential = new MockRefreshAzureCredential(expiresOn);


### PR DESCRIPTION
Re-enable HTTPS enforcement in bearerTokenPolicy