### PR TITLE
[App Config] update sync-token docs url from 404 to a valid url

### DIFF
--- a/sdk/appconfiguration/app-configuration/src/internal/synctokenpolicy.ts
+++ b/sdk/appconfiguration/app-configuration/src/internal/synctokenpolicy.ts
@@ -12,7 +12,7 @@ import {
 
 /**
  * The sync token header, as described here:
- * https://github.com/Azure/AppConfiguration/blob/master/docs/REST/consistency.md
+ * https://docs.microsoft.com/azure/azure-app-configuration/rest-api-consistency
  * @internal
  */
 export const SyncTokenHeaderName = "sync-token";
@@ -57,7 +57,7 @@ class SyncTokenPolicy extends BaseRequestPolicy {
  * caching and load balancing within App Configuration).
  *
  * (protocol and format described here)
- * https://github.com/Azure/AppConfiguration/blob/master/docs/REST/consistency.md
+ * https://docs.microsoft.com/azure/azure-app-configuration/rest-api-consistency
  *
  * @internal
  */


### PR DESCRIPTION
The docs have been moved
- from `https://github.com/Azure/AppConfiguration/blob/master/docs/REST/consistency.md`
- to `https://docs.microsoft.com/azure/azure-app-configuration/rest-api-consistency`

(Found by tracking the history in app-config repo.)

Fixes #16120