### PR TITLE
update the error handling for Logs Query and Logs Query Batch

### DIFF
--- a/sdk/monitor/monitor-query/CHANGELOG.md
+++ b/sdk/monitor/monitor-query/CHANGELOG.md
@@ -1,14 +1,34 @@
 # Release History
 
-## 1.0.0-beta.6 (Unreleased)
+## 1.0.0-beta.6 (2021-10-05)
 
 ### Features Added
 
+- Added `audience` property in `MetricsClientOptions`
+- Enabled browser support
+- Added different result objects `LogsQueryPartialResult`, `LogsQuerySuccessfulResult` or `LogsQueryError` based on the success scenarios for log queries.
+
 ### Breaking Changes
+
+- Renamed `ErrorInfo` to `LogsErrorInfo`, which now extends the `Error` class and `code` as an additional property. Removed all the other properties.
+- `query` method in `LogsQueryClient` renamed to `queryWorkspace`
+- `query` method in `MetricsQueryClient` renamed to `queryResource`
+- Renamed `credentialOptions.credentialScopes` property in `LogsQueryClientOptions` to `audience`
+- Renamed the status types in `LogsQueryResultStatus`. `Partial` to `PartialFailure` and `Failed` to `Failure`.
+- Renamed `timeGrain` in `MetricAvailability` to `granularity`
+- Renamed `TimeInterval` to `QueryTimeInterval`
+- Updated constants in `Durations` to camel-case.
+- Removed `throwOnAnyError` flag from `LogsQueryOptions` and `LogsQueryBatchOptions`
+- Removed the error classes `BatchError` and `AggregateBatchError`
+- Updated `LogsQueryBatchResult` object to be a list of objects with the following possible types:
+  - `LogsQueryPartialResult`
+  - `LogsQuerySuccessfulResult`
+  - `LogsQueryError`
+- Updated `LogsQueryResult` object to be of type `LogsQuerySuccessfulResult` or `LogsQueryPartialResult`
 
 ### Bugs Fixed
 
-### Other Changes
+- Updated `listMetricNamespaces` signature to return the list of appropriate `MetricsNamespaces` object type
 
 ## 1.0.0-beta.5 (2021-09-09)
 

--- a/sdk/monitor/monitor-query/README.md
+++ b/sdk/monitor/monitor-query/README.md
@@ -296,7 +296,6 @@ LogsQuerySuccessfulResult
         |---name
         |---type
 
-
 LogsQueryPartialResult
 |---statistics
 |---visualization

--- a/sdk/monitor/monitor-query/README.md
+++ b/sdk/monitor/monitor-query/README.md
@@ -140,7 +140,7 @@ run().catch((err) => console.log("ERROR:", err));
 
 #### Handle logs query response
 
-The `queryWorkspace` function of `LogsQueryClient` returns the `LogsQueryResult`. The `LogsQueryResult` can either be of type `LogsQuerySuccessfulResult` or `LogsQueryPartialResult`. Here's a hierarchy of the response:
+The `queryWorkspace` function of `LogsQueryClient` returns a `LogsQueryResult` object. The object type can be `LogsQuerySuccessfulResult` or `LogsQueryPartialResult`. Here's a hierarchy of the response:
 
 ```
 LogsQueryResult -- (LogsQuerySuccessfulResult | LogsQueryPartialResult)

--- a/sdk/monitor/monitor-query/README.md
+++ b/sdk/monitor/monitor-query/README.md
@@ -143,8 +143,6 @@ run().catch((err) => console.log("ERROR:", err));
 The `queryWorkspace` function of `LogsQueryClient` returns a `LogsQueryResult` object. The object type can be `LogsQuerySuccessfulResult` or `LogsQueryPartialResult`. Here's a hierarchy of the response:
 
 ```
-LogsQueryResult -- (LogsQuerySuccessfulResult | LogsQueryPartialResult)
-
 LogsQuerySuccessfulResult
 |---statistics
 |---visualization

--- a/sdk/monitor/monitor-query/README.md
+++ b/sdk/monitor/monitor-query/README.md
@@ -253,7 +253,7 @@ export async function main() {
         ` Query had errors:${response.partialError.message} with code ${response.partialError.code}`
       );
     } else {
-      console.log(`Printing Errors from query '${queriesBatch[i].query}'`);
+      console.log(`Printing errors from query '${queriesBatch[i].query}'`);
       console.log(` Query had errors:${response.message} with code ${response.code}`);
     }
     // next query

--- a/sdk/monitor/monitor-query/README.md
+++ b/sdk/monitor/monitor-query/README.md
@@ -341,7 +341,7 @@ async function processBatchResult(result: LogsQueryBatchResult) {
         ` Query had errors:${response.partialError.message} with code ${response.partialError.code}`
       );
     } else {
-      console.log(`Printing Errors from query '${queriesBatch[i].query}'`);
+      console.log(`Printing errors from query '${queriesBatch[i].query}'`);
       console.log(` Query had errors:${response.message} with code ${response.code}`);
     }
     // next query

--- a/sdk/monitor/monitor-query/README.md
+++ b/sdk/monitor/monitor-query/README.md
@@ -156,7 +156,6 @@ LogsQuerySuccessfulResult
         |---name
         |---type
 
-
 LogsQueryPartialResult
 |---statistics
 |---visualization

--- a/sdk/monitor/monitor-query/README.md
+++ b/sdk/monitor/monitor-query/README.md
@@ -334,7 +334,7 @@ async function processBatchResult(result: LogsQueryBatchResult) {
       processTables(response.tables);
     } else if (response.status === LogsQueryResultStatus.PartialFailure) {
       console.log(
-        `Printing Partial results from query '${queriesBatch[i].query}' for '${queriesBatch[i].timespan}'`
+        `Printing partial results from query '${queriesBatch[i].query}' for '${queriesBatch[i].timespan}'`
       );
       processTables(response.partialTables);
       console.log(

--- a/sdk/monitor/monitor-query/README.md
+++ b/sdk/monitor/monitor-query/README.md
@@ -320,7 +320,7 @@ LogsQueryError
 |--status ("Failure")
 ```
 
-For example, to handle a batch logs query response, you can refer the following code snippet and :
+For example, the following code handles a batch logs query response:
 
 ```ts
 async function processBatchResult(result: LogsQueryBatchResult) {

--- a/sdk/monitor/monitor-query/README.md
+++ b/sdk/monitor/monitor-query/README.md
@@ -284,7 +284,6 @@ The `queryBatch` function of `LogsQueryClient` returns a `LogsQueryBatchResult` 
 > Here's a hierarchy of the response:
 
 ```
-LogsQueryBatchResult (list of objects of `LogsQueryPartialResult` or `LogsQuerySuccessfulResult` or `LogsQueryError`)
 
 LogsQuerySuccessfulResult
 |---statistics

--- a/sdk/monitor/monitor-query/README.md
+++ b/sdk/monitor/monitor-query/README.md
@@ -246,7 +246,7 @@ export async function main() {
       processTables(response.tables);
     } else if (response.status === LogsQueryResultStatus.PartialFailure) {
       console.log(
-        `Printing Partial results from query '${queriesBatch[i].query}' for '${queriesBatch[i].timespan}'`
+        `Printing partial results from query '${queriesBatch[i].query}' for '${queriesBatch[i].timespan}'`
       );
       processTables(response.partialTables);
       console.log(

--- a/sdk/monitor/monitor-query/README.md
+++ b/sdk/monitor/monitor-query/README.md
@@ -102,15 +102,26 @@ async function run() {
   const result = await logsQueryClient.queryWorkspace(azureLogAnalyticsWorkspaceId, kustoQuery, {
     duration: Durations.twentyFourHours
   });
-  const tablesFromResult = result.tables;
 
-  if (tablesFromResult == null) {
-    console.log(`No results for query '${kustoQuery}'`);
-    return;
+  if (result.status === LogsQueryResultStatus.Success) {
+    const tablesFromResult: LogsTable[] = result.tables;
+
+    if (tablesFromResult.length === 0) {
+      console.log(`No results for query '${kustoQuery}'`);
+      return;
+    }
+    console.log(`This query has returned table(s) - `);
+    processTables(tablesFromResult);
+  } else {
+    console.log(`Error processing the query '${kustoQuery}' - ${result.partialError}`);
+    if (result.partialTables.length > 0) {
+      console.log(`This query has also returned partial data in the following table(s) - `);
+      processTables(result.partialTables);
+    }
   }
+}
 
-  console.log(`Results for query '${kustoQuery}'`);
-
+async function processTables(tablesFromResult: LogsTable[]) {
   for (const table of tablesFromResult) {
     const columnHeaderString = table.columnDescriptors
       .map((column) => `${column.name}(${column.type}) `)
@@ -123,20 +134,39 @@ async function run() {
     }
   }
 }
+
 run().catch((err) => console.log("ERROR:", err));
 ```
 
 #### Handle logs query response
 
-The `queryWorkspace` function of `LogsQueryClient` returns the `LogsQueryResult`. Here's a hierarchy of the response:
+The `queryWorkspace` function of `LogsQueryClient` returns the `LogsQueryResult`. The `LogsQueryResult` can either be of type `LogsQuerySuccessfulResult` or `LogsQueryPartialResult`. Here's a hierarchy of the response:
 
 ```
-LogsQueryResult
+LogsQueryResult -- (LogsQuerySuccessfulResult | LogsQueryPartialResult)
+
+LogsQuerySuccessfulResult
 |---statistics
 |---visualization
-|---error
-|---status ("PartialFailure" | "Success" | "Failure")
+|---status ("Success")
 |---tables (list of `LogsTable` objects)
+    |---name
+    |---rows
+    |---columnDescriptors (list of `LogsColumn` objects)
+        |---name
+        |---type
+
+
+LogsQueryPartialResult
+|---statistics
+|---visualization
+|---status ("PartialFailure")
+|---partialError
+    |--name
+    |--code
+    |--message
+    |--stack
+|---partialTables (list of `LogsTable` objects)
     |---name
     |---rows
     |---columnDescriptors (list of `LogsColumn` objects)
@@ -147,17 +177,17 @@ LogsQueryResult
 For example, to handle a response with tables:
 
 ```ts
-const tablesFromResult = result.tables;
+async function processTables(tablesFromResult: LogsTable[]) {
+  for (const table of tablesFromResult) {
+    const columnHeaderString = table.columnDescriptors
+      .map((column) => `${column.name}(${column.type}) `)
+      .join("| ");
+    console.log("| " + columnHeaderString);
 
-for (const table of tablesFromResult) {
-  const columnHeaderString = table.columnDescriptors
-    .map((column) => `${column.name}(${column.type}) `)
-    .join("| ");
-  console.log("| " + columnHeaderString);
-
-  for (const row of table.rows) {
-    const columnValuesString = row.map((columnValue) => `'${columnValue}' `).join("| ");
-    console.log("| " + columnValuesString);
+    for (const row of table.rows) {
+      const columnValuesString = row.map((columnValue) => `'${columnValue}' `).join("| ");
+      console.log("| " + columnValuesString);
+    }
   }
 }
 ```
@@ -210,89 +240,132 @@ export async function main() {
   }
 
   let i = 0;
-  for (const response of result.results) {
+  for (const response of result) {
     console.log(`Results for query with query: ${queriesBatch[i]}`);
-
-    if (response.error) {
-      console.log(` Query had errors:`, response.error);
+    if (response.status === LogsQueryResultStatus.Success) {
+      console.log(
+        `Printing results from query '${queriesBatch[i].query}' for '${queriesBatch[i].timespan}'`
+      );
+      processTables(response.tables);
+    } else if (response.status === LogsQueryResultStatus.PartialFailure) {
+      console.log(
+        `Printing Partial results from query '${queriesBatch[i].query}' for '${queriesBatch[i].timespan}'`
+      );
+      processTables(response.partialTables);
+      console.log(
+        ` Query had errors:${response.partialError.message} with code ${response.partialError.code}`
+      );
     } else {
-      if (response.tables == null) {
-        console.log(`No results for query`);
-      } else {
-        console.log(
-          `Printing results from query '${queriesBatch[i].query}' for '${queriesBatch[i].timespan}'`
-        );
-
-        for (const table of response.tables) {
-          const columnHeaderString = table.columnDescriptors
-            .map((column) => `${column.name}(${column.type}) `)
-            .join("| ");
-          console.log(columnHeaderString);
-
-          for (const row of table.rows) {
-            const columnValuesString = row.map((columnValue) => `'${columnValue}' `).join("| ");
-            console.log(columnValuesString);
-          }
-        }
-      }
+      console.log(`Printing Errors from query '${queriesBatch[i].query}'`);
+      console.log(` Query had errors:${response.message} with code ${response.code}`);
     }
     // next query
     i++;
+  }
+}
+
+async function processTables(tablesFromResult: LogsTable[]) {
+  for (const table of tablesFromResult) {
+    const columnHeaderString = table.columnDescriptors
+      .map((column) => `${column.name}(${column.type}) `)
+      .join("| ");
+    console.log("| " + columnHeaderString);
+
+    for (const row of table.rows) {
+      const columnValuesString = row.map((columnValue) => `'${columnValue}' `).join("| ");
+      console.log("| " + columnValuesString);
+    }
   }
 }
 ```
 
 #### Handle logs batch query response
 
-The `queryBatch` function of `LogsQueryClient` returns a `LogsQueryBatchResult` object. Here's a hierarchy of the response:
+The `queryBatch` function of `LogsQueryClient` returns a `LogsQueryBatchResult` object. LogsQueryBatchResult is a list of objects of either of these types -
+`LogsQueryPartialResult` or `LogsQuerySuccessfulResult` or `LogsQueryError`.
+
+> Here's a hierarchy of the response:
 
 ```
-LogsQueryBatchResult
-|---results (list of following objects)
-    |---statistics
-    |---visualization
-    |---error
-    |---status ("PartialFailure" | "Success" | "Failure")
-    |---tables (list of `LogsTable` objects)
+LogsQueryBatchResult (list of objects of `LogsQueryPartialResult` or `LogsQuerySuccessfulResult` or `LogsQueryError`)
+
+LogsQuerySuccessfulResult
+|---statistics
+|---visualization
+|---status ("Success")
+|---tables (list of `LogsTable` objects)
+    |---name
+    |---rows
+    |---columnDescriptors (list of `LogsColumn` objects)
         |---name
-        |---rows
-        |---columnDescriptors (list of `LogsColumn` objects)
-            |---name
-            |---type
+        |---type
+
+
+LogsQueryPartialResult
+|---statistics
+|---visualization
+|---status ("PartialFailure")
+|---partialError
+    |--name
+    |--code
+    |--message
+    |--stack
+|---partialTables (list of `LogsTable` objects)
+    |---name
+    |---rows
+    |---columnDescriptors (list of `LogsColumn` objects)
+        |---name
+        |---type
+
+LogsQueryError
+|--name
+|--code
+|--message
+|--stack
+|--status ("Failure")
 ```
 
-For example, to handle a batch logs query response:
+For example, to handle a batch logs query response, you can refer the following code snippet and :
 
 ```ts
-let i = 0;
-for (const response of result.results) {
-  console.log(`Results for query with query: ${queriesBatch[i]}`);
-
-  if (response.error) {
-    console.log(` Query had errors:`, response.error);
-  } else {
-    if (response.tables == null) {
-      console.log(`No results for query`);
-    } else {
+async function processBatchResult(result: LogsQueryBatchResult) {
+  let i = 0;
+  for (const response of result) {
+    console.log(`Results for query with query: ${queriesBatch[i]}`);
+    if (response.status === LogsQueryResultStatus.Success) {
       console.log(
         `Printing results from query '${queriesBatch[i].query}' for '${queriesBatch[i].timespan}'`
       );
+      processTables(response.tables);
+    } else if (response.status === LogsQueryResultStatus.PartialFailure) {
+      console.log(
+        `Printing Partial results from query '${queriesBatch[i].query}' for '${queriesBatch[i].timespan}'`
+      );
+      processTables(response.partialTables);
+      console.log(
+        ` Query had errors:${response.partialError.message} with code ${response.partialError.code}`
+      );
+    } else {
+      console.log(`Printing Errors from query '${queriesBatch[i].query}'`);
+      console.log(` Query had errors:${response.message} with code ${response.code}`);
+    }
+    // next query
+    i++;
+  }
+}
 
-      for (const table of response.tables) {
-        const columnHeaderString = table.columnDescriptors
-          .map((column) => `${column.name}(${column.type}) `)
-          .join("| ");
-        console.log(columnHeaderString);
+async function processTables(tablesFromResult: LogsTable[]) {
+  for (const table of tablesFromResult) {
+    const columnHeaderString = table.columnDescriptors
+      .map((column) => `${column.name}(${column.type}) `)
+      .join("| ");
+    console.log("| " + columnHeaderString);
 
-        for (const row of table.rows) {
-          const columnValuesString = row.map((columnValue) => `'${columnValue}' `).join("| ");
-          console.log(columnValuesString);
-        }
-      }
+    for (const row of table.rows) {
+      const columnValuesString = row.map((columnValue) => `'${columnValue}' `).join("| ");
+      console.log("| " + columnValuesString);
     }
   }
-  // next query
-  i++;
 }
 ```
 

--- a/sdk/monitor/monitor-query/README.md
+++ b/sdk/monitor/monitor-query/README.md
@@ -278,10 +278,13 @@ async function processTables(tablesFromResult: LogsTable[]) {
 
 #### Handle logs batch query response
 
-The `queryBatch` function of `LogsQueryClient` returns a `LogsQueryBatchResult` object. LogsQueryBatchResult is a list of objects of either of these types -
-`LogsQueryPartialResult` or `LogsQuerySuccessfulResult` or `LogsQueryError`.
+The `queryBatch` function of `LogsQueryClient` returns a `LogsQueryBatchResult` object. `LogsQueryBatchResult` contains a list of objects with the following possible types:
 
-> Here's a hierarchy of the response:
+- `LogsQueryPartialResult`
+- `LogsQuerySuccessfulResult`
+- `LogsQueryError`
+
+Here's a hierarchy of the response:
 
 ```
 

--- a/sdk/monitor/monitor-query/review/monitor-query.api.md
+++ b/sdk/monitor/monitor-query/review/monitor-query.api.md
@@ -68,15 +68,7 @@ export interface LogsQueryBatchOptions extends OperationOptions {
 }
 
 // @public
-export interface LogsQueryBatchResult {
-    results: {
-        tables?: LogsTable[];
-        error?: LogsErrorInfo;
-        status?: LogsQueryResultStatus;
-        statistics?: Record<string, unknown>;
-        visualization?: Record<string, unknown>;
-    }[];
-}
+export type LogsQueryBatchResult = Array<LogsQueryPartialResult | LogsQuerySuccessfulResult | LogsQueryError>;
 
 // @public
 export class LogsQueryClient {
@@ -92,6 +84,12 @@ export interface LogsQueryClientOptions extends CommonClientOptions {
 }
 
 // @public
+export interface LogsQueryError extends Error {
+    code: string;
+    status: LogsQueryResultStatus.Failure;
+}
+
+// @public
 export interface LogsQueryOptions extends OperationOptions {
     additionalWorkspaces?: string[];
     includeQueryStatistics?: boolean;
@@ -100,17 +98,35 @@ export interface LogsQueryOptions extends OperationOptions {
     throwOnAnyFailure?: boolean;
 }
 
-// @public
-export interface LogsQueryResult {
-    error?: LogsErrorInfo;
+// @public (undocumented)
+export interface LogsQueryPartialResult {
+    incompleteTables: LogsTable[];
+    partialError: LogsErrorInfo;
     statistics?: Record<string, unknown>;
-    status: LogsQueryResultStatus;
-    tables: LogsTable[];
+    status: LogsQueryResultStatus.PartialFailure;
     visualization?: Record<string, unknown>;
 }
 
 // @public
-export type LogsQueryResultStatus = "PartialFailure" | "Success" | "Failure";
+export type LogsQueryResult = LogsQuerySuccessfulResult | LogsQueryPartialResult;
+
+// @public
+export enum LogsQueryResultStatus {
+    // (undocumented)
+    Failure = "Failure",
+    // (undocumented)
+    PartialFailure = "PartialFailure",
+    // (undocumented)
+    Success = "Success"
+}
+
+// @public (undocumented)
+export interface LogsQuerySuccessfulResult {
+    statistics?: Record<string, unknown>;
+    status: LogsQueryResultStatus.Success;
+    tables: LogsTable[];
+    visualization?: Record<string, unknown>;
+}
 
 // @public
 export interface LogsTable {

--- a/sdk/monitor/monitor-query/review/monitor-query.api.md
+++ b/sdk/monitor/monitor-query/review/monitor-query.api.md
@@ -10,19 +10,7 @@ import { PagedAsyncIterableIterator } from '@azure/core-paging';
 import { TokenCredential } from '@azure/core-auth';
 
 // @public
-export class AggregateBatchError extends Error {
-    constructor(errors: LogsErrorInfo[]);
-    errors: BatchError[];
-}
-
-// @public
 export type AggregationType = "None" | "Average" | "Count" | "Minimum" | "Maximum" | "Total";
-
-// @public
-export class BatchError extends Error implements LogsErrorInfo {
-    constructor(errorInfo: LogsErrorInfo);
-    code: string;
-}
 
 // @public
 export const Durations: {
@@ -64,7 +52,6 @@ export interface LogsErrorInfo extends Error {
 
 // @public
 export interface LogsQueryBatchOptions extends OperationOptions {
-    throwOnAnyFailure?: boolean;
 }
 
 // @public
@@ -95,13 +82,12 @@ export interface LogsQueryOptions extends OperationOptions {
     includeQueryStatistics?: boolean;
     includeVisualization?: boolean;
     serverTimeoutInSeconds?: number;
-    throwOnAnyFailure?: boolean;
 }
 
 // @public
 export interface LogsQueryPartialResult {
-    incompleteTables: LogsTable[];
     partialError: LogsErrorInfo;
+    partialTables: LogsTable[];
     statistics?: Record<string, unknown>;
     status: LogsQueryResultStatus.PartialFailure;
     visualization?: Record<string, unknown>;

--- a/sdk/monitor/monitor-query/review/monitor-query.api.md
+++ b/sdk/monitor/monitor-query/review/monitor-query.api.md
@@ -98,7 +98,7 @@ export interface LogsQueryOptions extends OperationOptions {
     throwOnAnyFailure?: boolean;
 }
 
-// @public (undocumented)
+// @public
 export interface LogsQueryPartialResult {
     incompleteTables: LogsTable[];
     partialError: LogsErrorInfo;
@@ -112,15 +112,12 @@ export type LogsQueryResult = LogsQuerySuccessfulResult | LogsQueryPartialResult
 
 // @public
 export enum LogsQueryResultStatus {
-    // (undocumented)
     Failure = "Failure",
-    // (undocumented)
     PartialFailure = "PartialFailure",
-    // (undocumented)
     Success = "Success"
 }
 
-// @public (undocumented)
+// @public
 export interface LogsQuerySuccessfulResult {
     statistics?: Record<string, unknown>;
     status: LogsQueryResultStatus.Success;

--- a/sdk/monitor/monitor-query/samples-dev/logsQuery.ts
+++ b/sdk/monitor/monitor-query/samples-dev/logsQuery.ts
@@ -67,9 +67,9 @@ export async function main() {
     processTables(tablesFromResult);
   } else {
     console.log(`Error processing the query '${kustoQuery}' - ${result.partialError}`);
-    if (result.incompleteTables.length > 0) {
+    if (result.partialTables.length > 0) {
       console.log(`This query has also returned partial data in the following table(s) - `);
-      processTables(result.incompleteTables);
+      processTables(result.partialTables);
     }
   }
 }

--- a/sdk/monitor/monitor-query/samples-dev/logsQuery.ts
+++ b/sdk/monitor/monitor-query/samples-dev/logsQuery.ts
@@ -6,7 +6,13 @@
  */
 
 import { DefaultAzureCredential } from "@azure/identity";
-import { Durations, LogsQueryClient, LogsTable, LogsQueryOptions } from "@azure/monitor-query";
+import {
+  Durations,
+  LogsQueryClient,
+  LogsTable,
+  LogsQueryOptions,
+  LogsQueryResultStatus
+} from "@azure/monitor-query";
 import * as dotenv from "dotenv";
 dotenv.config();
 
@@ -41,14 +47,6 @@ export async function main() {
     { duration: Durations.oneHour },
     queryLogsOptions
   );
-
-  const tablesFromResult: LogsTable[] | undefined = result.tables;
-
-  if (tablesFromResult == null) {
-    console.log(`No results for query '${kustoQuery}'`);
-    return;
-  }
-
   const executionTime =
     result.statistics && result.statistics.query && (result.statistics.query as any).executionTime;
 
@@ -58,6 +56,25 @@ export async function main() {
     }`
   );
 
+  if (result.status === LogsQueryResultStatus.Success) {
+    const tablesFromResult: LogsTable[] = result.tables;
+
+    if (tablesFromResult.length === 0) {
+      console.log(`No results for query '${kustoQuery}'`);
+      return;
+    }
+    console.log(`This query has returned table(s) - `);
+    processTables(tablesFromResult);
+  } else {
+    console.log(`Error processing the query '${kustoQuery}' - ${result.partialError}`);
+    if (result.incompleteTables.length > 0) {
+      console.log(`This query has also returned partial data in the following table(s) - `);
+      processTables(result.incompleteTables);
+    }
+  }
+}
+
+async function processTables(tablesFromResult: LogsTable[]) {
   for (const table of tablesFromResult) {
     const columnHeaderString = table.columnDescriptors
       .map((column) => `${column.name}(${column.type}) `)

--- a/sdk/monitor/monitor-query/samples-dev/logsQueryBatch.ts
+++ b/sdk/monitor/monitor-query/samples-dev/logsQueryBatch.ts
@@ -6,7 +6,7 @@
  */
 
 import { DefaultAzureCredential } from "@azure/identity";
-import { LogsQueryClient } from "@azure/monitor-query";
+import { LogsQueryClient, LogsQueryResultStatus, LogsTable } from "@azure/monitor-query";
 import * as dotenv from "dotenv";
 dotenv.config();
 
@@ -47,40 +47,46 @@ export async function main() {
   ];
 
   const result = await logsQueryClient.queryBatch(queriesBatch);
-
-  if (result.results == null) {
+  if (result === null) {
     throw new Error("No response for query");
   }
 
   let i = 0;
-  for (const response of result.results) {
+  for (const response of result) {
     console.log(`Results for query with query: ${queriesBatch[i]}`);
-
-    if (response.error) {
-      console.log(` Query had errors:`, response.error);
+    if (response.status === LogsQueryResultStatus.Success) {
+      console.log(
+        `Printing results from query '${queriesBatch[i].query}' for '${queriesBatch[i].timespan}'`
+      );
+      processTables(response.tables);
+    } else if (response.status === LogsQueryResultStatus.PartialFailure) {
+      console.log(
+        `Printing Partial results from query '${queriesBatch[i].query}' for '${queriesBatch[i].timespan}'`
+      );
+      processTables(response.incompleteTables);
+      console.log(
+        ` Query had errors:${response.partialError.message} with code ${response.partialError.code}`
+      );
     } else {
-      if (response.tables == null) {
-        console.log(`No results for query`);
-      } else {
-        console.log(
-          `Printing results from query '${queriesBatch[i].query}' for '${queriesBatch[i].timespan}'`
-        );
-
-        for (const table of response.tables) {
-          const columnHeaderString = table.columnDescriptors
-            .map((column) => `${column.name}(${column.type}) `)
-            .join("| ");
-          console.log(columnHeaderString);
-
-          for (const row of table.rows) {
-            const columnValuesString = row.map((columnValue) => `'${columnValue}' `).join("| ");
-            console.log(columnValuesString);
-          }
-        }
-      }
+      console.log(`Printing Errors from query '${queriesBatch[i].query}'`);
+      console.log(` Query had errors:${response.message} with code ${response.code}`);
     }
     // next query
     i++;
+  }
+}
+
+async function processTables(tablesFromResult: LogsTable[]) {
+  for (const table of tablesFromResult) {
+    const columnHeaderString = table.columnDescriptors
+      .map((column) => `${column.name}(${column.type}) `)
+      .join("| ");
+    console.log("| " + columnHeaderString);
+
+    for (const row of table.rows) {
+      const columnValuesString = row.map((columnValue) => `'${columnValue}' `).join("| ");
+      console.log("| " + columnValuesString);
+    }
   }
 }
 

--- a/sdk/monitor/monitor-query/samples-dev/logsQueryBatch.ts
+++ b/sdk/monitor/monitor-query/samples-dev/logsQueryBatch.ts
@@ -68,7 +68,7 @@ export async function main() {
         ` Query had errors:${response.partialError.message} with code ${response.partialError.code}`
       );
     } else {
-      console.log(`Printing Errors from query '${queriesBatch[i].query}'`);
+      console.log(`Printing errors from query '${queriesBatch[i].query}'`);
       console.log(` Query had errors:${response.message} with code ${response.code}`);
     }
     // next query

--- a/sdk/monitor/monitor-query/samples-dev/logsQueryBatch.ts
+++ b/sdk/monitor/monitor-query/samples-dev/logsQueryBatch.ts
@@ -63,7 +63,7 @@ export async function main() {
       console.log(
         `Printing Partial results from query '${queriesBatch[i].query}' for '${queriesBatch[i].timespan}'`
       );
-      processTables(response.incompleteTables);
+      processTables(response.partialTables);
       console.log(
         ` Query had errors:${response.partialError.message} with code ${response.partialError.code}`
       );

--- a/sdk/monitor/monitor-query/samples-dev/logsQueryBatch.ts
+++ b/sdk/monitor/monitor-query/samples-dev/logsQueryBatch.ts
@@ -61,7 +61,7 @@ export async function main() {
       processTables(response.tables);
     } else if (response.status === LogsQueryResultStatus.PartialFailure) {
       console.log(
-        `Printing Partial results from query '${queriesBatch[i].query}' for '${queriesBatch[i].timespan}'`
+        `Printing partial results from query '${queriesBatch[i].query}' for '${queriesBatch[i].timespan}'`
       );
       processTables(response.partialTables);
       console.log(

--- a/sdk/monitor/monitor-query/samples-dev/logsQueryMultipleWorkspaces.ts
+++ b/sdk/monitor/monitor-query/samples-dev/logsQueryMultipleWorkspaces.ts
@@ -68,9 +68,9 @@ export async function main() {
     processTables(tablesFromResult);
   } else {
     console.log(`Error processing the query '${kustoQuery}' - ${result.partialError}`);
-    if (result.incompleteTables.length > 0) {
+    if (result.partialTables.length > 0) {
       console.log(`This query has also returned partial data in the following table(s) - `);
-      processTables(result.incompleteTables);
+      processTables(result.partialTables);
     }
   }
 }

--- a/sdk/monitor/monitor-query/samples-dev/logsQueryMultipleWorkspaces.ts
+++ b/sdk/monitor/monitor-query/samples-dev/logsQueryMultipleWorkspaces.ts
@@ -6,7 +6,13 @@
  */
 
 import { DefaultAzureCredential } from "@azure/identity";
-import { Durations, LogsQueryClient, LogsTable, LogsQueryOptions } from "@azure/monitor-query";
+import {
+  Durations,
+  LogsQueryClient,
+  LogsTable,
+  LogsQueryOptions,
+  LogsQueryResultStatus
+} from "@azure/monitor-query";
 import * as dotenv from "dotenv";
 dotenv.config();
 
@@ -44,14 +50,6 @@ export async function main() {
     { duration: Durations.oneHour },
     queryLogsOptions
   );
-
-  const tablesFromResult: LogsTable[] | undefined = result.tables;
-
-  if (tablesFromResult == null) {
-    console.log(`No results for query '${kustoQuery}'`);
-    return;
-  }
-
   const executionTime =
     result.statistics && result.statistics.query && (result.statistics.query as any).executionTime;
 
@@ -61,6 +59,23 @@ export async function main() {
     }`
   );
 
+  if (result.status === LogsQueryResultStatus.Success) {
+    const tablesFromResult: LogsTable[] = result.tables;
+    if (tablesFromResult == null) {
+      console.log(`No results for query '${kustoQuery}'`);
+      return;
+    }
+    processTables(tablesFromResult);
+  } else {
+    console.log(`Error processing the query '${kustoQuery}' - ${result.partialError}`);
+    if (result.incompleteTables.length > 0) {
+      console.log(`This query has also returned partial data in the following table(s) - `);
+      processTables(result.incompleteTables);
+    }
+  }
+}
+
+async function processTables(tablesFromResult: LogsTable[]) {
   for (const table of tablesFromResult) {
     const columnHeaderString = table.columnDescriptors
       .map((column) => `${column.name}(${column.type}) `)

--- a/sdk/monitor/monitor-query/samples/v1/javascript/logsQueryBatch.js
+++ b/sdk/monitor/monitor-query/samples/v1/javascript/logsQueryBatch.js
@@ -61,7 +61,7 @@ async function main() {
       processTables(response.tables);
     } else if (response.status === LogsQueryResultStatus.PartialFailure) {
       console.log(
-        `Printing Partial results from query '${queriesBatch[i].query}' for '${queriesBatch[i].timespan}'`
+        `Printing partial results from query '${queriesBatch[i].query}' for '${queriesBatch[i].timespan}'`
       );
       processTables(response.partialTables);
       console.log(

--- a/sdk/monitor/monitor-query/samples/v1/javascript/logsQueryBatch.js
+++ b/sdk/monitor/monitor-query/samples/v1/javascript/logsQueryBatch.js
@@ -6,7 +6,7 @@
  */
 
 const { DefaultAzureCredential } = require("@azure/identity");
-const { LogsQueryClient } = require("@azure/monitor-query");
+const { LogsQueryClient, LogsQueryResultStatus } = require("@azure/monitor-query");
 const dotenv = require("dotenv");
 dotenv.config();
 
@@ -47,40 +47,46 @@ async function main() {
   ];
 
   const result = await logsQueryClient.queryBatch(queriesBatch);
-
-  if (result.results == null) {
+  if (result === null) {
     throw new Error("No response for query");
   }
 
   let i = 0;
-  for (const response of result.results) {
+  for (const response of result) {
     console.log(`Results for query with query: ${queriesBatch[i]}`);
-
-    if (response.error) {
-      console.log(` Query had errors:`, response.error);
+    if (response.status === LogsQueryResultStatus.Success) {
+      console.log(
+        `Printing results from query '${queriesBatch[i].query}' for '${queriesBatch[i].timespan}'`
+      );
+      processTables(response.tables);
+    } else if (response.status === LogsQueryResultStatus.PartialFailure) {
+      console.log(
+        `Printing Partial results from query '${queriesBatch[i].query}' for '${queriesBatch[i].timespan}'`
+      );
+      processTables(response.partialTables);
+      console.log(
+        ` Query had errors:${response.partialError.message} with code ${response.partialError.code}`
+      );
     } else {
-      if (response.tables == null) {
-        console.log(`No results for query`);
-      } else {
-        console.log(
-          `Printing results from query '${queriesBatch[i].query}' for '${queriesBatch[i].timespan}'`
-        );
-
-        for (const table of response.tables) {
-          const columnHeaderString = table.columnDescriptors
-            .map((column) => `${column.name}(${column.type}) `)
-            .join("| ");
-          console.log(columnHeaderString);
-
-          for (const row of table.rows) {
-            const columnValuesString = row.map((columnValue) => `'${columnValue}' `).join("| ");
-            console.log(columnValuesString);
-          }
-        }
-      }
+      console.log(`Printing Errors from query '${queriesBatch[i].query}'`);
+      console.log(` Query had errors:${response.message} with code ${response.code}`);
     }
     // next query
     i++;
+  }
+}
+
+async function processTables(tablesFromResult) {
+  for (const table of tablesFromResult) {
+    const columnHeaderString = table.columnDescriptors
+      .map((column) => `${column.name}(${column.type}) `)
+      .join("| ");
+    console.log("| " + columnHeaderString);
+
+    for (const row of table.rows) {
+      const columnValuesString = row.map((columnValue) => `'${columnValue}' `).join("| ");
+      console.log("| " + columnValuesString);
+    }
   }
 }
 

--- a/sdk/monitor/monitor-query/samples/v1/javascript/logsQueryBatch.js
+++ b/sdk/monitor/monitor-query/samples/v1/javascript/logsQueryBatch.js
@@ -68,7 +68,7 @@ async function main() {
         ` Query had errors:${response.partialError.message} with code ${response.partialError.code}`
       );
     } else {
-      console.log(`Printing Errors from query '${queriesBatch[i].query}'`);
+      console.log(`Printing errors from query '${queriesBatch[i].query}'`);
       console.log(` Query had errors:${response.message} with code ${response.code}`);
     }
     // next query

--- a/sdk/monitor/monitor-query/samples/v1/javascript/logsQueryMultipleWorkspaces.js
+++ b/sdk/monitor/monitor-query/samples/v1/javascript/logsQueryMultipleWorkspaces.js
@@ -6,7 +6,7 @@
  */
 
 const { DefaultAzureCredential } = require("@azure/identity");
-const { Durations, LogsQueryClient } = require("@azure/monitor-query");
+const { Durations, LogsQueryClient, LogsQueryResultStatus } = require("@azure/monitor-query");
 const dotenv = require("dotenv");
 dotenv.config();
 
@@ -35,23 +35,15 @@ async function main() {
     additionalWorkspaces: [additionalWorkspaces1, additionalWorkspaces2]
   };
 
-  const result = await logsQueryClient.query(
+  const result = await logsQueryClient.queryWorkspace(
     monitorWorkspaceId,
     kustoQuery,
     // The timespan is an ISO8601 formatted time (or interval). Some common aliases
     // are available (like durationOf1Day, durationOf1Hour, durationOf48Hours, etc..) but any properly formatted ISO8601
     // value is valid.
-    { duration: Durations.OneHour },
+    { duration: Durations.oneHour },
     queryLogsOptions
   );
-
-  const tablesFromResult = result.tables;
-
-  if (tablesFromResult == null) {
-    console.log(`No results for query '${kustoQuery}'`);
-    return;
-  }
-
   const executionTime =
     result.statistics && result.statistics.query && result.statistics.query.executionTime;
 
@@ -61,6 +53,23 @@ async function main() {
     }`
   );
 
+  if (result.status === LogsQueryResultStatus.Success) {
+    const tablesFromResult = result.tables;
+    if (tablesFromResult == null) {
+      console.log(`No results for query '${kustoQuery}'`);
+      return;
+    }
+    processTables(tablesFromResult);
+  } else {
+    console.log(`Error processing the query '${kustoQuery}' - ${result.partialError}`);
+    if (result.partialTables.length > 0) {
+      console.log(`This query has also returned partial data in the following table(s) - `);
+      processTables(result.partialTables);
+    }
+  }
+}
+
+async function processTables(tablesFromResult) {
   for (const table of tablesFromResult) {
     const columnHeaderString = table.columnDescriptors
       .map((column) => `${column.name}(${column.type}) `)

--- a/sdk/monitor/monitor-query/samples/v1/javascript/metricsQuery.js
+++ b/sdk/monitor/monitor-query/samples/v1/javascript/metricsQuery.js
@@ -32,9 +32,9 @@ async function main() {
 
   if (metricNames.length > 0) {
     console.log(`Picking an example list of metrics to query: ${metricNames}`);
-    const metricsResponse = await metricsQueryClient.query(metricsResourceId, metricNames, {
+    const metricsResponse = await metricsQueryClient.queryResource(metricsResourceId, metricNames, {
       granularity: "PT1M",
-      timespan: { duration: Durations.FiveMinutes }
+      timespan: { duration: Durations.fiveMinutes }
     });
 
     console.log(

--- a/sdk/monitor/monitor-query/samples/v1/javascript/package.json
+++ b/sdk/monitor/monitor-query/samples/v1/javascript/package.json
@@ -25,6 +25,6 @@
   "dependencies": {
     "@azure/monitor-query": "next",
     "dotenv": "latest",
-    "@azure/identity": "^1.1.0"
+    "@azure/identity": "2.0.0-beta.7"
   }
 }

--- a/sdk/monitor/monitor-query/samples/v1/typescript/package.json
+++ b/sdk/monitor/monitor-query/samples/v1/typescript/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "@azure/monitor-query": "next",
     "dotenv": "latest",
-    "@azure/identity": "^1.1.0"
+    "@azure/identity": "2.0.0-beta.7"
   },
   "devDependencies": {
     "typescript": "~4.2.0",

--- a/sdk/monitor/monitor-query/samples/v1/typescript/src/logsQueryBatch.ts
+++ b/sdk/monitor/monitor-query/samples/v1/typescript/src/logsQueryBatch.ts
@@ -68,7 +68,7 @@ export async function main() {
         ` Query had errors:${response.partialError.message} with code ${response.partialError.code}`
       );
     } else {
-      console.log(`Printing Errors from query '${queriesBatch[i].query}'`);
+      console.log(`Printing errors from query '${queriesBatch[i].query}'`);
       console.log(` Query had errors:${response.message} with code ${response.code}`);
     }
     // next query

--- a/sdk/monitor/monitor-query/samples/v1/typescript/src/logsQueryBatch.ts
+++ b/sdk/monitor/monitor-query/samples/v1/typescript/src/logsQueryBatch.ts
@@ -6,7 +6,7 @@
  */
 
 import { DefaultAzureCredential } from "@azure/identity";
-import { LogsQueryClient } from "@azure/monitor-query";
+import { LogsQueryClient, LogsQueryResultStatus, LogsTable } from "@azure/monitor-query";
 import * as dotenv from "dotenv";
 dotenv.config();
 
@@ -47,40 +47,46 @@ export async function main() {
   ];
 
   const result = await logsQueryClient.queryBatch(queriesBatch);
-
-  if (result.results == null) {
+  if (result === null) {
     throw new Error("No response for query");
   }
 
   let i = 0;
-  for (const response of result.results) {
+  for (const response of result) {
     console.log(`Results for query with query: ${queriesBatch[i]}`);
-
-    if (response.error) {
-      console.log(` Query had errors:`, response.error);
+    if (response.status === LogsQueryResultStatus.Success) {
+      console.log(
+        `Printing results from query '${queriesBatch[i].query}' for '${queriesBatch[i].timespan}'`
+      );
+      processTables(response.tables);
+    } else if (response.status === LogsQueryResultStatus.PartialFailure) {
+      console.log(
+        `Printing Partial results from query '${queriesBatch[i].query}' for '${queriesBatch[i].timespan}'`
+      );
+      processTables(response.partialTables);
+      console.log(
+        ` Query had errors:${response.partialError.message} with code ${response.partialError.code}`
+      );
     } else {
-      if (response.tables == null) {
-        console.log(`No results for query`);
-      } else {
-        console.log(
-          `Printing results from query '${queriesBatch[i].query}' for '${queriesBatch[i].timespan}'`
-        );
-
-        for (const table of response.tables) {
-          const columnHeaderString = table.columnDescriptors
-            .map((column) => `${column.name}(${column.type}) `)
-            .join("| ");
-          console.log(columnHeaderString);
-
-          for (const row of table.rows) {
-            const columnValuesString = row.map((columnValue) => `'${columnValue}' `).join("| ");
-            console.log(columnValuesString);
-          }
-        }
-      }
+      console.log(`Printing Errors from query '${queriesBatch[i].query}'`);
+      console.log(` Query had errors:${response.message} with code ${response.code}`);
     }
     // next query
     i++;
+  }
+}
+
+async function processTables(tablesFromResult: LogsTable[]) {
+  for (const table of tablesFromResult) {
+    const columnHeaderString = table.columnDescriptors
+      .map((column) => `${column.name}(${column.type}) `)
+      .join("| ");
+    console.log("| " + columnHeaderString);
+
+    for (const row of table.rows) {
+      const columnValuesString = row.map((columnValue) => `'${columnValue}' `).join("| ");
+      console.log("| " + columnValuesString);
+    }
   }
 }
 

--- a/sdk/monitor/monitor-query/samples/v1/typescript/src/logsQueryBatch.ts
+++ b/sdk/monitor/monitor-query/samples/v1/typescript/src/logsQueryBatch.ts
@@ -61,7 +61,7 @@ export async function main() {
       processTables(response.tables);
     } else if (response.status === LogsQueryResultStatus.PartialFailure) {
       console.log(
-        `Printing Partial results from query '${queriesBatch[i].query}' for '${queriesBatch[i].timespan}'`
+        `Printing partial results from query '${queriesBatch[i].query}' for '${queriesBatch[i].timespan}'`
       );
       processTables(response.partialTables);
       console.log(

--- a/sdk/monitor/monitor-query/samples/v1/typescript/src/logsQueryMultipleWorkspaces.ts
+++ b/sdk/monitor/monitor-query/samples/v1/typescript/src/logsQueryMultipleWorkspaces.ts
@@ -6,7 +6,13 @@
  */
 
 import { DefaultAzureCredential } from "@azure/identity";
-import { Durations, LogsQueryClient, LogsTable, LogsQueryOptions } from "@azure/monitor-query";
+import {
+  Durations,
+  LogsQueryClient,
+  LogsTable,
+  LogsQueryOptions,
+  LogsQueryResultStatus
+} from "@azure/monitor-query";
 import * as dotenv from "dotenv";
 dotenv.config();
 
@@ -35,23 +41,15 @@ export async function main() {
     additionalWorkspaces: [additionalWorkspaces1, additionalWorkspaces2]
   };
 
-  const result = await logsQueryClient.query(
+  const result = await logsQueryClient.queryWorkspace(
     monitorWorkspaceId,
     kustoQuery,
     // The timespan is an ISO8601 formatted time (or interval). Some common aliases
     // are available (like durationOf1Day, durationOf1Hour, durationOf48Hours, etc..) but any properly formatted ISO8601
     // value is valid.
-    { duration: Durations.OneHour },
+    { duration: Durations.oneHour },
     queryLogsOptions
   );
-
-  const tablesFromResult: LogsTable[] | undefined = result.tables;
-
-  if (tablesFromResult == null) {
-    console.log(`No results for query '${kustoQuery}'`);
-    return;
-  }
-
   const executionTime =
     result.statistics && result.statistics.query && (result.statistics.query as any).executionTime;
 
@@ -61,6 +59,23 @@ export async function main() {
     }`
   );
 
+  if (result.status === LogsQueryResultStatus.Success) {
+    const tablesFromResult: LogsTable[] = result.tables;
+    if (tablesFromResult == null) {
+      console.log(`No results for query '${kustoQuery}'`);
+      return;
+    }
+    processTables(tablesFromResult);
+  } else {
+    console.log(`Error processing the query '${kustoQuery}' - ${result.partialError}`);
+    if (result.partialTables.length > 0) {
+      console.log(`This query has also returned partial data in the following table(s) - `);
+      processTables(result.partialTables);
+    }
+  }
+}
+
+async function processTables(tablesFromResult: LogsTable[]) {
   for (const table of tablesFromResult) {
     const columnHeaderString = table.columnDescriptors
       .map((column) => `${column.name}(${column.type}) `)

--- a/sdk/monitor/monitor-query/samples/v1/typescript/src/metricsQuery.ts
+++ b/sdk/monitor/monitor-query/samples/v1/typescript/src/metricsQuery.ts
@@ -32,9 +32,9 @@ export async function main() {
 
   if (metricNames.length > 0) {
     console.log(`Picking an example list of metrics to query: ${metricNames}`);
-    const metricsResponse = await metricsQueryClient.query(metricsResourceId, metricNames, {
+    const metricsResponse = await metricsQueryClient.queryResource(metricsResourceId, metricNames, {
       granularity: "PT1M",
-      timespan: { duration: Durations.FiveMinutes }
+      timespan: { duration: Durations.fiveMinutes }
     });
 
     console.log(

--- a/sdk/monitor/monitor-query/src/index.ts
+++ b/sdk/monitor/monitor-query/src/index.ts
@@ -17,9 +17,7 @@ export {
   LogsTable,
   LogsColumn,
   LogsQueryResultStatus,
-  LogsErrorInfo,
-  BatchError,
-  AggregateBatchError
+  LogsErrorInfo
 } from "./models/publicLogsModels";
 export {
   MetricsQueryClient,

--- a/sdk/monitor/monitor-query/src/index.ts
+++ b/sdk/monitor/monitor-query/src/index.ts
@@ -11,8 +11,9 @@ export {
   LogsQueryBatchResult,
   LogsQueryOptions,
   LogsQueryResult,
-  // TODO: design issues around this still pending.
-  // QueryStatistics,
+  LogsQueryError,
+  LogsQueryPartialResult,
+  LogsQuerySuccessfulResult,
   LogsTable,
   LogsColumn,
   LogsQueryResultStatus,

--- a/sdk/monitor/monitor-query/src/internal/modelConverters.ts
+++ b/sdk/monitor/monitor-query/src/internal/modelConverters.ts
@@ -433,7 +433,7 @@ export function computeResultType(
         visualization: generatedResponse.render,
         status: LogsQueryResultStatus.PartialFailure,
         statistics: generatedResponse.statistics,
-        incompleteTables: generatedResponse.tables?.map((table: GeneratedTable) =>
+        partialTables: generatedResponse.tables?.map((table: GeneratedTable) =>
           convertGeneratedTable(table)
         ),
         partialError: mapError(generatedResponse.error)

--- a/sdk/monitor/monitor-query/src/internal/modelConverters.ts
+++ b/sdk/monitor/monitor-query/src/internal/modelConverters.ts
@@ -48,7 +48,13 @@ import {
   convertIntervalToTimeIntervalObject,
   convertTimespanToInterval
 } from "../timespanConversion";
-import { LogsErrorInfo, LogsQueryResult } from "../models/publicLogsModels";
+import {
+  LogsErrorInfo,
+  LogsQueryError,
+  LogsQueryPartialResult,
+  LogsQueryResultStatus,
+  LogsQuerySuccessfulResult
+} from "../models/publicLogsModels";
 
 /**
  * @internal
@@ -115,36 +121,22 @@ export function convertResponseForQueryBatch(
    */
   const responseList = generatedResponse.responses || [];
 
-  const newResponse: LogsQueryBatchResult = {
-    results: responseList
-      ?.sort((a, b) => {
-        let left = 0;
-        if (a.id != null) {
-          left = parseInt(a.id, 10);
-        }
+  const newResponse: LogsQueryBatchResult = responseList
+    ?.sort((a, b) => {
+      let left = 0;
+      if (a.id != null) {
+        left = parseInt(a.id, 10);
+      }
 
-        let right = 0;
-        if (b.id != null) {
-          right = parseInt(b.id, 10);
-        }
+      let right = 0;
+      if (b.id != null) {
+        right = parseInt(b.id, 10);
+      }
 
-        return left - right;
-      })
-      ?.map((response: GeneratedBatchQueryResponse) => convertBatchQueryResponseHelper(response))
-  };
-  // compute status for failed or succeed or partial results
+      return left - right;
+    })
+    ?.map((response: GeneratedBatchQueryResponse) => convertBatchQueryResponseHelper(response));
 
-  const resultsCount = newResponse.results?.length ?? 0;
-  for (let i = 0; i < resultsCount; i++) {
-    const result = newResponse.results[i];
-    if (result.error && result.tables) {
-      result.status = "PartialFailure";
-    } else if (result.tables) {
-      result.status = "Success";
-    } else {
-      result.status = "Failure";
-    }
-  }
   (newResponse as any)["__fixApplied"] = fixApplied;
   return newResponse;
 }
@@ -410,43 +402,63 @@ export function convertGeneratedTable(table: GeneratedTable): LogsTable {
  */
 export function convertBatchQueryResponseHelper(
   response: GeneratedBatchQueryResponse
-): Partial<LogsQueryResult> {
+): LogsQueryPartialResult | LogsQuerySuccessfulResult | LogsQueryError {
   try {
     const parsedResponseBody: GeneratedBatchQueryResults = JSON.parse(
       response.body as any
     ) as GeneratedBatchQueryResults;
-    return {
-      visualization: parsedResponseBody.render,
-      status: "Success", // Assume success until shown otherwise.
-      statistics: parsedResponseBody.statistics,
-      error: mapError(parsedResponseBody.error), // ? { ...parsedResponseBody.error, name: "Error" } : undefined,
-      tables: parsedResponseBody.tables?.map((table: GeneratedTable) =>
-        convertGeneratedTable(table)
-      )
-    };
+
+    return computeResultType(parsedResponseBody);
   } catch (e) {
-    return {
-      visualization: response.body?.render,
-      status: "Success", // Assume success until shown otherwise.
-      statistics: response.body?.statistics,
-      error: mapError(response.body?.error),
-      tables: response.body?.tables?.map((table: GeneratedTable) => convertGeneratedTable(table))
-    };
+    if (response.body) return computeResultType(response.body);
+    else return {} as LogsQuerySuccessfulResult;
   }
 }
 
-export function mapError(error?: GeneratedErrorInfo): LogsErrorInfo | undefined {
-  if (error) {
-    let innermostError = error;
-    while (innermostError.innerError) {
-      innermostError = innermostError.innerError;
-    }
-
-    return {
-      name: "Error",
-      code: error.code,
-      message: `${error.message}.  ${innermostError.message}`
+export function computeResultType(
+  generatedResponse: GeneratedBatchQueryResults
+): LogsQueryPartialResult | LogsQuerySuccessfulResult | LogsQueryError {
+  if (!generatedResponse.error) {
+    const result: LogsQuerySuccessfulResult = {
+      visualization: generatedResponse.render,
+      status: LogsQueryResultStatus.Success,
+      statistics: generatedResponse.statistics,
+      tables:
+        generatedResponse.tables?.map((table: GeneratedTable) => convertGeneratedTable(table)) || []
     };
+    return result;
+  } else {
+    if (generatedResponse.tables) {
+      const result: LogsQueryPartialResult = {
+        visualization: generatedResponse.render,
+        status: LogsQueryResultStatus.PartialFailure,
+        statistics: generatedResponse.statistics,
+        incompleteTables: generatedResponse.tables?.map((table: GeneratedTable) =>
+          convertGeneratedTable(table)
+        ),
+        partialError: mapError(generatedResponse.error)
+      };
+      return result;
+    } else {
+      const errorInfo: LogsErrorInfo = mapError(generatedResponse.error);
+      const result: LogsQueryError = {
+        status: LogsQueryResultStatus.Failure,
+        ...errorInfo
+      };
+      return result;
+    }
   }
-  return undefined;
+}
+
+export function mapError(error: GeneratedErrorInfo): LogsErrorInfo {
+  let innermostError = error;
+  while (innermostError.innerError) {
+    innermostError = innermostError.innerError;
+  }
+
+  return {
+    name: "Error",
+    code: error.code,
+    message: `${error.message}.  ${innermostError.message}`
+  };
 }

--- a/sdk/monitor/monitor-query/src/logsQueryClient.ts
+++ b/sdk/monitor/monitor-query/src/logsQueryClient.ts
@@ -25,6 +25,7 @@ import { formatPreferHeader } from "./internal/util";
 import { CommonClientOptions, FullOperationResponse, OperationOptions } from "@azure/core-client";
 import { QueryTimeInterval } from "./models/timeInterval";
 import { convertTimespanToInterval } from "./timespanConversion";
+import { SDK_VERSION } from "./constants";
 
 const defaultMonitorScope = "https://api.loganalytics.io/.default";
 
@@ -63,7 +64,7 @@ export class LogsQueryClient {
     const credentialOptions = {
       credentialScopes: options?.audience
     };
-    const packageDetails = `azsdk-js-monitor-query/1.0.0-beta.6`;
+    const packageDetails = `azsdk-js-monitor-query/${SDK_VERSION}`;
     const userAgentPrefix =
       options?.userAgentOptions && options?.userAgentOptions.userAgentPrefix
         ? `${options?.userAgentOptions.userAgentPrefix} ${packageDetails}`

--- a/sdk/monitor/monitor-query/src/logsQueryClient.ts
+++ b/sdk/monitor/monitor-query/src/logsQueryClient.ts
@@ -63,12 +63,20 @@ export class LogsQueryClient {
     const credentialOptions = {
       credentialScopes: options?.audience
     };
+    const packageDetails = `azsdk-js-monitor-query/1.0.0-beta.6`;
+    const userAgentPrefix =
+      options?.userAgentOptions && options?.userAgentOptions.userAgentPrefix
+        ? `${options?.userAgentOptions.userAgentPrefix} ${packageDetails}`
+        : `${packageDetails}`;
     this._logAnalytics = new AzureLogAnalytics({
       ...options,
       $host: options?.endpoint,
       endpoint: options?.endpoint,
       credentialScopes: credentialOptions?.credentialScopes ?? defaultMonitorScope,
-      credential: tokenCredential
+      credential: tokenCredential,
+      userAgentOptions: {
+        userAgentPrefix
+      }
     });
   }
 

--- a/sdk/monitor/monitor-query/src/metricsQueryClient.ts
+++ b/sdk/monitor/monitor-query/src/metricsQueryClient.ts
@@ -32,7 +32,7 @@ import {
   convertResponseForMetrics,
   convertResponseForMetricsDefinitions
 } from "./internal/modelConverters";
-
+import { SDK_VERSION } from "./constants";
 const defaultMetricsScope = "https://management.azure.com/.default";
 
 /**
@@ -66,13 +66,20 @@ export class MetricsQueryClient {
     const credentialOptions = {
       credentialScopes: options?.audience
     };
-
+    const packageDetails = `azsdk-js-monitor-query/${SDK_VERSION}`;
+    const userAgentPrefix =
+      options?.userAgentOptions && options?.userAgentOptions.userAgentPrefix
+        ? `${options?.userAgentOptions.userAgentPrefix} ${packageDetails}`
+        : `${packageDetails}`;
     const serviceClientOptions = {
       ...options,
       $host: options?.endpoint,
       endpoint: options?.endpoint,
       credentialScopes: credentialOptions?.credentialScopes ?? defaultMetricsScope,
-      credential: tokenCredential
+      credential: tokenCredential,
+      userAgentOptions: {
+        userAgentPrefix
+      }
     };
 
     this._metricsClient = new GeneratedMetricsClient(

--- a/sdk/monitor/monitor-query/src/models/publicLogsModels.ts
+++ b/sdk/monitor/monitor-query/src/models/publicLogsModels.ts
@@ -35,10 +35,6 @@ export interface LogsQueryOptions extends OperationOptions {
    * Results will also include visualization information, in JSON format.
    */
   includeVisualization?: boolean;
-  /**
-   * If true, will cause this operation to throw if query operation did not succeed. default to "False"
-   */
-  throwOnAnyFailure?: boolean;
 }
 
 /**
@@ -58,27 +54,6 @@ export interface LogsErrorInfo extends Error {
   code: string;
 }
 
-/** Batch Error class for type of each error item in the {@link AggregateBatchError} list returned in logs query batch API */
-export class BatchError extends Error implements LogsErrorInfo {
-  /** A machine readable error code. */
-  code: string;
-
-  constructor(errorInfo: LogsErrorInfo) {
-    super();
-    this.name = "Error";
-    this.code = errorInfo.code;
-    this.message = errorInfo.message;
-  }
-}
-/** AggregateBatchError type for errors returned in logs query batch API*/
-export class AggregateBatchError extends Error {
-  /** Represents list of errors if thrown for the queries executed in the queryBatch operation */
-  errors: BatchError[];
-  constructor(errors: LogsErrorInfo[]) {
-    super();
-    this.errors = errors.map((x) => new BatchError(x));
-  }
-}
 /**
  * Tables and statistic results from a logs query.
  */
@@ -112,7 +87,7 @@ export interface LogsQuerySuccessfulResult {
 /** Result type for Partial Failure Scenario for logs queryWorkspace and queryBatch operations. */
 export interface LogsQueryPartialResult {
   /** Populated results from the query. */
-  incompleteTables: LogsTable[];
+  partialTables: LogsTable[];
   /** error information for partial errors or failed queries */
   partialError: LogsErrorInfo;
   /** Indicates that the query partially failed.*/
@@ -131,13 +106,8 @@ export interface LogsQueryError extends Error {
   status: LogsQueryResultStatus.Failure;
 }
 
-/** Configurable HTTP request settings and `throwOnAnyFailure` setting for the Logs query batch operation. */
-export interface LogsQueryBatchOptions extends OperationOptions {
-  /**
-   * If true, will cause the batch operation to throw if any query operations in the batch did not succeed.
-   */
-  throwOnAnyFailure?: boolean;
-}
+/** Configurable HTTP request settings for the Logs query batch operation. */
+export interface LogsQueryBatchOptions extends OperationOptions {}
 
 /** The Analytics query. Learn more about the [Analytics query syntax](https://azure.microsoft.com/documentation/articles/app-insights-analytics-reference/) */
 // NOTE: 'id' is added automatically by our LogsQueryClient.

--- a/sdk/monitor/monitor-query/src/models/publicLogsModels.ts
+++ b/sdk/monitor/monitor-query/src/models/publicLogsModels.ts
@@ -86,21 +86,22 @@ export class AggregateBatchError extends Error {
 export type LogsQueryResult = LogsQuerySuccessfulResult | LogsQueryPartialResult;
 
 /** Indicates if a query succeeded or failed or partially failed.
- * Represented by "Partial" | "Success" | "Failed".
- * For partially failed queries, users can find data in "tables" attribute
- * and error information in "error" attribute */
+ * Represented by PartialFailure" | "Success" | "Failure".
+ */
 export enum LogsQueryResultStatus {
+  /** Represents Partial Failure scenario where partial data and errors of type {@link LogsQueryPartialResult} is returned for query */
   PartialFailure = "PartialFailure",
+  /** Represents Failure scenario where only error of type {@link LogsQueryError} is returned for query */
   Failure = "Failure",
+  /** Represents Success scenario where all data of type {@link LogsQuerySuccessfulResult} is returned for query */
   Success = "Success"
 }
+
+/** Result type for Success Scenario for logs query workspace and query batch operations. */
 export interface LogsQuerySuccessfulResult {
   /** Populated results from the query. */
   tables: LogsTable[];
-  /** Indicates if a query succeeded or failed or partially failed.
-   * Represented by "Partial" | "Success" | "Failed".
-   * For partially failed queries, users can find data in "tables" attribute
-   * and error information in "error" attribute */
+  /** Indicates that the query succeeded */
   status: LogsQueryResultStatus.Success;
   /** Statistics represented in JSON format. */
   statistics?: Record<string, unknown>;
@@ -108,15 +109,13 @@ export interface LogsQuerySuccessfulResult {
   visualization?: Record<string, unknown>;
 }
 
+/** Result type for Partial Failure Scenario for logs queryWorkspace and queryBatch operations. */
 export interface LogsQueryPartialResult {
   /** Populated results from the query. */
   incompleteTables: LogsTable[];
   /** error information for partial errors or failed queries */
   partialError: LogsErrorInfo;
-  /** Indicates if a query succeeded or failed or partially failed.
-   * Represented by "Partial" | "Success" | "Failed".
-   * For partially failed queries, users can find data in "tables" attribute
-   * and error information in "error" attribute */
+  /** Indicates that the query partially failed.*/
   status: LogsQueryResultStatus.PartialFailure;
   /** Statistics represented in JSON format. */
   statistics?: Record<string, unknown>;
@@ -124,16 +123,14 @@ export interface LogsQueryPartialResult {
   visualization?: Record<string, unknown>;
 }
 
-/** The code and message for an error. */
+/** Result type for Failure Scenario representing error for logs queryWorkspace and queryBatch operations. */
 export interface LogsQueryError extends Error {
   /** A machine readable error code. */
   code: string;
-  /** Indicates if a query succeeded or failed or partially failed.
-   * Represented by "Partial" | "Success" | "Failed".
-   * For partially failed queries, users can find data in "tables" attribute
-   * and error information in "error" attribute */
+  /** Indicates that the query failed */
   status: LogsQueryResultStatus.Failure;
 }
+
 /** Configurable HTTP request settings and `throwOnAnyFailure` setting for the Logs query batch operation. */
 export interface LogsQueryBatchOptions extends OperationOptions {
   /**
@@ -180,39 +177,12 @@ export interface QueryBatch {
   includeVisualization?: boolean;
 }
 
-/** Results for a batch query. */
-// export interface LogsQueryBatchResult {
-//   /** An array of responses corresponding to each individual request in a batch. */
-//   results: {
-//     /** Populated results from the query */
-//     tables?: LogsTable[];
-//     /** error information for partial errors or failed queries */
-//     error?: LogsErrorInfo;
-//     /** Indicates if a query succeeded or failed or partially failed.
-//      * Represented by "Partial" | "Success" | "Failed".
-//      * For partially failed queries, users can find data in "tables" attribute
-//      * and error information in "error" attribute */
-//     status?: LogsQueryResultStatus;
-//     /** Statistics represented in JSON format. */
-//     statistics?: Record<string, unknown>;
-//     /** Visualization data in JSON format. */
-//     visualization?: Record<string, unknown>;
-//   }[];
-// }
-
-/** Results for a batch query. */
+/** Results for a batch query. Each result in the array is either of type
+ *  {@link LogsQueryError} or {@link LogsQueryPartialResult} or {@link LogsQuerySuccessfulResult}
+ */
 export type LogsQueryBatchResult = Array<
   LogsQueryPartialResult | LogsQuerySuccessfulResult | LogsQueryError
 >;
-// export interface LogsQueryBatchResult {
-//   /** An array of responses corresponding to each individual request in a batch. */
-//   results: LogsQuerySuccessfulResult[] | LogsQueryPartialResult[] | LogsQueryError[];
-// }
-/** Indicates if a query succeeded or failed or partially failed.
- * Represented by "Partial" | "Success" | "Failed".
- * For partially failed queries, users can find data in "tables" attribute
- * and error information in "error" attribute */
-//export type LogsQueryResultStatus = "PartialFailure" | "Success" | "Failure";
 
 /** Contains the columns and rows for one table in a query response. */
 export interface LogsTable {

--- a/sdk/monitor/monitor-query/src/models/publicLogsModels.ts
+++ b/sdk/monitor/monitor-query/src/models/publicLogsModels.ts
@@ -36,7 +36,7 @@ export interface LogsQueryOptions extends OperationOptions {
    */
   includeVisualization?: boolean;
   /**
-   * If true, will cause this operation to throw if query operation did not succeed.
+   * If true, will cause this operation to throw if query operation did not succeed. default to "False"
    */
   throwOnAnyFailure?: boolean;
 }
@@ -83,22 +83,57 @@ export class AggregateBatchError extends Error {
  * Tables and statistic results from a logs query.
  */
 
-export interface LogsQueryResult {
+export type LogsQueryResult = LogsQuerySuccessfulResult | LogsQueryPartialResult;
+
+/** Indicates if a query succeeded or failed or partially failed.
+ * Represented by "Partial" | "Success" | "Failed".
+ * For partially failed queries, users can find data in "tables" attribute
+ * and error information in "error" attribute */
+export enum LogsQueryResultStatus {
+  PartialFailure = "PartialFailure",
+  Failure = "Failure",
+  Success = "Success"
+}
+export interface LogsQuerySuccessfulResult {
   /** Populated results from the query. */
   tables: LogsTable[];
-  /** error information for partial errors or failed queries */
-  error?: LogsErrorInfo;
   /** Indicates if a query succeeded or failed or partially failed.
    * Represented by "Partial" | "Success" | "Failed".
    * For partially failed queries, users can find data in "tables" attribute
    * and error information in "error" attribute */
-  status: LogsQueryResultStatus;
+  status: LogsQueryResultStatus.Success;
   /** Statistics represented in JSON format. */
   statistics?: Record<string, unknown>;
   /** Visualization data in JSON format. */
   visualization?: Record<string, unknown>;
 }
 
+export interface LogsQueryPartialResult {
+  /** Populated results from the query. */
+  incompleteTables: LogsTable[];
+  /** error information for partial errors or failed queries */
+  partialError: LogsErrorInfo;
+  /** Indicates if a query succeeded or failed or partially failed.
+   * Represented by "Partial" | "Success" | "Failed".
+   * For partially failed queries, users can find data in "tables" attribute
+   * and error information in "error" attribute */
+  status: LogsQueryResultStatus.PartialFailure;
+  /** Statistics represented in JSON format. */
+  statistics?: Record<string, unknown>;
+  /** Visualization data in JSON format. */
+  visualization?: Record<string, unknown>;
+}
+
+/** The code and message for an error. */
+export interface LogsQueryError extends Error {
+  /** A machine readable error code. */
+  code: string;
+  /** Indicates if a query succeeded or failed or partially failed.
+   * Represented by "Partial" | "Success" | "Failed".
+   * For partially failed queries, users can find data in "tables" attribute
+   * and error information in "error" attribute */
+  status: LogsQueryResultStatus.Failure;
+}
 /** Configurable HTTP request settings and `throwOnAnyFailure` setting for the Logs query batch operation. */
 export interface LogsQueryBatchOptions extends OperationOptions {
   /**
@@ -146,30 +181,38 @@ export interface QueryBatch {
 }
 
 /** Results for a batch query. */
-export interface LogsQueryBatchResult {
-  /** An array of responses corresponding to each individual request in a batch. */
-  results: {
-    /** Populated results from the query */
-    tables?: LogsTable[];
-    /** error information for partial errors or failed queries */
-    error?: LogsErrorInfo;
-    /** Indicates if a query succeeded or failed or partially failed.
-     * Represented by "Partial" | "Success" | "Failed".
-     * For partially failed queries, users can find data in "tables" attribute
-     * and error information in "error" attribute */
-    status?: LogsQueryResultStatus;
-    /** Statistics represented in JSON format. */
-    statistics?: Record<string, unknown>;
-    /** Visualization data in JSON format. */
-    visualization?: Record<string, unknown>;
-  }[];
-}
+// export interface LogsQueryBatchResult {
+//   /** An array of responses corresponding to each individual request in a batch. */
+//   results: {
+//     /** Populated results from the query */
+//     tables?: LogsTable[];
+//     /** error information for partial errors or failed queries */
+//     error?: LogsErrorInfo;
+//     /** Indicates if a query succeeded or failed or partially failed.
+//      * Represented by "Partial" | "Success" | "Failed".
+//      * For partially failed queries, users can find data in "tables" attribute
+//      * and error information in "error" attribute */
+//     status?: LogsQueryResultStatus;
+//     /** Statistics represented in JSON format. */
+//     statistics?: Record<string, unknown>;
+//     /** Visualization data in JSON format. */
+//     visualization?: Record<string, unknown>;
+//   }[];
+// }
 
+/** Results for a batch query. */
+export type LogsQueryBatchResult = Array<
+  LogsQueryPartialResult | LogsQuerySuccessfulResult | LogsQueryError
+>;
+// export interface LogsQueryBatchResult {
+//   /** An array of responses corresponding to each individual request in a batch. */
+//   results: LogsQuerySuccessfulResult[] | LogsQueryPartialResult[] | LogsQueryError[];
+// }
 /** Indicates if a query succeeded or failed or partially failed.
  * Represented by "Partial" | "Success" | "Failed".
  * For partially failed queries, users can find data in "tables" attribute
  * and error information in "error" attribute */
-export type LogsQueryResultStatus = "PartialFailure" | "Success" | "Failure";
+//export type LogsQueryResultStatus = "PartialFailure" | "Success" | "Failure";
 
 /** Contains the columns and rows for one table in a query response. */
 export interface LogsTable {

--- a/sdk/monitor/monitor-query/src/models/publicLogsModels.ts
+++ b/sdk/monitor/monitor-query/src/models/publicLogsModels.ts
@@ -109,7 +109,7 @@ export interface LogsQueryError extends Error {
 /** Configurable HTTP request settings for the Logs query batch operation. */
 export interface LogsQueryBatchOptions extends OperationOptions {}
 
-/** The Analytics query. Learn more about the [Analytics query syntax](https://azure.microsoft.com/documentation/articles/app-insights-analytics-reference/) */
+/** The Kusto query. For more information about Kusto, see [Kusto query overview](https://docs.microsoft.com/azure/data-explorer/kusto/query). */
 // NOTE: 'id' is added automatically by our LogsQueryClient.
 export interface QueryBatch {
   /** The workspace for this query. */

--- a/sdk/monitor/monitor-query/test/public/logsQueryClient.spec.ts
+++ b/sdk/monitor/monitor-query/test/public/logsQueryClient.spec.ts
@@ -6,7 +6,13 @@ import { Context } from "mocha";
 import { env } from "process";
 import { createRecorderAndLogsClient, RecorderAndLogsClient } from "./shared/testShared";
 import { Recorder } from "@azure-tools/test-recorder";
-import { Durations, LogsQueryClient, QueryBatch } from "../../src";
+import {
+  BatchError,
+  Durations,
+  LogsQueryClient,
+  LogsQueryResultStatus,
+  QueryBatch
+} from "../../src";
 // import { runWithTelemetry } from "../setupOpenTelemetry";
 
 import { assertQueryTable, getMonitorWorkspaceId, loggerForTest } from "./shared/testShared";
@@ -135,71 +141,72 @@ describe("LogsQueryClient live tests", function() {
     const results = await logsClient.queryWorkspace(monitorWorkspaceId, constantsQuery, {
       duration: Durations.fiveMinutes
     });
+    if (results.status === LogsQueryResultStatus.Success) {
+      const table = results.tables[0];
 
-    const table = results.tables[0];
+      // check the column types all match what we expect.
+      assert.deepEqual(
+        [
+          {
+            name: "stringcolumn",
+            type: "string"
+          },
+          {
+            name: "boolcolumn",
+            type: "bool"
+          },
+          {
+            name: "datecolumn",
+            type: "datetime"
+          },
+          {
+            name: "intcolumn",
+            type: "int"
+          },
+          {
+            name: "longcolumn",
+            type: "long"
+          },
+          {
+            name: "realcolumn",
+            type: "real"
+          },
+          {
+            name: "dynamiccolumn",
+            type: "dynamic"
+          }
+        ],
+        table.columnDescriptors
+      );
 
-    // check the column types all match what we expect.
-    assert.deepEqual(
-      [
-        {
-          name: "stringcolumn",
-          type: "string"
-        },
-        {
-          name: "boolcolumn",
-          type: "bool"
-        },
-        {
-          name: "datecolumn",
-          type: "datetime"
-        },
-        {
-          name: "intcolumn",
-          type: "int"
-        },
-        {
-          name: "longcolumn",
-          type: "long"
-        },
-        {
-          name: "realcolumn",
-          type: "real"
-        },
-        {
-          name: "dynamiccolumn",
-          type: "dynamic"
-        }
-      ],
-      table.columnDescriptors
-    );
+      table.rows.map((rowValues) => {
+        const [
+          stringColumn,
+          boolColumn,
+          dateColumn,
+          intColumn,
+          longColumn,
+          realColumn,
+          dynamicColumn,
+          ...rest
+        ] = rowValues;
 
-    table.rows.map((rowValues) => {
-      const [
-        stringColumn,
-        boolColumn,
-        dateColumn,
-        intColumn,
-        longColumn,
-        realColumn,
-        dynamicColumn,
-        ...rest
-      ] = rowValues;
+        assert.strictEqual(stringColumn, "hello");
+        assert.equal((dateColumn as Date).valueOf(), new Date("2000-01-02 03:04:05Z").valueOf());
+        assert.strictEqual(boolColumn, true);
 
-      assert.strictEqual(stringColumn, "hello");
-      assert.equal((dateColumn as Date).valueOf(), new Date("2000-01-02 03:04:05Z").valueOf());
-      assert.strictEqual(boolColumn, true);
+        // all the number types (real, int, long) are all represented using `number`
+        assert.strictEqual(intColumn, 100);
+        assert.strictEqual(longColumn, 101);
+        assert.strictEqual(realColumn, 102.1);
 
-      // all the number types (real, int, long) are all represented using `number`
-      assert.strictEqual(intColumn, 100);
-      assert.strictEqual(longColumn, 101);
-      assert.strictEqual(realColumn, 102.1);
+        assert.deepEqual(dynamicColumn, {
+          hello: "world"
+        });
 
-      assert.deepEqual(dynamicColumn, {
-        hello: "world"
+        assert.isEmpty(rest);
       });
-
-      assert.isEmpty(rest);
-    });
+    }
   });
 
   it("queryLogsBatch with types", async () => {
@@ -225,82 +232,79 @@ describe("LogsQueryClient live tests", function() {
     if ((result as any)["__fixApplied"]) {
       console.log(`TODO: Fix was required to pass`);
     }
+    if (result[0].status === LogsQueryResultStatus.Success) {
+      const table = result[0].tables[0];
+      console.log(JSON.stringify(result[0].tables));
 
-    const table = result.results?.[0].tables?.[0];
-    console.log(JSON.stringify(result.results?.[0].tables));
-
-    if (table == null) {
-      throw new Error(JSON.stringify(result.results?.[0].error));
-    }
-
-    if (result.results?.[0].status === "PartialFailure") {
-      throw new Error(
-        JSON.stringify({ ...result.results?.[0].error, ...result.results?.[0].tables })
+      // check the column types all match what we expect.
+      assert.deepEqual(
+        [
+          {
+            name: "stringcolumn",
+            type: "string"
+          },
+          {
+            name: "boolcolumn",
+            type: "bool"
+          },
+          {
+            name: "datecolumn",
+            type: "datetime"
+          },
+          {
+            name: "intcolumn",
+            type: "int"
+          },
+          {
+            name: "longcolumn",
+            type: "long"
+          },
+          {
+            name: "realcolumn",
+            type: "real"
+          },
+          {
+            name: "dynamiccolumn",
+            type: "dynamic"
+          }
+        ],
+        table.columnDescriptors
       );
-    }
 
-    // check the column types all match what we expect.
-    assert.deepEqual(
-      [
-        {
-          name: "stringcolumn",
-          type: "string"
-        },
-        {
-          name: "boolcolumn",
-          type: "bool"
-        },
-        {
-          name: "datecolumn",
-          type: "datetime"
-        },
-        {
-          name: "intcolumn",
-          type: "int"
-        },
-        {
-          name: "longcolumn",
-          type: "long"
-        },
-        {
-          name: "realcolumn",
-          type: "real"
-        },
-        {
-          name: "dynamiccolumn",
-          type: "dynamic"
-        }
-      ],
-      table.columnDescriptors
-    );
+      table.rows.map((rowValues) => {
+        const [
+          stringColumn,
+          boolColumn,
+          dateColumn,
+          intColumn,
+          longColumn,
+          realColumn,
+          dynamicColumn,
+          ...rest
+        ] = rowValues;
 
-    table.rows.map((rowValues) => {
-      const [
-        stringColumn,
-        boolColumn,
-        dateColumn,
-        intColumn,
-        longColumn,
-        realColumn,
-        dynamicColumn,
-        ...rest
-      ] = rowValues;
+        assert.strictEqual(stringColumn, "hello");
+        assert.equal((dateColumn as Date).valueOf(), new Date("2000-01-02 03:04:05Z").valueOf());
+        assert.strictEqual(boolColumn, true);
 
-      assert.strictEqual(stringColumn, "hello");
-      assert.equal((dateColumn as Date).valueOf(), new Date("2000-01-02 03:04:05Z").valueOf());
-      assert.strictEqual(boolColumn, true);
+        // all the number types (real, int, long) are all represented using `number`
+        assert.strictEqual(intColumn, 100);
+        assert.strictEqual(longColumn, 101);
+        assert.strictEqual(realColumn, 102.1);
 
-      // all the number types (real, int, long) are all represented using `number`
-      assert.strictEqual(intColumn, 100);
-      assert.strictEqual(longColumn, 101);
-      assert.strictEqual(realColumn, 102.1);
+        assert.deepEqual(dynamicColumn, {
+          hello: "world"
+        });
 
-      assert.deepEqual(dynamicColumn, {
-        hello: "world"
+        assert.isEmpty(rest);
       });
-
-      assert.isEmpty(rest);
-    });
+    }
+    if (result[0].status === LogsQueryResultStatus.PartialFailure) {
+      throw new Error(JSON.stringify({ ...result[0].partialError, ...result[0].incompleteTables }));
+    }
+    if (result[0].status === LogsQueryResultStatus.Failure) {
+      throw new BatchError(result[0]);
+    }
   });
 
   describe.skip("Ingested data tests (can be slow due to loading times)", () => {
@@ -347,16 +351,17 @@ describe("LogsQueryClient live tests", function() {
 
       // TODO: the actual types aren't being deserialized (everything is coming back as 'string')
       // this is incorrect, it'll be updated.
-
-      assertQueryTable(
-        singleQueryLogsResult.tables?.[0],
-        {
-          name: "PrimaryResult",
-          columns: ["Kind", "Name", "Target", "TestRunId"],
-          rows: [["now", "testSpan", "testSpan", testRunId.toString()]]
-        },
-        "Query for the last day"
-      );
+      if (singleQueryLogsResult.status === LogsQueryResultStatus.Success) {
+        assertQueryTable(
+          singleQueryLogsResult.tables?.[0],
+          {
+            name: "PrimaryResult",
+            columns: ["Kind", "Name", "Target", "TestRunId"],
+            rows: [["now", "testSpan", "testSpan", testRunId.toString()]]
+          },
+          "Query for the last day"
+        );
+      }
     });
 
     it("queryLogsBatch", async () => {
@@ -380,26 +385,28 @@ describe("LogsQueryClient live tests", function() {
       if ((result as any)["__fixApplied"]) {
         console.log(`TODO: Fix was required to pass`);
       }
-
-      assertQueryTable(
-        result.results?.[0].tables?.[0],
-        {
-          name: "PrimaryResult",
-          columns: ["Kind", "Name", "Target", "TestRunId"],
-          rows: [["now", "testSpan", "testSpan", testRunId.toString()]]
-        },
-        "Standard results"
-      );
-
-      assertQueryTable(
-        result.results?.[1].tables?.[0],
-        {
-          name: "PrimaryResult",
-          columns: ["Count"],
-          rows: [["1"]]
-        },
-        "count table"
-      );
+      if (result[0].status === LogsQueryResultStatus.Success) {
+        assertQueryTable(
+          result[0].tables?.[0],
+          {
+            name: "PrimaryResult",
+            columns: ["Kind", "Name", "Target", "TestRunId"],
+            rows: [["now", "testSpan", "testSpan", testRunId.toString()]]
+          },
+          "Standard results"
+        );
+      }
+      if (result[1].status === LogsQueryResultStatus.Success) {
+        assertQueryTable(
+          result[1].tables?.[0],
+          {
+            name: "PrimaryResult",
+            columns: ["Count"],
+            rows: [["1"]]
+          },
+          "count table"
+        );
+      }
     });
 
     async function checkLogsHaveBeenIngested(args: {
@@ -419,13 +426,24 @@ describe("LogsQueryClient live tests", function() {
           duration: Durations.twentyFourHours
         });
 
-        const numRows = result.tables?.[0].rows?.length;
+        if (result.status === LogsQueryResultStatus.Success) {
+          const numRows = result.tables?.[0].rows?.length;
 
-        if (numRows != null && numRows > 0) {
-          loggerForTest.verbose(
-            `[Attempt: ${i}/${args.maxTries}] Results came back, done waiting.`
-          );
-          return;
+          if (numRows != null && numRows > 0) {
+            loggerForTest.verbose(
+              `[Attempt: ${i}/${args.maxTries}] Results came back, done waiting.`
+            );
+            return;
+          }
+        } else if (result.status === LogsQueryResultStatus.PartialFailure) {
+          const numRows = result.incompleteTables?.[0].rows?.length;
+
+          if (numRows != null && numRows > 0) {
+            loggerForTest.verbose(
+              `[Attempt: ${i}/${args.maxTries}] Partial Results came back, done waiting.`
+            );
+            return;
+          }
         }
 
         loggerForTest.verbose(

--- a/sdk/monitor/monitor-query/test/public/logsQueryClient.spec.ts
+++ b/sdk/monitor/monitor-query/test/public/logsQueryClient.spec.ts
@@ -6,13 +6,7 @@ import { Context } from "mocha";
 import { env } from "process";
 import { createRecorderAndLogsClient, RecorderAndLogsClient } from "./shared/testShared";
 import { Recorder } from "@azure-tools/test-recorder";
-import {
-  BatchError,
-  Durations,
-  LogsQueryClient,
-  LogsQueryResultStatus,
-  QueryBatch
-} from "../../src";
+import { Durations, LogsQueryClient, LogsQueryResultStatus, QueryBatch } from "../../src";
 // import { runWithTelemetry } from "../setupOpenTelemetry";
 
 import { assertQueryTable, getMonitorWorkspaceId, loggerForTest } from "./shared/testShared";
@@ -300,10 +294,10 @@ describe("LogsQueryClient live tests", function() {
       });
     }
     if (result[0].status === LogsQueryResultStatus.PartialFailure) {
-      throw new Error(JSON.stringify({ ...result[0].partialError, ...result[0].incompleteTables }));
+      throw new Error(JSON.stringify({ ...result[0].partialError, ...result[0].partialTables }));
     }
     if (result[0].status === LogsQueryResultStatus.Failure) {
-      throw new BatchError(result[0]);
+      throw new Error(JSON.stringify({ ...result[0] }));
     }
   });
 
@@ -436,7 +430,7 @@ describe("LogsQueryClient live tests", function() {
             return;
           }
         } else if (result.status === LogsQueryResultStatus.PartialFailure) {
-          const numRows = result.incompleteTables?.[0].rows?.length;
+          const numRows = result.partialTables?.[0].rows?.length;
 
           if (numRows != null && numRows > 0) {
             loggerForTest.verbose(


### PR DESCRIPTION
- Using a similar approach to Python by returning different types of result objects for each case
- The service team is concerned that if the user forgets to use the flag, how will they be notified that this is a partial failure case and not continue to blindly read the data from the result object. 
- This approach forces the user to be aware of the type of success scenario for the query as well as get the partial data by not just blindly "throwing" the error from the partial failure scenario.

Other changes:
- Updated the user agent to be same for both clients