### PR TITLE
[dev-tool] Use host package's TypeScript in module loader.

### DIFF
--- a/common/tools/dev-tool/register.js
+++ b/common/tools/dev-tool/register.js
@@ -13,19 +13,20 @@
  * old JavaScript, it is simple enough.
  */
 
+const path = require("path");
+const cwd = process.cwd();
+
 // This is the calling module, which will be the node repl context.
 const main = require.main || module.parent;
 
-const path = require("path");
+// We need to know which package name to monkey patch
+const { name: hostPackageName } = main.require("./package.json");
 
 // We need to use whatever version of TypeScript the calling package uses to inspect syntax nodes, because
 // that is what the ts-node invocation will use, and we need to agree with it on syntax brands.
-const ts = main.require("./node_modules/typescript");
-
-const cwd = process.cwd();
-
-// We need to know which package name to monkey patch
-const { name: hostPackageName } = main.require("./package.json");
+const ts = hostPackageName === "@azure/dev-tool"
+    ? require(path.join(cwd, "node_modules", "typescript"))
+    : main.require("typescript");
 
 // If we're bootstrapping a dev-tool command, we need to patch the package from
 // CWD instead.  This will still end up being dev-tool if we end up in a

--- a/common/tools/dev-tool/register.js
+++ b/common/tools/dev-tool/register.js
@@ -13,14 +13,16 @@
  * old JavaScript, it is simple enough.
  */
 
+// This is the calling module, which will be the node repl context.
+const main = require.main || module.parent;
+
 const path = require("path");
 
-const ts = require("typescript");
+// We need to use whatever version of TypeScript the calling package uses to inspect syntax nodes, because
+// that is what the ts-node invocation will use, and we need to agree with it on syntax brands.
+const ts = main.require("./node_modules/typescript");
 
 const cwd = process.cwd();
-
-// This is the calling module, which will be the node repl context.
-const main = module.parent;
 
 // We need to know which package name to monkey patch
 const { name: hostPackageName } = main.require("./package.json");


### PR DESCRIPTION
I upgraded dev-tool to use TypeScript 4.4.0, but this introduced a really weird issue where dev-tool would try to use a different version of TypeScript in its transforms than when it parses code, so samples running might not work if the package's TypeScript version was different from dev-tool's (the `kind` fields of syntax nodes are not stable, so for example an `ImportDeclaration` might be identified by `kind: 261` in one version of TypeScript and `kind: 260` in an older one if a new node was introduced, and so the parser and transforms have to agree about these IDs).

This change makes the dev-tool register.js module loader use the host package's TypeScript version.

@deyaaeldeen