### PR TITLE
Update CODEOWNERS for Digital twins

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -48,7 +48,7 @@
 /sdk/cosmosdb/ @kushagraThapar @simorenoh @simplynaveen20 @xinlian12 @moderakh 
 
 # PRLabel: %Digital Twins
-/sdk/digitaltwins/ @vishnureddy17
+/sdk/digitaltwins/ @johngallardo
 
 # PRLabel: %Event Grid
 /sdk/eventgrid/ @xirzec @ellismg


### PR DESCRIPTION
Ownership is transitioning to a new team. 