### PR TITLE
[KeyVault] - Retry flaky test

### DIFF
--- a/sdk/keyvault/keyvault-certificates/recordings/browsers/certificates_client__create_read_update_and_delete/recording_can_read_cancel_and_delete_a_certificates_operation.json
+++ b/sdk/keyvault/keyvault-certificates/recordings/browsers/certificates_client__create_read_update_and_delete/recording_can_read_cancel_and_delete_a_certificates_operation.json
@@ -2,28 +2,28 @@
  "recordings": [
   {
    "method": "POST",
-   "url": "https://keyvault_name.vault.azure.net/certificates/CRUDCertificateName-canreadcancelanddeleteacertificatesoperation-/create",
+   "url": "https://keyvault_name.vault.azure.net/certificates/crudcertoperation163217583204004746/create",
    "query": {
     "api-version": "7.2"
    },
    "requestBody": "",
    "status": 401,
-   "response": "{\"error\":{\"code\":\"Unauthorized\",\"message\":\"Request is missing a Bearer or PoP token.\"}}",
+   "response": "{\"error\":{\"code\":\"Unauthorized\",\"message\":\"AKV10000: Request is missing a Bearer or PoP token.\"}}",
    "responseHeaders": {
     "cache-control": "no-cache",
-    "content-length": "87",
+    "content-length": "97",
     "content-type": "application/json; charset=utf-8",
-    "date": "Tue, 16 Feb 2021 19:19:11 GMT",
+    "date": "Mon, 20 Sep 2021 22:10:31 GMT",
     "expires": "-1",
     "pragma": "no-cache",
-    "status": "401",
     "strict-transport-security": "max-age=31536000;includeSubDomains",
     "www-authenticate": "Bearer authorization=\"https://login.windows.net/12345678-1234-1234-1234-123456789012\", resource=\"https://vault.azure.net\"",
     "x-content-type-options": "nosniff",
+    "x-ms-client-request-id": "4933a8ba-f13d-49d1-88f7-be1ccd6bf36c",
     "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;",
     "x-ms-keyvault-region": "westus2",
-    "x-ms-keyvault-service-version": "1.2.164.2",
-    "x-ms-request-id": "d361dde1-822d-4d37-bf04-b3cc1eb99462",
+    "x-ms-keyvault-service-version": "1.9.79.2",
+    "x-ms-request-id": "dd63394a-c388-4521-b3e6-0ff883f030c6",
     "x-powered-by": "ASP.NET"
    }
   },
@@ -31,446 +31,244 @@
    "method": "POST",
    "url": "https://login.microsoftonline.com/12345678-1234-1234-1234-123456789012/oauth2/v2.0/token",
    "query": {},
-   "requestBody": "response_type=token&grant_type=client_credentials&client_id=azure_client_id&client_secret=azure_client_secret&scope=https%3A%2F%2Fvault.azure.net%2F.default",
+   "requestBody": "response_type=token&grant_type=client_credentials&client_id=azure_client_id&client_secret=azure_client_secret&scope=https%3A%2F%2Fsanitized%2F",
    "status": 200,
    "response": "{\"token_type\":\"Bearer\",\"expires_in\":86399,\"ext_expires_in\":86399,\"access_token\":\"access_token\"}",
    "responseHeaders": {
     "cache-control": "no-store, no-cache",
     "content-length": "1315",
     "content-type": "application/json; charset=utf-8",
-    "date": "Tue, 16 Feb 2021 19:19:10 GMT",
+    "date": "Mon, 20 Sep 2021 22:10:32 GMT",
     "expires": "-1",
+    "nel": "{\"report_to\":\"network-errors\",\"max_age\":86400,\"success_fraction\":0.001,\"failure_fraction\":1.0}",
     "p3p": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\"",
     "pragma": "no-cache",
     "referrer-policy": "strict-origin-when-cross-origin",
+    "report-to": "{\"group\":\"network-errors\",\"max_age\":86400,\"endpoints\":[{\"url\":\"https://identity.nel.measure.office.net/api/report?catId=GW+estsfd+wst\"}]}",
     "strict-transport-security": "max-age=31536000; includeSubDomains",
     "x-content-type-options": "nosniff",
-    "x-ms-ests-server": "2.1.11496.6 - WUS2 ProdSlices",
-    "x-ms-request-id": "83d649a2-1493-4ffd-9026-5cd730f63200"
+    "x-ms-ests-server": "2.1.12071.7 - SCUS ProdSlices",
+    "x-ms-request-id": "8024f362-7408-46c7-a6c9-36cd254eab00"
    }
   },
   {
    "method": "POST",
-   "url": "https://keyvault_name.vault.azure.net/certificates/CRUDCertificateName-canreadcancelanddeleteacertificatesoperation-/create",
+   "url": "https://keyvault_name.vault.azure.net/certificates/crudcertoperation163217583204004746/create",
    "query": {
     "api-version": "7.2"
    },
    "requestBody": "{\"policy\":{\"key_props\":{},\"secret_props\":{},\"x509_props\":{\"subject\":\"cn=MyCert\",\"sans\":{}},\"issuer\":{\"name\":\"Self\"},\"attributes\":{}},\"attributes\":{}}",
    "status": 202,
-   "response": "{\"id\":\"https://keyvault_name.vault.azure.net/certificates/CRUDCertificateName-canreadcancelanddeleteacertificatesoperation-/pending\",\"issuer\":{\"name\":\"Self\"},\"csr\":\"MIICoTCCAYkCAQAwETEPMA0GA1UEAxMGTXlDZXJ0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAp1JGLEmT0SxTGNdQaVPo23Atw0nwvvlK0aSp9Ym15BEAG7RPg4k9UTXOQIFuO/0Vs/RJ1Kjok96j/r4IYX1E69j3ipYgIXScy50P6Fe/TpmRDmXKxr5eXy0nqaM31zh7vqS8F1lQoK/bubbMw5z3H2/nI5gxUqXs5P+hlaL7raFZH7Hg3mNjd5wnMzYXavNiGyAnwndsxplQ+plnzIGrd5Q1Gj9MYyskov1FCqNyQAtO7CSv8Q6jXXeUoRKPK3KCLb+4fGx40OJJd98VtoajMO7yDjfVSOKXmNzZPZIa5yUCwnN4IeZJ+hmQXR8vx+x/95XrQRBUuHW2973fKh+s1QIDAQABoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwDQYJKoZIhvcNAQELBQADggEBAHH6ao6CBAH7a3XKp+xCouIdlMN8lVmLMwU4f+a/BEJA66dZxksBGcnOeZvRVIKjQ43vrp6mEdf6/XqTtWtda9xonZRBvev33buFhptA9I1o/fbvYCNrHNZeF9e6lJ6ixbZl+LP2F/EHiCw9bs+L4uI2wFCERJAcRAZtstWVzALIZhlIFclYdsLagEx66s4+t/5ULAD4bCz3Cdxdew3K0HkP3+5lbHHQOzJiZN3y+aJLbyKJnpl1dREAGycwFuJnNaReHFBzbVv5nj10vWwtnu+6uok9Q4Z0nJ6yT2cBLkso/8At5vS6dfqvSIuQ1nADsRpnaBfRPl1uhchN58Eox00=\",\"cancellation_requested\":false,\"status\":\"inProgress\",\"status_details\":\"Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.\",\"request_id\":\"1694491266ea41c59778a75ccaa29c7d\"}",
+   "response": "{\"id\":\"https://keyvault_name.vault.azure.net/certificates/crudcertoperation163217583204004746/pending\",\"issuer\":{\"name\":\"Self\"},\"csr\":\"MIICoTCCAYkCAQAwETEPMA0GA1UEAxMGTXlDZXJ0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAwPfojcWz97x2fVGJ3Xa74D2mv8aaos9ZDIKFahkG2bNmDFJMCXcqn7cjo2RTCOWut73mQU+qqPI82NwtL27VsXMqHUi4isM19wygKcC++OgWrPzWOv2FRfj0kiHUQKasbjRKD3yLLkzcSROPk/BtHUiAlwT5uhzPp8Qpo7O8m/HPzbYIZE9HQzRtTt37hf3LnMTkYdWVcjyCxyN2cBU95IMOkAvlZJPyWITw4AmLYUJYZ+NC/ftyX1pnbBha5+qS9j4kN7bvx2CNfP2cG3LpFUDzRzS3DSPfL6RZlIWvIwX+OmGE9L6W+NYzN7O8H1XFKNM22CcYAwLSYpatFat1xQIDAQABoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwDQYJKoZIhvcNAQELBQADggEBABtx9JVqfAxOSNhU5ir7DdGa8o9m/GGoZG84HPMvqb7A/M2SLopgtbdaRSr7ylD1+QcZWBUoVgl8QrotrBvyPVD4HVUWZtx0l7e/LYf/QoIMTMV4wmbqK7Q9fgYadjMHDu93bGLkBq0EWyVR3xghL2EYd2NANVKhBOVnIAm4alSRIeeIzqsrm+5Us1Z5DxWOQPtLvxVmhY0uB/fkSf4k3tL/j7Wc/yxl+6ZC1HpHSBERr0sunXkzctsBYm2k5Ep/OMkUmRFY5TaSKkyPB4E6wmYF20R3jJIM+jVD4AT/Ph8o0FTLX9Gv6uKTxjbyB1mo5ECW647EDGL8rCSMwwEgBMk=\",\"cancellation_requested\":false,\"status\":\"inProgress\",\"status_details\":\"Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.\",\"request_id\":\"ae726655ba7f46a180785d54d93f6bc6\"}",
    "responseHeaders": {
     "cache-control": "no-cache",
-    "content-length": "1348",
+    "content-length": "1302",
     "content-type": "application/json; charset=utf-8",
-    "date": "Tue, 16 Feb 2021 19:19:11 GMT",
+    "date": "Mon, 20 Sep 2021 22:10:32 GMT",
     "expires": "-1",
-    "location": "https://keyvault_name.vault.azure.net/certificates/CRUDCertificateName-canreadcancelanddeleteacertificatesoperation-/pending?api-version=7.2&request_id=1694491266ea41c59778a75ccaa29c7d",
+    "location": "https://keyvault_name.vault.azure.net/certificates/crudcertoperation163217583204004746/pending?api-version=7.2&request_id=ae726655ba7f46a180785d54d93f6bc6",
     "pragma": "no-cache",
     "retry-after": "10",
-    "status": "202",
     "strict-transport-security": "max-age=31536000;includeSubDomains",
     "x-content-type-options": "nosniff",
+    "x-ms-client-request-id": "4933a8ba-f13d-49d1-88f7-be1ccd6bf36c",
     "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;",
     "x-ms-keyvault-region": "westus2",
-    "x-ms-keyvault-service-version": "1.2.164.2",
-    "x-ms-request-id": "2de51202-7a11-4e0a-90d8-9dc0c0055328",
+    "x-ms-keyvault-service-version": "1.9.79.2",
+    "x-ms-request-id": "108a2b6d-e4e1-4fdf-8b05-10afa0e115f5",
     "x-powered-by": "ASP.NET"
    }
   },
   {
    "method": "GET",
-   "url": "https://keyvault_name.vault.azure.net/certificates/CRUDCertificateName-canreadcancelanddeleteacertificatesoperation-/pending",
+   "url": "https://keyvault_name.vault.azure.net/certificates/crudcertoperation163217583204004746/pending",
    "query": {
     "api-version": "7.2"
    },
    "requestBody": null,
    "status": 200,
-   "response": "{\"id\":\"https://keyvault_name.vault.azure.net/certificates/CRUDCertificateName-canreadcancelanddeleteacertificatesoperation-/pending\",\"issuer\":{\"name\":\"Self\"},\"csr\":\"MIICoTCCAYkCAQAwETEPMA0GA1UEAxMGTXlDZXJ0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAp1JGLEmT0SxTGNdQaVPo23Atw0nwvvlK0aSp9Ym15BEAG7RPg4k9UTXOQIFuO/0Vs/RJ1Kjok96j/r4IYX1E69j3ipYgIXScy50P6Fe/TpmRDmXKxr5eXy0nqaM31zh7vqS8F1lQoK/bubbMw5z3H2/nI5gxUqXs5P+hlaL7raFZH7Hg3mNjd5wnMzYXavNiGyAnwndsxplQ+plnzIGrd5Q1Gj9MYyskov1FCqNyQAtO7CSv8Q6jXXeUoRKPK3KCLb+4fGx40OJJd98VtoajMO7yDjfVSOKXmNzZPZIa5yUCwnN4IeZJ+hmQXR8vx+x/95XrQRBUuHW2973fKh+s1QIDAQABoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwDQYJKoZIhvcNAQELBQADggEBAHH6ao6CBAH7a3XKp+xCouIdlMN8lVmLMwU4f+a/BEJA66dZxksBGcnOeZvRVIKjQ43vrp6mEdf6/XqTtWtda9xonZRBvev33buFhptA9I1o/fbvYCNrHNZeF9e6lJ6ixbZl+LP2F/EHiCw9bs+L4uI2wFCERJAcRAZtstWVzALIZhlIFclYdsLagEx66s4+t/5ULAD4bCz3Cdxdew3K0HkP3+5lbHHQOzJiZN3y+aJLbyKJnpl1dREAGycwFuJnNaReHFBzbVv5nj10vWwtnu+6uok9Q4Z0nJ6yT2cBLkso/8At5vS6dfqvSIuQ1nADsRpnaBfRPl1uhchN58Eox00=\",\"cancellation_requested\":false,\"status\":\"inProgress\",\"status_details\":\"Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.\",\"request_id\":\"1694491266ea41c59778a75ccaa29c7d\"}",
+   "response": "{\"id\":\"https://keyvault_name.vault.azure.net/certificates/crudcertoperation163217583204004746/pending\",\"issuer\":{\"name\":\"Self\"},\"csr\":\"MIICoTCCAYkCAQAwETEPMA0GA1UEAxMGTXlDZXJ0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAwPfojcWz97x2fVGJ3Xa74D2mv8aaos9ZDIKFahkG2bNmDFJMCXcqn7cjo2RTCOWut73mQU+qqPI82NwtL27VsXMqHUi4isM19wygKcC++OgWrPzWOv2FRfj0kiHUQKasbjRKD3yLLkzcSROPk/BtHUiAlwT5uhzPp8Qpo7O8m/HPzbYIZE9HQzRtTt37hf3LnMTkYdWVcjyCxyN2cBU95IMOkAvlZJPyWITw4AmLYUJYZ+NC/ftyX1pnbBha5+qS9j4kN7bvx2CNfP2cG3LpFUDzRzS3DSPfL6RZlIWvIwX+OmGE9L6W+NYzN7O8H1XFKNM22CcYAwLSYpatFat1xQIDAQABoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwDQYJKoZIhvcNAQELBQADggEBABtx9JVqfAxOSNhU5ir7DdGa8o9m/GGoZG84HPMvqb7A/M2SLopgtbdaRSr7ylD1+QcZWBUoVgl8QrotrBvyPVD4HVUWZtx0l7e/LYf/QoIMTMV4wmbqK7Q9fgYadjMHDu93bGLkBq0EWyVR3xghL2EYd2NANVKhBOVnIAm4alSRIeeIzqsrm+5Us1Z5DxWOQPtLvxVmhY0uB/fkSf4k3tL/j7Wc/yxl+6ZC1HpHSBERr0sunXkzctsBYm2k5Ep/OMkUmRFY5TaSKkyPB4E6wmYF20R3jJIM+jVD4AT/Ph8o0FTLX9Gv6uKTxjbyB1mo5ECW647EDGL8rCSMwwEgBMk=\",\"cancellation_requested\":false,\"status\":\"inProgress\",\"status_details\":\"Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.\",\"request_id\":\"ae726655ba7f46a180785d54d93f6bc6\"}",
    "responseHeaders": {
     "cache-control": "no-cache",
-    "content-length": "1348",
+    "content-length": "1302",
     "content-type": "application/json; charset=utf-8",
-    "date": "Tue, 16 Feb 2021 19:19:11 GMT",
+    "date": "Mon, 20 Sep 2021 22:10:32 GMT",
     "expires": "-1",
     "pragma": "no-cache",
     "retry-after": "10",
-    "status": "200",
     "strict-transport-security": "max-age=31536000;includeSubDomains",
     "x-content-type-options": "nosniff",
+    "x-ms-client-request-id": "0610339e-f78a-4cca-8c4f-fffe96c80f93",
     "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;",
     "x-ms-keyvault-region": "westus2",
-    "x-ms-keyvault-service-version": "1.2.164.2",
-    "x-ms-request-id": "b020dbc4-d2b2-4ae7-ba43-a94d42ee550f",
+    "x-ms-keyvault-service-version": "1.9.79.2",
+    "x-ms-request-id": "64d5ebec-d1e4-42ca-9209-519ef75fa057",
     "x-powered-by": "ASP.NET"
    }
   },
   {
    "method": "GET",
-   "url": "https://keyvault_name.vault.azure.net/certificates/CRUDCertificateName-canreadcancelanddeleteacertificatesoperation-/",
+   "url": "https://keyvault_name.vault.azure.net/certificates/crudcertoperation163217583204004746/",
    "query": {
     "api-version": "7.2"
    },
    "requestBody": null,
    "status": 200,
-   "response": "{\"id\":\"https://keyvault_name.vault.azure.net/certificates/CRUDCertificateName-canreadcancelanddeleteacertificatesoperation-/4cf53285a5124e81a7908108f6e25f5a\",\"attributes\":{\"enabled\":false,\"nbf\":1613502551,\"exp\":1645039151,\"created\":1613503151,\"updated\":1613503151,\"recoveryLevel\":\"CustomizedRecoverable+Purgeable\",\"recoverableDays\":7},\"policy\":{\"id\":\"https://keyvault_name.vault.azure.net/certificates/CRUDCertificateName-canreadcancelanddeleteacertificatesoperation-/policy\",\"key_props\":{\"exportable\":true,\"kty\":\"RSA\",\"key_size\":2048,\"reuse_key\":false},\"secret_props\":{\"contentType\":\"application/x-pkcs12\"},\"x509_props\":{\"subject\":\"cn=MyCert\",\"sans\":{},\"ekus\":[\"1.3.6.1.5.5.7.3.1\",\"1.3.6.1.5.5.7.3.2\"],\"key_usage\":[\"digitalSignature\",\"keyEncipherment\"],\"validity_months\":12,\"basic_constraints\":{\"ca\":false}},\"lifetime_actions\":[{\"trigger\":{\"lifetime_percentage\":80},\"action\":{\"action_type\":\"AutoRenew\"}}],\"issuer\":{\"name\":\"Self\"},\"attributes\":{\"enabled\":true,\"created\":1613503152,\"updated\":1613503152}},\"pending\":{\"id\":\"https://keyvault_name.vault.azure.net/certificates/CRUDCertificateName-canreadcancelanddeleteacertificatesoperation-/pending\"}}",
+   "response": "{\"id\":\"https://keyvault_name.vault.azure.net/certificates/crudcertoperation163217583204004746/225037e718a34d11b09010b07a77fd4c\",\"attributes\":{\"enabled\":false,\"nbf\":1632175232,\"exp\":1663711832,\"created\":1632175832,\"updated\":1632175832,\"recoveryLevel\":\"CustomizedRecoverable+Purgeable\",\"recoverableDays\":7},\"policy\":{\"id\":\"https://keyvault_name.vault.azure.net/certificates/crudcertoperation163217583204004746/policy\",\"key_props\":{\"exportable\":true,\"kty\":\"RSA\",\"key_size\":2048,\"reuse_key\":false},\"secret_props\":{\"contentType\":\"application/x-pkcs12\"},\"x509_props\":{\"subject\":\"cn=MyCert\",\"sans\":{},\"ekus\":[\"1.3.6.1.5.5.7.3.1\",\"1.3.6.1.5.5.7.3.2\"],\"key_usage\":[\"digitalSignature\",\"keyEncipherment\"],\"validity_months\":12,\"basic_constraints\":{\"ca\":false}},\"lifetime_actions\":[{\"trigger\":{\"lifetime_percentage\":80},\"action\":{\"action_type\":\"AutoRenew\"}}],\"issuer\":{\"name\":\"Self\"},\"attributes\":{\"enabled\":true,\"created\":1632175832,\"updated\":1632175832}},\"pending\":{\"id\":\"https://keyvault_name.vault.azure.net/certificates/crudcertoperation163217583204004746/pending\"}}",
    "responseHeaders": {
     "cache-control": "no-cache",
-    "content-length": "1184",
+    "content-length": "1046",
     "content-type": "application/json; charset=utf-8",
-    "date": "Tue, 16 Feb 2021 19:19:11 GMT",
+    "date": "Mon, 20 Sep 2021 22:10:32 GMT",
     "expires": "-1",
     "pragma": "no-cache",
-    "status": "200",
     "strict-transport-security": "max-age=31536000;includeSubDomains",
     "x-content-type-options": "nosniff",
+    "x-ms-client-request-id": "adc1043c-6a0d-4d77-a817-4cd7ccf5f01f",
     "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;",
     "x-ms-keyvault-region": "westus2",
-    "x-ms-keyvault-service-version": "1.2.164.2",
-    "x-ms-request-id": "67070408-eeb2-4d33-a4fb-43aebe7a8e1e",
+    "x-ms-keyvault-service-version": "1.9.79.2",
+    "x-ms-request-id": "791076e2-ea8a-41e6-94c4-2da77a78d69d",
     "x-powered-by": "ASP.NET"
    }
   },
   {
    "method": "GET",
-   "url": "https://keyvault_name.vault.azure.net/certificates/CRUDCertificateName-canreadcancelanddeleteacertificatesoperation-/pending",
+   "url": "https://keyvault_name.vault.azure.net/certificates/crudcertoperation163217583204004746/pending",
    "query": {
     "api-version": "7.2"
    },
    "requestBody": null,
    "status": 200,
-   "response": "{\"id\":\"https://keyvault_name.vault.azure.net/certificates/CRUDCertificateName-canreadcancelanddeleteacertificatesoperation-/pending\",\"issuer\":{\"name\":\"Self\"},\"csr\":\"MIICoTCCAYkCAQAwETEPMA0GA1UEAxMGTXlDZXJ0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAp1JGLEmT0SxTGNdQaVPo23Atw0nwvvlK0aSp9Ym15BEAG7RPg4k9UTXOQIFuO/0Vs/RJ1Kjok96j/r4IYX1E69j3ipYgIXScy50P6Fe/TpmRDmXKxr5eXy0nqaM31zh7vqS8F1lQoK/bubbMw5z3H2/nI5gxUqXs5P+hlaL7raFZH7Hg3mNjd5wnMzYXavNiGyAnwndsxplQ+plnzIGrd5Q1Gj9MYyskov1FCqNyQAtO7CSv8Q6jXXeUoRKPK3KCLb+4fGx40OJJd98VtoajMO7yDjfVSOKXmNzZPZIa5yUCwnN4IeZJ+hmQXR8vx+x/95XrQRBUuHW2973fKh+s1QIDAQABoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwDQYJKoZIhvcNAQELBQADggEBAHH6ao6CBAH7a3XKp+xCouIdlMN8lVmLMwU4f+a/BEJA66dZxksBGcnOeZvRVIKjQ43vrp6mEdf6/XqTtWtda9xonZRBvev33buFhptA9I1o/fbvYCNrHNZeF9e6lJ6ixbZl+LP2F/EHiCw9bs+L4uI2wFCERJAcRAZtstWVzALIZhlIFclYdsLagEx66s4+t/5ULAD4bCz3Cdxdew3K0HkP3+5lbHHQOzJiZN3y+aJLbyKJnpl1dREAGycwFuJnNaReHFBzbVv5nj10vWwtnu+6uok9Q4Z0nJ6yT2cBLkso/8At5vS6dfqvSIuQ1nADsRpnaBfRPl1uhchN58Eox00=\",\"cancellation_requested\":false,\"status\":\"inProgress\",\"status_details\":\"Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.\",\"request_id\":\"1694491266ea41c59778a75ccaa29c7d\"}",
+   "response": "{\"id\":\"https://keyvault_name.vault.azure.net/certificates/crudcertoperation163217583204004746/pending\",\"issuer\":{\"name\":\"Self\"},\"csr\":\"MIICoTCCAYkCAQAwETEPMA0GA1UEAxMGTXlDZXJ0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAwPfojcWz97x2fVGJ3Xa74D2mv8aaos9ZDIKFahkG2bNmDFJMCXcqn7cjo2RTCOWut73mQU+qqPI82NwtL27VsXMqHUi4isM19wygKcC++OgWrPzWOv2FRfj0kiHUQKasbjRKD3yLLkzcSROPk/BtHUiAlwT5uhzPp8Qpo7O8m/HPzbYIZE9HQzRtTt37hf3LnMTkYdWVcjyCxyN2cBU95IMOkAvlZJPyWITw4AmLYUJYZ+NC/ftyX1pnbBha5+qS9j4kN7bvx2CNfP2cG3LpFUDzRzS3DSPfL6RZlIWvIwX+OmGE9L6W+NYzN7O8H1XFKNM22CcYAwLSYpatFat1xQIDAQABoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwDQYJKoZIhvcNAQELBQADggEBABtx9JVqfAxOSNhU5ir7DdGa8o9m/GGoZG84HPMvqb7A/M2SLopgtbdaRSr7ylD1+QcZWBUoVgl8QrotrBvyPVD4HVUWZtx0l7e/LYf/QoIMTMV4wmbqK7Q9fgYadjMHDu93bGLkBq0EWyVR3xghL2EYd2NANVKhBOVnIAm4alSRIeeIzqsrm+5Us1Z5DxWOQPtLvxVmhY0uB/fkSf4k3tL/j7Wc/yxl+6ZC1HpHSBERr0sunXkzctsBYm2k5Ep/OMkUmRFY5TaSKkyPB4E6wmYF20R3jJIM+jVD4AT/Ph8o0FTLX9Gv6uKTxjbyB1mo5ECW647EDGL8rCSMwwEgBMk=\",\"cancellation_requested\":false,\"status\":\"inProgress\",\"status_details\":\"Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.\",\"request_id\":\"ae726655ba7f46a180785d54d93f6bc6\"}",
    "responseHeaders": {
     "cache-control": "no-cache",
-    "content-length": "1348",
+    "content-length": "1302",
     "content-type": "application/json; charset=utf-8",
-    "date": "Tue, 16 Feb 2021 19:19:12 GMT",
+    "date": "Mon, 20 Sep 2021 22:10:32 GMT",
     "expires": "-1",
     "pragma": "no-cache",
     "retry-after": "10",
-    "status": "200",
     "strict-transport-security": "max-age=31536000;includeSubDomains",
     "x-content-type-options": "nosniff",
+    "x-ms-client-request-id": "0cc1df5f-6d10-43ac-bf06-a7609449e1b1",
     "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;",
     "x-ms-keyvault-region": "westus2",
-    "x-ms-keyvault-service-version": "1.2.164.2",
-    "x-ms-request-id": "af002994-5b77-4437-8ddb-4de00110db27",
+    "x-ms-keyvault-service-version": "1.9.79.2",
+    "x-ms-request-id": "af0fcba2-bad8-4aed-a220-195a89678321",
     "x-powered-by": "ASP.NET"
    }
   },
   {
    "method": "PATCH",
-   "url": "https://keyvault_name.vault.azure.net/certificates/CRUDCertificateName-canreadcancelanddeleteacertificatesoperation-/pending",
+   "url": "https://keyvault_name.vault.azure.net/certificates/crudcertoperation163217583204004746/pending",
    "query": {
     "api-version": "7.2"
    },
    "requestBody": "{\"cancellation_requested\":true}",
    "status": 200,
-   "response": "{\"id\":\"https://keyvault_name.vault.azure.net/certificates/CRUDCertificateName-canreadcancelanddeleteacertificatesoperation-/pending\",\"issuer\":{\"name\":\"Self\"},\"csr\":\"MIICoTCCAYkCAQAwETEPMA0GA1UEAxMGTXlDZXJ0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAp1JGLEmT0SxTGNdQaVPo23Atw0nwvvlK0aSp9Ym15BEAG7RPg4k9UTXOQIFuO/0Vs/RJ1Kjok96j/r4IYX1E69j3ipYgIXScy50P6Fe/TpmRDmXKxr5eXy0nqaM31zh7vqS8F1lQoK/bubbMw5z3H2/nI5gxUqXs5P+hlaL7raFZH7Hg3mNjd5wnMzYXavNiGyAnwndsxplQ+plnzIGrd5Q1Gj9MYyskov1FCqNyQAtO7CSv8Q6jXXeUoRKPK3KCLb+4fGx40OJJd98VtoajMO7yDjfVSOKXmNzZPZIa5yUCwnN4IeZJ+hmQXR8vx+x/95XrQRBUuHW2973fKh+s1QIDAQABoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwDQYJKoZIhvcNAQELBQADggEBAHH6ao6CBAH7a3XKp+xCouIdlMN8lVmLMwU4f+a/BEJA66dZxksBGcnOeZvRVIKjQ43vrp6mEdf6/XqTtWtda9xonZRBvev33buFhptA9I1o/fbvYCNrHNZeF9e6lJ6ixbZl+LP2F/EHiCw9bs+L4uI2wFCERJAcRAZtstWVzALIZhlIFclYdsLagEx66s4+t/5ULAD4bCz3Cdxdew3K0HkP3+5lbHHQOzJiZN3y+aJLbyKJnpl1dREAGycwFuJnNaReHFBzbVv5nj10vWwtnu+6uok9Q4Z0nJ6yT2cBLkso/8At5vS6dfqvSIuQ1nADsRpnaBfRPl1uhchN58Eox00=\",\"cancellation_requested\":true,\"status\":\"inProgress\",\"status_details\":\"Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.\",\"request_id\":\"1694491266ea41c59778a75ccaa29c7d\"}",
+   "response": "{\"id\":\"https://keyvault_name.vault.azure.net/certificates/crudcertoperation163217583204004746/pending\",\"issuer\":{\"name\":\"Self\"},\"csr\":\"MIICoTCCAYkCAQAwETEPMA0GA1UEAxMGTXlDZXJ0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAwPfojcWz97x2fVGJ3Xa74D2mv8aaos9ZDIKFahkG2bNmDFJMCXcqn7cjo2RTCOWut73mQU+qqPI82NwtL27VsXMqHUi4isM19wygKcC++OgWrPzWOv2FRfj0kiHUQKasbjRKD3yLLkzcSROPk/BtHUiAlwT5uhzPp8Qpo7O8m/HPzbYIZE9HQzRtTt37hf3LnMTkYdWVcjyCxyN2cBU95IMOkAvlZJPyWITw4AmLYUJYZ+NC/ftyX1pnbBha5+qS9j4kN7bvx2CNfP2cG3LpFUDzRzS3DSPfL6RZlIWvIwX+OmGE9L6W+NYzN7O8H1XFKNM22CcYAwLSYpatFat1xQIDAQABoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwDQYJKoZIhvcNAQELBQADggEBABtx9JVqfAxOSNhU5ir7DdGa8o9m/GGoZG84HPMvqb7A/M2SLopgtbdaRSr7ylD1+QcZWBUoVgl8QrotrBvyPVD4HVUWZtx0l7e/LYf/QoIMTMV4wmbqK7Q9fgYadjMHDu93bGLkBq0EWyVR3xghL2EYd2NANVKhBOVnIAm4alSRIeeIzqsrm+5Us1Z5DxWOQPtLvxVmhY0uB/fkSf4k3tL/j7Wc/yxl+6ZC1HpHSBERr0sunXkzctsBYm2k5Ep/OMkUmRFY5TaSKkyPB4E6wmYF20R3jJIM+jVD4AT/Ph8o0FTLX9Gv6uKTxjbyB1mo5ECW647EDGL8rCSMwwEgBMk=\",\"cancellation_requested\":true,\"status\":\"inProgress\",\"status_details\":\"Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.\",\"request_id\":\"ae726655ba7f46a180785d54d93f6bc6\"}",
    "responseHeaders": {
     "cache-control": "no-cache",
-    "content-length": "1347",
+    "content-length": "1301",
     "content-type": "application/json; charset=utf-8",
-    "date": "Tue, 16 Feb 2021 19:19:12 GMT",
+    "date": "Mon, 20 Sep 2021 22:10:32 GMT",
     "expires": "-1",
     "pragma": "no-cache",
-    "status": "200",
     "strict-transport-security": "max-age=31536000;includeSubDomains",
     "x-content-type-options": "nosniff",
+    "x-ms-client-request-id": "3dc746c9-e475-4f84-bb8c-736fd4e5f4a0",
     "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;",
     "x-ms-keyvault-region": "westus2",
-    "x-ms-keyvault-service-version": "1.2.164.2",
-    "x-ms-request-id": "bb0c0439-141e-440e-bed4-49e972465a55",
+    "x-ms-keyvault-service-version": "1.9.79.2",
+    "x-ms-request-id": "ed5285da-cb31-42d3-8161-45dca3353084",
     "x-powered-by": "ASP.NET"
    }
   },
   {
    "method": "DELETE",
-   "url": "https://keyvault_name.vault.azure.net/certificates/CRUDCertificateName-canreadcancelanddeleteacertificatesoperation-/pending",
+   "url": "https://keyvault_name.vault.azure.net/certificates/crudcertoperation163217583204004746/pending",
    "query": {
     "api-version": "7.2"
    },
    "requestBody": null,
    "status": 200,
-   "response": "{\"id\":\"https://keyvault_name.vault.azure.net/certificates/CRUDCertificateName-canreadcancelanddeleteacertificatesoperation-/pending\",\"issuer\":{\"name\":\"Self\"},\"csr\":\"MIICoTCCAYkCAQAwETEPMA0GA1UEAxMGTXlDZXJ0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAp1JGLEmT0SxTGNdQaVPo23Atw0nwvvlK0aSp9Ym15BEAG7RPg4k9UTXOQIFuO/0Vs/RJ1Kjok96j/r4IYX1E69j3ipYgIXScy50P6Fe/TpmRDmXKxr5eXy0nqaM31zh7vqS8F1lQoK/bubbMw5z3H2/nI5gxUqXs5P+hlaL7raFZH7Hg3mNjd5wnMzYXavNiGyAnwndsxplQ+plnzIGrd5Q1Gj9MYyskov1FCqNyQAtO7CSv8Q6jXXeUoRKPK3KCLb+4fGx40OJJd98VtoajMO7yDjfVSOKXmNzZPZIa5yUCwnN4IeZJ+hmQXR8vx+x/95XrQRBUuHW2973fKh+s1QIDAQABoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwDQYJKoZIhvcNAQELBQADggEBAHH6ao6CBAH7a3XKp+xCouIdlMN8lVmLMwU4f+a/BEJA66dZxksBGcnOeZvRVIKjQ43vrp6mEdf6/XqTtWtda9xonZRBvev33buFhptA9I1o/fbvYCNrHNZeF9e6lJ6ixbZl+LP2F/EHiCw9bs+L4uI2wFCERJAcRAZtstWVzALIZhlIFclYdsLagEx66s4+t/5ULAD4bCz3Cdxdew3K0HkP3+5lbHHQOzJiZN3y+aJLbyKJnpl1dREAGycwFuJnNaReHFBzbVv5nj10vWwtnu+6uok9Q4Z0nJ6yT2cBLkso/8At5vS6dfqvSIuQ1nADsRpnaBfRPl1uhchN58Eox00=\",\"cancellation_requested\":true,\"status\":\"inProgress\",\"status_details\":\"Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.\",\"request_id\":\"1694491266ea41c59778a75ccaa29c7d\"}",
+   "response": "{\"id\":\"https://keyvault_name.vault.azure.net/certificates/crudcertoperation163217583204004746/pending\",\"issuer\":{\"name\":\"Self\"},\"csr\":\"MIICoTCCAYkCAQAwETEPMA0GA1UEAxMGTXlDZXJ0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAwPfojcWz97x2fVGJ3Xa74D2mv8aaos9ZDIKFahkG2bNmDFJMCXcqn7cjo2RTCOWut73mQU+qqPI82NwtL27VsXMqHUi4isM19wygKcC++OgWrPzWOv2FRfj0kiHUQKasbjRKD3yLLkzcSROPk/BtHUiAlwT5uhzPp8Qpo7O8m/HPzbYIZE9HQzRtTt37hf3LnMTkYdWVcjyCxyN2cBU95IMOkAvlZJPyWITw4AmLYUJYZ+NC/ftyX1pnbBha5+qS9j4kN7bvx2CNfP2cG3LpFUDzRzS3DSPfL6RZlIWvIwX+OmGE9L6W+NYzN7O8H1XFKNM22CcYAwLSYpatFat1xQIDAQABoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwDQYJKoZIhvcNAQELBQADggEBABtx9JVqfAxOSNhU5ir7DdGa8o9m/GGoZG84HPMvqb7A/M2SLopgtbdaRSr7ylD1+QcZWBUoVgl8QrotrBvyPVD4HVUWZtx0l7e/LYf/QoIMTMV4wmbqK7Q9fgYadjMHDu93bGLkBq0EWyVR3xghL2EYd2NANVKhBOVnIAm4alSRIeeIzqsrm+5Us1Z5DxWOQPtLvxVmhY0uB/fkSf4k3tL/j7Wc/yxl+6ZC1HpHSBERr0sunXkzctsBYm2k5Ep/OMkUmRFY5TaSKkyPB4E6wmYF20R3jJIM+jVD4AT/Ph8o0FTLX9Gv6uKTxjbyB1mo5ECW647EDGL8rCSMwwEgBMk=\",\"cancellation_requested\":true,\"status\":\"inProgress\",\"status_details\":\"Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.\",\"request_id\":\"ae726655ba7f46a180785d54d93f6bc6\"}",
    "responseHeaders": {
     "cache-control": "no-cache",
-    "content-length": "1347",
+    "content-length": "1301",
     "content-type": "application/json; charset=utf-8",
-    "date": "Tue, 16 Feb 2021 19:19:12 GMT",
+    "date": "Mon, 20 Sep 2021 22:10:32 GMT",
     "expires": "-1",
     "pragma": "no-cache",
-    "status": "200",
     "strict-transport-security": "max-age=31536000;includeSubDomains",
     "x-content-type-options": "nosniff",
+    "x-ms-client-request-id": "f0fc1c5b-1e02-4348-96fb-bc52f7b82b06",
     "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;",
     "x-ms-keyvault-region": "westus2",
-    "x-ms-keyvault-service-version": "1.2.164.2",
-    "x-ms-request-id": "0ade378c-ad6b-4b95-b6d4-249548692881",
+    "x-ms-keyvault-service-version": "1.9.79.2",
+    "x-ms-request-id": "a3a9abbc-0f77-4fe9-8a70-804d0b74baec",
     "x-powered-by": "ASP.NET"
    }
   },
   {
    "method": "GET",
-   "url": "https://keyvault_name.vault.azure.net/certificates/CRUDCertificateName-canreadcancelanddeleteacertificatesoperation-/",
+   "url": "https://keyvault_name.vault.azure.net/certificates/crudcertoperation163217583204004746/",
    "query": {
     "api-version": "7.2"
    },
    "requestBody": null,
    "status": 200,
-   "response": "{\"id\":\"https://keyvault_name.vault.azure.net/certificates/CRUDCertificateName-canreadcancelanddeleteacertificatesoperation-/4cf53285a5124e81a7908108f6e25f5a\",\"attributes\":{\"enabled\":false,\"nbf\":1613502551,\"exp\":1645039151,\"created\":1613503151,\"updated\":1613503151,\"recoveryLevel\":\"CustomizedRecoverable+Purgeable\",\"recoverableDays\":7},\"policy\":{\"id\":\"https://keyvault_name.vault.azure.net/certificates/CRUDCertificateName-canreadcancelanddeleteacertificatesoperation-/policy\",\"key_props\":{\"exportable\":true,\"kty\":\"RSA\",\"key_size\":2048,\"reuse_key\":false},\"secret_props\":{\"contentType\":\"application/x-pkcs12\"},\"x509_props\":{\"subject\":\"cn=MyCert\",\"sans\":{},\"ekus\":[\"1.3.6.1.5.5.7.3.1\",\"1.3.6.1.5.5.7.3.2\"],\"key_usage\":[\"digitalSignature\",\"keyEncipherment\"],\"validity_months\":12,\"basic_constraints\":{\"ca\":false}},\"lifetime_actions\":[{\"trigger\":{\"lifetime_percentage\":80},\"action\":{\"action_type\":\"AutoRenew\"}}],\"issuer\":{\"name\":\"Self\"},\"attributes\":{\"enabled\":true,\"created\":1613503152,\"updated\":1613503152}}}",
+   "response": "{\"id\":\"https://keyvault_name.vault.azure.net/certificates/crudcertoperation163217583204004746/225037e718a34d11b09010b07a77fd4c\",\"attributes\":{\"enabled\":false,\"nbf\":1632175232,\"exp\":1663711832,\"created\":1632175832,\"updated\":1632175832,\"recoveryLevel\":\"CustomizedRecoverable+Purgeable\",\"recoverableDays\":7},\"policy\":{\"id\":\"https://keyvault_name.vault.azure.net/certificates/crudcertoperation163217583204004746/policy\",\"key_props\":{\"exportable\":true,\"kty\":\"RSA\",\"key_size\":2048,\"reuse_key\":false},\"secret_props\":{\"contentType\":\"application/x-pkcs12\"},\"x509_props\":{\"subject\":\"cn=MyCert\",\"sans\":{},\"ekus\":[\"1.3.6.1.5.5.7.3.1\",\"1.3.6.1.5.5.7.3.2\"],\"key_usage\":[\"digitalSignature\",\"keyEncipherment\"],\"validity_months\":12,\"basic_constraints\":{\"ca\":false}},\"lifetime_actions\":[{\"trigger\":{\"lifetime_percentage\":80},\"action\":{\"action_type\":\"AutoRenew\"}}],\"issuer\":{\"name\":\"Self\"},\"attributes\":{\"enabled\":true,\"created\":1632175832,\"updated\":1632175832}}}",
    "responseHeaders": {
     "cache-control": "no-cache",
-    "content-length": "1028",
+    "content-length": "936",
     "content-type": "application/json; charset=utf-8",
-    "date": "Tue, 16 Feb 2021 19:19:12 GMT",
+    "date": "Mon, 20 Sep 2021 22:10:32 GMT",
     "expires": "-1",
     "pragma": "no-cache",
-    "status": "200",
     "strict-transport-security": "max-age=31536000;includeSubDomains",
     "x-content-type-options": "nosniff",
+    "x-ms-client-request-id": "6fb0fbc9-4ab2-4749-b2a3-03b47bda5d20",
     "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;",
     "x-ms-keyvault-region": "westus2",
-    "x-ms-keyvault-service-version": "1.2.164.2",
-    "x-ms-request-id": "829cddf8-3497-4eeb-831e-bb78ab85f282",
+    "x-ms-keyvault-service-version": "1.9.79.2",
+    "x-ms-request-id": "91df96ad-795e-4877-98b7-3d079c36da1a",
     "x-powered-by": "ASP.NET"
    }
   },
   {
    "method": "GET",
-   "url": "https://keyvault_name.vault.azure.net/certificates/CRUDCertificateName-canreadcancelanddeleteacertificatesoperation-/pending",
+   "url": "https://keyvault_name.vault.azure.net/certificates/crudcertoperation163217583204004746/pending",
    "query": {
     "api-version": "7.2"
    },
    "requestBody": null,
    "status": 404,
-   "response": "{\"error\":{\"code\":\"PendingCertificateNotFound\",\"message\":\"Pending certificate not found: CRUDCertificateName-canreadcancelanddeleteacertificatesoperation-\"}}",
+   "response": "{\"error\":{\"code\":\"PendingCertificateNotFound\",\"message\":\"Pending certificate not found: crudcertoperation163217583204004746\"}}",
    "responseHeaders": {
     "cache-control": "no-cache",
-    "content-length": "172",
+    "content-length": "126",
     "content-type": "application/json; charset=utf-8",
-    "date": "Tue, 16 Feb 2021 19:19:12 GMT",
+    "date": "Mon, 20 Sep 2021 22:10:32 GMT",
     "expires": "-1",
     "pragma": "no-cache",
-    "status": "404",
     "strict-transport-security": "max-age=31536000;includeSubDomains",
     "x-content-type-options": "nosniff",
+    "x-ms-client-request-id": "1c4c1421-d033-4278-aa31-78defee531b7",
     "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;",
     "x-ms-keyvault-region": "westus2",
-    "x-ms-keyvault-service-version": "1.2.164.2",
-    "x-ms-request-id": "e2004d12-7078-4350-b79f-4ff72091bbd0",
-    "x-powered-by": "ASP.NET"
-   }
-  },
-  {
-   "method": "DELETE",
-   "url": "https://keyvault_name.vault.azure.net/certificates/CRUDCertificateName-canreadcancelanddeleteacertificatesoperation-",
-   "query": {
-    "api-version": "7.2"
-   },
-   "requestBody": null,
-   "status": 200,
-   "response": "{\"recoveryId\":\"https://keyvault_name.vault.azure.net/deletedcertificates/CRUDCertificateName-canreadcancelanddeleteacertificatesoperation-\",\"deletedDate\":1613503152,\"scheduledPurgeDate\":1614107952,\"id\":\"https://keyvault_name.vault.azure.net/certificates/CRUDCertificateName-canreadcancelanddeleteacertificatesoperation-/4cf53285a5124e81a7908108f6e25f5a\",\"attributes\":{\"enabled\":false,\"nbf\":1613502551,\"exp\":1645039151,\"created\":1613503151,\"updated\":1613503151,\"recoveryLevel\":\"CustomizedRecoverable+Purgeable\",\"recoverableDays\":7},\"policy\":{\"id\":\"https://keyvault_name.vault.azure.net/certificates/CRUDCertificateName-canreadcancelanddeleteacertificatesoperation-/policy\",\"key_props\":{\"exportable\":true,\"kty\":\"RSA\",\"key_size\":2048,\"reuse_key\":false},\"secret_props\":{\"contentType\":\"application/x-pkcs12\"},\"x509_props\":{\"subject\":\"cn=MyCert\",\"sans\":{},\"ekus\":[\"1.3.6.1.5.5.7.3.1\",\"1.3.6.1.5.5.7.3.2\"],\"key_usage\":[\"digitalSignature\",\"keyEncipherment\"],\"validity_months\":12,\"basic_constraints\":{\"ca\":false}},\"lifetime_actions\":[{\"trigger\":{\"lifetime_percentage\":80},\"action\":{\"action_type\":\"AutoRenew\"}}],\"issuer\":{\"name\":\"Self\"},\"attributes\":{\"enabled\":true,\"created\":1613503152,\"updated\":1613503152}}}",
-   "responseHeaders": {
-    "cache-control": "no-cache",
-    "content-length": "1236",
-    "content-type": "application/json; charset=utf-8",
-    "date": "Tue, 16 Feb 2021 19:19:12 GMT",
-    "expires": "-1",
-    "pragma": "no-cache",
-    "status": "200",
-    "strict-transport-security": "max-age=31536000;includeSubDomains",
-    "x-content-type-options": "nosniff",
-    "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;",
-    "x-ms-keyvault-region": "westus2",
-    "x-ms-keyvault-service-version": "1.2.164.2",
-    "x-ms-request-id": "28baf022-9d0e-4b4b-b7e1-a44e415b15a5",
-    "x-powered-by": "ASP.NET"
-   }
-  },
-  {
-   "method": "GET",
-   "url": "https://keyvault_name.vault.azure.net/deletedcertificates/CRUDCertificateName-canreadcancelanddeleteacertificatesoperation-",
-   "query": {
-    "api-version": "7.2"
-   },
-   "requestBody": null,
-   "status": 404,
-   "response": "{\"error\":{\"code\":\"CertificateNotFound\",\"message\":\"Deleted Certificate not found: CRUDCertificateName-canreadcancelanddeleteacertificatesoperation-\"}}",
-   "responseHeaders": {
-    "cache-control": "no-cache",
-    "content-length": "165",
-    "content-type": "application/json; charset=utf-8",
-    "date": "Tue, 16 Feb 2021 19:19:12 GMT",
-    "expires": "-1",
-    "pragma": "no-cache",
-    "status": "404",
-    "strict-transport-security": "max-age=31536000;includeSubDomains",
-    "x-content-type-options": "nosniff",
-    "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;",
-    "x-ms-keyvault-region": "westus2",
-    "x-ms-keyvault-service-version": "1.2.164.2",
-    "x-ms-request-id": "40a5a55c-5f37-4342-a145-fc5122644546",
-    "x-powered-by": "ASP.NET"
-   }
-  },
-  {
-   "method": "GET",
-   "url": "https://keyvault_name.vault.azure.net/deletedcertificates/CRUDCertificateName-canreadcancelanddeleteacertificatesoperation-",
-   "query": {
-    "api-version": "7.2"
-   },
-   "requestBody": null,
-   "status": 404,
-   "response": "{\"error\":{\"code\":\"CertificateNotFound\",\"message\":\"Deleted Certificate not found: CRUDCertificateName-canreadcancelanddeleteacertificatesoperation-\"}}",
-   "responseHeaders": {
-    "cache-control": "no-cache",
-    "content-length": "165",
-    "content-type": "application/json; charset=utf-8",
-    "date": "Tue, 16 Feb 2021 19:19:12 GMT",
-    "expires": "-1",
-    "pragma": "no-cache",
-    "status": "404",
-    "strict-transport-security": "max-age=31536000;includeSubDomains",
-    "x-content-type-options": "nosniff",
-    "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;",
-    "x-ms-keyvault-region": "westus2",
-    "x-ms-keyvault-service-version": "1.2.164.2",
-    "x-ms-request-id": "b84412d5-78b2-4d56-aade-1602aba6f159",
-    "x-powered-by": "ASP.NET"
-   }
-  },
-  {
-   "method": "GET",
-   "url": "https://keyvault_name.vault.azure.net/deletedcertificates/CRUDCertificateName-canreadcancelanddeleteacertificatesoperation-",
-   "query": {
-    "api-version": "7.2"
-   },
-   "requestBody": null,
-   "status": 404,
-   "response": "{\"error\":{\"code\":\"CertificateNotFound\",\"message\":\"Deleted Certificate not found: CRUDCertificateName-canreadcancelanddeleteacertificatesoperation-\"}}",
-   "responseHeaders": {
-    "cache-control": "no-cache",
-    "content-length": "165",
-    "content-type": "application/json; charset=utf-8",
-    "date": "Tue, 16 Feb 2021 19:19:14 GMT",
-    "expires": "-1",
-    "pragma": "no-cache",
-    "status": "404",
-    "strict-transport-security": "max-age=31536000;includeSubDomains",
-    "x-content-type-options": "nosniff",
-    "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;",
-    "x-ms-keyvault-region": "westus2",
-    "x-ms-keyvault-service-version": "1.2.164.2",
-    "x-ms-request-id": "6751e2eb-a46f-41a3-9e15-7e059615f9c3",
-    "x-powered-by": "ASP.NET"
-   }
-  },
-  {
-   "method": "GET",
-   "url": "https://keyvault_name.vault.azure.net/deletedcertificates/CRUDCertificateName-canreadcancelanddeleteacertificatesoperation-",
-   "query": {
-    "api-version": "7.2"
-   },
-   "requestBody": null,
-   "status": 404,
-   "response": "{\"error\":{\"code\":\"CertificateNotFound\",\"message\":\"Deleted Certificate not found: CRUDCertificateName-canreadcancelanddeleteacertificatesoperation-\"}}",
-   "responseHeaders": {
-    "cache-control": "no-cache",
-    "content-length": "165",
-    "content-type": "application/json; charset=utf-8",
-    "date": "Tue, 16 Feb 2021 19:19:16 GMT",
-    "expires": "-1",
-    "pragma": "no-cache",
-    "status": "404",
-    "strict-transport-security": "max-age=31536000;includeSubDomains",
-    "x-content-type-options": "nosniff",
-    "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;",
-    "x-ms-keyvault-region": "westus2",
-    "x-ms-keyvault-service-version": "1.2.164.2",
-    "x-ms-request-id": "458a405e-ea2f-4114-b1ca-ceeaa22bfe43",
-    "x-powered-by": "ASP.NET"
-   }
-  },
-  {
-   "method": "GET",
-   "url": "https://keyvault_name.vault.azure.net/deletedcertificates/CRUDCertificateName-canreadcancelanddeleteacertificatesoperation-",
-   "query": {
-    "api-version": "7.2"
-   },
-   "requestBody": null,
-   "status": 404,
-   "response": "{\"error\":{\"code\":\"CertificateNotFound\",\"message\":\"Deleted Certificate not found: CRUDCertificateName-canreadcancelanddeleteacertificatesoperation-\"}}",
-   "responseHeaders": {
-    "cache-control": "no-cache",
-    "content-length": "165",
-    "content-type": "application/json; charset=utf-8",
-    "date": "Tue, 16 Feb 2021 19:19:19 GMT",
-    "expires": "-1",
-    "pragma": "no-cache",
-    "status": "404",
-    "strict-transport-security": "max-age=31536000;includeSubDomains",
-    "x-content-type-options": "nosniff",
-    "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;",
-    "x-ms-keyvault-region": "westus2",
-    "x-ms-keyvault-service-version": "1.2.164.2",
-    "x-ms-request-id": "adec2b7c-7f91-450a-b30a-741ea2edbc76",
-    "x-powered-by": "ASP.NET"
-   }
-  },
-  {
-   "method": "GET",
-   "url": "https://keyvault_name.vault.azure.net/deletedcertificates/CRUDCertificateName-canreadcancelanddeleteacertificatesoperation-",
-   "query": {
-    "api-version": "7.2"
-   },
-   "requestBody": null,
-   "status": 200,
-   "response": "{\"recoveryId\":\"https://keyvault_name.vault.azure.net/deletedcertificates/CRUDCertificateName-canreadcancelanddeleteacertificatesoperation-\",\"deletedDate\":1613503152,\"scheduledPurgeDate\":1614107952,\"id\":\"https://keyvault_name.vault.azure.net/certificates/CRUDCertificateName-canreadcancelanddeleteacertificatesoperation-/4cf53285a5124e81a7908108f6e25f5a\",\"attributes\":{\"enabled\":false,\"nbf\":1613502551,\"exp\":1645039151,\"created\":1613503151,\"updated\":1613503151,\"recoveryLevel\":\"CustomizedRecoverable+Purgeable\",\"recoverableDays\":7},\"policy\":{\"id\":\"https://keyvault_name.vault.azure.net/certificates/CRUDCertificateName-canreadcancelanddeleteacertificatesoperation-/policy\",\"key_props\":{\"exportable\":true,\"kty\":\"RSA\",\"key_size\":2048,\"reuse_key\":false},\"secret_props\":{\"contentType\":\"application/x-pkcs12\"},\"x509_props\":{\"subject\":\"cn=MyCert\",\"sans\":{},\"ekus\":[\"1.3.6.1.5.5.7.3.1\",\"1.3.6.1.5.5.7.3.2\"],\"key_usage\":[\"digitalSignature\",\"keyEncipherment\"],\"validity_months\":12,\"basic_constraints\":{\"ca\":false}},\"lifetime_actions\":[{\"trigger\":{\"lifetime_percentage\":80},\"action\":{\"action_type\":\"AutoRenew\"}}],\"issuer\":{\"name\":\"Self\"},\"attributes\":{\"enabled\":true,\"created\":1613503152,\"updated\":1613503152}}}",
-   "responseHeaders": {
-    "cache-control": "no-cache",
-    "content-length": "1236",
-    "content-type": "application/json; charset=utf-8",
-    "date": "Tue, 16 Feb 2021 19:19:21 GMT",
-    "expires": "-1",
-    "pragma": "no-cache",
-    "status": "200",
-    "strict-transport-security": "max-age=31536000;includeSubDomains",
-    "x-content-type-options": "nosniff",
-    "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;",
-    "x-ms-keyvault-region": "westus2",
-    "x-ms-keyvault-service-version": "1.2.164.2",
-    "x-ms-request-id": "458da7b1-dd16-44c0-a978-dad1934bb60c",
-    "x-powered-by": "ASP.NET"
-   }
-  },
-  {
-   "method": "DELETE",
-   "url": "https://keyvault_name.vault.azure.net/deletedcertificates/CRUDCertificateName-canreadcancelanddeleteacertificatesoperation-",
-   "query": {
-    "api-version": "7.2"
-   },
-   "requestBody": null,
-   "status": 204,
-   "response": "",
-   "responseHeaders": {
-    "cache-control": "no-cache",
-    "date": "Tue, 16 Feb 2021 19:19:21 GMT",
-    "expires": "-1",
-    "pragma": "no-cache",
-    "status": "204",
-    "strict-transport-security": "max-age=31536000;includeSubDomains",
-    "x-content-type-options": "nosniff",
-    "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;",
-    "x-ms-keyvault-region": "westus2",
-    "x-ms-keyvault-service-version": "1.2.164.2",
-    "x-ms-request-id": "4c593dd8-ca77-4456-ac4e-260a5008b5ce",
+    "x-ms-keyvault-service-version": "1.9.79.2",
+    "x-ms-request-id": "cb348250-fce7-4448-a4e6-e601f2e4f981",
     "x-powered-by": "ASP.NET"
    }
   }
  ],
  "uniqueTestInfo": {
-  "uniqueName": {},
+  "uniqueName": {
+   "crudcertoperation": "crudcertoperation163217583204004746"
+  },
   "newDate": {}
  },
- "hash": "febc97be1252a6070f86b22b0a09a172"
+ "hash": "2111338004d4caa1823e07fd8e932780"
 }

--- a/sdk/keyvault/keyvault-certificates/recordings/node/certificates_client__create_read_update_and_delete/recording_can_read_cancel_and_delete_a_certificates_operation.js
+++ b/sdk/keyvault/keyvault-certificates/recordings/node/certificates_client__create_read_update_and_delete/recording_can_read_cancel_and_delete_a_certificates_operation.js
@@ -1,19 +1,19 @@
 let nock = require('nock');
 
-module.exports.hash = "27a751640ebbc0fefd0ca53954b2c0a5";
+module.exports.hash = "97931df48510b2b9037261d370f8dfef";
 
-module.exports.testInfo = {"uniqueName":{},"newDate":{}}
+module.exports.testInfo = {"uniqueName":{"crudcertoperation":"crudcertoperation163217582585603322"},"newDate":{}}
 
 nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
-  .post('/certificates/CRUDCertificateName-canreadcancelanddeleteacertificatesoperation-/create')
+  .post('/certificates/crudcertoperation163217582585603322/create')
   .query(true)
-  .reply(401, {"error":{"code":"Unauthorized","message":"Request is missing a Bearer or PoP token."}}, [
+  .reply(401, {"error":{"code":"Unauthorized","message":"AKV10000: Request is missing a Bearer or PoP token."}}, [
   'Cache-Control',
   'no-cache',
   'Pragma',
   'no-cache',
   'Content-Length',
-  '87',
+  '97',
   'Content-Type',
   'application/json; charset=utf-8',
   'Expires',
@@ -21,15 +21,15 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'WWW-Authenticate',
   'Bearer authorization="https://login.windows.net/12345678-1234-1234-1234-123456789012", resource="https://vault.azure.net"',
   'x-ms-keyvault-region',
-  'eastus',
+  'westus2',
   'x-ms-client-request-id',
-  'e20add9a-a389-4c3d-9986-05bd0c53d492',
+  '3a423d9d-b2b6-490a-9660-9e5705d41939',
   'x-ms-request-id',
-  '690d575a-4f43-4a00-87bc-0b5c0dfd3056',
+  '4d736683-48db-4c0a-a7e7-5c9fc8a1651a',
   'x-ms-keyvault-service-version',
-  '1.2.265.0',
+  '1.9.79.2',
   'x-ms-keyvault-network-info',
-  'conn_type=Ipv4;addr=IP_ADDRESS;act_addr_fam=InterNetwork;',
+  'conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;',
   'X-Powered-By',
   'ASP.NET',
   'Strict-Transport-Security',
@@ -37,7 +37,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Wed, 28 Apr 2021 20:35:08 GMT'
+  'Mon, 20 Sep 2021 22:10:26 GMT'
 ]);
 
 nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
@@ -59,26 +59,26 @@ nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
   'P3P',
   'CP="DSP CUR OTPi IND OTRi ONL FIN"',
   'x-ms-request-id',
-  '1f7f652c-fa4d-420a-b798-aea29e0bd402',
+  'a2ea8086-d757-4d4f-9f8b-1c11a4f86b00',
   'x-ms-ests-server',
-  '2.1.11654.16 - WUS2 ProdSlices',
+  '2.1.12025.15 - NCUS ProdSlices',
   'Set-Cookie',
-  'fpc=ApDQRp_1bOJGvyZBmEPP0xDmR1YbBQAAANi8G9gOAAAA; expires=Fri, 28-May-2021 20:35:08 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'fpc=AtSSgjqs29NOiHgx9X1CxH8; expires=Wed, 20-Oct-2021 22:10:26 GMT; path=/; secure; HttpOnly; SameSite=None',
   'Set-Cookie',
-  'esctx=AQABAAAAAAD--DLA3VO7QrddgJg7WevrrC5b5102AVpPt0HmbK8Pr0XZJG8OTPBN1E1bHRvve3DMlwQu6qu1hIYq7GO83H5zITIickCkH5hrXdkIg5Gcn9ayQWXAlrZgPh9cVGA_LPYzyohboKmQKspPsSCxlnwZCDQpeGZmLWDPXzcrGcPsV5WjeYYq5bm5v0uvFImRwRogAA; domain=.login.microsoftonline.com; path=/; secure; HttpOnly; SameSite=None',
+  'esctx=AQABAAAAAAD--DLA3VO7QrddgJg7WevrDpaXJXTyljgicR53KfVn_rwQ0w2fRjvOlQPeZl8hzMPAndzo-h_vxQh9NTcoZjtkg_mna4HwFL1nAOGRPzHKKNQnfBop_SLWspzEdE4E2W0BjzKSx0UgRYmJmlU_jzJudtzDXxd2fMyK_SEnxQThJfIX0r8BhBnNgSanrkZuHSsgAA; domain=.login.microsoftonline.com; path=/; secure; HttpOnly; SameSite=None',
   'Set-Cookie',
   'x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly',
   'Set-Cookie',
   'stsservicecookie=estsfd; path=/; secure; samesite=none; httponly',
   'Date',
-  'Wed, 28 Apr 2021 20:35:08 GMT',
+  'Mon, 20 Sep 2021 22:10:26 GMT',
   'Content-Length',
   '980'
 ]);
 
 nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
   .get('/12345678-1234-1234-1234-123456789012/v2.0/.well-known/openid-configuration')
-  .reply(200, {"token_endpoint":"https://login.microsoftonline.com/12345678-1234-1234-1234-123456789012/oauth2/v2.0/token","token_endpoint_auth_methods_supported":["client_secret_post","private_key_jwt","client_secret_basic"],"jwks_uri":"https://login.microsoftonline.com/12345678-1234-1234-1234-123456789012/discovery/v2.0/keys","response_modes_supported":["query","fragment","form_post"],"subject_types_supported":["pairwise"],"id_token_signing_alg_values_supported":["RS256"],"response_types_supported":["code","id_token","code id_token","id_token token"],"scopes_supported":["openid","profile","email","offline_access"],"issuer":"https://login.microsoftonline.com/12345678-1234-1234-1234-123456789012/v2.0","request_uri_parameter_supported":false,"userinfo_endpoint":"https://graph.microsoft.com/oidc/userinfo","authorization_endpoint":"https://login.microsoftonline.com/12345678-1234-1234-1234-123456789012/oauth2/v2.0/authorize","device_authorization_endpoint":"https://login.microsoftonline.com/12345678-1234-1234-1234-123456789012/oauth2/v2.0/devicecode","http_logout_supported":true,"frontchannel_logout_supported":true,"end_session_endpoint":"https://login.microsoftonline.com/12345678-1234-1234-1234-123456789012/oauth2/v2.0/logout","claims_supported":["sub","iss","cloud_instance_name","cloud_instance_host_name","cloud_graph_host_name","msgraph_host","aud","exp","iat","auth_time","acr","nonce","preferred_username","name","tid","ver","at_hash","c_hash","email"],"tenant_region_scope":"NA","cloud_instance_name":"microsoftonline.com","cloud_graph_host_name":"graph.windows.net","msgraph_host":"graph.microsoft.com","rbac_url":"https://pas.windows.net"}, [
+  .reply(200, {"token_endpoint":"https://login.microsoftonline.com/12345678-1234-1234-1234-123456789012/oauth2/v2.0/token","token_endpoint_auth_methods_supported":["client_secret_post","private_key_jwt","client_secret_basic"],"jwks_uri":"https://login.microsoftonline.com/12345678-1234-1234-1234-123456789012/discovery/v2.0/keys","response_modes_supported":["query","fragment","form_post"],"subject_types_supported":["pairwise"],"id_token_signing_alg_values_supported":["RS256"],"response_types_supported":["code","id_token","code id_token","id_token token"],"scopes_supported":["openid","profile","email","offline_access"],"issuer":"https://login.microsoftonline.com/12345678-1234-1234-1234-123456789012/v2.0","request_uri_parameter_supported":false,"userinfo_endpoint":"https://graph.microsoft.com/oidc/userinfo","authorization_endpoint":"https://login.microsoftonline.com/12345678-1234-1234-1234-123456789012/oauth2/v2.0/authorize","device_authorization_endpoint":"https://login.microsoftonline.com/12345678-1234-1234-1234-123456789012/oauth2/v2.0/devicecode","http_logout_supported":true,"frontchannel_logout_supported":true,"end_session_endpoint":"https://login.microsoftonline.com/12345678-1234-1234-1234-123456789012/oauth2/v2.0/logout","claims_supported":["sub","iss","cloud_instance_name","cloud_instance_host_name","cloud_graph_host_name","msgraph_host","aud","exp","iat","auth_time","acr","nonce","preferred_username","name","tid","ver","at_hash","c_hash","email"],"kerberos_endpoint":"https://login.microsoftonline.com/12345678-1234-1234-1234-123456789012/kerberos","tenant_region_scope":"WW","cloud_instance_name":"microsoftonline.com","cloud_graph_host_name":"graph.windows.net","msgraph_host":"graph.microsoft.com","rbac_url":"https://pas.windows.net"}, [
   'Cache-Control',
   'max-age=86400, private',
   'Content-Type',
@@ -94,29 +94,26 @@ nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
   'P3P',
   'CP="DSP CUR OTPi IND OTRi ONL FIN"',
   'x-ms-request-id',
-  '20a4bcc1-d3d5-44c9-a51b-a829e71ffe00',
+  'abac040e-0c8a-42ae-98a1-19b8869f6b00',
   'x-ms-ests-server',
-  '2.1.11654.16 - SCUS ProdSlices',
+  '2.1.12071.7 - NCUS ProdSlices',
   'Set-Cookie',
-  'fpc=ApDQRp_1bOJGvyZBmEPP0xDmR1YbBQAAANi8G9gOAAAA; expires=Fri, 28-May-2021 20:35:09 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'fpc=Aktt_JgaUpBDrJbPoVUK1zU; expires=Wed, 20-Oct-2021 22:10:26 GMT; path=/; secure; HttpOnly; SameSite=None',
   'Set-Cookie',
-  'esctx=AQABAAAAAAD--DLA3VO7QrddgJg7WevryHcp3W85z2veNVwhM0_UeriYuvauW9vvmnCXZz7DANRPYIQiVVpBdDHTuFmMRQznT1tSQbtgvRF3zC_h0QAwdfgECgfb9l89E3SO42jSrfOs1JCv_gwKZraNbB2waiVbkjD7S4YSI8K7DjvUzWxW4yiX1KJdmRygV54nKrjJb4MgAA; domain=.login.microsoftonline.com; path=/; secure; HttpOnly; SameSite=None',
+  'esctx=AQABAAAAAAD--DLA3VO7QrddgJg7WevrhxYqqKxsz_LGRlwgstv6uwvwEj6EDteKcEA2mb-9VaHQj49jY8ALFElfAfbxiUm9ehiSMrf5BcHwYxGLJeQMiM4y6hrdYHPzRfn4SwQCoHlmL6NLPdByCTlfph8yybf9IYyUw6z49Tzp6O9HJqix6dISLs381mVQOBOPtITE008gAA; domain=.login.microsoftonline.com; path=/; secure; HttpOnly; SameSite=None',
   'Set-Cookie',
   'x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly',
   'Set-Cookie',
   'stsservicecookie=estsfd; path=/; secure; samesite=none; httponly',
   'Date',
-  'Wed, 28 Apr 2021 20:35:08 GMT',
+  'Mon, 20 Sep 2021 22:10:26 GMT',
   'Content-Length',
-  '1651'
+  '1753'
 ]);
 
 nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
-  .filteringRequestBody(function (body) {
-            return body.replace(/client-request-id=[^&]*/g, "client-request-id=client-request-id");
-        })
-  .post('/12345678-1234-1234-1234-123456789012/oauth2/v2.0/token', "client_id=azure_client_id&scope=https%3A%2F%2Fvault.azure.net%2F.default%20openid%20profile%20offline_access&grant_type=client_credentials&client-request-id=client-request-id&client_secret=azure_client_secret")
-  .reply(200, {"token_type":"Bearer","expires_in":3599,"ext_expires_in":3599,"access_token":"access_token"}, [
+  .post('/12345678-1234-1234-1234-123456789012/oauth2/v2.0/token', "client_id=azure_client_id&scope=https%3A%2F%2Fsanitized%2F&grant_type=client_credentials&x-client-SKU=msal.js.node&x-client-VER=1.3.1&x-client-OS=linux&x-client-CPU=x64&x-ms-lib-capability=retry-after, h429&x-client-current-telemetry=5|771,2,,,|,&x-client-last-telemetry=5|0|||0,0&client-request-id=b22304b3-6bc2-4180-8264-883ee03e107f&client_secret=azure_client_secret&claims=%7B%22access_token%22%3A%7B%22xms_cc%22%3A%7B%22values%22%3A%5B%22CP1%22%5D%7D%7D%7D")
+  .reply(200, {"token_type":"Bearer","expires_in":86399,"ext_expires_in":86399,"access_token":"access_token"}, [
   'Cache-Control',
   'no-store, no-cache',
   'Pragma',
@@ -132,27 +129,27 @@ nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
   'P3P',
   'CP="DSP CUR OTPi IND OTRi ONL FIN"',
   'x-ms-request-id',
-  '20a4bcc1-d3d5-44c9-a51b-a829ee1ffe00',
+  '88defdb2-8005-44b7-b27b-a3d1b70db100',
   'x-ms-ests-server',
-  '2.1.11654.16 - SCUS ProdSlices',
+  '2.1.12071.7 - SCUS ProdSlices',
   'x-ms-clitelem',
   '1,0,0,,',
   'Set-Cookie',
-  'fpc=ApDQRp_1bOJGvyZBmEPP0xDmR1YbBgAAANi8G9gOAAAA; expires=Fri, 28-May-2021 20:35:09 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'fpc=AsrSLnNu6nJLkxryK4fkByqmCNGhAQAAANH92tgOAAAA; expires=Wed, 20-Oct-2021 22:10:26 GMT; path=/; secure; HttpOnly; SameSite=None',
   'Set-Cookie',
   'x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly',
   'Set-Cookie',
   'stsservicecookie=estsfd; path=/; secure; samesite=none; httponly',
   'Date',
-  'Wed, 28 Apr 2021 20:35:08 GMT',
+  'Mon, 20 Sep 2021 22:10:26 GMT',
   'Content-Length',
-  '1313'
+  '1315'
 ]);
 
 nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
-  .post('/certificates/CRUDCertificateName-canreadcancelanddeleteacertificatesoperation-/create', {"policy":{"key_props":{},"secret_props":{},"x509_props":{"subject":"cn=MyCert","sans":{}},"issuer":{"name":"Self"},"attributes":{}},"attributes":{}})
+  .post('/certificates/crudcertoperation163217582585603322/create', {"policy":{"key_props":{},"secret_props":{},"x509_props":{"subject":"cn=MyCert","sans":{}},"issuer":{"name":"Self"},"attributes":{}},"attributes":{}})
   .query(true)
-  .reply(202, {"id":"https://keyvault_name.vault.azure.net/certificates/CRUDCertificateName-canreadcancelanddeleteacertificatesoperation-/pending","issuer":{"name":"Self"},"csr":"MIICoTCCAYkCAQAwETEPMA0GA1UEAxMGTXlDZXJ0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA1Wi7Mebl61Cb7d+uAvPIPOzFsBbeLkksDtDyAoK+7xbLnZR3OBPhYk0fxQ30E4WsqRT9mis2QgRrCE6tsQeS0Jkt/stF6PUpsqr8IsyLObpgH5CnniTqjLcjY1z+o1jaJpN3jHfOl1+99MsbRhgHBSW/kY0nS/kmHXFGqMXUa0Ko57iDAYsEWv1lJRPcn81pyIzuzDjZPmbcvnn6IchtDDAoQRUKOoHrmuC+dHI2JOydy/B1UWxNm5lcKxhvHw0jq4asdQ+M+VmxZrf2saoXAhjutCF6hpssnDseNQ5yIxDbkHsfRJNCR+YFw8pdDrm2rcRTRZqBj/MFQsZ+gOsjpQIDAQABoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwDQYJKoZIhvcNAQELBQADggEBAMRPAXPYq278Ns3EKqjNPO2udDGVOnNMkzUZuTd4QfZtwFteAWbIPqHj/riJpISaRBhe7xBNe5Yw+eo7SCTSZK6qJLcC/Dme5DspzQLykHYf2rzVrEmpUy4WZU/uJiXKngmfyTPIpG9ONv3RSrBPoW6dw9HawLBcCQBOVrlNtfzW2zl4gEtnwHSgDMoYJFhtRnUpZfz8v19qtoem6enNPEXAX6ODGXJMLHoCkMj4R/3EZHHf5gJFNT+PY4VSAwUhdrKu6wkUdwr0BIOIaljZlv66EuWsOir9ybp6MXVY8Ks86VeBirzTb+HMYqAsFk0fm5OZDlWzeBOSzJVsGWXdlGc=","cancellation_requested":false,"status":"inProgress","status_details":"Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.","request_id":"ecb01dd4a2c04f429a023ac66345214f"}, [
+  .reply(202, {"id":"https://keyvault_name.vault.azure.net/certificates/crudcertoperation163217582585603322/pending","issuer":{"name":"Self"},"csr":"MIICoTCCAYkCAQAwETEPMA0GA1UEAxMGTXlDZXJ0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAsyKMqBkKG2iPqCcHDKn0bDTCq+oc0eRfFOa87ZJSEnoY4y4rY24SF/YfGg3xsb277bH9E6I9Ddd/hVVb1W90+AFmWTfjmO5085MZqMzvu22ZSMgs+HSmVfjF8IpBM87Jv9T+ldASoQVh1I4cLPi14IeMNx1jnTpeVresjgiOfEhr8mTG9smsrcK+EVvY4EEQ5id614BemSrY6HW6FVgbHhae76sLVjZkmUcD3hOOMX0ldUhyo4lQ5efX67v7PEGh/cwdpRYPgp9ilLsEeTz0+nVAEtKSaaHRC8Dmcqqf3ghHXTx70LXhz4eym/RDgpdeH85Q8GKttA9cb0j7uWJ1OQIDAQABoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwDQYJKoZIhvcNAQELBQADggEBAFQ3a8iRtaSoNOjTPA+eH8gkfjvvVy1BvTMyJ3AgQKgAJIG1IIN+npA4qZgZ1A92xXCJsKaYFm5gxvrsGiXkVDn5MFK0eUxEVmmT3zDpcF3EipadoZOcx5GNARd0s3tQmyILoWOokwE3JstuM689Hii1aOnjAM/3nY8A83bLrPp5CmFFlW1FCafm70ZqLeHt8Z4JeOcPmFlDIAVaB5Ie9yeZOySVejyU4Y8RN9E7Es+YwmY9j2G+zgm84tnoVKsNSExkX/SP8z1O+Es5WCnz0QrUdBmD9PglM1sHw3aj0rqKBp7Kb2hNcmLs7O5r2Vfyczi6ta5o3gNVHUSjvd4HAoc=","cancellation_requested":false,"status":"inProgress","status_details":"Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.","request_id":"b07519002560445299b63865c6e36c58"}, [
   'Cache-Control',
   'no-cache',
   'Pragma',
@@ -162,19 +159,19 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'Expires',
   '-1',
   'Location',
-  'https://keyvault_name.vault.azure.net/certificates/CRUDCertificateName-canreadcancelanddeleteacertificatesoperation-/pending?api-version=7.2&request_id=ecb01dd4a2c04f429a023ac66345214f',
+  'https://keyvault_name.vault.azure.net/certificates/crudcertoperation163217582585603322/pending?api-version=7.2&request_id=b07519002560445299b63865c6e36c58',
   'Retry-After',
   '10',
   'x-ms-keyvault-region',
-  'eastus',
+  'westus2',
   'x-ms-client-request-id',
-  'e20add9a-a389-4c3d-9986-05bd0c53d492',
+  '3a423d9d-b2b6-490a-9660-9e5705d41939',
   'x-ms-request-id',
-  '25c65da2-5391-4946-914d-83fce64ef9dc',
+  '0fd31cc6-b2d9-4c1d-8103-8cf2d4c7105e',
   'x-ms-keyvault-service-version',
-  '1.2.265.0',
+  '1.9.79.2',
   'x-ms-keyvault-network-info',
-  'conn_type=Ipv4;addr=IP_ADDRESS;act_addr_fam=InterNetwork;',
+  'conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;',
   'X-Powered-By',
   'ASP.NET',
   'Strict-Transport-Security',
@@ -182,85 +179,15 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Wed, 28 Apr 2021 20:35:08 GMT',
+  'Mon, 20 Sep 2021 22:10:26 GMT',
   'Content-Length',
-  '1358'
+  '1302'
 ]);
 
 nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
-  .get('/certificates/CRUDCertificateName-canreadcancelanddeleteacertificatesoperation-/pending')
+  .get('/certificates/crudcertoperation163217582585603322/pending')
   .query(true)
-  .reply(200, {"id":"https://keyvault_name.vault.azure.net/certificates/CRUDCertificateName-canreadcancelanddeleteacertificatesoperation-/pending","issuer":{"name":"Self"},"csr":"MIICoTCCAYkCAQAwETEPMA0GA1UEAxMGTXlDZXJ0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA1Wi7Mebl61Cb7d+uAvPIPOzFsBbeLkksDtDyAoK+7xbLnZR3OBPhYk0fxQ30E4WsqRT9mis2QgRrCE6tsQeS0Jkt/stF6PUpsqr8IsyLObpgH5CnniTqjLcjY1z+o1jaJpN3jHfOl1+99MsbRhgHBSW/kY0nS/kmHXFGqMXUa0Ko57iDAYsEWv1lJRPcn81pyIzuzDjZPmbcvnn6IchtDDAoQRUKOoHrmuC+dHI2JOydy/B1UWxNm5lcKxhvHw0jq4asdQ+M+VmxZrf2saoXAhjutCF6hpssnDseNQ5yIxDbkHsfRJNCR+YFw8pdDrm2rcRTRZqBj/MFQsZ+gOsjpQIDAQABoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwDQYJKoZIhvcNAQELBQADggEBAMRPAXPYq278Ns3EKqjNPO2udDGVOnNMkzUZuTd4QfZtwFteAWbIPqHj/riJpISaRBhe7xBNe5Yw+eo7SCTSZK6qJLcC/Dme5DspzQLykHYf2rzVrEmpUy4WZU/uJiXKngmfyTPIpG9ONv3RSrBPoW6dw9HawLBcCQBOVrlNtfzW2zl4gEtnwHSgDMoYJFhtRnUpZfz8v19qtoem6enNPEXAX6ODGXJMLHoCkMj4R/3EZHHf5gJFNT+PY4VSAwUhdrKu6wkUdwr0BIOIaljZlv66EuWsOir9ybp6MXVY8Ks86VeBirzTb+HMYqAsFk0fm5OZDlWzeBOSzJVsGWXdlGc=","cancellation_requested":false,"status":"inProgress","status_details":"Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.","request_id":"ecb01dd4a2c04f429a023ac66345214f"}, [
-  'Cache-Control',
-  'no-cache',
-  'Pragma',
-  'no-cache',
-  'Content-Type',
-  'application/json; charset=utf-8',
-  'Expires',
-  '-1',
-  'Retry-After',
-  '10',
-  'x-ms-keyvault-region',
-  'eastus',
-  'x-ms-client-request-id',
-  'e70bf9ae-c586-46e4-9a6b-8834833d252e',
-  'x-ms-request-id',
-  'a6a92107-3654-45b9-89da-d71ecef0aebf',
-  'x-ms-keyvault-service-version',
-  '1.2.265.0',
-  'x-ms-keyvault-network-info',
-  'conn_type=Ipv4;addr=IP_ADDRESS;act_addr_fam=InterNetwork;',
-  'X-Powered-By',
-  'ASP.NET',
-  'Strict-Transport-Security',
-  'max-age=31536000;includeSubDomains',
-  'X-Content-Type-Options',
-  'nosniff',
-  'Date',
-  'Wed, 28 Apr 2021 20:35:08 GMT',
-  'Content-Length',
-  '1358'
-]);
-
-nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
-  .get('/certificates/CRUDCertificateName-canreadcancelanddeleteacertificatesoperation-/')
-  .query(true)
-  .reply(200, {"id":"https://keyvault_name.vault.azure.net/certificates/CRUDCertificateName-canreadcancelanddeleteacertificatesoperation-/fcc7c2267fa84d5f98defdba0bd9a23e","attributes":{"enabled":false,"nbf":1619641509,"exp":1651178109,"created":1619642109,"updated":1619642109,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90},"policy":{"id":"https://keyvault_name.vault.azure.net/certificates/CRUDCertificateName-canreadcancelanddeleteacertificatesoperation-/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pkcs12"},"x509_props":{"subject":"cn=MyCert","sans":{},"ekus":["1.3.6.1.5.5.7.3.1","1.3.6.1.5.5.7.3.2"],"key_usage":["digitalSignature","keyEncipherment"],"validity_months":12,"basic_constraints":{"ca":false}},"lifetime_actions":[{"trigger":{"lifetime_percentage":80},"action":{"action_type":"AutoRenew"}}],"issuer":{"name":"Self"},"attributes":{"enabled":true,"created":1619642109,"updated":1619642109}},"pending":{"id":"https://keyvault_name.vault.azure.net/certificates/CRUDCertificateName-canreadcancelanddeleteacertificatesoperation-/pending"}}, [
-  'Cache-Control',
-  'no-cache',
-  'Pragma',
-  'no-cache',
-  'Content-Type',
-  'application/json; charset=utf-8',
-  'Expires',
-  '-1',
-  'x-ms-keyvault-region',
-  'eastus',
-  'x-ms-client-request-id',
-  '0b70fa5e-8912-4034-9f9c-2e756e78ceb5',
-  'x-ms-request-id',
-  '13d07c55-948b-41b9-b2bf-156312873961',
-  'x-ms-keyvault-service-version',
-  '1.2.265.0',
-  'x-ms-keyvault-network-info',
-  'conn_type=Ipv4;addr=IP_ADDRESS;act_addr_fam=InterNetwork;',
-  'X-Powered-By',
-  'ASP.NET',
-  'Strict-Transport-Security',
-  'max-age=31536000;includeSubDomains',
-  'X-Content-Type-Options',
-  'nosniff',
-  'Date',
-  'Wed, 28 Apr 2021 20:35:09 GMT',
-  'Content-Length',
-  '1205'
-]);
-
-nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
-  .get('/certificates/CRUDCertificateName-canreadcancelanddeleteacertificatesoperation-/pending')
-  .query(true)
-  .reply(200, {"id":"https://keyvault_name.vault.azure.net/certificates/CRUDCertificateName-canreadcancelanddeleteacertificatesoperation-/pending","issuer":{"name":"Self"},"csr":"MIICoTCCAYkCAQAwETEPMA0GA1UEAxMGTXlDZXJ0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA1Wi7Mebl61Cb7d+uAvPIPOzFsBbeLkksDtDyAoK+7xbLnZR3OBPhYk0fxQ30E4WsqRT9mis2QgRrCE6tsQeS0Jkt/stF6PUpsqr8IsyLObpgH5CnniTqjLcjY1z+o1jaJpN3jHfOl1+99MsbRhgHBSW/kY0nS/kmHXFGqMXUa0Ko57iDAYsEWv1lJRPcn81pyIzuzDjZPmbcvnn6IchtDDAoQRUKOoHrmuC+dHI2JOydy/B1UWxNm5lcKxhvHw0jq4asdQ+M+VmxZrf2saoXAhjutCF6hpssnDseNQ5yIxDbkHsfRJNCR+YFw8pdDrm2rcRTRZqBj/MFQsZ+gOsjpQIDAQABoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwDQYJKoZIhvcNAQELBQADggEBAMRPAXPYq278Ns3EKqjNPO2udDGVOnNMkzUZuTd4QfZtwFteAWbIPqHj/riJpISaRBhe7xBNe5Yw+eo7SCTSZK6qJLcC/Dme5DspzQLykHYf2rzVrEmpUy4WZU/uJiXKngmfyTPIpG9ONv3RSrBPoW6dw9HawLBcCQBOVrlNtfzW2zl4gEtnwHSgDMoYJFhtRnUpZfz8v19qtoem6enNPEXAX6ODGXJMLHoCkMj4R/3EZHHf5gJFNT+PY4VSAwUhdrKu6wkUdwr0BIOIaljZlv66EuWsOir9ybp6MXVY8Ks86VeBirzTb+HMYqAsFk0fm5OZDlWzeBOSzJVsGWXdlGc=","cancellation_requested":false,"status":"inProgress","status_details":"Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.","request_id":"ecb01dd4a2c04f429a023ac66345214f"}, [
+  .reply(200, {"id":"https://keyvault_name.vault.azure.net/certificates/crudcertoperation163217582585603322/pending","issuer":{"name":"Self"},"csr":"MIICoTCCAYkCAQAwETEPMA0GA1UEAxMGTXlDZXJ0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAsyKMqBkKG2iPqCcHDKn0bDTCq+oc0eRfFOa87ZJSEnoY4y4rY24SF/YfGg3xsb277bH9E6I9Ddd/hVVb1W90+AFmWTfjmO5085MZqMzvu22ZSMgs+HSmVfjF8IpBM87Jv9T+ldASoQVh1I4cLPi14IeMNx1jnTpeVresjgiOfEhr8mTG9smsrcK+EVvY4EEQ5id614BemSrY6HW6FVgbHhae76sLVjZkmUcD3hOOMX0ldUhyo4lQ5efX67v7PEGh/cwdpRYPgp9ilLsEeTz0+nVAEtKSaaHRC8Dmcqqf3ghHXTx70LXhz4eym/RDgpdeH85Q8GKttA9cb0j7uWJ1OQIDAQABoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwDQYJKoZIhvcNAQELBQADggEBAFQ3a8iRtaSoNOjTPA+eH8gkfjvvVy1BvTMyJ3AgQKgAJIG1IIN+npA4qZgZ1A92xXCJsKaYFm5gxvrsGiXkVDn5MFK0eUxEVmmT3zDpcF3EipadoZOcx5GNARd0s3tQmyILoWOokwE3JstuM689Hii1aOnjAM/3nY8A83bLrPp5CmFFlW1FCafm70ZqLeHt8Z4JeOcPmFlDIAVaB5Ie9yeZOySVejyU4Y8RN9E7Es+YwmY9j2G+zgm84tnoVKsNSExkX/SP8z1O+Es5WCnz0QrUdBmD9PglM1sHw3aj0rqKBp7Kb2hNcmLs7O5r2Vfyczi6ta5o3gNVHUSjvd4HAoc=","cancellation_requested":false,"status":"inProgress","status_details":"Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.","request_id":"b07519002560445299b63865c6e36c58"}, [
   'Cache-Control',
   'no-cache',
   'Pragma',
@@ -272,15 +199,15 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'Retry-After',
   '10',
   'x-ms-keyvault-region',
-  'eastus',
+  'westus2',
   'x-ms-client-request-id',
-  'cdec8fd3-b547-4f96-acce-3a4007b7a6d4',
+  'fe2a47e5-ce8e-4b73-9a9f-13d0b291f50a',
   'x-ms-request-id',
-  '2b4743d1-16b3-4b16-8142-887a52c2a754',
+  'ce7dfc86-49db-464c-8a07-3674445953bf',
   'x-ms-keyvault-service-version',
-  '1.2.265.0',
+  '1.9.79.2',
   'x-ms-keyvault-network-info',
-  'conn_type=Ipv4;addr=IP_ADDRESS;act_addr_fam=InterNetwork;',
+  'conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;',
   'X-Powered-By',
   'ASP.NET',
   'Strict-Transport-Security',
@@ -288,15 +215,15 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Wed, 28 Apr 2021 20:35:09 GMT',
+  'Mon, 20 Sep 2021 22:10:26 GMT',
   'Content-Length',
-  '1358'
+  '1302'
 ]);
 
 nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
-  .patch('/certificates/CRUDCertificateName-canreadcancelanddeleteacertificatesoperation-/pending', {"cancellation_requested":true})
+  .get('/certificates/crudcertoperation163217582585603322/')
   .query(true)
-  .reply(200, {"id":"https://keyvault_name.vault.azure.net/certificates/CRUDCertificateName-canreadcancelanddeleteacertificatesoperation-/pending","issuer":{"name":"Self"},"csr":"MIICoTCCAYkCAQAwETEPMA0GA1UEAxMGTXlDZXJ0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA1Wi7Mebl61Cb7d+uAvPIPOzFsBbeLkksDtDyAoK+7xbLnZR3OBPhYk0fxQ30E4WsqRT9mis2QgRrCE6tsQeS0Jkt/stF6PUpsqr8IsyLObpgH5CnniTqjLcjY1z+o1jaJpN3jHfOl1+99MsbRhgHBSW/kY0nS/kmHXFGqMXUa0Ko57iDAYsEWv1lJRPcn81pyIzuzDjZPmbcvnn6IchtDDAoQRUKOoHrmuC+dHI2JOydy/B1UWxNm5lcKxhvHw0jq4asdQ+M+VmxZrf2saoXAhjutCF6hpssnDseNQ5yIxDbkHsfRJNCR+YFw8pdDrm2rcRTRZqBj/MFQsZ+gOsjpQIDAQABoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwDQYJKoZIhvcNAQELBQADggEBAMRPAXPYq278Ns3EKqjNPO2udDGVOnNMkzUZuTd4QfZtwFteAWbIPqHj/riJpISaRBhe7xBNe5Yw+eo7SCTSZK6qJLcC/Dme5DspzQLykHYf2rzVrEmpUy4WZU/uJiXKngmfyTPIpG9ONv3RSrBPoW6dw9HawLBcCQBOVrlNtfzW2zl4gEtnwHSgDMoYJFhtRnUpZfz8v19qtoem6enNPEXAX6ODGXJMLHoCkMj4R/3EZHHf5gJFNT+PY4VSAwUhdrKu6wkUdwr0BIOIaljZlv66EuWsOir9ybp6MXVY8Ks86VeBirzTb+HMYqAsFk0fm5OZDlWzeBOSzJVsGWXdlGc=","cancellation_requested":true,"status":"inProgress","status_details":"Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.","request_id":"ecb01dd4a2c04f429a023ac66345214f"}, [
+  .reply(200, {"id":"https://keyvault_name.vault.azure.net/certificates/crudcertoperation163217582585603322/7b6db81563e048a395d93aab7de5d155","attributes":{"enabled":false,"nbf":1632175226,"exp":1663711826,"created":1632175826,"updated":1632175826,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7},"policy":{"id":"https://keyvault_name.vault.azure.net/certificates/crudcertoperation163217582585603322/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pkcs12"},"x509_props":{"subject":"cn=MyCert","sans":{},"ekus":["1.3.6.1.5.5.7.3.1","1.3.6.1.5.5.7.3.2"],"key_usage":["digitalSignature","keyEncipherment"],"validity_months":12,"basic_constraints":{"ca":false}},"lifetime_actions":[{"trigger":{"lifetime_percentage":80},"action":{"action_type":"AutoRenew"}}],"issuer":{"name":"Self"},"attributes":{"enabled":true,"created":1632175827,"updated":1632175827}},"pending":{"id":"https://keyvault_name.vault.azure.net/certificates/crudcertoperation163217582585603322/pending"}}, [
   'Cache-Control',
   'no-cache',
   'Pragma',
@@ -306,15 +233,15 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'Expires',
   '-1',
   'x-ms-keyvault-region',
-  'eastus',
+  'westus2',
   'x-ms-client-request-id',
-  '13b122e6-a0a4-4a41-9b5d-631a3ab600d5',
+  '86c12dec-d880-40b8-8464-282f4166e1fd',
   'x-ms-request-id',
-  '553f4955-343e-458e-b3e1-377a870ebed3',
+  '0365969d-24fb-4626-9063-c1ff45bd4f03',
   'x-ms-keyvault-service-version',
-  '1.2.265.0',
+  '1.9.79.2',
   'x-ms-keyvault-network-info',
-  'conn_type=Ipv4;addr=IP_ADDRESS;act_addr_fam=InterNetwork;',
+  'conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;',
   'X-Powered-By',
   'ASP.NET',
   'Strict-Transport-Security',
@@ -322,15 +249,51 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Wed, 28 Apr 2021 20:35:09 GMT',
+  'Mon, 20 Sep 2021 22:10:26 GMT',
   'Content-Length',
-  '1357'
+  '1046'
 ]);
 
 nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
-  .delete('/certificates/CRUDCertificateName-canreadcancelanddeleteacertificatesoperation-/pending')
+  .get('/certificates/crudcertoperation163217582585603322/pending')
   .query(true)
-  .reply(200, {"id":"https://keyvault_name.vault.azure.net/certificates/CRUDCertificateName-canreadcancelanddeleteacertificatesoperation-/pending","issuer":{"name":"Self"},"csr":"MIICoTCCAYkCAQAwETEPMA0GA1UEAxMGTXlDZXJ0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA1Wi7Mebl61Cb7d+uAvPIPOzFsBbeLkksDtDyAoK+7xbLnZR3OBPhYk0fxQ30E4WsqRT9mis2QgRrCE6tsQeS0Jkt/stF6PUpsqr8IsyLObpgH5CnniTqjLcjY1z+o1jaJpN3jHfOl1+99MsbRhgHBSW/kY0nS/kmHXFGqMXUa0Ko57iDAYsEWv1lJRPcn81pyIzuzDjZPmbcvnn6IchtDDAoQRUKOoHrmuC+dHI2JOydy/B1UWxNm5lcKxhvHw0jq4asdQ+M+VmxZrf2saoXAhjutCF6hpssnDseNQ5yIxDbkHsfRJNCR+YFw8pdDrm2rcRTRZqBj/MFQsZ+gOsjpQIDAQABoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwDQYJKoZIhvcNAQELBQADggEBAMRPAXPYq278Ns3EKqjNPO2udDGVOnNMkzUZuTd4QfZtwFteAWbIPqHj/riJpISaRBhe7xBNe5Yw+eo7SCTSZK6qJLcC/Dme5DspzQLykHYf2rzVrEmpUy4WZU/uJiXKngmfyTPIpG9ONv3RSrBPoW6dw9HawLBcCQBOVrlNtfzW2zl4gEtnwHSgDMoYJFhtRnUpZfz8v19qtoem6enNPEXAX6ODGXJMLHoCkMj4R/3EZHHf5gJFNT+PY4VSAwUhdrKu6wkUdwr0BIOIaljZlv66EuWsOir9ybp6MXVY8Ks86VeBirzTb+HMYqAsFk0fm5OZDlWzeBOSzJVsGWXdlGc=","cancellation_requested":true,"status":"inProgress","status_details":"Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.","request_id":"ecb01dd4a2c04f429a023ac66345214f"}, [
+  .reply(200, {"id":"https://keyvault_name.vault.azure.net/certificates/crudcertoperation163217582585603322/pending","issuer":{"name":"Self"},"csr":"MIICoTCCAYkCAQAwETEPMA0GA1UEAxMGTXlDZXJ0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAsyKMqBkKG2iPqCcHDKn0bDTCq+oc0eRfFOa87ZJSEnoY4y4rY24SF/YfGg3xsb277bH9E6I9Ddd/hVVb1W90+AFmWTfjmO5085MZqMzvu22ZSMgs+HSmVfjF8IpBM87Jv9T+ldASoQVh1I4cLPi14IeMNx1jnTpeVresjgiOfEhr8mTG9smsrcK+EVvY4EEQ5id614BemSrY6HW6FVgbHhae76sLVjZkmUcD3hOOMX0ldUhyo4lQ5efX67v7PEGh/cwdpRYPgp9ilLsEeTz0+nVAEtKSaaHRC8Dmcqqf3ghHXTx70LXhz4eym/RDgpdeH85Q8GKttA9cb0j7uWJ1OQIDAQABoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwDQYJKoZIhvcNAQELBQADggEBAFQ3a8iRtaSoNOjTPA+eH8gkfjvvVy1BvTMyJ3AgQKgAJIG1IIN+npA4qZgZ1A92xXCJsKaYFm5gxvrsGiXkVDn5MFK0eUxEVmmT3zDpcF3EipadoZOcx5GNARd0s3tQmyILoWOokwE3JstuM689Hii1aOnjAM/3nY8A83bLrPp5CmFFlW1FCafm70ZqLeHt8Z4JeOcPmFlDIAVaB5Ie9yeZOySVejyU4Y8RN9E7Es+YwmY9j2G+zgm84tnoVKsNSExkX/SP8z1O+Es5WCnz0QrUdBmD9PglM1sHw3aj0rqKBp7Kb2hNcmLs7O5r2Vfyczi6ta5o3gNVHUSjvd4HAoc=","cancellation_requested":false,"status":"inProgress","status_details":"Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.","request_id":"b07519002560445299b63865c6e36c58"}, [
+  'Cache-Control',
+  'no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'Retry-After',
+  '10',
+  'x-ms-keyvault-region',
+  'westus2',
+  'x-ms-client-request-id',
+  'f09f87e4-e31f-49c7-9347-0b3bf6c1f16c',
+  'x-ms-request-id',
+  '23af398f-1dac-4a62-a1c9-4814acb0aceb',
+  'x-ms-keyvault-service-version',
+  '1.9.79.2',
+  'x-ms-keyvault-network-info',
+  'conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;',
+  'X-Powered-By',
+  'ASP.NET',
+  'Strict-Transport-Security',
+  'max-age=31536000;includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Date',
+  'Mon, 20 Sep 2021 22:10:27 GMT',
+  'Content-Length',
+  '1302'
+]);
+
+nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
+  .patch('/certificates/crudcertoperation163217582585603322/pending', {"cancellation_requested":true})
+  .query(true)
+  .reply(200, {"id":"https://keyvault_name.vault.azure.net/certificates/crudcertoperation163217582585603322/pending","issuer":{"name":"Self"},"csr":"MIICoTCCAYkCAQAwETEPMA0GA1UEAxMGTXlDZXJ0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAsyKMqBkKG2iPqCcHDKn0bDTCq+oc0eRfFOa87ZJSEnoY4y4rY24SF/YfGg3xsb277bH9E6I9Ddd/hVVb1W90+AFmWTfjmO5085MZqMzvu22ZSMgs+HSmVfjF8IpBM87Jv9T+ldASoQVh1I4cLPi14IeMNx1jnTpeVresjgiOfEhr8mTG9smsrcK+EVvY4EEQ5id614BemSrY6HW6FVgbHhae76sLVjZkmUcD3hOOMX0ldUhyo4lQ5efX67v7PEGh/cwdpRYPgp9ilLsEeTz0+nVAEtKSaaHRC8Dmcqqf3ghHXTx70LXhz4eym/RDgpdeH85Q8GKttA9cb0j7uWJ1OQIDAQABoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwDQYJKoZIhvcNAQELBQADggEBAFQ3a8iRtaSoNOjTPA+eH8gkfjvvVy1BvTMyJ3AgQKgAJIG1IIN+npA4qZgZ1A92xXCJsKaYFm5gxvrsGiXkVDn5MFK0eUxEVmmT3zDpcF3EipadoZOcx5GNARd0s3tQmyILoWOokwE3JstuM689Hii1aOnjAM/3nY8A83bLrPp5CmFFlW1FCafm70ZqLeHt8Z4JeOcPmFlDIAVaB5Ie9yeZOySVejyU4Y8RN9E7Es+YwmY9j2G+zgm84tnoVKsNSExkX/SP8z1O+Es5WCnz0QrUdBmD9PglM1sHw3aj0rqKBp7Kb2hNcmLs7O5r2Vfyczi6ta5o3gNVHUSjvd4HAoc=","cancellation_requested":true,"status":"inProgress","status_details":"Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.","request_id":"b07519002560445299b63865c6e36c58"}, [
   'Cache-Control',
   'no-cache',
   'Pragma',
@@ -340,15 +303,15 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'Expires',
   '-1',
   'x-ms-keyvault-region',
-  'eastus',
+  'westus2',
   'x-ms-client-request-id',
-  '84e74077-aff6-46a0-829f-0e6602418d7e',
+  'd9f62039-d151-46b8-9519-483491c0f789',
   'x-ms-request-id',
-  'ca4d8396-96b1-4eaa-839d-9450bc5e9d5f',
+  '079b42c4-7850-489b-bbae-3a5ddb7384f9',
   'x-ms-keyvault-service-version',
-  '1.2.265.0',
+  '1.9.79.2',
   'x-ms-keyvault-network-info',
-  'conn_type=Ipv4;addr=IP_ADDRESS;act_addr_fam=InterNetwork;',
+  'conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;',
   'X-Powered-By',
   'ASP.NET',
   'Strict-Transport-Security',
@@ -356,15 +319,15 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Wed, 28 Apr 2021 20:35:09 GMT',
+  'Mon, 20 Sep 2021 22:10:27 GMT',
   'Content-Length',
-  '1357'
+  '1301'
 ]);
 
 nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
-  .get('/certificates/CRUDCertificateName-canreadcancelanddeleteacertificatesoperation-/')
+  .delete('/certificates/crudcertoperation163217582585603322/pending')
   .query(true)
-  .reply(200, {"id":"https://keyvault_name.vault.azure.net/certificates/CRUDCertificateName-canreadcancelanddeleteacertificatesoperation-/fcc7c2267fa84d5f98defdba0bd9a23e","attributes":{"enabled":false,"nbf":1619641509,"exp":1651178109,"created":1619642109,"updated":1619642109,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90},"policy":{"id":"https://keyvault_name.vault.azure.net/certificates/CRUDCertificateName-canreadcancelanddeleteacertificatesoperation-/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pkcs12"},"x509_props":{"subject":"cn=MyCert","sans":{},"ekus":["1.3.6.1.5.5.7.3.1","1.3.6.1.5.5.7.3.2"],"key_usage":["digitalSignature","keyEncipherment"],"validity_months":12,"basic_constraints":{"ca":false}},"lifetime_actions":[{"trigger":{"lifetime_percentage":80},"action":{"action_type":"AutoRenew"}}],"issuer":{"name":"Self"},"attributes":{"enabled":true,"created":1619642109,"updated":1619642109}}}, [
+  .reply(200, {"id":"https://keyvault_name.vault.azure.net/certificates/crudcertoperation163217582585603322/pending","issuer":{"name":"Self"},"csr":"MIICoTCCAYkCAQAwETEPMA0GA1UEAxMGTXlDZXJ0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAsyKMqBkKG2iPqCcHDKn0bDTCq+oc0eRfFOa87ZJSEnoY4y4rY24SF/YfGg3xsb277bH9E6I9Ddd/hVVb1W90+AFmWTfjmO5085MZqMzvu22ZSMgs+HSmVfjF8IpBM87Jv9T+ldASoQVh1I4cLPi14IeMNx1jnTpeVresjgiOfEhr8mTG9smsrcK+EVvY4EEQ5id614BemSrY6HW6FVgbHhae76sLVjZkmUcD3hOOMX0ldUhyo4lQ5efX67v7PEGh/cwdpRYPgp9ilLsEeTz0+nVAEtKSaaHRC8Dmcqqf3ghHXTx70LXhz4eym/RDgpdeH85Q8GKttA9cb0j7uWJ1OQIDAQABoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwDQYJKoZIhvcNAQELBQADggEBAFQ3a8iRtaSoNOjTPA+eH8gkfjvvVy1BvTMyJ3AgQKgAJIG1IIN+npA4qZgZ1A92xXCJsKaYFm5gxvrsGiXkVDn5MFK0eUxEVmmT3zDpcF3EipadoZOcx5GNARd0s3tQmyILoWOokwE3JstuM689Hii1aOnjAM/3nY8A83bLrPp5CmFFlW1FCafm70ZqLeHt8Z4JeOcPmFlDIAVaB5Ie9yeZOySVejyU4Y8RN9E7Es+YwmY9j2G+zgm84tnoVKsNSExkX/SP8z1O+Es5WCnz0QrUdBmD9PglM1sHw3aj0rqKBp7Kb2hNcmLs7O5r2Vfyczi6ta5o3gNVHUSjvd4HAoc=","cancellation_requested":true,"status":"inProgress","status_details":"Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.","request_id":"b07519002560445299b63865c6e36c58"}, [
   'Cache-Control',
   'no-cache',
   'Pragma',
@@ -374,15 +337,15 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'Expires',
   '-1',
   'x-ms-keyvault-region',
-  'eastus',
+  'westus2',
   'x-ms-client-request-id',
-  '9cff57b0-b88c-4616-a48e-2976f68e6114',
+  '89cdb365-d1f9-491c-9273-28af64ea08a6',
   'x-ms-request-id',
-  '81c44baf-5878-4812-8309-9c49a6326b44',
+  '75db12df-9f31-4783-98f9-a8b6698a5319',
   'x-ms-keyvault-service-version',
-  '1.2.265.0',
+  '1.9.79.2',
   'x-ms-keyvault-network-info',
-  'conn_type=Ipv4;addr=IP_ADDRESS;act_addr_fam=InterNetwork;',
+  'conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;',
   'X-Powered-By',
   'ASP.NET',
   'Strict-Transport-Security',
@@ -390,49 +353,15 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Wed, 28 Apr 2021 20:35:09 GMT',
+  'Mon, 20 Sep 2021 22:10:27 GMT',
   'Content-Length',
-  '1039'
+  '1301'
 ]);
 
 nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
-  .get('/certificates/CRUDCertificateName-canreadcancelanddeleteacertificatesoperation-/pending')
+  .get('/certificates/crudcertoperation163217582585603322/')
   .query(true)
-  .reply(404, {"error":{"code":"PendingCertificateNotFound","message":"Pending certificate not found: CRUDCertificateName-canreadcancelanddeleteacertificatesoperation-"}}, [
-  'Cache-Control',
-  'no-cache',
-  'Pragma',
-  'no-cache',
-  'Content-Length',
-  '172',
-  'Content-Type',
-  'application/json; charset=utf-8',
-  'Expires',
-  '-1',
-  'x-ms-keyvault-region',
-  'eastus',
-  'x-ms-client-request-id',
-  'ca19156f-c6dd-4a66-a529-e5a0a63cccb6',
-  'x-ms-request-id',
-  'b411430c-401b-4521-9269-126935156adc',
-  'x-ms-keyvault-service-version',
-  '1.2.265.0',
-  'x-ms-keyvault-network-info',
-  'conn_type=Ipv4;addr=IP_ADDRESS;act_addr_fam=InterNetwork;',
-  'X-Powered-By',
-  'ASP.NET',
-  'Strict-Transport-Security',
-  'max-age=31536000;includeSubDomains',
-  'X-Content-Type-Options',
-  'nosniff',
-  'Date',
-  'Wed, 28 Apr 2021 20:35:09 GMT'
-]);
-
-nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
-  .delete('/certificates/CRUDCertificateName-canreadcancelanddeleteacertificatesoperation-')
-  .query(true)
-  .reply(200, {"recoveryId":"https://keyvault_name.vault.azure.net/deletedcertificates/CRUDCertificateName-canreadcancelanddeleteacertificatesoperation-","deletedDate":1619642110,"scheduledPurgeDate":1627418110,"id":"https://keyvault_name.vault.azure.net/certificates/CRUDCertificateName-canreadcancelanddeleteacertificatesoperation-/fcc7c2267fa84d5f98defdba0bd9a23e","attributes":{"enabled":false,"nbf":1619641509,"exp":1651178109,"created":1619642109,"updated":1619642109,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90},"policy":{"id":"https://keyvault_name.vault.azure.net/certificates/CRUDCertificateName-canreadcancelanddeleteacertificatesoperation-/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pkcs12"},"x509_props":{"subject":"cn=MyCert","sans":{},"ekus":["1.3.6.1.5.5.7.3.1","1.3.6.1.5.5.7.3.2"],"key_usage":["digitalSignature","keyEncipherment"],"validity_months":12,"basic_constraints":{"ca":false}},"lifetime_actions":[{"trigger":{"lifetime_percentage":80},"action":{"action_type":"AutoRenew"}}],"issuer":{"name":"Self"},"attributes":{"enabled":true,"created":1619642109,"updated":1619642109}}}, [
+  .reply(200, {"id":"https://keyvault_name.vault.azure.net/certificates/crudcertoperation163217582585603322/7b6db81563e048a395d93aab7de5d155","attributes":{"enabled":false,"nbf":1632175226,"exp":1663711826,"created":1632175826,"updated":1632175826,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7},"policy":{"id":"https://keyvault_name.vault.azure.net/certificates/crudcertoperation163217582585603322/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pkcs12"},"x509_props":{"subject":"cn=MyCert","sans":{},"ekus":["1.3.6.1.5.5.7.3.1","1.3.6.1.5.5.7.3.2"],"key_usage":["digitalSignature","keyEncipherment"],"validity_months":12,"basic_constraints":{"ca":false}},"lifetime_actions":[{"trigger":{"lifetime_percentage":80},"action":{"action_type":"AutoRenew"}}],"issuer":{"name":"Self"},"attributes":{"enabled":true,"created":1632175827,"updated":1632175827}}}, [
   'Cache-Control',
   'no-cache',
   'Pragma',
@@ -442,15 +371,15 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'Expires',
   '-1',
   'x-ms-keyvault-region',
-  'eastus',
+  'westus2',
   'x-ms-client-request-id',
-  'f1f2b9a4-74e6-462b-bdc9-6472ce12fa5c',
+  '28a10ac5-2598-4586-90ec-4551ff1ee7a6',
   'x-ms-request-id',
-  'ac71e48e-586a-40eb-826b-9593ba708d01',
+  'eca137f0-008e-4470-97da-6edd39bae983',
   'x-ms-keyvault-service-version',
-  '1.2.265.0',
+  '1.9.79.2',
   'x-ms-keyvault-network-info',
-  'conn_type=Ipv4;addr=IP_ADDRESS;act_addr_fam=InterNetwork;',
+  'conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;',
   'X-Powered-By',
   'ASP.NET',
   'Strict-Transport-Security',
@@ -458,35 +387,35 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Wed, 28 Apr 2021 20:35:09 GMT',
+  'Mon, 20 Sep 2021 22:10:27 GMT',
   'Content-Length',
-  '1257'
+  '936'
 ]);
 
 nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
-  .get('/deletedcertificates/CRUDCertificateName-canreadcancelanddeleteacertificatesoperation-')
+  .get('/certificates/crudcertoperation163217582585603322/pending')
   .query(true)
-  .reply(404, {"error":{"code":"CertificateNotFound","message":"Deleted Certificate not found: CRUDCertificateName-canreadcancelanddeleteacertificatesoperation-"}}, [
+  .reply(404, {"error":{"code":"PendingCertificateNotFound","message":"Pending certificate not found: crudcertoperation163217582585603322"}}, [
   'Cache-Control',
   'no-cache',
   'Pragma',
   'no-cache',
   'Content-Length',
-  '165',
+  '126',
   'Content-Type',
   'application/json; charset=utf-8',
   'Expires',
   '-1',
   'x-ms-keyvault-region',
-  'eastus',
+  'westus2',
   'x-ms-client-request-id',
-  'ae9e076e-a93c-4e7c-95a3-8228ff30bdc6',
+  '23c0460a-3245-431b-a5af-4e5d0769464e',
   'x-ms-request-id',
-  '45ec8cc0-bed6-4197-81fa-cc0b3e61a7b9',
+  '56e7e288-1995-435c-9dc4-f4c5aafe706a',
   'x-ms-keyvault-service-version',
-  '1.2.265.0',
+  '1.9.79.2',
   'x-ms-keyvault-network-info',
-  'conn_type=Ipv4;addr=IP_ADDRESS;act_addr_fam=InterNetwork;',
+  'conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;',
   'X-Powered-By',
   'ASP.NET',
   'Strict-Transport-Security',
@@ -494,817 +423,5 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Wed, 28 Apr 2021 20:35:09 GMT'
-]);
-
-nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
-  .get('/deletedcertificates/CRUDCertificateName-canreadcancelanddeleteacertificatesoperation-')
-  .query(true)
-  .reply(404, {"error":{"code":"CertificateNotFound","message":"Deleted Certificate not found: CRUDCertificateName-canreadcancelanddeleteacertificatesoperation-"}}, [
-  'Cache-Control',
-  'no-cache',
-  'Pragma',
-  'no-cache',
-  'Content-Length',
-  '165',
-  'Content-Type',
-  'application/json; charset=utf-8',
-  'Expires',
-  '-1',
-  'x-ms-keyvault-region',
-  'eastus',
-  'x-ms-client-request-id',
-  '606abb7f-152e-45c9-a7b5-9054e8c22ea0',
-  'x-ms-request-id',
-  '7e262bb7-d27d-4319-b6f6-81e7442a4d7b',
-  'x-ms-keyvault-service-version',
-  '1.2.265.0',
-  'x-ms-keyvault-network-info',
-  'conn_type=Ipv4;addr=IP_ADDRESS;act_addr_fam=InterNetwork;',
-  'X-Powered-By',
-  'ASP.NET',
-  'Strict-Transport-Security',
-  'max-age=31536000;includeSubDomains',
-  'X-Content-Type-Options',
-  'nosniff',
-  'Date',
-  'Wed, 28 Apr 2021 20:35:09 GMT'
-]);
-
-nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
-  .get('/deletedcertificates/CRUDCertificateName-canreadcancelanddeleteacertificatesoperation-')
-  .query(true)
-  .reply(404, {"error":{"code":"CertificateNotFound","message":"Deleted Certificate not found: CRUDCertificateName-canreadcancelanddeleteacertificatesoperation-"}}, [
-  'Cache-Control',
-  'no-cache',
-  'Pragma',
-  'no-cache',
-  'Content-Length',
-  '165',
-  'Content-Type',
-  'application/json; charset=utf-8',
-  'Expires',
-  '-1',
-  'x-ms-keyvault-region',
-  'eastus',
-  'x-ms-client-request-id',
-  '7582da56-3d36-48b7-a907-7aab4a398c3a',
-  'x-ms-request-id',
-  '17a22256-6313-4b87-a311-4ce579ab9966',
-  'x-ms-keyvault-service-version',
-  '1.2.265.0',
-  'x-ms-keyvault-network-info',
-  'conn_type=Ipv4;addr=IP_ADDRESS;act_addr_fam=InterNetwork;',
-  'X-Powered-By',
-  'ASP.NET',
-  'Strict-Transport-Security',
-  'max-age=31536000;includeSubDomains',
-  'X-Content-Type-Options',
-  'nosniff',
-  'Date',
-  'Wed, 28 Apr 2021 20:35:11 GMT'
-]);
-
-nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
-  .get('/deletedcertificates/CRUDCertificateName-canreadcancelanddeleteacertificatesoperation-')
-  .query(true)
-  .reply(404, {"error":{"code":"CertificateNotFound","message":"Deleted Certificate not found: CRUDCertificateName-canreadcancelanddeleteacertificatesoperation-"}}, [
-  'Cache-Control',
-  'no-cache',
-  'Pragma',
-  'no-cache',
-  'Content-Length',
-  '165',
-  'Content-Type',
-  'application/json; charset=utf-8',
-  'Expires',
-  '-1',
-  'x-ms-keyvault-region',
-  'eastus',
-  'x-ms-client-request-id',
-  'f0258383-e7f1-43ff-ae19-c552537ef600',
-  'x-ms-request-id',
-  '6111f0f9-19ce-4876-8ab5-4bc4a71f2a0c',
-  'x-ms-keyvault-service-version',
-  '1.2.265.0',
-  'x-ms-keyvault-network-info',
-  'conn_type=Ipv4;addr=IP_ADDRESS;act_addr_fam=InterNetwork;',
-  'X-Powered-By',
-  'ASP.NET',
-  'Strict-Transport-Security',
-  'max-age=31536000;includeSubDomains',
-  'X-Content-Type-Options',
-  'nosniff',
-  'Date',
-  'Wed, 28 Apr 2021 20:35:14 GMT'
-]);
-
-nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
-  .get('/deletedcertificates/CRUDCertificateName-canreadcancelanddeleteacertificatesoperation-')
-  .query(true)
-  .reply(404, {"error":{"code":"CertificateNotFound","message":"Deleted Certificate not found: CRUDCertificateName-canreadcancelanddeleteacertificatesoperation-"}}, [
-  'Cache-Control',
-  'no-cache',
-  'Pragma',
-  'no-cache',
-  'Content-Length',
-  '165',
-  'Content-Type',
-  'application/json; charset=utf-8',
-  'Expires',
-  '-1',
-  'x-ms-keyvault-region',
-  'eastus',
-  'x-ms-client-request-id',
-  '7537170c-92df-4f4e-a0e9-97df64dba219',
-  'x-ms-request-id',
-  '46671eec-09ce-4383-809c-c68a97ee3bd3',
-  'x-ms-keyvault-service-version',
-  '1.2.265.0',
-  'x-ms-keyvault-network-info',
-  'conn_type=Ipv4;addr=IP_ADDRESS;act_addr_fam=InterNetwork;',
-  'X-Powered-By',
-  'ASP.NET',
-  'Strict-Transport-Security',
-  'max-age=31536000;includeSubDomains',
-  'X-Content-Type-Options',
-  'nosniff',
-  'Date',
-  'Wed, 28 Apr 2021 20:35:16 GMT'
-]);
-
-nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
-  .get('/deletedcertificates/CRUDCertificateName-canreadcancelanddeleteacertificatesoperation-')
-  .query(true)
-  .reply(404, {"error":{"code":"CertificateNotFound","message":"Deleted Certificate not found: CRUDCertificateName-canreadcancelanddeleteacertificatesoperation-"}}, [
-  'Cache-Control',
-  'no-cache',
-  'Pragma',
-  'no-cache',
-  'Content-Length',
-  '165',
-  'Content-Type',
-  'application/json; charset=utf-8',
-  'Expires',
-  '-1',
-  'x-ms-keyvault-region',
-  'eastus',
-  'x-ms-client-request-id',
-  '6048e164-27ab-459f-bc7f-76332364a0e1',
-  'x-ms-request-id',
-  '918cac6c-e300-4dcb-88d5-3f4de59d8a24',
-  'x-ms-keyvault-service-version',
-  '1.2.265.0',
-  'x-ms-keyvault-network-info',
-  'conn_type=Ipv4;addr=IP_ADDRESS;act_addr_fam=InterNetwork;',
-  'X-Powered-By',
-  'ASP.NET',
-  'Strict-Transport-Security',
-  'max-age=31536000;includeSubDomains',
-  'X-Content-Type-Options',
-  'nosniff',
-  'Date',
-  'Wed, 28 Apr 2021 20:35:18 GMT'
-]);
-
-nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
-  .get('/deletedcertificates/CRUDCertificateName-canreadcancelanddeleteacertificatesoperation-')
-  .query(true)
-  .reply(404, {"error":{"code":"CertificateNotFound","message":"Deleted Certificate not found: CRUDCertificateName-canreadcancelanddeleteacertificatesoperation-"}}, [
-  'Cache-Control',
-  'no-cache',
-  'Pragma',
-  'no-cache',
-  'Content-Length',
-  '165',
-  'Content-Type',
-  'application/json; charset=utf-8',
-  'Expires',
-  '-1',
-  'x-ms-keyvault-region',
-  'eastus',
-  'x-ms-client-request-id',
-  '5cef4807-279f-4843-88a6-33331b2831df',
-  'x-ms-request-id',
-  '3806c23d-bc06-4b77-898c-e7671abfa45b',
-  'x-ms-keyvault-service-version',
-  '1.2.265.0',
-  'x-ms-keyvault-network-info',
-  'conn_type=Ipv4;addr=IP_ADDRESS;act_addr_fam=InterNetwork;',
-  'X-Powered-By',
-  'ASP.NET',
-  'Strict-Transport-Security',
-  'max-age=31536000;includeSubDomains',
-  'X-Content-Type-Options',
-  'nosniff',
-  'Date',
-  'Wed, 28 Apr 2021 20:35:20 GMT'
-]);
-
-nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
-  .get('/deletedcertificates/CRUDCertificateName-canreadcancelanddeleteacertificatesoperation-')
-  .query(true)
-  .reply(404, {"error":{"code":"CertificateNotFound","message":"Deleted Certificate not found: CRUDCertificateName-canreadcancelanddeleteacertificatesoperation-"}}, [
-  'Cache-Control',
-  'no-cache',
-  'Pragma',
-  'no-cache',
-  'Content-Length',
-  '165',
-  'Content-Type',
-  'application/json; charset=utf-8',
-  'Expires',
-  '-1',
-  'x-ms-keyvault-region',
-  'eastus',
-  'x-ms-client-request-id',
-  'a46228cb-7697-455d-8275-f1fc1096b16e',
-  'x-ms-request-id',
-  '74f07e07-1ac6-44db-98ba-97d203dbfac0',
-  'x-ms-keyvault-service-version',
-  '1.2.265.0',
-  'x-ms-keyvault-network-info',
-  'conn_type=Ipv4;addr=IP_ADDRESS;act_addr_fam=InterNetwork;',
-  'X-Powered-By',
-  'ASP.NET',
-  'Strict-Transport-Security',
-  'max-age=31536000;includeSubDomains',
-  'X-Content-Type-Options',
-  'nosniff',
-  'Date',
-  'Wed, 28 Apr 2021 20:35:22 GMT'
-]);
-
-nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
-  .get('/deletedcertificates/CRUDCertificateName-canreadcancelanddeleteacertificatesoperation-')
-  .query(true)
-  .reply(404, {"error":{"code":"CertificateNotFound","message":"Deleted Certificate not found: CRUDCertificateName-canreadcancelanddeleteacertificatesoperation-"}}, [
-  'Cache-Control',
-  'no-cache',
-  'Pragma',
-  'no-cache',
-  'Content-Length',
-  '165',
-  'Content-Type',
-  'application/json; charset=utf-8',
-  'Expires',
-  '-1',
-  'x-ms-keyvault-region',
-  'eastus',
-  'x-ms-client-request-id',
-  'aecb17c6-8251-4adf-a8db-bbdac68188bf',
-  'x-ms-request-id',
-  '85930163-798e-41a8-a30a-703dabe3df14',
-  'x-ms-keyvault-service-version',
-  '1.2.265.0',
-  'x-ms-keyvault-network-info',
-  'conn_type=Ipv4;addr=IP_ADDRESS;act_addr_fam=InterNetwork;',
-  'X-Powered-By',
-  'ASP.NET',
-  'Strict-Transport-Security',
-  'max-age=31536000;includeSubDomains',
-  'X-Content-Type-Options',
-  'nosniff',
-  'Date',
-  'Wed, 28 Apr 2021 20:35:25 GMT'
-]);
-
-nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
-  .get('/deletedcertificates/CRUDCertificateName-canreadcancelanddeleteacertificatesoperation-')
-  .query(true)
-  .reply(404, {"error":{"code":"CertificateNotFound","message":"Deleted Certificate not found: CRUDCertificateName-canreadcancelanddeleteacertificatesoperation-"}}, [
-  'Cache-Control',
-  'no-cache',
-  'Pragma',
-  'no-cache',
-  'Content-Length',
-  '165',
-  'Content-Type',
-  'application/json; charset=utf-8',
-  'Expires',
-  '-1',
-  'x-ms-keyvault-region',
-  'eastus',
-  'x-ms-client-request-id',
-  'd6aad96a-3387-4448-b388-e31de48c2fe1',
-  'x-ms-request-id',
-  '342ac934-a39c-4baf-a3a9-fd7f06cb84c3',
-  'x-ms-keyvault-service-version',
-  '1.2.265.0',
-  'x-ms-keyvault-network-info',
-  'conn_type=Ipv4;addr=IP_ADDRESS;act_addr_fam=InterNetwork;',
-  'X-Powered-By',
-  'ASP.NET',
-  'Strict-Transport-Security',
-  'max-age=31536000;includeSubDomains',
-  'X-Content-Type-Options',
-  'nosniff',
-  'Date',
-  'Wed, 28 Apr 2021 20:35:27 GMT'
-]);
-
-nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
-  .get('/deletedcertificates/CRUDCertificateName-canreadcancelanddeleteacertificatesoperation-')
-  .query(true)
-  .reply(404, {"error":{"code":"CertificateNotFound","message":"Deleted Certificate not found: CRUDCertificateName-canreadcancelanddeleteacertificatesoperation-"}}, [
-  'Cache-Control',
-  'no-cache',
-  'Pragma',
-  'no-cache',
-  'Content-Length',
-  '165',
-  'Content-Type',
-  'application/json; charset=utf-8',
-  'Expires',
-  '-1',
-  'x-ms-keyvault-region',
-  'eastus',
-  'x-ms-client-request-id',
-  'f1652b57-3558-4c66-b5fb-8cc461b2bb8b',
-  'x-ms-request-id',
-  '3f9b1be3-626d-47a2-9578-dd5ce8e962b9',
-  'x-ms-keyvault-service-version',
-  '1.2.265.0',
-  'x-ms-keyvault-network-info',
-  'conn_type=Ipv4;addr=IP_ADDRESS;act_addr_fam=InterNetwork;',
-  'X-Powered-By',
-  'ASP.NET',
-  'Strict-Transport-Security',
-  'max-age=31536000;includeSubDomains',
-  'X-Content-Type-Options',
-  'nosniff',
-  'Date',
-  'Wed, 28 Apr 2021 20:35:28 GMT'
-]);
-
-nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
-  .get('/deletedcertificates/CRUDCertificateName-canreadcancelanddeleteacertificatesoperation-')
-  .query(true)
-  .reply(404, {"error":{"code":"CertificateNotFound","message":"Deleted Certificate not found: CRUDCertificateName-canreadcancelanddeleteacertificatesoperation-"}}, [
-  'Cache-Control',
-  'no-cache',
-  'Pragma',
-  'no-cache',
-  'Content-Length',
-  '165',
-  'Content-Type',
-  'application/json; charset=utf-8',
-  'Expires',
-  '-1',
-  'x-ms-keyvault-region',
-  'eastus',
-  'x-ms-client-request-id',
-  'af045b54-5f5d-4503-8c75-594f488408a8',
-  'x-ms-request-id',
-  'da2fe06f-11c6-4e8a-b87b-8b820cae9181',
-  'x-ms-keyvault-service-version',
-  '1.2.265.0',
-  'x-ms-keyvault-network-info',
-  'conn_type=Ipv4;addr=IP_ADDRESS;act_addr_fam=InterNetwork;',
-  'X-Powered-By',
-  'ASP.NET',
-  'Strict-Transport-Security',
-  'max-age=31536000;includeSubDomains',
-  'X-Content-Type-Options',
-  'nosniff',
-  'Date',
-  'Wed, 28 Apr 2021 20:35:31 GMT'
-]);
-
-nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
-  .get('/deletedcertificates/CRUDCertificateName-canreadcancelanddeleteacertificatesoperation-')
-  .query(true)
-  .reply(404, {"error":{"code":"CertificateNotFound","message":"Deleted Certificate not found: CRUDCertificateName-canreadcancelanddeleteacertificatesoperation-"}}, [
-  'Cache-Control',
-  'no-cache',
-  'Pragma',
-  'no-cache',
-  'Content-Length',
-  '165',
-  'Content-Type',
-  'application/json; charset=utf-8',
-  'Expires',
-  '-1',
-  'x-ms-keyvault-region',
-  'eastus',
-  'x-ms-client-request-id',
-  '6875edea-d545-46b3-ac8e-77ae2ec94d8c',
-  'x-ms-request-id',
-  'db0e585c-bf78-4d2f-9881-546199c41911',
-  'x-ms-keyvault-service-version',
-  '1.2.265.0',
-  'x-ms-keyvault-network-info',
-  'conn_type=Ipv4;addr=IP_ADDRESS;act_addr_fam=InterNetwork;',
-  'X-Powered-By',
-  'ASP.NET',
-  'Strict-Transport-Security',
-  'max-age=31536000;includeSubDomains',
-  'X-Content-Type-Options',
-  'nosniff',
-  'Date',
-  'Wed, 28 Apr 2021 20:35:33 GMT'
-]);
-
-nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
-  .get('/deletedcertificates/CRUDCertificateName-canreadcancelanddeleteacertificatesoperation-')
-  .query(true)
-  .reply(404, {"error":{"code":"CertificateNotFound","message":"Deleted Certificate not found: CRUDCertificateName-canreadcancelanddeleteacertificatesoperation-"}}, [
-  'Cache-Control',
-  'no-cache',
-  'Pragma',
-  'no-cache',
-  'Content-Length',
-  '165',
-  'Content-Type',
-  'application/json; charset=utf-8',
-  'Expires',
-  '-1',
-  'x-ms-keyvault-region',
-  'eastus',
-  'x-ms-client-request-id',
-  'c826bb88-4db5-4128-ac61-57040384dee2',
-  'x-ms-request-id',
-  'ccad05ff-c970-45c4-b2f9-1f2314912989',
-  'x-ms-keyvault-service-version',
-  '1.2.265.0',
-  'x-ms-keyvault-network-info',
-  'conn_type=Ipv4;addr=IP_ADDRESS;act_addr_fam=InterNetwork;',
-  'X-Powered-By',
-  'ASP.NET',
-  'Strict-Transport-Security',
-  'max-age=31536000;includeSubDomains',
-  'X-Content-Type-Options',
-  'nosniff',
-  'Date',
-  'Wed, 28 Apr 2021 20:35:35 GMT'
-]);
-
-nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
-  .get('/deletedcertificates/CRUDCertificateName-canreadcancelanddeleteacertificatesoperation-')
-  .query(true)
-  .reply(404, {"error":{"code":"CertificateNotFound","message":"Deleted Certificate not found: CRUDCertificateName-canreadcancelanddeleteacertificatesoperation-"}}, [
-  'Cache-Control',
-  'no-cache',
-  'Pragma',
-  'no-cache',
-  'Content-Length',
-  '165',
-  'Content-Type',
-  'application/json; charset=utf-8',
-  'Expires',
-  '-1',
-  'x-ms-keyvault-region',
-  'eastus',
-  'x-ms-client-request-id',
-  'b3d27777-1054-456a-808d-ca7456832be9',
-  'x-ms-request-id',
-  'd133bc40-2851-4cec-9141-67d299e04d38',
-  'x-ms-keyvault-service-version',
-  '1.2.265.0',
-  'x-ms-keyvault-network-info',
-  'conn_type=Ipv4;addr=IP_ADDRESS;act_addr_fam=InterNetwork;',
-  'X-Powered-By',
-  'ASP.NET',
-  'Strict-Transport-Security',
-  'max-age=31536000;includeSubDomains',
-  'X-Content-Type-Options',
-  'nosniff',
-  'Date',
-  'Wed, 28 Apr 2021 20:35:38 GMT'
-]);
-
-nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
-  .get('/deletedcertificates/CRUDCertificateName-canreadcancelanddeleteacertificatesoperation-')
-  .query(true)
-  .reply(404, {"error":{"code":"CertificateNotFound","message":"Deleted Certificate not found: CRUDCertificateName-canreadcancelanddeleteacertificatesoperation-"}}, [
-  'Cache-Control',
-  'no-cache',
-  'Pragma',
-  'no-cache',
-  'Content-Length',
-  '165',
-  'Content-Type',
-  'application/json; charset=utf-8',
-  'Expires',
-  '-1',
-  'x-ms-keyvault-region',
-  'eastus',
-  'x-ms-client-request-id',
-  '52ffc9c7-dc1f-4930-8539-27505d677116',
-  'x-ms-request-id',
-  'e3610e08-e975-4ae5-b139-30bd39beff58',
-  'x-ms-keyvault-service-version',
-  '1.2.265.0',
-  'x-ms-keyvault-network-info',
-  'conn_type=Ipv4;addr=IP_ADDRESS;act_addr_fam=InterNetwork;',
-  'X-Powered-By',
-  'ASP.NET',
-  'Strict-Transport-Security',
-  'max-age=31536000;includeSubDomains',
-  'X-Content-Type-Options',
-  'nosniff',
-  'Date',
-  'Wed, 28 Apr 2021 20:35:40 GMT'
-]);
-
-nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
-  .get('/deletedcertificates/CRUDCertificateName-canreadcancelanddeleteacertificatesoperation-')
-  .query(true)
-  .reply(404, {"error":{"code":"CertificateNotFound","message":"Deleted Certificate not found: CRUDCertificateName-canreadcancelanddeleteacertificatesoperation-"}}, [
-  'Cache-Control',
-  'no-cache',
-  'Pragma',
-  'no-cache',
-  'Content-Length',
-  '165',
-  'Content-Type',
-  'application/json; charset=utf-8',
-  'Expires',
-  '-1',
-  'x-ms-keyvault-region',
-  'eastus',
-  'x-ms-client-request-id',
-  '2c27bbc3-d485-40eb-b0b3-1cd9edbf29a3',
-  'x-ms-request-id',
-  'de618378-3a7f-42fb-861e-f8ee15378f88',
-  'x-ms-keyvault-service-version',
-  '1.2.265.0',
-  'x-ms-keyvault-network-info',
-  'conn_type=Ipv4;addr=IP_ADDRESS;act_addr_fam=InterNetwork;',
-  'X-Powered-By',
-  'ASP.NET',
-  'Strict-Transport-Security',
-  'max-age=31536000;includeSubDomains',
-  'X-Content-Type-Options',
-  'nosniff',
-  'Date',
-  'Wed, 28 Apr 2021 20:35:42 GMT'
-]);
-
-nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
-  .get('/deletedcertificates/CRUDCertificateName-canreadcancelanddeleteacertificatesoperation-')
-  .query(true)
-  .reply(404, {"error":{"code":"CertificateNotFound","message":"Deleted Certificate not found: CRUDCertificateName-canreadcancelanddeleteacertificatesoperation-"}}, [
-  'Cache-Control',
-  'no-cache',
-  'Pragma',
-  'no-cache',
-  'Content-Length',
-  '165',
-  'Content-Type',
-  'application/json; charset=utf-8',
-  'Expires',
-  '-1',
-  'x-ms-keyvault-region',
-  'eastus',
-  'x-ms-client-request-id',
-  'e659541c-2f06-474b-9aaf-98f4ff675dc3',
-  'x-ms-request-id',
-  '15b02486-c1ee-494a-9c9e-b5667a8986be',
-  'x-ms-keyvault-service-version',
-  '1.2.265.0',
-  'x-ms-keyvault-network-info',
-  'conn_type=Ipv4;addr=IP_ADDRESS;act_addr_fam=InterNetwork;',
-  'X-Powered-By',
-  'ASP.NET',
-  'Strict-Transport-Security',
-  'max-age=31536000;includeSubDomains',
-  'X-Content-Type-Options',
-  'nosniff',
-  'Date',
-  'Wed, 28 Apr 2021 20:35:43 GMT'
-]);
-
-nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
-  .get('/deletedcertificates/CRUDCertificateName-canreadcancelanddeleteacertificatesoperation-')
-  .query(true)
-  .reply(404, {"error":{"code":"CertificateNotFound","message":"Deleted Certificate not found: CRUDCertificateName-canreadcancelanddeleteacertificatesoperation-"}}, [
-  'Cache-Control',
-  'no-cache',
-  'Pragma',
-  'no-cache',
-  'Content-Length',
-  '165',
-  'Content-Type',
-  'application/json; charset=utf-8',
-  'Expires',
-  '-1',
-  'x-ms-keyvault-region',
-  'eastus',
-  'x-ms-client-request-id',
-  '1a96f2c7-9e2d-40df-a929-1d61c734b72b',
-  'x-ms-request-id',
-  '7de3394f-7762-495d-a94d-c77e07ea4437',
-  'x-ms-keyvault-service-version',
-  '1.2.265.0',
-  'x-ms-keyvault-network-info',
-  'conn_type=Ipv4;addr=IP_ADDRESS;act_addr_fam=InterNetwork;',
-  'X-Powered-By',
-  'ASP.NET',
-  'Strict-Transport-Security',
-  'max-age=31536000;includeSubDomains',
-  'X-Content-Type-Options',
-  'nosniff',
-  'Date',
-  'Wed, 28 Apr 2021 20:35:46 GMT'
-]);
-
-nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
-  .get('/deletedcertificates/CRUDCertificateName-canreadcancelanddeleteacertificatesoperation-')
-  .query(true)
-  .reply(404, {"error":{"code":"CertificateNotFound","message":"Deleted Certificate not found: CRUDCertificateName-canreadcancelanddeleteacertificatesoperation-"}}, [
-  'Cache-Control',
-  'no-cache',
-  'Pragma',
-  'no-cache',
-  'Content-Length',
-  '165',
-  'Content-Type',
-  'application/json; charset=utf-8',
-  'Expires',
-  '-1',
-  'x-ms-keyvault-region',
-  'eastus',
-  'x-ms-client-request-id',
-  'acb7539f-4a12-4a48-be1c-bc3b0150f5cb',
-  'x-ms-request-id',
-  'ea3bc2e9-abcc-41dc-b54d-50e8f5cea39f',
-  'x-ms-keyvault-service-version',
-  '1.2.265.0',
-  'x-ms-keyvault-network-info',
-  'conn_type=Ipv4;addr=IP_ADDRESS;act_addr_fam=InterNetwork;',
-  'X-Powered-By',
-  'ASP.NET',
-  'Strict-Transport-Security',
-  'max-age=31536000;includeSubDomains',
-  'X-Content-Type-Options',
-  'nosniff',
-  'Date',
-  'Wed, 28 Apr 2021 20:35:48 GMT'
-]);
-
-nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
-  .get('/deletedcertificates/CRUDCertificateName-canreadcancelanddeleteacertificatesoperation-')
-  .query(true)
-  .reply(404, {"error":{"code":"CertificateNotFound","message":"Deleted Certificate not found: CRUDCertificateName-canreadcancelanddeleteacertificatesoperation-"}}, [
-  'Cache-Control',
-  'no-cache',
-  'Pragma',
-  'no-cache',
-  'Content-Length',
-  '165',
-  'Content-Type',
-  'application/json; charset=utf-8',
-  'Expires',
-  '-1',
-  'x-ms-keyvault-region',
-  'eastus',
-  'x-ms-client-request-id',
-  '4351ecbd-92e1-4642-a217-41bcbb351a64',
-  'x-ms-request-id',
-  '212f60e6-90c6-4548-9111-323a406e9912',
-  'x-ms-keyvault-service-version',
-  '1.2.265.0',
-  'x-ms-keyvault-network-info',
-  'conn_type=Ipv4;addr=IP_ADDRESS;act_addr_fam=InterNetwork;',
-  'X-Powered-By',
-  'ASP.NET',
-  'Strict-Transport-Security',
-  'max-age=31536000;includeSubDomains',
-  'X-Content-Type-Options',
-  'nosniff',
-  'Date',
-  'Wed, 28 Apr 2021 20:35:50 GMT'
-]);
-
-nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
-  .get('/deletedcertificates/CRUDCertificateName-canreadcancelanddeleteacertificatesoperation-')
-  .query(true)
-  .reply(404, {"error":{"code":"CertificateNotFound","message":"Deleted Certificate not found: CRUDCertificateName-canreadcancelanddeleteacertificatesoperation-"}}, [
-  'Cache-Control',
-  'no-cache',
-  'Pragma',
-  'no-cache',
-  'Content-Length',
-  '165',
-  'Content-Type',
-  'application/json; charset=utf-8',
-  'Expires',
-  '-1',
-  'x-ms-keyvault-region',
-  'eastus',
-  'x-ms-client-request-id',
-  '63990973-faf1-423b-a6c3-316e849eca59',
-  'x-ms-request-id',
-  '01a59369-6e80-4982-bde7-7acf2125803d',
-  'x-ms-keyvault-service-version',
-  '1.2.265.0',
-  'x-ms-keyvault-network-info',
-  'conn_type=Ipv4;addr=IP_ADDRESS;act_addr_fam=InterNetwork;',
-  'X-Powered-By',
-  'ASP.NET',
-  'Strict-Transport-Security',
-  'max-age=31536000;includeSubDomains',
-  'X-Content-Type-Options',
-  'nosniff',
-  'Date',
-  'Wed, 28 Apr 2021 20:35:52 GMT'
-]);
-
-nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
-  .get('/deletedcertificates/CRUDCertificateName-canreadcancelanddeleteacertificatesoperation-')
-  .query(true)
-  .reply(404, {"error":{"code":"CertificateNotFound","message":"Deleted Certificate not found: CRUDCertificateName-canreadcancelanddeleteacertificatesoperation-"}}, [
-  'Cache-Control',
-  'no-cache',
-  'Pragma',
-  'no-cache',
-  'Content-Length',
-  '165',
-  'Content-Type',
-  'application/json; charset=utf-8',
-  'Expires',
-  '-1',
-  'x-ms-keyvault-region',
-  'eastus',
-  'x-ms-client-request-id',
-  '38aeffe1-7f4f-4456-984d-b21ba68b53f1',
-  'x-ms-request-id',
-  'f79500b9-4ad5-4c82-b6d4-67450f828145',
-  'x-ms-keyvault-service-version',
-  '1.2.265.0',
-  'x-ms-keyvault-network-info',
-  'conn_type=Ipv4;addr=IP_ADDRESS;act_addr_fam=InterNetwork;',
-  'X-Powered-By',
-  'ASP.NET',
-  'Strict-Transport-Security',
-  'max-age=31536000;includeSubDomains',
-  'X-Content-Type-Options',
-  'nosniff',
-  'Date',
-  'Wed, 28 Apr 2021 20:35:55 GMT'
-]);
-
-nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
-  .get('/deletedcertificates/CRUDCertificateName-canreadcancelanddeleteacertificatesoperation-')
-  .query(true)
-  .reply(200, {"recoveryId":"https://keyvault_name.vault.azure.net/deletedcertificates/CRUDCertificateName-canreadcancelanddeleteacertificatesoperation-","deletedDate":1619642110,"scheduledPurgeDate":1627418110,"id":"https://keyvault_name.vault.azure.net/certificates/CRUDCertificateName-canreadcancelanddeleteacertificatesoperation-/fcc7c2267fa84d5f98defdba0bd9a23e","attributes":{"enabled":false,"nbf":1619641509,"exp":1651178109,"created":1619642109,"updated":1619642109,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90},"policy":{"id":"https://keyvault_name.vault.azure.net/certificates/CRUDCertificateName-canreadcancelanddeleteacertificatesoperation-/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pkcs12"},"x509_props":{"subject":"cn=MyCert","sans":{},"ekus":["1.3.6.1.5.5.7.3.1","1.3.6.1.5.5.7.3.2"],"key_usage":["digitalSignature","keyEncipherment"],"validity_months":12,"basic_constraints":{"ca":false}},"lifetime_actions":[{"trigger":{"lifetime_percentage":80},"action":{"action_type":"AutoRenew"}}],"issuer":{"name":"Self"},"attributes":{"enabled":true,"created":1619642109,"updated":1619642109}}}, [
-  'Cache-Control',
-  'no-cache',
-  'Pragma',
-  'no-cache',
-  'Content-Type',
-  'application/json; charset=utf-8',
-  'Expires',
-  '-1',
-  'x-ms-keyvault-region',
-  'eastus',
-  'x-ms-client-request-id',
-  '2e551864-ab07-466c-ac7c-c22d8adca185',
-  'x-ms-request-id',
-  '67ae449e-4333-48eb-b73d-b45be98b0680',
-  'x-ms-keyvault-service-version',
-  '1.2.265.0',
-  'x-ms-keyvault-network-info',
-  'conn_type=Ipv4;addr=IP_ADDRESS;act_addr_fam=InterNetwork;',
-  'X-Powered-By',
-  'ASP.NET',
-  'Strict-Transport-Security',
-  'max-age=31536000;includeSubDomains',
-  'X-Content-Type-Options',
-  'nosniff',
-  'Date',
-  'Wed, 28 Apr 2021 20:35:56 GMT',
-  'Content-Length',
-  '1257'
-]);
-
-nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
-  .delete('/deletedcertificates/CRUDCertificateName-canreadcancelanddeleteacertificatesoperation-')
-  .query(true)
-  .reply(204, "", [
-  'Cache-Control',
-  'no-cache',
-  'Pragma',
-  'no-cache',
-  'Expires',
-  '-1',
-  'x-ms-keyvault-region',
-  'eastus',
-  'x-ms-client-request-id',
-  '845b3556-35a8-49fa-a642-84035889a086',
-  'x-ms-request-id',
-  '8e6ed29c-d904-4775-9ea5-b71da70296d7',
-  'x-ms-keyvault-service-version',
-  '1.2.265.0',
-  'x-ms-keyvault-network-info',
-  'conn_type=Ipv4;addr=IP_ADDRESS;act_addr_fam=InterNetwork;',
-  'X-Powered-By',
-  'ASP.NET',
-  'Strict-Transport-Security',
-  'max-age=31536000;includeSubDomains',
-  'X-Content-Type-Options',
-  'nosniff',
-  'Date',
-  'Wed, 28 Apr 2021 20:35:57 GMT'
+  'Mon, 20 Sep 2021 22:10:27 GMT'
 ]);

--- a/sdk/keyvault/keyvault-certificates/test/public/CRUD.spec.ts
+++ b/sdk/keyvault/keyvault-certificates/test/public/CRUD.spec.ts
@@ -552,7 +552,10 @@ describe("Certificates client - create, read, update and delete", () => {
   });
 
   it("can read, cancel and delete a certificate's operation", async function(this: Context) {
-    const certificateName = testClient.formatName(`${prefix}-${this!.test!.title}-${suffix}`);
+    // Known flaky test due to the lag between the request and when the job gets picked up by the service.
+    this.retries(2);
+
+    const certificateName = recorder.getUniqueName("crudcertoperation");
     await client.beginCreateCertificate(
       certificateName,
       basicCertificatePolicy,


### PR DESCRIPTION
## What

- Automatically retry a certificate test that is known to be flaky up to 2 times (so 3 times total)
- Use the recorder.getUniqueName instead of the test name for the certificate name

## Why

- This test has been flaky for quite some time, and is known to fail when the service does not pick up the cancel operation job fast enough. This is both known and expected and the client should be resilient to such things. But in this case we are explicitly testing the error case and I did not want to remove that bit of safety
- Switching to using the recorder is IMO a preferred approach - and I have been doing that every time I re-record a test.

Resolves #17737 
Resolves #17599