### PR TITLE
[Identity] Small improvements to the InteractiveBrowserCredential live tests

### DIFF
--- a/sdk/identity/identity/test/manual/nodeTest.js
+++ b/sdk/identity/identity/test/manual/nodeTest.js
@@ -5,6 +5,7 @@ const dotenv = require("dotenv");
 // Ensure you have a .env file in the same directory with something similar to:
 //
 //   AZURE_CLIENT_ID="value"
+//   AZURE_TENANT_ID="value"
 //   AZURE_CLIENT_SECRET="value"
 //   SERVICE_BUS_ENDPOINT="value"
 //   QUEUE_NAME="value"

--- a/sdk/identity/identity/test/manual/nodeTestSilent.js
+++ b/sdk/identity/identity/test/manual/nodeTestSilent.js
@@ -1,10 +1,14 @@
 const identity = require("@azure/identity");
 const serviceBus = require("@azure/service-bus");
 const dotenv = require("dotenv");
+const { cachePersistencePlugin } = require("@azure/identity-cache-persistence");
+
+identity.useIdentityPlugin(cachePersistencePlugin);
 
 // Ensure you have a .env file in the same directory with something similar to:
 //
 //   AZURE_CLIENT_ID="value"
+//   AZURE_TENANT_ID="value"
 //   AZURE_CLIENT_SECRET="value"
 //   SERVICE_BUS_ENDPOINT="value"
 //   QUEUE_NAME="value"

--- a/sdk/identity/identity/test/manual/package.json
+++ b/sdk/identity/identity/test/manual/package.json
@@ -16,11 +16,12 @@
     "@azure/service-bus": "^7.0.3",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
-    "tslib": "^1.9.3"
+    "tslib": "1.9.3"
   },
   "devDependencies": {
+    "@azure/identity-cache-persistence": "^1.0.0-beta.2",
     "@types/express": "^4.16.0",
-    "@types/node": "^12.0.0",
+    "@types/node": "12.0.0",
     "@types/react": "^16.8.24",
     "@types/react-dom": "^16.8.5",
     "@types/webpack": "^4.4.13",


### PR DESCRIPTION
The newer version of these packages cause new errors, so I’m sticking with the older ones just to have a more consistent experience over time. I’m also adding the new persistent cache plugin.