### PR TITLE
Fixing nightly run smoke test

### DIFF
--- a/common/smoke-test/Initialize-SmokeTests.ps1
+++ b/common/smoke-test/Initialize-SmokeTests.ps1
@@ -90,7 +90,7 @@ function Set-EnvironmentVariables {
 
 function New-DeployManifest {
   Write-Verbose "Detecting samples..."
-  $packageDir = Get-ChildItem -Directory -Path "$repoRoot/sdk/$ServiceDirectory/*"
+  $packageDir = Get-ChildItem -Directory -Path "$repoRoot/sdk/$ServiceDirectory/*" | Where-Object { Test-Path "$_/samples/*/javascript/package.json" }
 
   $javascriptSamples = @()
   $packageDir.ForEach{

--- a/eng/pipelines/templates/jobs/smoke.tests.yml
+++ b/eng/pipelines/templates/jobs/smoke.tests.yml
@@ -130,7 +130,6 @@ jobs:
         displayName: Install dev-tool
 
       - download: current
-        artifact: ${{parameters.ArtifactName}}
       - pwsh: |
           $(Build.SourcesDirectory)/eng/common/scripts/Import-AzModules.ps1
 
@@ -141,17 +140,6 @@ jobs:
           $packageOverrides = @()
           $packageOverrides += (dir env: | Where-Object { $_.Name.StartsWith("SMOKE_PACKAGE_") }).Value
 
-          $packageArtifact = Get-ChildItem $(Pipeline.Workspace)/${{parameters.ArtifactName}}/${{parameters.Artifact.name}}/*.tgz
-          if ($packageArtifact.name -notmatch "${{parameters.Artifact.name}}") {
-            Write-Error "Package name mismatch: expecting ${{parameters.Artifact.name}}, found $packageArtifact.name"
-            exit 1
-          }
-          if ($packageArtifact.count -ne 1) {
-            Write-Error "Got $packageArtifact.count packages, expecting 1."
-            exit 1
-          }
-          $result = $(System.DefaultWorkingDirectory)/eng/scripts/get-npm-tags.ps1 -packageArtifact $packageArtifact -workingDirectory $(System.DefaultWorkingDirectory)/temp
-
           if ([System.Convert]::ToBoolean("${{ parameters.Daily }}")) {
             ./Initialize-SmokeTests.ps1 `
               -CI `
@@ -161,6 +149,17 @@ jobs:
               @subscriptionConfiguration `
               -AdditionalParameters $(ArmTemplateParameters)
           } else {
+            $packageArtifact = Get-ChildItem $(Pipeline.Workspace)/${{parameters.ArtifactName}}/${{parameters.Artifact.name}}/*.tgz
+            if ($packageArtifact.name -notmatch "${{parameters.Artifact.name}}") {
+              Write-Error "Package name mismatch: expecting ${{parameters.Artifact.name}}, found $packageArtifact.name"
+              exit 1
+            }
+            if ($packageArtifact.count -ne 1) {
+              Write-Error "Got $packageArtifact.count packages, expecting 1."
+              exit 1
+            }
+            $result = $(System.DefaultWorkingDirectory)/eng/scripts/get-npm-tags.ps1 -packageArtifact $packageArtifact -workingDirectory $(System.DefaultWorkingDirectory)/temp
+
             ./Initialize-SmokeTests.ps1 `
               -CI `
               -Verbose `

--- a/sdk/appconfiguration/app-configuration/package.json
+++ b/sdk/appconfiguration/app-configuration/package.json
@@ -151,6 +151,10 @@
     ],
     "requiredResources": {
       "Azure App Configuration account": "https://docs.microsoft.com/azure/azure-app-configuration/quickstart-aspnet-core-app?tabs=core5x#create-an-app-configuration-store"
-    }
+    },
+    "skip": [
+      "featureFlag.js",
+      "secretReference.js"
+    ]
   }
 }

--- a/sdk/communication/communication-sms/package.json
+++ b/sdk/communication/communication-sms/package.json
@@ -145,6 +145,9 @@
     ],
     "requiredResources": {
       "Azure Communication Services account": "https://docs.microsoft.com/azure/communication-services/quickstarts/create-communication-resource"
-    }
+    },
+    "skip": [
+      "sendSmsWithOptions.js"
+    ]
   }
 }

--- a/sdk/search/search-documents/package.json
+++ b/sdk/search/search-documents/package.json
@@ -140,6 +140,7 @@
     ],
     "requiredResources": {
       "Azure Search Documents instance": "https://docs.microsoft.com/azure/search/search-create-service-portal"
-    }
+    },
+    "skipFolder": true
   }
 }


### PR DESCRIPTION
Bug fix for nightly smoke test to run properly. However, I'm adding some skips for the files/folders with ES6 syntax (export instead of module.export that node supports).

Also tried running node with ESM devDependencies, but the package was last updated 2 years ago, the version of acorn it uses is too old to handle the newest ES syntax (?? and ?.).