### PR TITLE
Updates to CodeOwners file for folks no longer with the team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -66,7 +66,7 @@
 /sdk/keyvault/ @maorleger @sadasant 
 
 # PRLabel: %Service Bus
-/sdk/servicebus/ @deyaaeldeen @jeremymeng @HarshaNalluru @ramya-rao-a
+/sdk/servicebus/ @deyaaeldeen @jeremymeng @HarshaNalluru @ramya-rao-a @richardpark-msft 
 
 # PRLabel: %Storage
 /sdk/storage/ @XiaoningLiu @jeremymeng @vinjiang @jiacfan @ljian3377 @EmmaZhu


### PR DESCRIPTION
Chris Radek, Jonathan Turner and Steve Faulkner have left Microsoft
Richard Park has moved to the Azure SDK for Go team

Making updates to the code owners file to reflect this