### PR TITLE
Re-enable api extractor when building abort-controller

### DIFF
--- a/sdk/core/abort-controller/package.json
+++ b/sdk/core/abort-controller/package.json
@@ -10,7 +10,7 @@
     "build:samples": "echo Obsolete",
     "build:test": "tsc -p . && rollup -c 2>&1",
     "build:types": "downlevel-dts types/src types/3.1",
-    "build": "npm run clean && tsc -p . && rollup -c 2>&1 && npm run build:types",
+    "build": "npm run clean && npm run extract-api && rollup -c 2>&1 && npm run build:types",
     "check-format": "prettier --list-different --config ../../../.prettierrc.json --ignore-path ../../../.prettierignore \"src/**/*.ts\" \"test/**/*.ts\" \"*.{js,json}\"",
     "clean": "rimraf dist dist-* temp types *.tgz *.log",
     "docs": "typedoc --excludePrivate --excludeNotExported --excludeExternals --stripInternal --mode file --out ./dist/docs ./src",

--- a/sdk/core/abort-controller/package.json
+++ b/sdk/core/abort-controller/package.json
@@ -10,7 +10,7 @@
     "build:samples": "echo Obsolete",
     "build:test": "tsc -p . && rollup -c 2>&1",
     "build:types": "downlevel-dts types/src types/3.1",
-    "build": "npm run clean && npm run extract-api && rollup -c 2>&1 && npm run build:types",
+    "build": "npm run clean && tsc -p . && rollup -c 2>&1 && api-extractor run --local && npm run build:types",
     "check-format": "prettier --list-different --config ../../../.prettierrc.json --ignore-path ../../../.prettierignore \"src/**/*.ts\" \"test/**/*.ts\" \"*.{js,json}\"",
     "clean": "rimraf dist dist-* temp types *.tgz *.log",
     "docs": "typedoc --excludePrivate --excludeNotExported --excludeExternals --stripInternal --mode file --out ./dist/docs ./src",


### PR DESCRIPTION
This PR re-enables the use of api extractor in the build step for the abort-controller package.
I no longer see the problems reported in #10320 

Fixes #10320