### PR TITLE
[Identity] Disabling regional authority support

### DIFF
--- a/sdk/identity/identity/CHANGELOG.md
+++ b/sdk/identity/identity/CHANGELOG.md
@@ -9,6 +9,7 @@
 #### Breaking Changes from 2.0.0-beta.4
 
 - Removed the `allowMultiTenantAuthentication` option from all of the credentials. Multi-tenant authentication is now enabled by default. On Node.js, it can be disabled with the `AZURE_IDENTITY_DISABLE_MULTITENANTAUTH` environment variable.
+- Removed rdded regional support from client credential types. Also removed support for the `AZURE_REGIONAL_AUTHORITY_NAME` environment variable.
 
 
 ### Bugs Fixed

--- a/sdk/identity/identity/CHANGELOG.md
+++ b/sdk/identity/identity/CHANGELOG.md
@@ -9,7 +9,7 @@
 #### Breaking Changes from 2.0.0-beta.4
 
 - Removed the `allowMultiTenantAuthentication` option from all of the credentials. Multi-tenant authentication is now enabled by default. On Node.js, it can be disabled with the `AZURE_IDENTITY_DISABLE_MULTITENANTAUTH` environment variable.
-- Removed rdded regional support from client credential types. Also removed support for the `AZURE_REGIONAL_AUTHORITY_NAME` environment variable.
+- Removed support for specific Azure regions on `ClientSecretCredential` and `ClientCertificateCredential. This feature will be added back on the next beta.
 
 
 ### Bugs Fixed

--- a/sdk/identity/identity/review/identity.api.md
+++ b/sdk/identity/identity/review/identity.api.md
@@ -114,7 +114,6 @@ export class ClientCertificateCredential implements TokenCredential {
 
 // @public
 export interface ClientCertificateCredentialOptions extends TokenCredentialOptions, CredentialPersistenceOptions {
-    regionalAuthority?: string;
     sendCertificateChain?: boolean;
 }
 
@@ -126,7 +125,6 @@ export class ClientSecretCredential implements TokenCredential {
 
 // @public
 export interface ClientSecretCredentialOptions extends TokenCredentialOptions, CredentialPersistenceOptions {
-    regionalAuthority?: string;
 }
 
 // @public
@@ -273,63 +271,6 @@ export interface OnBehalfOfCredentialSecretConfiguration {
     clientSecret: string;
     tenantId: string;
     userAssertionToken: string;
-}
-
-// @public
-export enum RegionalAuthority {
-    AsiaEast = "eastasia",
-    AsiaSouthEast = "southeastasia",
-    AustraliaCentral = "australiacentral",
-    AustraliaCentral2 = "australiacentral2",
-    AustraliaEast = "australiaeast",
-    AustraliaSouthEast = "australiasoutheast",
-    AutoDiscoverRegion = "AutoDiscoverRegion",
-    BrazilSouth = "brazilsouth",
-    CanadaCentral = "canadacentral",
-    CanadaEast = "canadaeast",
-    ChinaEast = "chinaeast",
-    ChinaEast2 = "chinaeast2",
-    ChinaNorth = "chinanorth",
-    ChinaNorth2 = "chinanorth2",
-    EuropeNorth = "northeurope",
-    EuropeWest = "westeurope",
-    FranceCentral = "francecentral",
-    FranceSouth = "francesouth",
-    GermanyCentral = "germanycentral",
-    GermanyNorth = "germanynorth",
-    GermanyNorthEast = "germanynortheast",
-    GermanyWestCentral = "germanywestcentral",
-    GovernmentUSArizona = "usgovarizona",
-    GovernmentUSDodCentral = "usdodcentral",
-    GovernmentUSDodEast = "usdodeast",
-    GovernmentUSIowa = "usgoviowa",
-    GovernmentUSTexas = "usgovtexas",
-    GovernmentUSVirginia = "usgovvirginia",
-    IndiaCentral = "centralindia",
-    IndiaSouth = "southindia",
-    IndiaWest = "westindia",
-    JapanEast = "japaneast",
-    JapanWest = "japanwest",
-    KoreaCentral = "koreacentral",
-    KoreaSouth = "koreasouth",
-    NorwayEast = "norwayeast",
-    NorwayWest = "norwaywest",
-    SouthAfricaNorth = "southafricanorth",
-    SouthAfricaWest = "southafricawest",
-    SwitzerlandNorth = "switzerlandnorth",
-    SwitzerlandWest = "switzerlandwest",
-    UAECentral = "uaecentral",
-    UAENorth = "uaenorth",
-    UKSouth = "uksouth",
-    UKWest = "ukwest",
-    USCentral = "centralus",
-    USEast = "eastus",
-    USEast2 = "eastus2",
-    USNorthCentral = "northcentralus",
-    USSouthCentral = "southcentralus",
-    USWest = "westus",
-    USWest2 = "westus2",
-    USWestCentral = "westcentralus"
 }
 
 // @public

--- a/sdk/identity/identity/src/credentials/clientCertificateCredentialOptions.ts
+++ b/sdk/identity/identity/src/credentials/clientCertificateCredentialOptions.ts
@@ -15,10 +15,11 @@ export interface ClientCertificateCredentialOptions
    * Set this option to send base64 encoded public certificate in the client assertion header as an x5c claim
    */
   sendCertificateChain?: boolean;
-  /**
-   * Specifies a regional authority. Please refer to the {@link RegionalAuthority} type for the accepted values.
-   * If {@link RegionalAuthority.AutoDiscoverRegion} is specified, we will try to discover the regional authority endpoint.
-   * If the property is not specified, the credential uses the global authority endpoint.
-   */
-  regionalAuthority?: string;
+  // TODO: Export again once we're ready to release this feature.
+  // /**
+  //  * Specifies a regional authority. Please refer to the {@link RegionalAuthority} type for the accepted values.
+  //  * If {@link RegionalAuthority.AutoDiscoverRegion} is specified, we will try to discover the regional authority endpoint.
+  //  * If the property is not specified, the credential uses the global authority endpoint.
+  //  */
+  // regionalAuthority?: string;
 }

--- a/sdk/identity/identity/src/credentials/clientSecretCredentialOptions.ts
+++ b/sdk/identity/identity/src/credentials/clientSecretCredentialOptions.ts
@@ -10,10 +10,11 @@ import { CredentialPersistenceOptions } from "./credentialPersistenceOptions";
 export interface ClientSecretCredentialOptions
   extends TokenCredentialOptions,
     CredentialPersistenceOptions {
-  /**
-   * Specifies a regional authority. Please refer to the {@link RegionalAuthority} type for the accepted values.
-   * If {@link RegionalAuthority.AutoDiscoverRegion} is specified, we will try to discover the regional authority endpoint.
-   * If the property is not specified, the credential uses the global authority endpoint.
-   */
-  regionalAuthority?: string;
+  // TODO: Export again once we're ready to release this feature.
+  // /**
+  //  * Specifies a regional authority. Please refer to the {@link RegionalAuthority} type for the accepted values.
+  //  * If {@link RegionalAuthority.AutoDiscoverRegion} is specified, we will try to discover the regional authority endpoint.
+  //  * If the property is not specified, the credential uses the global authority endpoint.
+  //  */
+  // regionalAuthority?: string;
 }

--- a/sdk/identity/identity/src/index.ts
+++ b/sdk/identity/identity/src/index.ts
@@ -12,7 +12,10 @@ export { AuthenticationRecord } from "./msal/types";
 export { AuthenticationRequiredError } from "./msal/errors";
 export { serializeAuthenticationRecord, deserializeAuthenticationRecord } from "./msal/utils";
 export { TokenCredentialOptions } from "./client/identityClient";
-export { RegionalAuthority } from "./regionalAuthority";
+
+// TODO: Export again once we're ready to release this feature.
+// export { RegionalAuthority } from "./regionalAuthority";
+
 export { InteractiveCredentialOptions } from "./credentials/interactiveCredentialOptions";
 
 export { ChainedTokenCredential } from "./credentials/chainedTokenCredential";

--- a/sdk/identity/identity/src/msal/nodeFlows/nodeCommon.ts
+++ b/sdk/identity/identity/src/msal/nodeFlows/nodeCommon.ts
@@ -24,6 +24,7 @@ import {
 } from "../utils";
 import { TokenCachePersistenceOptions } from "./tokenCachePersistenceOptions";
 import { processMultiTenantRequest } from "../../util/validateMultiTenant";
+import { RegionalAuthority } from "../../regionalAuthority";
 
 /**
  * Union of the constructor parameters that all MSAL flow types for Node.
@@ -99,11 +100,10 @@ export abstract class MsalNode extends MsalBaseUtilities implements MsalFlow {
       );
     }
 
-    // TODO: Uncomment once we're ready to release this feature.
-    // this.azureRegion = options.regionalAuthority ?? process.env.AZURE_REGIONAL_AUTHORITY_NAME;
-    // if (this.azureRegion === RegionalAuthority.AutoDiscoverRegion) {
-    //   this.azureRegion = "AUTO_DISCOVER";
-    // }
+    this.azureRegion = options.regionalAuthority ?? process.env.AZURE_REGIONAL_AUTHORITY_NAME;
+    if (this.azureRegion === RegionalAuthority.AutoDiscoverRegion) {
+      this.azureRegion = "AUTO_DISCOVER";
+    }
   }
 
   /**

--- a/sdk/identity/identity/src/msal/nodeFlows/nodeCommon.ts
+++ b/sdk/identity/identity/src/msal/nodeFlows/nodeCommon.ts
@@ -23,7 +23,6 @@ import {
   publicToMsal
 } from "../utils";
 import { TokenCachePersistenceOptions } from "./tokenCachePersistenceOptions";
-import { RegionalAuthority } from "../../regionalAuthority";
 import { processMultiTenantRequest } from "../../util/validateMultiTenant";
 
 /**
@@ -100,10 +99,11 @@ export abstract class MsalNode extends MsalBaseUtilities implements MsalFlow {
       );
     }
 
-    this.azureRegion = options.regionalAuthority ?? process.env.AZURE_REGIONAL_AUTHORITY_NAME;
-    if (this.azureRegion === RegionalAuthority.AutoDiscoverRegion) {
-      this.azureRegion = "AUTO_DISCOVER";
-    }
+    // TODO: Uncomment once we're ready to release this feature.
+    // this.azureRegion = options.regionalAuthority ?? process.env.AZURE_REGIONAL_AUTHORITY_NAME;
+    // if (this.azureRegion === RegionalAuthority.AutoDiscoverRegion) {
+    //   this.azureRegion = "AUTO_DISCOVER";
+    // }
   }
 
   /**

--- a/sdk/identity/identity/test/internal/node/clientCertificateCredential.spec.ts
+++ b/sdk/identity/identity/test/internal/node/clientCertificateCredential.spec.ts
@@ -9,7 +9,7 @@ import * as path from "path";
 import { AbortController } from "@azure/abort-controller";
 import { env, isPlaybackMode, delay } from "@azure-tools/test-recorder";
 import { ConfidentialClientApplication } from "@azure/msal-node";
-import { ClientCertificateCredential, RegionalAuthority } from "../../../src";
+import { ClientCertificateCredential } from "../../../src";
 import { MsalTestCleanup, msalNodeTestSetup } from "../../msalTestUtils";
 import { MsalNode } from "../../../src/msal/nodeFlows/nodeCommon";
 import { Context } from "mocha";
@@ -121,13 +121,15 @@ describe("ClientCertificateCredential (internal)", function() {
     assert.equal(doGetTokenSpy.callCount, 2);
   });
 
-  it("supports specifying the regional authority", async function() {
+  // TODO: Enable again once we're ready to release this feature.
+  it.skip("supports specifying the regional authority", async function() {
     const credential = new ClientCertificateCredential(
       env.AZURE_TENANT_ID,
       env.AZURE_CLIENT_ID,
       certificatePath,
       {
-        regionalAuthority: RegionalAuthority.AutoDiscoverRegion
+        // TODO: Uncomment once we're ready to release this feature.
+        // regionalAuthority: RegionalAuthority.AutoDiscoverRegion
       }
     );
 

--- a/sdk/identity/identity/test/internal/node/clientSecretCredential.spec.ts
+++ b/sdk/identity/identity/test/internal/node/clientSecretCredential.spec.ts
@@ -8,7 +8,7 @@ import { assert } from "chai";
 import { AbortController } from "@azure/abort-controller";
 import { env, delay } from "@azure-tools/test-recorder";
 import { ConfidentialClientApplication } from "@azure/msal-node";
-import { ClientSecretCredential, RegionalAuthority } from "../../../src";
+import { ClientSecretCredential } from "../../../src";
 import { MsalTestCleanup, msalNodeTestSetup } from "../../msalTestUtils";
 import { MsalNode } from "../../../src/msal/nodeFlows/nodeCommon";
 import { Context } from "mocha";
@@ -85,13 +85,15 @@ describe("ClientSecretCredential (internal)", function() {
     assert.equal(doGetTokenSpy.callCount, 1);
   });
 
-  it("supports specifying the regional authority", async function() {
+  // TODO: Enable again once we're ready to release this feature.
+  it.skip("supports specifying the regional authority", async function() {
     const credential = new ClientSecretCredential(
       env.AZURE_TENANT_ID,
       env.AZURE_CLIENT_ID,
       env.AZURE_CLIENT_SECRET,
       {
-        regionalAuthority: RegionalAuthority.AutoDiscoverRegion
+        // TODO: Uncomment once we're ready to release this feature.
+        // regionalAuthority: RegionalAuthority.AutoDiscoverRegion
       }
     );
 

--- a/sdk/identity/identity/test/public/node/clientSecretCredential.spec.ts
+++ b/sdk/identity/identity/test/public/node/clientSecretCredential.spec.ts
@@ -7,7 +7,7 @@ import { assert } from "chai";
 import { env, delay, isRecordMode } from "@azure-tools/test-recorder";
 import { AbortController } from "@azure/abort-controller";
 import { MsalTestCleanup, msalNodeTestSetup, testTracing } from "../../msalTestUtils";
-import { ClientSecretCredential, RegionalAuthority } from "../../../src";
+import { ClientSecretCredential } from "../../../src";
 import { Context } from "mocha";
 
 describe("ClientSecretCredential", function() {
@@ -81,7 +81,8 @@ describe("ClientSecretCredential", function() {
     })
   );
 
-  it("supports specifying the regional authority", async function(this: Context) {
+  // TODO: Enable again once we're ready to release this feature.
+  it.skip("supports specifying the regional authority", async function(this: Context) {
     // This test is extremely slow. Let's skip it for now.
     // I've tried Sinon's clock and it doesn't affect it.
     // We have internal tests that check that the parameters are properly sent to MSAL, which should be enough from the perspective of the SDK.
@@ -94,7 +95,8 @@ describe("ClientSecretCredential", function() {
       env.AZURE_CLIENT_ID,
       env.AZURE_CLIENT_SECRET,
       {
-        regionalAuthority: RegionalAuthority.AutoDiscoverRegion
+        // TODO: Uncomment again once we're ready to release this feature.
+        // regionalAuthority: RegionalAuthority.AutoDiscoverRegion
       }
     );
 


### PR DESCRIPTION
This PR removes regional authority support in a way that it is easy to add right after the GA.