### PR TITLE
[Schema Registry Avro] make schema group optional

### DIFF
--- a/sdk/schemaregistry/schema-registry-avro/CHANGELOG.md
+++ b/sdk/schemaregistry/schema-registry-avro/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Breaking Changes
 
-- `schemaGroup` is no longer a constructor parameter and has been moved to the constructor options.
+- `schemaGroup` is no longer a constructor parameter and has been moved to the constructor options because it is only required for serialization.
 
 ### Bugs Fixed
 

--- a/sdk/schemaregistry/schema-registry-avro/CHANGELOG.md
+++ b/sdk/schemaregistry/schema-registry-avro/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Breaking Changes
 
+- `schemaGroup` is no longer a constructor parameter and has been moved to the constructor options.
+
 ### Bugs Fixed
 
 ### Other Changes

--- a/sdk/schemaregistry/schema-registry-avro/README.md
+++ b/sdk/schemaregistry/schema-registry-avro/README.md
@@ -71,7 +71,7 @@ const { SchemaRegistryClient } = require("@azure/schema-registry");
 const { SchemaRegistryAvroSerializer } = require("@azure/schema-registry-avro");
 
 const client = new SchemaRegistryClient("<endpoint>", new DefaultAzureCredential());
-const serializer = new SchemaRegistryAvroSerializer(client, "<group>");
+const serializer = new SchemaRegistryAvroSerializer(client, { groupName: "<group>" });
 
 // Example Avro schema
 const schema = JSON.stringify({

--- a/sdk/schemaregistry/schema-registry-avro/review/schema-registry-avro.api.md
+++ b/sdk/schemaregistry/schema-registry-avro/review/schema-registry-avro.api.md
@@ -10,7 +10,7 @@ import { SchemaRegistry } from '@azure/schema-registry';
 
 // @public
 export class SchemaRegistryAvroSerializer {
-    constructor(client: SchemaRegistry, groupName: string, options?: SchemaRegistryAvroSerializerOptions);
+    constructor(client: SchemaRegistry, options?: SchemaRegistryAvroSerializerOptions);
     deserialize(input: Buffer | Blob | Uint8Array): Promise<unknown>;
     serialize(value: unknown, schema: string): Promise<Uint8Array>;
 }
@@ -18,6 +18,7 @@ export class SchemaRegistryAvroSerializer {
 // @public
 export interface SchemaRegistryAvroSerializerOptions {
     autoRegisterSchemas?: boolean;
+    groupName?: string;
 }
 
 // (No @packageDocumentation comment for this package)

--- a/sdk/schemaregistry/schema-registry-avro/samples-dev/schemaRegistryAvroSample.ts
+++ b/sdk/schemaregistry/schema-registry-avro/samples-dev/schemaRegistryAvroSample.ts
@@ -60,7 +60,7 @@ export async function main() {
   await client.registerSchema(schemaDescription);
 
   // Create a new serializer backed by the client
-  const serializer = new SchemaRegistryAvroSerializer(client, groupName);
+  const serializer = new SchemaRegistryAvroSerializer(client, { groupName });
 
   // serialize an object that matches the schema
   const value: User = { firstName: "Jane", lastName: "Doe" };

--- a/sdk/schemaregistry/schema-registry-avro/src/schemaRegistryAvroSerializer.ts
+++ b/sdk/schemaregistry/schema-registry-avro/src/schemaRegistryAvroSerializer.ts
@@ -190,7 +190,7 @@ export class SchemaRegistryAvroSerializer {
 
     if (!this.schemaGroup) {
       throw new Error(
-        "Schema group must have been specified in the constructor options when the client was created."
+        "Schema group must have been specified in the constructor options when the client was created in order to serialize."
       );
     }
 

--- a/sdk/schemaregistry/schema-registry-avro/test/utils/mockedSerializer.ts
+++ b/sdk/schemaregistry/schema-registry-avro/test/utils/mockedSerializer.ts
@@ -13,7 +13,7 @@ export async function createTestSerializer(
   if (!autoRegisterSchemas) {
     await registerTestSchema(registry);
   }
-  return new SchemaRegistryAvroSerializer(registry, testGroup, { autoRegisterSchemas });
+  return new SchemaRegistryAvroSerializer(registry, { autoRegisterSchemas, groupName: testGroup });
 }
 
 export async function registerTestSchema(registry: SchemaRegistry): Promise<string> {


### PR DESCRIPTION
Related issue: https://github.com/Azure/azure-sdk-for-js/issues/17697

Makes schema group optional since it is only needed to call `serialize` but not needed for `deserialize`.