### PR TITLE
Update API Extractor for all packages

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -1274,43 +1274,12 @@ packages:
     engines: {node: '>=8'}
     dev: false
 
-  /@microsoft/api-extractor-model/7.12.2:
-    resolution: {integrity: sha512-EU+U09Mj65zUH0qwPF4PFJiL6Y+PQQE/RRGEHEDGJJzab/mRQDpKOyrzSdb00xvcd/URehIHJqC55cY2Y4jGOA==}
-    dependencies:
-      '@microsoft/tsdoc': 0.12.24
-      '@rushstack/node-core-library': 3.36.0
-    dev: false
-
   /@microsoft/api-extractor-model/7.13.9:
     resolution: {integrity: sha512-t/XKTr8MlHRWgDr1fkyCzTQRR5XICf/WzIFs8yw1JLU8Olw99M3by4/dtpOZNskfqoW+J8NwOxovduU2csi4Ww==}
     dependencies:
       '@microsoft/tsdoc': 0.13.2
       '@microsoft/tsdoc-config': 0.15.2
       '@rushstack/node-core-library': 3.41.0
-    dev: false
-
-  /@microsoft/api-extractor-model/7.7.10:
-    resolution: {integrity: sha512-gMFDXwUgoQYz9TgatyNPALDdZN4xBC3Un3fGwlzME+vM13PoJ26pGuqI7kv/OlK9+q2sgrEdxWns8D3UnLf2TA==}
-    dependencies:
-      '@microsoft/tsdoc': 0.12.19
-      '@rushstack/node-core-library': 3.19.6
-    dev: false
-
-  /@microsoft/api-extractor/7.13.2:
-    resolution: {integrity: sha512-2fD0c8OxZW+e6NTaxbtrdNxXVuX7aqil3+cqig3pKsHymvUuRJVCEAcAJmZrJ/ENqYXNiB265EyqOT6VxbMysw==}
-    hasBin: true
-    dependencies:
-      '@microsoft/api-extractor-model': 7.12.2
-      '@microsoft/tsdoc': 0.12.24
-      '@rushstack/node-core-library': 3.36.0
-      '@rushstack/rig-package': 0.2.10
-      '@rushstack/ts-command-line': 4.7.8
-      colors: 1.2.5
-      lodash: 4.17.21
-      resolve: 1.17.0
-      semver: 7.3.5
-      source-map: 0.6.1
-      typescript: 4.1.6
     dev: false
 
   /@microsoft/api-extractor/7.18.11:
@@ -1331,21 +1300,6 @@ packages:
       typescript: 4.4.3
     dev: false
 
-  /@microsoft/api-extractor/7.7.11:
-    resolution: {integrity: sha512-kd2kakdDoRgI54J5H11a76hyYZBMhtp4piwWAy4bYTwlQT0v/tp+G/UMMgjUL4vKf0kTNhitEUX/0LfQb1AHzQ==}
-    hasBin: true
-    dependencies:
-      '@microsoft/api-extractor-model': 7.7.10
-      '@microsoft/tsdoc': 0.12.19
-      '@rushstack/node-core-library': 3.19.6
-      '@rushstack/ts-command-line': 4.3.13
-      colors: 1.2.5
-      lodash: 4.17.21
-      resolve: 1.8.1
-      source-map: 0.6.1
-      typescript: 3.7.7
-    dev: false
-
   /@microsoft/tsdoc-config/0.15.2:
     resolution: {integrity: sha512-mK19b2wJHSdNf8znXSMYVShAHktVr/ib0Ck2FA3lsVBSEhSI/TfXT7DJQkAYgcztTuwazGcg58ZjYdk0hTCVrA==}
     dependencies:
@@ -1353,14 +1307,6 @@ packages:
       ajv: 6.12.6
       jju: 1.4.0
       resolve: 1.19.0
-    dev: false
-
-  /@microsoft/tsdoc/0.12.19:
-    resolution: {integrity: sha512-IpgPxHrNxZiMNUSXqR1l/gePKPkfAmIKoDRP9hp7OwjU29ZR8WCJsOJ8iBKgw0Qk+pFwR+8Y1cy8ImLY6e9m4A==}
-    dev: false
-
-  /@microsoft/tsdoc/0.12.24:
-    resolution: {integrity: sha512-Mfmij13RUTmHEMi9vRUhMXD7rnGR2VvxeNYtaGtaJ4redwwjT4UXYJ+nzmVJF7hhd4pn/Fx5sncDKxMVFJSWPg==}
     dev: false
 
   /@microsoft/tsdoc/0.13.2:
@@ -1623,32 +1569,6 @@ packages:
       rollup: 1.32.1
     dev: false
 
-  /@rushstack/node-core-library/3.19.6:
-    resolution: {integrity: sha512-1+FoymIdr9W9k0D8fdZBBPwi5YcMwh/RyESuL5bY29rLICFxSLOPK+ImVZ1OcWj9GEMsvDx5pNpJ311mHQk+MA==}
-    dependencies:
-      '@types/node': 10.17.13
-      colors: 1.2.5
-      fs-extra: 7.0.1
-      jju: 1.4.0
-      semver: 5.3.0
-      timsort: 0.3.0
-      z-schema: 3.18.4
-    dev: false
-
-  /@rushstack/node-core-library/3.36.0:
-    resolution: {integrity: sha512-bID2vzXpg8zweXdXgQkKToEdZwVrVCN9vE9viTRk58gqzYaTlz4fMId6V3ZfpXN6H0d319uGi2KDlm+lUEeqCg==}
-    dependencies:
-      '@types/node': 10.17.13
-      colors: 1.2.5
-      fs-extra: 7.0.1
-      import-lazy: 4.0.0
-      jju: 1.4.0
-      resolve: 1.17.0
-      semver: 7.3.5
-      timsort: 0.3.0
-      z-schema: 3.18.4
-    dev: false
-
   /@rushstack/node-core-library/3.41.0:
     resolution: {integrity: sha512-JxdmqR+SHU04jTDaZhltMZL3/XTz2ZZM47DTN+FSPUGUVp6WmxLlvJnT5FoHrOZWUjL/FoIlZUdUPTSXjTjIcg==}
     dependencies:
@@ -1663,35 +1583,11 @@ packages:
       z-schema: 3.18.4
     dev: false
 
-  /@rushstack/rig-package/0.2.10:
-    resolution: {integrity: sha512-WXYerEJEPf8bS3ruqfM57NnwXtA7ehn8VJjLjrjls6eSduE5CRydcob/oBTzlHKsQ7N196XKlqQl9P6qIyYG2A==}
-    dependencies:
-      resolve: 1.17.0
-      strip-json-comments: 3.1.1
-    dev: false
-
   /@rushstack/rig-package/0.3.1:
     resolution: {integrity: sha512-DXQmrPWOCNoE2zPzHCShE1y47FlgbAg48wpaY058Qo/yKDzL0GlEGf5Ra2NIt22pMcp0R/HHh+kZGbqTnF4CrA==}
     dependencies:
       resolve: 1.17.0
       strip-json-comments: 3.1.1
-    dev: false
-
-  /@rushstack/ts-command-line/4.3.13:
-    resolution: {integrity: sha512-BUBbjYu67NJGQkpHu8aYm7kDoMFizL1qx78+72XE3mX/vDdXYJzw/FWS7TPcMJmY4kNlYs979v2B0Q0qa2wRiw==}
-    dependencies:
-      '@types/argparse': 1.0.33
-      argparse: 1.0.10
-      colors: 1.2.5
-    dev: false
-
-  /@rushstack/ts-command-line/4.7.8:
-    resolution: {integrity: sha512-8ghIWhkph7NnLCMDJtthpsb7TMOsVGXVDvmxjE/CeklTqjbbUFBjGXizJfpbEkRQTELuZQ2+vGn7sGwIWKN2uA==}
-    dependencies:
-      '@types/argparse': 1.0.38
-      argparse: 1.0.10
-      colors: 1.2.5
-      string-argv: 0.3.1
     dev: false
 
   /@rushstack/ts-command-line/4.9.1:
@@ -1746,10 +1642,6 @@ packages:
 
   /@tsconfig/node16/1.0.2:
     resolution: {integrity: sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==}
-    dev: false
-
-  /@types/argparse/1.0.33:
-    resolution: {integrity: sha512-VQgHxyPMTj3hIlq9SY1mctqx+Jj8kpQfoLvDlVSDNOyuYs8JYfkuY3OW/4+dO657yPmNhHpePRx0/Tje5ImNVQ==}
     dev: false
 
   /@types/argparse/1.0.38:
@@ -1937,10 +1829,6 @@ packages:
     dependencies:
       '@types/node': 12.20.27
       form-data: 3.0.1
-    dev: false
-
-  /@types/node/10.17.13:
-    resolution: {integrity: sha512-pMCcqU2zT4TjqYFrWtYHKal7Sl30Ims6ulZ4UFXxI4xbtQqK/qqKwkDoBFCfooRqqmRu9vY3xaJRwxSh673aYg==}
     dev: false
 
   /@types/node/12.20.24:
@@ -6600,12 +6488,6 @@ packages:
       path-parse: 1.0.7
     dev: false
 
-  /resolve/1.8.1:
-    resolution: {integrity: sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==}
-    dependencies:
-      path-parse: 1.0.7
-    dev: false
-
   /reusify/1.0.4:
     resolution: {integrity: sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
@@ -6756,11 +6638,6 @@ packages:
   /semaphore/1.1.0:
     resolution: {integrity: sha512-O4OZEaNtkMd/K0i6js9SL+gqy0ZCBMgUvlSqHKi4IBdjhe7wB8pwztUk1BbZ1fmrvpwFrPbHzqd2w5pTcJH6LA==}
     engines: {node: '>=0.8.0'}
-    dev: false
-
-  /semver/5.3.0:
-    resolution: {integrity: sha1-myzl094C0XxgEq0yaqa00M9U+U8=}
-    hasBin: true
     dev: false
 
   /semver/5.7.1:
@@ -7580,12 +7457,6 @@ packages:
     hasBin: true
     dev: false
 
-  /typescript/4.1.6:
-    resolution: {integrity: sha512-pxnwLxeb/Z5SP80JDRzVjh58KsM6jZHRAOtTpS7sXLS4ogXNKC9ANxHHZqLLeVHZN35jCtI4JdmLLbLiC1kBow==}
-    engines: {node: '>=4.2.0'}
-    hasBin: true
-    dev: false
-
   /typescript/4.2.4:
     resolution: {integrity: sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==}
     engines: {node: '>=4.2.0'}
@@ -8036,11 +7907,11 @@ packages:
     dev: false
 
   file:projects/abort-controller.tgz:
-    resolution: {integrity: sha512-F0UODn3OfxiXEQnhR58UOsRkForwyumaX3cEVJBnRaZ59S8BVPjWKSS79mgRbh/w1R/rNv5Fj2vqDFt3eValTg==, tarball: file:projects/abort-controller.tgz}
+    resolution: {integrity: sha512-ZpsapeQj2laRVoc2MKLBCVl2i9Bpv1TNVKRygDMarl1LQe8GRoFE1NcABgOMkcAWBlvvCKWv5GwbibJmGu5z8Q==, tarball: file:projects/abort-controller.tgz}
     name: '@rush-temp/abort-controller'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.7.11
+      '@microsoft/api-extractor': 7.18.11
       '@types/chai': 4.2.22
       '@types/mocha': 7.0.2
       '@types/node': 12.20.27
@@ -8079,13 +7950,13 @@ packages:
     dev: false
 
   file:projects/agrifood-farming.tgz:
-    resolution: {integrity: sha512-cqKpvpFUi1vmXReL/3Kr/NFHD4h94JoyZFOQ1m+wfBVnwVOuv/43PvlE7u3zvnOf4dPqk+EvhWUWYNBrTPx/tw==, tarball: file:projects/agrifood-farming.tgz}
+    resolution: {integrity: sha512-doOPU3+EB1HeT/+wPsN3iRalkIAm97H3z6Qp/3uXpTl73QcnhML7f3rA0If5cwtNAeD21y7lMDeqxA2fHwKjuw==, tarball: file:projects/agrifood-farming.tgz}
     name: '@rush-temp/agrifood-farming'
     version: 0.0.0
     dependencies:
       '@azure-rest/core-client-paging': 1.0.0-beta.1
       '@azure/identity': 1.5.2
-      '@microsoft/api-extractor': 7.13.2
+      '@microsoft/api-extractor': 7.18.11
       '@types/chai': 4.2.22
       '@types/mocha': 7.0.2
       '@types/node': 12.20.27
@@ -8126,13 +7997,13 @@ packages:
     dev: false
 
   file:projects/ai-anomaly-detector.tgz:
-    resolution: {integrity: sha512-8eiHwPfczMiT5YmtQc9kG/TZx5SqySlXAShKgCR1ILFNYndPrk6ngtkx6OmCFzhePZajVB1iQhMA2bXyF5X87A==, tarball: file:projects/ai-anomaly-detector.tgz}
+    resolution: {integrity: sha512-V0r3PZ3S4eIrQjS2KbFFLbPdzya0AVbXcOm8ToCisNVSpxIfQzp3HQ176/l4Ny+xri4qCZCNYcmNAJRXX7lf6Q==, tarball: file:projects/ai-anomaly-detector.tgz}
     name: '@rush-temp/ai-anomaly-detector'
     version: 0.0.0
     dependencies:
       '@azure/core-tracing': 1.0.0-preview.13
       '@azure/identity': 2.0.0-beta.6
-      '@microsoft/api-extractor': 7.7.11
+      '@microsoft/api-extractor': 7.18.11
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-json': 4.1.0_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
@@ -8180,12 +8051,12 @@ packages:
     dev: false
 
   file:projects/ai-document-translator.tgz:
-    resolution: {integrity: sha512-RTnU8NxdkRVFfwo3U+Xeiq7/nhTYqqiMPhh61x4ff25/2pI9x3II0hGAJsMA1hTYKoItr8EDGrZWrVTFx7FRTA==, tarball: file:projects/ai-document-translator.tgz}
+    resolution: {integrity: sha512-aVjpA7a84YiyFSakcI2FuS2iyTL51HF9S9ZLK1CLW3HB4d4/nU1zZLlj+BG6pyoTFL3lAs9rIkToNWTqRMujsQ==, tarball: file:projects/ai-document-translator.tgz}
     name: '@rush-temp/ai-document-translator'
     version: 0.0.0
     dependencies:
       '@azure/identity': 1.5.2
-      '@microsoft/api-extractor': 7.13.2
+      '@microsoft/api-extractor': 7.18.11
       '@types/chai': 4.2.22
       '@types/mocha': 7.0.2
       '@types/node': 12.20.27
@@ -8225,13 +8096,13 @@ packages:
     dev: false
 
   file:projects/ai-form-recognizer.tgz:
-    resolution: {integrity: sha512-YvthO3IXaeYFhgEYtwpgosyRaBw1k6lRXJ1RZKardk2SuNeSKCaIusZS8pHvdb2uWbSYN7dzUIMPCBN1Dro1mA==, tarball: file:projects/ai-form-recognizer.tgz}
+    resolution: {integrity: sha512-4kZitcEGzsKyuIfpEwGlbPC/1SGCMEAt4nY1JBHoLSVhBRdz5sYcvOOCClwiuy+Rj7RGY3z5whUtV3XZIQdwFQ==, tarball: file:projects/ai-form-recognizer.tgz}
     name: '@rush-temp/ai-form-recognizer'
     version: 0.0.0
     dependencies:
       '@azure/core-tracing': 1.0.0-preview.13
       '@azure/identity': 2.0.0-beta.6
-      '@microsoft/api-extractor': 7.7.11
+      '@microsoft/api-extractor': 7.18.11
       '@types/chai': 4.2.22
       '@types/mocha': 7.0.2
       '@types/node': 12.20.27
@@ -8273,13 +8144,13 @@ packages:
     dev: false
 
   file:projects/ai-metrics-advisor.tgz:
-    resolution: {integrity: sha512-egylYR9c3D3cVW5/T7dfRBrr7Y4Ds0mqOkDD4/P0eKAATclq0w578MYQP/MMLM40tRHmiNXe1ZyxZw2++wterw==, tarball: file:projects/ai-metrics-advisor.tgz}
+    resolution: {integrity: sha512-SNGpBK4Ge2B9exp2asWgInh3fi/DENoemqWCgbxRZbGB1WAUkwlEpm3mQtaLPmjn/p78GG1EsX48cb3OdPh6MQ==, tarball: file:projects/ai-metrics-advisor.tgz}
     name: '@rush-temp/ai-metrics-advisor'
     version: 0.0.0
     dependencies:
       '@azure/core-tracing': 1.0.0-preview.13
       '@azure/identity': 1.5.2
-      '@microsoft/api-extractor': 7.7.11
+      '@microsoft/api-extractor': 7.18.11
       '@types/chai': 4.2.22
       '@types/mocha': 7.0.2
       '@types/node': 12.20.27
@@ -8324,7 +8195,7 @@ packages:
     dev: false
 
   file:projects/ai-text-analytics.tgz:
-    resolution: {integrity: sha512-ZxFZFGVS8QE7mgdOlzQBb8QoHd1lb+hed1Dp5KojWLWTKmOv7X4WxVPIDiVbIj8ebpPjAd4cHhua0frdwCiSig==, tarball: file:projects/ai-text-analytics.tgz}
+    resolution: {integrity: sha512-QJl0L6l7DxDarzFIgyyt+ci2dZt8YwdkzPrsQ07Wo0afRnipNhj1wCb21dGocFfLqCa+i2+IyCpVjdv5zCt31A==, tarball: file:projects/ai-text-analytics.tgz}
     name: '@rush-temp/ai-text-analytics'
     version: 0.0.0
     dependencies:
@@ -8377,14 +8248,14 @@ packages:
     dev: false
 
   file:projects/app-configuration.tgz:
-    resolution: {integrity: sha512-/U5KWOuiyI9hrAutHmMPodzoL6WOmKw0+XNTscQv6Wa80Nwz+sYN3MfqyTRLi0TRHdeRXPGptZ4NxXkUU9hB1g==, tarball: file:projects/app-configuration.tgz}
+    resolution: {integrity: sha512-9RxrPnjfQrTUBBlhahdw1Hg9jkJrzquYaf35tL6qgnCsKd5sg1JZ7o7xflb9MpyFwcJfgiCfuNq0j0/OBezcLA==, tarball: file:projects/app-configuration.tgz}
     name: '@rush-temp/app-configuration'
     version: 0.0.0
     dependencies:
       '@azure/core-tracing': 1.0.0-preview.13
       '@azure/identity': 2.0.0-beta.6
       '@azure/keyvault-secrets': 4.3.0
-      '@microsoft/api-extractor': 7.7.11
+      '@microsoft/api-extractor': 7.18.11
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-inject': 4.0.2_rollup@1.32.1
       '@rollup/plugin-json': 4.1.0_rollup@1.32.1
@@ -8438,12 +8309,12 @@ packages:
     dev: false
 
   file:projects/arm-apimanagement.tgz:
-    resolution: {integrity: sha512-R1mmbnd4t5ez09UNfYHCKQI/ZPdKG63PTOG0cqqe+Ewz/Jux/sCsuFa8eAWymyPsK63rSB+RvXZbfK1QIt6VKA==, tarball: file:projects/arm-apimanagement.tgz}
+    resolution: {integrity: sha512-Fhy/ZVzzeHAI6KpTIXUXFfm/Snv32HwUcw9otxvEujalkzeZr8Zqj2A5sL+Z4JCsXIiEdRu0ERDezW/zC9zBQw==, tarball: file:projects/arm-apimanagement.tgz}
     name: '@rush-temp/arm-apimanagement'
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.0.0-beta.6
-      '@microsoft/api-extractor': 7.7.11
+      '@microsoft/api-extractor': 7.18.11
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-json': 4.1.0_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
@@ -8462,11 +8333,11 @@ packages:
     dev: false
 
   file:projects/arm-appservice.tgz:
-    resolution: {integrity: sha512-O5f+BWzGqVFxpvEE9Tgt55OyDt1qgN3vO5dj4MHkff8gcwl9zmYQaQ+MEod9jGYgC2rZkCXlfLl9NmSDyoV54g==, tarball: file:projects/arm-appservice.tgz}
+    resolution: {integrity: sha512-aJraI3T9AOAXBy7uKxYZ7jX01W4DOG73u2YEMJ1PdasBSnwJ/SjH9ZI5RT1CbaRqdUAuJsFBhHJdDKc0mXQG2A==, tarball: file:projects/arm-appservice.tgz}
     name: '@rush-temp/arm-appservice'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.7.11
+      '@microsoft/api-extractor': 7.18.11
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-json': 4.1.0_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
@@ -8481,11 +8352,11 @@ packages:
     dev: false
 
   file:projects/arm-authorization.tgz:
-    resolution: {integrity: sha512-uEY4hjyOxufuVrMwUbobOnaDrWnQSYJ/w9bvzk6AK0LOLWsRF/Wni7IK1hgVVi67EnCordoSuwTOtFiv+g8B4A==, tarball: file:projects/arm-authorization.tgz}
+    resolution: {integrity: sha512-WM4xyGTydD8+/LHQL+nCUBAiJs8qQUhNlY/Wei33PvR7RkQiVC6n8Jzd7UijWW8poj/hawJyABuQxU+Pese58A==, tarball: file:projects/arm-authorization.tgz}
     name: '@rush-temp/arm-authorization'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.7.11
+      '@microsoft/api-extractor': 7.18.11
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-json': 4.1.0_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
@@ -8499,11 +8370,11 @@ packages:
     dev: false
 
   file:projects/arm-compute.tgz:
-    resolution: {integrity: sha512-T3UFCbTMY/dds1j8CFcJLUkkyV3oR9pnPcpbK3DvLauxAZGylmQbuZv36iTLpGpMO0cxKIdgGm1G6EdgfgMOPw==, tarball: file:projects/arm-compute.tgz}
+    resolution: {integrity: sha512-Xn4t1yWRD9vhj8MkZ02f2OIV3CaCIUFJwRTL8dTxVsafJbmeFJqs97mzIem8G2yosfRQxJx4Lxyb+Z6vmL1zBQ==, tarball: file:projects/arm-compute.tgz}
     name: '@rush-temp/arm-compute'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.7.11
+      '@microsoft/api-extractor': 7.18.11
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-json': 4.1.0_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
@@ -8517,12 +8388,12 @@ packages:
     dev: false
 
   file:projects/arm-eventgrid.tgz:
-    resolution: {integrity: sha512-PMzPDLEcZd3yBiZ0C/SDkxjGo5O570UkCFe+WEB3nBKU11CYeCiDKSNS9OIkwR2clJCkLkU6hrlygp9a18N3Fg==, tarball: file:projects/arm-eventgrid.tgz}
+    resolution: {integrity: sha512-+XOrFix8ZFVM4KwSCHmgXW5R2T/NPMLuaz69Ml0hPJBGDg8Fgjgj5jErmZ8ZEXpZFkI3i3ax0d8fBB1mNY9+SQ==, tarball: file:projects/arm-eventgrid.tgz}
     name: '@rush-temp/arm-eventgrid'
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.0.0-beta.6
-      '@microsoft/api-extractor': 7.7.11
+      '@microsoft/api-extractor': 7.18.11
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-json': 4.1.0_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
@@ -8541,11 +8412,11 @@ packages:
     dev: false
 
   file:projects/arm-eventhub.tgz:
-    resolution: {integrity: sha512-prxNN24vp5ndwaqivPOFLkNF0Id6m0zm5YL0Azqgv6PoZzThFLxEkgaWtsUxFQicLGqXWB7XomzA0EUyPHyDbQ==, tarball: file:projects/arm-eventhub.tgz}
+    resolution: {integrity: sha512-XdKP2K9Up2NfmnQhsC180QQm04AS0+LtDMDaIj7equptk2zQLRuEuQtzB2K69tOsgkAgO4VzBxxfoQLI5OfEEg==, tarball: file:projects/arm-eventhub.tgz}
     name: '@rush-temp/arm-eventhub'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.7.11
+      '@microsoft/api-extractor': 7.18.11
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-json': 4.1.0_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
@@ -8559,11 +8430,11 @@ packages:
     dev: false
 
   file:projects/arm-features.tgz:
-    resolution: {integrity: sha512-Jdqy3BnYfdYfUwQ4L97IVWbg0zwT9HuL1PJ/8JZrmqMo6RZOE1jUDnYcSRA2h7Ke1Rhe8rHi0g80U3EWbWvr9A==, tarball: file:projects/arm-features.tgz}
+    resolution: {integrity: sha512-mCciFjE3JlWC8Z2rx2nj87jDLeSH+37kGZJxt81t4od4QUsCcIJmwmVTt/bbcZSntwu57tCawTyp91nh2FlLEA==, tarball: file:projects/arm-features.tgz}
     name: '@rush-temp/arm-features'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.7.11
+      '@microsoft/api-extractor': 7.18.11
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-json': 4.1.0_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
@@ -8578,11 +8449,11 @@ packages:
     dev: false
 
   file:projects/arm-keyvault.tgz:
-    resolution: {integrity: sha512-v75V6krb8/ZT8DT7FKKuDcto86Imeg9rTTBruOW3WnqxcVWNAdgIe+1ZWZxLeaUxSPLntYlCfreanFYO7952Eg==, tarball: file:projects/arm-keyvault.tgz}
+    resolution: {integrity: sha512-FnvWshHbYbXqHFfanHE8YzqznZBDWFIDY3Cud0PNTTds8esvpH3gRYEuZWYMcLGXymShlYeLdYaUcxMEk1/eCA==, tarball: file:projects/arm-keyvault.tgz}
     name: '@rush-temp/arm-keyvault'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.7.11
+      '@microsoft/api-extractor': 7.18.11
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-json': 4.1.0_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
@@ -8597,11 +8468,11 @@ packages:
     dev: false
 
   file:projects/arm-links.tgz:
-    resolution: {integrity: sha512-rp7358CAZYQTk14rux456WPw0drTcb6tLaCbzxS10sUYP18FSZAdXMThbRk6FWXcyGiNdiYWIDg99JUxOoS2hQ==, tarball: file:projects/arm-links.tgz}
+    resolution: {integrity: sha512-zxqOUfFGnAdGAHNsj/VAFy0h9uSgI7VCtBCD/41wYchyF5OckL1/ql6m5Kw/CpdwJxx0vuLiXS7xJtDPehG/3g==, tarball: file:projects/arm-links.tgz}
     name: '@rush-temp/arm-links'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.7.11
+      '@microsoft/api-extractor': 7.18.11
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-json': 4.1.0_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
@@ -8616,11 +8487,11 @@ packages:
     dev: false
 
   file:projects/arm-locks.tgz:
-    resolution: {integrity: sha512-Pbwm7icKOAqRDLs7DB00ERbjwjtOHOCWtyxLuzSvnu14uHgTS7Hdc25em9Zj2kIIn9Fqq2EGPytZkfq4BA2Ayg==, tarball: file:projects/arm-locks.tgz}
+    resolution: {integrity: sha512-Mh2K3/qtCk0subKuIb8mJpqw06b2umM15k5VAv9/FlyGUkg+L+Y4l66LFzZ0jZ7CUZQ7iiCdaAReDHaFFBfKhg==, tarball: file:projects/arm-locks.tgz}
     name: '@rush-temp/arm-locks'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.7.11
+      '@microsoft/api-extractor': 7.18.11
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-json': 4.1.0_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
@@ -8635,11 +8506,11 @@ packages:
     dev: false
 
   file:projects/arm-managedapplications.tgz:
-    resolution: {integrity: sha512-rd/IuR0zgpA58pTS328g3AzEcjXlQiUW9hWYUWJXCdYCjKl5u89SJ1rNNMheQXMXs9qUv6hFG6tt8q1ZCDirtQ==, tarball: file:projects/arm-managedapplications.tgz}
+    resolution: {integrity: sha512-S57AX6NhmfsjZR4IQc45ymobG+BiQakRsjxEq0bVZxD5PO1gaU//rpEr3GbVs82i0fUVsTECdOcuDjQilXEifA==, tarball: file:projects/arm-managedapplications.tgz}
     name: '@rush-temp/arm-managedapplications'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.7.11
+      '@microsoft/api-extractor': 7.18.11
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-json': 4.1.0_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
@@ -8654,11 +8525,11 @@ packages:
     dev: false
 
   file:projects/arm-network.tgz:
-    resolution: {integrity: sha512-Q7ixqI/vd+XixRZLhqDeyeSBGkpyEW+1n0wphunRHGVUrcwHddiEGB2rdiWFXJaCP47WG/EngiRCqMGGKTr+lg==, tarball: file:projects/arm-network.tgz}
+    resolution: {integrity: sha512-V6PUn85sJgrqj+Q1dtj+3y1rIaeirmEAWQHqs7LwG28ZatoFcvTCCPZdDniK8Feb1rIHR19GE8UG0za33HiPjw==, tarball: file:projects/arm-network.tgz}
     name: '@rush-temp/arm-network'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.7.11
+      '@microsoft/api-extractor': 7.18.11
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-json': 4.1.0_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
@@ -8672,11 +8543,11 @@ packages:
     dev: false
 
   file:projects/arm-policy.tgz:
-    resolution: {integrity: sha512-1cDd7l+RfNr7rAJxGMqLHW/zYV/F5tRFsA1R6RplSOTGg8yo1foORk8QvIa+oumecW/uYGC/jePfHrx55atGMQ==, tarball: file:projects/arm-policy.tgz}
+    resolution: {integrity: sha512-lKzDSKhoHFS6qttMoOn8BYpXGwvkgnZHQlgA52pgsAVYdAnlp/CwOxtmq/pysPuRoeg/9/2LGX0zT3XCl1JOsg==, tarball: file:projects/arm-policy.tgz}
     name: '@rush-temp/arm-policy'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.7.11
+      '@microsoft/api-extractor': 7.18.11
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-json': 4.1.0_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
@@ -8691,11 +8562,11 @@ packages:
     dev: false
 
   file:projects/arm-purview.tgz:
-    resolution: {integrity: sha512-oNNMNU6y5mHqW3Lg2ASVmmohPywUvskEN2oDdwQI+g/cBrpnxoiPRIgSAkPkOzRxWPRXxv7LgQIxl8AaisYCpg==, tarball: file:projects/arm-purview.tgz}
+    resolution: {integrity: sha512-3yTP1x0NsuoF22Z+MwjuLYQlboJwRDH24Dr7HapItun5Mkbjj4efeEuMJLg7lRT32YVtkIGE5OEQOXEXIMXgRA==, tarball: file:projects/arm-purview.tgz}
     name: '@rush-temp/arm-purview'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.7.11
+      '@microsoft/api-extractor': 7.18.11
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-json': 4.1.0_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
@@ -8709,12 +8580,12 @@ packages:
     dev: false
 
   file:projects/arm-rediscache.tgz:
-    resolution: {integrity: sha512-vz7HvSxGxgPV2+zCKE1wL04XxeVFUhpqKkRbcvxlSSZJe3uCJSr3iqt9YqGM0SaV84IV3lv0MCrIeyOm1DX3bQ==, tarball: file:projects/arm-rediscache.tgz}
+    resolution: {integrity: sha512-Yl7pHqZkwRoVW+qpmcxEuwqyrvsm+88gPuDVmaMIrZq2y/wmbnkEah6sHl0kM0tM5RWJ+SinUHJ1+FMbQlVGHQ==, tarball: file:projects/arm-rediscache.tgz}
     name: '@rush-temp/arm-rediscache'
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.0.0-beta.6
-      '@microsoft/api-extractor': 7.7.11
+      '@microsoft/api-extractor': 7.18.11
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-json': 4.1.0_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
@@ -8733,11 +8604,11 @@ packages:
     dev: false
 
   file:projects/arm-resources-subscriptions.tgz:
-    resolution: {integrity: sha512-6GWFjnVvh/TZyCDi+Fj6ShcBGzmKQ8mvChj7v+n68IPy8QUwXlB08EvQ5zo/7+jii9EwFGCBOQok/5+BISRnJg==, tarball: file:projects/arm-resources-subscriptions.tgz}
+    resolution: {integrity: sha512-85EwJst/1klI+zYcCVmpb7xnk12tSFqcHCRSMr8KA+j2WZuI4dW1vVaS0Qm9yeecG2H2yheqZLDXXwvm6B7NYg==, tarball: file:projects/arm-resources-subscriptions.tgz}
     name: '@rush-temp/arm-resources-subscriptions'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.7.11
+      '@microsoft/api-extractor': 7.18.11
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-json': 4.1.0_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
@@ -8752,11 +8623,11 @@ packages:
     dev: false
 
   file:projects/arm-resources.tgz:
-    resolution: {integrity: sha512-qCoJfklY7j2h5N8EgS7J/9fgg52p1QJminenS8L2y2O8z2mnEc/qr5PqkypeM7GZaQXUf0vK68A0U6fOEuWRxg==, tarball: file:projects/arm-resources.tgz}
+    resolution: {integrity: sha512-y3NszE6ozZSl0b3T5+1JF45w64NDRTeMC+41eT+EH0e35qU/EvHrpLqqM8lu+nDIOLb6nnEPkTqsh5oDr4OhbA==, tarball: file:projects/arm-resources.tgz}
     name: '@rush-temp/arm-resources'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.7.11
+      '@microsoft/api-extractor': 7.18.11
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-json': 4.1.0_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
@@ -8771,11 +8642,11 @@ packages:
     dev: false
 
   file:projects/arm-servicebus.tgz:
-    resolution: {integrity: sha512-q1Mf8xx0bI00+fi1OIqZeMgMxlWfliTjUdbCEdsmFUI9XhB+LZ83NIyXB5uNECvuIiOca9aJr/0rxaop11KKLg==, tarball: file:projects/arm-servicebus.tgz}
+    resolution: {integrity: sha512-IUTGAWXcntlWJN71Tv3hOp8z6RQtTIn6WfNio1IXRKipZ7MTm3UvLDaZFkYIS8tPqzP6+ErnOt+i/twF6uGHzg==, tarball: file:projects/arm-servicebus.tgz}
     name: '@rush-temp/arm-servicebus'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.7.11
+      '@microsoft/api-extractor': 7.18.11
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-json': 4.1.0_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
@@ -8789,11 +8660,11 @@ packages:
     dev: false
 
   file:projects/arm-sql.tgz:
-    resolution: {integrity: sha512-1nv+fHLm/8KtX6rSVv/pmclEN7WzLAFtJuFqOOGUCSYEH0uK/vjrTWdV9/z5v2hCopmTGrnLM1m1JyQTwEL5aA==, tarball: file:projects/arm-sql.tgz}
+    resolution: {integrity: sha512-0gHhfD0wWxyOvy8b2PNcSz3ERLTuG/cidoCDVdlMVXIswWY3A9sv9N9rw6C+P1dDPdEnmKoob1ojQiZ4XyvWyw==, tarball: file:projects/arm-sql.tgz}
     name: '@rush-temp/arm-sql'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.7.11
+      '@microsoft/api-extractor': 7.18.11
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-json': 4.1.0_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
@@ -8807,11 +8678,11 @@ packages:
     dev: false
 
   file:projects/arm-storage.tgz:
-    resolution: {integrity: sha512-qBc4PYovQxo5tZRHGNtgQLmfF7Uq8FVopd9F1Ghu5qcS68wESbBhwZ1px9/EjPWIHpPyrBzazFRMlvT+5gcthA==, tarball: file:projects/arm-storage.tgz}
+    resolution: {integrity: sha512-1m+K2hw43LlztosVI/kDOIl0VDd082HKZCs5VzWq64pB6WiMMSonAJVKnHVNEon7U+i6tm1M+CRP34RnFhtj2Q==, tarball: file:projects/arm-storage.tgz}
     name: '@rush-temp/arm-storage'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.7.11
+      '@microsoft/api-extractor': 7.18.11
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-json': 4.1.0_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
@@ -8826,11 +8697,11 @@ packages:
     dev: false
 
   file:projects/arm-templatespecs.tgz:
-    resolution: {integrity: sha512-xJ4r+nZre0Bli2nfn7U0n/MX7cbpw0zyG40XetY8XvGX5C07tKzeRa+1ptGSuaw8U3o4BOSWsDVCA6Z/YEZt2g==, tarball: file:projects/arm-templatespecs.tgz}
+    resolution: {integrity: sha512-RgFlqAwnq0UphGTsIEF+hkpnM8jej+SkZtCk9SNx58wLRKIVX9+CDqYOXqtsHgKwYSP+vIopZcyKqYefF7/VPg==, tarball: file:projects/arm-templatespecs.tgz}
     name: '@rush-temp/arm-templatespecs'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.7.11
+      '@microsoft/api-extractor': 7.18.11
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-json': 4.1.0_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
@@ -8845,11 +8716,11 @@ packages:
     dev: false
 
   file:projects/arm-webpubsub.tgz:
-    resolution: {integrity: sha512-0EU10j+ZIAl/Hj/KR+2LjjS6Ik8nlvNX3xGtR9cxSIl2Wle+EOw+3YtTQt1E4spSlsWnPcvZXJ3WKyV8mvt6vg==, tarball: file:projects/arm-webpubsub.tgz}
+    resolution: {integrity: sha512-outReJxntlsc+34E+MMqYNybnLClXCh8GSmgwhybPn1YwfEUFmD2lG9P+w4HDstkAshJ0gDu5su/JBlpU94AkQ==, tarball: file:projects/arm-webpubsub.tgz}
     name: '@rush-temp/arm-webpubsub'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.7.11
+      '@microsoft/api-extractor': 7.18.11
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-json': 4.1.0_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
@@ -8864,13 +8735,13 @@ packages:
     dev: false
 
   file:projects/attestation.tgz:
-    resolution: {integrity: sha512-MWwZlGPsxTbmfdj0axvPY0KVohkpCJZTd40tbKbMYtamWCOp1j/3Xx6XEOBdF9GGfezIpGtJSla5ERFd9Q2hbQ==, tarball: file:projects/attestation.tgz}
+    resolution: {integrity: sha512-WCiF7953kXpj9h/IPV9Y4KbomhboEkBQUzfVQE7FefAYJh8JjcfaSGGwX/FJXSZPCBgorfG7OjQ+i6y4d3eYTg==, tarball: file:projects/attestation.tgz}
     name: '@rush-temp/attestation'
     version: 0.0.0
     dependencies:
       '@azure/core-tracing': 1.0.0-preview.13
       '@azure/identity': 2.0.0-beta.6
-      '@microsoft/api-extractor': 7.7.11
+      '@microsoft/api-extractor': 7.18.11
       '@types/chai': 4.2.22
       '@types/chai-as-promised': 7.1.4
       '@types/mocha': 7.0.2
@@ -8922,14 +8793,14 @@ packages:
     dev: false
 
   file:projects/communication-chat.tgz:
-    resolution: {integrity: sha512-+NrWprQdQDByOujthknzzOHYc1QFEiUfHIeoE3yRoPmS3eX1ghAInV7LBDcm4zm6o2FRMCDxcTJto9iZhigI3Q==, tarball: file:projects/communication-chat.tgz}
+    resolution: {integrity: sha512-hwiUYIKo2uze93jsrAMKE3tCLOj/s3JiffASzXFcXMNMzzXJT0ikVatL0u0MZXaplZHFyMcHJ1/tjCuSQE9Cew==, tarball: file:projects/communication-chat.tgz}
     name: '@rush-temp/communication-chat'
     version: 0.0.0
     dependencies:
       '@azure/communication-identity': 1.0.0
       '@azure/communication-signaling': 1.0.0-beta.10
       '@azure/core-tracing': 1.0.0-preview.13
-      '@microsoft/api-extractor': 7.7.11
+      '@microsoft/api-extractor': 7.18.11
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-json': 4.1.0_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
@@ -8984,12 +8855,12 @@ packages:
     dev: false
 
   file:projects/communication-common.tgz:
-    resolution: {integrity: sha512-Y6t2s/oqQpZpz7TOgPeLrg8lQOBAuzUW0jj9j7hl6sa/WgFTXm+4aOeocTsPFGrDKtPxrjOuZmLv7LMtsYfinQ==, tarball: file:projects/communication-common.tgz}
+    resolution: {integrity: sha512-fwGyN4Eqeo8BLJIXXrRwk7ZsugwP93sZTBIMQyVX/Sbd0J6f1FZI0df2R4Nwtmw7OD2SjnngCbwL+uX+X5KfPQ==, tarball: file:projects/communication-common.tgz}
     name: '@rush-temp/communication-common'
     version: 0.0.0
     dependencies:
       '@azure/core-tracing': 1.0.0-preview.13
-      '@microsoft/api-extractor': 7.7.11
+      '@microsoft/api-extractor': 7.18.11
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-json': 4.1.0_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
@@ -9042,13 +8913,13 @@ packages:
     dev: false
 
   file:projects/communication-identity.tgz:
-    resolution: {integrity: sha512-hN3srNgjmJdDIoAO1Su+GZsI1qh5b54PAmbyr3spfLMnzejf5ljcxCZWSHAO7gYwvGT+Av4CICtWtUuyFLaQHg==, tarball: file:projects/communication-identity.tgz}
+    resolution: {integrity: sha512-xrKP7DoDLOgOa/dRPiyWT/AQ7PdXejQtwV+hD2K9vK9+CGuwpBmdONAz2+qPQhCwrcz47lKDB62YD+Svp3jiAg==, tarball: file:projects/communication-identity.tgz}
     name: '@rush-temp/communication-identity'
     version: 0.0.0
     dependencies:
       '@azure/core-tracing': 1.0.0-preview.13
       '@azure/identity': 2.0.0-beta.6
-      '@microsoft/api-extractor': 7.7.11
+      '@microsoft/api-extractor': 7.18.11
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-json': 4.1.0_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
@@ -9100,14 +8971,14 @@ packages:
     dev: false
 
   file:projects/communication-network-traversal.tgz:
-    resolution: {integrity: sha512-+ULxT3XN8qSsW68KcALoAriUSlCBTR7TU/qXsydwS+BfhMMG2voGPXEjRSKJc7PRMi1mR0Z7tWW4nFNy7EnuYg==, tarball: file:projects/communication-network-traversal.tgz}
+    resolution: {integrity: sha512-cAbotaWlwtYYV5m5+rXDMjIsDtQ2GDrxf+qqjUqHjczm4B+dmQoNASgTjpjuN1YtIkILoTgS40G7+VP6w5MKhA==, tarball: file:projects/communication-network-traversal.tgz}
     name: '@rush-temp/communication-network-traversal'
     version: 0.0.0
     dependencies:
       '@azure/communication-identity': 1.0.0
       '@azure/core-tracing': 1.0.0-preview.13
       '@azure/identity': 2.0.0-beta.6
-      '@microsoft/api-extractor': 7.7.11
+      '@microsoft/api-extractor': 7.18.11
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-json': 4.1.0_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
@@ -9159,13 +9030,13 @@ packages:
     dev: false
 
   file:projects/communication-phone-numbers.tgz:
-    resolution: {integrity: sha512-EpHIaOTq9RyLWOVSd9tPraMODTp7u10AlJbZHOsCrWbOhXm9eiJY2h4l7CI9yiQ0KSOJ+KG7sotMSdPh5Grzkw==, tarball: file:projects/communication-phone-numbers.tgz}
+    resolution: {integrity: sha512-HA74Chs+pE5JgaZa8dKNUGGUHbJnUUw+E6N6uD0cusLZnLlJAWo6ow668DINvBZYMfLSl6KIg7AmyxUThBpnGg==, tarball: file:projects/communication-phone-numbers.tgz}
     name: '@rush-temp/communication-phone-numbers'
     version: 0.0.0
     dependencies:
       '@azure/core-tracing': 1.0.0-preview.13
       '@azure/identity': 2.0.0-beta.6
-      '@microsoft/api-extractor': 7.7.11
+      '@microsoft/api-extractor': 7.18.11
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-json': 4.1.0_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
@@ -9217,13 +9088,13 @@ packages:
     dev: false
 
   file:projects/communication-sms.tgz:
-    resolution: {integrity: sha512-qN1zBX/BCstzeKeHn84XCJTeq/Cs3F+5/xu9fiXVxGnzaQBlZCuWSFTn8vSEKEuK4ZxQu9IXSD9pJmAOP5u6Qg==, tarball: file:projects/communication-sms.tgz}
+    resolution: {integrity: sha512-H5dujcvqO7roaJBGtx7BC4goJxuheZymZnrffRv8oEy2EgO9LoDFv1dOuMWqkmTr+wzmxJpjOkAsTQ/Kxr7Hiw==, tarball: file:projects/communication-sms.tgz}
     name: '@rush-temp/communication-sms'
     version: 0.0.0
     dependencies:
       '@azure/core-tracing': 1.0.0-preview.13
       '@azure/identity': 2.0.0-beta.6
-      '@microsoft/api-extractor': 7.7.11
+      '@microsoft/api-extractor': 7.18.11
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-json': 4.1.0_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
@@ -9274,12 +9145,12 @@ packages:
     dev: false
 
   file:projects/confidential-ledger.tgz:
-    resolution: {integrity: sha512-lQYlLhA8jsiSwPsCRn0A+03cVkbIds7xTk4dqHv3dUeXmFoKYxUvPd6hBQfnVSMjrLZj6QMiViKnUS8/b5SUkA==, tarball: file:projects/confidential-ledger.tgz}
+    resolution: {integrity: sha512-tM0C9+IHHB3iahb5JZjv7kBRlZKW7Zhfzffbq7dBK9iG7nJSwN5Lo06gjWU2CqaURKblLAoqaDCtfxd/Jjdq3A==, tarball: file:projects/confidential-ledger.tgz}
     name: '@rush-temp/confidential-ledger'
     version: 0.0.0
     dependencies:
       '@azure/identity': 1.5.2
-      '@microsoft/api-extractor': 7.13.2
+      '@microsoft/api-extractor': 7.18.11
       '@types/chai': 4.2.22
       '@types/mocha': 7.0.2
       '@types/node': 12.20.27
@@ -9319,13 +9190,13 @@ packages:
     dev: false
 
   file:projects/container-registry.tgz:
-    resolution: {integrity: sha512-x1+6Vq4/SBsQKlK+DOBTsie+XrqCviHhBTfolK4sxjuP6/0g78eUsUrfsWxBgjUSNgT/A04F6/7PAlecV7sh9Q==, tarball: file:projects/container-registry.tgz}
+    resolution: {integrity: sha512-y1eFD8iLlsErUCtE7MkKK+mkgCJbZ0iGB/AyfUumCggxjLXipP+HBP+yA7H6/tMNE5fQxw/rVpwcQPLG2dFiHA==, tarball: file:projects/container-registry.tgz}
     name: '@rush-temp/container-registry'
     version: 0.0.0
     dependencies:
       '@azure/core-tracing': 1.0.0-preview.13
       '@azure/identity': 2.0.0-beta.6
-      '@microsoft/api-extractor': 7.7.11
+      '@microsoft/api-extractor': 7.18.11
       '@types/chai': 4.2.22
       '@types/chai-as-promised': 7.1.4
       '@types/mocha': 7.0.2
@@ -9367,11 +9238,11 @@ packages:
     dev: false
 
   file:projects/core-amqp.tgz:
-    resolution: {integrity: sha512-j8n967+bYNorq6kf5yo+IYaJuXJ0Qd7fcmB8QRkX1GaUdlfJ1Nf/3AMHdK4GQjCHeqKmUqgcC7yv8b2d2SsLmw==, tarball: file:projects/core-amqp.tgz}
+    resolution: {integrity: sha512-lTO3pzPfXSJWZLbjcL4+Aovmcj8qiunMbfRK3r5Gckzfx1xlbR0TPV77GG/IeGZVHRNIVgeXKc1R5JxdIZjeHA==, tarball: file:projects/core-amqp.tgz}
     name: '@rush-temp/core-amqp'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.7.11
+      '@microsoft/api-extractor': 7.18.11
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-inject': 4.0.2_rollup@1.32.1
       '@rollup/plugin-json': 4.1.0_rollup@1.32.1
@@ -9440,11 +9311,11 @@ packages:
     dev: false
 
   file:projects/core-auth.tgz:
-    resolution: {integrity: sha512-pdVm8tTyrBXIMYR5CFDSjZLbIDYsKQNbABEICJfRW3c77f0pPGadRdvC34rieD68ZfNxIZ3wtxKEJdma8HPQYQ==, tarball: file:projects/core-auth.tgz}
+    resolution: {integrity: sha512-5za6xyOYzRmSo5PeWlUk551FZeM+MkLHFd0l2Oh84pwtIDbMS3gr6txPMJ8k088/Dhvr+HDNTGRhGsGlZqgIig==, tarball: file:projects/core-auth.tgz}
     name: '@rush-temp/core-auth'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.7.11
+      '@microsoft/api-extractor': 7.18.11
       '@types/chai': 4.2.22
       '@types/mocha': 7.0.2
       '@types/node': 12.20.27
@@ -9467,12 +9338,12 @@ packages:
     dev: false
 
   file:projects/core-client-1.tgz:
-    resolution: {integrity: sha512-NDupGVfdPfzkzttVKtuqCLAc8YWmDA/4T4AWigniK83WS2b7JyG5G8N2oSpdIBdMsqZxTmInZkuFmeXzAyBUkQ==, tarball: file:projects/core-client-1.tgz}
+    resolution: {integrity: sha512-Jrk9XZOCfamdJtybs9LCJtiu3FTJk7aVJq5A9sVtFpvycqk7OvjKp/MvK8qNoFH78eLnpk0BYH5rSqtkYYR9yg==, tarball: file:projects/core-client-1.tgz}
     name: '@rush-temp/core-client-1'
     version: 0.0.0
     dependencies:
       '@azure/core-tracing': 1.0.0-preview.13
-      '@microsoft/api-extractor': 7.7.11
+      '@microsoft/api-extractor': 7.18.11
       '@types/chai': 4.2.22
       '@types/mocha': 7.0.2
       '@types/node': 12.20.27
@@ -9514,11 +9385,11 @@ packages:
     dev: false
 
   file:projects/core-client-lro.tgz:
-    resolution: {integrity: sha512-M4evzMVsUDQjqh47XEQtziCB+jT5OhhmOrmpzyI1yE/2vYMM3Bz0kZPBWGq9KZDcBmkFCNNHhjk4uY8oG/BWMA==, tarball: file:projects/core-client-lro.tgz}
+    resolution: {integrity: sha512-KwN4VXaNjq7h7f9ks2/0vkiPronTala/qLwbIxxO5gZjRbmDpUu999lOwD/ynCFzB7hK4tDYwtxgOsOFKMPIcQ==, tarball: file:projects/core-client-lro.tgz}
     name: '@rush-temp/core-client-lro'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.13.2
+      '@microsoft/api-extractor': 7.18.11
       '@types/chai': 4.2.22
       '@types/mocha': 7.0.2
       '@types/node': 12.20.27
@@ -9555,11 +9426,11 @@ packages:
     dev: false
 
   file:projects/core-client-paging.tgz:
-    resolution: {integrity: sha512-jR9MSynY/6hjmMjyWjs+hFAAwk0VN2zJV0yBg0vH/9dv5ANOkjoAYfk54Vu3V0CHHQ7njmLScWqrFdqcRkqypw==, tarball: file:projects/core-client-paging.tgz}
+    resolution: {integrity: sha512-knla0zW4914qdG1a6+9Z16YO6LHkdRA5zNU31aE24S2h9GBRwIjqkY2nHzS4ox8BdW+jUQMq1jsglh/ZRCMOfQ==, tarball: file:projects/core-client-paging.tgz}
     name: '@rush-temp/core-client-paging'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.13.2
+      '@microsoft/api-extractor': 7.18.11
       '@types/chai': 4.2.22
       '@types/mocha': 7.0.2
       '@types/node': 12.20.27
@@ -9596,11 +9467,11 @@ packages:
     dev: false
 
   file:projects/core-client.tgz:
-    resolution: {integrity: sha512-VGDp4uzLU6NL5A31+vMbrE2BUlAtWssXoUiG5q21WDHo/5bdVv5Ksl+r9UzYxzgaEWDeNVr5KxfoBvZo7+xJAw==, tarball: file:projects/core-client.tgz}
+    resolution: {integrity: sha512-b55vwGtHq3Db8JgYLspyAdlZJUp1X3ZzFkHELYLsbSIFglv8eYG4WY1SvO/UtZAGIRCZhlZK8NdoxZpjBdQlLQ==, tarball: file:projects/core-client.tgz}
     name: '@rush-temp/core-client'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.13.2
+      '@microsoft/api-extractor': 7.18.11
       '@types/chai': 4.2.22
       '@types/mocha': 7.0.2
       '@types/node': 12.20.27
@@ -9637,11 +9508,11 @@ packages:
     dev: false
 
   file:projects/core-crypto.tgz:
-    resolution: {integrity: sha512-ZU0iT6qVHE8T+fmuz9RUnJa9PWbee+NOun/0gVTto1le3NyXWX85zwsFpE7//wfKXTJnbqCyHmjdi3spPf3Xxg==, tarball: file:projects/core-crypto.tgz}
+    resolution: {integrity: sha512-J2pLnKslszxb3f01A/fO+69mI9MUGiFZIcThEAccAja3ngH+G596d2tDeVVj8dJ3j5fiu+DvrbRwNeUndO6+8w==, tarball: file:projects/core-crypto.tgz}
     name: '@rush-temp/core-crypto'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.7.11
+      '@microsoft/api-extractor': 7.18.11
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-node-resolve': 8.4.0_rollup@1.32.1
       '@rollup/plugin-replace': 2.4.2_rollup@1.32.1
@@ -9682,13 +9553,13 @@ packages:
     dev: false
 
   file:projects/core-http.tgz:
-    resolution: {integrity: sha512-MJUdEy4pMGC01kff4D+AFuhxFi5t1/ScfH0cidXKo84ShEx2+hsMSjBEBYaXhk+8ui17KNlnmUL13kV4COcsgA==, tarball: file:projects/core-http.tgz}
+    resolution: {integrity: sha512-/1F76o1Bjt4fx38H40DKgXtwrNhq+bbaSlFeQS1oMht1Ha4YQjQFS9ANOdWi8Ow7lJPNCZHbYsZLODNg5OMiqA==, tarball: file:projects/core-http.tgz}
     name: '@rush-temp/core-http'
     version: 0.0.0
     dependencies:
       '@azure/core-tracing': 1.0.0-preview.13
       '@azure/logger-js': 1.3.2
-      '@microsoft/api-extractor': 7.7.11
+      '@microsoft/api-extractor': 7.18.11
       '@opentelemetry/api': 1.0.3
       '@types/chai': 4.2.22
       '@types/express': 4.17.13
@@ -9751,12 +9622,12 @@ packages:
     dev: false
 
   file:projects/core-lro.tgz:
-    resolution: {integrity: sha512-z8/722+S5EkVfUX05siniqgWzHf/T9KLJtklWQ4muXkGcZuVuKpzmsdhFPhMIJXcSeJHxLn6B4b0+lNQi4y1hw==, tarball: file:projects/core-lro.tgz}
+    resolution: {integrity: sha512-WUSPTclSRJt3FWVbGlOE9zpGuO7v1HqY+s+PpW7zAvB4blKWqK48H/bRG83H/6uNl5zHkHb+zeWj0Gh2BIXQJQ==, tarball: file:projects/core-lro.tgz}
     name: '@rush-temp/core-lro'
     version: 0.0.0
     dependencies:
       '@azure/core-tracing': 1.0.0-preview.13
-      '@microsoft/api-extractor': 7.7.11
+      '@microsoft/api-extractor': 7.18.11
       '@types/chai': 4.2.22
       '@types/mocha': 7.0.2
       '@types/node': 12.20.27
@@ -9796,11 +9667,11 @@ packages:
     dev: false
 
   file:projects/core-paging.tgz:
-    resolution: {integrity: sha512-L14f29bGNZ2/Q8Ax9MfR7QWs85WhJsUAlujI+yHvwRdAyKzlVNIPv0Z+y05QO35MeIlIfhyLoYY42kIbFIJaEw==, tarball: file:projects/core-paging.tgz}
+    resolution: {integrity: sha512-UjHPixglA9K1Yn2RahHbaLPYGstD1B2lvrMTRTgMgwaeFQuzHajn6TQBvO4bs4Yg9Sjl+XwKGFYWP8LEGTba7A==, tarball: file:projects/core-paging.tgz}
     name: '@rush-temp/core-paging'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.7.11
+      '@microsoft/api-extractor': 7.18.11
       '@types/chai': 4.2.22
       '@types/mocha': 7.0.2
       '@types/node': 12.20.27
@@ -9834,12 +9705,12 @@ packages:
     dev: false
 
   file:projects/core-rest-pipeline.tgz:
-    resolution: {integrity: sha512-yU0cVnVZqgRpjXEoM7jEqcw6GkcPpv8nNk1dXrmEssR1sql4JIDVpC/PHvt2mK7QHCMwMtKooQS7drskRFB0Eg==, tarball: file:projects/core-rest-pipeline.tgz}
+    resolution: {integrity: sha512-wxzY3+t7F39z7Kq8lUkS6fRk/2LXYGd1tmzyspZHHKrXTwZ5llcznQOiqV9bIJROXpo9/nzBJXS1jOm5S7VI8g==, tarball: file:projects/core-rest-pipeline.tgz}
     name: '@rush-temp/core-rest-pipeline'
     version: 0.0.0
     dependencies:
       '@azure/core-tracing': 1.0.0-preview.13
-      '@microsoft/api-extractor': 7.7.11
+      '@microsoft/api-extractor': 7.18.11
       '@opentelemetry/api': 1.0.3
       '@types/chai': 4.2.22
       '@types/mocha': 7.0.2
@@ -9885,11 +9756,11 @@ packages:
     dev: false
 
   file:projects/core-tracing.tgz:
-    resolution: {integrity: sha512-hjSwB3OLU9ukMINsZaZWCTbo94TiJjihe2mLVuIWmd5x1kT9gTL0n9JmcToqc0WKJ1s3Ek8CieRv51HqlEHzFw==, tarball: file:projects/core-tracing.tgz}
+    resolution: {integrity: sha512-f61XTsl+LjwqPrnFo3B2Y62ZxqWYFKRTNrV/BYqo72zS8RAfNJ/5McNTZf3KF5XMRsmDNlNCerx9M3KHWcQilA==, tarball: file:projects/core-tracing.tgz}
     name: '@rush-temp/core-tracing'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.7.11
+      '@microsoft/api-extractor': 7.18.11
       '@opentelemetry/api': 1.0.3
       '@opentelemetry/tracing': 0.22.0_@opentelemetry+api@1.0.3
       '@types/chai': 4.2.22
@@ -9929,11 +9800,11 @@ packages:
     dev: false
 
   file:projects/core-util.tgz:
-    resolution: {integrity: sha512-ydQLFeHsAKS+g+FQV69KApmwIDrJ49u3dn/79yNATb5guThjqMlLEHio9p8JX2mO1vdwwZ8122dwdOezxCZolQ==, tarball: file:projects/core-util.tgz}
+    resolution: {integrity: sha512-FNsdK96TLCqM6bDGl1STn9VB1HoJAtmAOPF9/CRLGETEbi/z4JECaCo6bAS8kKXWk7P33UkPLYp8IF8n2bSgdg==, tarball: file:projects/core-util.tgz}
     name: '@rush-temp/core-util'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.7.11
+      '@microsoft/api-extractor': 7.18.11
       '@types/chai': 4.2.22
       '@types/mocha': 7.0.2
       '@types/node': 12.20.27
@@ -9972,11 +9843,11 @@ packages:
     dev: false
 
   file:projects/core-xml.tgz:
-    resolution: {integrity: sha512-7HkopyqzugsgMp7OWJt5PWvGY7w+YPNwbjjmjQFhcuynt1Mho/LlTvo9c9W/TX/Mb4BLRp7bWUfErSqgaYQOKQ==, tarball: file:projects/core-xml.tgz}
+    resolution: {integrity: sha512-jZ9OmhFtUTs6H+ar4gjE3WwO/OeCG99di7P0AOLV5kQdDREn79Eb+Q8JdoRj1iwxksdiPGX92gzI4dCKXOtECw==, tarball: file:projects/core-xml.tgz}
     name: '@rush-temp/core-xml'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.7.11
+      '@microsoft/api-extractor': 7.18.11
       '@types/chai': 4.2.22
       '@types/mocha': 7.0.2
       '@types/node': 12.20.27
@@ -10017,12 +9888,12 @@ packages:
     dev: false
 
   file:projects/cosmos.tgz:
-    resolution: {integrity: sha512-aX90/ox0j6fweUFec+mWpKjlynQd15yFsiW8Aj9jpVyXWQ9tbi+fwwg4Jn302v1cBhDI+CuI+wN0LkcdawweRA==, tarball: file:projects/cosmos.tgz}
+    resolution: {integrity: sha512-rbYrnRMXOmlicZimLcuEC9eIo2cHUw2z09TE6kYtr6BBgvlJtglTUZKuE+Ps+kmRwGzj+JD6p6I/zdJCpNhL1g==, tarball: file:projects/cosmos.tgz}
     name: '@rush-temp/cosmos'
     version: 0.0.0
     dependencies:
       '@azure/identity': 1.5.2_debug@4.3.2
-      '@microsoft/api-extractor': 7.7.11
+      '@microsoft/api-extractor': 7.18.11
       '@rollup/plugin-json': 4.1.0_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
       '@types/debug': 4.1.7
@@ -10068,13 +9939,13 @@ packages:
     dev: false
 
   file:projects/data-tables.tgz:
-    resolution: {integrity: sha512-5lC14kRDR5gwBUEBKDcVadiXycIhD8S7vqwj2ZU48opjaXppInwQC/PfMG6LcU+r3ABnKb+C8nVOLoFScSb04A==, tarball: file:projects/data-tables.tgz}
+    resolution: {integrity: sha512-QVH8MmS+iHCq4uEmPqO+BY9AzhaEYPZdcFvJvLbtz7wnYXbo/DkCYJ/LFUUMRGhDRcnyWa1MSX5SZBnamREInQ==, tarball: file:projects/data-tables.tgz}
     name: '@rush-temp/data-tables'
     version: 0.0.0
     dependencies:
       '@azure/core-tracing': 1.0.0-preview.13
       '@azure/identity': 2.0.0-beta.6
-      '@microsoft/api-extractor': 7.7.11
+      '@microsoft/api-extractor': 7.18.11
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-inject': 4.0.2_rollup@1.32.1
       '@rollup/plugin-json': 4.1.0_rollup@1.32.1
@@ -10171,13 +10042,13 @@ packages:
     dev: false
 
   file:projects/digital-twins-core.tgz:
-    resolution: {integrity: sha512-sQ2dM4V47Cltcn560kx15C1QwQceO8PTBOsRnr5sqphKGbMQhnGp7/3DIFN3KrPuFPRG/pp+GXAdCeD+CNjNLg==, tarball: file:projects/digital-twins-core.tgz}
+    resolution: {integrity: sha512-UcshBEsZQQ02dzIZeX9ca/nCNd0aRmyoPRns78e11xTfFaBW5fNOdRYaxPmd/VElK/GpNlJ0zxSRVcFwBiq+ZA==, tarball: file:projects/digital-twins-core.tgz}
     name: '@rush-temp/digital-twins-core'
     version: 0.0.0
     dependencies:
       '@azure/core-tracing': 1.0.0-preview.13
       '@azure/identity': 2.0.0-beta.6
-      '@microsoft/api-extractor': 7.7.11
+      '@microsoft/api-extractor': 7.18.11
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-json': 4.1.0_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
@@ -10267,7 +10138,7 @@ packages:
     dev: false
 
   file:projects/event-hubs.tgz:
-    resolution: {integrity: sha512-D3tr8uQ85UFSFzCGQBpvzM6AUzjVjad/XlSja8lQeXnHUeHAfx/YH3FRGkXlsYYmVmDHLEOHTrxwBDzVZSuOoA==, tarball: file:projects/event-hubs.tgz}
+    resolution: {integrity: sha512-X6hU9D0COSgqBdE0v5ubVDlylLhVlTTtohW9ID8uxNtxuaxS+xkW/5gR+IMsfQtmt8CzUZD95yuWwlDF/O6w8Q==, tarball: file:projects/event-hubs.tgz}
     name: '@rush-temp/event-hubs'
     version: 0.0.0
     dependencies:
@@ -10346,13 +10217,13 @@ packages:
     dev: false
 
   file:projects/event-processor-host.tgz:
-    resolution: {integrity: sha512-DBoiJ/Npr6TC+tymF8vFyLfOSLD8+awqx+67/3ew0cAG6w1XPnIgTVUmxmM9RdnCX6KZGMB1tAc9SP7YJeU49g==, tarball: file:projects/event-processor-host.tgz}
+    resolution: {integrity: sha512-1bsUaKknmTfFOC0w6wjYVciwePXLbmv5WQ8+YE0WLn04UW7kZala/RhlIolUx1TlS35vDKb73NHLz87KGe3g9w==, tarball: file:projects/event-processor-host.tgz}
     name: '@rush-temp/event-processor-host'
     version: 0.0.0
     dependencies:
       '@azure/event-hubs': 2.1.4
       '@azure/ms-rest-nodeauth': 0.9.3_debug@4.3.2
-      '@microsoft/api-extractor': 7.7.11
+      '@microsoft/api-extractor': 7.18.11
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-json': 4.1.0_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
@@ -10401,12 +10272,12 @@ packages:
     dev: false
 
   file:projects/eventgrid.tgz:
-    resolution: {integrity: sha512-B/oYQdCdjNKQTyDcJc+21hLvAyjcHSaxLgmQ+MGAKNLw2nkO9UQ7/svM4x+p5o4BiCAJX/fqY5Klw0u2x60OGw==, tarball: file:projects/eventgrid.tgz}
+    resolution: {integrity: sha512-8gU5FFbkNjNAarqfpkhmSf/agfq7aOZLTVsKRv81V7Gan+oKBq76y+uFqN1JXIqJgBo7dFkxqdqL/uDG27rtFQ==, tarball: file:projects/eventgrid.tgz}
     name: '@rush-temp/eventgrid'
     version: 0.0.0
     dependencies:
       '@azure/core-tracing': 1.0.0-preview.13
-      '@microsoft/api-extractor': 7.7.11
+      '@microsoft/api-extractor': 7.18.11
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-json': 4.1.0_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
@@ -10463,11 +10334,11 @@ packages:
     dev: false
 
   file:projects/eventhubs-checkpointstore-blob.tgz:
-    resolution: {integrity: sha512-B4QWcYsEpvqsxwP4Vnt+/nt6dFKBBs7yYS7sEF+s9cxcouETF0PB3KtdUW/lj7ixxMrnXtCUumcqMGmIRuexog==, tarball: file:projects/eventhubs-checkpointstore-blob.tgz}
+    resolution: {integrity: sha512-E6sQfQX3qOFrO9jaM3t3BEmzLi/WaaSGztfqG6yao71uVdOYqkns2Spgs88aOaACQfKSgVGTWHgpiN+iypWevA==, tarball: file:projects/eventhubs-checkpointstore-blob.tgz}
     name: '@rush-temp/eventhubs-checkpointstore-blob'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.7.11
+      '@microsoft/api-extractor': 7.18.11
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-inject': 4.0.2_rollup@1.32.1
       '@rollup/plugin-json': 4.1.0_rollup@1.32.1
@@ -10527,11 +10398,11 @@ packages:
     dev: false
 
   file:projects/eventhubs-checkpointstore-table.tgz:
-    resolution: {integrity: sha512-aRc5dOiDNYOAJkUeHp/h1M6BeiFTbKMG7diR6+6tVFdJI0gvVDvrOK6gtsdO86jsMdqoffmu13SZuLwFHWPFJw==, tarball: file:projects/eventhubs-checkpointstore-table.tgz}
+    resolution: {integrity: sha512-vMgklRUPWo2o8+joA8Ie0q6493HbIQCE+ee/+jvWSDb3JT8F05rt6Ox+SQhqI4Q9ckTMtbNb0NhEYZ94ya2HGg==, tarball: file:projects/eventhubs-checkpointstore-table.tgz}
     name: '@rush-temp/eventhubs-checkpointstore-table'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.7.11
+      '@microsoft/api-extractor': 7.18.11
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-inject': 4.0.2_rollup@1.32.1
       '@rollup/plugin-json': 4.1.0_rollup@1.32.1
@@ -10590,13 +10461,13 @@ packages:
     dev: false
 
   file:projects/identity-cache-persistence.tgz:
-    resolution: {integrity: sha512-ETCkr+UfX8rXnhq6tZ/jSpZLJdcP/JiXhvq9cpDnVvxcAWyeJdGUhX3WUhOl4va4jD0HyUy5zjwAsrDvfHV1Wg==, tarball: file:projects/identity-cache-persistence.tgz}
+    resolution: {integrity: sha512-swWbMKiyh1Z1dpfNo79dT4yOk43QPVlfWwIaZxVP+GfiqrTqew0RZXvlPCdhlBjTGrrnLaL/9hMZaa5MsBaFww==, tarball: file:projects/identity-cache-persistence.tgz}
     name: '@rush-temp/identity-cache-persistence'
     version: 0.0.0
     dependencies:
       '@azure/msal-node': 1.3.1
       '@azure/msal-node-extensions': 1.0.0-alpha.9
-      '@microsoft/api-extractor': 7.7.11
+      '@microsoft/api-extractor': 7.18.11
       '@types/jws': 3.2.4
       '@types/mocha': 7.0.2
       '@types/node': 12.20.27
@@ -10627,11 +10498,11 @@ packages:
     dev: false
 
   file:projects/identity-vscode.tgz:
-    resolution: {integrity: sha512-6DB5l5krRBSviDlAKWbX+EWsKUu3GTeDr1QleUWxM/Dz2LPI6sktK/DhGiG/DD5GO/vTScDenqhgtkMPge1lDw==, tarball: file:projects/identity-vscode.tgz}
+    resolution: {integrity: sha512-kAAolzHI69agkgisFp1t7k6QJ7u4B3t1XV/OyHsyHaZAQwlKddwL6TVK1SfiTUxq17u7Bc2OzzWN7RPMEsElKw==, tarball: file:projects/identity-vscode.tgz}
     name: '@rush-temp/identity-vscode'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.7.11
+      '@microsoft/api-extractor': 7.18.11
       '@types/jws': 3.2.4
       '@types/mocha': 7.0.2
       '@types/node': 12.20.27
@@ -10662,7 +10533,7 @@ packages:
     dev: false
 
   file:projects/identity.tgz:
-    resolution: {integrity: sha512-7/sEYYWDS7Cggbgrtix8TWZS5jyoAdu9Gw3/lNDAGfd1esL6LyEREAyT8PVzTRUd/ax6BleHvxDNB3ZzXt3Qwg==, tarball: file:projects/identity.tgz}
+    resolution: {integrity: sha512-eCD9KQuFyyjZeb0kS077iCU4UDl5M8OLnndQsn0z11tRhRVHXLtdekSjiYbOcbCXUY9QFePX2ogJ7jdesrfqlg==, tarball: file:projects/identity.tgz}
     name: '@rush-temp/identity'
     version: 0.0.0
     dependencies:
@@ -10670,7 +10541,7 @@ packages:
       '@azure/msal-browser': 2.17.0
       '@azure/msal-common': 4.5.1
       '@azure/msal-node': 1.3.1
-      '@microsoft/api-extractor': 7.7.11
+      '@microsoft/api-extractor': 7.18.11
       '@types/chai': 4.2.22
       '@types/jws': 3.2.4
       '@types/mocha': 7.0.2
@@ -10717,13 +10588,13 @@ packages:
     dev: false
 
   file:projects/iot-device-update.tgz:
-    resolution: {integrity: sha512-DOkGgC0zGQZGz5CArpHHsu/0v+XVKygrO/9dRJ8xM2ZKrYzn3xrrUDAjPeqJCvaSIc52FSn8hbb5dFLVSzYj1Q==, tarball: file:projects/iot-device-update.tgz}
+    resolution: {integrity: sha512-F6Jo5aKP6ZqZ2giFJ0cBlooNsMrehgBPy7AHG40ICMPOgs4QAaApVKcilWpI2SNVrdHUfcr8NvIUGVv5blpJQg==, tarball: file:projects/iot-device-update.tgz}
     name: '@rush-temp/iot-device-update'
     version: 0.0.0
     dependencies:
       '@azure/core-tracing': 1.0.0-preview.13
       '@azure/identity': 2.0.0-beta.6
-      '@microsoft/api-extractor': 7.7.11
+      '@microsoft/api-extractor': 7.18.11
       '@types/node': 12.20.27
       '@types/uuid': 8.3.1
       cross-env: 7.0.3
@@ -10745,12 +10616,12 @@ packages:
     dev: false
 
   file:projects/iot-modelsrepository.tgz:
-    resolution: {integrity: sha512-v9t60H5+wWyZDwepDik+S7scqG+cqEbjtOQ0gHN5Lc8iU5zTEwyUxEc0loDdt8Ssopx0aipTo0iD259rh6E9kg==, tarball: file:projects/iot-modelsrepository.tgz}
+    resolution: {integrity: sha512-PSSdmkBx4wQnURsHp5Z+BBUnbuDMluUF+vxO/9GzTAhuaqh9vEv+sW5MPfGzOO2vm2z7oa+lxpkR0vZ6aErexA==, tarball: file:projects/iot-modelsrepository.tgz}
     name: '@rush-temp/iot-modelsrepository'
     version: 0.0.0
     dependencies:
       '@azure/core-tracing': 1.0.0-preview.13
-      '@microsoft/api-extractor': 7.7.11
+      '@microsoft/api-extractor': 7.18.11
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-json': 4.1.0_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
@@ -10802,13 +10673,13 @@ packages:
     dev: false
 
   file:projects/keyvault-admin.tgz:
-    resolution: {integrity: sha512-sPfcSpG2bj1ZQaEJjRvYdpImotADgwahBhf64pzotWETsYH2v6i79bqaYTEvjJWL8Se5TzXIbzL1PeMzY0V80Q==, tarball: file:projects/keyvault-admin.tgz}
+    resolution: {integrity: sha512-pIuLYfl8T68ROSaC/BGGCBovefnySYcKbmdsjAMb08EEaMdtmc8kkgvl1Pl/wGE7sn+qBsJ3PGTBqE877SerIA==, tarball: file:projects/keyvault-admin.tgz}
     name: '@rush-temp/keyvault-admin'
     version: 0.0.0
     dependencies:
       '@azure/core-tracing': 1.0.0-preview.13
       '@azure/keyvault-keys': 4.3.0
-      '@microsoft/api-extractor': 7.7.11
+      '@microsoft/api-extractor': 7.18.11
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-json': 4.1.0_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
@@ -10848,13 +10719,13 @@ packages:
     dev: false
 
   file:projects/keyvault-certificates.tgz:
-    resolution: {integrity: sha512-CtrJZLopz0ZdjSJ67+mjEP0pVr+ahlmdqmuHm8BWe6nHv4Q0LIK8sC67jXUADi0ow3YveCf+4659w3R2RJGBuA==, tarball: file:projects/keyvault-certificates.tgz}
+    resolution: {integrity: sha512-qhqbAyrcbpwFAXoB9tEV5chIkZ3ZLQt8daht2lArH+jjzEmg2sW8O7g481PENCKJsF7aPzgT9J2A216FmiJYNg==, tarball: file:projects/keyvault-certificates.tgz}
     name: '@rush-temp/keyvault-certificates'
     version: 0.0.0
     dependencies:
       '@azure/core-tracing': 1.0.0-preview.13
       '@azure/keyvault-secrets': 4.3.0
-      '@microsoft/api-extractor': 7.7.11
+      '@microsoft/api-extractor': 7.18.11
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-json': 4.1.0_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
@@ -10923,12 +10794,12 @@ packages:
     dev: false
 
   file:projects/keyvault-keys.tgz:
-    resolution: {integrity: sha512-qyVgXM2CL95HxDi90zOKMHc49d3n43Fuih5xo8wyc88x+NW7ueGD5aC76ZmLivqT+OK/cr+wMYiM4VL5khN7HQ==, tarball: file:projects/keyvault-keys.tgz}
+    resolution: {integrity: sha512-JCYND/8Uc299aUJiKsVLzOQ/la/EWi4rGGPd/+je17GwgoIzp1AxVnY5Btdyc27TQHcXebP5Dp7csuc9tc5B2w==, tarball: file:projects/keyvault-keys.tgz}
     name: '@rush-temp/keyvault-keys'
     version: 0.0.0
     dependencies:
       '@azure/core-tracing': 1.0.0-preview.13
-      '@microsoft/api-extractor': 7.7.11
+      '@microsoft/api-extractor': 7.18.11
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-json': 4.1.0_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
@@ -10985,12 +10856,12 @@ packages:
     dev: false
 
   file:projects/keyvault-secrets.tgz:
-    resolution: {integrity: sha512-ZllwmMvvKcvY7PRn5T9MKqYhzCRNsFJTKBJtAKCToOG94EMxL7nnbBUd0lNx82TEfoXMIoAsJnkOqRXL6ovECQ==, tarball: file:projects/keyvault-secrets.tgz}
+    resolution: {integrity: sha512-UIONXBT2X6Cyj2uiTe1Z0xoC7WbHCEZM57q0FILhGEBsCcCMNvWIbCCespo+y5tq6ifDsfBUKzIYlSgpH/U0eA==, tarball: file:projects/keyvault-secrets.tgz}
     name: '@rush-temp/keyvault-secrets'
     version: 0.0.0
     dependencies:
       '@azure/core-tracing': 1.0.0-preview.13
-      '@microsoft/api-extractor': 7.7.11
+      '@microsoft/api-extractor': 7.18.11
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-json': 4.1.0_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
@@ -11044,11 +10915,11 @@ packages:
     dev: false
 
   file:projects/logger.tgz:
-    resolution: {integrity: sha512-nXyObeQKB1ZJEkCCaJWSEvvm9rhW9p6ipMklG3GZA0Q/HYWIFx0aURxjxUQjXdkxklhZuYDBa36nCcRqW4wnyg==, tarball: file:projects/logger.tgz}
+    resolution: {integrity: sha512-wKayf8GP0FcmHSww21Po1LMloUqf6N4xGbzCNFv0MSSKw7u9RaQiap7OajybLqzsyPvAjGb/yLDup+K2w1VdLg==, tarball: file:projects/logger.tgz}
     name: '@rush-temp/logger'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.7.11
+      '@microsoft/api-extractor': 7.18.11
       '@types/chai': 4.2.22
       '@types/mocha': 7.0.2
       '@types/node': 12.20.27
@@ -11091,12 +10962,12 @@ packages:
     dev: false
 
   file:projects/mixed-reality-authentication.tgz:
-    resolution: {integrity: sha512-ErptpvBcEPQAfndtyGGq9V2o2/LBnk3udcH1KZDWWMrj2P0YCeY4GClQexhIu7uGMqQs3rYlxTbRXXPqXOfaLQ==, tarball: file:projects/mixed-reality-authentication.tgz}
+    resolution: {integrity: sha512-w2qqeee2O2OvZ9g7vJUYsPsFVIb2Cg0cMMIbdClkyiFSaffz2naAKkmkulR5FDfzoK3Eka/J4sAb5RugzoEQXw==, tarball: file:projects/mixed-reality-authentication.tgz}
     name: '@rush-temp/mixed-reality-authentication'
     version: 0.0.0
     dependencies:
       '@azure/core-tracing': 1.0.0-preview.13
-      '@microsoft/api-extractor': 7.7.11
+      '@microsoft/api-extractor': 7.18.11
       '@types/chai': 4.2.22
       '@types/chai-as-promised': 7.1.4
       '@types/mocha': 7.0.2
@@ -11138,13 +11009,13 @@ packages:
     dev: false
 
   file:projects/mixed-reality-remote-rendering.tgz:
-    resolution: {integrity: sha512-6lrEwlNs+K79brLQYvizXCb/5II9iFYjZABJT/AX7YS8gzmHbC2iR+M5MbxgxoXYzK9x+GVQLWwqwOZ0fwz/qg==, tarball: file:projects/mixed-reality-remote-rendering.tgz}
+    resolution: {integrity: sha512-bkO+RqEzutaWd9pgHnbYW+L49YzP+MnO19vEUxROPomVn4frVNBMOUv3tPdZ21k3A8HT+PHFSzU6zAUX0P8dPQ==, tarball: file:projects/mixed-reality-remote-rendering.tgz}
     name: '@rush-temp/mixed-reality-remote-rendering'
     version: 0.0.0
     dependencies:
       '@azure/core-tracing': 1.0.0-preview.13
       '@azure/identity': 1.5.2
-      '@microsoft/api-extractor': 7.7.11
+      '@microsoft/api-extractor': 7.18.11
       '@types/chai': 4.2.22
       '@types/chai-as-promised': 7.1.4
       '@types/mocha': 7.0.2
@@ -11204,11 +11075,11 @@ packages:
     dev: false
 
   file:projects/monitor-opentelemetry-exporter.tgz:
-    resolution: {integrity: sha512-xdhJhH/kOB2G0j4C1AUPp762y1L//QDotcRzJcqZxg8s15KL1KQoY7x+1y0sk7UXaQk80YfPb1sdj3ovD8Y5vQ==, tarball: file:projects/monitor-opentelemetry-exporter.tgz}
+    resolution: {integrity: sha512-Ogww3f0xEORxYeBAKIqIP063Ws3EVbbj90CxAYyfPmbhf1nkQHHlnG60s+pxJFqgk6/5Xk0NSOdrCo2/VBT0jA==, tarball: file:projects/monitor-opentelemetry-exporter.tgz}
     name: '@rush-temp/monitor-opentelemetry-exporter'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.7.11
+      '@microsoft/api-extractor': 7.18.11
       '@opentelemetry/api': 1.0.3
       '@opentelemetry/core': 0.22.0_@opentelemetry+api@1.0.3
       '@opentelemetry/instrumentation': 0.22.0_@opentelemetry+api@1.0.3
@@ -11241,13 +11112,13 @@ packages:
     dev: false
 
   file:projects/monitor-query.tgz:
-    resolution: {integrity: sha512-pIaZvhGUj1JGFR945VFkaCNPoKaIMwhXIfz3XmdW55rJfRCmWm8x1ZHYmNjbepyWNK9C58Y1UCXv/P1n1LQqDg==, tarball: file:projects/monitor-query.tgz}
+    resolution: {integrity: sha512-UgcANjV5jnSjCoWWNOq+vt32vd1WiUus0ThQqcU/qhGDVMZS0XF/dn9xex0xEYlAYFEuFqbtXqW0vsrPj6qPFw==, tarball: file:projects/monitor-query.tgz}
     name: '@rush-temp/monitor-query'
     version: 0.0.0
     dependencies:
       '@azure/core-tracing': 1.0.0-preview.13
       '@azure/monitor-opentelemetry-exporter': 1.0.0-beta.4
-      '@microsoft/api-extractor': 7.7.11
+      '@microsoft/api-extractor': 7.18.11
       '@opentelemetry/api': 1.0.3
       '@opentelemetry/node': 0.22.0_@opentelemetry+api@1.0.3
       '@opentelemetry/tracing': 0.22.0_@opentelemetry+api@1.0.3
@@ -11678,13 +11549,13 @@ packages:
     dev: false
 
   file:projects/purview-account.tgz:
-    resolution: {integrity: sha512-tc6KFxfVCGUIwZjdgRZ80vPbwro2EwMEy4B3MQahsza/FZ4i3AHouoborKtNJg30pkTh1n2l7xOeaQJr/hQ7wg==, tarball: file:projects/purview-account.tgz}
+    resolution: {integrity: sha512-KCHH4nNsKIKCXPC8nJ42CiEto01FIZeTJHMPT0mPvuWf9MNBVf87oWMiuyZeKCBvJNaSIct+f2WZlscwn5Aarg==, tarball: file:projects/purview-account.tgz}
     name: '@rush-temp/purview-account'
     version: 0.0.0
     dependencies:
       '@azure-rest/core-client-paging': 1.0.0-beta.1
       '@azure/identity': 1.5.2
-      '@microsoft/api-extractor': 7.13.2
+      '@microsoft/api-extractor': 7.18.11
       '@types/chai': 4.2.22
       '@types/mocha': 7.0.2
       '@types/node': 12.20.27
@@ -11725,12 +11596,12 @@ packages:
     dev: false
 
   file:projects/purview-catalog.tgz:
-    resolution: {integrity: sha512-BpZ4lOcV2MTB83zU2HMD+uUDLS9RjPLFiZXEL0RfjELRDVYHW7Mzc8iHm4hh0z0KJ8LgJU6IicmaNvMP/X8LBA==, tarball: file:projects/purview-catalog.tgz}
+    resolution: {integrity: sha512-3FMBNLShCDqvunEG+r39NKhWJgrdEAH8bu7BG6o7R1clrDjcIdF7A40KhzupbzNFVivid4XVBIZu3g+teRscNw==, tarball: file:projects/purview-catalog.tgz}
     name: '@rush-temp/purview-catalog'
     version: 0.0.0
     dependencies:
       '@azure/identity': 1.5.2
-      '@microsoft/api-extractor': 7.13.2
+      '@microsoft/api-extractor': 7.18.11
       '@types/chai': 4.2.22
       '@types/mocha': 7.0.2
       '@types/node': 12.20.27
@@ -11771,12 +11642,12 @@ packages:
     dev: false
 
   file:projects/purview-scanning.tgz:
-    resolution: {integrity: sha512-HX4JV2mB44SB0PkGp9I4CQ/Bu0yYtFOkwu5WHNn9sathdM9wxEbX+GXP/1e9Xh4EpGweOSDprabMN+IGzK+4Tw==, tarball: file:projects/purview-scanning.tgz}
+    resolution: {integrity: sha512-J5aFa1rvlycJ0Ft4gDLVaKh8dk8ogozpEPm06Kww8Fz0ILU/e/xn+nPsym5efllz6WDkDAPSWJ7SuvnJ3699NQ==, tarball: file:projects/purview-scanning.tgz}
     name: '@rush-temp/purview-scanning'
     version: 0.0.0
     dependencies:
       '@azure/identity': 1.5.2
-      '@microsoft/api-extractor': 7.13.2
+      '@microsoft/api-extractor': 7.18.11
       '@types/chai': 4.2.22
       '@types/mocha': 7.0.2
       '@types/node': 12.20.27
@@ -11817,13 +11688,13 @@ packages:
     dev: false
 
   file:projects/quantum-jobs.tgz:
-    resolution: {integrity: sha512-XVXR8wpPwC2WRY092LdqozMHD1gvgjrVSjDF0KKIKPyFUYOgu2O4dnPFZZuMyiEvw/I53IZ91v7ddx5RzgHtqg==, tarball: file:projects/quantum-jobs.tgz}
+    resolution: {integrity: sha512-kWnI7vdbdXE7QP9RCw7lbQFhXASXOZS9zaOb2eW0URnFuVyTt01IG89yJAM96Xo284TqaWxlhrKe1hKIv/g/PA==, tarball: file:projects/quantum-jobs.tgz}
     name: '@rush-temp/quantum-jobs'
     version: 0.0.0
     dependencies:
       '@azure/core-tracing': 1.0.0-preview.13
       '@azure/identity': 2.0.0-beta.6
-      '@microsoft/api-extractor': 7.7.11
+      '@microsoft/api-extractor': 7.18.11
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-json': 4.1.0_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
@@ -11875,7 +11746,7 @@ packages:
     dev: false
 
   file:projects/schema-registry-avro.tgz:
-    resolution: {integrity: sha512-HjDqcDAbRqLD2/+t/axLJZmLPbrB8hb9uuMIJkgyxd17AIurR/+Lnav4TS602wRdz0dh8z/P5g9C8UwisZzN3A==, tarball: file:projects/schema-registry-avro.tgz}
+    resolution: {integrity: sha512-4wULpLuLiMk7+loAe+RwRq6u0i6mPpBa5tfSgnso/gWqPQpMh+UfNseudJInXH0KXwTZMwvkwjQCP/dwvkeG4A==, tarball: file:projects/schema-registry-avro.tgz}
     name: '@rush-temp/schema-registry-avro'
     version: 0.0.0
     dependencies:
@@ -11928,7 +11799,7 @@ packages:
     dev: false
 
   file:projects/schema-registry.tgz:
-    resolution: {integrity: sha512-CK90yKC6T3N9W5ztNkzNudrnx6OqMsx/a2V555nwfw9YElcaIirssUSY9zp8Rjs4TqN+XCIrBJ9kzgdiGLqsOQ==, tarball: file:projects/schema-registry.tgz}
+    resolution: {integrity: sha512-G8eTfYzkcvXZl1dGHdC49aRh7neBVZQIXZOBOZxisYwjmQPTe+qLT0pONNw+IMvlwdObNpea1NJLuwvDWIy2kg==, tarball: file:projects/schema-registry.tgz}
     name: '@rush-temp/schema-registry'
     version: 0.0.0
     dependencies:
@@ -11975,12 +11846,12 @@ packages:
     dev: false
 
   file:projects/search-documents.tgz:
-    resolution: {integrity: sha512-Zd+NkUqwflzdPeO2VxTN+gw4TDX4KAHQkJ9RQLde8UouilOdprUfOIpobSfaGWeb0UuxdbZbmumR9MUJQfvBLg==, tarball: file:projects/search-documents.tgz}
+    resolution: {integrity: sha512-eeR62qM3z5Dlp84mV4//oBv8+IssnkMf2EJotuSAmu9nerY0YcpaD9ehkQIo2DthheWlte7ah55M3+0OZPmb2A==, tarball: file:projects/search-documents.tgz}
     name: '@rush-temp/search-documents'
     version: 0.0.0
     dependencies:
       '@azure/core-tracing': 1.0.0-preview.13
-      '@microsoft/api-extractor': 7.7.11
+      '@microsoft/api-extractor': 7.18.11
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-json': 4.1.0_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
@@ -12035,13 +11906,13 @@ packages:
     dev: false
 
   file:projects/service-bus.tgz:
-    resolution: {integrity: sha512-xh1FsCAYQEN2au5fCao9WDKzmIls6PF2KVZkSOZaTxhSeYcZmijoOVP0biICIL7nzqT5iLQv5wCEdnSLkFGZMg==, tarball: file:projects/service-bus.tgz}
+    resolution: {integrity: sha512-QsDT4NFK11R0FYevLep0I1H91vtF+UWZ6+38gGSjR73WP4InQbZ0MC1wiO0SnBXa77lht3/KWaxUKezX5rcd9w==, tarball: file:projects/service-bus.tgz}
     name: '@rush-temp/service-bus'
     version: 0.0.0
     dependencies:
       '@azure/core-tracing': 1.0.0-preview.13
       '@azure/identity': 2.0.0-beta.6_debug@4.3.2
-      '@microsoft/api-extractor': 7.7.11
+      '@microsoft/api-extractor': 7.18.11
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-inject': 4.0.2_rollup@1.32.1
       '@rollup/plugin-json': 4.1.0_rollup@1.32.1
@@ -12115,12 +11986,12 @@ packages:
     dev: false
 
   file:projects/storage-blob-changefeed.tgz:
-    resolution: {integrity: sha512-uZenRe2at7wbgePzuFBTf8sohGr7PrBDjkC5Q09SvIdoKlij+/obtyjn4f79xwIrOC71ENNirCfLl1EjWZzY9w==, tarball: file:projects/storage-blob-changefeed.tgz}
+    resolution: {integrity: sha512-QXiZMYw6VsMK+53NbgOHycQ4fUkCXHQZkDH4g4txQrkPCCl3Sf/H69NAuWgdnBRMLnX7zOGsBkld+NQx0lmbpw==, tarball: file:projects/storage-blob-changefeed.tgz}
     name: '@rush-temp/storage-blob-changefeed'
     version: 0.0.0
     dependencies:
       '@azure/core-tracing': 1.0.0-preview.13
-      '@microsoft/api-extractor': 7.7.11
+      '@microsoft/api-extractor': 7.18.11
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
       '@rollup/plugin-node-resolve': 8.4.0_rollup@1.32.1
@@ -12178,13 +12049,13 @@ packages:
     dev: false
 
   file:projects/storage-blob.tgz:
-    resolution: {integrity: sha512-oG2JiQptBvC9GwPPVrw2Mb7SmWBWG1H/S9Jwkdyuq3pRcRFBe12vvGwvYgI4v3uEvEu7oHaiS2VPVSwhvAXgAg==, tarball: file:projects/storage-blob.tgz}
+    resolution: {integrity: sha512-KABn6rAH7Wx+XeoPZmTgU+BOJKPy6K0096mgY7tHQUQya+ERvuQUeajnFofoicMWo3agVKvbguj6E7Ra5RYLCg==, tarball: file:projects/storage-blob.tgz}
     name: '@rush-temp/storage-blob'
     version: 0.0.0
     dependencies:
       '@azure/core-tracing': 1.0.0-preview.13
       '@azure/identity': 2.0.0-beta.6
-      '@microsoft/api-extractor': 7.7.11
+      '@microsoft/api-extractor': 7.18.11
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-json': 4.1.0_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
@@ -12243,13 +12114,13 @@ packages:
     dev: false
 
   file:projects/storage-file-datalake.tgz:
-    resolution: {integrity: sha512-ZCFFMiB1Ot1bBuotstCNTDgAlXMyyXpJZgkpQ2qGnmKjUP2D/sSiq2WhoaNmIZzTLuZhsbJEL6Mu4zap2c2X8A==, tarball: file:projects/storage-file-datalake.tgz}
+    resolution: {integrity: sha512-BY1TQc+J5gR5e5T6VtAwf5EbSr39mWmaH6PUoPkTtr8Ucy5mYZLLWSX5CXBVY6/Cf/wVNnix5N5cZ/I75u2C/w==, tarball: file:projects/storage-file-datalake.tgz}
     name: '@rush-temp/storage-file-datalake'
     version: 0.0.0
     dependencies:
       '@azure/core-tracing': 1.0.0-preview.13
       '@azure/identity': 2.0.0-beta.6
-      '@microsoft/api-extractor': 7.7.11
+      '@microsoft/api-extractor': 7.18.11
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-json': 4.1.0_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
@@ -12307,12 +12178,12 @@ packages:
     dev: false
 
   file:projects/storage-file-share.tgz:
-    resolution: {integrity: sha512-iK17NEJFe9iwEmfdp9JAJwaSXsF4cWq/GjLWXG1EGUKQ39mrbUzX6xNlTet116MCfEC3nOYUSWGHY6LJbxGGGw==, tarball: file:projects/storage-file-share.tgz}
+    resolution: {integrity: sha512-MvLxske7z6M2cblVJ3p9M5f7uoaZJynIHHpnavQtPdOQw941AOfaI+Sdf4IoSRN6DtBW+F71/rOk/hepxSuMsg==, tarball: file:projects/storage-file-share.tgz}
     name: '@rush-temp/storage-file-share'
     version: 0.0.0
     dependencies:
       '@azure/core-tracing': 1.0.0-preview.13
-      '@microsoft/api-extractor': 7.7.11
+      '@microsoft/api-extractor': 7.18.11
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
       '@rollup/plugin-node-resolve': 8.4.0_rollup@1.32.1
@@ -12368,11 +12239,11 @@ packages:
     dev: false
 
   file:projects/storage-internal-avro.tgz:
-    resolution: {integrity: sha512-iffCllVZwHZmId0hpCngIyOUXYVWkXE+qzcP0xDD/h9WuMVS1Z70+DApW18k2KoSmH1/RkiQM5mybp/f8nUhyQ==, tarball: file:projects/storage-internal-avro.tgz}
+    resolution: {integrity: sha512-h4R5NafhZZvBq8OM9gK3/YFjhV7gSzIMWbQMy8FYpF8psshzU9pHkWGwpIEkJuGNiDzAacOdbHub5i0sKRqHdA==, tarball: file:projects/storage-internal-avro.tgz}
     name: '@rush-temp/storage-internal-avro'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.7.11
+      '@microsoft/api-extractor': 7.18.11
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
       '@rollup/plugin-node-resolve': 8.4.0_rollup@1.32.1
@@ -12425,13 +12296,13 @@ packages:
     dev: false
 
   file:projects/storage-queue.tgz:
-    resolution: {integrity: sha512-P8fE8ianJFOaHSuwKFp4zXeYVNG8bA9dsRW8RkH9+Zarg3pSLPhHIM70pSCTJBmaI9lDSsanhJIHacK55/zhaw==, tarball: file:projects/storage-queue.tgz}
+    resolution: {integrity: sha512-W8Z2982Tt/KCje2JX8gr5hJF4Hwydoc6ukQ/tncUNGNs9rh6uxQjpxX1WpXGiCsYlj8H201HE24erqxl108Akw==, tarball: file:projects/storage-queue.tgz}
     name: '@rush-temp/storage-queue'
     version: 0.0.0
     dependencies:
       '@azure/core-tracing': 1.0.0-preview.13
       '@azure/identity': 2.0.0-beta.6
-      '@microsoft/api-extractor': 7.7.11
+      '@microsoft/api-extractor': 7.18.11
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
       '@rollup/plugin-node-resolve': 8.4.0_rollup@1.32.1
@@ -12486,13 +12357,13 @@ packages:
     dev: false
 
   file:projects/synapse-access-control.tgz:
-    resolution: {integrity: sha512-fXpynEKAT+081vxYyKEdqJk2XD4NNHix5UKR2gsKWlCNKerWh1vfMrfInOUUHCsyidVHpzWVMgaK4rcIskiUog==, tarball: file:projects/synapse-access-control.tgz}
+    resolution: {integrity: sha512-UNCiaEhH+yE54M4DhU4L+gTLIQIzHaqYqnGk/CGQLpcX6JMQy/iPYVS6iW/Ro3jQBhagJh4Fzvf2GCDscsobGA==, tarball: file:projects/synapse-access-control.tgz}
     name: '@rush-temp/synapse-access-control'
     version: 0.0.0
     dependencies:
       '@azure/core-tracing': 1.0.0-preview.13
       '@azure/identity': 2.0.0-beta.6
-      '@microsoft/api-extractor': 7.7.11
+      '@microsoft/api-extractor': 7.18.11
       '@types/chai': 4.2.22
       '@types/chai-as-promised': 7.1.4
       '@types/mocha': 7.0.2
@@ -12540,13 +12411,13 @@ packages:
     dev: false
 
   file:projects/synapse-artifacts.tgz:
-    resolution: {integrity: sha512-cKJhR8vNTMPT1wzvBfZDQPWhP8/BXsqapXgO6DFd0ab4lHXm/t1bvRA4dhZVcerttsaOuqDwn/7suhy/kK2ntA==, tarball: file:projects/synapse-artifacts.tgz}
+    resolution: {integrity: sha512-pOvRyfKxkUFqnumJiBGQIBzrksSlrmylytkwCC43IiHvAV33E9tPR2OzpisCytvydZFTVf/LOZor3U+5mgz9DA==, tarball: file:projects/synapse-artifacts.tgz}
     name: '@rush-temp/synapse-artifacts'
     version: 0.0.0
     dependencies:
       '@azure/core-tracing': 1.0.0-preview.13
       '@azure/identity': 2.0.0-beta.6
-      '@microsoft/api-extractor': 7.7.11
+      '@microsoft/api-extractor': 7.18.11
       '@types/chai': 4.2.22
       '@types/chai-as-promised': 7.1.4
       '@types/mocha': 7.0.2
@@ -12594,13 +12465,13 @@ packages:
     dev: false
 
   file:projects/synapse-managed-private-endpoints.tgz:
-    resolution: {integrity: sha512-HWoyPUk0hC/+xreznV9W8M/m3PHHO7EPDBgxHbsjroOuYYedMYtd6NO7RY2xWpsIGT0283awU7LpMGhrALxBzw==, tarball: file:projects/synapse-managed-private-endpoints.tgz}
+    resolution: {integrity: sha512-Udx0UgQ5KSq1sIJgbjGUCt3CkebS95i3fMHbpCmHm7LI0eTWbWtpxVu6LUJiHz4hLTKCbpHYsHdXDKD7JIHSQw==, tarball: file:projects/synapse-managed-private-endpoints.tgz}
     name: '@rush-temp/synapse-managed-private-endpoints'
     version: 0.0.0
     dependencies:
       '@azure/core-tracing': 1.0.0-preview.13
       '@azure/identity': 2.0.0-beta.6
-      '@microsoft/api-extractor': 7.7.11
+      '@microsoft/api-extractor': 7.18.11
       '@types/chai': 4.2.22
       '@types/chai-as-promised': 7.1.4
       '@types/mocha': 7.0.2
@@ -12641,12 +12512,12 @@ packages:
     dev: false
 
   file:projects/synapse-monitoring.tgz:
-    resolution: {integrity: sha512-9xAsBYW7D1aeS2rUguFu9kpfkN4cXMYhida3m8TnwxetVkpOPFyIZ02UsUXMOxDPEEerAeYEWVo8E1tS3evR5Q==, tarball: file:projects/synapse-monitoring.tgz}
+    resolution: {integrity: sha512-6H+/OE0Cl6lLymcfOL/ZYgOnTlCq4rf28I1TxkPAzc+ar/dk+D3LVpCE0jnk9+w0YYGvjDSl/PzPVQaQ87HCcA==, tarball: file:projects/synapse-monitoring.tgz}
     name: '@rush-temp/synapse-monitoring'
     version: 0.0.0
     dependencies:
       '@azure/core-tracing': 1.0.0-preview.13
-      '@microsoft/api-extractor': 7.7.11
+      '@microsoft/api-extractor': 7.18.11
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       eslint: 7.32.0
       rimraf: 3.0.2
@@ -12662,13 +12533,13 @@ packages:
     dev: false
 
   file:projects/synapse-spark.tgz:
-    resolution: {integrity: sha512-QZRJ/07S1hSuTRj4VyMM2nwC60FJ5O27eoaePeKPgUa7z4/i7vWpr7la8JSDXu+iYdZUG/2U2FCQuLRmMYoQYA==, tarball: file:projects/synapse-spark.tgz}
+    resolution: {integrity: sha512-5+Of1VnBg8aV3/cWzwq/waKO9hdDhrfqX5c5QtqiAnBZ2XfJ/401VA8Hcf+SqDwytpfH/5ytMeDIv72pqJNAyA==, tarball: file:projects/synapse-spark.tgz}
     name: '@rush-temp/synapse-spark'
     version: 0.0.0
     dependencies:
       '@azure/core-tracing': 1.0.0-preview.13
       '@azure/identity': 2.0.0-beta.6
-      '@microsoft/api-extractor': 7.7.11
+      '@microsoft/api-extractor': 7.18.11
       '@types/chai': 4.2.22
       '@types/chai-as-promised': 7.1.4
       '@types/mocha': 7.0.2
@@ -12709,13 +12580,13 @@ packages:
     dev: false
 
   file:projects/template.tgz:
-    resolution: {integrity: sha512-Lxk07hkq8XQsOcKBYKnoR/mlC3Fb5T5uFvaatoZLvKY5LWsNewhJyq2GG/AexHT5HTYHU45Vquf66pCGmbmlBg==, tarball: file:projects/template.tgz}
+    resolution: {integrity: sha512-R1EmHfonJO9INyZFiX/CgXQRHWsfffeexFaGukg7yvul4GmNOTd9X5RjdnZB35sUHNa8ErlFVcbBVb4hrZ4XWg==, tarball: file:projects/template.tgz}
     name: '@rush-temp/template'
     version: 0.0.0
     dependencies:
       '@azure/core-tracing': 1.0.0-preview.13
       '@azure/identity': 2.0.0-beta.5
-      '@microsoft/api-extractor': 7.7.11
+      '@microsoft/api-extractor': 7.18.11
       '@types/chai': 4.2.22
       '@types/chai-as-promised': 7.1.4
       '@types/mocha': 7.0.2
@@ -12902,12 +12773,12 @@ packages:
     dev: false
 
   file:projects/test-utils.tgz:
-    resolution: {integrity: sha512-KYPqGE75cahX+es1MnTMiFT3HkhcVE0xdDnNC2RUsyvwWAxewMbXns2ozRdYuR66khLy6BuVwPK6CqQPAtlqjw==, tarball: file:projects/test-utils.tgz}
+    resolution: {integrity: sha512-mNAkFGRCdahoUfUgUBHK/rXrhHNsoD91poUZvHUzfF4V5Gf5+FJSetlGsuoN0loxj1ZFSLY88FvRmMDpAGAYmw==, tarball: file:projects/test-utils.tgz}
     name: '@rush-temp/test-utils'
     version: 0.0.0
     dependencies:
       '@azure/core-tracing': 1.0.0-preview.13
-      '@microsoft/api-extractor': 7.7.11
+      '@microsoft/api-extractor': 7.18.11
       '@opentelemetry/api': 1.0.3
       '@types/chai': 4.2.22
       '@types/mocha': 7.0.2
@@ -12992,12 +12863,12 @@ packages:
     dev: false
 
   file:projects/video-analyzer-edge.tgz:
-    resolution: {integrity: sha512-+wAv6j5J2g+RNNNOSaA5mDBxH0nspdnIyM48CELNP3iwW4ZM3KrZdGqD0BgNgZYpPCzhlI/+artUZs5mf2pS1g==, tarball: file:projects/video-analyzer-edge.tgz}
+    resolution: {integrity: sha512-Cl4jjmfkJuO8NZ72KUrRa1bQlcQGLYRpJcCwlmQY3LIhRTDAz0eJYbSiAjzq0S15LzmCw/2mzVoMK6kP+vgNvQ==, tarball: file:projects/video-analyzer-edge.tgz}
     name: '@rush-temp/video-analyzer-edge'
     version: 0.0.0
     dependencies:
       '@azure/core-tracing': 1.0.0-preview.13
-      '@microsoft/api-extractor': 7.7.11
+      '@microsoft/api-extractor': 7.18.11
       '@types/chai': 4.2.22
       '@types/chai-as-promised': 7.1.4
       '@types/mocha': 7.0.2
@@ -13039,11 +12910,11 @@ packages:
     dev: false
 
   file:projects/web-pubsub-express.tgz:
-    resolution: {integrity: sha512-TPhljtupasgCaq4ORSBcoBeEBxj9xq51XZsd0sMD416cqmyf3+p3pk+Zh/9jwiFKbPRUJ/ng77bKmaWzFyIplg==, tarball: file:projects/web-pubsub-express.tgz}
+    resolution: {integrity: sha512-BwLiUnPrFgV4H1B+OpDkMtThaGZGb2/4SmiL2CCuXJNbSFQ/0tHKPrYiHuvSu0IQNqxtmvPZvX188OTw7LxnYA==, tarball: file:projects/web-pubsub-express.tgz}
     name: '@rush-temp/web-pubsub-express'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.7.11
+      '@microsoft/api-extractor': 7.18.11
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-json': 4.1.0_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
@@ -13100,13 +12971,13 @@ packages:
     dev: false
 
   file:projects/web-pubsub.tgz:
-    resolution: {integrity: sha512-eBs+8SrQtA8RFex4gaAX5AOUb/EAfnr9xXrRJapyn2DkguDc4KkkcFyHna29FTAJ/+em4SekK8n8BPA4TIIxgg==, tarball: file:projects/web-pubsub.tgz}
+    resolution: {integrity: sha512-oVNzjy9G/kKI1/CctYffS7IPtBPbpwziyDHpPPtsZDbYyQSUfLghCp4z84SeNabCyRDc0Obr2i9LAE/0h8X7jA==, tarball: file:projects/web-pubsub.tgz}
     name: '@rush-temp/web-pubsub'
     version: 0.0.0
     dependencies:
       '@azure/core-tracing': 1.0.0-preview.13
       '@azure/identity': 1.5.2
-      '@microsoft/api-extractor': 7.7.11
+      '@microsoft/api-extractor': 7.18.11
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-json': 4.1.0_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1

--- a/sdk/agrifood/agrifood-farming-rest/package.json
+++ b/sdk/agrifood/agrifood-farming-rest/package.json
@@ -96,7 +96,7 @@
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
     "@azure/identity": "^1.1.0",
     "@azure-tools/test-recorder": "^1.0.0",
-    "@microsoft/api-extractor": "7.13.2",
+    "@microsoft/api-extractor": "^7.18.11",
     "@types/chai": "^4.1.6",
     "@types/mocha": "^7.0.2",
     "@types/node": "^12.0.0",

--- a/sdk/anomalydetector/ai-anomaly-detector/package.json
+++ b/sdk/anomalydetector/ai-anomaly-detector/package.json
@@ -72,7 +72,7 @@
     "@azure/dev-tool": "^1.0.0",
     "@azure/identity": "2.0.0-beta.6",
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@rollup/plugin-commonjs": "11.0.2",
     "@rollup/plugin-json": "^4.0.0",
     "@rollup/plugin-multi-entry": "^3.0.0",

--- a/sdk/anomalydetector/ai-anomaly-detector/review/ai-anomaly-detector.api.md
+++ b/sdk/anomalydetector/ai-anomaly-detector/review/ai-anomaly-detector.api.md
@@ -4,6 +4,8 @@
 
 ```ts
 
+/// <reference types="node" />
+
 import * as coreHttp from '@azure/core-http';
 import { KeyCredential } from '@azure/core-auth';
 import { PagedAsyncIterableIterator } from '@azure/core-paging';
@@ -363,7 +365,6 @@ export interface TimeSeriesPoint {
     timestamp?: Date;
     value: number;
 }
-
 
 // (No @packageDocumentation comment for this package)
 

--- a/sdk/apimanagement/arm-apimanagement/package.json
+++ b/sdk/apimanagement/arm-apimanagement/package.json
@@ -28,7 +28,7 @@
   "module": "./dist-esm/src/index.js",
   "types": "./types/arm-apimanagement.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@rollup/plugin-commonjs": "11.0.2",
     "@rollup/plugin-json": "^4.0.0",
     "@rollup/plugin-multi-entry": "^3.0.0",

--- a/sdk/apimanagement/arm-apimanagement/review/arm-apimanagement.api.md
+++ b/sdk/apimanagement/arm-apimanagement/review/arm-apimanagement.api.md
@@ -677,7 +677,7 @@ export class ApiManagementClient extends ApiManagementClientContext {
     beginPerformConnectivityCheckAsync(resourceGroupName: string, serviceName: string, connectivityCheckRequestParams: ConnectivityCheckRequest, options?: ApiManagementClientPerformConnectivityCheckAsyncOptionalParams): Promise<PollerLike<PollOperationState<ApiManagementClientPerformConnectivityCheckAsyncResponse>, ApiManagementClientPerformConnectivityCheckAsyncResponse>>;
     beginPerformConnectivityCheckAsyncAndWait(resourceGroupName: string, serviceName: string, connectivityCheckRequestParams: ConnectivityCheckRequest, options?: ApiManagementClientPerformConnectivityCheckAsyncOptionalParams): Promise<ApiManagementClientPerformConnectivityCheckAsyncResponse>;
     // (undocumented)
-    cache: Cache;
+    cache: Cache_2;
     // (undocumented)
     certificate: Certificate;
     // (undocumented)
@@ -715,7 +715,7 @@ export class ApiManagementClient extends ApiManagementClientContext {
     // (undocumented)
     networkStatus: NetworkStatus;
     // (undocumented)
-    notification: Notification;
+    notification: Notification_2;
     // (undocumented)
     notificationRecipientEmail: NotificationRecipientEmail;
     // (undocumented)
@@ -2405,7 +2405,7 @@ export interface BodyDiagnosticSettings {
 }
 
 // @public
-export interface Cache {
+interface Cache_2 {
     createOrUpdate(resourceGroupName: string, serviceName: string, cacheId: string, parameters: CacheContract, options?: CacheCreateOrUpdateOptionalParams): Promise<CacheCreateOrUpdateResponse>;
     delete(resourceGroupName: string, serviceName: string, cacheId: string, ifMatch: string, options?: CacheDeleteOptionalParams): Promise<void>;
     get(resourceGroupName: string, serviceName: string, cacheId: string, options?: CacheGetOptionalParams): Promise<CacheGetResponse>;
@@ -2413,6 +2413,7 @@ export interface Cache {
     listByService(resourceGroupName: string, serviceName: string, options?: CacheListByServiceOptionalParams): PagedAsyncIterableIterator<CacheContract>;
     update(resourceGroupName: string, serviceName: string, cacheId: string, ifMatch: string, parameters: CacheUpdateParameters, options?: CacheUpdateOptionalParams): Promise<CacheUpdateResponse>;
 }
+export { Cache_2 as Cache }
 
 // @public
 export interface CacheCollection {
@@ -3559,7 +3560,7 @@ export type GatewayHostnameConfigurationListByServiceResponse = GatewayHostnameC
 
 // @public
 export interface GatewayKeyRegenerationRequestContract {
-    keyType: KeyType;
+    keyType: KeyType_2;
 }
 
 // @public
@@ -3612,7 +3613,7 @@ export interface GatewayTokenContract {
 // @public
 export interface GatewayTokenRequestContract {
     expiry: Date;
-    keyType: KeyType;
+    keyType: KeyType_2;
 }
 
 // @public
@@ -4134,7 +4135,8 @@ export type IssueUpdateContractProperties = IssueContractBaseProperties & {
 };
 
 // @public
-export type KeyType = "primary" | "secondary";
+type KeyType_2 = "primary" | "secondary";
+export { KeyType_2 as KeyType }
 
 // @public
 export interface KeyVaultContractCreateProperties {
@@ -5010,11 +5012,12 @@ export interface NetworkStatusListByServiceOptionalParams extends coreClient.Ope
 export type NetworkStatusListByServiceResponse = NetworkStatusContractByLocation[];
 
 // @public
-export interface Notification {
+interface Notification_2 {
     createOrUpdate(resourceGroupName: string, serviceName: string, notificationName: NotificationName, options?: NotificationCreateOrUpdateOptionalParams): Promise<NotificationCreateOrUpdateResponse>;
     get(resourceGroupName: string, serviceName: string, notificationName: NotificationName, options?: NotificationGetOptionalParams): Promise<NotificationGetResponse>;
     listByService(resourceGroupName: string, serviceName: string, options?: NotificationListByServiceOptionalParams): PagedAsyncIterableIterator<NotificationContract>;
 }
+export { Notification_2 as Notification }
 
 // @public
 export interface NotificationCollection {
@@ -7827,7 +7830,7 @@ export type UserSubscriptionListResponse = SubscriptionCollection;
 // @public
 export interface UserTokenParameters {
     expiry?: Date;
-    keyType?: KeyType;
+    keyType?: KeyType_2;
 }
 
 // @public
@@ -7887,7 +7890,6 @@ export interface X509CertificateName {
     issuerCertificateThumbprint?: string;
     name?: string;
 }
-
 
 // (No @packageDocumentation comment for this package)
 

--- a/sdk/appconfiguration/app-configuration/package.json
+++ b/sdk/appconfiguration/app-configuration/package.json
@@ -99,7 +99,7 @@
     "@azure/identity": "2.0.0-beta.6",
     "@azure/keyvault-secrets": "^4.2.0",
     "@azure-tools/test-recorder": "^1.0.0",
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@rollup/plugin-commonjs": "11.0.2",
     "@rollup/plugin-inject": "^4.0.0",
     "@rollup/plugin-json": "^4.0.0",

--- a/sdk/appconfiguration/app-configuration/review/app-configuration.api.md
+++ b/sdk/appconfiguration/app-configuration/review/app-configuration.api.md
@@ -4,6 +4,8 @@
 
 ```ts
 
+/// <reference lib="esnext.asynciterable" />
+
 import { HttpResponse } from '@azure/core-http';
 import { OperationOptions } from '@azure/core-http';
 import { PagedAsyncIterableIterator } from '@azure/core-paging';
@@ -217,7 +219,6 @@ export interface SetReadOnlyResponse extends ConfigurationSetting, SyncTokenHead
 export interface SyncTokenHeaderField {
     syncToken?: string;
 }
-
 
 // (No @packageDocumentation comment for this package)
 

--- a/sdk/appservice/arm-appservice/package.json
+++ b/sdk/appservice/arm-appservice/package.json
@@ -28,7 +28,7 @@
   "module": "./dist-esm/index.js",
   "types": "./types/arm-appservice.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@rollup/plugin-commonjs": "11.0.2",
     "@rollup/plugin-json": "^4.0.0",
     "@rollup/plugin-multi-entry": "^3.0.0",

--- a/sdk/appservice/arm-appservice/review/arm-appservice.api.md
+++ b/sdk/appservice/arm-appservice/review/arm-appservice.api.md
@@ -4,6 +4,8 @@
 
 ```ts
 
+/// <reference types="node" />
+
 import * as coreAuth from '@azure/core-auth';
 import * as coreClient from '@azure/core-client';
 import { PagedAsyncIterableIterator } from '@azure/core-paging';
@@ -10625,7 +10627,6 @@ export type WorkerPoolResource = ProxyOnlyResource & {
 
 // @public
 export type WorkerSizeOptions = "Small" | "Medium" | "Large" | "D1" | "D2" | "D3" | "SmallV3" | "MediumV3" | "LargeV3" | "NestedSmall" | "NestedSmallLinux" | "Default";
-
 
 // (No @packageDocumentation comment for this package)
 

--- a/sdk/attestation/attestation/package.json
+++ b/sdk/attestation/attestation/package.json
@@ -105,7 +105,7 @@
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
     "@azure/identity": "2.0.0-beta.6",
     "@azure-tools/test-recorder": "^1.0.0",
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@types/chai": "^4.1.6",
     "@types/chai-as-promised": "^7.1.0",
     "@types/mocha": "^7.0.2",

--- a/sdk/attestation/attestation/review/attestation.api.md
+++ b/sdk/attestation/attestation/review/attestation.api.md
@@ -4,6 +4,8 @@
 
 ```ts
 
+/// <reference types="node" />
+
 import { CommonClientOptions } from '@azure/core-client';
 import { OperationOptions } from '@azure/core-client';
 import { TokenCredential } from '@azure/core-auth';
@@ -17,7 +19,7 @@ export class AttestationAdministrationClient {
     removePolicyManagementCertificate(pemCertificate: string, privateKey: string, certificate: string, options?: AttestationAdministrationClientPolicyCertificateOperationOptions): Promise<AttestationResponse<PolicyCertificatesModificationResult>>;
     resetPolicy(attestationType: AttestationType, options?: AttestationAdministrationClientPolicyOperationOptions): Promise<AttestationResponse<PolicyResult>>;
     setPolicy(attestationType: AttestationType, newPolicyDocument: string, options?: AttestationAdministrationClientPolicyOperationOptions): Promise<AttestationResponse<PolicyResult>>;
-    }
+}
 
 // @public
 export interface AttestationAdministrationClientOperationOptions extends OperationOptions {
@@ -48,7 +50,7 @@ export class AttestationClient {
     attestTpm(request: string, options?: AttestTpmOptions): Promise<string>;
     getAttestationSigners(options?: AttestationClientOperationOptions): Promise<AttestationSigner[]>;
     getOpenIdMetadata(options?: AttestationClientOperationOptions): Promise<Record<string, unknown>>;
-    }
+}
 
 // @public
 export interface AttestationClientOperationOptions extends OperationOptions {
@@ -206,7 +208,6 @@ export interface PolicyResult {
     policySigner?: AttestationSigner;
     policyTokenHash: Uint8Array;
 }
-
 
 // (No @packageDocumentation comment for this package)
 

--- a/sdk/authorization/arm-authorization/package.json
+++ b/sdk/authorization/arm-authorization/package.json
@@ -26,7 +26,7 @@
   "module": "./dist-esm/index.js",
   "types": "./types/arm-authorization.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@rollup/plugin-commonjs": "11.0.2",
     "@rollup/plugin-json": "^4.0.0",
     "@rollup/plugin-multi-entry": "^3.0.0",

--- a/sdk/communication/communication-chat/package.json
+++ b/sdk/communication/communication-chat/package.json
@@ -82,7 +82,7 @@
     "@azure/dev-tool": "^1.0.0",
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
     "@azure-tools/test-recorder": "^1.0.0",
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@rollup/plugin-commonjs": "11.0.2",
     "@rollup/plugin-json": "^4.0.0",
     "@rollup/plugin-multi-entry": "^3.0.0",

--- a/sdk/communication/communication-chat/review/communication-chat.api.md
+++ b/sdk/communication/communication-chat/review/communication-chat.api.md
@@ -4,6 +4,8 @@
 
 ```ts
 
+/// <reference lib="esnext.asynciterable" />
+
 import { ChatMessageDeletedEvent } from '@azure/communication-signaling';
 import { ChatMessageEditedEvent } from '@azure/communication-signaling';
 import { ChatMessageReceivedEvent } from '@azure/communication-signaling';
@@ -64,7 +66,7 @@ export class ChatClient {
     on(event: "participantsRemoved", listener: (e: ParticipantsRemovedEvent) => void): void;
     startRealtimeNotifications(): Promise<void>;
     stopRealtimeNotifications(): Promise<void>;
-    }
+}
 
 // @public
 export interface ChatClientOptions extends CommonClientOptions {
@@ -271,7 +273,6 @@ export interface UpdateMessageOptions extends OperationOptions {
 // @public
 export interface UpdateTopicOptions extends OperationOptions {
 }
-
 
 // (No @packageDocumentation comment for this package)
 

--- a/sdk/communication/communication-common/package.json
+++ b/sdk/communication/communication-common/package.json
@@ -73,7 +73,7 @@
   "devDependencies": {
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
     "@azure/dev-tool": "^1.0.0",
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@rollup/plugin-commonjs": "11.0.2",
     "@rollup/plugin-json": "^4.0.0",
     "@rollup/plugin-multi-entry": "^3.0.0",

--- a/sdk/communication/communication-identity/package.json
+++ b/sdk/communication/communication-identity/package.json
@@ -89,7 +89,7 @@
     "@azure/test-utils": "^1.0.0",
     "@azure-tools/test-recorder": "^1.0.0",
     "@azure/identity": "2.0.0-beta.6",
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@rollup/plugin-commonjs": "11.0.2",
     "@rollup/plugin-json": "^4.0.0",
     "@rollup/plugin-multi-entry": "^3.0.0",

--- a/sdk/communication/communication-network-traversal/package.json
+++ b/sdk/communication/communication-network-traversal/package.json
@@ -88,7 +88,7 @@
     "@azure/identity": "2.0.0-beta.6",
     "@azure/test-utils": "^1.0.0",
     "@azure-tools/test-recorder": "^1.0.0",
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@rollup/plugin-commonjs": "11.0.2",
     "@rollup/plugin-json": "^4.0.0",
     "@rollup/plugin-multi-entry": "^3.0.0",

--- a/sdk/communication/communication-phone-numbers/package.json
+++ b/sdk/communication/communication-phone-numbers/package.json
@@ -77,7 +77,7 @@
     "@azure/test-utils": "^1.0.0",
     "@azure-tools/test-recorder": "^1.0.0",
     "@azure/identity": "2.0.0-beta.6",
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@rollup/plugin-commonjs": "11.0.2",
     "@rollup/plugin-json": "^4.0.0",
     "@rollup/plugin-multi-entry": "^3.0.0",

--- a/sdk/communication/communication-phone-numbers/review/communication-phone-numbers.api.md
+++ b/sdk/communication/communication-phone-numbers/review/communication-phone-numbers.api.md
@@ -4,6 +4,8 @@
 
 ```ts
 
+/// <reference lib="esnext.asynciterable" />
+
 import { KeyCredential } from '@azure/core-auth';
 import { OperationOptions } from '@azure/core-http';
 import { PagedAsyncIterableIterator } from '@azure/core-paging';
@@ -124,7 +126,6 @@ export interface ReleasePhoneNumberResult {
 export interface SearchAvailablePhoneNumbersRequest extends PhoneNumberSearchRequest {
     countryCode: string;
 }
-
 
 // (No @packageDocumentation comment for this package)
 

--- a/sdk/communication/communication-sms/package.json
+++ b/sdk/communication/communication-sms/package.json
@@ -79,7 +79,7 @@
     "@azure/identity": "2.0.0-beta.6",
     "@azure/test-utils": "^1.0.0",
     "@azure-tools/test-recorder": "^1.0.0",
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@rollup/plugin-commonjs": "11.0.2",
     "@rollup/plugin-json": "^4.0.0",
     "@rollup/plugin-multi-entry": "^3.0.0",

--- a/sdk/communication/communication-sms/review/communication-sms.api.md
+++ b/sdk/communication/communication-sms/review/communication-sms.api.md
@@ -4,6 +4,8 @@
 
 ```ts
 
+/// <reference lib="esnext.asynciterable" />
+
 import { KeyCredential } from '@azure/core-auth';
 import { OperationOptions } from '@azure/core-http';
 import { PipelineOptions } from '@azure/core-http';
@@ -42,7 +44,6 @@ export interface SmsSendResult {
     successful: boolean;
     to: string;
 }
-
 
 // (No @packageDocumentation comment for this package)
 

--- a/sdk/compute/arm-compute/package.json
+++ b/sdk/compute/arm-compute/package.json
@@ -28,7 +28,7 @@
   "module": "./dist-esm/index.js",
   "types": "./types/arm-compute.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@rollup/plugin-commonjs": "11.0.2",
     "@rollup/plugin-json": "^4.0.0",
     "@rollup/plugin-multi-entry": "^3.0.0",

--- a/sdk/compute/arm-compute/review/arm-compute.api.md
+++ b/sdk/compute/arm-compute/review/arm-compute.api.md
@@ -4,6 +4,8 @@
 
 ```ts
 
+/// <reference types="node" />
+
 import * as coreAuth from '@azure/core-auth';
 import * as coreClient from '@azure/core-client';
 import { PagedAsyncIterableIterator } from '@azure/core-paging';
@@ -2471,13 +2473,14 @@ export type HyperVGenerationType = string;
 export type HyperVGenerationTypes = string;
 
 // @public
-export type Image = Resource & {
+type Image_2 = Resource & {
     extendedLocation?: ExtendedLocation;
     sourceVirtualMachine?: SubResource;
     storageProfile?: ImageStorageProfile;
     readonly provisioningState?: string;
     hyperVGeneration?: HyperVGenerationTypes;
 };
+export { Image_2 as Image }
 
 // @public
 export type ImageDataDisk = ImageDisk & {
@@ -2504,7 +2507,7 @@ export interface ImageDiskReference {
 // @public
 export interface ImageListResult {
     nextLink?: string;
-    value: Image[];
+    value: Image_2[];
 }
 
 // @public
@@ -2532,15 +2535,15 @@ export type ImageReference = SubResource & {
 
 // @public
 export interface Images {
-    beginCreateOrUpdate(resourceGroupName: string, imageName: string, parameters: Image, options?: ImagesCreateOrUpdateOptionalParams): Promise<PollerLike<PollOperationState<ImagesCreateOrUpdateResponse>, ImagesCreateOrUpdateResponse>>;
-    beginCreateOrUpdateAndWait(resourceGroupName: string, imageName: string, parameters: Image, options?: ImagesCreateOrUpdateOptionalParams): Promise<ImagesCreateOrUpdateResponse>;
+    beginCreateOrUpdate(resourceGroupName: string, imageName: string, parameters: Image_2, options?: ImagesCreateOrUpdateOptionalParams): Promise<PollerLike<PollOperationState<ImagesCreateOrUpdateResponse>, ImagesCreateOrUpdateResponse>>;
+    beginCreateOrUpdateAndWait(resourceGroupName: string, imageName: string, parameters: Image_2, options?: ImagesCreateOrUpdateOptionalParams): Promise<ImagesCreateOrUpdateResponse>;
     beginDelete(resourceGroupName: string, imageName: string, options?: ImagesDeleteOptionalParams): Promise<PollerLike<PollOperationState<void>, void>>;
     beginDeleteAndWait(resourceGroupName: string, imageName: string, options?: ImagesDeleteOptionalParams): Promise<void>;
     beginUpdate(resourceGroupName: string, imageName: string, parameters: ImageUpdate, options?: ImagesUpdateOptionalParams): Promise<PollerLike<PollOperationState<ImagesUpdateResponse>, ImagesUpdateResponse>>;
     beginUpdateAndWait(resourceGroupName: string, imageName: string, parameters: ImageUpdate, options?: ImagesUpdateOptionalParams): Promise<ImagesUpdateResponse>;
     get(resourceGroupName: string, imageName: string, options?: ImagesGetOptionalParams): Promise<ImagesGetResponse>;
-    list(options?: ImagesListOptionalParams): PagedAsyncIterableIterator<Image>;
-    listByResourceGroup(resourceGroupName: string, options?: ImagesListByResourceGroupOptionalParams): PagedAsyncIterableIterator<Image>;
+    list(options?: ImagesListOptionalParams): PagedAsyncIterableIterator<Image_2>;
+    listByResourceGroup(resourceGroupName: string, options?: ImagesListByResourceGroupOptionalParams): PagedAsyncIterableIterator<Image_2>;
 }
 
 // @public
@@ -2550,7 +2553,7 @@ export interface ImagesCreateOrUpdateOptionalParams extends coreClient.Operation
 }
 
 // @public
-export type ImagesCreateOrUpdateResponse = Image;
+export type ImagesCreateOrUpdateResponse = Image_2;
 
 // @public
 export interface ImagesDeleteOptionalParams extends coreClient.OperationOptions {
@@ -2564,7 +2567,7 @@ export interface ImagesGetOptionalParams extends coreClient.OperationOptions {
 }
 
 // @public
-export type ImagesGetResponse = Image;
+export type ImagesGetResponse = Image_2;
 
 // @public
 export interface ImagesListByResourceGroupNextOptionalParams extends coreClient.OperationOptions {
@@ -2608,7 +2611,7 @@ export interface ImagesUpdateOptionalParams extends coreClient.OperationOptions 
 }
 
 // @public
-export type ImagesUpdateResponse = Image;
+export type ImagesUpdateResponse = Image_2;
 
 // @public
 export type ImageUpdate = UpdateResource & {
@@ -7535,7 +7538,6 @@ export interface WinRMListener {
     certificateUrl?: string;
     protocol?: ProtocolTypes;
 }
-
 
 // (No @packageDocumentation comment for this package)
 

--- a/sdk/confidentialledger/confidential-ledger-rest/package.json
+++ b/sdk/confidentialledger/confidential-ledger-rest/package.json
@@ -94,7 +94,7 @@
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
     "@azure/identity": "^1.1.0",
     "@azure-tools/test-recorder": "^1.0.0",
-    "@microsoft/api-extractor": "7.13.2",
+    "@microsoft/api-extractor": "^7.18.11",
     "@types/chai": "^4.1.6",
     "@types/mocha": "^7.0.2",
     "@types/node": "^12.0.0",

--- a/sdk/containerregistry/container-registry/package.json
+++ b/sdk/containerregistry/container-registry/package.json
@@ -88,7 +88,7 @@
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
     "@azure/identity": "2.0.0-beta.6",
     "@azure-tools/test-recorder": "^1.0.0",
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@types/chai": "^4.1.6",
     "@types/chai-as-promised": "^7.1.0",
     "@types/mocha": "^7.0.2",

--- a/sdk/containerregistry/container-registry/review/container-registry.api.md
+++ b/sdk/containerregistry/container-registry/review/container-registry.api.md
@@ -4,6 +4,9 @@
 
 ```ts
 
+/// <reference types="node" />
+/// <reference lib="esnext.asynciterable" />
+
 import { OperationOptions } from '@azure/core-client';
 import { PagedAsyncIterableIterator } from '@azure/core-paging';
 import { PipelineOptions } from '@azure/core-rest-pipeline';
@@ -228,7 +231,6 @@ export interface UpdateTagPropertiesOptions extends OperationOptions {
     canRead?: boolean;
     canWrite?: boolean;
 }
-
 
 // (No @packageDocumentation comment for this package)
 

--- a/sdk/core/abort-controller/package.json
+++ b/sdk/core/abort-controller/package.json
@@ -75,7 +75,7 @@
   "devDependencies": {
     "@azure/dev-tool": "^1.0.0",
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@types/chai": "^4.1.6",
     "@types/mocha": "^7.0.2",
     "@types/node": "^12.0.0",

--- a/sdk/core/core-amqp/package.json
+++ b/sdk/core/core-amqp/package.json
@@ -83,7 +83,7 @@
   },
   "devDependencies": {
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@rollup/plugin-commonjs": "11.0.2",
     "@rollup/plugin-inject": "^4.0.0",
     "@rollup/plugin-json": "^4.0.0",

--- a/sdk/core/core-amqp/review/core-amqp.api.md
+++ b/sdk/core/core-amqp/review/core-amqp.api.md
@@ -4,9 +4,12 @@
 
 ```ts
 
+/// <reference types="node" />
+
 import { AbortSignalLike } from '@azure/abort-controller';
 import { AccessToken } from '@azure/core-auth';
 import { AmqpError } from 'rhea-promise';
+import { AzureLogger } from '@azure/logger';
 import { Connection } from 'rhea-promise';
 import { Message } from 'rhea-promise';
 import { MessageHeader } from 'rhea-promise';
@@ -427,7 +430,7 @@ export function isSasTokenProvider(thing: unknown): thing is SasTokenProvider;
 export function isSystemError(err: unknown): err is NetworkSystemError;
 
 // @public
-export const logger: import("@azure/logger").AzureLogger;
+export const logger: AzureLogger;
 
 // @public
 export class MessagingError extends Error {
@@ -600,7 +603,6 @@ export interface WebSocketOptions {
     webSocket?: WebSocketImpl;
     webSocketConstructorOptions?: any;
 }
-
 
 // (No @packageDocumentation comment for this package)
 

--- a/sdk/core/core-auth/package.json
+++ b/sdk/core/core-auth/package.json
@@ -69,7 +69,7 @@
   "devDependencies": {
     "@azure/dev-tool": "^1.0.0",
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@types/chai": "^4.1.6",
     "@types/mocha": "^7.0.2",
     "@types/node": "^12.0.0",

--- a/sdk/core/core-client-lro-rest/package.json
+++ b/sdk/core/core-client-lro-rest/package.json
@@ -65,7 +65,7 @@
     "@azure/core-rest-pipeline": "^1.1.0",
     "@azure/dev-tool": "^1.0.0",
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
-    "@microsoft/api-extractor": "7.13.2",
+    "@microsoft/api-extractor": "^7.18.11",
     "@types/chai": "^4.1.6",
     "@types/mocha": "^7.0.2",
     "@types/node": "^12.0.0",

--- a/sdk/core/core-client-paging-rest/package.json
+++ b/sdk/core/core-client-paging-rest/package.json
@@ -63,7 +63,7 @@
     "tslib": "^2.2.0"
   },
   "devDependencies": {
-    "@microsoft/api-extractor": "7.13.2",
+    "@microsoft/api-extractor": "^7.18.11",
     "@types/chai": "^4.1.6",
     "@types/mocha": "^7.0.2",
     "@types/node": "^12.0.0",

--- a/sdk/core/core-client-paging-rest/review/core-client-paging.api.md
+++ b/sdk/core/core-client-paging-rest/review/core-client-paging.api.md
@@ -4,6 +4,8 @@
 
 ```ts
 
+/// <reference lib="esnext.asynciterable" />
+
 import { Client } from '@azure-rest/core-client';
 import { HttpResponse } from '@azure-rest/core-client';
 import { PagedAsyncIterableIterator } from '@azure/core-paging';
@@ -18,6 +20,5 @@ export interface PaginateOptions {
 
 // @public
 export function paginateResponse<TElement>(client: Client, initialResponse: HttpResponse, options?: PaginateOptions): PagedAsyncIterableIterator<TElement>;
-
 
 ```

--- a/sdk/core/core-client-rest/package.json
+++ b/sdk/core/core-client-rest/package.json
@@ -63,7 +63,7 @@
     "tslib": "^2.2.0"
   },
   "devDependencies": {
-    "@microsoft/api-extractor": "7.13.2",
+    "@microsoft/api-extractor": "^7.18.11",
     "@types/chai": "^4.1.6",
     "@types/mocha": "^7.0.2",
     "@types/node": "^12.0.0",

--- a/sdk/core/core-client/package.json
+++ b/sdk/core/core-client/package.json
@@ -75,7 +75,7 @@
   },
   "devDependencies": {
     "@azure/core-xml": "^1.0.0",
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@types/chai": "^4.1.6",
     "@types/mocha": "^7.0.2",
     "@types/node": "^12.0.0",

--- a/sdk/core/core-crypto/package.json
+++ b/sdk/core/core-crypto/package.json
@@ -71,7 +71,7 @@
   },
   "devDependencies": {
     "@azure/dev-tool": "^1.0.0",
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@rollup/plugin-commonjs": "11.0.2",
     "@rollup/plugin-node-resolve": "^8.0.0",
     "@rollup/plugin-replace": "^2.2.0",

--- a/sdk/core/core-http/package.json
+++ b/sdk/core/core-http/package.json
@@ -133,7 +133,7 @@
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
     "@azure/dev-tool": "^1.0.0",
     "@azure/logger-js": "^1.0.2",
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@opentelemetry/api": "^1.0.1",
     "@types/chai": "^4.1.6",
     "@types/express": "^4.16.0",

--- a/sdk/core/core-http/review/core-http.api.md
+++ b/sdk/core/core-http/review/core-http.api.md
@@ -4,6 +4,8 @@
 
 ```ts
 
+/// <reference types="node" />
+
 import { AbortSignalLike } from '@azure/abort-controller';
 import { AccessToken } from '@azure/core-auth';
 import { Context } from '@azure/core-tracing';
@@ -30,7 +32,7 @@ export class AccessTokenRefresher {
     constructor(credential: TokenCredential, scopes: string | string[], requiredMillisecondsBeforeNewRefresh?: number);
     isReady(): boolean;
     refresh(options: GetTokenOptions): Promise<AccessToken | undefined>;
-    }
+}
 
 // @public
 export interface ApiKeyCredentialOptions {
@@ -179,7 +181,7 @@ export class DefaultHttpClient extends FetchHttpClient {
     prepareRequest(httpRequest: WebResourceLike): Promise<Partial<RequestInit>>;
     // (undocumented)
     processRequest(operationResponse: HttpOperationResponse): Promise<void>;
-    }
+}
 
 // @public
 export function delay<T>(delayInMs: number, value?: T, options?: {
@@ -250,7 +252,7 @@ export class ExpiringAccessTokenCache implements AccessTokenCache {
     getCachedToken(): AccessToken | undefined;
     // (undocumented)
     setCachedToken(accessToken: AccessToken | undefined): void;
-    }
+}
 
 // @public (undocumented)
 export function exponentialRetryPolicy(retryCount?: number, retryInterval?: number, maxRetryInterval?: number): RequestPolicyFactory;
@@ -772,7 +774,7 @@ export class ServiceClient {
     protected requestContentType?: string;
     sendOperationRequest(operationArguments: OperationArguments, operationSpec: OperationSpec, callback?: ServiceCallback<any>): Promise<RestResponse>;
     sendRequest(options: RequestPrepareOptions | WebResourceLike): Promise<HttpOperationResponse>;
-    }
+}
 
 // @public (undocumented)
 export interface ServiceClientCredentials {
@@ -989,7 +991,6 @@ export const XML_ATTRKEY = "$";
 
 // @public
 export const XML_CHARKEY = "_";
-
 
 // (No @packageDocumentation comment for this package)
 

--- a/sdk/core/core-lro/package.json
+++ b/sdk/core/core-lro/package.json
@@ -99,7 +99,7 @@
     "@azure/core-rest-pipeline": "^1.1.0",
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
     "@azure/dev-tool": "^1.0.0",
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@types/chai": "^4.1.6",
     "@types/mocha": "^7.0.2",
     "@types/node": "^12.0.0",

--- a/sdk/core/core-paging/package.json
+++ b/sdk/core/core-paging/package.json
@@ -74,7 +74,7 @@
   },
   "devDependencies": {
     "@azure/dev-tool": "^1.0.0",
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
     "@types/chai": "^4.1.6",
     "@types/mocha": "^7.0.2",

--- a/sdk/core/core-rest-pipeline/package.json
+++ b/sdk/core/core-rest-pipeline/package.json
@@ -93,7 +93,7 @@
     "uuid": "^8.3.0"
   },
   "devDependencies": {
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@opentelemetry/api": "^1.0.1",
     "@types/chai": "^4.1.6",
     "@types/mocha": "^7.0.2",

--- a/sdk/core/core-rest-pipeline/review/core-rest-pipeline.api.md
+++ b/sdk/core/core-rest-pipeline/review/core-rest-pipeline.api.md
@@ -4,6 +4,8 @@
 
 ```ts
 
+/// <reference types="node" />
+
 import { AbortSignalLike } from '@azure/abort-controller';
 import { AccessToken } from '@azure/core-auth';
 import { Debugger } from '@azure/logger';
@@ -346,7 +348,6 @@ export const userAgentPolicyName = "userAgentPolicy";
 export interface UserAgentPolicyOptions {
     userAgentPrefix?: string;
 }
-
 
 // (No @packageDocumentation comment for this package)
 

--- a/sdk/core/core-tracing/package.json
+++ b/sdk/core/core-tracing/package.json
@@ -64,7 +64,7 @@
     "@azure/core-auth": "^1.3.0",
     "@azure/dev-tool": "^1.0.0",
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@opentelemetry/tracing": "^0.22.0",
     "@types/chai": "^4.1.6",
     "@types/mocha": "^7.0.2",

--- a/sdk/core/core-tracing/review/core-tracing.api.md
+++ b/sdk/core/core-tracing/review/core-tracing.api.md
@@ -12,7 +12,8 @@ export interface Context {
 }
 
 // @public
-export const context: ContextAPI;
+const context_2: ContextAPI;
+export { context_2 as context }
 
 // @public
 export interface ContextAPI {
@@ -181,7 +182,6 @@ export interface TraceState {
     set(key: string, value: string): TraceState;
     unset(key: string): TraceState;
 }
-
 
 // (No @packageDocumentation comment for this package)
 

--- a/sdk/core/core-util/package.json
+++ b/sdk/core/core-util/package.json
@@ -70,7 +70,7 @@
   },
   "devDependencies": {
     "@azure/dev-tool": "^1.0.0",
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@types/chai": "^4.1.6",
     "@types/mocha": "^7.0.2",
     "@types/node": "^12.0.0",

--- a/sdk/core/core-xml/package.json
+++ b/sdk/core/core-xml/package.json
@@ -71,7 +71,7 @@
   },
   "devDependencies": {
     "@azure/dev-tool": "^1.0.0",
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@types/chai": "^4.1.6",
     "@types/mocha": "^7.0.2",
     "@types/node": "^12.0.0",

--- a/sdk/core/logger/package.json
+++ b/sdk/core/logger/package.json
@@ -70,7 +70,7 @@
   "devDependencies": {
     "@azure/dev-tool": "^1.0.0",
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@types/chai": "^4.1.6",
     "@types/mocha": "^7.0.2",
     "@types/node": "^12.0.0",

--- a/sdk/cosmosdb/cosmos/package.json
+++ b/sdk/cosmosdb/cosmos/package.json
@@ -101,7 +101,7 @@
     "@azure/dev-tool": "^1.0.0",
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
     "@azure/identity": "^1.1.0",
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@rollup/plugin-json": "^4.0.0",
     "@rollup/plugin-multi-entry": "^3.0.0",
     "@types/debug": "^4.1.4",

--- a/sdk/cosmosdb/cosmos/review/cosmos.api.md
+++ b/sdk/cosmosdb/cosmos/review/cosmos.api.md
@@ -4,7 +4,10 @@
 
 ```ts
 
-import { AbortSignal } from 'node-abort-controller';
+/// <reference lib="dom" />
+/// <reference lib="esnext.asynciterable" />
+
+import { AbortSignal as AbortSignal_2 } from 'node-abort-controller';
 import { Pipeline } from '@azure/core-rest-pipeline';
 import { TokenCredential } from '@azure/core-auth';
 
@@ -52,7 +55,7 @@ export class ChangeFeedIterator<T> {
     fetchNext(): Promise<ChangeFeedResponse<Array<T & Resource>>>;
     getAsyncIterator(): AsyncIterable<ChangeFeedResponse<Array<T & Resource>>>;
     get hasMoreResults(): boolean;
-    }
+}
 
 // @public
 export interface ChangeFeedOptions {
@@ -86,7 +89,7 @@ export class ClientContext {
         partitionKey: string;
         resourceId: string;
         options?: RequestOptions;
-    }): Promise<Response<any>>;
+    }): Promise<Response_2<any>>;
     // (undocumented)
     bulk<T>({ body, path, partitionKeyRangeId, resourceId, bulkOptions, options }: {
         body: T;
@@ -95,7 +98,7 @@ export class ClientContext {
         resourceId: string;
         bulkOptions?: BulkOptions;
         options?: RequestOptions;
-    }): Promise<Response<any>>;
+    }): Promise<Response_2<any>>;
     // (undocumented)
     clearSessionToken(path: string): void;
     // (undocumented)
@@ -106,7 +109,7 @@ export class ClientContext {
         resourceId: string;
         options?: RequestOptions;
         partitionKey?: PartitionKey;
-    }): Promise<Response<T & U & Resource>>;
+    }): Promise<Response_2<T & U & Resource>>;
     // (undocumented)
     delete<T>({ path, resourceType, resourceId, options, partitionKey }: {
         path: string;
@@ -114,17 +117,17 @@ export class ClientContext {
         resourceId: string;
         options?: RequestOptions;
         partitionKey?: PartitionKey;
-    }): Promise<Response<T & Resource>>;
+    }): Promise<Response_2<T & Resource>>;
     // (undocumented)
     execute<T>({ sprocLink, params, options, partitionKey }: {
         sprocLink: string;
         params?: any[];
         options?: RequestOptions;
         partitionKey?: PartitionKey;
-    }): Promise<Response<T>>;
-    getDatabaseAccount(options?: RequestOptions): Promise<Response<DatabaseAccount>>;
+    }): Promise<Response_2<T>>;
+    getDatabaseAccount(options?: RequestOptions): Promise<Response_2<DatabaseAccount>>;
     // (undocumented)
-    getQueryPlan(path: string, resourceType: ResourceType, resourceId: string, query: SqlQuerySpec | string, options?: FeedOptions): Promise<Response<PartitionedQueryExecutionInfo>>;
+    getQueryPlan(path: string, resourceType: ResourceType, resourceId: string, query: SqlQuerySpec | string, options?: FeedOptions): Promise<Response_2<PartitionedQueryExecutionInfo>>;
     // (undocumented)
     getReadEndpoint(): Promise<string>;
     // (undocumented)
@@ -145,7 +148,7 @@ export class ClientContext {
         resourceId: string;
         options?: RequestOptions;
         partitionKey?: PartitionKey;
-    }): Promise<Response<T & Resource>>;
+    }): Promise<Response_2<T & Resource>>;
     // (undocumented)
     queryFeed<T>({ path, resourceType, resourceId, resultFn, query, options, partitionKeyRangeId, partitionKey }: {
         path: string;
@@ -158,7 +161,7 @@ export class ClientContext {
         options: FeedOptions;
         partitionKeyRangeId?: string;
         partitionKey?: PartitionKey;
-    }): Promise<Response<T & Resource>>;
+    }): Promise<Response_2<T & Resource>>;
     // (undocumented)
     queryPartitionKeyRanges(collectionLink: string, query?: string | SqlQuerySpec, options?: FeedOptions): QueryIterator<PartitionKeyRange>;
     // (undocumented)
@@ -168,7 +171,7 @@ export class ClientContext {
         resourceId: string;
         options?: RequestOptions;
         partitionKey?: PartitionKey;
-    }): Promise<Response<T & Resource>>;
+    }): Promise<Response_2<T & Resource>>;
     // (undocumented)
     replace<T>({ body, path, resourceType, resourceId, options, partitionKey }: {
         body: any;
@@ -177,7 +180,7 @@ export class ClientContext {
         resourceId: string;
         options?: RequestOptions;
         partitionKey?: PartitionKey;
-    }): Promise<Response<T & Resource>>;
+    }): Promise<Response_2<T & Resource>>;
     // (undocumented)
     upsert<T, U = T>({ body, path, resourceType, resourceId, options, partitionKey }: {
         body: T;
@@ -186,7 +189,7 @@ export class ClientContext {
         resourceId: string;
         options?: RequestOptions;
         partitionKey?: PartitionKey;
-    }): Promise<Response<T & U & Resource>>;
+    }): Promise<Response_2<T & U & Resource>>;
 }
 
 // @public (undocumented)
@@ -451,7 +454,7 @@ export class Container {
     // @deprecated
     getPartitionKeyDefinition(): Promise<ResourceResponse<PartitionKeyDefinition>>;
     // (undocumented)
-    getQueryPlan(query: string | SqlQuerySpec): Promise<Response<PartitionedQueryExecutionInfo>>;
+    getQueryPlan(query: string | SqlQuerySpec): Promise<Response_2<PartitionedQueryExecutionInfo>>;
     // (undocumented)
     readonly id: string;
     item(id: string, partitionKeyValue?: PartitionKey): Item;
@@ -615,8 +618,8 @@ export class DatabaseAccount {
     // @deprecated
     get MediaLink(): string;
     readonly mediaLink: string;
-    readonly readableLocations: Location[];
-    readonly writableLocations: Location[];
+    readonly readableLocations: Location_2[];
+    readonly writableLocations: Location_2[];
 }
 
 // @public (undocumented)
@@ -788,7 +791,7 @@ export class GlobalEndpointManager {
     refreshEndpointList(): Promise<void>;
     // (undocumented)
     resolveServiceEndpoint(resourceType: ResourceType, operationType: OperationType): Promise<string>;
-    }
+}
 
 // @public (undocumented)
 export interface GroupByAliasToAggregateType {
@@ -887,7 +890,7 @@ export class ItemResponse<T extends ItemDefinition> extends ResourceResponse<T &
 // @public
 export class Items {
     constructor(container: Container, clientContext: ClientContext);
-    batch(operations: OperationInput[], partitionKey?: string, options?: RequestOptions): Promise<Response<any>>;
+    batch(operations: OperationInput[], partitionKey?: string, options?: RequestOptions): Promise<Response_2<any>>;
     bulk(operations: OperationInput[], bulkOptions?: BulkOptions, options?: RequestOptions): Promise<OperationResponse[]>;
     changeFeed(partitionKey: string | number | boolean, changeFeedOptions?: ChangeFeedOptions): ChangeFeedIterator<any>;
     changeFeed(changeFeedOptions?: ChangeFeedOptions): ChangeFeedIterator<any>;
@@ -926,7 +929,7 @@ export interface JSONObject {
 export type JSONValue = boolean | number | string | null | JSONArray | JSONObject;
 
 // @public
-export interface Location {
+interface Location_2 {
     // (undocumented)
     databaseAccountEndpoint: string;
     // (undocumented)
@@ -934,9 +937,10 @@ export interface Location {
     // (undocumented)
     unavailable?: boolean;
 }
+export { Location_2 as Location }
 
 // @public
-export type Next<T> = (context: RequestContext) => Promise<Response<T>>;
+export type Next<T> = (context: RequestContext) => Promise<Response_2<T>>;
 
 // @public
 export class Offer {
@@ -1174,7 +1178,7 @@ export class PermissionResponse extends ResourceResponse<PermissionDefinition & 
 }
 
 // @public
-export class Permissions {
+class Permissions_2 {
     constructor(user: User, clientContext: ClientContext);
     create(body: PermissionDefinition, options?: RequestOptions): Promise<PermissionResponse>;
     query(query: SqlQuerySpec, options?: FeedOptions): QueryIterator<any>;
@@ -1184,14 +1188,16 @@ export class Permissions {
     // (undocumented)
     readonly user: User;
 }
+export { Permissions_2 as Permissions }
 
 // @public
-export type Plugin<T> = (context: RequestContext, next: Next<T>) => Promise<Response<T>>;
+type Plugin_2<T> = (context: RequestContext, next: Next<T>) => Promise<Response_2<T>>;
+export { Plugin_2 as Plugin }
 
 // @public
 export interface PluginConfig {
     on: keyof typeof PluginOn;
-    plugin: Plugin<any>;
+    plugin: Plugin_2<any>;
 }
 
 // @public
@@ -1235,7 +1241,7 @@ export class QueryIterator<T> {
     getAsyncIterator(): AsyncIterable<FeedResponse<T>>;
     hasMoreResults(): boolean;
     reset(): void;
-    }
+}
 
 // @public (undocumented)
 export class QueryMetrics {
@@ -1437,7 +1443,7 @@ export interface RequestContext {
 }
 
 // @public (undocumented)
-export interface RequestInfo {
+interface RequestInfo_2 {
     // (undocumented)
     headers: CosmosHeaders;
     // (undocumented)
@@ -1449,6 +1455,7 @@ export interface RequestInfo {
     // (undocumented)
     verb: HTTPMethod;
 }
+export { RequestInfo_2 as RequestInfo }
 
 // @public
 export interface RequestOptions extends SharedOptions {
@@ -1527,7 +1534,7 @@ export enum ResourceType {
 }
 
 // @public (undocumented)
-export interface Response<T> {
+interface Response_2<T> {
     // (undocumented)
     code?: number;
     // (undocumented)
@@ -1537,6 +1544,7 @@ export interface Response<T> {
     // (undocumented)
     substatus?: number;
 }
+export { Response_2 as Response }
 
 // @public
 export interface RetryOptions {
@@ -1580,7 +1588,7 @@ export function setAuthorizationTokenHeaderUsingMasterKey(verb: HTTPMethod, reso
 
 // @public
 export interface SharedOptions {
-    abortSignal?: AbortSignal;
+    abortSignal?: AbortSignal_2;
     initialHeaders?: CosmosHeaders;
     sessionToken?: string;
 }
@@ -1781,7 +1789,7 @@ export class TimeSpan {
 }
 
 // @public (undocumented)
-export type TokenProvider = (requestInfo: RequestInfo) => Promise<string>;
+export type TokenProvider = (requestInfo: RequestInfo_2) => Promise<string>;
 
 // @public
 export class Trigger {
@@ -1876,7 +1884,7 @@ export class User {
     // (undocumented)
     readonly id: string;
     permission(id: string): Permission;
-    readonly permissions: Permissions;
+    readonly permissions: Permissions_2;
     read(options?: RequestOptions): Promise<UserResponse>;
     replace(body: UserDefinition, options?: RequestOptions): Promise<UserResponse>;
     get url(): string;
@@ -1946,7 +1954,6 @@ export class Users {
     readAll(options?: FeedOptions): QueryIterator<UserDefinition & Resource>;
     upsert(body: UserDefinition, options?: RequestOptions): Promise<UserResponse>;
 }
-
 
 // (No @packageDocumentation comment for this package)
 

--- a/sdk/deviceupdate/iot-device-update/package.json
+++ b/sdk/deviceupdate/iot-device-update/package.json
@@ -26,7 +26,7 @@
     "@azure/dev-tool": "^1.0.0",
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
     "@azure/identity": "2.0.0-beta.6",
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@types/node": "^12.0.0",
     "@types/uuid": "^8.0.0",
     "cross-env": "^7.0.2",

--- a/sdk/digitaltwins/digital-twins-core/package.json
+++ b/sdk/digitaltwins/digital-twins-core/package.json
@@ -76,7 +76,7 @@
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
     "@azure/identity": "2.0.0-beta.6",
     "@azure-tools/test-recorder": "^1.0.0",
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@rollup/plugin-commonjs": "11.0.2",
     "@rollup/plugin-json": "^4.0.0",
     "@rollup/plugin-multi-entry": "^3.0.0",

--- a/sdk/digitaltwins/digital-twins-core/review/digital-twins-core.api.md
+++ b/sdk/digitaltwins/digital-twins-core/review/digital-twins-core.api.md
@@ -4,6 +4,8 @@
 
 ```ts
 
+/// <reference lib="esnext.asynciterable" />
+
 import * as coreHttp from '@azure/core-http';
 import { OperationOptions } from '@azure/core-http';
 import { PagedAsyncIterableIterator } from '@azure/core-paging';
@@ -343,7 +345,6 @@ export interface RelationshipCollection {
     nextLink?: string;
     value?: any[];
 }
-
 
 // (No @packageDocumentation comment for this package)
 

--- a/sdk/documenttranslator/ai-document-translator-rest/package.json
+++ b/sdk/documenttranslator/ai-document-translator-rest/package.json
@@ -99,7 +99,7 @@
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
     "@azure/identity": "^1.1.0",
     "@azure-tools/test-recorder": "^1.0.0",
-    "@microsoft/api-extractor": "7.13.2",
+    "@microsoft/api-extractor": "^7.18.11",
     "@types/chai": "^4.1.6",
     "@types/mocha": "^7.0.2",
     "@types/node": "^12.0.0",

--- a/sdk/eventgrid/arm-eventgrid/package.json
+++ b/sdk/eventgrid/arm-eventgrid/package.json
@@ -20,7 +20,7 @@
   "module": "./dist-esm/src/index.js",
   "types": "./types/arm-eventgrid.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@rollup/plugin-commonjs": "11.0.2",
     "@rollup/plugin-json": "^4.0.0",
     "@rollup/plugin-multi-entry": "^3.0.0",

--- a/sdk/eventgrid/eventgrid/package.json
+++ b/sdk/eventgrid/eventgrid/package.json
@@ -102,7 +102,7 @@
     "@azure/service-bus": "^7.0.0",
     "@azure/test-utils": "^1.0.0",
     "@azure-tools/test-recorder": "^1.0.0",
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@rollup/plugin-commonjs": "11.0.2",
     "@rollup/plugin-json": "^4.0.0",
     "@rollup/plugin-multi-entry": "^3.0.0",

--- a/sdk/eventhub/arm-eventhub/package.json
+++ b/sdk/eventhub/arm-eventhub/package.json
@@ -28,7 +28,7 @@
   "module": "./dist-esm/index.js",
   "types": "./types/arm-eventhub.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@rollup/plugin-commonjs": "11.0.2",
     "@rollup/plugin-json": "^4.0.0",
     "@rollup/plugin-multi-entry": "^3.0.0",

--- a/sdk/eventhub/arm-eventhub/review/arm-eventhub.api.md
+++ b/sdk/eventhub/arm-eventhub/review/arm-eventhub.api.md
@@ -604,7 +604,8 @@ export interface IpFilterRuleListResult {
 }
 
 // @public
-export type KeyType = "PrimaryKey" | "SecondaryKey";
+type KeyType_2 = "PrimaryKey" | "SecondaryKey";
+export { KeyType_2 as KeyType }
 
 // @public
 export interface KeyVaultProperties {
@@ -1088,7 +1089,7 @@ export type ProvisioningStateDR = "Accepted" | "Succeeded" | "Failed";
 // @public
 export interface RegenerateAccessKeyParameters {
     key?: string;
-    keyType: KeyType;
+    keyType: KeyType_2;
 }
 
 // @public
@@ -1159,7 +1160,6 @@ export interface VirtualNetworkRuleListResult {
     nextLink?: string;
     value?: VirtualNetworkRule[];
 }
-
 
 // (No @packageDocumentation comment for this package)
 

--- a/sdk/eventhub/event-hubs/package.json
+++ b/sdk/eventhub/event-hubs/package.json
@@ -131,7 +131,7 @@
     "@azure/mock-hub": "^1.0.0",
     "@azure/test-utils": "^1.0.0",
     "@azure/test-utils-perfstress": "^1.0.0",
-    "@microsoft/api-extractor": "^7.18.7",
+    "@microsoft/api-extractor": "^7.18.11",
     "@rollup/plugin-commonjs": "11.0.2",
     "@rollup/plugin-inject": "^4.0.0",
     "@rollup/plugin-json": "^4.0.0",

--- a/sdk/eventhub/event-processor-host/package.json
+++ b/sdk/eventhub/event-processor-host/package.json
@@ -87,7 +87,7 @@
   "devDependencies": {
     "@azure/dev-tool": "^1.0.0",
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@rollup/plugin-commonjs": "11.0.2",
     "@rollup/plugin-json": "^4.0.0",
     "@rollup/plugin-multi-entry": "^3.0.0",

--- a/sdk/eventhub/eventhubs-checkpointstore-blob/package.json
+++ b/sdk/eventhub/eventhubs-checkpointstore-blob/package.json
@@ -69,7 +69,7 @@
   "devDependencies": {
     "@azure/dev-tool": "^1.0.0",
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@rollup/plugin-commonjs": "11.0.2",
     "@rollup/plugin-inject": "^4.0.0",
     "@rollup/plugin-json": "^4.0.0",

--- a/sdk/eventhub/eventhubs-checkpointstore-blob/review/eventhubs-checkpointstore-blob.api.md
+++ b/sdk/eventhub/eventhubs-checkpointstore-blob/review/eventhubs-checkpointstore-blob.api.md
@@ -4,6 +4,7 @@
 
 ```ts
 
+import { AzureLogger } from '@azure/logger';
 import { Checkpoint } from '@azure/event-hubs';
 import { CheckpointStore } from '@azure/event-hubs';
 import { ContainerClient } from '@azure/storage-blob';
@@ -20,8 +21,7 @@ export class BlobCheckpointStore implements CheckpointStore {
 }
 
 // @public
-export const logger: import("@azure/logger").AzureLogger;
-
+export const logger: AzureLogger;
 
 // (No @packageDocumentation comment for this package)
 

--- a/sdk/eventhub/eventhubs-checkpointstore-table/package.json
+++ b/sdk/eventhub/eventhubs-checkpointstore-table/package.json
@@ -68,7 +68,7 @@
   "devDependencies": {
     "@azure/dev-tool": "^1.0.0",
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@rollup/plugin-commonjs": "11.0.2",
     "@rollup/plugin-inject": "^4.0.0",
     "@rollup/plugin-json": "^4.0.0",

--- a/sdk/eventhub/eventhubs-checkpointstore-table/review/eventhubs-checkpointstore-table.api.md
+++ b/sdk/eventhub/eventhubs-checkpointstore-table/review/eventhubs-checkpointstore-table.api.md
@@ -4,13 +4,14 @@
 
 ```ts
 
+import { AzureLogger } from '@azure/logger';
 import { Checkpoint } from '@azure/event-hubs';
 import { CheckpointStore } from '@azure/event-hubs';
 import { PartitionOwnership } from '@azure/event-hubs';
 import { TableClient } from '@azure/data-tables';
 
 // @public
-export const logger: import("@azure/logger").AzureLogger;
+export const logger: AzureLogger;
 
 // @public
 export class TableCheckpointStore implements CheckpointStore {
@@ -20,7 +21,6 @@ export class TableCheckpointStore implements CheckpointStore {
     listOwnership(fullyQualifiedNamespace: string, eventHubName: string, consumerGroup: string): Promise<PartitionOwnership[]>;
     updateCheckpoint(checkpoint: Checkpoint): Promise<void>;
 }
-
 
 // (No @packageDocumentation comment for this package)
 

--- a/sdk/features/arm-features/package.json
+++ b/sdk/features/arm-features/package.json
@@ -26,7 +26,7 @@
   "module": "./esm/index.js",
   "types": "./esm/index.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@rollup/plugin-commonjs": "11.0.2",
     "@rollup/plugin-json": "^4.0.0",
     "@rollup/plugin-multi-entry": "^3.0.0",

--- a/sdk/formrecognizer/ai-form-recognizer/package.json
+++ b/sdk/formrecognizer/ai-form-recognizer/package.json
@@ -95,7 +95,7 @@
     "@azure/identity": "2.0.0-beta.6",
     "@azure/test-utils": "^1.0.0",
     "@azure-tools/test-recorder": "^1.0.0",
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@types/chai": "^4.1.6",
     "@types/mocha": "^7.0.2",
     "@types/node": "^12.0.0",

--- a/sdk/formrecognizer/ai-form-recognizer/review/ai-form-recognizer.api.md
+++ b/sdk/formrecognizer/ai-form-recognizer/review/ai-form-recognizer.api.md
@@ -4,6 +4,9 @@
 
 ```ts
 
+/// <reference types="node" />
+/// <reference lib="esnext.asynciterable" />
+
 import { AzureKeyCredential } from '@azure/core-auth';
 import * as coreHttp from '@azure/core-http';
 import { KeyCredential } from '@azure/core-auth';
@@ -286,7 +289,7 @@ export class FormRecognizerClient {
     beginRecognizeReceipts(receipt: FormRecognizerRequestBody, options?: BeginRecognizeReceiptsOptions): Promise<FormPollerLike>;
     beginRecognizeReceiptsFromUrl(receiptUrl: string, options?: BeginRecognizeReceiptsOptions): Promise<FormPollerLike>;
     readonly endpointUrl: string;
-    }
+}
 
 // @public
 export interface FormRecognizerClientOptions extends PipelineOptions {
@@ -367,7 +370,7 @@ export class FormTrainingClient {
     getCustomModel(modelId: string, options?: GetModelOptions): Promise<FormModelResponse>;
     getFormRecognizerClient(): FormRecognizerClient;
     listCustomModels(options?: ListModelsOptions): PagedAsyncIterableIterator<CustomFormModelInfo, ListCustomModelsResponse>;
-    }
+}
 
 // @public
 export interface FormTrainingPollOperationOptions<TState extends PollOperationState<unknown>> {
@@ -628,9 +631,7 @@ export interface ModelsSummary {
 
 // @public
 type ModelStatus = "creating" | "ready" | "invalid";
-
 export { ModelStatus as CustomFormModelStatus }
-
 export { ModelStatus }
 
 // @public
@@ -715,7 +716,6 @@ export interface TrainResult {
     fields?: FormFieldsReport[];
     trainingDocuments: TrainingDocumentInfo[];
 }
-
 
 // (No @packageDocumentation comment for this package)
 

--- a/sdk/identity/identity-cache-persistence/package.json
+++ b/sdk/identity/identity-cache-persistence/package.json
@@ -71,7 +71,7 @@
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
     "@azure/dev-tool": "^1.0.0",
     "@azure-tools/test-recorder": "^1.0.0",
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@types/jws": "^3.2.2",
     "@types/mocha": "^7.0.2",
     "@types/node": "^12.0.0",

--- a/sdk/identity/identity-vscode/package.json
+++ b/sdk/identity/identity-vscode/package.json
@@ -68,7 +68,7 @@
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
     "@azure/dev-tool": "^1.0.0",
     "@azure-tools/test-recorder": "^1.0.0",
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@types/jws": "^3.2.2",
     "@types/mocha": "^7.0.2",
     "@types/node": "^12.0.0",

--- a/sdk/identity/identity/package.json
+++ b/sdk/identity/identity/package.json
@@ -114,7 +114,7 @@
     "@azure/dev-tool": "^1.0.0",
     "@azure/test-utils": "^1.0.0",
     "@azure-tools/test-recorder": "^1.0.0",
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@types/jws": "^3.2.2",
     "@types/mocha": "^7.0.2",
     "@types/node": "^12.0.0",

--- a/sdk/iot/iot-modelsrepository/package.json
+++ b/sdk/iot/iot-modelsrepository/package.json
@@ -75,7 +75,7 @@
     "@azure/dev-tool": "^1.0.0",
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
     "@azure-tools/test-recorder": "^1.0.0",
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@rollup/plugin-commonjs": "11.0.2",
     "@rollup/plugin-json": "^4.0.0",
     "@rollup/plugin-multi-entry": "^3.0.0",

--- a/sdk/keyvault/arm-keyvault/package.json
+++ b/sdk/keyvault/arm-keyvault/package.json
@@ -28,7 +28,7 @@
   "module": "./dist-esm/index.js",
   "types": "./types/arm-keyvault.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@rollup/plugin-commonjs": "11.0.2",
     "@rollup/plugin-json": "^4.0.0",
     "@rollup/plugin-multi-entry": "^3.0.0",

--- a/sdk/keyvault/arm-keyvault/review/arm-keyvault.api.md
+++ b/sdk/keyvault/arm-keyvault/review/arm-keyvault.api.md
@@ -14,7 +14,7 @@ import { PollOperationState } from '@azure/core-lro';
 export interface AccessPolicyEntry {
     applicationId?: string;
     objectId: string;
-    permissions: Permissions;
+    permissions: Permissions_2;
     tenantId: string;
 }
 
@@ -984,12 +984,13 @@ export interface OperationsListOptionalParams extends coreClient.OperationOption
 export type OperationsListResponse = OperationListResult;
 
 // @public
-export interface Permissions {
+interface Permissions_2 {
     certificates?: CertificatePermissions[];
     keys?: KeyPermissions[];
     secrets?: SecretPermissions[];
     storage?: StoragePermissions[];
 }
+export { Permissions_2 as Permissions }
 
 // @public
 export interface PrivateEndpoint {
@@ -1513,7 +1514,6 @@ export interface VirtualNetworkRule {
     id: string;
     ignoreMissingVnetServiceEndpoint?: boolean;
 }
-
 
 // (No @packageDocumentation comment for this package)
 

--- a/sdk/keyvault/keyvault-admin/package.json
+++ b/sdk/keyvault/keyvault-admin/package.json
@@ -124,7 +124,7 @@
     "@azure/keyvault-keys": "^4.2.1",
     "@azure/test-utils": "^1.0.0",
     "@azure-tools/test-recorder": "^1.0.0",
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@rollup/plugin-commonjs": "11.0.2",
     "@rollup/plugin-json": "^4.0.0",
     "@rollup/plugin-multi-entry": "^3.0.0",

--- a/sdk/keyvault/keyvault-admin/review/keyvault-admin.api.md
+++ b/sdk/keyvault/keyvault-admin/review/keyvault-admin.api.md
@@ -4,6 +4,8 @@
 
 ```ts
 
+/// <reference lib="esnext.asynciterable" />
+
 import { CommonClientOptions } from '@azure/core-client';
 import { OperationOptions } from '@azure/core-client';
 import { PagedAsyncIterableIterator } from '@azure/core-paging';
@@ -241,7 +243,6 @@ export interface SetRoleDefinitionOptions extends OperationOptions {
 
 // @public
 export type SUPPORTED_API_VERSIONS = "7.2" | "7.3-preview";
-
 
 // (No @packageDocumentation comment for this package)
 

--- a/sdk/keyvault/keyvault-certificates/package.json
+++ b/sdk/keyvault/keyvault-certificates/package.json
@@ -121,7 +121,7 @@
     "@azure/keyvault-secrets": "^4.2.0",
     "@azure/test-utils": "^1.0.0",
     "@azure-tools/test-recorder": "^1.0.0",
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@rollup/plugin-commonjs": "11.0.2",
     "@rollup/plugin-json": "^4.0.0",
     "@rollup/plugin-multi-entry": "^3.0.0",

--- a/sdk/keyvault/keyvault-certificates/review/keyvault-certificates.api.md
+++ b/sdk/keyvault/keyvault-certificates/review/keyvault-certificates.api.md
@@ -4,6 +4,9 @@
 
 ```ts
 
+/// <reference lib="esnext.asynciterable" />
+
+import { AzureLogger } from '@azure/logger';
 import * as coreHttp from '@azure/core-http';
 import { PagedAsyncIterableIterator } from '@azure/core-paging';
 import { PipelineOptions } from '@azure/core-http';
@@ -419,7 +422,7 @@ export type ListPropertiesOfCertificateVersionsOptions = coreHttp.OperationOptio
 export type ListPropertiesOfIssuersOptions = coreHttp.OperationOptions;
 
 // @public
-export const logger: import("@azure/logger").AzureLogger;
+export const logger: AzureLogger;
 
 // @public
 export type MergeCertificateOptions = coreHttp.OperationOptions;
@@ -490,7 +493,6 @@ export interface X509CertificateProperties {
     subjectAlternativeNames?: CoreSubjectAlternativeNames;
     validityInMonths?: number;
 }
-
 
 // (No @packageDocumentation comment for this package)
 

--- a/sdk/keyvault/keyvault-keys/package.json
+++ b/sdk/keyvault/keyvault-keys/package.json
@@ -117,7 +117,7 @@
     "@azure/identity": "2.0.0-beta.7",
     "@azure/test-utils": "^1.0.0",
     "@azure-tools/test-recorder": "^1.0.0",
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@rollup/plugin-commonjs": "11.0.2",
     "@rollup/plugin-json": "^4.0.0",
     "@rollup/plugin-multi-entry": "^3.0.0",

--- a/sdk/keyvault/keyvault-keys/review/keyvault-keys.api.md
+++ b/sdk/keyvault/keyvault-keys/review/keyvault-keys.api.md
@@ -4,6 +4,9 @@
 
 ```ts
 
+/// <reference lib="esnext.asynciterable" />
+
+import { AzureLogger } from '@azure/logger';
 import * as coreHttp from '@azure/core-http';
 import { PagedAsyncIterableIterator } from '@azure/core-paging';
 import { PageSettings } from '@azure/core-paging';
@@ -92,7 +95,7 @@ export interface CreateRsaKeyOptions extends CreateKeyOptions {
 // @public
 export class CryptographyClient {
     constructor(key: string | KeyVaultKey, credential: TokenCredential, pipelineOptions?: CryptographyClientOptions);
-    constructor(key: JsonWebKey);
+    constructor(key: JsonWebKey_2);
     decrypt(decryptParameters: DecryptParameters, options?: DecryptOptions): Promise<DecryptResult>;
     // @deprecated
     decrypt(algorithm: EncryptionAlgorithm, ciphertext: Uint8Array, options?: DecryptOptions): Promise<DecryptResult>;
@@ -134,9 +137,9 @@ export interface DecryptResult {
 // @public
 export interface DeletedKey {
     id?: string;
-    key?: JsonWebKey;
+    key?: JsonWebKey_2;
     keyOperations?: KeyOperation[];
-    keyType?: KeyType;
+    keyType?: KeyType_2;
     name: string;
     properties: KeyProperties & {
         readonly recoveryId?: string;
@@ -204,7 +207,7 @@ export interface ImportKeyOptions extends coreHttp.OperationOptions {
 }
 
 // @public
-export interface JsonWebKey {
+interface JsonWebKey_2 {
     crv?: KeyCurveName;
     d?: Uint8Array;
     dp?: Uint8Array;
@@ -215,7 +218,7 @@ export interface JsonWebKey {
     // @deprecated
     keyOps?: KeyOperation[];
     kid?: string;
-    kty?: KeyType;
+    kty?: KeyType_2;
     n?: Uint8Array;
     p?: Uint8Array;
     q?: Uint8Array;
@@ -224,6 +227,7 @@ export interface JsonWebKey {
     x?: Uint8Array;
     y?: Uint8Array;
 }
+export { JsonWebKey_2 as JsonWebKey }
 
 // @public
 export class KeyClient {
@@ -232,7 +236,7 @@ export class KeyClient {
     beginDeleteKey(name: string, options?: BeginDeleteKeyOptions): Promise<PollerLike<PollOperationState<DeletedKey>, DeletedKey>>;
     beginRecoverDeletedKey(name: string, options?: BeginRecoverDeletedKeyOptions): Promise<PollerLike<PollOperationState<DeletedKey>, DeletedKey>>;
     createEcKey(name: string, options?: CreateEcKeyOptions): Promise<KeyVaultKey>;
-    createKey(name: string, keyType: KeyType, options?: CreateKeyOptions): Promise<KeyVaultKey>;
+    createKey(name: string, keyType: KeyType_2, options?: CreateKeyOptions): Promise<KeyVaultKey>;
     createOctKey(name: string, options?: CreateOctKeyOptions): Promise<KeyVaultKey>;
     createRsaKey(name: string, options?: CreateRsaKeyOptions): Promise<KeyVaultKey>;
     getCryptographyClient(keyName: string, options?: GetCryptographyClientOptions): CryptographyClient;
@@ -240,7 +244,7 @@ export class KeyClient {
     getKey(name: string, options?: GetKeyOptions): Promise<KeyVaultKey>;
     getKeyRotationPolicy(name: string, options?: GetKeyRotationPolicyOptions): Promise<KeyRotationPolicy>;
     getRandomBytes(count: number, options?: GetRandomBytesOptions): Promise<RandomBytes>;
-    importKey(name: string, key: JsonWebKey, options?: ImportKeyOptions): Promise<KeyVaultKey>;
+    importKey(name: string, key: JsonWebKey_2, options?: ImportKeyOptions): Promise<KeyVaultKey>;
     listDeletedKeys(options?: ListDeletedKeysOptions): PagedAsyncIterableIterator<DeletedKey>;
     listPropertiesOfKeys(options?: ListPropertiesOfKeysOptions): PagedAsyncIterableIterator<KeyProperties>;
     listPropertiesOfKeyVersions(name: string, options?: ListPropertiesOfKeyVersionsOptions): PagedAsyncIterableIterator<KeyProperties>;
@@ -325,14 +329,15 @@ export interface KeyRotationPolicyProperties {
 }
 
 // @public
-export type KeyType = string;
+type KeyType_2 = string;
+export { KeyType_2 as KeyType }
 
 // @public
 export interface KeyVaultKey {
     id?: string;
-    key?: JsonWebKey;
+    key?: JsonWebKey_2;
     keyOperations?: KeyOperation[];
-    keyType?: KeyType;
+    keyType?: KeyType_2;
     name: string;
     properties: KeyProperties;
 }
@@ -435,7 +440,7 @@ export interface ListPropertiesOfKeyVersionsOptions extends coreHttp.OperationOp
 }
 
 // @public
-export const logger: import("@azure/logger").AzureLogger;
+export const logger: AzureLogger;
 
 export { PagedAsyncIterableIterator }
 
@@ -559,7 +564,6 @@ export interface WrapResult {
     keyID?: string;
     result: Uint8Array;
 }
-
 
 // (No @packageDocumentation comment for this package)
 

--- a/sdk/keyvault/keyvault-secrets/package.json
+++ b/sdk/keyvault/keyvault-secrets/package.json
@@ -116,7 +116,7 @@
     "@azure/identity": "2.0.0-beta.7",
     "@azure/test-utils": "^1.0.0",
     "@azure-tools/test-recorder": "^1.0.0",
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@rollup/plugin-commonjs": "11.0.2",
     "@rollup/plugin-json": "^4.0.0",
     "@rollup/plugin-multi-entry": "^3.0.0",

--- a/sdk/keyvault/keyvault-secrets/review/keyvault-secrets.api.md
+++ b/sdk/keyvault/keyvault-secrets/review/keyvault-secrets.api.md
@@ -4,6 +4,9 @@
 
 ```ts
 
+/// <reference lib="esnext.asynciterable" />
+
+import { AzureLogger } from '@azure/logger';
 import * as coreHttp from '@azure/core-http';
 import { PagedAsyncIterableIterator } from '@azure/core-paging';
 import { PageSettings } from '@azure/core-paging';
@@ -89,7 +92,7 @@ export interface ListPropertiesOfSecretVersionsOptions extends coreHttp.Operatio
 }
 
 // @public
-export const logger: import("@azure/logger").AzureLogger;
+export const logger: AzureLogger;
 
 export { PagedAsyncIterableIterator }
 
@@ -185,7 +188,6 @@ export interface UpdateSecretPropertiesOptions extends coreHttp.OperationOptions
         [propertyName: string]: string;
     };
 }
-
 
 // (No @packageDocumentation comment for this package)
 

--- a/sdk/links/arm-links/package.json
+++ b/sdk/links/arm-links/package.json
@@ -26,7 +26,7 @@
   "module": "./esm/index.js",
   "types": "./esm/index.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@rollup/plugin-commonjs": "11.0.2",
     "@rollup/plugin-json": "^4.0.0",
     "@rollup/plugin-multi-entry": "^3.0.0",

--- a/sdk/locks/arm-locks/package.json
+++ b/sdk/locks/arm-locks/package.json
@@ -26,7 +26,7 @@
   "module": "./esm/index.js",
   "types": "./esm/index.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@rollup/plugin-commonjs": "11.0.2",
     "@rollup/plugin-json": "^4.0.0",
     "@rollup/plugin-multi-entry": "^3.0.0",

--- a/sdk/managedapplications/arm-managedapplications/package.json
+++ b/sdk/managedapplications/arm-managedapplications/package.json
@@ -28,7 +28,7 @@
   "module": "./esm/index.js",
   "types": "./esm/index.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@rollup/plugin-commonjs": "11.0.2",
     "@rollup/plugin-json": "^4.0.0",
     "@rollup/plugin-multi-entry": "^3.0.0",

--- a/sdk/metricsadvisor/ai-metrics-advisor/package.json
+++ b/sdk/metricsadvisor/ai-metrics-advisor/package.json
@@ -93,7 +93,7 @@
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
     "@azure/identity": "^1.1.0",
     "@azure-tools/test-recorder": "^1.0.0",
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@types/chai": "^4.1.6",
     "@types/mocha": "^7.0.2",
     "@types/node": "^12.0.0",

--- a/sdk/metricsadvisor/ai-metrics-advisor/review/ai-metrics-advisor.api.md
+++ b/sdk/metricsadvisor/ai-metrics-advisor/review/ai-metrics-advisor.api.md
@@ -4,6 +4,8 @@
 
 ```ts
 
+/// <reference lib="esnext.asynciterable" />
+
 import { OperationOptions } from '@azure/core-http';
 import { PagedAsyncIterableIterator } from '@azure/core-paging';
 import { PipelineOptions } from '@azure/core-http';
@@ -905,7 +907,7 @@ export class MetricsAdvisorClient {
     listMetricDimensionValues(metricId: string, dimensionName: string, options?: ListMetricDimensionValuesOptions): PagedAsyncIterableIterator<string, DimensionValuesPageResponse>;
     listMetricEnrichmentStatus(metricId: string, startTime: Date | string, endTime: Date | string, options?: ListMetricEnrichmentStatusOptions): PagedAsyncIterableIterator<EnrichmentStatus, MetricEnrichmentStatusPageResponse>;
     listMetricSeriesDefinitions(metricId: string, activeSince: Date | string, options?: ListMetricSeriesDefinitionsOptions): PagedAsyncIterableIterator<MetricSeriesDefinition, MetricSeriesPageResponse>;
-    }
+}
 
 // @public
 export interface MetricsAdvisorClientOptions extends PipelineOptions {
@@ -1129,7 +1131,6 @@ export type WebNotificationHookPatch = {
     hookType: "Webhook";
     hookParameter?: Partial<WebhookHookParameter>;
 } & NotificationHookPatch;
-
 
 // (No @packageDocumentation comment for this package)
 

--- a/sdk/mixedreality/mixed-reality-authentication/package.json
+++ b/sdk/mixedreality/mixed-reality-authentication/package.json
@@ -76,7 +76,7 @@
     "@azure/dev-tool": "^1.0.0",
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
     "@azure-tools/test-recorder": "^1.0.0",
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@types/chai": "^4.1.6",
     "@types/chai-as-promised": "^7.1.0",
     "@types/mocha": "^7.0.2",

--- a/sdk/monitor/monitor-opentelemetry-exporter/package.json
+++ b/sdk/monitor/monitor-opentelemetry-exporter/package.json
@@ -86,7 +86,7 @@
   "devDependencies": {
     "@azure/dev-tool": "^1.0.0",
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@opentelemetry/instrumentation": "0.22.0",
     "@opentelemetry/instrumentation-http": "0.22.0",
     "@opentelemetry/node": "0.22.0",

--- a/sdk/monitor/monitor-query/package.json
+++ b/sdk/monitor/monitor-query/package.json
@@ -112,7 +112,7 @@
     "@azure/identity": "2.0.0-beta.7",
     "@azure/monitor-opentelemetry-exporter": "1.0.0-beta.4",
     "@azure-tools/test-recorder": "^1.0.0",
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@opentelemetry/api": "^1.0.1",
     "@opentelemetry/node": "0.22.0",
     "@opentelemetry/tracing": "^0.22.0",

--- a/sdk/network/arm-network/package.json
+++ b/sdk/network/arm-network/package.json
@@ -28,7 +28,7 @@
   "module": "./dist-esm/index.js",
   "types": "./types/arm-network.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@rollup/plugin-commonjs": "11.0.2",
     "@rollup/plugin-json": "^4.0.0",
     "@rollup/plugin-multi-entry": "^3.0.0",

--- a/sdk/policy/arm-policy/package.json
+++ b/sdk/policy/arm-policy/package.json
@@ -26,7 +26,7 @@
   "module": "./esm/index.js",
   "types": "./esm/index.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@rollup/plugin-commonjs": "11.0.2",
     "@rollup/plugin-json": "^4.0.0",
     "@rollup/plugin-multi-entry": "^3.0.0",

--- a/sdk/purview/arm-purview/package.json
+++ b/sdk/purview/arm-purview/package.json
@@ -28,7 +28,7 @@
   "module": "./dist-esm/index.js",
   "types": "./types/arm-purview.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@rollup/plugin-commonjs": "11.0.2",
     "@rollup/plugin-json": "^4.0.0",
     "@rollup/plugin-multi-entry": "^3.0.0",

--- a/sdk/purview/purview-account-rest/package.json
+++ b/sdk/purview/purview-account-rest/package.json
@@ -94,7 +94,7 @@
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
     "@azure/identity": "^1.1.0",
     "@azure-tools/test-recorder": "^1.0.0",
-    "@microsoft/api-extractor": "7.13.2",
+    "@microsoft/api-extractor": "^7.18.11",
     "@types/chai": "^4.1.6",
     "@types/mocha": "^7.0.2",
     "@types/node": "^12.0.0",

--- a/sdk/purview/purview-catalog-rest/package.json
+++ b/sdk/purview/purview-catalog-rest/package.json
@@ -93,7 +93,7 @@
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
     "@azure/identity": "^1.1.0",
     "@azure-tools/test-recorder": "^1.0.0",
-    "@microsoft/api-extractor": "7.13.2",
+    "@microsoft/api-extractor": "^7.18.11",
     "@types/chai": "^4.1.6",
     "@types/mocha": "^7.0.2",
     "@types/node": "^12.0.0",

--- a/sdk/purview/purview-scanning-rest/package.json
+++ b/sdk/purview/purview-scanning-rest/package.json
@@ -93,7 +93,7 @@
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
     "@azure/identity": "^1.1.0",
     "@azure-tools/test-recorder": "^1.0.0",
-    "@microsoft/api-extractor": "7.13.2",
+    "@microsoft/api-extractor": "^7.18.11",
     "@types/chai": "^4.1.6",
     "@types/mocha": "^7.0.2",
     "@types/node": "^12.0.0",

--- a/sdk/quantum/quantum-jobs/package.json
+++ b/sdk/quantum/quantum-jobs/package.json
@@ -74,7 +74,7 @@
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
     "@azure/identity": "2.0.0-beta.6",
     "@azure-tools/test-recorder": "^1.0.0",
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@rollup/plugin-commonjs": "11.0.2",
     "@rollup/plugin-json": "^4.0.0",
     "@rollup/plugin-multi-entry": "^3.0.0",

--- a/sdk/quantum/quantum-jobs/review/quantum-jobs.api.md
+++ b/sdk/quantum/quantum-jobs/review/quantum-jobs.api.md
@@ -59,7 +59,7 @@ export class Jobs {
     create(jobId: string, job: JobDetails, options?: coreHttp.OperationOptions): Promise<JobsCreateResponse>;
     get(jobId: string, options?: coreHttp.OperationOptions): Promise<JobsGetResponse>;
     list(options?: coreHttp.OperationOptions): PagedAsyncIterableIterator<JobDetails>;
-    }
+}
 
 // @public
 export type JobsCreateResponse = JobDetails & {
@@ -197,7 +197,7 @@ export class QuantumJobClient extends QuantumJobClientContext {
     // (undocumented)
     quotas: Quotas;
     // (undocumented)
-    storage: Storage;
+    storage: Storage_2;
 }
 
 // @public (undocumented)
@@ -240,7 +240,7 @@ export interface QuotaList {
 export class Quotas {
     constructor(client: QuantumJobClient);
     list(options?: coreHttp.OperationOptions): PagedAsyncIterableIterator<Quota>;
-    }
+}
 
 // @public
 export type QuotasListNextResponse = QuotaList & {
@@ -269,10 +269,11 @@ export interface SasUriResponse {
 }
 
 // @public
-export class Storage {
+class Storage_2 {
     constructor(client: QuantumJobClient);
     sasUri(blobDetails: BlobDetails, options?: coreHttp.OperationOptions): Promise<StorageSasUriResponse>;
 }
+export { Storage_2 as Storage }
 
 // @public
 export type StorageSasUriResponse = SasUriResponse & {
@@ -292,7 +293,6 @@ export interface TargetStatus {
     readonly id?: string;
     readonly statusPage?: string;
 }
-
 
 // (No @packageDocumentation comment for this package)
 

--- a/sdk/redis/arm-rediscache/package.json
+++ b/sdk/redis/arm-rediscache/package.json
@@ -29,7 +29,7 @@
   "module": "./dist-esm/src/index.js",
   "types": "./types/arm-rediscache.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@rollup/plugin-commonjs": "11.0.2",
     "@rollup/plugin-json": "^4.0.0",
     "@rollup/plugin-multi-entry": "^3.0.0",

--- a/sdk/remoterendering/mixed-reality-remote-rendering/package.json
+++ b/sdk/remoterendering/mixed-reality-remote-rendering/package.json
@@ -90,7 +90,7 @@
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
     "@azure/identity": "^1.1.0",
     "@azure-tools/test-recorder": "^1.0.0",
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@types/chai": "^4.1.6",
     "@types/chai-as-promised": "^7.1.0",
     "@types/mocha": "^7.0.2",

--- a/sdk/resources-subscriptions/arm-resources-subscriptions/package.json
+++ b/sdk/resources-subscriptions/arm-resources-subscriptions/package.json
@@ -18,7 +18,7 @@
   "module": "./dist-esm/index.js",
   "types": "./types/arm-resources-subscriptions.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@rollup/plugin-commonjs": "11.0.2",
     "@rollup/plugin-json": "^4.0.0",
     "@rollup/plugin-multi-entry": "^3.0.0",

--- a/sdk/resources-subscriptions/arm-resources-subscriptions/review/arm-resources-subscriptions.api.md
+++ b/sdk/resources-subscriptions/arm-resources-subscriptions/review/arm-resources-subscriptions.api.md
@@ -62,7 +62,7 @@ export enum KnownResourceNameStatus {
 }
 
 // @public
-export interface Location {
+interface Location_2 {
     readonly displayName?: string;
     readonly id?: string;
     metadata?: LocationMetadata;
@@ -71,10 +71,11 @@ export interface Location {
     readonly subscriptionId?: string;
     readonly type?: LocationType;
 }
+export { Location_2 as Location }
 
 // @public
 export interface LocationListResult {
-    value?: Location[];
+    value?: Location_2[];
 }
 
 // @public
@@ -208,7 +209,7 @@ export interface SubscriptionPolicies {
 export interface Subscriptions {
     get(subscriptionId: string, options?: SubscriptionsGetOptionalParams): Promise<SubscriptionsGetResponse>;
     list(options?: SubscriptionsListOptionalParams): PagedAsyncIterableIterator<Subscription>;
-    listLocations(subscriptionId: string, options?: SubscriptionsListLocationsOptionalParams): PagedAsyncIterableIterator<Location>;
+    listLocations(subscriptionId: string, options?: SubscriptionsListLocationsOptionalParams): PagedAsyncIterableIterator<Location_2>;
 }
 
 // @public
@@ -284,7 +285,6 @@ export interface TenantsListOptionalParams extends coreClient.OperationOptions {
 
 // @public
 export type TenantsListResponse = TenantListResult;
-
 
 // (No @packageDocumentation comment for this package)
 

--- a/sdk/resources/arm-resources/package.json
+++ b/sdk/resources/arm-resources/package.json
@@ -28,7 +28,7 @@
   "module": "./esm/index.js",
   "types": "./esm/index.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@rollup/plugin-commonjs": "11.0.2",
     "@rollup/plugin-json": "^4.0.0",
     "@rollup/plugin-multi-entry": "^3.0.0",

--- a/sdk/schemaregistry/schema-registry-avro/package.json
+++ b/sdk/schemaregistry/schema-registry-avro/package.json
@@ -82,7 +82,7 @@
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
     "@azure/identity": "2.0.0-beta.6",
     "@azure-tools/test-recorder": "^1.0.0",
-    "@microsoft/api-extractor": "^7.18.7",
+    "@microsoft/api-extractor": "^7.18.11",
     "@rollup/plugin-commonjs": "11.0.2",
     "@rollup/plugin-inject": "^4.0.0",
     "@rollup/plugin-replace": "^2.2.0",

--- a/sdk/schemaregistry/schema-registry/package.json
+++ b/sdk/schemaregistry/schema-registry/package.json
@@ -91,7 +91,7 @@
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
     "@azure/identity": "2.0.0-beta.6",
     "@azure-tools/test-recorder": "^1.0.0",
-    "@microsoft/api-extractor": "^7.18.7",
+    "@microsoft/api-extractor": "^7.18.11",
     "@types/chai": "^4.1.6",
     "@types/chai-as-promised": "^7.1.0",
     "@types/mocha": "^7.0.2",

--- a/sdk/search/search-documents/package.json
+++ b/sdk/search/search-documents/package.json
@@ -87,7 +87,7 @@
     "@azure/dev-tool": "^1.0.0",
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
     "@azure-tools/test-recorder": "^1.0.0",
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@rollup/plugin-json": "^4.0.0",
     "@rollup/plugin-multi-entry": "^3.0.0",
     "@rollup/plugin-replace": "^2.2.0",

--- a/sdk/search/search-documents/review/search-documents.api.md
+++ b/sdk/search/search-documents/review/search-documents.api.md
@@ -4,6 +4,8 @@
 
 ```ts
 
+/// <reference lib="esnext.asynciterable" />
+
 import { AzureKeyCredential } from '@azure/core-auth';
 import { KeyCredential } from '@azure/core-auth';
 import { OperationOptions } from '@azure/core-http';
@@ -1739,7 +1741,7 @@ export class SearchIndexClient {
     listIndexesNames(options?: ListIndexesOptions): IndexNameIterator;
     listSynonymMaps(options?: ListSynonymMapsOptions): Promise<Array<SynonymMap>>;
     listSynonymMapsNames(options?: ListSynonymMapsOptions): Promise<Array<string>>;
-    }
+}
 
 // @public
 export interface SearchIndexClientOptions extends PipelineOptions {
@@ -2360,7 +2362,6 @@ export type WordDelimiterTokenFilter = BaseTokenFilter & {
     stemEnglishPossessive?: boolean;
     protectedWords?: string[];
 };
-
 
 // (No @packageDocumentation comment for this package)
 

--- a/sdk/servicebus/arm-servicebus/package.json
+++ b/sdk/servicebus/arm-servicebus/package.json
@@ -28,7 +28,7 @@
   "module": "./dist-esm/index.js",
   "types": "./types/arm-servicebus.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@rollup/plugin-commonjs": "11.0.2",
     "@rollup/plugin-json": "^4.0.0",
     "@rollup/plugin-multi-entry": "^3.0.0",

--- a/sdk/servicebus/arm-servicebus/review/arm-servicebus.api.md
+++ b/sdk/servicebus/arm-servicebus/review/arm-servicebus.api.md
@@ -293,7 +293,8 @@ export interface IpFilterRuleListResult {
 }
 
 // @public
-export type KeyType = "PrimaryKey" | "SecondaryKey";
+type KeyType_2 = "PrimaryKey" | "SecondaryKey";
+export { KeyType_2 as KeyType }
 
 // @public
 export interface KeyVaultProperties {
@@ -974,7 +975,7 @@ export type QueuesRegenerateKeysResponse = AccessKeys;
 // @public
 export interface RegenerateAccessKeyParameters {
     key?: string;
-    keyType: KeyType;
+    keyType: KeyType_2;
 }
 
 // @public
@@ -1444,7 +1445,6 @@ export interface VirtualNetworkRuleListResult {
     nextLink?: string;
     value?: VirtualNetworkRule[];
 }
-
 
 // (No @packageDocumentation comment for this package)
 

--- a/sdk/servicebus/service-bus/package.json
+++ b/sdk/servicebus/service-bus/package.json
@@ -133,7 +133,7 @@
     "@azure/identity": "2.0.0-beta.6",
     "@azure/test-utils": "^1.0.0",
     "@azure/test-utils-perfstress": "^1.0.0",
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@rollup/plugin-commonjs": "11.0.2",
     "@rollup/plugin-inject": "^4.0.0",
     "@rollup/plugin-json": "^4.0.0",

--- a/sdk/servicebus/service-bus/review/service-bus.api.md
+++ b/sdk/servicebus/service-bus/review/service-bus.api.md
@@ -4,11 +4,13 @@
 
 ```ts
 
+/// <reference types="node" />
+
 import { AmqpAnnotatedMessage } from '@azure/core-amqp';
 import { delay } from '@azure/core-amqp';
 import { Delivery } from 'rhea-promise';
 import { HttpResponse } from '@azure/core-http';
-import Long from 'long';
+import { default as Long_2 } from 'long';
 import { MessagingError } from '@azure/core-amqp';
 import { NamedKeyCredential } from '@azure/core-auth';
 import { OperationOptions } from '@azure/core-http';
@@ -171,7 +173,7 @@ export function parseServiceBusConnectionString(connectionString: string): Servi
 
 // @public
 export interface PeekMessagesOptions extends OperationOptionsBase {
-    fromSequenceNumber?: Long;
+    fromSequenceNumber?: Long_2;
 }
 
 // @public
@@ -311,66 +313,66 @@ export class ServiceBusError extends MessagingError {
     constructor(message: string, code: ServiceBusErrorCode);
     constructor(messagingError: MessagingError);
     code: ServiceBusErrorCode;
-    }
+}
 
 // @public
 export type ServiceBusErrorCode =
 /**
- * The exception was the result of a general error within the client library.
- */
+* The exception was the result of a general error within the client library.
+*/
 "GeneralError"
 /**
- * A Service Bus resource cannot be found by the Service Bus service.
- */
- | "MessagingEntityNotFound"
+* A Service Bus resource cannot be found by the Service Bus service.
+*/
+| "MessagingEntityNotFound"
 /**
- * The lock on the message is lost. Callers should attempt to receive and process the message again.
- */
- | "MessageLockLost"
+* The lock on the message is lost. Callers should attempt to receive and process the message again.
+*/
+| "MessageLockLost"
 /**
- * The requested message was not found.
- */
- | "MessageNotFound"
+* The requested message was not found.
+*/
+| "MessageNotFound"
 /**
- * A message is larger than the maximum size allowed for its transport.
- */
- | "MessageSizeExceeded"
+* A message is larger than the maximum size allowed for its transport.
+*/
+| "MessageSizeExceeded"
 /**
- * An entity with the same name exists under the same namespace.
- */
- | "MessagingEntityAlreadyExists"
+* An entity with the same name exists under the same namespace.
+*/
+| "MessagingEntityAlreadyExists"
 /**
- * The Messaging Entity is disabled. Enable the entity again using Portal.
- */
- | "MessagingEntityDisabled"
+* The Messaging Entity is disabled. Enable the entity again using Portal.
+*/
+| "MessagingEntityDisabled"
 /**
- * The quota applied to an Service Bus resource has been exceeded while interacting with the Azure Service Bus service.
- */
- | "QuotaExceeded"
+* The quota applied to an Service Bus resource has been exceeded while interacting with the Azure Service Bus service.
+*/
+| "QuotaExceeded"
 /**
- * The Azure Service Bus service reports that it is busy in response to a client request to perform an operation.
- */
- | "ServiceBusy"
+* The Azure Service Bus service reports that it is busy in response to a client request to perform an operation.
+*/
+| "ServiceBusy"
 /**
- * An operation or other request timed out while interacting with the Azure Service Bus service.
- */
- | "ServiceTimeout"
+* An operation or other request timed out while interacting with the Azure Service Bus service.
+*/
+| "ServiceTimeout"
 /**
- * There was a general communications error encountered when interacting with the Azure Service Bus service.
- */
- | "ServiceCommunicationProblem"
+* There was a general communications error encountered when interacting with the Azure Service Bus service.
+*/
+| "ServiceCommunicationProblem"
 /**
- * The requested session cannot be locked.
- */
- | "SessionCannotBeLocked"
+* The requested session cannot be locked.
+*/
+| "SessionCannotBeLocked"
 /**
- * The lock on the session has expired. Callers should request the session again.
- */
- | "SessionLockLost"
+* The lock on the session has expired. Callers should request the session again.
+*/
+| "SessionLockLost"
 /**
- * The user doesn't have access to the entity.
- */
- | "UnauthorizedAccess";
+* The user doesn't have access to the entity.
+*/
+| "UnauthorizedAccess";
 
 // @public
 export interface ServiceBusMessage {
@@ -415,7 +417,7 @@ export interface ServiceBusReceivedMessage extends ServiceBusMessage {
     lockedUntilUtc?: Date;
     readonly lockToken?: string;
     readonly _rawAmqpMessage: AmqpAnnotatedMessage;
-    readonly sequenceNumber?: Long;
+    readonly sequenceNumber?: Long_2;
 }
 
 // @public
@@ -435,7 +437,7 @@ export interface ServiceBusReceiver {
     getMessageIterator(options?: GetMessageIteratorOptions): AsyncIterableIterator<ServiceBusReceivedMessage>;
     isClosed: boolean;
     peekMessages(maxMessageCount: number, options?: PeekMessagesOptions): Promise<ServiceBusReceivedMessage[]>;
-    receiveDeferredMessages(sequenceNumbers: Long | Long[], options?: OperationOptionsBase): Promise<ServiceBusReceivedMessage[]>;
+    receiveDeferredMessages(sequenceNumbers: Long_2 | Long_2[], options?: OperationOptionsBase): Promise<ServiceBusReceivedMessage[]>;
     receiveMessages(maxMessageCount: number, options?: ReceiveMessagesOptions): Promise<ServiceBusReceivedMessage[]>;
     receiveMode: "peekLock" | "receiveAndDelete";
     renewMessageLock(message: ServiceBusReceivedMessage): Promise<Date>;
@@ -453,12 +455,12 @@ export interface ServiceBusReceiverOptions {
 
 // @public
 export interface ServiceBusSender {
-    cancelScheduledMessages(sequenceNumbers: Long | Long[], options?: OperationOptionsBase): Promise<void>;
+    cancelScheduledMessages(sequenceNumbers: Long_2 | Long_2[], options?: OperationOptionsBase): Promise<void>;
     close(): Promise<void>;
     createMessageBatch(options?: CreateMessageBatchOptions): Promise<ServiceBusMessageBatch>;
     entityPath: string;
     isClosed: boolean;
-    scheduleMessages(messages: ServiceBusMessage | ServiceBusMessage[] | AmqpAnnotatedMessage | AmqpAnnotatedMessage[], scheduledEnqueueTimeUtc: Date, options?: OperationOptionsBase): Promise<Long[]>;
+    scheduleMessages(messages: ServiceBusMessage | ServiceBusMessage[] | AmqpAnnotatedMessage | AmqpAnnotatedMessage[], scheduledEnqueueTimeUtc: Date, options?: OperationOptionsBase): Promise<Long_2[]>;
     sendMessages(messages: ServiceBusMessage | ServiceBusMessage[] | ServiceBusMessageBatch | AmqpAnnotatedMessage | AmqpAnnotatedMessage[], options?: OperationOptionsBase): Promise<void>;
 }
 
@@ -583,7 +585,6 @@ export { WebSocketOptions }
 export type WithResponse<T extends object> = T & {
     _response: HttpResponse;
 };
-
 
 // (No @packageDocumentation comment for this package)
 

--- a/sdk/sql/arm-sql/package.json
+++ b/sdk/sql/arm-sql/package.json
@@ -28,7 +28,7 @@
   "module": "./dist-esm/index.js",
   "types": "./types/arm-sql.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@rollup/plugin-commonjs": "11.0.2",
     "@rollup/plugin-json": "^4.0.0",
     "@rollup/plugin-multi-entry": "^3.0.0",

--- a/sdk/storage/arm-storage/package.json
+++ b/sdk/storage/arm-storage/package.json
@@ -28,7 +28,7 @@
   "module": "./esm/index.js",
   "types": "./esm/index.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@rollup/plugin-commonjs": "11.0.2",
     "@rollup/plugin-json": "^4.0.0",
     "@rollup/plugin-multi-entry": "^3.0.0",

--- a/sdk/storage/arm-storage/review/arm-storage.api.md
+++ b/sdk/storage/arm-storage/review/arm-storage.api.md
@@ -24,7 +24,7 @@ export type AccessTier = "Hot" | "Cool";
 export interface AccountSasParameters {
     iPAddressOrRange?: string;
     keyToSign?: string;
-    permissions: Permissions;
+    permissions: Permissions_2;
     protocols?: HttpProtocol;
     resourceTypes: SignedResourceTypes;
     services: Services;
@@ -621,7 +621,7 @@ export type EncryptionScopeState = string;
 // @public
 export interface EncryptionService {
     enabled?: boolean;
-    keyType?: KeyType;
+    keyType?: KeyType_2;
     readonly lastEnabledTime?: Date;
 }
 
@@ -929,7 +929,8 @@ export interface KeyPolicy {
 export type KeySource = string;
 
 // @public
-export type KeyType = string;
+type KeyType_2 = string;
+export { KeyType_2 as KeyType }
 
 // @public
 export interface KeyVaultProperties {
@@ -1784,7 +1785,8 @@ export interface OperationsListOptionalParams extends coreClient.OperationOption
 export type OperationsListResponse = OperationListResult;
 
 // @public
-export type Permissions = string;
+type Permissions_2 = string;
+export { Permissions_2 as Permissions }
 
 // @public
 export interface PrivateEndpoint {
@@ -2047,7 +2049,7 @@ export interface ServiceSasParameters {
     keyToSign?: string;
     partitionKeyEnd?: string;
     partitionKeyStart?: string;
-    permissions?: Permissions;
+    permissions?: Permissions_2;
     protocols?: HttpProtocol;
     resource?: SignedResource;
     rowKeyEnd?: string;
@@ -2651,7 +2653,6 @@ export interface VirtualNetworkRule {
     state?: State;
     virtualNetworkResourceId: string;
 }
-
 
 // (No @packageDocumentation comment for this package)
 

--- a/sdk/storage/storage-blob-changefeed/package.json
+++ b/sdk/storage/storage-blob-changefeed/package.json
@@ -108,7 +108,7 @@
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
     "@azure/test-utils": "^1.0.0",
     "@azure-tools/test-recorder": "^1.0.0",
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@rollup/plugin-multi-entry": "^3.0.0",
     "@rollup/plugin-replace": "^2.2.0",
     "@types/mocha": "^7.0.2",

--- a/sdk/storage/storage-blob/package.json
+++ b/sdk/storage/storage-blob/package.json
@@ -142,7 +142,7 @@
     "@azure/test-utils": "^1.0.0",
     "@azure-tools/test-recorder": "^1.0.0",
     "@azure/test-utils-perfstress": "^1.0.0",
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@rollup/plugin-multi-entry": "^3.0.0",
     "@rollup/plugin-replace": "^2.2.0",
     "@rollup/plugin-json": "^4.0.0",

--- a/sdk/storage/storage-blob/review/storage-blob.api.md
+++ b/sdk/storage/storage-blob/review/storage-blob.api.md
@@ -4,7 +4,10 @@
 
 ```ts
 
+/// <reference types="node" />
+
 import { AbortSignalLike } from '@azure/abort-controller';
+import { AzureLogger } from '@azure/logger';
 import { BaseRequestPolicy } from '@azure/core-http';
 import * as coreHttp from '@azure/core-http';
 import { deserializationPolicy } from '@azure/core-http';
@@ -110,7 +113,7 @@ export interface AccountSASSignatureValues {
 }
 
 // @public
-export class AnonymousCredential extends Credential {
+export class AnonymousCredential extends Credential_2 {
     create(nextPolicy: RequestPolicy, options: RequestPolicyOptions): AnonymousCredentialPolicy;
 }
 
@@ -863,7 +866,7 @@ export class BlobLeaseClient {
     releaseLease(options?: LeaseOperationOptions): Promise<LeaseOperationResponse>;
     renewLease(options?: LeaseOperationOptions): Promise<Lease>;
     get url(): string;
-    }
+}
 
 // @public (undocumented)
 export interface BlobPrefix {
@@ -1556,7 +1559,7 @@ export interface BlockBlobStageBlockFromURLOptions extends CommonOptions {
     conditions?: LeaseAccessConditions;
     customerProvidedKey?: CpkInfo;
     encryptionScope?: string;
-    range?: Range;
+    range?: Range_2;
     sourceAuthorization?: HttpAuthorization;
     sourceContentCrc64?: Uint8Array;
     sourceContentMD5?: Uint8Array;
@@ -2165,9 +2168,10 @@ export interface CpkInfo {
 }
 
 // @public
-export abstract class Credential implements RequestPolicyFactory {
+abstract class Credential_2 implements RequestPolicyFactory {
     create(_nextPolicy: RequestPolicy, _options: RequestPolicyOptions): RequestPolicy;
 }
+export { Credential_2 as Credential }
 
 // @public
 export abstract class CredentialPolicy extends BaseRequestPolicy {
@@ -2401,7 +2405,7 @@ export interface ListContainersSegmentResponse {
 }
 
 // @public
-export const logger: import("@azure/logger").AzureLogger;
+export const logger: AzureLogger;
 
 // @public
 export interface Logging {
@@ -2780,8 +2784,8 @@ export type PageBlobUploadPagesResponse = PageBlobUploadPagesHeaders & {
 
 // @public
 export interface PageList {
-    clearRange?: Range[];
-    pageRange?: Range[];
+    clearRange?: Range_2[];
+    pageRange?: Range_2[];
 }
 
 // @public
@@ -2834,10 +2838,11 @@ export enum PremiumPageBlobTier {
 export type PublicAccessType = "container" | "blob";
 
 // @public
-export interface Range {
+interface Range_2 {
     count?: number;
     offset: number;
 }
+export { Range_2 as Range }
 
 // @public
 export type RehydratePriority = "High" | "Standard";
@@ -3201,7 +3206,7 @@ export class StorageRetryPolicy extends BaseRequestPolicy {
 export class StorageRetryPolicyFactory implements RequestPolicyFactory {
     constructor(retryOptions?: StorageRetryOptions);
     create(nextPolicy: RequestPolicy, options: RequestPolicyOptions): StorageRetryPolicy;
-    }
+}
 
 // @public
 export enum StorageRetryPolicyType {
@@ -3210,7 +3215,7 @@ export enum StorageRetryPolicyType {
 }
 
 // @public
-export class StorageSharedKeyCredential extends Credential {
+export class StorageSharedKeyCredential extends Credential_2 {
     constructor(accountName: string, accountKey: string);
     readonly accountName: string;
     computeHMACSHA256(stringToSign: string): string;
@@ -3257,7 +3262,6 @@ export interface UserDelegationKeyModel {
 }
 
 export { WebResource }
-
 
 // (No @packageDocumentation comment for this package)
 

--- a/sdk/storage/storage-file-datalake/package.json
+++ b/sdk/storage/storage-file-datalake/package.json
@@ -121,7 +121,7 @@
     "@azure/test-utils": "^1.0.0",
     "@azure-tools/test-recorder": "^1.0.0",
     "@azure/test-utils-perfstress": "^1.0.0",
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@rollup/plugin-commonjs": "11.0.2",
     "@rollup/plugin-json": "^4.0.0",
     "@rollup/plugin-multi-entry": "^3.0.0",

--- a/sdk/storage/storage-file-datalake/review/storage-file-datalake.api.md
+++ b/sdk/storage/storage-file-datalake/review/storage-file-datalake.api.md
@@ -4,7 +4,10 @@
 
 ```ts
 
+/// <reference types="node" />
+
 import { AbortSignalLike } from '@azure/abort-controller';
+import { AzureLogger } from '@azure/logger';
 import { BaseRequestPolicy } from '@azure/core-http';
 import { BlobLeaseClient } from '@azure/storage-blob';
 import { BlobQueryArrowConfiguration } from '@azure/storage-blob';
@@ -126,7 +129,7 @@ export interface AccountSASSignatureValues {
 }
 
 // @public
-export class AnonymousCredential extends Credential {
+export class AnonymousCredential extends Credential_2 {
     create(nextPolicy: RequestPolicy, options: RequestPolicyOptions): AnonymousCredentialPolicy;
 }
 
@@ -252,9 +255,10 @@ export interface CommonOptions {
 export type CopyStatusType = "pending" | "success" | "aborted" | "failed";
 
 // @public
-export abstract class Credential implements RequestPolicyFactory {
+abstract class Credential_2 implements RequestPolicyFactory {
     create(_nextPolicy: RequestPolicy, _options: RequestPolicyOptions): RequestPolicy;
 }
+export { Credential_2 as Credential }
 
 // @public
 export abstract class CredentialPolicy extends BaseRequestPolicy {
@@ -1182,7 +1186,7 @@ export type ListPathsSegmentResponse = FileSystemListPathsHeaders & PathListMode
 };
 
 // @public
-export const logger: import("@azure/logger").AzureLogger;
+export const logger: AzureLogger;
 
 // @public
 export interface Metadata {
@@ -1384,9 +1388,7 @@ type PathFlushDataResponse = PathFlushDataHeaders & {
         parsedHeaders: PathFlushDataHeaders;
     };
 };
-
 export { PathFlushDataResponse as FileFlushResponse }
-
 export { PathFlushDataResponse as FileUploadResponse }
 
 // @public (undocumented)
@@ -1694,9 +1696,7 @@ type PathSetAccessControlResponse = PathSetAccessControlHeaders & {
         parsedHeaders: PathSetAccessControlHeaders;
     };
 };
-
 export { PathSetAccessControlResponse }
-
 export { PathSetAccessControlResponse as PathSetPermissionsResponse }
 
 // @public (undocumented)
@@ -2050,7 +2050,7 @@ export class StorageRetryPolicy extends BaseRequestPolicy {
 export class StorageRetryPolicyFactory implements RequestPolicyFactory {
     constructor(retryOptions?: StorageRetryOptions);
     create(nextPolicy: RequestPolicy, options: RequestPolicyOptions): StorageRetryPolicy;
-    }
+}
 
 // @public
 export enum StorageRetryPolicyType {
@@ -2059,7 +2059,7 @@ export enum StorageRetryPolicyType {
 }
 
 // @public
-export class StorageSharedKeyCredential extends Credential {
+export class StorageSharedKeyCredential extends Credential_2 {
     constructor(accountName: string, accountKey: string);
     readonly accountName: string;
     computeHMACSHA256(stringToSign: string): string;
@@ -2099,7 +2099,6 @@ export interface UserDelegationKey {
 export { UserDelegationKeyModel }
 
 export { WebResource }
-
 
 // (No @packageDocumentation comment for this package)
 

--- a/sdk/storage/storage-file-share/package.json
+++ b/sdk/storage/storage-file-share/package.json
@@ -128,7 +128,7 @@
     "@azure/test-utils": "^1.0.0",
     "@azure-tools/test-recorder": "^1.0.0",
     "@azure/test-utils-perfstress": "^1.0.0",
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@rollup/plugin-commonjs": "11.0.2",
     "@rollup/plugin-multi-entry": "^3.0.0",
     "@rollup/plugin-node-resolve": "^8.0.0",

--- a/sdk/storage/storage-file-share/review/storage-file-share.api.md
+++ b/sdk/storage/storage-file-share/review/storage-file-share.api.md
@@ -4,7 +4,10 @@
 
 ```ts
 
+/// <reference types="node" />
+
 import { AbortSignalLike } from '@azure/abort-controller';
+import { AzureLogger } from '@azure/logger';
 import { BaseRequestPolicy } from '@azure/core-http';
 import * as coreHttp from '@azure/core-http';
 import { deserializationPolicy } from '@azure/core-http';
@@ -80,7 +83,7 @@ export interface AccountSASSignatureValues {
 }
 
 // @public
-export class AnonymousCredential extends Credential {
+export class AnonymousCredential extends Credential_2 {
     create(nextPolicy: RequestPolicy, options: RequestPolicyOptions): AnonymousCredentialPolicy;
 }
 
@@ -150,9 +153,10 @@ export interface CorsRule {
 }
 
 // @public
-export abstract class Credential implements RequestPolicyFactory {
+abstract class Credential_2 implements RequestPolicyFactory {
     create(_nextPolicy: RequestPolicy, _options: RequestPolicyOptions): RequestPolicy;
 }
+export { Credential_2 as Credential }
 
 // @public
 export abstract class CredentialPolicy extends BaseRequestPolicy {
@@ -732,7 +736,7 @@ export interface FileGetRangeListHeaders {
 export interface FileGetRangeListOptions extends CommonOptions {
     abortSignal?: AbortSignalLike;
     leaseAccessConditions?: LeaseAccessConditions;
-    range?: Range;
+    range?: Range_2;
 }
 
 // @public
@@ -1203,7 +1207,7 @@ export interface ListSharesResponseModel {
 }
 
 // @public
-export const logger: import("@azure/logger").AzureLogger;
+export const logger: AzureLogger;
 
 // @public (undocumented)
 export interface Metadata {
@@ -1220,7 +1224,7 @@ export interface Metrics {
 }
 
 // @public
-export function newPipeline(credential?: Credential, pipelineOptions?: StoragePipelineOptions): Pipeline;
+export function newPipeline(credential?: Credential_2, pipelineOptions?: StoragePipelineOptions): Pipeline;
 
 // @public
 export type PermissionCopyModeType = "source" | "override";
@@ -1239,10 +1243,11 @@ export interface PipelineOptions {
 }
 
 // @public
-export interface Range {
+interface Range_2 {
     count?: number;
     offset: number;
 }
+export { Range_2 as Range }
 
 // @public
 export interface RangeModel {
@@ -1388,7 +1393,7 @@ export type ShareAccessTier = "TransactionOptimized" | "Hot" | "Cool";
 // @public
 export class ShareClient extends StorageClient {
     constructor(connectionString: string, name: string, options?: StoragePipelineOptions);
-    constructor(url: string, credential?: Credential, options?: StoragePipelineOptions);
+    constructor(url: string, credential?: Credential_2, options?: StoragePipelineOptions);
     constructor(url: string, pipeline: Pipeline);
     create(options?: ShareCreateOptions): Promise<ShareCreateResponse>;
     createDirectory(directoryName: string, options?: DirectoryCreateOptions): Promise<{
@@ -1533,7 +1538,7 @@ export type ShareDeleteResponse = ShareDeleteHeaders & {
 
 // @public
 export class ShareDirectoryClient extends StorageClient {
-    constructor(url: string, credential?: Credential, options?: StoragePipelineOptions);
+    constructor(url: string, credential?: Credential_2, options?: StoragePipelineOptions);
     constructor(url: string, pipeline: Pipeline);
     create(options?: DirectoryCreateOptions): Promise<DirectoryCreateResponse>;
     createFile(fileName: string, size: number, options?: FileCreateOptions): Promise<{
@@ -1566,7 +1571,7 @@ export class ShareDirectoryClient extends StorageClient {
     setMetadata(metadata?: Metadata, options?: DirectorySetMetadataOptions): Promise<DirectorySetMetadataResponse>;
     setProperties(properties?: DirectoryProperties): Promise<DirectorySetPropertiesResponse>;
     get shareName(): string;
-    }
+}
 
 // @public
 export interface ShareExistsOptions extends CommonOptions {
@@ -1576,7 +1581,7 @@ export interface ShareExistsOptions extends CommonOptions {
 
 // @public
 export class ShareFileClient extends StorageClient {
-    constructor(url: string, credential?: Credential, options?: StoragePipelineOptions);
+    constructor(url: string, credential?: Credential_2, options?: StoragePipelineOptions);
     constructor(url: string, pipeline: Pipeline);
     abortCopyFromURL(copyId: string, options?: FileAbortCopyFromURLOptions): Promise<FileAbortCopyResponse>;
     clearRange(offset: number, contentLength: number, options?: FileClearRangeOptions): Promise<FileUploadRangeResponse>;
@@ -1794,7 +1799,7 @@ export class ShareLeaseClient {
     releaseLease(options?: LeaseOperationOptions): Promise<LeaseOperationResponse>;
     renewLease(options?: LeaseOperationOptions): Promise<LeaseOperationResponse>;
     get url(): string;
-    }
+}
 
 // @public
 export interface SharePermission {
@@ -1868,7 +1873,7 @@ export class ShareSASPermissions {
 
 // @public
 export class ShareServiceClient extends StorageClient {
-    constructor(url: string, credential?: Credential, options?: StoragePipelineOptions);
+    constructor(url: string, credential?: Credential_2, options?: StoragePipelineOptions);
     constructor(url: string, pipeline: Pipeline);
     createShare(shareName: string, options?: ShareCreateOptions): Promise<{
         shareCreateResponse: ShareCreateResponse;
@@ -2046,7 +2051,7 @@ export class StorageRetryPolicy extends BaseRequestPolicy {
 export class StorageRetryPolicyFactory implements RequestPolicyFactory {
     constructor(retryOptions?: StorageRetryOptions);
     create(nextPolicy: RequestPolicy, options: RequestPolicyOptions): StorageRetryPolicy;
-    }
+}
 
 // @public
 export enum StorageRetryPolicyType {
@@ -2055,7 +2060,7 @@ export enum StorageRetryPolicyType {
 }
 
 // @public
-export class StorageSharedKeyCredential extends Credential {
+export class StorageSharedKeyCredential extends Credential_2 {
     constructor(accountName: string, accountKey: string);
     readonly accountName: string;
     computeHMACSHA256(stringToSign: string): string;
@@ -2075,7 +2080,6 @@ export type TimeNowType = "now";
 export type TimePreserveType = "preserve";
 
 export { WebResource }
-
 
 // (No @packageDocumentation comment for this package)
 

--- a/sdk/storage/storage-internal-avro/package.json
+++ b/sdk/storage/storage-internal-avro/package.json
@@ -71,7 +71,7 @@
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
     "@azure/dev-tool": "^1.0.0",
     "@azure-tools/test-recorder": "^1.0.0",
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@rollup/plugin-multi-entry": "^3.0.0",
     "@rollup/plugin-replace": "^2.2.0",
     "@types/mocha": "^7.0.2",

--- a/sdk/storage/storage-internal-avro/review/storage-internal-avro.api.md
+++ b/sdk/storage/storage-internal-avro/review/storage-internal-avro.api.md
@@ -4,6 +4,8 @@
 
 ```ts
 
+/// <reference types="node" />
+
 import { AbortSignalLike } from '@azure/abort-controller';
 
 // @public (undocumented)
@@ -23,7 +25,7 @@ export class AvroReadableFromStream extends AvroReadable {
     get position(): number;
     // (undocumented)
     read(size: number, options?: AvroReadableReadOptions): Promise<Uint8Array>;
-    }
+}
 
 // @public (undocumented)
 export class AvroReader {
@@ -39,8 +41,7 @@ export class AvroReader {
     //
     // (undocumented)
     parseObjects(options?: AvroParseOptions): AsyncIterableIterator<Record<string, any> | null>;
-    }
-
+}
 
 // (No @packageDocumentation comment for this package)
 

--- a/sdk/storage/storage-queue/package.json
+++ b/sdk/storage/storage-queue/package.json
@@ -121,7 +121,7 @@
     "@azure/identity": "2.0.0-beta.6",
     "@azure/test-utils": "^1.0.0",
     "@azure-tools/test-recorder": "^1.0.0",
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@rollup/plugin-commonjs": "11.0.2",
     "@rollup/plugin-multi-entry": "^3.0.0",
     "@rollup/plugin-node-resolve": "^8.0.0",

--- a/sdk/storage/storage-queue/review/storage-queue.api.md
+++ b/sdk/storage/storage-queue/review/storage-queue.api.md
@@ -5,6 +5,7 @@
 ```ts
 
 import { AbortSignalLike } from '@azure/abort-controller';
+import { AzureLogger } from '@azure/logger';
 import { BaseRequestPolicy } from '@azure/core-http';
 import * as coreHttp from '@azure/core-http';
 import { deserializationPolicy } from '@azure/core-http';
@@ -80,7 +81,7 @@ export interface AccountSASSignatureValues {
 }
 
 // @public
-export class AnonymousCredential extends Credential {
+export class AnonymousCredential extends Credential_2 {
     create(nextPolicy: RequestPolicy, options: RequestPolicyOptions): AnonymousCredentialPolicy;
 }
 
@@ -106,9 +107,10 @@ export interface CorsRule {
 }
 
 // @public
-export abstract class Credential implements RequestPolicyFactory {
+abstract class Credential_2 implements RequestPolicyFactory {
     create(_nextPolicy: RequestPolicy, _options: RequestPolicyOptions): RequestPolicy;
 }
+export { Credential_2 as Credential }
 
 // @public
 export abstract class CredentialPolicy extends BaseRequestPolicy {
@@ -184,7 +186,7 @@ export interface ListQueuesSegmentResponse {
 }
 
 // @public
-export const logger: import("@azure/logger").AzureLogger;
+export const logger: AzureLogger;
 
 // @public
 export interface Logging {
@@ -857,7 +859,7 @@ export class StorageRetryPolicy extends BaseRequestPolicy {
 export class StorageRetryPolicyFactory implements RequestPolicyFactory {
     constructor(retryOptions?: StorageRetryOptions);
     create(nextPolicy: RequestPolicy, options: RequestPolicyOptions): StorageRetryPolicy;
-    }
+}
 
 // @public
 export enum StorageRetryPolicyType {
@@ -866,7 +868,7 @@ export enum StorageRetryPolicyType {
 }
 
 // @public
-export class StorageSharedKeyCredential extends Credential {
+export class StorageSharedKeyCredential extends Credential_2 {
     constructor(accountName: string, accountKey: string);
     readonly accountName: string;
     computeHMACSHA256(stringToSign: string): string;
@@ -880,7 +882,6 @@ export class StorageSharedKeyCredentialPolicy extends CredentialPolicy {
 }
 
 export { WebResource }
-
 
 // (No @packageDocumentation comment for this package)
 

--- a/sdk/synapse/synapse-access-control/package.json
+++ b/sdk/synapse/synapse-access-control/package.json
@@ -47,7 +47,7 @@
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
     "@azure/identity": "2.0.0-beta.6",
     "@azure-tools/test-recorder": "^1.0.0",
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@types/chai": "^4.1.6",
     "@types/mocha": "^7.0.2",
     "chai": "^4.2.0",

--- a/sdk/synapse/synapse-artifacts/package.json
+++ b/sdk/synapse/synapse-artifacts/package.json
@@ -38,7 +38,7 @@
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
     "@azure/identity": "2.0.0-beta.6",
     "@azure-tools/test-recorder": "^1.0.0",
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@types/chai": "^4.1.6",
     "@types/mocha": "^7.0.2",
     "chai": "^4.2.0",

--- a/sdk/synapse/synapse-managed-private-endpoints/package.json
+++ b/sdk/synapse/synapse-managed-private-endpoints/package.json
@@ -53,7 +53,7 @@
     "rimraf": "^3.0.0",
     "rollup": "^1.16.3",
     "uglify-js": "^3.4.9",
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "typedoc": "0.15.2",
     "@types/chai": "^4.1.6",
     "@types/mocha": "^7.0.2",

--- a/sdk/synapse/synapse-monitoring/package.json
+++ b/sdk/synapse/synapse-monitoring/package.json
@@ -37,7 +37,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "@rollup/plugin-commonjs": "11.0.2",
     "uglify-js": "^3.4.9",
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "typedoc": "0.15.2"
   },
   "bugs": {

--- a/sdk/synapse/synapse-spark/package.json
+++ b/sdk/synapse/synapse-spark/package.json
@@ -35,7 +35,7 @@
     "rimraf": "^3.0.0",
     "rollup": "^1.16.3",
     "uglify-js": "^3.4.9",
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "typedoc": "0.15.2",
     "@azure-tools/test-recorder": "^1.0.0",
     "@azure/identity": "2.0.0-beta.6",

--- a/sdk/tables/data-tables/package.json
+++ b/sdk/tables/data-tables/package.json
@@ -89,7 +89,7 @@
   "devDependencies": {
     "@azure/identity": "2.0.0-beta.6",
     "@azure/dev-tool": "^1.0.0",
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@rollup/plugin-commonjs": "11.0.2",
     "@rollup/plugin-json": "^4.0.0",
     "@rollup/plugin-multi-entry": "^3.0.0",

--- a/sdk/template/template/package.json
+++ b/sdk/template/template/package.json
@@ -89,7 +89,7 @@
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
     "@azure/identity": "2.0.0-beta.5",
     "@azure-tools/test-recorder": "^1.0.0",
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@types/chai": "^4.1.6",
     "@types/chai-as-promised": "^7.1.0",
     "@types/mocha": "^7.0.2",

--- a/sdk/templatespecs/arm-templatespecs/package.json
+++ b/sdk/templatespecs/arm-templatespecs/package.json
@@ -18,7 +18,7 @@
   "module": "./dist-esm/index.js",
   "types": "./types/arm-templatespecs.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@rollup/plugin-commonjs": "11.0.2",
     "@rollup/plugin-json": "^4.0.0",
     "@rollup/plugin-multi-entry": "^3.0.0",

--- a/sdk/test-utils/test-utils/package.json
+++ b/sdk/test-utils/test-utils/package.json
@@ -63,7 +63,7 @@
   "devDependencies": {
     "@azure/dev-tool": "^1.0.0",
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@opentelemetry/api": "^1.0.1",
     "@types/chai": "^4.1.6",
     "@types/mocha": "^7.0.2",

--- a/sdk/textanalytics/ai-text-analytics/package.json
+++ b/sdk/textanalytics/ai-text-analytics/package.json
@@ -104,7 +104,7 @@
     "@azure/identity": "2.0.0-beta.6",
     "@azure/test-utils": "^1.0.0",
     "@azure-tools/test-recorder": "^1.0.0",
-    "@microsoft/api-extractor": "^7.18.7",
+    "@microsoft/api-extractor": "^7.18.11",
     "@types/chai": "^4.1.6",
     "@types/chai-as-promised": "^7.1.0",
     "@types/mocha": "^7.0.2",

--- a/sdk/videoanalyzer/video-analyzer-edge/package.json
+++ b/sdk/videoanalyzer/video-analyzer-edge/package.json
@@ -68,7 +68,7 @@
   "devDependencies": {
     "@azure/dev-tool": "^1.0.0",
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@types/chai": "^4.1.6",
     "@types/chai-as-promised": "^7.1.0",
     "@types/mocha": "^7.0.2",

--- a/sdk/videoanalyzer/video-analyzer-edge/review/video-analyzer-edge.api.md
+++ b/sdk/videoanalyzer/video-analyzer-edge/review/video-analyzer-edge.api.md
@@ -24,34 +24,34 @@ export type CognitiveServicesVisionProcessor = ProcessorNodeBase & {
 };
 
 // @public
-export function createRequest(request: "pipelineTopologySet", payload: PipelineTopology): Request<PipelineTopology>;
+export function createRequest(request: "pipelineTopologySet", payload: PipelineTopology): Request_2<PipelineTopology>;
 
 // @public
-export function createRequest(request: "pipelineTopologyGet", payload: string): Request<NameObject>;
+export function createRequest(request: "pipelineTopologyGet", payload: string): Request_2<NameObject>;
 
 // @public
-export function createRequest(request: "pipelineTopologyList"): Request;
+export function createRequest(request: "pipelineTopologyList"): Request_2;
 
 // @public
-export function createRequest(request: "pipelineTopologyDelete", payload: string): Request<NameObject>;
+export function createRequest(request: "pipelineTopologyDelete", payload: string): Request_2<NameObject>;
 
 // @public
-export function createRequest(request: "livePipelineSet", payload: LivePipeline): Request<LivePipeline>;
+export function createRequest(request: "livePipelineSet", payload: LivePipeline): Request_2<LivePipeline>;
 
 // @public
-export function createRequest(request: "livePipelineGet", payload: string): Request<NameObject>;
+export function createRequest(request: "livePipelineGet", payload: string): Request_2<NameObject>;
 
 // @public
-export function createRequest(request: "livePipelineList"): Request;
+export function createRequest(request: "livePipelineList"): Request_2;
 
 // @public
-export function createRequest(request: "livePipelineDelete", payload: string): Request<NameObject>;
+export function createRequest(request: "livePipelineDelete", payload: string): Request_2<NameObject>;
 
 // @public
-export function createRequest(request: "livePipelineActivate", payload: string): Request<NameObject>;
+export function createRequest(request: "livePipelineActivate", payload: string): Request_2<NameObject>;
 
 // @public
-export function createRequest(request: "livePipelineDeactivate", payload: string): Request<NameObject>;
+export function createRequest(request: "livePipelineDeactivate", payload: string): Request_2<NameObject>;
 
 // @public
 export interface CredentialsBase {
@@ -451,12 +451,13 @@ export interface ProcessorNodeBase {
 export type ProcessorNodeBaseUnion = ProcessorNodeBase | MotionDetectionProcessor | ObjectTrackingProcessor | LineCrossingProcessor | ExtensionProcessorBaseUnion | SignalGateProcessor | CognitiveServicesVisionProcessor;
 
 // @public
-export interface Request<T = Record<string, unknown>> {
+interface Request_2<T = Record<string, unknown>> {
     methodName: string;
     payload: T & {
         "@apiVersion": string;
     };
 }
+export { Request_2 as Request }
 
 // @public
 export type RequestType = "pipelineTopologySet" | "pipelineTopologyGet" | "pipelineTopologyList" | "pipelineTopologyDelete" | "livePipelineSet" | "livePipelineGet" | "livePipelineList" | "livePipelineDelete" | "livePipelineActivate" | "livePipelineDeactivate";
@@ -665,7 +666,6 @@ export type VideoSink = SinkNodeBase & {
     localMediaCachePath: string;
     localMediaCacheMaximumSizeMiB: string;
 };
-
 
 // (No @packageDocumentation comment for this package)
 

--- a/sdk/web-pubsub/arm-webpubsub/package.json
+++ b/sdk/web-pubsub/arm-webpubsub/package.json
@@ -28,7 +28,7 @@
   "module": "./esm/index.js",
   "types": "./esm/index.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@rollup/plugin-commonjs": "11.0.2",
     "@rollup/plugin-json": "^4.0.0",
     "@rollup/plugin-multi-entry": "^3.0.0",

--- a/sdk/web-pubsub/arm-webpubsub/review/arm-webpubsub.api.md
+++ b/sdk/web-pubsub/arm-webpubsub/review/arm-webpubsub.api.md
@@ -67,7 +67,8 @@ export interface EventHandlerTemplate {
 }
 
 // @public
-export type KeyType = string;
+type KeyType_2 = string;
+export { KeyType_2 as KeyType }
 
 // @public
 export enum KnownACLAction {
@@ -345,7 +346,7 @@ export type ProxyResource = Resource & {};
 
 // @public
 export interface RegenerateKeyParameters {
-    keyType?: KeyType;
+    keyType?: KeyType_2;
 }
 
 // @public
@@ -778,7 +779,6 @@ export interface WebPubSubUpdateOptionalParams extends coreClient.OperationOptio
 
 // @public
 export type WebPubSubUpdateResponse = WebPubSubResource;
-
 
 // (No @packageDocumentation comment for this package)
 

--- a/sdk/web-pubsub/web-pubsub-express/package.json
+++ b/sdk/web-pubsub/web-pubsub-express/package.json
@@ -63,7 +63,7 @@
     "@azure/dev-tool": "^1.0.0",
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
     "@azure-tools/test-recorder": "^1.0.0",
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@rollup/plugin-commonjs": "11.0.2",
     "@rollup/plugin-json": "^4.0.0",
     "@rollup/plugin-multi-entry": "^3.0.0",

--- a/sdk/web-pubsub/web-pubsub/package.json
+++ b/sdk/web-pubsub/web-pubsub/package.json
@@ -84,7 +84,7 @@
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
     "@azure/identity": "^1.1.0",
     "@azure-tools/test-recorder": "^1.0.0",
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@rollup/plugin-commonjs": "11.0.2",
     "@rollup/plugin-json": "^4.0.0",
     "@rollup/plugin-multi-entry": "^3.0.0",


### PR DESCRIPTION
## What

- Update API Extractor to the latest version (currently 7.18.11)
- Regenerate all API reviews by building all the packages

## Why

This is something we keep bumping into. First, we needed to upgrade API Extractor to allow us to re-export directly from
`@opentelemetry/api`. Then, it looks like we needed this to upgrade TypeScript to 4.4. 

We are way behind on this version, and it's time to upgrade.

## Callouts

How noisy is this?! Here's what's happening - somewhere around 7.9 I think API Extractor improved the way it detects name
collisions with predefined globals. Things like KeyType, Response, etc. 

If there's a clash, the generated API markdown file will rename <Item> to <Item_2> to make the name collision explicit.

Talking to folks on the team, and the poor souls that will be doing API Review approvals, we agreed that doing the upgrade
in one fell swoop is the way to go. 

Resolves #9410 