### PR TITLE
Accounting for packages without samples

### DIFF
--- a/common/smoke-test/Initialize-SmokeTests.ps1
+++ b/common/smoke-test/Initialize-SmokeTests.ps1
@@ -90,7 +90,7 @@ function Set-EnvironmentVariables {
 
 function New-DeployManifest {
   Write-Verbose "Detecting samples..."
-  $packageDir = Get-ChildItem -Directory -Path "$repoRoot/sdk/$ServiceDirectory/*"
+  $packageDir = Get-ChildItem -Directory -Path "$repoRoot/sdk/$ServiceDirectory/*" | Where-Object { Test-Path "$_/samples/*/javascript/package.json" }
 
   $javascriptSamples = @()
   $packageDir.ForEach{


### PR DESCRIPTION
this fixes the issue with packages blocked for release due to not having samples folder for smoke tests.

===Edit===
No samples directory:
https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1107050&view=logs&j=66d14cf6-6122-58f9-3fdb-c50d455b9823&t=d0e17a21-7b52-5788-da92-bac4253f8e0f&l=162
With samples directory:
https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1107042&view=results