### PR TITLE
[KeyVault] - Add key_ops to JWK and deprecate keyOps

### DIFF
--- a/sdk/keyvault/keyvault-keys/CHANGELOG.md
+++ b/sdk/keyvault/keyvault-keys/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Added support for automated key rotation in Azure Key Vault.
   - Added `KeyClient.rotateKey` to rotate a key on-demand.
   - Added `KeyClient.updateKeyRotationPolicy` to update a key's automated rotation policy.
+- Added `JsonWebKey.key_ops` property to `JsonWebKey` in addition to the existing `JsonWebKey.keyOps` property in order to comply with the JSON Web Key spec.
 
 ### Breaking Changes
 

--- a/sdk/keyvault/keyvault-keys/review/keyvault-keys.api.md
+++ b/sdk/keyvault/keyvault-keys/review/keyvault-keys.api.md
@@ -211,6 +211,8 @@ export interface JsonWebKey {
     dq?: Uint8Array;
     e?: Uint8Array;
     k?: Uint8Array;
+    key_ops?: KeyOperation[];
+    // @deprecated
     keyOps?: KeyOperation[];
     kid?: string;
     kty?: KeyType;

--- a/sdk/keyvault/keyvault-keys/src/cryptographyClientModels.ts
+++ b/sdk/keyvault/keyvault-keys/src/cryptographyClientModels.ts
@@ -1,10 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { CryptographyOptions, KeyVaultKey } from "./keysModels";
+import { CryptographyOptions, KeyVaultKey, JsonWebKey } from "./keysModels";
 
 import {
-  JsonWebKey,
   JsonWebKeyCurveName as KeyCurveName,
   KnownJsonWebKeyCurveName as KnownKeyCurveNames,
   JsonWebKeyEncryptionAlgorithm as EncryptionAlgorithm,

--- a/sdk/keyvault/keyvault-keys/src/keysModels.ts
+++ b/sdk/keyvault/keyvault-keys/src/keysModels.ts
@@ -49,8 +49,15 @@ export interface JsonWebKey {
   /**
    * Json web key operations. For more
    * information on possible key operations, see KeyOperation.
+   *
+   * @deprecated Use {@link key_ops} instead. keyOps will be removed in version 5.x of `@azure/keyvault-keys`.
    */
   keyOps?: KeyOperation[];
+  /**
+   * Json web key operations. For more
+   * information on possible key operations, see KeyOperation.
+   */
+  key_ops?: KeyOperation[];
   /**
    * RSA modulus.
    */

--- a/sdk/keyvault/keyvault-keys/src/transformations.ts
+++ b/sdk/keyvault/keyvault-keys/src/transformations.ts
@@ -14,8 +14,6 @@ import { parseKeyVaultKeyIdentifier } from "./identifier";
 import {
   DeletedKey,
   KeyVaultKey,
-  JsonWebKey,
-  KeyOperation,
   KeyProperties,
   KeyRotationPolicy,
   KeyRotationPolicyProperties
@@ -37,10 +35,10 @@ export function getKeyFromKeyBundle(
   delete keyBundle.attributes;
 
   const resultObject: KeyVaultKey | DeletedKey = {
-    key: keyBundle.key as JsonWebKey,
+    key: { ...keyBundle.key, key_ops: keyBundle.key?.keyOps },
     id: keyBundle.key ? keyBundle.key.kid : undefined,
     name: parsedId.name,
-    keyOperations: keyBundle.key ? (keyBundle.key.keyOps as KeyOperation[]) : undefined,
+    keyOperations: keyBundle.key ? keyBundle.key.keyOps : undefined,
     keyType: keyBundle.key ? keyBundle.key.kty : undefined,
     properties: {
       tags: keyBundle.tags,

--- a/sdk/keyvault/keyvault-keys/test/internal/transformations.spec.ts
+++ b/sdk/keyvault/keyvault-keys/test/internal/transformations.spec.ts
@@ -59,7 +59,8 @@ describe("Transformations", () => {
         kid:
           "https://azure_managedhsm.managedhsm.azure.net/keys/transformations/f03e8b3d76554e8b9749994bcf72fc61",
         kty: "oct-HSM",
-        keyOps: ["encrypt", "decrypt"]
+        keyOps: ["encrypt", "decrypt"],
+        key_ops: ["encrypt", "decrypt"]
       },
       name: "transformations",
       id:
@@ -126,7 +127,8 @@ describe("Transformations", () => {
         kid:
           "https://azure_managedhsm.managedhsm.azure.net/keys/transformations/f03e8b3d76554e8b9749994bcf72fc61",
         kty: "oct-HSM",
-        keyOps: ["encrypt", "decrypt"]
+        keyOps: ["encrypt", "decrypt"],
+        key_ops: ["encrypt", "decrypt"]
       },
       name: "transformations",
       id:


### PR DESCRIPTION
## What

- Add `key_ops` to `JsonWebKey` model
- Mark `keyOps` as deprecated in `JsonWebKey`

## Why

As per [IETF rfc7517](https://datatracker.ietf.org/doc/html/rfc7517#section-4.3) the correct name for this field is `key_ops`... our TypeScript codegen will of course camelCase this
but snake_case is the expected convention.

I am only marking `keyOps` as deprecated in the JWK, and of course we will continue to populate it for 4.x, but this will
allow anyone to take the key material and use it where a JWK is expected without any conversions.

Resolves #17721