### PR TITLE
[Schema Registry] Load tests env vars after recorder initialization

### DIFF
--- a/sdk/schemaregistry/schema-registry/package.json
+++ b/sdk/schemaregistry/schema-registry/package.json
@@ -87,7 +87,6 @@
     "tslib": "^2.2.0"
   },
   "devDependencies": {
-    "@azure/core-util": "^1.0.0-beta.1",
     "@azure/dev-tool": "^1.0.0",
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
     "@azure/identity": "2.0.0-beta.6",

--- a/sdk/schemaregistry/schema-registry/test/schemaRegistry.spec.ts
+++ b/sdk/schemaregistry/schema-registry/test/schemaRegistry.spec.ts
@@ -19,27 +19,6 @@ const options: OperationOptions = {
   }
 };
 
-const schema: SchemaDescription = {
-  name: "azsdk_js_test",
-  groupName: testEnv.SCHEMA_REGISTRY_GROUP,
-  format: "avro",
-  definition: JSON.stringify({
-    type: "record",
-    name: "User",
-    namespace: "com.azure.schemaregistry.samples",
-    fields: [
-      {
-        name: "name",
-        type: "string"
-      },
-      {
-        name: "favoriteNumber",
-        type: "int"
-      }
-    ]
-  })
-};
-
 function assertIsNotNullUndefinedOrEmpty(
   x: SchemaProperties | string | null | undefined
 ): asserts x {
@@ -62,9 +41,30 @@ function assertIsValidSchemaId(
 describe("SchemaRegistryClient", function() {
   let recorder: Recorder;
   let client: SchemaRegistryClient;
+  let schema: SchemaDescription;
 
   beforeEach(function(this: Context) {
     ({ client, recorder } = createRecordedClient(this));
+    schema = {
+      name: "azsdk_js_test",
+      groupName: testEnv.SCHEMA_REGISTRY_GROUP,
+      format: "avro",
+      definition: JSON.stringify({
+        type: "record",
+        name: "User",
+        namespace: "com.azure.schemaregistry.samples",
+        fields: [
+          {
+            name: "name",
+            type: "string"
+          },
+          {
+            name: "favoriteNumber",
+            type: "int"
+          }
+        ]
+      })
+    };
   });
 
   afterEach(async function() {

--- a/sdk/schemaregistry/schema-registry/test/utils/recordedClient.ts
+++ b/sdk/schemaregistry/schema-registry/test/utils/recordedClient.ts
@@ -2,17 +2,11 @@
 // Licensed under the MIT license.
 
 import { Context } from "mocha";
-import * as dotenv from "dotenv";
 
 import { env, Recorder, record, RecorderEnvironmentSetup } from "@azure-tools/test-recorder";
 import { ClientSecretCredential } from "@azure/identity";
-import { isNode } from "@azure/core-util";
 
 import { SchemaRegistryClient } from "../../src/index";
-
-if (isNode) {
-  dotenv.config();
-}
 
 export interface RecordedClient {
   client: SchemaRegistryClient;


### PR DESCRIPTION
Otherwise, the variables in the .env file will be loaded and their original values used instead of being rewritten to the dummay ones. Thanks @HarshaNalluru for helping investigating this!

Also, no need to call dotenv in the tests since the recorder does that for us.