### PR TITLE
[Perf Framework] _cachedParsedOptions & simplifying options bag

### DIFF
--- a/sdk/storage/perf-tests/storage-blob/test/dowloadWithSAS.spec.ts
+++ b/sdk/storage/perf-tests/storage-blob/test/dowloadWithSAS.spec.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { PerfStressOptionDictionary, getEnvVar, drainStream } from "@azure/test-utils-perfstress";
+import { getEnvVar, drainStream } from "@azure/test-utils-perfstress";
 import { StorageBlobTest } from "./storageTest.spec";
 import {
   BlockBlobClient,
@@ -19,7 +19,7 @@ interface StorageBlobDownloadTestOptions {
 export class StorageBlobDownloadWithSASTest extends StorageBlobTest<
   StorageBlobDownloadTestOptions
 > {
-  public options: PerfStressOptionDictionary<StorageBlobDownloadTestOptions> = {
+  public options = this.getParsedOptions({
     size: {
       required: true,
       description: "Size in bytes",
@@ -27,7 +27,7 @@ export class StorageBlobDownloadWithSASTest extends StorageBlobTest<
       longName: "size",
       defaultValue: 10240
     }
-  };
+  });
 
   static blobName = generateUuid();
   blockBlobClient: BlockBlobClient;
@@ -65,8 +65,8 @@ export class StorageBlobDownloadWithSASTest extends StorageBlobTest<
 
     // Create a blob
     await this.blockBlobClient.upload(
-      Buffer.alloc(this.parsedOptions.size.value!),
-      this.parsedOptions.size.value!
+      Buffer.alloc(this.options.size.value!),
+      this.options.size.value!
     );
   }
 

--- a/sdk/storage/perf-tests/storage-blob/test/download.spec.ts
+++ b/sdk/storage/perf-tests/storage-blob/test/download.spec.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { drainStream, PerfStressOptionDictionary } from "@azure/test-utils-perfstress";
+import { drainStream } from "@azure/test-utils-perfstress";
 import { StorageBlobTest } from "./storageTest.spec";
 import { BlockBlobClient } from "@azure/storage-blob";
 import { generateUuid } from "@azure/core-http";
@@ -11,7 +11,7 @@ interface StorageBlobDownloadTestOptions {
 }
 
 export class StorageBlobDownloadTest extends StorageBlobTest<StorageBlobDownloadTestOptions> {
-  public options: PerfStressOptionDictionary<StorageBlobDownloadTestOptions> = {
+  public options = this.getParsedOptions({
     size: {
       required: true,
       description: "Size in bytes",
@@ -19,7 +19,7 @@ export class StorageBlobDownloadTest extends StorageBlobTest<StorageBlobDownload
       longName: "size",
       defaultValue: 10240
     }
-  };
+  });
 
   static blobName = generateUuid();
   blockBlobClient: BlockBlobClient;
@@ -36,8 +36,8 @@ export class StorageBlobDownloadTest extends StorageBlobTest<StorageBlobDownload
 
     // Create a blob
     await this.blockBlobClient.upload(
-      Buffer.alloc(this.parsedOptions.size.value!),
-      this.parsedOptions.size.value!
+      Buffer.alloc(this.options.size.value!),
+      this.options.size.value!
     );
   }
 

--- a/sdk/storage/perf-tests/storage-blob/test/listBlobs.spec.ts
+++ b/sdk/storage/perf-tests/storage-blob/test/listBlobs.spec.ts
@@ -2,21 +2,21 @@
 // Licensed under the MIT license.
 
 import { generateUuid } from "@azure/core-http";
-import { PerfStressOptionDictionary, executeParallel } from "@azure/test-utils-perfstress";
+import { executeParallel } from "@azure/test-utils-perfstress";
 import { StorageBlobTest } from "./storageTest.spec";
 interface StorageBlobListTestOptions {
   count: number;
 }
 
 export class StorageBlobListTest extends StorageBlobTest<StorageBlobListTestOptions> {
-  public options: PerfStressOptionDictionary<StorageBlobListTestOptions> = {
+  public options = this.getParsedOptions({
     count: {
       required: true,
       description: "Number of blobs to be listed",
       longName: "count",
       defaultValue: 10
     }
-  };
+  });
 
   public async globalSetup() {
     await super.globalSetup();
@@ -24,7 +24,7 @@ export class StorageBlobListTest extends StorageBlobTest<StorageBlobListTestOpti
       async (_count: number, _parallelIndex: number) => {
         await this.containerClient.uploadBlockBlob(generateUuid(), Buffer.alloc(0), 0);
       },
-      this.parsedOptions.count.value!,
+      this.options.count.value!,
       32
     );
   }

--- a/sdk/storage/perf-tests/storage-blob/test/upload.spec.ts
+++ b/sdk/storage/perf-tests/storage-blob/test/upload.spec.ts
@@ -2,7 +2,6 @@
 // Licensed under the MIT license.
 
 import { generateUuid } from "@azure/core-http";
-import { PerfStressOptionDictionary } from "@azure/test-utils-perfstress";
 import { StorageBlobTest } from "./storageTest.spec";
 
 interface StorageBlobUploadTestOptions {
@@ -12,7 +11,7 @@ interface StorageBlobUploadTestOptions {
 export class StorageBlobUploadTest extends StorageBlobTest<StorageBlobUploadTestOptions> {
   blobName: string;
   buffer: Buffer;
-  public options: PerfStressOptionDictionary<StorageBlobUploadTestOptions> = {
+  public options = this.getParsedOptions({
     size: {
       required: true,
       description: "Size in bytes",
@@ -20,19 +19,19 @@ export class StorageBlobUploadTest extends StorageBlobTest<StorageBlobUploadTest
       longName: "size",
       defaultValue: 10240
     }
-  };
+  });
 
   constructor() {
     super();
     this.blobName = generateUuid();
-    this.buffer = Buffer.alloc(this.parsedOptions.size.value!);
+    this.buffer = Buffer.alloc(this.options.size.value!);
   }
 
   async runAsync(): Promise<void> {
     await this.containerClient.uploadBlockBlob(
       this.blobName,
       this.buffer,
-      this.parsedOptions.size.value!
+      this.options.size.value!
     );
   }
 }

--- a/sdk/storage/perf-tests/storage-blob/test/uploadFromFile.spec.ts
+++ b/sdk/storage/perf-tests/storage-blob/test/uploadFromFile.spec.ts
@@ -23,7 +23,7 @@ export class StorageBlobUploadFileTest extends StorageBlobUploadTest {
   public async globalSetup() {
     await super.globalSetup();
     if (!(await fileExists(dirName))) await mkdir(dirName);
-    await writeFile(fileName, Buffer.alloc(this.parsedOptions.size.value!));
+    await writeFile(fileName, Buffer.alloc(this.options.size.value!));
   }
 
   public async globalCleanup() {

--- a/sdk/test-utils/perfstress/CHANGELOG.md
+++ b/sdk/test-utils/perfstress/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 1.0.0 (Unreleased)
 
+### 2021-10-04
+
+- [Improvement] `parsedOptions` was calculated each time it is accessed, cached it in [#18030](https://github.com/Azure/azure-sdk-for-js/pull/18030) instead.
+
 ### 2021-09-24
 
 - Instead of using the cached proxy-clients(to leverage the proxy-tool), we now get a new client for each of the instantiated PerfStressTest classes. [#17832](https://github.com/Azure/azure-sdk-for-js/pull/17832)

--- a/sdk/test-utils/perfstress/src/options.ts
+++ b/sdk/test-utils/perfstress/src/options.ts
@@ -54,6 +54,15 @@ export type PerfStressOptionDictionary<TOptions = {}> = {
 };
 
 /**
+ * Type that can come handy when dealing with both the default options and the custom options provided in the test.
+ *
+ * Expands to `PerfStressOptionDictionary<TOptions> & PerfStressOptionDictionary<DefaultPerfStressOptions>`
+ */
+export type PerfOptions<TOptions = {}> = PerfStressOptionDictionary<
+  TOptions & DefaultPerfStressOptions
+>;
+
+/**
  * These represent the default options the tests can assume.
  *
  * @interface DefaultPerfStressOptions

--- a/sdk/test-utils/perfstress/src/program.ts
+++ b/sdk/test-utils/perfstress/src/program.ts
@@ -5,9 +5,9 @@ import { AbortController } from "@azure/abort-controller";
 import { PerfStressTest, PerfStressTestConstructor } from "./tests";
 import {
   PerfStressOptionDictionary,
-  parsePerfStressOption,
   defaultPerfStressOptions,
-  DefaultPerfStressOptions
+  DefaultPerfStressOptions,
+  parsePerfStressOption
 } from "./options";
 import { PerfStressParallel } from "./parallel";
 import { TestProxyHttpClientV1, TestProxyHttpClient } from "./testProxyHttpClient";
@@ -263,11 +263,11 @@ export class PerfStressProgram {
     // --help, or -h
     if (this.parsedDefaultOptions.help.value) {
       console.log(`=== Help: Options that can be sent to ${this.testName} ===`);
-      console.table(this.tests[0].parsedOptions);
+      console.table(this.tests[0].options);
       return;
     }
 
-    const options = this.tests[0].parsedOptions;
+    const options = this.tests[0].options;
     console.log("=== Parsed options ===");
     console.table(options);
 
@@ -286,7 +286,7 @@ export class PerfStressProgram {
       }
     }
 
-    if (this.tests[0].parsedOptions["test-proxy"].value) {
+    if (this.tests[0].options["test-proxy"]?.value) {
       // Records requests(in runAsync method) for all the instantiated PerfStressTest classes,
       // and asks the proxy-tool to start playing back for future requests.
       await Promise.all(this.tests.map((test) => this.recordAndStartPlayback(test)));
@@ -301,7 +301,7 @@ export class PerfStressProgram {
       await this.runTest(i, Number(options.duration.value), "test");
     }
 
-    if (this.tests[0].parsedOptions["test-proxy"].value) {
+    if (this.tests[0].options["test-proxy"]?.value) {
       await Promise.all(this.tests.map((test) => this.stopPlayback(test)));
     }
 

--- a/sdk/test-utils/perfstress/src/tests.ts
+++ b/sdk/test-utils/perfstress/src/tests.ts
@@ -24,6 +24,8 @@ export interface PerfStressTestConstructor<TOptions extends {} = {}> {
   new (): PerfStressTest<TOptions>;
 }
 
+let _cachedParsedOptions = {};
+
 /**
  * Conveys the structure of any PerfStress test.
  * It allows developers to define the optional parameters to receive
@@ -39,14 +41,17 @@ export abstract class PerfStressTest<TOptions = {}> {
   public abstract options: PerfStressOptionDictionary<TOptions>;
 
   public get parsedOptions(): PerfStressOptionDictionary<TOptions & DefaultPerfStressOptions> {
+    if (!_cachedParsedOptions) {
+      _cachedParsedOptions = parsePerfStressOption({
+        ...this.options,
+        ...defaultPerfStressOptions
+      });
+    }
     // This cast is needed because TS thinks
     //   PerfStressOptionDictionary<TOptions & DefaultPerfStressOptions>
     //   is different from
     //   PerfStressOptionDictionary<TOptions> & PerfStressOptionDictionary<DefaultPerfStressOptions>
-    return parsePerfStressOption({
-      ...this.options,
-      ...defaultPerfStressOptions
-    }) as PerfStressOptionDictionary<TOptions & DefaultPerfStressOptions>;
+    return _cachedParsedOptions as PerfStressOptionDictionary<TOptions & DefaultPerfStressOptions>;
   }
 
   // Before and after running a bunch of the same test.

--- a/sdk/test-utils/perfstress/test/delay.spec.ts
+++ b/sdk/test-utils/perfstress/test/delay.spec.ts
@@ -36,7 +36,7 @@ export class Delay500ms extends PerfStressTest {
   /**
    * This test doesn't receive command line parameters.
    */
-  public options = {};
+  public options = this.getParsedOptions({});
 
   /**
    * Waits 500 milliseconds.

--- a/sdk/test-utils/perfstress/test/exception.spec.ts
+++ b/sdk/test-utils/perfstress/test/exception.spec.ts
@@ -9,7 +9,7 @@ import { PerfStressTest } from "../src";
  * Otherwise, errors thrown on every test call, where the test being called is a function returning a promise (an asynchronous function).
  */
 export class Exception extends PerfStressTest {
-  public options = {};
+  public options = this.getParsedOptions({});
 
   async runAsync(): Promise<void> {
     try {

--- a/sdk/test-utils/perfstress/test/nodeFetch.spec.ts
+++ b/sdk/test-utils/perfstress/test/nodeFetch.spec.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { PerfStressTest, PerfStressOptionDictionary } from "../src";
+import { PerfStressTest } from "../src";
 
 import fetch from "node-fetch";
 import * as http from "http";
@@ -17,7 +17,7 @@ export class NodeFetchTest extends PerfStressTest<NodeFetchOptions> {
 
   private url: string = "";
 
-  public options: PerfStressOptionDictionary<NodeFetchOptions> = {
+  public options = this.getParsedOptions({
     url: {
       required: true,
       description: "Required option",
@@ -26,7 +26,7 @@ export class NodeFetchTest extends PerfStressTest<NodeFetchOptions> {
       defaultValue: "http://bing.com",
       value: "http://bing.com"
     }
-  };
+  });
 
   public setup() {
     this.url = this.options.url.value as string;

--- a/sdk/test-utils/perfstress/test/noop.spec.ts
+++ b/sdk/test-utils/perfstress/test/noop.spec.ts
@@ -7,7 +7,7 @@ import { PerfStressTest } from "../src";
  * Should test the raw performance impact of the PerfStress framework for both synchronous and asynchronous tests.
  */
 export class NoOp extends PerfStressTest {
-  public options = {};
+  public options = this.getParsedOptions({});
 
   async runAsync(): Promise<void> {}
 }

--- a/sdk/test-utils/perfstress/test/options.spec.ts
+++ b/sdk/test-utils/perfstress/test/options.spec.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 
 import { default as minimist, ParsedArgs as MinimistParsedArgs } from "minimist";
-import { PerfStressTest, PerfStressOptionDictionary } from "../src";
+import { PerfStressTest } from "../src";
 
 interface OptionsTestOptions {
   "non-req": string;
@@ -17,7 +17,7 @@ interface OptionsTestOptions {
  * Showcases and verifies some of the expected behaviors of the PerfStress options
  */
 export class OptionsTest extends PerfStressTest<OptionsTestOptions> {
-  public options: PerfStressOptionDictionary<OptionsTestOptions> = {
+  public options = this.getParsedOptions({
     "non-req": {
       description: "Non-required option"
     },
@@ -41,7 +41,8 @@ export class OptionsTest extends PerfStressTest<OptionsTestOptions> {
       description: "Required option with default value",
       defaultValue: 10
     }
-  };
+  });
+
   public minimistResult: MinimistParsedArgs;
 
   constructor() {

--- a/sdk/test-utils/perfstress/test/perfStressPolicy.spec.ts
+++ b/sdk/test-utils/perfstress/test/perfStressPolicy.spec.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 
 import * as url from "url";
-import { PerfStressTest, PerfStressOptionDictionary, PerfStressPolicy } from "../src";
+import { PerfStressTest, PerfStressPolicy } from "../src";
 import {
   WebResource,
   HttpOperationResponse,
@@ -25,16 +25,17 @@ const defaultResponse = {
  * Similar to the tests available in the core-http package of the default policies provided.
  */
 export class PerfStressPolicyTest extends PerfStressTest<PerfStressPolicyOptions> {
-  public options: PerfStressOptionDictionary<PerfStressPolicyOptions> = {
+  public options = this.getParsedOptions({
     url: {
       required: true,
       description: "URL that will replace any request's original targeted URL",
       shortName: "u"
     }
-  };
+  });
+
   async runAsync(): Promise<void> {
-    const targetUrl = url.parse(this.parsedOptions.url.value!);
-    const differentUrl = url.parse(this.parsedOptions.url.value!);
+    const targetUrl = url.parse(this.options.url.value!);
+    const differentUrl = url.parse(this.options.url.value!);
     differentUrl.host = `not-${differentUrl.host}`;
 
     const request = new WebResource(url.format(differentUrl));

--- a/sdk/test-utils/perfstress/test/setupCleanup.spec.ts
+++ b/sdk/test-utils/perfstress/test/setupCleanup.spec.ts
@@ -1,14 +1,14 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { PerfStressTest, PerfStressOptionDictionary } from "../src";
+import { PerfStressTest } from "../src";
 
 /**
  * Showcases and verifies some of the expected behaviors of the setup, globalSetup, cleanup and globalCleanup methods
  * of the PerfStressTest class.
  */
 export class SetupCleanupTest extends PerfStressTest {
-  public options: PerfStressOptionDictionary = {};
+  public options = this.getParsedOptions({});
 
   public state = {
     globalSetup: 0,
@@ -35,12 +35,12 @@ export class SetupCleanupTest extends PerfStressTest {
     if (this.state.globalSetup !== 1) {
       throw new Error("globalCleanup() should be called exactly once.");
     }
-    if (this.state.setup !== this.parsedOptions.parallel.value) {
+    if (this.state.setup !== this.options.parallel.value) {
       throw new Error(
         "setup() should be called exactly as many times as the parallel paramter says."
       );
     }
-    if (this.state.cleanup !== this.parsedOptions.parallel.value) {
+    if (this.state.cleanup !== this.options.parallel.value) {
       throw new Error(
         "cleanup() should be called exactly as many times as the parallel paramter says."
       );

--- a/sdk/test-utils/perfstress/test/sleep.spec.ts
+++ b/sdk/test-utils/perfstress/test/sleep.spec.ts
@@ -9,7 +9,7 @@ export class SleepTest extends PerfStressTest {
   private static instanceCount: number = 0;
   private secondsPerOperation: number = 0;
 
-  public options = {};
+  public options = this.getParsedOptions({});
 
   constructor() {
     super();


### PR DESCRIPTION
- `parsedOptions` was calculated each time it is accessed, cached it instead.
- Simplifying options bag - merging "parsedOptions" into "options" for convenience and transparency
- (TODO) Update all the perf projects with the new design changes.
- Adds a new PerfOptions interface for convenience.