### PR TITLE
Enable release stage selection at queue time

### DIFF
--- a/eng/pipelines/templates/stages/archetype-js-release.yml
+++ b/eng/pipelines/templates/stages/archetype-js-release.yml
@@ -10,9 +10,9 @@ parameters:
   ServiceDirectory: ''
 
 stages:
-  - ${{if and(eq(variables['Build.Reason'], 'Manual'), eq(variables['System.TeamProject'], 'internal'))}}:
+  - ${{if and(in(variables['Build.Reason'], 'Manual', ''), eq(variables['System.TeamProject'], 'internal'))}}:
     - ${{ each artifact in parameters.Artifacts }}:
-      - stage: Release_${{artifact.safeName}}
+      - stage:
         displayName: 'Release: ${{artifact.name}}'
         dependsOn: ${{parameters.DependsOn}}
         condition: and(succeeded(), ne(variables['SetDevVersion'], 'true'), ne(variables['Skip.Release'], 'true'), ne(variables['Build.Repository.Name'], 'Azure/azure-sdk-for-js-pr'))
@@ -53,7 +53,7 @@ stages:
                         ReleaseSha: $(Build.SourceVersion)
                         RepoId: Azure/azure-sdk-for-js
                         WorkingDirectory: $(System.DefaultWorkingDirectory)
-                    
+
           - ${{if ne(artifact.skipPublishPackage, 'true')}}:
             - deployment: PublishPackage
               displayName: "Publish to npmjs"
@@ -123,13 +123,13 @@ stages:
                     steps:
                       - template: /eng/common/pipelines/templates/steps/sparse-checkout.yml
                         parameters:
-                          SkipDefaultCheckout: true 
+                          SkipDefaultCheckout: true
                           Paths:
                             - sdk/**/*.md
                       - download: current
                       - template: /eng/common/pipelines/templates/steps/update-docsms-metadata.yml
                         parameters:
-                          PackageInfoLocations: 
+                          PackageInfoLocations:
                             - $(Pipeline.Workspace)/${{parameters.ArtifactName}}/PackageInfo/${{artifact.name}}.json
                           RepoId: Azure/azure-sdk-for-js
                           WorkingDirectory: $(System.DefaultWorkingDirectory)
@@ -265,10 +265,10 @@ stages:
                 }
                 echo "##vso[task.setvariable variable=NpmToken]$npmToken"
                 echo "##vso[task.setvariable variable=Registry]$registry"
-              displayName: Detecting package archive_${{artifact.safeName}}
+              displayName: Detecting package archive_${{artifact.name}}
 
             - task: PowerShell@2
-              displayName: "Publish_${{artifact.safeName}} to dev feed"
+              displayName: "Publish_${{artifact.name}} to dev feed"
               inputs:
                 targetType: filePath
                 filePath: "eng/tools/publish-to-npm.ps1"
@@ -282,7 +282,7 @@ stages:
       steps:
         - template: /eng/common/pipelines/templates/steps/sparse-checkout.yml
           parameters:
-            SkipDefaultCheckout: true 
+            SkipDefaultCheckout: true
             Paths:
               - sdk/**/*.md
         - download: current


### PR DESCRIPTION
- Remove the need for safeName and let Devops generate a unique identifier since we only ever use the display name. This allows us to stop setting safeName in all our artifact lists, of course that clean-up is a separate set of work.
- When you are trying to queue a manual run DevOps sets Build.Reason to empty which blocks the full generation of stages in the stage selection UI. To work around this we check for Build.Reason empty or Manual. This allows for teams to uncheck a release stage for any packages that they don't plan to release.