### PR TITLE
[Identity] Removing null from the AzurePowerShellCredential getToken

### DIFF
--- a/sdk/identity/identity/review/identity.api.md
+++ b/sdk/identity/identity/review/identity.api.md
@@ -88,7 +88,7 @@ export interface AzureCliCredentialOptions extends TokenCredentialOptions {
 // @public
 export class AzurePowerShellCredential implements TokenCredential {
     constructor(options?: AzurePowerShellCredentialOptions);
-    getToken(scopes: string | string[], options?: GetTokenOptions): Promise<AccessToken | null>;
+    getToken(scopes: string | string[], options?: GetTokenOptions): Promise<AccessToken>;
     }
 
 // @public

--- a/sdk/identity/identity/src/credentials/azurePowerShellCredential.ts
+++ b/sdk/identity/identity/src/credentials/azurePowerShellCredential.ts
@@ -165,7 +165,7 @@ export class AzurePowerShellCredential implements TokenCredential {
   public async getToken(
     scopes: string | string[],
     options: GetTokenOptions = {}
-  ): Promise<AccessToken | null> {
+  ): Promise<AccessToken> {
     return trace(`${this.constructor.name}.getToken`, options, async () => {
       const tenantId = processMultiTenantRequest(
         this.tenantId,


### PR DESCRIPTION
This | null isn’t needed :)