### PR TITLE
Remove canary test matrix node verison filter

### DIFF
--- a/eng/pipelines/templates/stages/archetype-sdk-tests.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-tests.yml
@@ -47,7 +47,6 @@ parameters:
         Location: 'centraluseuap'
         MatrixFilters:
           - OSVmImage=.*Ubuntu.*
-          - NodeTestVersion=10.x
           - DependencyVersion=^$
       UsGov:
         SubscriptionConfiguration: $(sub-config-gov-test-resources)


### PR DESCRIPTION
The canary cloud test matrix filters were created with the intent to only run a single test job for canary. The filter was a little too specific, and broke when [this change](https://github.com/Azure/azure-sdk-for-js/commit/072f7ab0b8bb3ba656071a3b3282c0b95576d519#diff-6d57a4119ae22b0fede4d3aab5dff565cee910416d4eaa647d83e1d749c9b559) updated the matrix such that there was no longer a matching entry for ubuntu+node10.

Since there is only one matching ubuntu entry with this filter anyway, remove the restrictive node 10 filter so it's more future proof.

CC @praveenkuttappan 