### PR TITLE
[Identity] What if we accepted the PEM certificate string contents?

### DIFF
--- a/sdk/identity/identity/CHANGELOG.md
+++ b/sdk/identity/identity/CHANGELOG.md
@@ -4,7 +4,13 @@
 
 ### Features Added
 
+- `ClientCertificateCredential` now accepts the string contents of the PEM certificate besides the path to the PEM certificate through the new type `ClientCertificateCredentialPEMConfiguration`.
+
 ### Breaking Changes
+
+#### Breaking changes from 2.0.0-beta.6 and 1.5.2
+
+- `ClientCertificateCredential` now won't accept a PEM certificate path as its third parameter. It will accept an object with the type `ClientCertificateCredentialPEMConfiguration` containing either a property named `certificate` with the string contents of the PEM certificate, or a property named `certificatePath`, with the path to the PEM certificate.
 
 #### Breaking Changes from 2.0.0-beta.4
 

--- a/sdk/identity/identity/recordings/node/clientcertificatecredential/recording_authenticates_with_a_pem_certificate_string_directly.js
+++ b/sdk/identity/identity/recordings/node/clientcertificatecredential/recording_authenticates_with_a_pem_certificate_string_directly.js
@@ -1,0 +1,111 @@
+let nock = require('nock');
+
+module.exports.hash = "38da4cb7a62135aa74a632f2c43db5f5";
+
+module.exports.testInfo = {"uniqueName":{},"newDate":{}}
+
+nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
+  .get('/common/discovery/instance')
+  .query(true)
+  .reply(200, {"tenant_discovery_endpoint":"https://login.microsoftonline.com/12345678-1234-1234-1234-123456789012/v2.0/.well-known/openid-configuration","api-version":"1.1","metadata":[{"preferred_network":"login.microsoftonline.com","preferred_cache":"login.windows.net","aliases":["login.microsoftonline.com","login.windows.net","login.microsoft.com","sts.windows.net"]},{"preferred_network":"login.partner.microsoftonline.cn","preferred_cache":"login.partner.microsoftonline.cn","aliases":["login.partner.microsoftonline.cn","login.chinacloudapi.cn"]},{"preferred_network":"login.microsoftonline.de","preferred_cache":"login.microsoftonline.de","aliases":["login.microsoftonline.de"]},{"preferred_network":"login.microsoftonline.us","preferred_cache":"login.microsoftonline.us","aliases":["login.microsoftonline.us","login.usgovcloudapi.net"]},{"preferred_network":"login-us.microsoftonline.com","preferred_cache":"login-us.microsoftonline.com","aliases":["login-us.microsoftonline.com"]}]}, [
+  'Cache-Control',
+  'max-age=86400, private',
+  'Content-Length',
+  '980',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Access-Control-Allow-Origin',
+  '*',
+  'Access-Control-Allow-Methods',
+  'GET, OPTIONS',
+  'P3P',
+  'CP="DSP CUR OTPi IND OTRi ONL FIN"',
+  'x-ms-request-id',
+  '2f3aa91d-85fa-46e5-9332-53f7527d5c00',
+  'x-ms-ests-server',
+  '2.1.11562.8 - EUS ProdSlices',
+  'Set-Cookie',
+  'fpc=fpc;; expires=Sat, 17-Apr-2021 00:06:25 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'Set-Cookie',
+  'esctx=esctx; domain=.login.microsoftonline.com; path=/; secure; HttpOnly; SameSite=None',
+  'Set-Cookie',
+  'x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly',
+  'Set-Cookie',
+  'stsservicecookie=estsfd; path=/; secure; samesite=none; httponly',
+  'Date',
+  'Thu, 18 Mar 2021 00:06:25 GMT'
+]);
+
+nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
+  .get('/12345678-1234-1234-1234-123456789012/v2.0/.well-known/openid-configuration')
+  .reply(200, {"token_endpoint":"https://login.microsoftonline.com/12345678-1234-1234-1234-123456789012/oauth2/v2.0/token","token_endpoint_auth_methods_supported":["client_secret_post","private_key_jwt","client_secret_basic"],"jwks_uri":"https://login.microsoftonline.com/12345678-1234-1234-1234-123456789012/discovery/v2.0/keys","response_modes_supported":["query","fragment","form_post"],"subject_types_supported":["pairwise"],"id_token_signing_alg_values_supported":["RS256"],"response_types_supported":["code","id_token","code id_token","id_token token"],"scopes_supported":["openid","profile","email","offline_access"],"issuer":"https://login.microsoftonline.com/12345678-1234-1234-1234-123456789012/v2.0","request_uri_parameter_supported":false,"userinfo_endpoint":"https://graph.microsoft.com/oidc/userinfo","authorization_endpoint":"https://login.microsoftonline.com/12345678-1234-1234-1234-123456789012/oauth2/v2.0/authorize","device_authorization_endpoint":"https://login.microsoftonline.com/12345678-1234-1234-1234-123456789012/oauth2/v2.0/devicecode","http_logout_supported":true,"frontchannel_logout_supported":true,"end_session_endpoint":"https://login.microsoftonline.com/12345678-1234-1234-1234-123456789012/oauth2/v2.0/logout","claims_supported":["sub","iss","cloud_instance_name","cloud_instance_host_name","cloud_graph_host_name","msgraph_host","aud","exp","iat","auth_time","acr","nonce","preferred_username","name","tid","ver","at_hash","c_hash","email"],"tenant_region_scope":"NA","cloud_instance_name":"microsoftonline.com","cloud_graph_host_name":"graph.windows.net","msgraph_host":"graph.microsoft.com","rbac_url":"https://pas.windows.net"}, [
+  'Cache-Control',
+  'max-age=86400, private',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Access-Control-Allow-Origin',
+  '*',
+  'Access-Control-Allow-Methods',
+  'GET, OPTIONS',
+  'P3P',
+  'CP="DSP CUR OTPi IND OTRi ONL FIN"',
+  'x-ms-request-id',
+  'ed427c4c-2412-4779-b953-022030bb9f00',
+  'x-ms-ests-server',
+  '2.1.11562.8 - NCUS ProdSlices',
+  'Set-Cookie',
+  'fpc=fpc;; expires=Sat, 17-Apr-2021 00:06:25 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'Set-Cookie',
+  'esctx=esctx; domain=.login.microsoftonline.com; path=/; secure; HttpOnly; SameSite=None',
+  'Set-Cookie',
+  'x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly',
+  'Set-Cookie',
+  'stsservicecookie=estsfd; path=/; secure; samesite=none; httponly',
+  'Date',
+  'Thu, 18 Mar 2021 00:06:25 GMT',
+  'Content-Length',
+  '1651'
+]);
+
+nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
+  .post('/12345678-1234-1234-1234-123456789012/oauth2/v2.0/token', "client_id=azure_client_id&scope=https%3A%2F%2Fvault.azure.net%2F.default%20openid%20profile%20offline_access&grant_type=client_credentials&client-request-id=client-request-id&client_assertion=client_assertion&client_assertion_type=urn%3Aietf%3Aparams%3Aoauth%3Aclient-assertion-type%3Ajwt-bearer")
+  .reply(200, {"token_type":"Bearer","expires_in":3599,"ext_expires_in":3599,"access_token":"access_token"}, [
+  'Cache-Control',
+  'no-store, no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Length',
+  '1313',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'P3P',
+  'CP="DSP CUR OTPi IND OTRi ONL FIN"',
+  'x-ms-request-id',
+  '765f6b5f-61c2-4629-b6b7-6f0949a92e01',
+  'x-ms-ests-server',
+  '2.1.11562.8 - WUS2 ProdSlices',
+  'x-ms-clitelem',
+  '1,0,0,,',
+  'Set-Cookie',
+  'fpc=fpc;; expires=Sat, 17-Apr-2021 00:06:25 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'Set-Cookie',
+  'x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly',
+  'Set-Cookie',
+  'stsservicecookie=estsfd; path=/; secure; samesite=none; httponly',
+  'Date',
+  'Thu, 18 Mar 2021 00:06:25 GMT'
+]);

--- a/sdk/identity/identity/recordings/node/clientcertificatecredential_internal/recording_throws_when_given_a_certificate_that_isnt_pemformatted.js
+++ b/sdk/identity/identity/recordings/node/clientcertificatecredential_internal/recording_throws_when_given_a_certificate_that_isnt_pemformatted.js
@@ -1,0 +1,5 @@
+let nock = require('nock');
+
+module.exports.hash = "c100a894aa2deeedb7bb51aef7bef444";
+
+module.exports.testInfo = {"uniqueName":{},"newDate":{}}

--- a/sdk/identity/identity/review/identity.api.md
+++ b/sdk/identity/identity/review/identity.api.md
@@ -108,7 +108,8 @@ export class ChainedTokenCredential implements TokenCredential {
 
 // @public
 export class ClientCertificateCredential implements TokenCredential {
-    constructor(tenantId: string, clientId: string, certificatePath: string, options?: ClientCertificateCredentialOptions);
+    // Warning: (ae-forgotten-export) The symbol "ClientCertificateCredentialPEMConfiguration" needs to be exported by the entry point index.d.ts
+    constructor(tenantId: string, clientId: string, configuration: ClientCertificateCredentialPEMConfiguration, options?: ClientCertificateCredentialOptions);
     getToken(scopes: string | string[], options?: GetTokenOptions): Promise<AccessToken>;
     }
 

--- a/sdk/identity/identity/src/credentials/clientCertificateCredential.ts
+++ b/sdk/identity/identity/src/credentials/clientCertificateCredential.ts
@@ -9,7 +9,33 @@ import { trace } from "../util/tracing";
 import { MsalFlow } from "../msal/flows";
 import { ClientCertificateCredentialOptions } from "./clientCertificateCredentialOptions";
 
-const logger = credentialLogger("ClientCertificateCredential");
+const credentialName = "ClientCertificateCredential";
+const logger = credentialLogger(credentialName);
+
+/**
+ * Required configuration options for the {@link ClientCertificateCredential}, with either the string contents of a PEM certificate, or the path to a PEM certificate.
+ */
+export type ClientCertificateCredentialPEMConfiguration =
+  | {
+      /**
+       * The PEM-encoded public/private key certificate on the filesystem.
+       */
+      certificate: string;
+      /**
+       * The PEM-encoded public/private key certificate on the filesystem     should not be provided if `certificate` is provided.
+       */
+      certificatePath?: never;
+    }
+  | {
+      /**
+       * The PEM-encoded public/private key certificate on the filesystem should not be provided if `certificatePath` is provided.
+       */
+      certificate?: never;
+      /**
+       * The path to the PEM-encoded public/private key certificate on the filesystem.
+       */
+      certificatePath: string;
+    };
 
 /**
  * Enables authentication to Azure Active Directory using a PEM-encoded
@@ -28,23 +54,26 @@ export class ClientCertificateCredential implements TokenCredential {
    *
    * @param tenantId - The Azure Active Directory tenant (directory) ID.
    * @param clientId - The client (application) ID of an App Registration in the tenant.
-   * @param certificatePath - The path to a PEM-encoded public/private key certificate on the filesystem.
+   * @param configuration - Other parameters required, including the PEM-encoded certificate as a string, or as a path on the filesystem.
    * @param options - Options for configuring the client which makes the authentication request.
    */
   constructor(
     tenantId: string,
     clientId: string,
-    certificatePath: string,
+    configuration: ClientCertificateCredentialPEMConfiguration,
     options: ClientCertificateCredentialOptions = {}
   ) {
-    if (!tenantId || !clientId || !certificatePath) {
+    if (!tenantId || !clientId) {
+      throw new Error(`${credentialName}: tenantId and clientId are required parameters.`);
+    }
+    if (!configuration || !(configuration.certificate || configuration.certificatePath)) {
       throw new Error(
-        "ClientCertificateCredential: tenantId, clientId, and certificatePath are required parameters."
+        `${credentialName}: Provide either a PEM certificate in string form, or the path to that certificate in the filesystem.`
       );
     }
     this.msalFlow = new MsalClientCertificate({
       ...options,
-      certificatePath,
+      configuration,
       logger,
       clientId,
       tenantId,
@@ -62,7 +91,7 @@ export class ClientCertificateCredential implements TokenCredential {
    *                TokenCredential implementation might make.
    */
   async getToken(scopes: string | string[], options: GetTokenOptions = {}): Promise<AccessToken> {
-    return trace(`${this.constructor.name}.getToken`, options, async (newOptions) => {
+    return trace(`${credentialName}.getToken`, options, async (newOptions) => {
       const arrayScopes = Array.isArray(scopes) ? scopes : [scopes];
       return this.msalFlow.getToken(arrayScopes, newOptions);
     });

--- a/sdk/identity/identity/src/credentials/environmentCredential.ts
+++ b/sdk/identity/identity/src/credentials/environmentCredential.ts
@@ -114,7 +114,7 @@ export class EnvironmentCredential implements TokenCredential {
       this._credential = new ClientCertificateCredential(
         tenantId,
         clientId,
-        certificatePath,
+        { certificatePath },
         options
       );
       return;

--- a/sdk/identity/identity/src/msal/nodeFlows/msalClientCertificate.ts
+++ b/sdk/identity/identity/src/msal/nodeFlows/msalClientCertificate.ts
@@ -9,6 +9,7 @@ import { AccessToken } from "@azure/core-auth";
 import { MsalNodeOptions, MsalNode } from "./nodeCommon";
 import { formatError } from "../../util/logging";
 import { CredentialFlowGetTokenOptions } from "../credentials";
+import { ClientCertificateCredentialPEMConfiguration } from "../../credentials/clientCertificateCredential";
 
 const readFileAsync = promisify(readFile);
 
@@ -20,7 +21,7 @@ export interface MSALClientCertificateOptions extends MsalNodeOptions {
   /**
    * Location of the PEM certificate.
    */
-  certificatePath: string;
+  configuration: ClientCertificateCredentialPEMConfiguration;
   /**
    * Option to include x5c header for SubjectName and Issuer name authorization.
    * Set this option to send base64 encoded public certificate in the client assertion header as an x5c claim
@@ -50,18 +51,19 @@ interface CertificateParts {
 /**
  * Tries to asynchronously load a certificate from the given path.
  *
- * @param certificatePath - Path to the certificate.
+ * @param configuration - Either the PEM value or the path to the certificate.
  * @param sendCertificateChain - Option to include x5c header for SubjectName and Issuer name authorization.
  * @returns - The certificate parts, or `undefined` if the certificate could not be loaded.
  * @internal
  */
 export async function parseCertificate(
-  certificatePath: string,
+  configuration: ClientCertificateCredentialPEMConfiguration,
   sendCertificateChain?: boolean
 ): Promise<CertificateParts> {
   const certificateParts: Partial<CertificateParts> = {};
 
-  certificateParts.certificateContents = await readFileAsync(certificatePath, "utf8");
+  certificateParts.certificateContents =
+    configuration.certificate || (await readFileAsync(configuration.certificatePath!, "utf8"));
   if (sendCertificateChain) {
     certificateParts.x5c = certificateParts.certificateContents;
   }
@@ -95,20 +97,20 @@ export async function parseCertificate(
  * @internal
  */
 export class MsalClientCertificate extends MsalNode {
-  private certificatePath: string;
+  private configuration: ClientCertificateCredentialPEMConfiguration;
   private sendCertificateChain?: boolean;
 
   constructor(options: MSALClientCertificateOptions) {
     super(options);
     this.requiresConfidential = true;
-    this.certificatePath = options.certificatePath;
+    this.configuration = options.configuration;
     this.sendCertificateChain = options.sendCertificateChain;
   }
 
   // Changing the MSAL configuration asynchronously
   async init(options?: CredentialFlowGetTokenOptions): Promise<void> {
     try {
-      const parts = await parseCertificate(this.certificatePath, this.sendCertificateChain);
+      const parts = await parseCertificate(this.configuration, this.sendCertificateChain);
       this.msalConfig.auth.clientCertificate = {
         thumbprint: parts.thumbprint,
         privateKey: parts.certificateContents,

--- a/sdk/identity/identity/src/msal/nodeFlows/msalOnBehalfOf.ts
+++ b/sdk/identity/identity/src/msal/nodeFlows/msalOnBehalfOf.ts
@@ -55,7 +55,10 @@ export class MsalOnBehalfOf extends MsalNode {
   async init(options?: CredentialFlowGetTokenOptions): Promise<void> {
     if (this.certificatePath) {
       try {
-        const parts = await parseCertificate(this.certificatePath, this.sendCertificateChain);
+        const parts = await parseCertificate(
+          { certificatePath: this.certificatePath },
+          this.sendCertificateChain
+        );
         this.msalConfig.auth.clientCertificate = {
           thumbprint: parts.thumbprint,
           privateKey: parts.certificateContents,

--- a/sdk/identity/identity/test/public/node/clientCertificateCredential.spec.ts
+++ b/sdk/identity/identity/test/public/node/clientCertificateCredential.spec.ts
@@ -10,6 +10,7 @@ import { env, isPlaybackMode, delay, isLiveMode } from "@azure-tools/test-record
 import { MsalTestCleanup, msalNodeTestSetup, testTracing } from "../../msalTestUtils";
 import { ClientCertificateCredential } from "../../../src";
 import { Context } from "mocha";
+import { readFileSync } from "fs";
 
 const ASSET_PATH = "assets";
 
@@ -30,18 +31,25 @@ describe("ClientCertificateCredential", function() {
       // Live test run not supported on CI at the moment. Locally should work though.
       this.skip();
     }
-    if (isPlaybackMode()) {
-      // MSAL creates a client assertion based on the certificate that I haven't been able to mock.
-      // This assertion could be provided as parameters, but we don't have that in the public API yet,
-      // and I'm trying to avoid having to generate one ourselves.
+
+    const credential = new ClientCertificateCredential(env.AZURE_TENANT_ID, env.AZURE_CLIENT_ID, {
+      certificatePath
+    });
+
+    const token = await credential.getToken(scope);
+    assert.ok(token?.token);
+    assert.ok(token?.expiresOnTimestamp! > Date.now());
+  });
+
+  it("authenticates with a PEM certificate string directly", async function(this: Context) {
+    if (isLiveMode()) {
+      // Live test run not supported on CI at the moment. Locally should work though.
       this.skip();
     }
 
-    const credential = new ClientCertificateCredential(
-      env.AZURE_TENANT_ID,
-      env.AZURE_CLIENT_ID,
-      certificatePath
-    );
+    const credential = new ClientCertificateCredential(env.AZURE_TENANT_ID, env.AZURE_CLIENT_ID, {
+      certificate: readFileSync(certificatePath, { encoding: "utf-8" })
+    });
 
     const token = await credential.getToken(scope);
     assert.ok(token?.token);
@@ -63,7 +71,7 @@ describe("ClientCertificateCredential", function() {
     const credential = new ClientCertificateCredential(
       env.AZURE_TENANT_ID,
       env.AZURE_CLIENT_ID,
-      certificatePath,
+      { certificatePath },
       { sendCertificateChain: true }
     );
 
@@ -73,11 +81,9 @@ describe("ClientCertificateCredential", function() {
   });
 
   it("allows cancelling the authentication", async function() {
-    const credential = new ClientCertificateCredential(
-      env.AZURE_TENANT_ID,
-      env.AZURE_CLIENT_ID,
+    const credential = new ClientCertificateCredential(env.AZURE_TENANT_ID, env.AZURE_CLIENT_ID, {
       certificatePath
-    );
+    });
 
     const controller = new AbortController();
     const getTokenPromise = credential.getToken(scope, {
@@ -113,7 +119,7 @@ describe("ClientCertificateCredential", function() {
         const credential = new ClientCertificateCredential(
           env.AZURE_TENANT_ID,
           env.AZURE_CLIENT_ID,
-          certificatePath
+          { certificatePath }
         );
 
         await credential.getToken(scope, {


### PR DESCRIPTION
This PR serves to explore the idea of changing the public API of ClientCertificateCredential before we release v2, to allow users to either pass the path to a PEM certificate in the filesystem, or the string certificate contents directly.

This could help us provide a better experience for issues similar to #17715

Feedback appreciated 🙏 