### PR TITLE
[Text Analytics] Add tests for Custom Text

### DIFF
--- a/sdk/textanalytics/ai-text-analytics/review/ai-text-analytics.api.md
+++ b/sdk/textanalytics/ai-text-analytics/review/ai-text-analytics.api.md
@@ -35,9 +35,9 @@ export type AnalyzeActionsPollerLike = PollerLike<AnalyzeActionsOperationState, 
 // @public
 export interface AnalyzeActionsResult {
     analyzeSentimentResults: AnalyzeSentimentActionResult[];
-    customClassifyDocumentMultiCategories?: CustomClassifyDocumentMultiCategoriesActionResult[];
-    customClassifyDocumentSingleCategory?: CustomClassifyDocumentSingleCategoryActionResult[];
-    customRecognizeEntities?: CustomRecognizeEntitiesActionResult[];
+    customClassifyDocumentMultiCategoriesResults: CustomClassifyDocumentMultiCategoriesActionResult[];
+    customClassifyDocumentSingleCategoryResults: CustomClassifyDocumentSingleCategoryActionResult[];
+    customRecognizeEntitiesResults: CustomRecognizeEntitiesActionResult[];
     extractKeyPhrasesResults: ExtractKeyPhrasesActionResult[];
     extractSummaryResults: ExtractSummaryActionResult[];
     recognizeEntitiesResults: RecognizeCategorizedEntitiesActionResult[];
@@ -789,9 +789,9 @@ export interface TextAnalyticsActionErrorResult {
 // @public
 export interface TextAnalyticsActions {
     analyzeSentimentActions?: AnalyzeSentimentAction[];
-    customClassifyDocumentMultiCategories?: CustomClassifyDocumentMultiCategoriesAction[];
-    customClassifyDocumentSingleCategory?: CustomClassifyDocumentSingleCategoryAction[];
-    customRecognizeEntities?: CustomRecognizeEntitiesAction[];
+    customClassifyDocumentMultiCategoriesActions?: CustomClassifyDocumentMultiCategoriesAction[];
+    customClassifyDocumentSingleCategoryActions?: CustomClassifyDocumentSingleCategoryAction[];
+    customRecognizeEntitiesActions?: CustomRecognizeEntitiesAction[];
     extractKeyPhrasesActions?: ExtractKeyPhrasesAction[];
     extractSummaryActions?: ExtractSummaryAction[];
     recognizeEntitiesActions?: RecognizeCategorizedEntitiesAction[];
@@ -898,7 +898,6 @@ export type TokenSentimentValue = "positive" | "mixed" | "negative";
 
 // @public
 export type WarningCode = string;
-
 
 // (No @packageDocumentation comment for this package)
 

--- a/sdk/textanalytics/ai-text-analytics/src/analyzeActionsResult.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/analyzeActionsResult.ts
@@ -72,15 +72,15 @@ export interface AnalyzeActionsResult {
   /**
    * Array of the results for each recognize custom entities action.
    */
-  customRecognizeEntities?: CustomRecognizeEntitiesActionResult[];
+  customRecognizeEntitiesResults: CustomRecognizeEntitiesActionResult[];
   /**
    * Array of the results for each custom classify document single category action.
    */
-  customClassifyDocumentSingleCategory?: CustomClassifyDocumentSingleCategoryActionResult[];
+  customClassifyDocumentSingleCategoryResults: CustomClassifyDocumentSingleCategoryActionResult[];
   /**
    * Array of the results for each custom classify document multi categories action.
    */
-  customClassifyDocumentMultiCategories?: CustomClassifyDocumentMultiCategoriesActionResult[];
+  customClassifyDocumentMultiCategoriesResults: CustomClassifyDocumentMultiCategoriesActionResult[];
 }
 
 /**
@@ -637,19 +637,19 @@ export function createAnalyzeActionsResult(
       response.tasks.extractiveSummarizationTasks ?? [],
       extractSummarySentencesActionErrors
     ),
-    customRecognizeEntities: makeActionResult(
+    customRecognizeEntitiesResults: makeActionResult(
       documents,
       makeCustomRecognizeEntitiesResultArray,
       response.tasks.customEntityRecognitionTasks ?? [],
       customRecognizeEntitiesActionErrors
     ),
-    customClassifyDocumentSingleCategory: makeActionResult(
+    customClassifyDocumentSingleCategoryResults: makeActionResult(
       documents,
       makeCustomClassifyDocumentSingleCategoryResultArray,
-      response.tasks.customSingleClassificationTasks ?? [],
+      response.tasks.customClassificationTasks ?? [],
       customClassifyDocumentSingleCategoryActionErrors
     ),
-    customClassifyDocumentMultiCategories: makeActionResult(
+    customClassifyDocumentMultiCategoriesResults: makeActionResult(
       documents,
       makeCustomClassifyDocumentMultiCategoriesResultArray,
       response.tasks.customMultiClassificationTasks ?? [],

--- a/sdk/textanalytics/ai-text-analytics/src/analyzeActionsResult.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/analyzeActionsResult.ts
@@ -646,7 +646,7 @@ export function createAnalyzeActionsResult(
     customClassifyDocumentSingleCategoryResults: makeActionResult(
       documents,
       makeCustomClassifyDocumentSingleCategoryResultArray,
-      response.tasks.customClassificationTasks ?? [],
+      response.tasks.customSingleClassificationTasks ?? [],
       customClassifyDocumentSingleCategoryActionErrors
     ),
     customClassifyDocumentMultiCategoriesResults: makeActionResult(

--- a/sdk/textanalytics/ai-text-analytics/src/generated/models/index.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/generated/models/index.ts
@@ -207,7 +207,7 @@ export interface TasksStateTasks {
   sentimentAnalysisTasks?: TasksStateTasksSentimentAnalysisTasksItem[];
   extractiveSummarizationTasks?: TasksStateTasksExtractiveSummarizationTasksItem[];
   customEntityRecognitionTasks?: TasksStateTasksCustomEntityRecognitionTasksItem[];
-  customSingleClassificationTasks?: TasksStateTasksCustomSingleClassificationTasksItem[];
+  customClassificationTasks?: TasksStateTasksCustomClassificationTasksItem[];
   customMultiClassificationTasks?: TasksStateTasksCustomMultiClassificationTasksItem[];
 }
 
@@ -790,7 +790,7 @@ export type TasksStateTasksExtractiveSummarizationTasksItem = TaskState &
 export type TasksStateTasksCustomEntityRecognitionTasksItem = TaskState &
   CustomEntitiesTaskResult & {};
 
-export type TasksStateTasksCustomSingleClassificationTasksItem = TaskState &
+export type TasksStateTasksCustomClassificationTasksItem = TaskState &
   CustomSingleClassificationTaskResult & {};
 
 export type TasksStateTasksCustomMultiClassificationTasksItem = TaskState &

--- a/sdk/textanalytics/ai-text-analytics/src/generated/models/index.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/generated/models/index.ts
@@ -207,7 +207,7 @@ export interface TasksStateTasks {
   sentimentAnalysisTasks?: TasksStateTasksSentimentAnalysisTasksItem[];
   extractiveSummarizationTasks?: TasksStateTasksExtractiveSummarizationTasksItem[];
   customEntityRecognitionTasks?: TasksStateTasksCustomEntityRecognitionTasksItem[];
-  customClassificationTasks?: TasksStateTasksCustomClassificationTasksItem[];
+  customSingleClassificationTasks?: TasksStateTasksCustomSingleClassificationTasksItem[];
   customMultiClassificationTasks?: TasksStateTasksCustomMultiClassificationTasksItem[];
 }
 
@@ -790,7 +790,7 @@ export type TasksStateTasksExtractiveSummarizationTasksItem = TaskState &
 export type TasksStateTasksCustomEntityRecognitionTasksItem = TaskState &
   CustomEntitiesTaskResult & {};
 
-export type TasksStateTasksCustomClassificationTasksItem = TaskState &
+export type TasksStateTasksCustomSingleClassificationTasksItem = TaskState &
   CustomSingleClassificationTaskResult & {};
 
 export type TasksStateTasksCustomMultiClassificationTasksItem = TaskState &

--- a/sdk/textanalytics/ai-text-analytics/src/generated/models/mappers.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/generated/models/mappers.ts
@@ -980,14 +980,14 @@ export const TasksStateTasks: coreClient.CompositeMapper = {
           }
         }
       },
-      customClassificationTasks: {
-        serializedName: "customClassificationTasks",
+      customSingleClassificationTasks: {
+        serializedName: "customSingleClassificationTasks",
         type: {
           name: "Sequence",
           element: {
             type: {
               name: "Composite",
-              className: "TasksStateTasksCustomClassificationTasksItem"
+              className: "TasksStateTasksCustomSingleClassificationTasksItem"
             }
           }
         }
@@ -3299,10 +3299,10 @@ export const TasksStateTasksCustomEntityRecognitionTasksItem: coreClient.Composi
   }
 };
 
-export const TasksStateTasksCustomClassificationTasksItem: coreClient.CompositeMapper = {
+export const TasksStateTasksCustomSingleClassificationTasksItem: coreClient.CompositeMapper = {
   type: {
     name: "Composite",
-    className: "TasksStateTasksCustomClassificationTasksItem",
+    className: "TasksStateTasksCustomSingleClassificationTasksItem",
     modelProperties: {
       ...TaskState.type.modelProperties,
       ...CustomSingleClassificationTaskResult.type.modelProperties

--- a/sdk/textanalytics/ai-text-analytics/src/generated/models/mappers.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/generated/models/mappers.ts
@@ -551,14 +551,14 @@ export const CustomEntitiesTaskParameters: coreClient.CompositeMapper = {
     className: "CustomEntitiesTaskParameters",
     modelProperties: {
       projectName: {
-        serializedName: "projectName",
+        serializedName: "project-name",
         required: true,
         type: {
           name: "String"
         }
       },
       deploymentName: {
-        serializedName: "deploymentName",
+        serializedName: "deployment-name",
         required: true,
         type: {
           name: "String"
@@ -603,14 +603,14 @@ export const CustomSingleClassificationTaskParameters: coreClient.CompositeMappe
     className: "CustomSingleClassificationTaskParameters",
     modelProperties: {
       projectName: {
-        serializedName: "projectName",
+        serializedName: "project-name",
         required: true,
         type: {
           name: "String"
         }
       },
       deploymentName: {
-        serializedName: "deploymentName",
+        serializedName: "deployment-name",
         required: true,
         type: {
           name: "String"
@@ -649,14 +649,14 @@ export const CustomMultiClassificationTaskParameters: coreClient.CompositeMapper
     className: "CustomMultiClassificationTaskParameters",
     modelProperties: {
       projectName: {
-        serializedName: "projectName",
+        serializedName: "project-name",
         required: true,
         type: {
           name: "String"
         }
       },
       deploymentName: {
-        serializedName: "deploymentName",
+        serializedName: "deployment-name",
         required: true,
         type: {
           name: "String"
@@ -980,14 +980,14 @@ export const TasksStateTasks: coreClient.CompositeMapper = {
           }
         }
       },
-      customSingleClassificationTasks: {
-        serializedName: "customSingleClassificationTasks",
+      customClassificationTasks: {
+        serializedName: "customClassificationTasks",
         type: {
           name: "Sequence",
           element: {
             type: {
               name: "Composite",
-              className: "TasksStateTasksCustomSingleClassificationTasksItem"
+              className: "TasksStateTasksCustomClassificationTasksItem"
             }
           }
         }
@@ -3299,10 +3299,10 @@ export const TasksStateTasksCustomEntityRecognitionTasksItem: coreClient.Composi
   }
 };
 
-export const TasksStateTasksCustomSingleClassificationTasksItem: coreClient.CompositeMapper = {
+export const TasksStateTasksCustomClassificationTasksItem: coreClient.CompositeMapper = {
   type: {
     name: "Composite",
-    className: "TasksStateTasksCustomSingleClassificationTasksItem",
+    className: "TasksStateTasksCustomClassificationTasksItem",
     modelProperties: {
       ...TaskState.type.modelProperties,
       ...CustomSingleClassificationTaskResult.type.modelProperties

--- a/sdk/textanalytics/ai-text-analytics/src/textAnalyticsClient.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/textAnalyticsClient.ts
@@ -410,15 +410,15 @@ export interface TextAnalyticsActions {
   /**
    * A collection of descriptions of custom entity recognition actions. However, currently, the service can accept up to one action only for `customRecognizeEntities`.
    */
-  customRecognizeEntities?: CustomRecognizeEntitiesAction[];
+  customRecognizeEntitiesActions?: CustomRecognizeEntitiesAction[];
   /**
    * A collection of descriptions of custom single classification actions. However, currently, the service can accept up to one action only for `customClassifyDocumentSingleCategory`.
    */
-  customClassifyDocumentSingleCategory?: CustomClassifyDocumentSingleCategoryAction[];
+  customClassifyDocumentSingleCategoryActions?: CustomClassifyDocumentSingleCategoryAction[];
   /**
    * A collection of descriptions of custom multi classification actions. However, currently, the service can accept up to one action only for `customClassifyDocumentMultiCategories`.
    */
-  customClassifyDocumentMultiCategories?: CustomClassifyDocumentMultiCategoriesAction[];
+  customClassifyDocumentMultiCategoriesActions?: CustomClassifyDocumentMultiCategoriesAction[];
 }
 /**
  * Client class for interacting with Azure Text Analytics.
@@ -1204,13 +1204,13 @@ function compileAnalyzeInput(actions: TextAnalyticsActions): GeneratedActions {
     extractiveSummarizationTasks: actions.extractSummaryActions?.map(
       compose(setStrEncodingParam, compose(setSentenceCount, compose(setOrderBy, addParamsToTask)))
     ),
-    customEntityRecognitionTasks: actions.customRecognizeEntities?.map(
+    customEntityRecognitionTasks: actions.customRecognizeEntitiesActions?.map(
       compose(setStrEncodingParam, addParamsToTask)
     ),
-    customSingleClassificationTasks: actions.customClassifyDocumentSingleCategory?.map(
+    customSingleClassificationTasks: actions.customClassifyDocumentSingleCategoryActions?.map(
       addParamsToTask
     ),
-    customMultiClassificationTasks: actions.customClassifyDocumentMultiCategories?.map(
+    customMultiClassificationTasks: actions.customClassifyDocumentMultiCategoriesActions?.map(
       addParamsToTask
     )
   };

--- a/sdk/textanalytics/ai-text-analytics/swagger/README.md
+++ b/sdk/textanalytics/ai-text-analytics/swagger/README.md
@@ -12,7 +12,8 @@ generate-metadata: false
 license-header: MICROSOFT_MIT_NO_VERSION
 output-folder: ../
 source-code-folder-path: ./src/generated
-input-file: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/5efb2eca2fc3d94f27015f5d3176786c7497f946/specification/cognitiveservices/data-plane/TextAnalytics/preview/v3.2-preview.2/TextAnalytics.json
+# input-file: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/5efb2eca2fc3d94f27015f5d3176786c7497f946/specification/cognitiveservices/data-plane/TextAnalytics/preview/v3.2-preview.2/TextAnalytics.json
+input-file: https://raw.githubusercontent.com/deyaaeldeen/azure-rest-api-specs/textanalytics/v3.2-preview.2-patched/specification/cognitiveservices/data-plane/TextAnalytics/preview/v3.2-preview.2/TextAnalytics.json
 add-credentials: false
 package-version: 5.2.0-beta.2
 v3: true

--- a/sdk/textanalytics/ai-text-analytics/test/public/textAnalyticsClient.spec.ts
+++ b/sdk/textanalytics/ai-text-analytics/test/public/textAnalyticsClient.spec.ts
@@ -962,12 +962,11 @@ matrix([["APIKey", "AAD"]] as const, async (authMethod: AuthMethod) => {
                     assert.ok(result.id);
                     assert.ok(result.entities);
                     for (const entity of result.entities) {
-                      assert.ok(entity.category);
-                      assert.ok(entity.confidenceScore);
-                      assert.ok(entity.length);
-                      assert.ok(entity.offset);
-                      assert.ok(entity.subCategory);
-                      assert.ok(entity.text);
+                      assert.ok(entity.category, "entity category not found");
+                      assert.ok(entity.confidenceScore, "confidence score not found");
+                      assert.ok(entity.length, "length not found");
+                      assert.ok(entity.offset, "offset not found");
+                      assert.ok(entity.text, "text not found");
                     }
                   } else {
                     assert.fail("did not expect document errors but got one.");

--- a/sdk/textanalytics/ai-text-analytics/test/public/textAnalyticsClient.spec.ts
+++ b/sdk/textanalytics/ai-text-analytics/test/public/textAnalyticsClient.spec.ts
@@ -927,6 +927,165 @@ matrix([["APIKey", "AAD"]] as const, async (authMethod: AuthMethod) => {
       });
 
       describe("#analyze", function() {
+        it.only("single custom entity recognition action", async function() {
+          const docs = [
+            {
+              id: "1",
+              language: "en",
+              text:
+                "A recent report by the Government Accountability Office (GAO) found that the dramatic increase in oil and natural gas development on federal lands over the past six years has stretched the staff of the BLM to a point that it has been unable to meet its environmental protection responsibilities."
+            }
+          ];
+
+          const poller = await client.beginAnalyzeActions(
+            docs,
+            {
+              customRecognizeEntitiesActions: [
+                {
+                  projectName: "88ee0f78-fbca-444d-98e2-7c4c8631e494",
+                  deploymentName: "88ee0f78-fbca-444d-98e2-7c4c8631e494"
+                }
+              ]
+            },
+            {
+              updateIntervalInMs: pollingInterval
+            }
+          );
+          const results = await poller.pollUntilDone();
+          for await (const page of results) {
+            const entitiesResult = page.customRecognizeEntitiesResults;
+            if (entitiesResult.length === 1) {
+              const action = entitiesResult[0];
+              if (!action.error) {
+                for (const result of action.results) {
+                  if (!result.error) {
+                    assert.ok(result.id);
+                    assert.ok(result.entities);
+                    for (const entity of result.entities) {
+                      assert.ok(entity.category);
+                      assert.ok(entity.confidenceScore);
+                      assert.ok(entity.length);
+                      assert.ok(entity.offset);
+                      assert.ok(entity.subCategory);
+                      assert.ok(entity.text);
+                    }
+                  } else {
+                    assert.fail("did not expect document errors but got one.");
+                  }
+                }
+              }
+            } else {
+              assert.fail("expected an array of entities results but did not get one.");
+            }
+          }
+        });
+
+        it.only("single custom document single category classification action", async function() {
+          const docs = [
+            {
+              id: "1",
+              language: "en",
+              text:
+                "A recent report by the Government Accountability Office (GAO) found that the dramatic increase in oil and natural gas development on federal lands over the past six years has stretched the staff of the BLM to a point that it has been unable to meet its environmental protection responsibilities."
+            }
+          ];
+
+          const poller = await client.beginAnalyzeActions(
+            docs,
+            {
+              customClassifyDocumentSingleCategoryActions: [
+                {
+                  projectName: "659c1851-be0b-4142-b12a-087da9785926",
+                  deploymentName: "659c1851-be0b-4142-b12a-087da9785926"
+                }
+              ]
+            },
+            {
+              updateIntervalInMs: pollingInterval
+            }
+          );
+          const results = await poller.pollUntilDone();
+          for await (const page of results) {
+            const classificationResult = page.customClassifyDocumentSingleCategoryResults;
+            if (classificationResult.length === 1) {
+              const action = classificationResult[0];
+              if (!action.error) {
+                for (const result of action.results) {
+                  if (!result.error) {
+                    assert.ok(result.id);
+                    assert.ok(result.classification);
+                    assert.ok(result.classification.category);
+                    assert.ok(result.classification.confidenceScore);
+                  } else {
+                    assert.fail("did not expect document errors but got one.");
+                  }
+                }
+              }
+            } else {
+              assert.fail(
+                `expected an array of single category classification results but got: ${JSON.stringify(
+                  classificationResult
+                )}`
+              );
+            }
+          }
+        });
+
+        it.only("single custom document multiple category classification action", async function() {
+          const docs = [
+            {
+              id: "1",
+              language: "en",
+              text:
+                "A recent report by the Government Accountability Office (GAO) found that the dramatic increase in oil and natural gas development on federal lands over the past six years has stretched the staff of the BLM to a point that it has been unable to meet its environmental protection responsibilities."
+            }
+          ];
+
+          const poller = await client.beginAnalyzeActions(
+            docs,
+            {
+              customClassifyDocumentMultiCategoriesActions: [
+                {
+                  projectName: "7cdace98-537b-494a-b69a-c19754718025",
+                  deploymentName: "7cdace98-537b-494a-b69a-c19754718025"
+                }
+              ]
+            },
+            {
+              updateIntervalInMs: pollingInterval
+            }
+          );
+          const results = await poller.pollUntilDone();
+          for await (const page of results) {
+            const classificationResult = page.customClassifyDocumentMultiCategoriesResults;
+            if (classificationResult.length === 1) {
+              const action = classificationResult[0];
+              if (!action.error) {
+                for (const result of action.results) {
+                  if (!result.error) {
+                    assert.ok(result.id);
+                    assert.ok(result.classifications);
+                    for (const classification of result.classifications) {
+                      assert.ok(classification.category);
+                      assert.ok(classification.confidenceScore);
+                    }
+                  } else {
+                    assert.fail(
+                      `did not expect document errors but got: ${JSON.stringify(
+                        classificationResult
+                      )}`
+                    );
+                  }
+                }
+              }
+            } else {
+              assert.fail(
+                "expected an array of multi category classification results but did not get one."
+              );
+            }
+          }
+        });
+
         it("single extract summary action", async function() {
           // Source: https://news.microsoft.com/innovation-stories/cloud-pc-windows-365/
           const windows365ArticlePart1 = `

--- a/sdk/textanalytics/ai-text-analytics/test/public/textAnalyticsClient.spec.ts
+++ b/sdk/textanalytics/ai-text-analytics/test/public/textAnalyticsClient.spec.ts
@@ -927,7 +927,7 @@ matrix([["APIKey", "AAD"]] as const, async (authMethod: AuthMethod) => {
       });
 
       describe("#analyze", function() {
-        it.only("single custom entity recognition action", async function() {
+        it("single custom entity recognition action", async function() {
           const docs = [
             {
               id: "1",
@@ -979,7 +979,7 @@ matrix([["APIKey", "AAD"]] as const, async (authMethod: AuthMethod) => {
           }
         });
 
-        it.only("single custom document single category classification action", async function() {
+        it("single custom document single category classification action", async function() {
           const docs = [
             {
               id: "1",
@@ -1030,7 +1030,7 @@ matrix([["APIKey", "AAD"]] as const, async (authMethod: AuthMethod) => {
           }
         });
 
-        it.only("single custom document multiple category classification action", async function() {
+        it("single custom document multiple category classification action", async function() {
           const docs = [
             {
               id: "1",


### PR DESCRIPTION
I edited the swagger to match most of the runtime responses we get now to get going with testing in [here](https://github.com/deyaaeldeen/azure-rest-api-specs/blob/textanalytics/v3.2-preview.2-patched/specification/cognitiveservices/data-plane/TextAnalytics/preview/v3.2-preview.2/TextAnalytics.json). 

## Changes

- rename `projectName` to `project-name` in inputs
- rename `deploymentName` to `deployment-name` in inputs
- ~rename the input property `customSingleClassificationTasks` to `customClassificationTasks`~

~However for custom entities, there is a significant change and I did not attempt to resolve this yet in the swagger. For some reason, the service groups entities in the `matches` property by their category but it should flatten that into a list of entities instead.~