### PR TITLE
[Text Analytics] Refine proposed API View

### DIFF
--- a/sdk/textanalytics/ai-text-analytics/CHANGELOG.md
+++ b/sdk/textanalytics/ai-text-analytics/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Features Added
 
 - We are now targeting the service's v3.2-preview.2 API as the default instead of v3.2-preview.1.
-- Adding support for a three new actions in `beginAnalyzeActions`: `customRecognizeEntities`, `customClassifyDocumentSingleCategory`, and `customClassifyDocumentMultiCategories`. The new actions allow you to use custom models to perform entity recognition and classification actions.
+- Adding support for a three new actions in `beginAnalyzeActions`: `recognizeCustomEntities`, `classifyDocumentSingleCategory`, and `classifyDocumentMultiCategories`. The new actions allow you to use custom models to perform entity recognition and classification actions.
 
 ### Breaking Changes
 

--- a/sdk/textanalytics/ai-text-analytics/review/ai-text-analytics.api.md
+++ b/sdk/textanalytics/ai-text-analytics/review/ai-text-analytics.api.md
@@ -35,11 +35,11 @@ export type AnalyzeActionsPollerLike = PollerLike<AnalyzeActionsOperationState, 
 // @public
 export interface AnalyzeActionsResult {
     analyzeSentimentResults: AnalyzeSentimentActionResult[];
-    customClassifyDocumentMultiCategoriesResults: CustomClassifyDocumentMultiCategoriesActionResult[];
-    customClassifyDocumentSingleCategoryResults: CustomClassifyDocumentSingleCategoryActionResult[];
-    customRecognizeEntitiesResults: CustomRecognizeEntitiesActionResult[];
+    classifyDocumentMultiCategoriesResults: ClassifyDocumentMultiCategoriesActionResult[];
+    classifyDocumentSingleCategoryResults: ClassifyDocumentSingleCategoryActionResult[];
     extractKeyPhrasesResults: ExtractKeyPhrasesActionResult[];
     extractSummaryResults: ExtractSummaryActionResult[];
+    recognizeCustomEntitiesResults: RecognizeCustomEntitiesActionResult[];
     recognizeEntitiesResults: RecognizeCategorizedEntitiesActionResult[];
     recognizeLinkedEntitiesResults: RecognizeLinkedEntitiesActionResult[];
     recognizePiiEntitiesResults: RecognizePiiEntitiesActionResult[];
@@ -143,106 +143,71 @@ export interface ClassificationResult {
 }
 
 // @public
-export interface CustomClassifyDocumentMultiCategoriesAction extends CustomTextAnalyticsAction {
+export interface ClassifyDocumentMultiCategoriesAction extends CustomTextAnalyticsAction {
     disableServiceLogs?: boolean;
 }
 
 // @public
-export type CustomClassifyDocumentMultiCategoriesActionErrorResult = TextAnalyticsActionErrorResult;
+export type ClassifyDocumentMultiCategoriesActionErrorResult = TextAnalyticsActionErrorResult;
 
 // @public
-export type CustomClassifyDocumentMultiCategoriesActionResult = CustomClassifyDocumentMultiCategoriesActionSuccessResult | CustomClassifyDocumentMultiCategoriesActionErrorResult;
+export type ClassifyDocumentMultiCategoriesActionResult = ClassifyDocumentMultiCategoriesActionSuccessResult | ClassifyDocumentMultiCategoriesActionErrorResult;
 
 // @public
-export interface CustomClassifyDocumentMultiCategoriesActionSuccessResult extends TextAnalyticsActionSuccessState {
-    results: CustomClassifyDocumentMultiCategoriesResultArray;
+export interface ClassifyDocumentMultiCategoriesActionSuccessResult extends TextAnalyticsActionSuccessState {
+    results: ClassifyDocumentMultiCategoriesResultArray;
 }
 
 // @public
-export type CustomClassifyDocumentMultiCategoriesErrorResult = TextAnalyticsErrorResult;
+export type ClassifyDocumentMultiCategoriesErrorResult = TextAnalyticsErrorResult;
 
 // @public
-export type CustomClassifyDocumentMultiCategoriesResult = CustomClassifyDocumentMultiCategoriesSuccessResult | CustomClassifyDocumentMultiCategoriesErrorResult;
+export type ClassifyDocumentMultiCategoriesResult = ClassifyDocumentMultiCategoriesSuccessResult | ClassifyDocumentMultiCategoriesErrorResult;
 
 // @public
-export interface CustomClassifyDocumentMultiCategoriesResultArray extends Array<CustomClassifyDocumentMultiCategoriesResult> {
+export interface ClassifyDocumentMultiCategoriesResultArray extends Array<ClassifyDocumentMultiCategoriesResult> {
     deploymentName: string;
     projectName: string;
     statistics?: TextDocumentBatchStatistics;
 }
 
 // @public
-export interface CustomClassifyDocumentMultiCategoriesSuccessResult extends TextAnalyticsSuccessResult {
+export interface ClassifyDocumentMultiCategoriesSuccessResult extends TextAnalyticsSuccessResult {
     classifications: DocumentClassification[];
 }
 
 // @public
-export interface CustomClassifyDocumentSingleCategoryAction extends CustomTextAnalyticsAction {
+export interface ClassifyDocumentSingleCategoryAction extends CustomTextAnalyticsAction {
     disableServiceLogs?: boolean;
 }
 
 // @public
-export type CustomClassifyDocumentSingleCategoryActionErrorResult = TextAnalyticsActionErrorResult;
+export type ClassifyDocumentSingleCategoryActionErrorResult = TextAnalyticsActionErrorResult;
 
 // @public
-export type CustomClassifyDocumentSingleCategoryActionResult = CustomClassifyDocumentSingleCategoryActionSuccessResult | CustomClassifyDocumentSingleCategoryActionErrorResult;
+export type ClassifyDocumentSingleCategoryActionResult = ClassifyDocumentSingleCategoryActionSuccessResult | ClassifyDocumentSingleCategoryActionErrorResult;
 
 // @public
-export interface CustomClassifyDocumentSingleCategoryActionSuccessResult extends TextAnalyticsActionSuccessState {
-    results: CustomClassifyDocumentSingleCategoryResultArray;
+export interface ClassifyDocumentSingleCategoryActionSuccessResult extends TextAnalyticsActionSuccessState {
+    results: ClassifyDocumentSingleCategoryResultArray;
 }
 
 // @public
-export type CustomClassifyDocumentSingleCategoryErrorResult = TextAnalyticsErrorResult;
+export type ClassifyDocumentSingleCategoryErrorResult = TextAnalyticsErrorResult;
 
 // @public
-export type CustomClassifyDocumentSingleCategoryResult = CustomClassifyDocumentSingleCategorySuccessResult | CustomClassifyDocumentSingleCategoryErrorResult;
+export type ClassifyDocumentSingleCategoryResult = ClassifyDocumentSingleCategorySuccessResult | ClassifyDocumentSingleCategoryErrorResult;
 
 // @public
-export interface CustomClassifyDocumentSingleCategoryResultArray extends Array<CustomClassifyDocumentSingleCategoryResult> {
+export interface ClassifyDocumentSingleCategoryResultArray extends Array<ClassifyDocumentSingleCategoryResult> {
     deploymentName: string;
     projectName: string;
     statistics?: TextDocumentBatchStatistics;
 }
 
 // @public
-export interface CustomClassifyDocumentSingleCategorySuccessResult extends TextAnalyticsSuccessResult {
+export interface ClassifyDocumentSingleCategorySuccessResult extends TextAnalyticsSuccessResult {
     classification: DocumentClassification;
-}
-
-// @public
-export interface CustomRecognizeEntitiesAction extends CustomTextAnalyticsAction {
-    disableServiceLogs?: boolean;
-    stringIndexType?: StringIndexType;
-}
-
-// @public
-export type CustomRecognizeEntitiesActionResult = CustomRecongizeEntitiesActionSuccessResult | CustomRecongizeEntitiesActionErrorResult;
-
-// @public
-export type CustomRecognizeEntitiesErrorResult = TextAnalyticsErrorResult;
-
-// @public
-export type CustomRecognizeEntitiesResult = CustomRecognizeEntitiesSuccessResult | CustomRecognizeEntitiesErrorResult;
-
-// @public
-export interface CustomRecognizeEntitiesResultArray extends Array<CustomRecognizeEntitiesResult> {
-    deploymentName: string;
-    projectName: string;
-    statistics?: TextDocumentBatchStatistics;
-}
-
-// @public
-export interface CustomRecognizeEntitiesSuccessResult extends TextAnalyticsSuccessResult {
-    entities: CategorizedEntity[];
-}
-
-// @public
-export type CustomRecongizeEntitiesActionErrorResult = TextAnalyticsActionErrorResult;
-
-// @public
-export interface CustomRecongizeEntitiesActionSuccessResult extends TextAnalyticsActionSuccessState {
-    results: CustomRecognizeEntitiesResultArray;
 }
 
 // @public
@@ -631,6 +596,33 @@ export interface RecognizeCategorizedEntitiesSuccessResult extends TextAnalytics
 }
 
 // @public
+export interface RecognizeCustomEntitiesAction extends CustomTextAnalyticsAction {
+    disableServiceLogs?: boolean;
+    stringIndexType?: StringIndexType;
+}
+
+// @public
+export type RecognizeCustomEntitiesActionResult = RecongizeCustomEntitiesActionSuccessResult | RecongizeCustomEntitiesActionErrorResult;
+
+// @public
+export type RecognizeCustomEntitiesErrorResult = TextAnalyticsErrorResult;
+
+// @public
+export type RecognizeCustomEntitiesResult = RecognizeCustomEntitiesSuccessResult | RecognizeCustomEntitiesErrorResult;
+
+// @public
+export interface RecognizeCustomEntitiesResultArray extends Array<RecognizeCustomEntitiesResult> {
+    deploymentName: string;
+    projectName: string;
+    statistics?: TextDocumentBatchStatistics;
+}
+
+// @public
+export interface RecognizeCustomEntitiesSuccessResult extends TextAnalyticsSuccessResult {
+    entities: CategorizedEntity[];
+}
+
+// @public
 export interface RecognizeLinkedEntitiesAction extends TextAnalyticsAction {
     disableServiceLogs?: boolean;
     stringIndexType?: StringIndexType;
@@ -713,6 +705,14 @@ export interface RecognizePiiEntitiesSuccessResult extends TextAnalyticsSuccessR
     redactedText: string;
 }
 
+// @public
+export type RecongizeCustomEntitiesActionErrorResult = TextAnalyticsActionErrorResult;
+
+// @public
+export interface RecongizeCustomEntitiesActionSuccessResult extends TextAnalyticsActionSuccessState {
+    results: RecognizeCustomEntitiesResultArray;
+}
+
 // @public (undocumented)
 export interface SentenceAssessment {
     confidenceScores: TargetConfidenceScoreLabel;
@@ -789,11 +789,11 @@ export interface TextAnalyticsActionErrorResult {
 // @public
 export interface TextAnalyticsActions {
     analyzeSentimentActions?: AnalyzeSentimentAction[];
-    customClassifyDocumentMultiCategoriesActions?: CustomClassifyDocumentMultiCategoriesAction[];
-    customClassifyDocumentSingleCategoryActions?: CustomClassifyDocumentSingleCategoryAction[];
-    customRecognizeEntitiesActions?: CustomRecognizeEntitiesAction[];
+    classifyDocumentMultiCategoriesActions?: ClassifyDocumentMultiCategoriesAction[];
+    classifyDocumentSingleCategoryActions?: ClassifyDocumentSingleCategoryAction[];
     extractKeyPhrasesActions?: ExtractKeyPhrasesAction[];
     extractSummaryActions?: ExtractSummaryAction[];
+    recognizeCustomEntitiesActions?: RecognizeCustomEntitiesAction[];
     recognizeEntitiesActions?: RecognizeCategorizedEntitiesAction[];
     recognizeLinkedEntitiesActions?: RecognizeLinkedEntitiesAction[];
     recognizePiiEntitiesActions?: RecognizePiiEntitiesAction[];

--- a/sdk/textanalytics/ai-text-analytics/src/analyzeActionsResult.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/analyzeActionsResult.ts
@@ -7,13 +7,13 @@ import {
   makeAnalyzeSentimentResultArray
 } from "./analyzeSentimentResultArray";
 import {
-  CustomClassifyDocumentMultiCategoriesResultArray,
-  makeCustomClassifyDocumentMultiCategoriesResultArray
-} from "./customClassifyDocumentMultiCategoriesResultArray";
+  ClassifyDocumentMultiCategoriesResultArray,
+  makeClassifyDocumentMultiCategoriesResultArray
+} from "./classifyDocumentMultiCategoriesResultArray";
 import {
-  CustomClassifyDocumentSingleCategoryResultArray,
-  makeCustomClassifyDocumentSingleCategoryResultArray
-} from "./customClassifyDocumentSingleCategoryResultArray";
+  ClassifyDocumentSingleCategoryResultArray,
+  makeClassifyDocumentSingleCategoryResultArray
+} from "./classifyDocumentSingleCategoryResultArray";
 import {
   ExtractKeyPhrasesResultArray,
   makeExtractKeyPhrasesResultArray
@@ -28,9 +28,9 @@ import {
   RecognizeCategorizedEntitiesResultArray
 } from "./recognizeCategorizedEntitiesResultArray";
 import {
-  makeCustomRecognizeEntitiesResultArray,
-  CustomRecognizeEntitiesResultArray
-} from "./customRecognizeEntitiesResultArray";
+  makeRecognizeCustomEntitiesResultArray,
+  RecognizeCustomEntitiesResultArray
+} from "./recognizeCustomEntitiesResultArray";
 import {
   makeRecognizeLinkedEntitiesResultArray,
   RecognizeLinkedEntitiesResultArray
@@ -72,15 +72,15 @@ export interface AnalyzeActionsResult {
   /**
    * Array of the results for each recognize custom entities action.
    */
-  customRecognizeEntitiesResults: CustomRecognizeEntitiesActionResult[];
+  recognizeCustomEntitiesResults: RecognizeCustomEntitiesActionResult[];
   /**
    * Array of the results for each custom classify document single category action.
    */
-  customClassifyDocumentSingleCategoryResults: CustomClassifyDocumentSingleCategoryActionResult[];
+  classifyDocumentSingleCategoryResults: ClassifyDocumentSingleCategoryActionResult[];
   /**
    * Array of the results for each custom classify document multi categories action.
    */
-  customClassifyDocumentMultiCategoriesResults: CustomClassifyDocumentMultiCategoriesActionResult[];
+  classifyDocumentMultiCategoriesResults: ClassifyDocumentMultiCategoriesActionResult[];
 }
 
 /**
@@ -248,71 +248,71 @@ export type ExtractSummaryActionResult =
 /**
  * The error of a custom recognize entities action.
  */
-export type CustomRecongizeEntitiesActionErrorResult = TextAnalyticsActionErrorResult;
+export type RecongizeCustomEntitiesActionErrorResult = TextAnalyticsActionErrorResult;
 
 /**
  * The results of a succeeded custom recognize entities action.
  */
-export interface CustomRecongizeEntitiesActionSuccessResult
+export interface RecongizeCustomEntitiesActionSuccessResult
   extends TextAnalyticsActionSuccessState {
   /**
    * Array of the results for each custom recognize entities action.
    */
-  results: CustomRecognizeEntitiesResultArray;
+  results: RecognizeCustomEntitiesResultArray;
 }
 
 /**
  * The result of a custom recognize entities action.
  */
-export type CustomRecognizeEntitiesActionResult =
-  | CustomRecongizeEntitiesActionSuccessResult
-  | CustomRecongizeEntitiesActionErrorResult;
+export type RecognizeCustomEntitiesActionResult =
+  | RecongizeCustomEntitiesActionSuccessResult
+  | RecongizeCustomEntitiesActionErrorResult;
 
 /**
  * The error of a custom classify document single category action.
  */
-export type CustomClassifyDocumentSingleCategoryActionErrorResult = TextAnalyticsActionErrorResult;
+export type ClassifyDocumentSingleCategoryActionErrorResult = TextAnalyticsActionErrorResult;
 
 /**
  * The results of a succeeded custom classify document single category action.
  */
-export interface CustomClassifyDocumentSingleCategoryActionSuccessResult
+export interface ClassifyDocumentSingleCategoryActionSuccessResult
   extends TextAnalyticsActionSuccessState {
   /**
    * Array of the results for each custom classify document single category action.
    */
-  results: CustomClassifyDocumentSingleCategoryResultArray;
+  results: ClassifyDocumentSingleCategoryResultArray;
 }
 
 /**
  * The result of a custom classify document single category action.
  */
-export type CustomClassifyDocumentSingleCategoryActionResult =
-  | CustomClassifyDocumentSingleCategoryActionSuccessResult
-  | CustomClassifyDocumentSingleCategoryActionErrorResult;
+export type ClassifyDocumentSingleCategoryActionResult =
+  | ClassifyDocumentSingleCategoryActionSuccessResult
+  | ClassifyDocumentSingleCategoryActionErrorResult;
 
 /**
  * The error of a custom classify document multi categories action.
  */
-export type CustomClassifyDocumentMultiCategoriesActionErrorResult = TextAnalyticsActionErrorResult;
+export type ClassifyDocumentMultiCategoriesActionErrorResult = TextAnalyticsActionErrorResult;
 
 /**
  * The results of a succeeded custom classify document multi categories action.
  */
-export interface CustomClassifyDocumentMultiCategoriesActionSuccessResult
+export interface ClassifyDocumentMultiCategoriesActionSuccessResult
   extends TextAnalyticsActionSuccessState {
   /**
    * Array of the results for each custom classify document multi categories action.
    */
-  results: CustomClassifyDocumentMultiCategoriesResultArray;
+  results: ClassifyDocumentMultiCategoriesResultArray;
 }
 
 /**
  * The result of a custom classify document multi categories action.
  */
-export type CustomClassifyDocumentMultiCategoriesActionResult =
-  | CustomClassifyDocumentMultiCategoriesActionSuccessResult
-  | CustomClassifyDocumentMultiCategoriesActionErrorResult;
+export type ClassifyDocumentMultiCategoriesActionResult =
+  | ClassifyDocumentMultiCategoriesActionSuccessResult
+  | ClassifyDocumentMultiCategoriesActionErrorResult;
 
 /**
  * The results of an analyze Actions operation represented as a paged iterator that
@@ -347,9 +347,9 @@ type TextAnalyticsActionType =
   | "RecognizeLinkedEntities"
   | "AnalyzeSentiment"
   | "ExtractSummary"
-  | "CustomRecognizeEntities"
-  | "CustomClassifyDocumentSingleCategory"
-  | "CustomClassifyDocumentMultiCategories";
+  | "RecognizeCustomEntities"
+  | "ClassifyDocumentSingleCategory"
+  | "ClassifyDocumentMultiCategories";
 
 /**
  * The type of an action error with the type of the action that erred and its
@@ -402,13 +402,13 @@ function convertTaskTypeToActionType(taskType: string): TextAnalyticsActionType 
       return "ExtractSummary";
     }
     case "customEntityRecognitionTasks": {
-      return "CustomRecognizeEntities";
+      return "RecognizeCustomEntities";
     }
     case "customSingleClassificationTasks": {
-      return "CustomClassifyDocumentSingleCategory";
+      return "ClassifyDocumentSingleCategory";
     }
     case "customMultiClassificationTasks": {
-      return "CustomClassifyDocumentMultiCategories";
+      return "ClassifyDocumentMultiCategories";
     }
     default: {
       throw new Error(`unexpected action type from the service: ${taskType}`);
@@ -461,9 +461,9 @@ function categorizeActionErrors(
   recognizeLinkedEntitiesActionErrors: TextAnalyticsActionError[],
   analyzeSentimentActionErrors: TextAnalyticsActionError[],
   extractSummarySentencesActionErrors: TextAnalyticsActionError[],
-  customRecognizeEntitiesActionErrors: TextAnalyticsActionError[],
-  customClassifyDocumentSingleCategoryActionErrors: TextAnalyticsActionError[],
-  customClassifyDocumentMultiCategoriesActionErrors: TextAnalyticsActionError[]
+  recognizeCustomEntitiesActionErrors: TextAnalyticsActionError[],
+  classifyDocumentSingleCategoryActionErrors: TextAnalyticsActionError[],
+  classifyDocumentMultiCategoriesActionErrors: TextAnalyticsActionError[]
 ): void {
   for (const error of erredActions) {
     const actionError = parseActionError(error);
@@ -492,16 +492,16 @@ function categorizeActionErrors(
         extractSummarySentencesActionErrors.push(actionError);
         break;
       }
-      case "CustomRecognizeEntities": {
-        customRecognizeEntitiesActionErrors.push(actionError);
+      case "RecognizeCustomEntities": {
+        recognizeCustomEntitiesActionErrors.push(actionError);
         break;
       }
-      case "CustomClassifyDocumentSingleCategory": {
-        customClassifyDocumentSingleCategoryActionErrors.push(actionError);
+      case "ClassifyDocumentSingleCategory": {
+        classifyDocumentSingleCategoryActionErrors.push(actionError);
         break;
       }
-      case "CustomClassifyDocumentMultiCategories": {
-        customClassifyDocumentMultiCategoriesActionErrors.push(actionError);
+      case "ClassifyDocumentMultiCategories": {
+        classifyDocumentMultiCategoriesActionErrors.push(actionError);
         break;
       }
     }
@@ -585,9 +585,9 @@ export function createAnalyzeActionsResult(
   const recognizeLinkedEntitiesActionErrors: TextAnalyticsActionError[] = [];
   const analyzeSentimentActionErrors: TextAnalyticsActionError[] = [];
   const extractSummarySentencesActionErrors: TextAnalyticsActionError[] = [];
-  const customRecognizeEntitiesActionErrors: TextAnalyticsActionError[] = [];
-  const customClassifyDocumentSingleCategoryActionErrors: TextAnalyticsActionError[] = [];
-  const customClassifyDocumentMultiCategoriesActionErrors: TextAnalyticsActionError[] = [];
+  const recognizeCustomEntitiesActionErrors: TextAnalyticsActionError[] = [];
+  const classifyDocumentSingleCategoryActionErrors: TextAnalyticsActionError[] = [];
+  const classifyDocumentMultiCategoriesActionErrors: TextAnalyticsActionError[] = [];
   categorizeActionErrors(
     response?.errors ?? [],
     recognizeEntitiesActionErrors,
@@ -596,9 +596,9 @@ export function createAnalyzeActionsResult(
     recognizeLinkedEntitiesActionErrors,
     analyzeSentimentActionErrors,
     extractSummarySentencesActionErrors,
-    customRecognizeEntitiesActionErrors,
-    customClassifyDocumentSingleCategoryActionErrors,
-    customClassifyDocumentMultiCategoriesActionErrors
+    recognizeCustomEntitiesActionErrors,
+    classifyDocumentSingleCategoryActionErrors,
+    classifyDocumentMultiCategoriesActionErrors
   );
   return {
     recognizeEntitiesResults: makeActionResult(
@@ -637,23 +637,23 @@ export function createAnalyzeActionsResult(
       response.tasks.extractiveSummarizationTasks ?? [],
       extractSummarySentencesActionErrors
     ),
-    customRecognizeEntitiesResults: makeActionResult(
+    recognizeCustomEntitiesResults: makeActionResult(
       documents,
-      makeCustomRecognizeEntitiesResultArray,
+      makeRecognizeCustomEntitiesResultArray,
       response.tasks.customEntityRecognitionTasks ?? [],
-      customRecognizeEntitiesActionErrors
+      recognizeCustomEntitiesActionErrors
     ),
-    customClassifyDocumentSingleCategoryResults: makeActionResult(
+    classifyDocumentSingleCategoryResults: makeActionResult(
       documents,
-      makeCustomClassifyDocumentSingleCategoryResultArray,
+      makeClassifyDocumentSingleCategoryResultArray,
       response.tasks.customSingleClassificationTasks ?? [],
-      customClassifyDocumentSingleCategoryActionErrors
+      classifyDocumentSingleCategoryActionErrors
     ),
-    customClassifyDocumentMultiCategoriesResults: makeActionResult(
+    classifyDocumentMultiCategoriesResults: makeActionResult(
       documents,
-      makeCustomClassifyDocumentMultiCategoriesResultArray,
+      makeClassifyDocumentMultiCategoriesResultArray,
       response.tasks.customMultiClassificationTasks ?? [],
-      customClassifyDocumentMultiCategoriesActionErrors
+      classifyDocumentMultiCategoriesActionErrors
     )
   };
 }

--- a/sdk/textanalytics/ai-text-analytics/src/classifyDocumentMultiCategoriesResult.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/classifyDocumentMultiCategoriesResult.ts
@@ -8,21 +8,20 @@ import {
   makeTextAnalyticsErrorResult
 } from "./textAnalyticsResult";
 import { TextAnalyticsError, MultiClassificationDocument } from "./generated/models";
-import { DocumentClassification } from "./customClassifyDocumentSingleCategoryResult";
+import { DocumentClassification } from "./classifyDocumentSingleCategoryResult";
 
 /**
  * The result of the custom classify document multi categories operation on a multi document.
  */
-export type CustomClassifyDocumentMultiCategoriesResult =
-  | CustomClassifyDocumentMultiCategoriesSuccessResult
-  | CustomClassifyDocumentMultiCategoriesErrorResult;
+export type ClassifyDocumentMultiCategoriesResult =
+  | ClassifyDocumentMultiCategoriesSuccessResult
+  | ClassifyDocumentMultiCategoriesErrorResult;
 
 /**
  * The result of the custom classify document multi categories operation on a multi document,
  * containing the result of the classification.
  */
-export interface CustomClassifyDocumentMultiCategoriesSuccessResult
-  extends TextAnalyticsSuccessResult {
+export interface ClassifyDocumentMultiCategoriesSuccessResult extends TextAnalyticsSuccessResult {
   /**
    * The collection of classifications in the input document.
    */
@@ -32,14 +31,14 @@ export interface CustomClassifyDocumentMultiCategoriesSuccessResult
 /**
  * An error result from the custom classify document multi categories operation on a multi document.
  */
-export type CustomClassifyDocumentMultiCategoriesErrorResult = TextAnalyticsErrorResult;
+export type ClassifyDocumentMultiCategoriesErrorResult = TextAnalyticsErrorResult;
 
 /**
  * @internal
  */
-export function makeCustomClassifyDocumentMultiCategoriesResult(
+export function makeClassifyDocumentMultiCategoriesResult(
   result: MultiClassificationDocument
-): CustomClassifyDocumentMultiCategoriesSuccessResult {
+): ClassifyDocumentMultiCategoriesSuccessResult {
   const { id, warnings, statistics, classifications } = result;
   return {
     ...makeTextAnalyticsSuccessResult(id, warnings, statistics),
@@ -50,9 +49,9 @@ export function makeCustomClassifyDocumentMultiCategoriesResult(
 /**
  * @internal
  */
-export function makeCustomClassifyDocumentMultiCategoriesErrorResult(
+export function makeClassifyDocumentMultiCategoriesErrorResult(
   id: string,
   error: TextAnalyticsError
-): CustomClassifyDocumentMultiCategoriesErrorResult {
+): ClassifyDocumentMultiCategoriesErrorResult {
   return makeTextAnalyticsErrorResult(id, error);
 }

--- a/sdk/textanalytics/ai-text-analytics/src/classifyDocumentMultiCategoriesResultArray.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/classifyDocumentMultiCategoriesResultArray.ts
@@ -4,20 +4,21 @@
 import {
   TextDocumentBatchStatistics,
   TextDocumentInput,
-  CustomEntitiesResult
+  CustomMultiClassificationResult
 } from "./generated/models";
 import {
-  CustomRecognizeEntitiesResult,
-  makeCustomRecognizeEntitiesResult,
-  makeCustomRecognizeEntitiesErrorResult
-} from "./customRecognizeEntitiesResult";
+  ClassifyDocumentMultiCategoriesResult,
+  makeClassifyDocumentMultiCategoriesResult,
+  makeClassifyDocumentMultiCategoriesErrorResult
+} from "./classifyDocumentMultiCategoriesResult";
 import { combineSuccessfulAndErroneousDocumentsWithStatisticsAndCustomProjectInfo } from "./textAnalyticsResult";
 
 /**
- * Array of `CustomRecognizeEntitiesResult` objects corresponding to a batch of input documents, and
+ * Array of `CustomClassifyDocumentMultiCategoriesResult` objects corresponding to a batch of input documents, and
  * annotated with information about the batch operation.
  */
-export interface CustomRecognizeEntitiesResultArray extends Array<CustomRecognizeEntitiesResult> {
+export interface ClassifyDocumentMultiCategoriesResultArray
+  extends Array<ClassifyDocumentMultiCategoriesResult> {
   /**
    * Statistics about the input document batch and how it was processed
    * by the service. This property will have a value when includeStatistics is set to true
@@ -39,14 +40,14 @@ export interface CustomRecognizeEntitiesResultArray extends Array<CustomRecogniz
 /**
  * @internal
  */
-export function makeCustomRecognizeEntitiesResultArray(
+export function makeClassifyDocumentMultiCategoriesResultArray(
   input: TextDocumentInput[],
-  response: CustomEntitiesResult
-): CustomRecognizeEntitiesResultArray {
+  response: CustomMultiClassificationResult
+): ClassifyDocumentMultiCategoriesResultArray {
   return combineSuccessfulAndErroneousDocumentsWithStatisticsAndCustomProjectInfo(
     input,
     response,
-    makeCustomRecognizeEntitiesResult,
-    makeCustomRecognizeEntitiesErrorResult
+    makeClassifyDocumentMultiCategoriesResult,
+    makeClassifyDocumentMultiCategoriesErrorResult
   );
 }

--- a/sdk/textanalytics/ai-text-analytics/src/classifyDocumentSingleCategoryResult.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/classifyDocumentSingleCategoryResult.ts
@@ -16,16 +16,15 @@ import {
 /**
  * The result of the custom classify document single category operation on a single document.
  */
-export type CustomClassifyDocumentSingleCategoryResult =
-  | CustomClassifyDocumentSingleCategorySuccessResult
-  | CustomClassifyDocumentSingleCategoryErrorResult;
+export type ClassifyDocumentSingleCategoryResult =
+  | ClassifyDocumentSingleCategorySuccessResult
+  | ClassifyDocumentSingleCategoryErrorResult;
 
 /**
  * The result of the custom classify document single category operation on a single document,
  * containing the result of the classification.
  */
-export interface CustomClassifyDocumentSingleCategorySuccessResult
-  extends TextAnalyticsSuccessResult {
+export interface ClassifyDocumentSingleCategorySuccessResult extends TextAnalyticsSuccessResult {
   /**
    * The classification result of the input document.
    */
@@ -40,14 +39,14 @@ export interface DocumentClassification extends ClassificationResult {}
 /**
  * An error result from the custom classify document single category operation on a single document.
  */
-export type CustomClassifyDocumentSingleCategoryErrorResult = TextAnalyticsErrorResult;
+export type ClassifyDocumentSingleCategoryErrorResult = TextAnalyticsErrorResult;
 
 /**
  * @internal
  */
-export function makeCustomClassifyDocumentSingleCategoryResult(
+export function makeClassifyDocumentSingleCategoryResult(
   result: SingleClassificationDocument
-): CustomClassifyDocumentSingleCategorySuccessResult {
+): ClassifyDocumentSingleCategorySuccessResult {
   const { id, warnings, statistics, classification } = result;
   return {
     ...makeTextAnalyticsSuccessResult(id, warnings, statistics),
@@ -58,9 +57,9 @@ export function makeCustomClassifyDocumentSingleCategoryResult(
 /**
  * @internal
  */
-export function makeCustomClassifyDocumentSingleCategoryErrorResult(
+export function makeClassifyDocumentSingleCategoryErrorResult(
   id: string,
   error: TextAnalyticsError
-): CustomClassifyDocumentSingleCategoryErrorResult {
+): ClassifyDocumentSingleCategoryErrorResult {
   return makeTextAnalyticsErrorResult(id, error);
 }

--- a/sdk/textanalytics/ai-text-analytics/src/classifyDocumentSingleCategoryResultArray.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/classifyDocumentSingleCategoryResultArray.ts
@@ -7,18 +7,18 @@ import {
   CustomSingleClassificationResult
 } from "./generated/models";
 import {
-  CustomClassifyDocumentSingleCategoryResult,
-  makeCustomClassifyDocumentSingleCategoryResult,
-  makeCustomClassifyDocumentSingleCategoryErrorResult
-} from "./customClassifyDocumentSingleCategoryResult";
+  ClassifyDocumentSingleCategoryResult,
+  makeClassifyDocumentSingleCategoryResult,
+  makeClassifyDocumentSingleCategoryErrorResult
+} from "./classifyDocumentSingleCategoryResult";
 import { combineSuccessfulAndErroneousDocumentsWithStatisticsAndCustomProjectInfo } from "./textAnalyticsResult";
 
 /**
  * Array of `CustomClassifyDocumentSingleCategoryResultArray` objects corresponding to a batch of input documents, and
  * annotated with information about the batch operation.
  */
-export interface CustomClassifyDocumentSingleCategoryResultArray
-  extends Array<CustomClassifyDocumentSingleCategoryResult> {
+export interface ClassifyDocumentSingleCategoryResultArray
+  extends Array<ClassifyDocumentSingleCategoryResult> {
   /**
    * Statistics about the input document batch and how it was processed
    * by the service. This property will have a value when includeStatistics is set to true
@@ -40,14 +40,14 @@ export interface CustomClassifyDocumentSingleCategoryResultArray
 /**
  * @internal
  */
-export function makeCustomClassifyDocumentSingleCategoryResultArray(
+export function makeClassifyDocumentSingleCategoryResultArray(
   input: TextDocumentInput[],
   response: CustomSingleClassificationResult
-): CustomClassifyDocumentSingleCategoryResultArray {
+): ClassifyDocumentSingleCategoryResultArray {
   return combineSuccessfulAndErroneousDocumentsWithStatisticsAndCustomProjectInfo(
     input,
     response,
-    makeCustomClassifyDocumentSingleCategoryResult,
-    makeCustomClassifyDocumentSingleCategoryErrorResult
+    makeClassifyDocumentSingleCategoryResult,
+    makeClassifyDocumentSingleCategoryErrorResult
   );
 }

--- a/sdk/textanalytics/ai-text-analytics/src/index.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/index.ts
@@ -35,9 +35,9 @@ export {
   AnalyzeSentimentAction,
   ExtractSummaryAction,
   KnownSummarySentencesSortBy as KnownSummarySentencesOrderBy,
-  CustomRecognizeEntitiesAction,
-  CustomClassifyDocumentSingleCategoryAction,
-  CustomClassifyDocumentMultiCategoriesAction
+  RecognizeCustomEntitiesAction,
+  ClassifyDocumentSingleCategoryAction,
+  ClassifyDocumentMultiCategoriesAction
 } from "./textAnalyticsClient";
 export { TextAnalyticsOperationOptions } from "./textAnalyticsOperationOptions";
 export {
@@ -84,24 +84,24 @@ export {
 } from "./extractSummaryResult";
 export { ExtractSummaryResultArray } from "./extractSummaryResultArray";
 export {
-  CustomRecognizeEntitiesErrorResult,
-  CustomRecognizeEntitiesResult,
-  CustomRecognizeEntitiesSuccessResult
-} from "./customRecognizeEntitiesResult";
-export { CustomRecognizeEntitiesResultArray } from "./customRecognizeEntitiesResultArray";
+  RecognizeCustomEntitiesErrorResult,
+  RecognizeCustomEntitiesResult,
+  RecognizeCustomEntitiesSuccessResult
+} from "./recognizeCustomEntitiesResult";
+export { RecognizeCustomEntitiesResultArray } from "./recognizeCustomEntitiesResultArray";
 export {
-  CustomClassifyDocumentSingleCategoryErrorResult,
-  CustomClassifyDocumentSingleCategoryResult,
-  CustomClassifyDocumentSingleCategorySuccessResult,
+  ClassifyDocumentSingleCategoryErrorResult,
+  ClassifyDocumentSingleCategoryResult,
+  ClassifyDocumentSingleCategorySuccessResult,
   DocumentClassification
-} from "./customClassifyDocumentSingleCategoryResult";
-export { CustomClassifyDocumentSingleCategoryResultArray } from "./customClassifyDocumentSingleCategoryResultArray";
+} from "./classifyDocumentSingleCategoryResult";
+export { ClassifyDocumentSingleCategoryResultArray } from "./classifyDocumentSingleCategoryResultArray";
 export {
-  CustomClassifyDocumentMultiCategoriesErrorResult,
-  CustomClassifyDocumentMultiCategoriesResult,
-  CustomClassifyDocumentMultiCategoriesSuccessResult
-} from "./customClassifyDocumentMultiCategoriesResult";
-export { CustomClassifyDocumentMultiCategoriesResultArray } from "./customClassifyDocumentMultiCategoriesResultArray";
+  ClassifyDocumentMultiCategoriesErrorResult,
+  ClassifyDocumentMultiCategoriesResult,
+  ClassifyDocumentMultiCategoriesSuccessResult
+} from "./classifyDocumentMultiCategoriesResult";
+export { ClassifyDocumentMultiCategoriesResultArray } from "./classifyDocumentMultiCategoriesResultArray";
 export {
   RecognizeLinkedEntitiesResult,
   RecognizeLinkedEntitiesErrorResult,
@@ -145,15 +145,15 @@ export {
   ExtractSummaryActionResult,
   ExtractSummaryActionSuccessResult,
   ExtractSummaryActionErrorResult,
-  CustomRecognizeEntitiesActionResult,
-  CustomRecongizeEntitiesActionErrorResult,
-  CustomRecongizeEntitiesActionSuccessResult,
-  CustomClassifyDocumentMultiCategoriesActionErrorResult,
-  CustomClassifyDocumentMultiCategoriesActionResult,
-  CustomClassifyDocumentMultiCategoriesActionSuccessResult,
-  CustomClassifyDocumentSingleCategoryActionErrorResult,
-  CustomClassifyDocumentSingleCategoryActionResult,
-  CustomClassifyDocumentSingleCategoryActionSuccessResult
+  RecognizeCustomEntitiesActionResult,
+  RecongizeCustomEntitiesActionErrorResult,
+  RecongizeCustomEntitiesActionSuccessResult,
+  ClassifyDocumentMultiCategoriesActionErrorResult,
+  ClassifyDocumentMultiCategoriesActionResult,
+  ClassifyDocumentMultiCategoriesActionSuccessResult,
+  ClassifyDocumentSingleCategoryActionErrorResult,
+  ClassifyDocumentSingleCategoryActionResult,
+  ClassifyDocumentSingleCategoryActionSuccessResult
 } from "./analyzeActionsResult";
 export {
   ErrorCode,

--- a/sdk/textanalytics/ai-text-analytics/src/recognizeCustomEntitiesResult.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/recognizeCustomEntitiesResult.ts
@@ -13,15 +13,15 @@ import { CategorizedEntity } from "./recognizeCategorizedEntitiesResult";
 /**
  * The result of the custom recognize entities operation on a single document.
  */
-export type CustomRecognizeEntitiesResult =
-  | CustomRecognizeEntitiesSuccessResult
-  | CustomRecognizeEntitiesErrorResult;
+export type RecognizeCustomEntitiesResult =
+  | RecognizeCustomEntitiesSuccessResult
+  | RecognizeCustomEntitiesErrorResult;
 
 /**
  * The result of the recognize custom entities operation on a single document,
  * containing a collection of the entities identified in that document.
  */
-export interface CustomRecognizeEntitiesSuccessResult extends TextAnalyticsSuccessResult {
+export interface RecognizeCustomEntitiesSuccessResult extends TextAnalyticsSuccessResult {
   /**
    * The collection of entities identified in the input document.
    */
@@ -31,14 +31,14 @@ export interface CustomRecognizeEntitiesSuccessResult extends TextAnalyticsSucce
 /**
  * An error result from the recognize custom entities operation on a single document.
  */
-export type CustomRecognizeEntitiesErrorResult = TextAnalyticsErrorResult;
+export type RecognizeCustomEntitiesErrorResult = TextAnalyticsErrorResult;
 
 /**
  * @internal
  */
-export function makeCustomRecognizeEntitiesResult(
+export function makeRecognizeCustomEntitiesResult(
   result: DocumentEntities
-): CustomRecognizeEntitiesSuccessResult {
+): RecognizeCustomEntitiesSuccessResult {
   const { id, warnings, statistics, entities } = result;
   return {
     ...makeTextAnalyticsSuccessResult(id, warnings, statistics),
@@ -49,9 +49,9 @@ export function makeCustomRecognizeEntitiesResult(
 /**
  * @internal
  */
-export function makeCustomRecognizeEntitiesErrorResult(
+export function makeRecognizeCustomEntitiesErrorResult(
   id: string,
   error: TextAnalyticsError
-): CustomRecognizeEntitiesErrorResult {
+): RecognizeCustomEntitiesErrorResult {
   return makeTextAnalyticsErrorResult(id, error);
 }

--- a/sdk/textanalytics/ai-text-analytics/src/recognizeCustomEntitiesResultArray.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/recognizeCustomEntitiesResultArray.ts
@@ -4,21 +4,20 @@
 import {
   TextDocumentBatchStatistics,
   TextDocumentInput,
-  CustomMultiClassificationResult
+  CustomEntitiesResult
 } from "./generated/models";
 import {
-  CustomClassifyDocumentMultiCategoriesResult,
-  makeCustomClassifyDocumentMultiCategoriesResult,
-  makeCustomClassifyDocumentMultiCategoriesErrorResult
-} from "./customClassifyDocumentMultiCategoriesResult";
+  RecognizeCustomEntitiesResult,
+  makeRecognizeCustomEntitiesResult,
+  makeRecognizeCustomEntitiesErrorResult
+} from "./recognizeCustomEntitiesResult";
 import { combineSuccessfulAndErroneousDocumentsWithStatisticsAndCustomProjectInfo } from "./textAnalyticsResult";
 
 /**
- * Array of `CustomClassifyDocumentMultiCategoriesResult` objects corresponding to a batch of input documents, and
+ * Array of `CustomRecognizeEntitiesResult` objects corresponding to a batch of input documents, and
  * annotated with information about the batch operation.
  */
-export interface CustomClassifyDocumentMultiCategoriesResultArray
-  extends Array<CustomClassifyDocumentMultiCategoriesResult> {
+export interface RecognizeCustomEntitiesResultArray extends Array<RecognizeCustomEntitiesResult> {
   /**
    * Statistics about the input document batch and how it was processed
    * by the service. This property will have a value when includeStatistics is set to true
@@ -40,14 +39,14 @@ export interface CustomClassifyDocumentMultiCategoriesResultArray
 /**
  * @internal
  */
-export function makeCustomClassifyDocumentMultiCategoriesResultArray(
+export function makeRecognizeCustomEntitiesResultArray(
   input: TextDocumentInput[],
-  response: CustomMultiClassificationResult
-): CustomClassifyDocumentMultiCategoriesResultArray {
+  response: CustomEntitiesResult
+): RecognizeCustomEntitiesResultArray {
   return combineSuccessfulAndErroneousDocumentsWithStatisticsAndCustomProjectInfo(
     input,
     response,
-    makeCustomClassifyDocumentMultiCategoriesResult,
-    makeCustomClassifyDocumentMultiCategoriesErrorResult
+    makeRecognizeCustomEntitiesResult,
+    makeRecognizeCustomEntitiesErrorResult
   );
 }

--- a/sdk/textanalytics/ai-text-analytics/src/textAnalyticsClient.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/textAnalyticsClient.ts
@@ -340,7 +340,7 @@ export interface ExtractSummaryAction extends TextAnalyticsAction {
 /**
  * Options for a custom recognize entities action.
  */
-export interface CustomRecognizeEntitiesAction extends CustomTextAnalyticsAction {
+export interface RecognizeCustomEntitiesAction extends CustomTextAnalyticsAction {
   /**
    * Specifies the measurement unit used to calculate the offset and length properties.
    * Possible units are "TextElements_v8", "UnicodeCodePoint", and "Utf16CodeUnit".
@@ -358,7 +358,7 @@ export interface CustomRecognizeEntitiesAction extends CustomTextAnalyticsAction
 /**
  * Options for an custom classify document single category action.
  */
-export interface CustomClassifyDocumentSingleCategoryAction extends CustomTextAnalyticsAction {
+export interface ClassifyDocumentSingleCategoryAction extends CustomTextAnalyticsAction {
   /**
    * If set to true, you opt-out of having your text input logged for troubleshooting. By default, Text Analytics
    * logs your input text for 48 hours, solely to allow for troubleshooting issues. Setting this parameter to true,
@@ -370,7 +370,7 @@ export interface CustomClassifyDocumentSingleCategoryAction extends CustomTextAn
 /**
  * Options for a custom classify document multi categories action.
  */
-export interface CustomClassifyDocumentMultiCategoriesAction extends CustomTextAnalyticsAction {
+export interface ClassifyDocumentMultiCategoriesAction extends CustomTextAnalyticsAction {
   /**
    * If set to true, you opt-out of having your text input logged for troubleshooting. By default, Text Analytics
    * logs your input text for 48 hours, solely to allow for troubleshooting issues. Setting this parameter to true,
@@ -410,15 +410,15 @@ export interface TextAnalyticsActions {
   /**
    * A collection of descriptions of custom entity recognition actions. However, currently, the service can accept up to one action only for `customRecognizeEntities`.
    */
-  customRecognizeEntitiesActions?: CustomRecognizeEntitiesAction[];
+  recognizeCustomEntitiesActions?: RecognizeCustomEntitiesAction[];
   /**
    * A collection of descriptions of custom single classification actions. However, currently, the service can accept up to one action only for `customClassifyDocumentSingleCategory`.
    */
-  customClassifyDocumentSingleCategoryActions?: CustomClassifyDocumentSingleCategoryAction[];
+  classifyDocumentSingleCategoryActions?: ClassifyDocumentSingleCategoryAction[];
   /**
    * A collection of descriptions of custom multi classification actions. However, currently, the service can accept up to one action only for `customClassifyDocumentMultiCategories`.
    */
-  customClassifyDocumentMultiCategoriesActions?: CustomClassifyDocumentMultiCategoriesAction[];
+  classifyDocumentMultiCategoriesActions?: ClassifyDocumentMultiCategoriesAction[];
 }
 /**
  * Client class for interacting with Azure Text Analytics.
@@ -1204,13 +1204,13 @@ function compileAnalyzeInput(actions: TextAnalyticsActions): GeneratedActions {
     extractiveSummarizationTasks: actions.extractSummaryActions?.map(
       compose(setStrEncodingParam, compose(setSentenceCount, compose(setOrderBy, addParamsToTask)))
     ),
-    customEntityRecognitionTasks: actions.customRecognizeEntitiesActions?.map(
+    customEntityRecognitionTasks: actions.recognizeCustomEntitiesActions?.map(
       compose(setStrEncodingParam, addParamsToTask)
     ),
-    customSingleClassificationTasks: actions.customClassifyDocumentSingleCategoryActions?.map(
+    customSingleClassificationTasks: actions.classifyDocumentSingleCategoryActions?.map(
       addParamsToTask
     ),
-    customMultiClassificationTasks: actions.customClassifyDocumentMultiCategoriesActions?.map(
+    customMultiClassificationTasks: actions.classifyDocumentMultiCategoriesActions?.map(
       addParamsToTask
     )
   };

--- a/sdk/textanalytics/ai-text-analytics/test/public/textAnalyticsClient.spec.ts
+++ b/sdk/textanalytics/ai-text-analytics/test/public/textAnalyticsClient.spec.ts
@@ -940,7 +940,7 @@ matrix([["APIKey", "AAD"]] as const, async (authMethod: AuthMethod) => {
           const poller = await client.beginAnalyzeActions(
             docs,
             {
-              customRecognizeEntitiesActions: [
+              recognizeCustomEntitiesActions: [
                 {
                   projectName: "88ee0f78-fbca-444d-98e2-7c4c8631e494",
                   deploymentName: "88ee0f78-fbca-444d-98e2-7c4c8631e494"
@@ -953,7 +953,7 @@ matrix([["APIKey", "AAD"]] as const, async (authMethod: AuthMethod) => {
           );
           const results = await poller.pollUntilDone();
           for await (const page of results) {
-            const entitiesResult = page.customRecognizeEntitiesResults;
+            const entitiesResult = page.recognizeCustomEntitiesResults;
             if (entitiesResult.length === 1) {
               const action = entitiesResult[0];
               if (!action.error) {
@@ -992,7 +992,7 @@ matrix([["APIKey", "AAD"]] as const, async (authMethod: AuthMethod) => {
           const poller = await client.beginAnalyzeActions(
             docs,
             {
-              customClassifyDocumentSingleCategoryActions: [
+              classifyDocumentSingleCategoryActions: [
                 {
                   projectName: "659c1851-be0b-4142-b12a-087da9785926",
                   deploymentName: "659c1851-be0b-4142-b12a-087da9785926"
@@ -1005,7 +1005,7 @@ matrix([["APIKey", "AAD"]] as const, async (authMethod: AuthMethod) => {
           );
           const results = await poller.pollUntilDone();
           for await (const page of results) {
-            const classificationResult = page.customClassifyDocumentSingleCategoryResults;
+            const classificationResult = page.classifyDocumentSingleCategoryResults;
             if (classificationResult.length === 1) {
               const action = classificationResult[0];
               if (!action.error) {
@@ -1043,7 +1043,7 @@ matrix([["APIKey", "AAD"]] as const, async (authMethod: AuthMethod) => {
           const poller = await client.beginAnalyzeActions(
             docs,
             {
-              customClassifyDocumentMultiCategoriesActions: [
+              classifyDocumentMultiCategoriesActions: [
                 {
                   projectName: "7cdace98-537b-494a-b69a-c19754718025",
                   deploymentName: "7cdace98-537b-494a-b69a-c19754718025"
@@ -1056,7 +1056,7 @@ matrix([["APIKey", "AAD"]] as const, async (authMethod: AuthMethod) => {
           );
           const results = await poller.pollUntilDone();
           for await (const page of results) {
-            const classificationResult = page.customClassifyDocumentMultiCategoriesResults;
+            const classificationResult = page.classifyDocumentMultiCategoriesResults;
             if (classificationResult.length === 1) {
               const action = classificationResult[0];
               if (!action.error) {


### PR DESCRIPTION
API View: https://apiview.dev/Assemblies/Review/8754191c44914b7e88232f8aba5073de?diffRevisionId=1d6eefc1d5554d08bbc44593306c97b2&doc=False&diffOnly=True

Updates the proposed names as follows:
- `customRecognizeEntities` to `recognizeCustomEntities`
- `customClassifyDocumentSingleCategory` to `classifyDocumentSingleCategory`
- `customClassifyDocumentMultipleCategories` to `classifyDocumentMultipleCategories`

That was based on the following arguments:
- custom as a prefix would improve the intelligence experience for finding all Custom Text capabilities. However, we agreed that the typical customer would like to try one particular action at a time so we hypothesize that the first thing they will type is `classify` or `recognize` instead of `custom`.
- we prefer `classifyDocumentSingleCategory` instead of `classifySingleCategory` to make it clear that we classify documents not categories.

### Alternative proposal for `recognizeCustomEntities`

One idea we explored is combining `recognizeCustomEntities` and `recognizeEntities` into one since they share the same output structure and only differ in how to reference the model: either using `projectName` and `deploymentName` for the former or `modelVersion` for the latter. However, we suspect that one of them could evolve in the future in a different way from the other in terms of the output structure but we can consult the service team on this. This PR does not implement this proposal but we will bring it up in the [archboard meeting](https://github.com/Azure/azure-sdk/issues/3294) on 9/23.