### PR TITLE
[Text Analytics] Add samples for Custom Text

### DIFF
--- a/sdk/textanalytics/ai-text-analytics/samples-dev/customText.ts
+++ b/sdk/textanalytics/ai-text-analytics/samples-dev/customText.ts
@@ -1,0 +1,136 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+/**
+ * This sample extracts key phrases, entities, and pii entities from several documents
+ *  using a long-running operation. This functionality uses the generic analysis
+ * endpoint, which provides a way to group several different Text Analytics actions
+ * into a single request.
+ *
+ * @summary applies multiple Text Analytics actions per document
+ * @azsdk-weight 40
+ */
+
+import {
+  TextAnalyticsClient,
+  AzureKeyCredential,
+  TextAnalyticsActions
+} from "@azure/ai-text-analytics";
+
+// Load the .env file if it exists
+import * as dotenv from "dotenv";
+dotenv.config();
+
+// You will need to set these environment variables or edit the following values
+const endpoint = process.env["ENDPOINT"] || "<cognitive services endpoint>";
+const apiKey = process.env["TEXT_ANALYTICS_API_KEY"] || "<api key>";
+
+const documents = [
+  "Microsoft was founded by Bill Gates and Paul Allen.",
+  "Redmond is a city in King County, Washington, United States, located 15 miles east of Seattle.",
+  "I need to take my cat to the veterinarian.",
+  "The employee's SSN is 555-55-5555.",
+  "We went to Contoso Steakhouse located at midtown NYC last week for a dinner party, and we adore the spot! They provide marvelous food and they have a great menu. The chief cook happens to be the owner (I think his name is John Doe) and he is super nice, coming out of the kitchen and greeted us all. We enjoyed very much dining in the place! The Sirloin steak I ordered was tender and juicy, and the place was impeccably clean. You can even pre-order from their online menu at www.contososteakhouse.com, call 312-555-0176 or send email to order@contososteakhouse.com! The only complaint I have is the food didn't come fast enough. Overall I highly recommend it!"
+];
+
+export async function main() {
+  console.log("== Analyze Sample ==");
+
+  const client = new TextAnalyticsClient(endpoint, new AzureKeyCredential(apiKey));
+
+  const actions: TextAnalyticsActions = {
+    recognizeCustomEntitiesActions: [
+      {
+        projectName: process.env["RECOGNIZE_CUSTOM_ENTITIES_PROJECT_NAME"]!,
+        deploymentName: process.env["RECOGNIZE_CUSTOM_ENTITIES_DEPLOYMENT_NAME"]!
+      }
+    ],
+    classifyDocumentSingleCategoryActions: [
+      {
+        projectName: process.env["CLASSIFY_DOCUMENT_SINGLE_CATEGORY_PROJECT_NAME"]!,
+        deploymentName: process.env["CLASSIFY_DOCUMENT_SINGLE_CATEGORY_DEPLOYMENT_NAME"]!
+      }
+    ],
+    classifyDocumentMultiCategoriesActions: [
+      {
+        projectName: process.env["CLASSIFY_DOCUMENT_MULTIPLE_CATEGORY_PROJECT_NAME"]!,
+        deploymentName: process.env["CLASSIFY_DOCUMENT_MULTIPLE_CATEGORY_DEPLOYMENT_NAME"]!
+      }
+    ]
+  };
+  const poller = await client.beginAnalyzeActions(documents, actions, "en", {
+    includeStatistics: true
+  });
+
+  poller.onProgress(() => {
+    console.log(
+      `Number of actions still in progress: ${poller.getOperationState().actionsInProgressCount}`
+    );
+  });
+
+  console.log(`The analyze actions operation created on ${poller.getOperationState().createdOn}`);
+
+  console.log(
+    `The analyze actions operation results will expire on ${poller.getOperationState().expiresOn}`
+  );
+
+  const resultPages = await poller.pollUntilDone();
+
+  for await (const page of resultPages) {
+    const customEntitiesAction = page.recognizeCustomEntitiesResults[0];
+    if (!customEntitiesAction.error) {
+      for (const doc of customEntitiesAction.results) {
+        console.log(`- Document ${doc.id}`);
+        if (!doc.error) {
+          console.log("\tEntities:");
+          for (const entity of doc.entities) {
+            console.log(`\t- Entity ${entity.text} of type ${entity.category}`);
+          }
+        } else {
+          console.error("\tError:", doc.error);
+        }
+      }
+      console.log("Action statistics: ");
+      console.log(JSON.stringify(customEntitiesAction.results.statistics));
+    }
+
+    const singleCatClassificationAction = page.classifyDocumentSingleCategoryResults[0];
+    if (!singleCatClassificationAction.error) {
+      for (const doc of singleCatClassificationAction.results) {
+        console.log(`- Document ${doc.id}`);
+        if (!doc.error) {
+          console.log(
+            `\t- Detected Category ${doc.classification.category} with confidence score ${doc.classification.confidenceScore}`
+          );
+        } else {
+          console.error("\tError:", doc.error);
+        }
+      }
+      console.log("Action statistics: ");
+      console.log(JSON.stringify(singleCatClassificationAction.results.statistics));
+    }
+
+    const multipleCatClassificationAction = page.classifyDocumentMultiCategoriesResults[0];
+    if (!multipleCatClassificationAction.error) {
+      for (const doc of multipleCatClassificationAction.results) {
+        console.log(`- Document ${doc.id}`);
+        if (!doc.error) {
+          console.log("\tCategories:");
+          for (const category of doc.classifications) {
+            console.log(
+              `\t- Category ${category.category} with confidence score ${category.confidenceScore}`
+            );
+          }
+        } else {
+          console.error("\tError:", doc.error);
+        }
+      }
+      console.log("Action statistics: ");
+      console.log(JSON.stringify(multipleCatClassificationAction.results.statistics));
+    }
+  }
+}
+
+main().catch((err) => {
+  console.error("The sample encountered an error:", err);
+});

--- a/sdk/textanalytics/ai-text-analytics/samples/v5/javascript/README.md
+++ b/sdk/textanalytics/ai-text-analytics/samples/v5/javascript/README.md
@@ -26,6 +26,7 @@ These sample programs show how to use the JavaScript client libraries for Azure 
 | [alternativeDocumentInput.js][alternativedocumentinput]                   | uses objects with attached metadata instead of simple strings as inputs for flexibility |
 | [authenticationMethods.js][authenticationmethods]                         | authenticates a service client using both Azure Active Directory and an API key         |
 | [beginAnalyzeActions.js][beginanalyzeactions]                             | applies multiple Text Analytics actions per document                                    |
+| [customText.js][customtext]                                               | applies multiple Text Analytics actions per document                                    |
 
 ## Prerequisites
 
@@ -78,6 +79,7 @@ Take a look at our [API Documentation][apiref] for more information about the AP
 [alternativedocumentinput]: https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/textanalytics/ai-text-analytics/samples/v5/javascript/alternativeDocumentInput.js
 [authenticationmethods]: https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/textanalytics/ai-text-analytics/samples/v5/javascript/authenticationMethods.js
 [beginanalyzeactions]: https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/textanalytics/ai-text-analytics/samples/v5/javascript/beginAnalyzeActions.js
+[customtext]: https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/textanalytics/ai-text-analytics/samples/v5/javascript/customText.js
 [apiref]: https://docs.microsoft.com/javascript/api/@azure/ai-text-analytics
 [freesub]: https://azure.microsoft.com/free/
 [createinstance_azurecognitiveservicesinstance]: https://docs.microsoft.com/azure/cognitive-services/cognitive-services-apis-create-account

--- a/sdk/textanalytics/ai-text-analytics/samples/v5/javascript/customText.js
+++ b/sdk/textanalytics/ai-text-analytics/samples/v5/javascript/customText.js
@@ -1,0 +1,131 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+/**
+ * This sample extracts key phrases, entities, and pii entities from several documents
+ *  using a long-running operation. This functionality uses the generic analysis
+ * endpoint, which provides a way to group several different Text Analytics actions
+ * into a single request.
+ *
+ * @summary applies multiple Text Analytics actions per document
+ */
+
+const { TextAnalyticsClient, AzureKeyCredential } = require("@azure/ai-text-analytics");
+
+// Load the .env file if it exists
+const dotenv = require("dotenv");
+dotenv.config();
+
+// You will need to set these environment variables or edit the following values
+const endpoint = process.env["ENDPOINT"] || "<cognitive services endpoint>";
+const apiKey = process.env["TEXT_ANALYTICS_API_KEY"] || "<api key>";
+
+const documents = [
+  "Microsoft was founded by Bill Gates and Paul Allen.",
+  "Redmond is a city in King County, Washington, United States, located 15 miles east of Seattle.",
+  "I need to take my cat to the veterinarian.",
+  "The employee's SSN is 555-55-5555.",
+  "We went to Contoso Steakhouse located at midtown NYC last week for a dinner party, and we adore the spot! They provide marvelous food and they have a great menu. The chief cook happens to be the owner (I think his name is John Doe) and he is super nice, coming out of the kitchen and greeted us all. We enjoyed very much dining in the place! The Sirloin steak I ordered was tender and juicy, and the place was impeccably clean. You can even pre-order from their online menu at www.contososteakhouse.com, call 312-555-0176 or send email to order@contososteakhouse.com! The only complaint I have is the food didn't come fast enough. Overall I highly recommend it!"
+];
+
+async function main() {
+  console.log("== Analyze Sample ==");
+
+  const client = new TextAnalyticsClient(endpoint, new AzureKeyCredential(apiKey));
+
+  const actions = {
+    recognizeCustomEntitiesActions: [
+      {
+        projectName: process.env["RECOGNIZE_CUSTOM_ENTITIES_PROJECT_NAME"],
+        deploymentName: process.env["RECOGNIZE_CUSTOM_ENTITIES_DEPLOYMENT_NAME"]
+      }
+    ],
+    classifyDocumentSingleCategoryActions: [
+      {
+        projectName: process.env["CLASSIFY_DOCUMENT_SINGLE_CATEGORY_PROJECT_NAME"],
+        deploymentName: process.env["CLASSIFY_DOCUMENT_SINGLE_CATEGORY_DEPLOYMENT_NAME"]
+      }
+    ],
+    classifyDocumentMultiCategoriesActions: [
+      {
+        projectName: process.env["CLASSIFY_DOCUMENT_MULTIPLE_CATEGORY_PROJECT_NAME"],
+        deploymentName: process.env["CLASSIFY_DOCUMENT_MULTIPLE_CATEGORY_DEPLOYMENT_NAME"]
+      }
+    ]
+  };
+  const poller = await client.beginAnalyzeActions(documents, actions, "en", {
+    includeStatistics: true
+  });
+
+  poller.onProgress(() => {
+    console.log(
+      `Number of actions still in progress: ${poller.getOperationState().actionsInProgressCount}`
+    );
+  });
+
+  console.log(`The analyze actions operation created on ${poller.getOperationState().createdOn}`);
+
+  console.log(
+    `The analyze actions operation results will expire on ${poller.getOperationState().expiresOn}`
+  );
+
+  const resultPages = await poller.pollUntilDone();
+
+  for await (const page of resultPages) {
+    const customEntitiesAction = page.recognizeCustomEntitiesResults[0];
+    if (!customEntitiesAction.error) {
+      for (const doc of customEntitiesAction.results) {
+        console.log(`- Document ${doc.id}`);
+        if (!doc.error) {
+          console.log("\tEntities:");
+          for (const entity of doc.entities) {
+            console.log(`\t- Entity ${entity.text} of type ${entity.category}`);
+          }
+        } else {
+          console.error("\tError:", doc.error);
+        }
+      }
+      console.log("Action statistics: ");
+      console.log(JSON.stringify(customEntitiesAction.results.statistics));
+    }
+
+    const singleCatClassificationAction = page.classifyDocumentSingleCategoryResults[0];
+    if (!singleCatClassificationAction.error) {
+      for (const doc of singleCatClassificationAction.results) {
+        console.log(`- Document ${doc.id}`);
+        if (!doc.error) {
+          console.log(
+            `\t- Detected Category ${doc.classification.category} with confidence score ${doc.classification.confidenceScore}`
+          );
+        } else {
+          console.error("\tError:", doc.error);
+        }
+      }
+      console.log("Action statistics: ");
+      console.log(JSON.stringify(singleCatClassificationAction.results.statistics));
+    }
+
+    const multipleCatClassificationAction = page.classifyDocumentMultiCategoriesResults[0];
+    if (!multipleCatClassificationAction.error) {
+      for (const doc of multipleCatClassificationAction.results) {
+        console.log(`- Document ${doc.id}`);
+        if (!doc.error) {
+          console.log("\tCategories:");
+          for (const category of doc.classifications) {
+            console.log(
+              `\t- Category ${category.category} with confidence score ${category.confidenceScore}`
+            );
+          }
+        } else {
+          console.error("\tError:", doc.error);
+        }
+      }
+      console.log("Action statistics: ");
+      console.log(JSON.stringify(multipleCatClassificationAction.results.statistics));
+    }
+  }
+}
+
+main().catch((err) => {
+  console.error("The sample encountered an error:", err);
+});

--- a/sdk/textanalytics/ai-text-analytics/samples/v5/javascript/package.json
+++ b/sdk/textanalytics/ai-text-analytics/samples/v5/javascript/package.json
@@ -26,8 +26,8 @@
   },
   "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/textanalytics/ai-text-analytics",
   "dependencies": {
-    "@azure/ai-text-analytics": "latest",
-    "@azure/identity": "2.0.0-beta.5",
-    "dotenv": "latest"
+    "@azure/ai-text-analytics": "next",
+    "dotenv": "latest",
+    "@azure/identity": "2.0.0-beta.6"
   }
 }

--- a/sdk/textanalytics/ai-text-analytics/samples/v5/typescript/README.md
+++ b/sdk/textanalytics/ai-text-analytics/samples/v5/typescript/README.md
@@ -26,6 +26,7 @@ These sample programs show how to use the TypeScript client libraries for Azure 
 | [alternativeDocumentInput.ts][alternativedocumentinput]                   | uses objects with attached metadata instead of simple strings as inputs for flexibility |
 | [authenticationMethods.ts][authenticationmethods]                         | authenticates a service client using both Azure Active Directory and an API key         |
 | [beginAnalyzeActions.ts][beginanalyzeactions]                             | applies multiple Text Analytics actions per document                                    |
+| [customText.ts][customtext]                                               | applies multiple Text Analytics actions per document                                    |
 
 ## Prerequisites
 
@@ -90,6 +91,7 @@ Take a look at our [API Documentation][apiref] for more information about the AP
 [alternativedocumentinput]: https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/textanalytics/ai-text-analytics/samples/v5/typescript/src/alternativeDocumentInput.ts
 [authenticationmethods]: https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/textanalytics/ai-text-analytics/samples/v5/typescript/src/authenticationMethods.ts
 [beginanalyzeactions]: https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/textanalytics/ai-text-analytics/samples/v5/typescript/src/beginAnalyzeActions.ts
+[customtext]: https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/textanalytics/ai-text-analytics/samples/v5/typescript/src/customText.ts
 [apiref]: https://docs.microsoft.com/javascript/api/@azure/ai-text-analytics
 [freesub]: https://azure.microsoft.com/free/
 [createinstance_azurecognitiveservicesinstance]: https://docs.microsoft.com/azure/cognitive-services/cognitive-services-apis-create-account

--- a/sdk/textanalytics/ai-text-analytics/samples/v5/typescript/package.json
+++ b/sdk/textanalytics/ai-text-analytics/samples/v5/typescript/package.json
@@ -30,9 +30,9 @@
   },
   "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/textanalytics/ai-text-analytics",
   "dependencies": {
-    "@azure/ai-text-analytics": "latest",
+    "@azure/ai-text-analytics": "next",
     "dotenv": "latest",
-    "@azure/identity": "2.0.0-beta.5"
+    "@azure/identity": "2.0.0-beta.6"
   },
   "devDependencies": {
     "typescript": "~4.2.0",

--- a/sdk/textanalytics/ai-text-analytics/samples/v5/typescript/src/customText.ts
+++ b/sdk/textanalytics/ai-text-analytics/samples/v5/typescript/src/customText.ts
@@ -1,0 +1,135 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+/**
+ * This sample extracts key phrases, entities, and pii entities from several documents
+ *  using a long-running operation. This functionality uses the generic analysis
+ * endpoint, which provides a way to group several different Text Analytics actions
+ * into a single request.
+ *
+ * @summary applies multiple Text Analytics actions per document
+ */
+
+import {
+  TextAnalyticsClient,
+  AzureKeyCredential,
+  TextAnalyticsActions
+} from "@azure/ai-text-analytics";
+
+// Load the .env file if it exists
+import * as dotenv from "dotenv";
+dotenv.config();
+
+// You will need to set these environment variables or edit the following values
+const endpoint = process.env["ENDPOINT"] || "<cognitive services endpoint>";
+const apiKey = process.env["TEXT_ANALYTICS_API_KEY"] || "<api key>";
+
+const documents = [
+  "Microsoft was founded by Bill Gates and Paul Allen.",
+  "Redmond is a city in King County, Washington, United States, located 15 miles east of Seattle.",
+  "I need to take my cat to the veterinarian.",
+  "The employee's SSN is 555-55-5555.",
+  "We went to Contoso Steakhouse located at midtown NYC last week for a dinner party, and we adore the spot! They provide marvelous food and they have a great menu. The chief cook happens to be the owner (I think his name is John Doe) and he is super nice, coming out of the kitchen and greeted us all. We enjoyed very much dining in the place! The Sirloin steak I ordered was tender and juicy, and the place was impeccably clean. You can even pre-order from their online menu at www.contososteakhouse.com, call 312-555-0176 or send email to order@contososteakhouse.com! The only complaint I have is the food didn't come fast enough. Overall I highly recommend it!"
+];
+
+export async function main() {
+  console.log("== Analyze Sample ==");
+
+  const client = new TextAnalyticsClient(endpoint, new AzureKeyCredential(apiKey));
+
+  const actions: TextAnalyticsActions = {
+    recognizeCustomEntitiesActions: [
+      {
+        projectName: process.env["RECOGNIZE_CUSTOM_ENTITIES_PROJECT_NAME"]!,
+        deploymentName: process.env["RECOGNIZE_CUSTOM_ENTITIES_DEPLOYMENT_NAME"]!
+      }
+    ],
+    classifyDocumentSingleCategoryActions: [
+      {
+        projectName: process.env["CLASSIFY_DOCUMENT_SINGLE_CATEGORY_PROJECT_NAME"]!,
+        deploymentName: process.env["CLASSIFY_DOCUMENT_SINGLE_CATEGORY_DEPLOYMENT_NAME"]!
+      }
+    ],
+    classifyDocumentMultiCategoriesActions: [
+      {
+        projectName: process.env["CLASSIFY_DOCUMENT_MULTIPLE_CATEGORY_PROJECT_NAME"]!,
+        deploymentName: process.env["CLASSIFY_DOCUMENT_MULTIPLE_CATEGORY_DEPLOYMENT_NAME"]!
+      }
+    ]
+  };
+  const poller = await client.beginAnalyzeActions(documents, actions, "en", {
+    includeStatistics: true
+  });
+
+  poller.onProgress(() => {
+    console.log(
+      `Number of actions still in progress: ${poller.getOperationState().actionsInProgressCount}`
+    );
+  });
+
+  console.log(`The analyze actions operation created on ${poller.getOperationState().createdOn}`);
+
+  console.log(
+    `The analyze actions operation results will expire on ${poller.getOperationState().expiresOn}`
+  );
+
+  const resultPages = await poller.pollUntilDone();
+
+  for await (const page of resultPages) {
+    const customEntitiesAction = page.recognizeCustomEntitiesResults[0];
+    if (!customEntitiesAction.error) {
+      for (const doc of customEntitiesAction.results) {
+        console.log(`- Document ${doc.id}`);
+        if (!doc.error) {
+          console.log("\tEntities:");
+          for (const entity of doc.entities) {
+            console.log(`\t- Entity ${entity.text} of type ${entity.category}`);
+          }
+        } else {
+          console.error("\tError:", doc.error);
+        }
+      }
+      console.log("Action statistics: ");
+      console.log(JSON.stringify(customEntitiesAction.results.statistics));
+    }
+
+    const singleCatClassificationAction = page.classifyDocumentSingleCategoryResults[0];
+    if (!singleCatClassificationAction.error) {
+      for (const doc of singleCatClassificationAction.results) {
+        console.log(`- Document ${doc.id}`);
+        if (!doc.error) {
+          console.log(
+            `\t- Detected Category ${doc.classification.category} with confidence score ${doc.classification.confidenceScore}`
+          );
+        } else {
+          console.error("\tError:", doc.error);
+        }
+      }
+      console.log("Action statistics: ");
+      console.log(JSON.stringify(singleCatClassificationAction.results.statistics));
+    }
+
+    const multipleCatClassificationAction = page.classifyDocumentMultiCategoriesResults[0];
+    if (!multipleCatClassificationAction.error) {
+      for (const doc of multipleCatClassificationAction.results) {
+        console.log(`- Document ${doc.id}`);
+        if (!doc.error) {
+          console.log("\tCategories:");
+          for (const category of doc.classifications) {
+            console.log(
+              `\t- Category ${category.category} with confidence score ${category.confidenceScore}`
+            );
+          }
+        } else {
+          console.error("\tError:", doc.error);
+        }
+      }
+      console.log("Action statistics: ");
+      console.log(JSON.stringify(multipleCatClassificationAction.results.statistics));
+    }
+  }
+}
+
+main().catch((err) => {
+  console.error("The sample encountered an error:", err);
+});


### PR DESCRIPTION
As the title said, a sample is being added that shows how to use recognize custom entities, classify document both single and multiple categories. The project name and deployment name are being loaded from environment variables.