### PR TITLE
[Schema Registry] Enable min/max testing

### DIFF
--- a/sdk/schemaregistry/schema-registry/test/public/schemaRegistry.spec.ts
+++ b/sdk/schemaregistry/schema-registry/test/public/schemaRegistry.spec.ts
@@ -1,15 +1,15 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { createRecordedClient, testEnv } from "./utils/recordedClient";
+import { createRecordedClient } from "./utils/recordedClient";
 import { Context } from "mocha";
-import { Recorder } from "@azure-tools/test-recorder";
+import { Recorder, env } from "@azure-tools/test-recorder";
 import { assert, use as chaiUse } from "chai";
 import chaiPromises from "chai-as-promised";
 chaiUse(chaiPromises);
 import { ClientSecretCredential } from "@azure/identity";
 
-import { SchemaRegistryClient, SchemaDescription, SchemaProperties } from "../src/index";
+import { SchemaRegistryClient, SchemaDescription, SchemaProperties } from "../../src/index";
 import { FullOperationResponse, OperationOptions } from "@azure/core-client";
 
 const options: OperationOptions = {
@@ -46,7 +46,7 @@ describe("SchemaRegistryClient", function() {
     ({ client, recorder } = createRecordedClient(this));
     schema = {
       name: "azsdk_js_test",
-      groupName: testEnv.SCHEMA_REGISTRY_GROUP,
+      groupName: env.SCHEMA_REGISTRY_GROUP,
       format: "avro",
       definition: JSON.stringify({
         type: "record",
@@ -136,7 +136,7 @@ describe("SchemaRegistryClient", function() {
   it("schema with whitespace", async () => {
     const schema2: SchemaDescription = {
       name: "azsdk_js_test2",
-      groupName: testEnv.SCHEMA_REGISTRY_GROUP,
+      groupName: env.SCHEMA_REGISTRY_GROUP,
       format: "avro",
       definition:
         "{\n" +

--- a/sdk/schemaregistry/schema-registry/test/public/utils/recordedClient.ts
+++ b/sdk/schemaregistry/schema-registry/test/public/utils/recordedClient.ts
@@ -6,7 +6,7 @@ import { Context } from "mocha";
 import { env, Recorder, record, RecorderEnvironmentSetup } from "@azure-tools/test-recorder";
 import { ClientSecretCredential } from "@azure/identity";
 
-import { SchemaRegistryClient } from "../../src/index";
+import { SchemaRegistryClient } from "../../../src/index";
 
 export interface RecordedClient {
   client: SchemaRegistryClient;
@@ -20,12 +20,6 @@ const replaceableVariables: { [k: string]: string } = {
   SCHEMA_REGISTRY_ENDPOINT: "https://endpoint",
   SCHEMA_REGISTRY_GROUP: "group-1"
 };
-
-export const testEnv = new Proxy(replaceableVariables, {
-  get: (target, key: string) => {
-    return env[key] || target[key];
-  }
-});
 
 const environmentSetup: RecorderEnvironmentSetup = {
   replaceableVariables,
@@ -47,10 +41,10 @@ const environmentSetup: RecorderEnvironmentSetup = {
 export function createRecordedClient(context: Context): RecordedClient {
   const recorder = record(context, environmentSetup);
   const credential = new ClientSecretCredential(
-    testEnv.AZURE_TENANT_ID,
-    testEnv.AZURE_CLIENT_ID,
-    testEnv.AZURE_CLIENT_SECRET
+    env.AZURE_TENANT_ID,
+    env.AZURE_CLIENT_ID,
+    env.AZURE_CLIENT_SECRET
   );
-  const client = new SchemaRegistryClient(testEnv.SCHEMA_REGISTRY_ENDPOINT, credential);
+  const client = new SchemaRegistryClient(env.SCHEMA_REGISTRY_ENDPOINT, credential);
   return { client, recorder };
 }


### PR DESCRIPTION
This PR does the following:
- moves the test suite into a new directory called `public` to enable min/max testing. @KarishmaGhiya is there anything I need to do?
- remove `testEnv` and just use `env` to reference environment variables inside tests.