### PR TITLE
Add typescript to dictionaries in cspell.json

### DIFF
--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -2,7 +2,7 @@
   "version": "0.1",
   "language": "en",
   "languageId": "typescript,javascript",
-  "dictionaries": ["powershell"],
+  "dictionaries": ["powershell", "typescript"],
   "ignorePaths": [
     "**/node_modules/**",
     "**/recordings/**",


### PR DESCRIPTION
Fixes #15248 
Add typescript to dictionaries in cspell.json
Tested by adding `instanceof` in any .md file and run `npx cspell --config .vscode/cspell.json`
```
npx cspell --config .vscode/cspell.json README.md 
1/1 .\README.md 495.98ms X
c:\Users\kevan\Desktop\test\azure-sdk-for-js\README.md:55:110 - Unknown word (MSRC)
c:\Users\kevan\Desktop\test\azure-sdk-for-js\README.md:55:325 - Unknown word (MSRC)
CSpell: Files checked: 1, Issues found: 2 in 1 files                    
```