### PR TITLE
Increase timeout for resource deploying step in smoke tests

### DIFF
--- a/common/smoke-test/Initialize-SmokeTests.ps1
+++ b/common/smoke-test/Initialize-SmokeTests.ps1
@@ -234,8 +234,8 @@ function Deploy-TestResources {
     }
 
     if (-not $DryRun) {
-      Write-Verbose "Waiting for all deploy jobs to finish (will timeout after 15 minutes)..."
-      $entryDeployJobs | Wait-Job -TimeoutSec (15*60)
+      Write-Verbose "Waiting for all deploy jobs to finish (will timeout after 30 minutes)..."
+      $entryDeployJobs | Wait-Job -TimeoutSec (30*60)
       if ($entryDeployJobs | Where-Object {$_.State -eq "Running"}) {
         $entryDeployJobs
         throw "Timed out waiting for deploy jobs to finish:"


### PR DESCRIPTION
Some nightly smoke tests runs have failed due to a timeout in the `Deploy Smoke Test resources and prepare samples` step. Timeout was increased from 15 to 30 minutes.