### PR TITLE
Fix constant optional property

### DIFF
--- a/sdk/core/core-client/src/operationHelpers.ts
+++ b/sdk/core/core-client/src/operationHelpers.ts
@@ -32,7 +32,7 @@ export function getOperationArgumentValueFromParameter(
   }
   if (Array.isArray(parameterPath)) {
     if (parameterPath.length > 0) {
-      if (parameterMapper.isConstant) {
+      if (parameterMapper.isConstant && parameterMapper.required) {
         value = parameterMapper.defaultValue;
       } else {
         let propertySearchResult = getPropertyFromParameterPath(operationArguments, parameterPath);

--- a/sdk/core/core-client/src/serializer.ts
+++ b/sdk/core/core-client/src/serializer.ts
@@ -125,7 +125,7 @@ class SerializerImpl implements Serializer {
       payload = [];
     }
 
-    if (mapper.isConstant) {
+    if (mapper.isConstant && mapper.required) {
       object = mapper.defaultValue;
     }
 
@@ -312,7 +312,7 @@ class SerializerImpl implements Serializer {
       }
     }
 
-    if (mapper.isConstant) {
+    if (mapper.isConstant && mapper.required) {
       payload = mapper.defaultValue;
     }
 

--- a/sdk/core/core-client/src/serializer.ts
+++ b/sdk/core/core-client/src/serializer.ts
@@ -312,7 +312,7 @@ class SerializerImpl implements Serializer {
       }
     }
 
-    if (mapper.isConstant && mapper.required) {
+    if (mapper.isConstant && !payload && mapper.defaultValue) {
       payload = mapper.defaultValue;
     }
 

--- a/sdk/core/core-client/test/serializationPolicy.spec.ts
+++ b/sdk/core/core-client/test/serializationPolicy.spec.ts
@@ -874,6 +874,169 @@ describe("serializationPolicy", function() {
       assert.strictEqual(httpRequest.body, "body value");
     });
 
+    it("serialize the optional constant value correctly", () => {
+      const httpRequest = createPipelineRequest({ url: "https://example.com" });
+      serializeRequestBody(
+        httpRequest,
+        {
+          flattenParameterGroup: {
+            productId: "123",
+            description: "product description",
+            maxProductDisplayName: "max name",
+            capacity: "Large",
+            odataValue: "http://foo",
+            name: "groupproduct"
+          },
+          options: undefined
+        },
+        {
+          httpMethod: "PUT",
+          mediaType: "json",
+          responses: {
+            200: {
+              bodyMapper: {
+                type: {
+                  name: "Composite",
+                  className: "SimpleProduct",
+                  modelProperties: {
+                    productId: {
+                      serializedName: "base_product_id",
+                      required: true,
+                      type: {
+                        name: "String"
+                      }
+                    },
+                    description: {
+                      serializedName: "base_product_description",
+                      type: {
+                        name: "String"
+                      }
+                    },
+                    maxProductDisplayName: {
+                      serializedName: "details.max_product_display_name",
+                      type: {
+                        name: "String"
+                      }
+                    },
+                    capacity: {
+                      isConstant: true,
+                      serializedName: "details.max_product_capacity",
+                      type: {
+                        name: "String"
+                      }
+                    },
+                    genericValue: {
+                      serializedName: "details.max_product_image.generic_value",
+                      type: {
+                        name: "String"
+                      }
+                    },
+                    odataValue: {
+                      serializedName: "details.max_product_image.@odata\\.value",
+                      type: {
+                        name: "String"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            default: {
+              bodyMapper: {
+                type: {
+                  name: "Composite",
+                  className: "ErrorModel",
+                  modelProperties: {
+                    status: {
+                      serializedName: "status",
+                      type: {
+                        name: "Number"
+                      }
+                    },
+                    message: {
+                      serializedName: "message",
+                      type: {
+                        name: "String"
+                      }
+                    },
+                    parentError: {
+                      serializedName: "parentError",
+                      type: {
+                        name: "Composite",
+                        className: "ErrorModel"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          requestBody: {
+            parameterPath: {
+              productId: ["flattenParameterGroup", "productId"],
+              description: ["flattenParameterGroup", "description"],
+              maxProductDisplayName: ["flattenParameterGroup", "maxProductDisplayName"],
+              capacity: ["flattenParameterGroup", "capacity"],
+              genericValue: ["flattenParameterGroup", "genericValue"],
+              odataValue: ["flattenParameterGroup", "odataValue"]
+            },
+            mapper: {
+              required: true,
+              type: {
+                name: "Composite",
+                className: "SimpleProduct",
+                modelProperties: {
+                  productId: {
+                    serializedName: "base_product_id",
+                    required: true,
+                    type: {
+                      name: "String"
+                    }
+                  },
+                  description: {
+                    serializedName: "base_product_description",
+                    type: {
+                      name: "String"
+                    }
+                  },
+                  maxProductDisplayName: {
+                    serializedName: "details.max_product_display_name",
+                    type: {
+                      name: "String"
+                    }
+                  },
+                  capacity: {
+                    isConstant: true,
+                    serializedName: "details.max_product_capacity",
+                    type: {
+                      name: "String"
+                    }
+                  },
+                  genericValue: {
+                    serializedName: "details.max_product_image.generic_value",
+                    type: {
+                      name: "String"
+                    }
+                  },
+                  odataValue: {
+                    serializedName: "details.max_product_image.@odata\\.value",
+                    type: {
+                      name: "String"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          serializer: createSerializer()
+        }
+      );
+      assert.strictEqual(
+        httpRequest.body,
+        `{"base_product_id":"123","base_product_description":"product description","details":{"max_product_display_name":"max name","max_product_capacity":"Large","max_product_image":{"@odata.value":"http://foo"}}}`
+      );
+    });
+
     it("should serialize a string send with the mediaType 'text' as just a string", () => {
       const httpRequest = createPipelineRequest({ url: "https://example.com" });
       serializeRequestBody(

--- a/sdk/core/core-client/test/serializationPolicy.spec.ts
+++ b/sdk/core/core-client/test/serializationPolicy.spec.ts
@@ -87,6 +87,7 @@ describe("serializationPolicy", function() {
               isConstant: true,
               serializedName: "nullBody",
               nullable: true,
+              required: true,
               type: {
                 name: "String"
               }

--- a/sdk/core/core-client/test/serializer.spec.ts
+++ b/sdk/core/core-client/test/serializer.spec.ts
@@ -1117,6 +1117,81 @@ describe("Serializer", function() {
       );
     });
 
+    it("should correctly deserialize the constant optional parameter", function() {
+      const mapper: Mapper = {
+        type: {
+          name: "Composite",
+          className: "SimpleProduct",
+          modelProperties: {
+            capacity: {
+              isConstant: true,
+              serializedName: "details.max_product_capacity",
+              type: {
+                name: "String"
+              }
+            },
+            description: {
+              serializedName: "base_product_description",
+              type: {
+                name: "String"
+              }
+            },
+            genericValue: {
+              serializedName: "details.max_product_image.generic_value",
+              type: {
+                name: "String"
+              }
+            },
+            maxProductDisplayName: {
+              serializedName: "details.max_product_display_name",
+              type: {
+                name: "String"
+              }
+            },
+            odataValue: {
+              serializedName: "details.max_product_image.@odata\\.value",
+              type: {
+                name: "String"
+              }
+            },
+            productId: {
+              required: true,
+              serializedName: "base_product_id",
+              type: {
+                name: "String"
+              }
+            }
+          }
+        }
+      };
+      const responseBody = {
+        base_product_description: "product description",
+        base_product_id: "123",
+        details: {
+          max_product_capacity: "Large",
+          max_product_display_name: "max name",
+          max_product_image: {
+            "@odata.value": "http://foo",
+            generic_value: "https://generic"
+          }
+        }
+      };
+
+      const parsedResponse = Serializer.deserialize(
+        mapper,
+        responseBody,
+        "operationRes.parsedBody"
+      );
+      assert.deepEqual(parsedResponse, {
+        capacity: "Large",
+        description: "product description",
+        genericValue: "https://generic",
+        maxProductDisplayName: "max name",
+        odataValue: "http://foo",
+        productId: "123"
+      });
+    });
+
     it("should correctly deserialize an array of array of object types", function() {
       const mapper: Mapper = {
         serializedName: "arrayObj",

--- a/sdk/core/core-client/test/serializer.spec.ts
+++ b/sdk/core/core-client/test/serializer.spec.ts
@@ -42,7 +42,8 @@ describe("Serializer", function() {
         {
           id: 1,
           name: "testProduct",
-          maxProductDisplayName: "MaxDisplayName"
+          maxProductDisplayName: "MaxDisplayName",
+          capacity: "Large"
         },
         "SimpleProduct"
       );
@@ -65,7 +66,8 @@ describe("Serializer", function() {
         {
           id: 1,
           name: "testProduct",
-          maxProductDisplayName: "MaxDisplayName"
+          maxProductDisplayName: "MaxDisplayName",
+          capacity: "Large"
         },
         "SimpleProduct"
       );

--- a/sdk/core/core-client/test/serviceClient.spec.ts
+++ b/sdk/core/core-client/test/serviceClient.spec.ts
@@ -727,6 +727,7 @@ describe("ServiceClient", function() {
       const parameterMapper: Mapper = {
         serializedName: "my-parameter",
         isConstant: true,
+        required: true,
         defaultValue: 1,
         type: {
           name: MapperTypeNames.Number
@@ -754,6 +755,7 @@ describe("ServiceClient", function() {
         serializedName: "my-parameter",
         isConstant: true,
         defaultValue: 4,
+        required: true,
         type: {
           name: MapperTypeNames.Number
         }

--- a/sdk/core/core-client/test/testMappers.ts
+++ b/sdk/core/core-client/test/testMappers.ts
@@ -292,7 +292,6 @@ internalMappers.SimpleProduct = {
         }
       },
       capacity: {
-        defaultValue: "Large",
         isConstant: true,
         serializedName: "details.max_product_capacity",
         type: {
@@ -324,7 +323,6 @@ internalMappers.SimpleProductConstFirst = {
         }
       },
       capacity: {
-        defaultValue: "Large",
         isConstant: true,
         serializedName: "details.max_product_capacity",
         type: {

--- a/sdk/core/core-client/test/urlHelpers.spec.ts
+++ b/sdk/core/core-client/test/urlHelpers.spec.ts
@@ -95,6 +95,7 @@ describe("getRequestUrl", function() {
       mapper: {
         defaultValue: "",
         isConstant: true,
+        required: true,
         serializedName: "stringQuery",
         type: {
           name: "String"

--- a/sdk/core/core-http/src/serializer.ts
+++ b/sdk/core/core-http/src/serializer.ts
@@ -293,7 +293,7 @@ export class Serializer {
       }
     }
 
-    if (mapper.isConstant && mapper.required) {
+    if (mapper.isConstant && !payload && mapper.defaultValue) {
       payload = mapper.defaultValue;
     }
 

--- a/sdk/core/core-http/src/serializer.ts
+++ b/sdk/core/core-http/src/serializer.ts
@@ -108,7 +108,7 @@ export class Serializer {
       payload = [];
     }
 
-    if (mapper.isConstant) {
+    if (mapper.isConstant && mapper.required) {
       object = mapper.defaultValue;
     }
 
@@ -293,7 +293,7 @@ export class Serializer {
       }
     }
 
-    if (mapper.isConstant) {
+    if (mapper.isConstant && mapper.required) {
       payload = mapper.defaultValue;
     }
 

--- a/sdk/core/core-http/src/serviceClient.ts
+++ b/sdk/core/core-http/src/serviceClient.ts
@@ -887,7 +887,7 @@ export function getOperationArgumentValueFromParameterPath(
   const serializerOptions = operationArguments.options?.serializerOptions;
   if (Array.isArray(parameterPath)) {
     if (parameterPath.length > 0) {
-      if (parameterMapper.isConstant) {
+      if (parameterMapper.isConstant && parameterMapper.required) {
         value = parameterMapper.defaultValue;
       } else {
         let propertySearchResult: PropertySearchResult = getPropertyFromParameterPath(

--- a/sdk/core/core-http/test/serializationTests.ts
+++ b/sdk/core/core-http/test/serializationTests.ts
@@ -38,7 +38,8 @@ describe("msrest", function() {
         {
           id: 1,
           name: "testProduct",
-          maxProductDisplayName: "MaxDisplayName"
+          maxProductDisplayName: "MaxDisplayName",
+          capacity: "Large"
         },
         "SimpleProduct"
       );
@@ -62,7 +63,8 @@ describe("msrest", function() {
         {
           id: 1,
           name: "testProduct",
-          maxProductDisplayName: "MaxDisplayName"
+          maxProductDisplayName: "MaxDisplayName",
+          capacity: "Large"
         },
         "SimpleProduct"
       );

--- a/sdk/core/core-http/test/serviceClientTests.ts
+++ b/sdk/core/core-http/test/serviceClientTests.ts
@@ -1690,6 +1690,7 @@ describe("ServiceClient", function() {
       const parameterMapper: Mapper = {
         serializedName: "my-parameter",
         isConstant: true,
+        required: true,
         defaultValue: 1,
         type: {
           name: MapperType.Number
@@ -1717,6 +1718,7 @@ describe("ServiceClient", function() {
       const parameterPath: ParameterPath = "myParameter";
       const parameterMapper: Mapper = {
         serializedName: "my-parameter",
+        required: true,
         isConstant: true,
         defaultValue: 4,
         type: {


### PR DESCRIPTION
During the recent work in the SDK generator, I have come across a scenario, where there is a `constant` property which is also an optional property.  

For example, look at the following:

```
........
capacity: {
        defaultValue: "Large"
        isConstant: true,
        serializedName: "details.max_product_capacity",
        type: {
          name: "String"
        }
}
```

There is a problem with the above definition. Because, `capacity` is optional, even if the user does not provide any value to it (even though `Large` is the only accepted value), it is always sent in the request body and it is not correctly deserialized also. 

This PR fixes the issue. The SDK generator will also be fixed (by Jonathan) to ensure the `defaultValue` will be included only if there is a `required` property and it is set to true. The PR has test cases for serialize and deserialize options also.

@xirzec @jeremymeng Please review and approve the PR.

@ramya-rao-a FYI.....