### PR TITLE
[KeyVault][Test] remove async iterator polyfill

### DIFF
--- a/sdk/keyvault/keyvault-admin/test/utils/common.ts
+++ b/sdk/keyvault/keyvault-admin/test/utils/common.ts
@@ -4,11 +4,6 @@
 import * as assert from "assert";
 import { env } from "@azure-tools/test-recorder";
 
-// Async iterator's polyfill for Node 8
-if (!Symbol || !(Symbol as any).asyncIterator) {
-  (Symbol as any).asyncIterator = Symbol.for("Symbol.asyncIterator");
-}
-
 export async function assertThrowsAbortError(cb: () => Promise<any>): Promise<void> {
   let passed = false;
   try {

--- a/sdk/keyvault/keyvault-certificates/test/utils/utils.common.ts
+++ b/sdk/keyvault/keyvault-certificates/test/utils/utils.common.ts
@@ -4,11 +4,6 @@
 import { env } from "@azure-tools/test-recorder";
 import * as assert from "assert";
 
-// Async iterator's polyfill for Node 8
-if (!Symbol || !(Symbol as any).asyncIterator) {
-  (Symbol as any).asyncIterator = Symbol.for("Symbol.asyncIterator");
-}
-
 export function getKeyvaultName(): string {
   const keyVaultEnvVarName = "KEYVAULT_NAME";
   const keyVaultName: string | undefined = env[keyVaultEnvVarName];

--- a/sdk/keyvault/keyvault-keys/test/utils/utils.common.ts
+++ b/sdk/keyvault/keyvault-keys/test/utils/utils.common.ts
@@ -6,11 +6,6 @@ import { env } from "@azure-tools/test-recorder";
 import * as assert from "assert";
 import { LATEST_API_VERSION } from "../../src/keysModels";
 
-// Async iterator's polyfill for Node 8
-if (!Symbol || !(Symbol as any).asyncIterator) {
-  (Symbol as any).asyncIterator = Symbol.for("Symbol.asyncIterator");
-}
-
 export function getKeyvaultName(): string {
   const keyVaultEnvVarName = "KEYVAULT_NAME";
   const keyVaultName: string | undefined = env[keyVaultEnvVarName];

--- a/sdk/keyvault/keyvault-secrets/test/utils/utils.common.ts
+++ b/sdk/keyvault/keyvault-secrets/test/utils/utils.common.ts
@@ -3,11 +3,6 @@
 
 import * as assert from "assert";
 
-// Async iterator's polyfill for Node 8
-if (!Symbol || !(Symbol as any).asyncIterator) {
-  (Symbol as any).asyncIterator = Symbol.for("Symbol.asyncIterator");
-}
-
 export async function assertThrowsAbortError(cb: () => Promise<any>): Promise<void> {
   let passed = false;
   try {


### PR DESCRIPTION
since Node 8 is no longer supported.