### PR TITLE
Reduce page width for code snippets in ref docs

### DIFF
--- a/sdk/storage/storage-blob/src/ContainerClient.ts
+++ b/sdk/storage/storage-blob/src/ContainerClient.ts
@@ -1614,7 +1614,7 @@ export class ContainerClient extends StorageClient {
    *   if (item.kind === "prefix") {
    *     console.log(`\tBlobPrefix: ${item.name}`);
    *   } else {
-   *     console.log(`\tBlobItem: name - ${item.name}, last modified - ${item.properties.lastModified}`);
+   *     console.log(`\tBlobItem: name - ${item.name}`);
    *   }
    * }
    * ```
@@ -1629,7 +1629,7 @@ export class ContainerClient extends StorageClient {
    *   if (item.kind === "prefix") {
    *     console.log(`\tBlobPrefix: ${item.name}`);
    *   } else {
-   *     console.log(`\tBlobItem: name - ${item.name}, last modified - ${item.properties.lastModified}`);
+   *     console.log(`\tBlobItem: name - ${item.name}`);
    *   }
    *   entity = await iter.next();
    * }
@@ -1647,7 +1647,7 @@ export class ContainerClient extends StorageClient {
    *     }
    *   }
    *   for (const blob of response.segment.blobItems) {
-   *     console.log(`\tBlobItem: name - ${blob.name}, last modified - ${blob.properties.lastModified}`);
+   *     console.log(`\tBlobItem: name - ${blob.name}`);
    *   }
    * }
    * ```
@@ -1658,7 +1658,9 @@ export class ContainerClient extends StorageClient {
    * console.log("Listing blobs by hierarchy by page, specifying a prefix and a max page size");
    *
    * let i = 1;
-   * for await (const response of containerClient.listBlobsByHierarchy("/", { prefix: "prefix2/sub1/"}).byPage({ maxPageSize: 2 })) {
+   * for await (const response of containerClient
+   *   .listBlobsByHierarchy("/", { prefix: "prefix2/sub1/" })
+   *   .byPage({ maxPageSize: 2 })) {
    *   console.log(`Page ${i++}`);
    *   const segment = response.segment;
    *
@@ -1669,7 +1671,7 @@ export class ContainerClient extends StorageClient {
    *   }
    *
    *   for (const blob of response.segment.blobItems) {
-   *     console.log(`\tBlobItem: name - ${blob.name}, last modified - ${blob.properties.lastModified}`);
+   *     console.log(`\tBlobItem: name - ${blob.name}`);
    *   }
    * }
    * ```


### PR DESCRIPTION
The ref docs for `listBlobsByHierarchy` under the [Methods](https://docs.microsoft.com/en-us/javascript/api/@azure/storage-blob/containerclient?view=azure-node-latest#methods) are causing the entire table to be too wide. This is because the code snippets used here do not wrap

While this should ideally be fixed by the reference doc rendering platform, this PR updates the ref docs to not have too long lines to see if this fixes the issue
- removed the printing of last modified as it does not add any value to us showing of async iterator works
- formatted one of the code snippets to span across multiple lines