### PR TITLE
[Tables] Expose continuation token on TableServiceClient.listTables

### DIFF
--- a/sdk/tables/data-tables/CHANGELOG.md
+++ b/sdk/tables/data-tables/CHANGELOG.md
@@ -3,14 +3,17 @@
 ## 12.2.0 (Unreleased)
 
 ### Features Added
-- Take `continuationToken` as a `PageSetting` and expose it in the page when listing entities `byPage`. [#18179](https://github.com/Azure/azure-sdk-for-js/pull/18179)
+
+- TableClient `listEntities` expose and can take as PageSetting `continuationToken` as a `PageSetting` when using `byPage`. [#18179](https://github.com/Azure/azure-sdk-for-js/pull/18179)
+- TableServiceClient `listTables` expose and can take PageSetting `continuationToken` as a `PageSetting` when using `byPage`. [#18277](https://github.com/Azure/azure-sdk-for-js/pull/18277)
 
 ### Breaking Changes
 
 ### Bugs Fixed
+
 - Document usage of SDK with Azurite. [#18211](https://github.com/Azure/azure-sdk-for-js/pull/18211)
 - Issue #17407 - Correctly handle etag in select filter. [#18211](https://github.com/Azure/azure-sdk-for-js/pull/18211)
-- Issue #18079  - Correctly handle creating entities with properties containing empty strings "". Fixes Insert throws "Unknown EDM type object" error with property value { value: "", type: "String" }. [#18211](https://github.com/Azure/azure-sdk-for-js/pull/18211)
+- Issue #18079 - Correctly handle creating entities with properties containing empty strings "". Fixes Insert throws "Unknown EDM type object" error with property value { value: "", type: "String" }. [#18211](https://github.com/Azure/azure-sdk-for-js/pull/18211)
 - Issue #18148 - Correctly deserialize Decimal numbers checking for isSafeInteger. Fixes listEntities always returns an Int32 type for a value of "1.23456789012346e+24". [#18211](https://github.com/Azure/azure-sdk-for-js/pull/18211)
 
 ### Other Changes

--- a/sdk/tables/data-tables/recordings/browsers/tableserviceclient_sasconnectionstring_listtables/recording_should_list_a_specific_page_with_continuationtoken.json
+++ b/sdk/tables/data-tables/recordings/browsers/tableserviceclient_sasconnectionstring_listtables/recording_should_list_a_specific_page_with_continuationtoken.json
@@ -1,0 +1,431 @@
+{
+ "recordings": [
+  {
+   "method": "GET",
+   "url": "https://fakeaccount.table.core.windows.net/Tables",
+   "query": {
+    "$top": "2"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"odata.metadata\":\"https://fakeaccount.table.core.windows.net/$metadata#Tables\",\"value\":[{\"TableName\":\"byPageTest\"},{\"TableName\":\"CreateSimpleEntityBatchPerf\"}]}",
+   "responseHeaders": {
+    "access-control-allow-origin": "*",
+    "access-control-expose-headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,X-Content-Type-Options,Cache-Control,x-ms-continuation-NextTableName,Content-Type,Content-Length,Date,Transfer-Encoding",
+    "cache-control": "no-cache",
+    "content-type": "application/json;odata=minimalmetadata;streaming=true;charset=utf-8",
+    "date": "Tue, 19 Oct 2021 23:46:12 GMT",
+    "server": "Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-ms-client-request-id": "c6b146ea-aba9-4f26-b066-005f1fe420c4",
+    "x-ms-continuation-nexttablename": "1!44!Y3JlYXRldGFibGVuZXcBMDFkNzY2YmM1MmE5N2JhMA--",
+    "x-ms-request-id": "5cd645e9-f002-00e0-3543-c56737000000",
+    "x-ms-version": "2019-02-02"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://fakeaccount.table.core.windows.net/Tables",
+   "query": {
+    "$top": "2",
+    "NextTableName": "1!44!Y3JlYXRldGFibGVuZXcBMDFkNzY2YmM1MmE5N2JhMA--"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"odata.metadata\":\"https://fakeaccount.table.core.windows.net/$metadata#Tables\",\"value\":[{\"TableName\":\"createTableNew\"},{\"TableName\":\"createTableNew2\"}]}",
+   "responseHeaders": {
+    "access-control-allow-origin": "*",
+    "access-control-expose-headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,X-Content-Type-Options,Cache-Control,x-ms-continuation-NextTableName,Content-Type,Content-Length,Date,Transfer-Encoding",
+    "cache-control": "no-cache",
+    "content-type": "application/json;odata=minimalmetadata;streaming=true;charset=utf-8",
+    "date": "Tue, 19 Oct 2021 23:46:12 GMT",
+    "server": "Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-ms-client-request-id": "11cef58e-f15e-410a-a1ce-ab57da4644a8",
+    "x-ms-continuation-nexttablename": "1!44!Y3JlYXRldGFibGVvbGQBMDFkNzY2YmQ2ZWMzODZlYQ--",
+    "x-ms-request-id": "5cd645ee-f002-00e0-3a43-c56737000000",
+    "x-ms-version": "2019-02-02"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://fakeaccount.table.core.windows.net/Tables",
+   "query": {
+    "$top": "2",
+    "NextTableName": "1!44!Y3JlYXRldGFibGVvbGQBMDFkNzY2YmQ2ZWMzODZlYQ--"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"odata.metadata\":\"https://fakeaccount.table.core.windows.net/$metadata#Tables\",\"value\":[{\"TableName\":\"createTableOld\"},{\"TableName\":\"doublesTest\"}]}",
+   "responseHeaders": {
+    "access-control-allow-origin": "*",
+    "access-control-expose-headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,X-Content-Type-Options,Cache-Control,x-ms-continuation-NextTableName,Content-Type,Content-Length,Date,Transfer-Encoding",
+    "cache-control": "no-cache",
+    "content-type": "application/json;odata=minimalmetadata;streaming=true;charset=utf-8",
+    "date": "Tue, 19 Oct 2021 23:46:12 GMT",
+    "server": "Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-ms-client-request-id": "3847b261-bf26-46e8-8b50-4c3a942a2545",
+    "x-ms-continuation-nexttablename": "1!76!bGlzdHRhYmxldGVzdHNhc2Nvbm5lY3Rpb25zdHJpbmdicm93c2VyMAEwMWQ3YzU0MzdmMzQ5OGEx",
+    "x-ms-request-id": "5cd645f2-f002-00e0-3e43-c56737000000",
+    "x-ms-version": "2019-02-02"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://fakeaccount.table.core.windows.net/Tables",
+   "query": {
+    "$top": "2",
+    "NextTableName": "1!76!bGlzdHRhYmxldGVzdHNhc2Nvbm5lY3Rpb25zdHJpbmdicm93c2VyMAEwMWQ3YzU0MzdmMzQ5OGEx"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"odata.metadata\":\"https://fakeaccount.table.core.windows.net/$metadata#Tables\",\"value\":[{\"TableName\":\"ListTableTestSASConnectionStringbrowser0\"},{\"TableName\":\"ListTableTestSASConnectionStringbrowser1\"}]}",
+   "responseHeaders": {
+    "access-control-allow-origin": "*",
+    "access-control-expose-headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,X-Content-Type-Options,Cache-Control,x-ms-continuation-NextTableName,Content-Type,Content-Length,Date,Transfer-Encoding",
+    "cache-control": "no-cache",
+    "content-type": "application/json;odata=minimalmetadata;streaming=true;charset=utf-8",
+    "date": "Tue, 19 Oct 2021 23:46:12 GMT",
+    "server": "Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-ms-client-request-id": "5b681761-8663-49ae-bc55-3ff7d20dfeb0",
+    "x-ms-continuation-nexttablename": "1!80!bGlzdHRhYmxldGVzdHNhc2Nvbm5lY3Rpb25zdHJpbmdicm93c2VyMTABMDFkN2M1NDM3ZjZmZmU2ZQ--",
+    "x-ms-request-id": "5cd645f6-f002-00e0-4143-c56737000000",
+    "x-ms-version": "2019-02-02"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://fakeaccount.table.core.windows.net/Tables",
+   "query": {
+    "$top": "2",
+    "NextTableName": "1!80!bGlzdHRhYmxldGVzdHNhc2Nvbm5lY3Rpb25zdHJpbmdicm93c2VyMTABMDFkN2M1NDM3ZjZmZmU2ZQ--"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"odata.metadata\":\"https://fakeaccount.table.core.windows.net/$metadata#Tables\",\"value\":[{\"TableName\":\"ListTableTestSASConnectionStringbrowser10\"},{\"TableName\":\"ListTableTestSASConnectionStringbrowser11\"}]}",
+   "responseHeaders": {
+    "access-control-allow-origin": "*",
+    "access-control-expose-headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,X-Content-Type-Options,Cache-Control,x-ms-continuation-NextTableName,Content-Type,Content-Length,Date,Transfer-Encoding",
+    "cache-control": "no-cache",
+    "content-type": "application/json;odata=minimalmetadata;streaming=true;charset=utf-8",
+    "date": "Tue, 19 Oct 2021 23:46:12 GMT",
+    "server": "Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-ms-client-request-id": "b68069a6-5483-4853-9cc4-d62477c25a93",
+    "x-ms-continuation-nexttablename": "1!80!bGlzdHRhYmxldGVzdHNhc2Nvbm5lY3Rpb25zdHJpbmdicm93c2VyMTIBMDFkN2M1NDM3ZjdiYzA1Mw--",
+    "x-ms-request-id": "5cd645fe-f002-00e0-4943-c56737000000",
+    "x-ms-version": "2019-02-02"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://fakeaccount.table.core.windows.net/Tables",
+   "query": {
+    "$top": "2",
+    "NextTableName": "1!80!bGlzdHRhYmxldGVzdHNhc2Nvbm5lY3Rpb25zdHJpbmdicm93c2VyMTIBMDFkN2M1NDM3ZjdiYzA1Mw--"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"odata.metadata\":\"https://fakeaccount.table.core.windows.net/$metadata#Tables\",\"value\":[{\"TableName\":\"ListTableTestSASConnectionStringbrowser12\"},{\"TableName\":\"ListTableTestSASConnectionStringbrowser13\"}]}",
+   "responseHeaders": {
+    "access-control-allow-origin": "*",
+    "access-control-expose-headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,X-Content-Type-Options,Cache-Control,x-ms-continuation-NextTableName,Content-Type,Content-Length,Date,Transfer-Encoding",
+    "cache-control": "no-cache",
+    "content-type": "application/json;odata=minimalmetadata;streaming=true;charset=utf-8",
+    "date": "Tue, 19 Oct 2021 23:46:12 GMT",
+    "server": "Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-ms-client-request-id": "50744132-a936-4134-aaa2-8bf1e0c8a5fa",
+    "x-ms-continuation-nexttablename": "1!80!bGlzdHRhYmxldGVzdHNhc2Nvbm5lY3Rpb25zdHJpbmdicm93c2VyMTQBMDFkN2M1NDM3Zjg3ZDA2OQ--",
+    "x-ms-request-id": "5cd64608-f002-00e0-5043-c56737000000",
+    "x-ms-version": "2019-02-02"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://fakeaccount.table.core.windows.net/Tables",
+   "query": {
+    "$top": "2",
+    "NextTableName": "1!80!bGlzdHRhYmxldGVzdHNhc2Nvbm5lY3Rpb25zdHJpbmdicm93c2VyMTQBMDFkN2M1NDM3Zjg3ZDA2OQ--"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"odata.metadata\":\"https://fakeaccount.table.core.windows.net/$metadata#Tables\",\"value\":[{\"TableName\":\"ListTableTestSASConnectionStringbrowser14\"},{\"TableName\":\"ListTableTestSASConnectionStringbrowser15\"}]}",
+   "responseHeaders": {
+    "access-control-allow-origin": "*",
+    "access-control-expose-headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,X-Content-Type-Options,Cache-Control,x-ms-continuation-NextTableName,Content-Type,Content-Length,Date,Transfer-Encoding",
+    "cache-control": "no-cache",
+    "content-type": "application/json;odata=minimalmetadata;streaming=true;charset=utf-8",
+    "date": "Tue, 19 Oct 2021 23:46:12 GMT",
+    "server": "Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-ms-client-request-id": "85840fc6-a90f-4b5f-b5df-3806ffc2ab24",
+    "x-ms-continuation-nexttablename": "1!80!bGlzdHRhYmxldGVzdHNhc2Nvbm5lY3Rpb25zdHJpbmdicm93c2VyMTYBMDFkN2M1NDM3ZjkzMWQwNQ--",
+    "x-ms-request-id": "5cd6460b-f002-00e0-5343-c56737000000",
+    "x-ms-version": "2019-02-02"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://fakeaccount.table.core.windows.net/Tables",
+   "query": {
+    "$top": "2",
+    "NextTableName": "1!80!bGlzdHRhYmxldGVzdHNhc2Nvbm5lY3Rpb25zdHJpbmdicm93c2VyMTYBMDFkN2M1NDM3ZjkzMWQwNQ--"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"odata.metadata\":\"https://fakeaccount.table.core.windows.net/$metadata#Tables\",\"value\":[{\"TableName\":\"ListTableTestSASConnectionStringbrowser16\"},{\"TableName\":\"ListTableTestSASConnectionStringbrowser17\"}]}",
+   "responseHeaders": {
+    "access-control-allow-origin": "*",
+    "access-control-expose-headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,X-Content-Type-Options,Cache-Control,x-ms-continuation-NextTableName,Content-Type,Content-Length,Date,Transfer-Encoding",
+    "cache-control": "no-cache",
+    "content-type": "application/json;odata=minimalmetadata;streaming=true;charset=utf-8",
+    "date": "Tue, 19 Oct 2021 23:46:12 GMT",
+    "server": "Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-ms-client-request-id": "70d147f6-3593-4f01-8573-1a5b9341454d",
+    "x-ms-continuation-nexttablename": "1!80!bGlzdHRhYmxldGVzdHNhc2Nvbm5lY3Rpb25zdHJpbmdicm93c2VyMTgBMDFkN2M1NDM3ZjlmYTI1Yw--",
+    "x-ms-request-id": "5cd64612-f002-00e0-5843-c56737000000",
+    "x-ms-version": "2019-02-02"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://fakeaccount.table.core.windows.net/Tables",
+   "query": {
+    "$top": "2",
+    "NextTableName": "1!80!bGlzdHRhYmxldGVzdHNhc2Nvbm5lY3Rpb25zdHJpbmdicm93c2VyMTgBMDFkN2M1NDM3ZjlmYTI1Yw--"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"odata.metadata\":\"https://fakeaccount.table.core.windows.net/$metadata#Tables\",\"value\":[{\"TableName\":\"ListTableTestSASConnectionStringbrowser18\"},{\"TableName\":\"ListTableTestSASConnectionStringbrowser19\"}]}",
+   "responseHeaders": {
+    "access-control-allow-origin": "*",
+    "access-control-expose-headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,X-Content-Type-Options,Cache-Control,x-ms-continuation-NextTableName,Content-Type,Content-Length,Date,Transfer-Encoding",
+    "cache-control": "no-cache",
+    "content-type": "application/json;odata=minimalmetadata;streaming=true;charset=utf-8",
+    "date": "Tue, 19 Oct 2021 23:46:12 GMT",
+    "server": "Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-ms-client-request-id": "a902226c-f685-4879-902a-52f08cde4eb2",
+    "x-ms-continuation-nexttablename": "1!76!bGlzdHRhYmxldGVzdHNhc2Nvbm5lY3Rpb25zdHJpbmdicm93c2VyMgEwMWQ3YzU0MzdmM2ZlNTNj",
+    "x-ms-request-id": "5cd6461a-f002-00e0-6043-c56737000000",
+    "x-ms-version": "2019-02-02"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://fakeaccount.table.core.windows.net/Tables",
+   "query": {
+    "$top": "2",
+    "NextTableName": "1!76!bGlzdHRhYmxldGVzdHNhc2Nvbm5lY3Rpb25zdHJpbmdicm93c2VyMgEwMWQ3YzU0MzdmM2ZlNTNj"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"odata.metadata\":\"https://fakeaccount.table.core.windows.net/$metadata#Tables\",\"value\":[{\"TableName\":\"ListTableTestSASConnectionStringbrowser2\"},{\"TableName\":\"ListTableTestSASConnectionStringbrowser3\"}]}",
+   "responseHeaders": {
+    "access-control-allow-origin": "*",
+    "access-control-expose-headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,X-Content-Type-Options,Cache-Control,x-ms-continuation-NextTableName,Content-Type,Content-Length,Date,Transfer-Encoding",
+    "cache-control": "no-cache",
+    "content-type": "application/json;odata=minimalmetadata;streaming=true;charset=utf-8",
+    "date": "Tue, 19 Oct 2021 23:46:12 GMT",
+    "server": "Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-ms-client-request-id": "3b513493-9806-4133-b5a4-a6fababba192",
+    "x-ms-continuation-nexttablename": "1!76!bGlzdHRhYmxldGVzdHNhc2Nvbm5lY3Rpb25zdHJpbmdicm93c2VyNAEwMWQ3YzU0MzdmNGM2YTkz",
+    "x-ms-request-id": "5cd64621-f002-00e0-6643-c56737000000",
+    "x-ms-version": "2019-02-02"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://fakeaccount.table.core.windows.net/Tables",
+   "query": {
+    "$top": "2",
+    "NextTableName": "1!76!bGlzdHRhYmxldGVzdHNhc2Nvbm5lY3Rpb25zdHJpbmdicm93c2VyNAEwMWQ3YzU0MzdmNGM2YTkz"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"odata.metadata\":\"https://fakeaccount.table.core.windows.net/$metadata#Tables\",\"value\":[{\"TableName\":\"ListTableTestSASConnectionStringbrowser4\"},{\"TableName\":\"ListTableTestSASConnectionStringbrowser5\"}]}",
+   "responseHeaders": {
+    "access-control-allow-origin": "*",
+    "access-control-expose-headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,X-Content-Type-Options,Cache-Control,x-ms-continuation-NextTableName,Content-Type,Content-Length,Date,Transfer-Encoding",
+    "cache-control": "no-cache",
+    "content-type": "application/json;odata=minimalmetadata;streaming=true;charset=utf-8",
+    "date": "Tue, 19 Oct 2021 23:46:12 GMT",
+    "server": "Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-ms-client-request-id": "f97b910e-07f0-4f6f-b783-b691b435f6bf",
+    "x-ms-continuation-nexttablename": "1!76!bGlzdHRhYmxldGVzdHNhc2Nvbm5lY3Rpb25zdHJpbmdicm93c2VyNgEwMWQ3YzU0MzdmNTdkZTRh",
+    "x-ms-request-id": "5cd6462e-f002-00e0-7143-c56737000000",
+    "x-ms-version": "2019-02-02"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://fakeaccount.table.core.windows.net/Tables",
+   "query": {
+    "$top": "2",
+    "NextTableName": "1!76!bGlzdHRhYmxldGVzdHNhc2Nvbm5lY3Rpb25zdHJpbmdicm93c2VyNgEwMWQ3YzU0MzdmNTdkZTRh"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"odata.metadata\":\"https://fakeaccount.table.core.windows.net/$metadata#Tables\",\"value\":[{\"TableName\":\"ListTableTestSASConnectionStringbrowser6\"},{\"TableName\":\"ListTableTestSASConnectionStringbrowser7\"}]}",
+   "responseHeaders": {
+    "access-control-allow-origin": "*",
+    "access-control-expose-headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,X-Content-Type-Options,Cache-Control,x-ms-continuation-NextTableName,Content-Type,Content-Length,Date,Transfer-Encoding",
+    "cache-control": "no-cache",
+    "content-type": "application/json;odata=minimalmetadata;streaming=true;charset=utf-8",
+    "date": "Tue, 19 Oct 2021 23:46:12 GMT",
+    "server": "Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-ms-client-request-id": "9388195d-37c8-4b37-a865-f6758d5f063a",
+    "x-ms-continuation-nexttablename": "1!76!bGlzdHRhYmxldGVzdHNhc2Nvbm5lY3Rpb25zdHJpbmdicm93c2VyOAEwMWQ3YzU0MzdmNjRiMWNm",
+    "x-ms-request-id": "5cd64639-f002-00e0-7b43-c56737000000",
+    "x-ms-version": "2019-02-02"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://fakeaccount.table.core.windows.net/Tables",
+   "query": {
+    "$top": "2",
+    "NextTableName": "1!76!bGlzdHRhYmxldGVzdHNhc2Nvbm5lY3Rpb25zdHJpbmdicm93c2VyOAEwMWQ3YzU0MzdmNjRiMWNm"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"odata.metadata\":\"https://fakeaccount.table.core.windows.net/$metadata#Tables\",\"value\":[{\"TableName\":\"ListTableTestSASConnectionStringbrowser8\"},{\"TableName\":\"ListTableTestSASConnectionStringbrowser9\"}]}",
+   "responseHeaders": {
+    "access-control-allow-origin": "*",
+    "access-control-expose-headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,X-Content-Type-Options,Cache-Control,x-ms-continuation-NextTableName,Content-Type,Content-Length,Date,Transfer-Encoding",
+    "cache-control": "no-cache",
+    "content-type": "application/json;odata=minimalmetadata;streaming=true;charset=utf-8",
+    "date": "Tue, 19 Oct 2021 23:46:12 GMT",
+    "server": "Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-ms-client-request-id": "ff5925b5-4c37-4ef9-aa30-e8b39d338339",
+    "x-ms-continuation-nexttablename": "1!72!bGlzdHRhYmxldGVzdHNhc2Nvbm5lY3Rpb25zdHJpbmdub2RlMAEwMWQ3YzU0Mzc5NWYxYTE4",
+    "x-ms-request-id": "5cd64643-f002-00e0-0443-c56737000000",
+    "x-ms-version": "2019-02-02"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://fakeaccount.table.core.windows.net/Tables",
+   "query": {
+    "$top": "2",
+    "NextTableName": "1!72!bGlzdHRhYmxldGVzdHNhc2Nvbm5lY3Rpb25zdHJpbmdub2RlMAEwMWQ3YzU0Mzc5NWYxYTE4"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"odata.metadata\":\"https://fakeaccount.table.core.windows.net/$metadata#Tables\",\"value\":[{\"TableName\":\"TestChars\"},{\"TableName\":\"TestChars2\"}]}",
+   "responseHeaders": {
+    "access-control-allow-origin": "*",
+    "access-control-expose-headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,X-Content-Type-Options,Cache-Control,x-ms-continuation-NextTableName,Content-Type,Content-Length,Date,Transfer-Encoding",
+    "cache-control": "no-cache",
+    "content-type": "application/json;odata=minimalmetadata;streaming=true;charset=utf-8",
+    "date": "Tue, 19 Oct 2021 23:46:12 GMT",
+    "server": "Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-ms-client-request-id": "9488c949-ba40-419c-9f43-20d92fb30561",
+    "x-ms-continuation-nexttablename": "1!36!dGVzdGNoYXJzMwEwMWQ3YThkYWYwYjJiYjlj",
+    "x-ms-request-id": "5cd6464b-f002-00e0-0b43-c56737000000",
+    "x-ms-version": "2019-02-02"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://fakeaccount.table.core.windows.net/Tables",
+   "query": {
+    "$top": "2",
+    "NextTableName": "1!36!dGVzdGNoYXJzMwEwMWQ3YThkYWYwYjJiYjlj"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"odata.metadata\":\"https://fakeaccount.table.core.windows.net/$metadata#Tables\",\"value\":[{\"TableName\":\"TestChars3\"},{\"TableName\":\"testTable\"}]}",
+   "responseHeaders": {
+    "access-control-allow-origin": "*",
+    "access-control-expose-headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,X-Content-Type-Options,Cache-Control,x-ms-continuation-NextTableName,Content-Type,Content-Length,Date,Transfer-Encoding",
+    "cache-control": "no-cache",
+    "content-type": "application/json;odata=minimalmetadata;streaming=true;charset=utf-8",
+    "date": "Tue, 19 Oct 2021 23:46:12 GMT",
+    "server": "Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-ms-client-request-id": "d7976108-3330-4177-bfde-7e52451fa144",
+    "x-ms-continuation-nexttablename": "1!72!dGVzdHRhYmxlc2FzY29ubmVjdGlvbnN0cmluZ2Jyb3dzZXIBMDFkN2M1NDM3ZjFlZTllYg--",
+    "x-ms-request-id": "5cd64653-f002-00e0-1343-c56737000000",
+    "x-ms-version": "2019-02-02"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://fakeaccount.table.core.windows.net/Tables",
+   "query": {
+    "$top": "2",
+    "NextTableName": "1!72!dGVzdHRhYmxlc2FzY29ubmVjdGlvbnN0cmluZ2Jyb3dzZXIBMDFkN2M1NDM3ZjFlZTllYg--"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"odata.metadata\":\"https://fakeaccount.table.core.windows.net/$metadata#Tables\",\"value\":[{\"TableName\":\"TestTestTest\"}]}",
+   "responseHeaders": {
+    "access-control-allow-origin": "*",
+    "access-control-expose-headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,X-Content-Type-Options,Cache-Control,Content-Type,Content-Length,Date,Transfer-Encoding",
+    "cache-control": "no-cache",
+    "content-type": "application/json;odata=minimalmetadata;streaming=true;charset=utf-8",
+    "date": "Tue, 19 Oct 2021 23:46:12 GMT",
+    "server": "Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-ms-client-request-id": "491bf70e-8254-4c40-878b-ce8be63b05b0",
+    "x-ms-request-id": "5cd64658-f002-00e0-1843-c56737000000",
+    "x-ms-version": "2019-02-02"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://fakeaccount.table.core.windows.net/Tables",
+   "query": {
+    "$top": "2",
+    "NextTableName": "1!72!dGVzdHRhYmxlc2FzY29ubmVjdGlvbnN0cmluZ2Jyb3dzZXIBMDFkN2M1NDM3ZjFlZTllYg--"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"odata.metadata\":\"https://fakeaccount.table.core.windows.net/$metadata#Tables\",\"value\":[{\"TableName\":\"TestTestTest\"}]}",
+   "responseHeaders": {
+    "access-control-allow-origin": "*",
+    "access-control-expose-headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,X-Content-Type-Options,Cache-Control,Content-Type,Content-Length,Date,Transfer-Encoding",
+    "cache-control": "no-cache",
+    "content-type": "application/json;odata=minimalmetadata;streaming=true;charset=utf-8",
+    "date": "Tue, 19 Oct 2021 23:46:12 GMT",
+    "server": "Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-ms-client-request-id": "98dc1fc8-0b41-46bb-909b-04d290ab039f",
+    "x-ms-request-id": "5cd64662-f002-00e0-2243-c56737000000",
+    "x-ms-version": "2019-02-02"
+   }
+  }
+ ],
+ "uniqueTestInfo": {
+  "uniqueName": {},
+  "newDate": {}
+ },
+ "hash": "24e801c345adecf0ecd7dfb9310860ed"
+}

--- a/sdk/tables/data-tables/recordings/browsers/tableserviceclient_tokencredential_listtables/recording_should_list_a_specific_page_with_continuationtoken.json
+++ b/sdk/tables/data-tables/recordings/browsers/tableserviceclient_tokencredential_listtables/recording_should_list_a_specific_page_with_continuationtoken.json
@@ -1,0 +1,455 @@
+{
+ "recordings": [
+  {
+   "method": "POST",
+   "url": "https://login.microsoftonline.com/88888888-8888-8888-8888-888888888888/oauth2/v2.0/token",
+   "query": {},
+   "requestBody": "response_type=token&grant_type=client_credentials&client_id=azure_client_id&client_secret=azure_client_secret&scope=https%3A%2F%2Fsanitized%2F",
+   "status": 200,
+   "response": "{\"token_type\":\"Bearer\",\"expires_in\":86399,\"ext_expires_in\":86399,\"access_token\":\"access_token\"}",
+   "responseHeaders": {
+    "cache-control": "no-store, no-cache",
+    "content-length": "1318",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Tue, 19 Oct 2021 23:46:09 GMT",
+    "expires": "-1",
+    "nel": "{\"report_to\":\"network-errors\",\"max_age\":86400,\"success_fraction\":0.001,\"failure_fraction\":1.0}",
+    "p3p": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\"",
+    "pragma": "no-cache",
+    "referrer-policy": "strict-origin-when-cross-origin",
+    "report-to": "{\"group\":\"network-errors\",\"max_age\":86400,\"endpoints\":[{\"url\":\"https://identity.nel.measure.office.net/api/report?catId=GW+estsfd+wst\"}]}",
+    "strict-transport-security": "max-age=31536000; includeSubDomains",
+    "x-content-type-options": "nosniff",
+    "x-ms-ests-server": "2.1.12158.6 - EUS ProdSlices",
+    "x-ms-request-id": "7f37af71-c1be-4bb7-9391-2a96a5acf600"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://fakeaccount.table.core.windows.net/Tables",
+   "query": {
+    "$top": "2"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"odata.metadata\":\"https://fakeaccount.table.core.windows.net/$metadata#Tables\",\"value\":[{\"TableName\":\"byPageTest\"},{\"TableName\":\"CreateSimpleEntityBatchPerf\"}]}",
+   "responseHeaders": {
+    "access-control-allow-origin": "*",
+    "access-control-expose-headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,X-Content-Type-Options,Cache-Control,x-ms-continuation-NextTableName,Content-Type,Content-Length,Date,Transfer-Encoding",
+    "cache-control": "no-cache",
+    "content-type": "application/json;odata=minimalmetadata;streaming=true;charset=utf-8",
+    "date": "Tue, 19 Oct 2021 23:46:09 GMT",
+    "server": "Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-ms-client-request-id": "e3fbf4bb-b2ea-4605-bdd0-992d8afe657e",
+    "x-ms-continuation-nexttablename": "1!44!Y3JlYXRldGFibGVuZXcBMDFkNzY2YmM1MmE5N2JhMA--",
+    "x-ms-request-id": "5cd64294-f002-00e0-2843-c56737000000",
+    "x-ms-version": "2019-02-02"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://fakeaccount.table.core.windows.net/Tables",
+   "query": {
+    "$top": "2",
+    "NextTableName": "1!44!Y3JlYXRldGFibGVuZXcBMDFkNzY2YmM1MmE5N2JhMA--"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"odata.metadata\":\"https://fakeaccount.table.core.windows.net/$metadata#Tables\",\"value\":[{\"TableName\":\"createTableNew\"},{\"TableName\":\"createTableNew2\"}]}",
+   "responseHeaders": {
+    "access-control-allow-origin": "*",
+    "access-control-expose-headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,X-Content-Type-Options,Cache-Control,x-ms-continuation-NextTableName,Content-Type,Content-Length,Date,Transfer-Encoding",
+    "cache-control": "no-cache",
+    "content-type": "application/json;odata=minimalmetadata;streaming=true;charset=utf-8",
+    "date": "Tue, 19 Oct 2021 23:46:09 GMT",
+    "server": "Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-ms-client-request-id": "5ed93656-42e9-4f62-a9af-549850a69951",
+    "x-ms-continuation-nexttablename": "1!44!Y3JlYXRldGFibGVvbGQBMDFkNzY2YmQ2ZWMzODZlYQ--",
+    "x-ms-request-id": "5cd642a4-f002-00e0-3743-c56737000000",
+    "x-ms-version": "2019-02-02"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://fakeaccount.table.core.windows.net/Tables",
+   "query": {
+    "$top": "2",
+    "NextTableName": "1!44!Y3JlYXRldGFibGVvbGQBMDFkNzY2YmQ2ZWMzODZlYQ--"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"odata.metadata\":\"https://fakeaccount.table.core.windows.net/$metadata#Tables\",\"value\":[{\"TableName\":\"createTableOld\"},{\"TableName\":\"doublesTest\"}]}",
+   "responseHeaders": {
+    "access-control-allow-origin": "*",
+    "access-control-expose-headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,X-Content-Type-Options,Cache-Control,x-ms-continuation-NextTableName,Content-Type,Content-Length,Date,Transfer-Encoding",
+    "cache-control": "no-cache",
+    "content-type": "application/json;odata=minimalmetadata;streaming=true;charset=utf-8",
+    "date": "Tue, 19 Oct 2021 23:46:09 GMT",
+    "server": "Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-ms-client-request-id": "bc0ed706-61aa-407c-af00-21c456250658",
+    "x-ms-continuation-nexttablename": "1!72!bGlzdHRhYmxldGVzdHNhc2Nvbm5lY3Rpb25zdHJpbmdub2RlMAEwMWQ3YzU0Mzc5NWYxYTE4",
+    "x-ms-request-id": "5cd642b3-f002-00e0-4643-c56737000000",
+    "x-ms-version": "2019-02-02"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://fakeaccount.table.core.windows.net/Tables",
+   "query": {
+    "$top": "2",
+    "NextTableName": "1!72!bGlzdHRhYmxldGVzdHNhc2Nvbm5lY3Rpb25zdHJpbmdub2RlMAEwMWQ3YzU0Mzc5NWYxYTE4"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"odata.metadata\":\"https://fakeaccount.table.core.windows.net/$metadata#Tables\",\"value\":[{\"TableName\":\"ListTableTestTokenCredentialbrowser0\"},{\"TableName\":\"ListTableTestTokenCredentialbrowser1\"}]}",
+   "responseHeaders": {
+    "access-control-allow-origin": "*",
+    "access-control-expose-headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,X-Content-Type-Options,Cache-Control,x-ms-continuation-NextTableName,Content-Type,Content-Length,Date,Transfer-Encoding",
+    "cache-control": "no-cache",
+    "content-type": "application/json;odata=minimalmetadata;streaming=true;charset=utf-8",
+    "date": "Tue, 19 Oct 2021 23:46:09 GMT",
+    "server": "Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-ms-client-request-id": "97f4593e-e6e3-47e5-946d-11739b8ee200",
+    "x-ms-continuation-nexttablename": "1!72!bGlzdHRhYmxldGVzdHRva2VuY3JlZGVudGlhbGJyb3dzZXIxMAEwMWQ3YzU0MzdkNDkxMzdk",
+    "x-ms-request-id": "5cd642bd-f002-00e0-4f43-c56737000000",
+    "x-ms-version": "2019-02-02"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://fakeaccount.table.core.windows.net/Tables",
+   "query": {
+    "$top": "2",
+    "NextTableName": "1!72!bGlzdHRhYmxldGVzdHRva2VuY3JlZGVudGlhbGJyb3dzZXIxMAEwMWQ3YzU0MzdkNDkxMzdk"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"odata.metadata\":\"https://fakeaccount.table.core.windows.net/$metadata#Tables\",\"value\":[{\"TableName\":\"ListTableTestTokenCredentialbrowser10\"},{\"TableName\":\"ListTableTestTokenCredentialbrowser11\"}]}",
+   "responseHeaders": {
+    "access-control-allow-origin": "*",
+    "access-control-expose-headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,X-Content-Type-Options,Cache-Control,x-ms-continuation-NextTableName,Content-Type,Content-Length,Date,Transfer-Encoding",
+    "cache-control": "no-cache",
+    "content-type": "application/json;odata=minimalmetadata;streaming=true;charset=utf-8",
+    "date": "Tue, 19 Oct 2021 23:46:09 GMT",
+    "server": "Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-ms-client-request-id": "3b5ac40a-c3e7-45d7-8a52-10fcff528fc3",
+    "x-ms-continuation-nexttablename": "1!72!bGlzdHRhYmxldGVzdHRva2VuY3JlZGVudGlhbGJyb3dzZXIxMgEwMWQ3YzU0MzdkNThjZGIx",
+    "x-ms-request-id": "5cd642cb-f002-00e0-5b43-c56737000000",
+    "x-ms-version": "2019-02-02"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://fakeaccount.table.core.windows.net/Tables",
+   "query": {
+    "$top": "2",
+    "NextTableName": "1!72!bGlzdHRhYmxldGVzdHRva2VuY3JlZGVudGlhbGJyb3dzZXIxMgEwMWQ3YzU0MzdkNThjZGIx"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"odata.metadata\":\"https://fakeaccount.table.core.windows.net/$metadata#Tables\",\"value\":[{\"TableName\":\"ListTableTestTokenCredentialbrowser12\"},{\"TableName\":\"ListTableTestTokenCredentialbrowser13\"}]}",
+   "responseHeaders": {
+    "access-control-allow-origin": "*",
+    "access-control-expose-headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,X-Content-Type-Options,Cache-Control,x-ms-continuation-NextTableName,Content-Type,Content-Length,Date,Transfer-Encoding",
+    "cache-control": "no-cache",
+    "content-type": "application/json;odata=minimalmetadata;streaming=true;charset=utf-8",
+    "date": "Tue, 19 Oct 2021 23:46:09 GMT",
+    "server": "Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-ms-client-request-id": "72a0840c-b6f4-4c11-948b-9569d06943b4",
+    "x-ms-continuation-nexttablename": "1!72!bGlzdHRhYmxldGVzdHRva2VuY3JlZGVudGlhbGJyb3dzZXIxNAEwMWQ3YzU0MzdkNjc0ZjMy",
+    "x-ms-request-id": "5cd642e1-f002-00e0-7043-c56737000000",
+    "x-ms-version": "2019-02-02"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://fakeaccount.table.core.windows.net/Tables",
+   "query": {
+    "$top": "2",
+    "NextTableName": "1!72!bGlzdHRhYmxldGVzdHRva2VuY3JlZGVudGlhbGJyb3dzZXIxNAEwMWQ3YzU0MzdkNjc0ZjMy"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"odata.metadata\":\"https://fakeaccount.table.core.windows.net/$metadata#Tables\",\"value\":[{\"TableName\":\"ListTableTestTokenCredentialbrowser14\"},{\"TableName\":\"ListTableTestTokenCredentialbrowser15\"}]}",
+   "responseHeaders": {
+    "access-control-allow-origin": "*",
+    "access-control-expose-headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,X-Content-Type-Options,Cache-Control,x-ms-continuation-NextTableName,Content-Type,Content-Length,Date,Transfer-Encoding",
+    "cache-control": "no-cache",
+    "content-type": "application/json;odata=minimalmetadata;streaming=true;charset=utf-8",
+    "date": "Tue, 19 Oct 2021 23:46:09 GMT",
+    "server": "Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-ms-client-request-id": "92113825-ef0c-4d13-b7de-ffb5a5d91f52",
+    "x-ms-continuation-nexttablename": "1!72!bGlzdHRhYmxldGVzdHRva2VuY3JlZGVudGlhbGJyb3dzZXIxNgEwMWQ3YzU0MzdkNzVmN2Nh",
+    "x-ms-request-id": "5cd642e7-f002-00e0-7643-c56737000000",
+    "x-ms-version": "2019-02-02"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://fakeaccount.table.core.windows.net/Tables",
+   "query": {
+    "$top": "2",
+    "NextTableName": "1!72!bGlzdHRhYmxldGVzdHRva2VuY3JlZGVudGlhbGJyb3dzZXIxNgEwMWQ3YzU0MzdkNzVmN2Nh"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"odata.metadata\":\"https://fakeaccount.table.core.windows.net/$metadata#Tables\",\"value\":[{\"TableName\":\"ListTableTestTokenCredentialbrowser16\"},{\"TableName\":\"ListTableTestTokenCredentialbrowser17\"}]}",
+   "responseHeaders": {
+    "access-control-allow-origin": "*",
+    "access-control-expose-headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,X-Content-Type-Options,Cache-Control,x-ms-continuation-NextTableName,Content-Type,Content-Length,Date,Transfer-Encoding",
+    "cache-control": "no-cache",
+    "content-type": "application/json;odata=minimalmetadata;streaming=true;charset=utf-8",
+    "date": "Tue, 19 Oct 2021 23:46:09 GMT",
+    "server": "Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-ms-client-request-id": "b74f3c96-e0ba-417a-bdb3-892d03cf931b",
+    "x-ms-continuation-nexttablename": "1!72!bGlzdHRhYmxldGVzdHRva2VuY3JlZGVudGlhbGJyb3dzZXIxOAEwMWQ3YzU0MzdkODRhMDY2",
+    "x-ms-request-id": "5cd642ea-f002-00e0-7943-c56737000000",
+    "x-ms-version": "2019-02-02"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://fakeaccount.table.core.windows.net/Tables",
+   "query": {
+    "$top": "2",
+    "NextTableName": "1!72!bGlzdHRhYmxldGVzdHRva2VuY3JlZGVudGlhbGJyb3dzZXIxOAEwMWQ3YzU0MzdkODRhMDY2"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"odata.metadata\":\"https://fakeaccount.table.core.windows.net/$metadata#Tables\",\"value\":[{\"TableName\":\"ListTableTestTokenCredentialbrowser18\"},{\"TableName\":\"ListTableTestTokenCredentialbrowser19\"}]}",
+   "responseHeaders": {
+    "access-control-allow-origin": "*",
+    "access-control-expose-headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,X-Content-Type-Options,Cache-Control,x-ms-continuation-NextTableName,Content-Type,Content-Length,Date,Transfer-Encoding",
+    "cache-control": "no-cache",
+    "content-type": "application/json;odata=minimalmetadata;streaming=true;charset=utf-8",
+    "date": "Tue, 19 Oct 2021 23:46:09 GMT",
+    "server": "Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-ms-client-request-id": "888a3528-f4c3-4d7d-97fc-99f8136b9e46",
+    "x-ms-continuation-nexttablename": "1!72!bGlzdHRhYmxldGVzdHRva2VuY3JlZGVudGlhbGJyb3dzZXIyATAxZDdjNTQzN2QwZGZiZDU-",
+    "x-ms-request-id": "5cd642f9-f002-00e0-0743-c56737000000",
+    "x-ms-version": "2019-02-02"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://fakeaccount.table.core.windows.net/Tables",
+   "query": {
+    "$top": "2",
+    "NextTableName": "1!72!bGlzdHRhYmxldGVzdHRva2VuY3JlZGVudGlhbGJyb3dzZXIyATAxZDdjNTQzN2QwZGZiZDU-"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"odata.metadata\":\"https://fakeaccount.table.core.windows.net/$metadata#Tables\",\"value\":[{\"TableName\":\"ListTableTestTokenCredentialbrowser2\"},{\"TableName\":\"ListTableTestTokenCredentialbrowser3\"}]}",
+   "responseHeaders": {
+    "access-control-allow-origin": "*",
+    "access-control-expose-headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,X-Content-Type-Options,Cache-Control,x-ms-continuation-NextTableName,Content-Type,Content-Length,Date,Transfer-Encoding",
+    "cache-control": "no-cache",
+    "content-type": "application/json;odata=minimalmetadata;streaming=true;charset=utf-8",
+    "date": "Tue, 19 Oct 2021 23:46:09 GMT",
+    "server": "Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-ms-client-request-id": "1a9cbf49-f3e7-44a8-b835-95e6e243561d",
+    "x-ms-continuation-nexttablename": "1!72!bGlzdHRhYmxldGVzdHRva2VuY3JlZGVudGlhbGJyb3dzZXI0ATAxZDdjNTQzN2QxZTUyNjk-",
+    "x-ms-request-id": "5cd642ff-f002-00e0-0d43-c56737000000",
+    "x-ms-version": "2019-02-02"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://fakeaccount.table.core.windows.net/Tables",
+   "query": {
+    "$top": "2",
+    "NextTableName": "1!72!bGlzdHRhYmxldGVzdHRva2VuY3JlZGVudGlhbGJyb3dzZXI0ATAxZDdjNTQzN2QxZTUyNjk-"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"odata.metadata\":\"https://fakeaccount.table.core.windows.net/$metadata#Tables\",\"value\":[{\"TableName\":\"ListTableTestTokenCredentialbrowser4\"},{\"TableName\":\"ListTableTestTokenCredentialbrowser5\"}]}",
+   "responseHeaders": {
+    "access-control-allow-origin": "*",
+    "access-control-expose-headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,X-Content-Type-Options,Cache-Control,x-ms-continuation-NextTableName,Content-Type,Content-Length,Date,Transfer-Encoding",
+    "cache-control": "no-cache",
+    "content-type": "application/json;odata=minimalmetadata;streaming=true;charset=utf-8",
+    "date": "Tue, 19 Oct 2021 23:46:09 GMT",
+    "server": "Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-ms-client-request-id": "d3ac742c-9672-4fc8-91fd-39fc330f29cd",
+    "x-ms-continuation-nexttablename": "1!72!bGlzdHRhYmxldGVzdHRva2VuY3JlZGVudGlhbGJyb3dzZXI2ATAxZDdjNTQzN2QyYzEwNzc-",
+    "x-ms-request-id": "5cd64306-f002-00e0-1443-c56737000000",
+    "x-ms-version": "2019-02-02"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://fakeaccount.table.core.windows.net/Tables",
+   "query": {
+    "$top": "2",
+    "NextTableName": "1!72!bGlzdHRhYmxldGVzdHRva2VuY3JlZGVudGlhbGJyb3dzZXI2ATAxZDdjNTQzN2QyYzEwNzc-"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"odata.metadata\":\"https://fakeaccount.table.core.windows.net/$metadata#Tables\",\"value\":[{\"TableName\":\"ListTableTestTokenCredentialbrowser6\"},{\"TableName\":\"ListTableTestTokenCredentialbrowser7\"}]}",
+   "responseHeaders": {
+    "access-control-allow-origin": "*",
+    "access-control-expose-headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,X-Content-Type-Options,Cache-Control,x-ms-continuation-NextTableName,Content-Type,Content-Length,Date,Transfer-Encoding",
+    "cache-control": "no-cache",
+    "content-type": "application/json;odata=minimalmetadata;streaming=true;charset=utf-8",
+    "date": "Tue, 19 Oct 2021 23:46:09 GMT",
+    "server": "Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-ms-client-request-id": "751f9fe9-384c-4769-81a9-e312d64f058e",
+    "x-ms-continuation-nexttablename": "1!72!bGlzdHRhYmxldGVzdHRva2VuY3JlZGVudGlhbGJyb3dzZXI4ATAxZDdjNTQzN2QzYTQzY2E-",
+    "x-ms-request-id": "5cd64310-f002-00e0-1d43-c56737000000",
+    "x-ms-version": "2019-02-02"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://fakeaccount.table.core.windows.net/Tables",
+   "query": {
+    "$top": "2",
+    "NextTableName": "1!72!bGlzdHRhYmxldGVzdHRva2VuY3JlZGVudGlhbGJyb3dzZXI4ATAxZDdjNTQzN2QzYTQzY2E-"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"odata.metadata\":\"https://fakeaccount.table.core.windows.net/$metadata#Tables\",\"value\":[{\"TableName\":\"ListTableTestTokenCredentialbrowser8\"},{\"TableName\":\"ListTableTestTokenCredentialbrowser9\"}]}",
+   "responseHeaders": {
+    "access-control-allow-origin": "*",
+    "access-control-expose-headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,X-Content-Type-Options,Cache-Control,x-ms-continuation-NextTableName,Content-Type,Content-Length,Date,Transfer-Encoding",
+    "cache-control": "no-cache",
+    "content-type": "application/json;odata=minimalmetadata;streaming=true;charset=utf-8",
+    "date": "Tue, 19 Oct 2021 23:46:09 GMT",
+    "server": "Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-ms-client-request-id": "9851edf7-7c99-4a62-8695-ea6fcc1e1346",
+    "x-ms-continuation-nexttablename": "1!68!bGlzdHRhYmxldGVzdHRva2VuY3JlZGVudGlhbG5vZGUwATAxZDdjNTQzNzZlY2U4MDI-",
+    "x-ms-request-id": "5cd6431f-f002-00e0-2c43-c56737000000",
+    "x-ms-version": "2019-02-02"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://fakeaccount.table.core.windows.net/Tables",
+   "query": {
+    "$top": "2",
+    "NextTableName": "1!68!bGlzdHRhYmxldGVzdHRva2VuY3JlZGVudGlhbG5vZGUwATAxZDdjNTQzNzZlY2U4MDI-"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"odata.metadata\":\"https://fakeaccount.table.core.windows.net/$metadata#Tables\",\"value\":[{\"TableName\":\"TestChars\"},{\"TableName\":\"TestChars2\"}]}",
+   "responseHeaders": {
+    "access-control-allow-origin": "*",
+    "access-control-expose-headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,X-Content-Type-Options,Cache-Control,x-ms-continuation-NextTableName,Content-Type,Content-Length,Date,Transfer-Encoding",
+    "cache-control": "no-cache",
+    "content-type": "application/json;odata=minimalmetadata;streaming=true;charset=utf-8",
+    "date": "Tue, 19 Oct 2021 23:46:09 GMT",
+    "server": "Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-ms-client-request-id": "02002cb4-e243-408c-99a6-81a026837090",
+    "x-ms-continuation-nexttablename": "1!36!dGVzdGNoYXJzMwEwMWQ3YThkYWYwYjJiYjlj",
+    "x-ms-request-id": "5cd6432e-f002-00e0-3a43-c56737000000",
+    "x-ms-version": "2019-02-02"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://fakeaccount.table.core.windows.net/Tables",
+   "query": {
+    "$top": "2",
+    "NextTableName": "1!36!dGVzdGNoYXJzMwEwMWQ3YThkYWYwYjJiYjlj"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"odata.metadata\":\"https://fakeaccount.table.core.windows.net/$metadata#Tables\",\"value\":[{\"TableName\":\"TestChars3\"},{\"TableName\":\"testTable\"}]}",
+   "responseHeaders": {
+    "access-control-allow-origin": "*",
+    "access-control-expose-headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,X-Content-Type-Options,Cache-Control,x-ms-continuation-NextTableName,Content-Type,Content-Length,Date,Transfer-Encoding",
+    "cache-control": "no-cache",
+    "content-type": "application/json;odata=minimalmetadata;streaming=true;charset=utf-8",
+    "date": "Tue, 19 Oct 2021 23:46:09 GMT",
+    "server": "Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-ms-client-request-id": "b294a86b-6f0d-404f-a7ac-50c8242b4877",
+    "x-ms-continuation-nexttablename": "1!68!dGVzdHRhYmxlc2FzY29ubmVjdGlvbnN0cmluZ25vZGUBMDFkN2M1NDM3OTRmMTFiNw--",
+    "x-ms-request-id": "5cd64337-f002-00e0-4243-c56737000000",
+    "x-ms-version": "2019-02-02"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://fakeaccount.table.core.windows.net/Tables",
+   "query": {
+    "$top": "2",
+    "NextTableName": "1!68!dGVzdHRhYmxlc2FzY29ubmVjdGlvbnN0cmluZ25vZGUBMDFkN2M1NDM3OTRmMTFiNw--"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"odata.metadata\":\"https://fakeaccount.table.core.windows.net/$metadata#Tables\",\"value\":[{\"TableName\":\"TestTestTest\"}]}",
+   "responseHeaders": {
+    "access-control-allow-origin": "*",
+    "access-control-expose-headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,X-Content-Type-Options,Cache-Control,Content-Type,Content-Length,Date,Transfer-Encoding",
+    "cache-control": "no-cache",
+    "content-type": "application/json;odata=minimalmetadata;streaming=true;charset=utf-8",
+    "date": "Tue, 19 Oct 2021 23:46:10 GMT",
+    "server": "Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-ms-client-request-id": "d24ac604-243d-409c-8bae-490539cdbd58",
+    "x-ms-request-id": "5cd64342-f002-00e0-4d43-c56737000000",
+    "x-ms-version": "2019-02-02"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://fakeaccount.table.core.windows.net/Tables",
+   "query": {
+    "$top": "2",
+    "NextTableName": "1!68!dGVzdHRhYmxlc2FzY29ubmVjdGlvbnN0cmluZ25vZGUBMDFkN2M1NDM3OTRmMTFiNw--"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"odata.metadata\":\"https://fakeaccount.table.core.windows.net/$metadata#Tables\",\"value\":[{\"TableName\":\"TestTestTest\"}]}",
+   "responseHeaders": {
+    "access-control-allow-origin": "*",
+    "access-control-expose-headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,X-Content-Type-Options,Cache-Control,Content-Type,Content-Length,Date,Transfer-Encoding",
+    "cache-control": "no-cache",
+    "content-type": "application/json;odata=minimalmetadata;streaming=true;charset=utf-8",
+    "date": "Tue, 19 Oct 2021 23:46:10 GMT",
+    "server": "Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-ms-client-request-id": "02b66f1b-6cbf-42d3-a529-f577a941c724",
+    "x-ms-request-id": "5cd6434f-f002-00e0-5943-c56737000000",
+    "x-ms-version": "2019-02-02"
+   }
+  }
+ ],
+ "uniqueTestInfo": {
+  "uniqueName": {},
+  "newDate": {}
+ },
+ "hash": "24e801c345adecf0ecd7dfb9310860ed"
+}

--- a/sdk/tables/data-tables/recordings/node/tableserviceclient_sasconnectionstring_listtables/recording_should_list_a_specific_page_with_continuationtoken.js
+++ b/sdk/tables/data-tables/recordings/node/tableserviceclient_sasconnectionstring_listtables/recording_should_list_a_specific_page_with_continuationtoken.js
@@ -1,0 +1,511 @@
+let nock = require('nock');
+
+module.exports.hash = "e362ada74cb298d39243b965b65024cc";
+
+module.exports.testInfo = {"uniqueName":{},"newDate":{}}
+
+nock('https://fakeaccount.table.core.windows.net:443', {"encodedQueryParams":true})
+  .get('/Tables')
+  .query(true)
+  .reply(200, {"odata.metadata":"https://fakeaccount.table.core.windows.net/$metadata#Tables","value":[{"TableName":"byPageTest"},{"TableName":"CreateSimpleEntityBatchPerf"}]}, [
+  'Cache-Control',
+  'no-cache',
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json;odata=minimalmetadata;streaming=true;charset=utf-8',
+  'Server',
+  'Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '1030341d-8002-0001-6243-c58042000000',
+  'x-ms-client-request-id',
+  '560a9fd3-fb61-4d25-ab42-05b357959905',
+  'x-ms-version',
+  '2019-02-02',
+  'X-Content-Type-Options',
+  'nosniff',
+  'x-ms-continuation-NextTableName',
+  '1!44!Y3JlYXRldGFibGVuZXcBMDFkNzY2YmM1MmE5N2JhMA--',
+  'Access-Control-Expose-Headers',
+  'x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,X-Content-Type-Options,Cache-Control,x-ms-continuation-NextTableName,Content-Type,Content-Length,Date,Transfer-Encoding',
+  'Access-Control-Allow-Origin',
+  '*',
+  'Date',
+  'Tue, 19 Oct 2021 23:46:02 GMT'
+]);
+
+nock('https://fakeaccount.table.core.windows.net:443', {"encodedQueryParams":true})
+  .get('/Tables')
+  .query(true)
+  .reply(200, {"odata.metadata":"https://fakeaccount.table.core.windows.net/$metadata#Tables","value":[{"TableName":"createTableNew"},{"TableName":"createTableNew2"}]}, [
+  'Cache-Control',
+  'no-cache',
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json;odata=minimalmetadata;streaming=true;charset=utf-8',
+  'Server',
+  'Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '10303423-8002-0001-6843-c58042000000',
+  'x-ms-client-request-id',
+  'd76bb7f6-f16f-402f-8936-c75a0389d456',
+  'x-ms-version',
+  '2019-02-02',
+  'X-Content-Type-Options',
+  'nosniff',
+  'x-ms-continuation-NextTableName',
+  '1!44!Y3JlYXRldGFibGVvbGQBMDFkNzY2YmQ2ZWMzODZlYQ--',
+  'Access-Control-Expose-Headers',
+  'x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,X-Content-Type-Options,Cache-Control,x-ms-continuation-NextTableName,Content-Type,Content-Length,Date,Transfer-Encoding',
+  'Access-Control-Allow-Origin',
+  '*',
+  'Date',
+  'Tue, 19 Oct 2021 23:46:02 GMT'
+]);
+
+nock('https://fakeaccount.table.core.windows.net:443', {"encodedQueryParams":true})
+  .get('/Tables')
+  .query(true)
+  .reply(200, {"odata.metadata":"https://fakeaccount.table.core.windows.net/$metadata#Tables","value":[{"TableName":"createTableOld"},{"TableName":"doublesTest"}]}, [
+  'Cache-Control',
+  'no-cache',
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json;odata=minimalmetadata;streaming=true;charset=utf-8',
+  'Server',
+  'Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '1030342b-8002-0001-7043-c58042000000',
+  'x-ms-client-request-id',
+  '572aa7b7-7f26-4fd7-9a58-fd387e9bc90b',
+  'x-ms-version',
+  '2019-02-02',
+  'X-Content-Type-Options',
+  'nosniff',
+  'x-ms-continuation-NextTableName',
+  '1!72!bGlzdHRhYmxldGVzdHNhc2Nvbm5lY3Rpb25zdHJpbmdub2RlMAEwMWQ3YzU0Mzc5NWYxYTE4',
+  'Access-Control-Expose-Headers',
+  'x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,X-Content-Type-Options,Cache-Control,x-ms-continuation-NextTableName,Content-Type,Content-Length,Date,Transfer-Encoding',
+  'Access-Control-Allow-Origin',
+  '*',
+  'Date',
+  'Tue, 19 Oct 2021 23:46:02 GMT'
+]);
+
+nock('https://fakeaccount.table.core.windows.net:443', {"encodedQueryParams":true})
+  .get('/Tables')
+  .query(true)
+  .reply(200, {"odata.metadata":"https://fakeaccount.table.core.windows.net/$metadata#Tables","value":[{"TableName":"ListTableTestSASConnectionStringnode0"},{"TableName":"ListTableTestSASConnectionStringnode1"}]}, [
+  'Cache-Control',
+  'no-cache',
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json;odata=minimalmetadata;streaming=true;charset=utf-8',
+  'Server',
+  'Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '1030343e-8002-0001-0243-c58042000000',
+  'x-ms-client-request-id',
+  'e9d96fa6-4f17-4307-a68a-c78e8bc88b4a',
+  'x-ms-version',
+  '2019-02-02',
+  'X-Content-Type-Options',
+  'nosniff',
+  'x-ms-continuation-NextTableName',
+  '1!76!bGlzdHRhYmxldGVzdHNhc2Nvbm5lY3Rpb25zdHJpbmdub2RlMTABMDFkN2M1NDM3OTlhNThkOA--',
+  'Access-Control-Expose-Headers',
+  'x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,X-Content-Type-Options,Cache-Control,x-ms-continuation-NextTableName,Content-Type,Content-Length,Date,Transfer-Encoding',
+  'Access-Control-Allow-Origin',
+  '*',
+  'Date',
+  'Tue, 19 Oct 2021 23:46:02 GMT'
+]);
+
+nock('https://fakeaccount.table.core.windows.net:443', {"encodedQueryParams":true})
+  .get('/Tables')
+  .query(true)
+  .reply(200, {"odata.metadata":"https://fakeaccount.table.core.windows.net/$metadata#Tables","value":[{"TableName":"ListTableTestSASConnectionStringnode10"},{"TableName":"ListTableTestSASConnectionStringnode11"}]}, [
+  'Cache-Control',
+  'no-cache',
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json;odata=minimalmetadata;streaming=true;charset=utf-8',
+  'Server',
+  'Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '1030344d-8002-0001-1143-c58042000000',
+  'x-ms-client-request-id',
+  '5bad2345-6bde-47e0-a9e4-860c3b6d26c4',
+  'x-ms-version',
+  '2019-02-02',
+  'X-Content-Type-Options',
+  'nosniff',
+  'x-ms-continuation-NextTableName',
+  '1!76!bGlzdHRhYmxldGVzdHNhc2Nvbm5lY3Rpb25zdHJpbmdub2RlMTIBMDFkN2M1NDM3OWE2NjhlMQ--',
+  'Access-Control-Expose-Headers',
+  'x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,X-Content-Type-Options,Cache-Control,x-ms-continuation-NextTableName,Content-Type,Content-Length,Date,Transfer-Encoding',
+  'Access-Control-Allow-Origin',
+  '*',
+  'Date',
+  'Tue, 19 Oct 2021 23:46:03 GMT'
+]);
+
+nock('https://fakeaccount.table.core.windows.net:443', {"encodedQueryParams":true})
+  .get('/Tables')
+  .query(true)
+  .reply(200, {"odata.metadata":"https://fakeaccount.table.core.windows.net/$metadata#Tables","value":[{"TableName":"ListTableTestSASConnectionStringnode12"},{"TableName":"ListTableTestSASConnectionStringnode13"}]}, [
+  'Cache-Control',
+  'no-cache',
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json;odata=minimalmetadata;streaming=true;charset=utf-8',
+  'Server',
+  'Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '10303456-8002-0001-1a43-c58042000000',
+  'x-ms-client-request-id',
+  '54ffe0a8-71e3-4f7d-a0fc-ca14652da82b',
+  'x-ms-version',
+  '2019-02-02',
+  'X-Content-Type-Options',
+  'nosniff',
+  'x-ms-continuation-NextTableName',
+  '1!76!bGlzdHRhYmxldGVzdHNhc2Nvbm5lY3Rpb25zdHJpbmdub2RlMTQBMDFkN2M1NDM3OWIxMTkyYQ--',
+  'Access-Control-Expose-Headers',
+  'x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,X-Content-Type-Options,Cache-Control,x-ms-continuation-NextTableName,Content-Type,Content-Length,Date,Transfer-Encoding',
+  'Access-Control-Allow-Origin',
+  '*',
+  'Date',
+  'Tue, 19 Oct 2021 23:46:03 GMT'
+]);
+
+nock('https://fakeaccount.table.core.windows.net:443', {"encodedQueryParams":true})
+  .get('/Tables')
+  .query(true)
+  .reply(200, {"odata.metadata":"https://fakeaccount.table.core.windows.net/$metadata#Tables","value":[{"TableName":"ListTableTestSASConnectionStringnode14"},{"TableName":"ListTableTestSASConnectionStringnode15"}]}, [
+  'Cache-Control',
+  'no-cache',
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json;odata=minimalmetadata;streaming=true;charset=utf-8',
+  'Server',
+  'Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '10303462-8002-0001-2543-c58042000000',
+  'x-ms-client-request-id',
+  'bd0b55a4-485e-4f58-af00-fed920ed838e',
+  'x-ms-version',
+  '2019-02-02',
+  'X-Content-Type-Options',
+  'nosniff',
+  'x-ms-continuation-NextTableName',
+  '1!76!bGlzdHRhYmxldGVzdHNhc2Nvbm5lY3Rpb25zdHJpbmdub2RlMTYBMDFkN2M1NDM3OWJjM2ViNw--',
+  'Access-Control-Expose-Headers',
+  'x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,X-Content-Type-Options,Cache-Control,x-ms-continuation-NextTableName,Content-Type,Content-Length,Date,Transfer-Encoding',
+  'Access-Control-Allow-Origin',
+  '*',
+  'Date',
+  'Tue, 19 Oct 2021 23:46:03 GMT'
+]);
+
+nock('https://fakeaccount.table.core.windows.net:443', {"encodedQueryParams":true})
+  .get('/Tables')
+  .query(true)
+  .reply(200, {"odata.metadata":"https://fakeaccount.table.core.windows.net/$metadata#Tables","value":[{"TableName":"ListTableTestSASConnectionStringnode16"},{"TableName":"ListTableTestSASConnectionStringnode17"}]}, [
+  'Cache-Control',
+  'no-cache',
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json;odata=minimalmetadata;streaming=true;charset=utf-8',
+  'Server',
+  'Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '10303470-8002-0001-3343-c58042000000',
+  'x-ms-client-request-id',
+  '68179e8b-25ae-4a50-85e3-a0a85fba0ab2',
+  'x-ms-version',
+  '2019-02-02',
+  'X-Content-Type-Options',
+  'nosniff',
+  'x-ms-continuation-NextTableName',
+  '1!76!bGlzdHRhYmxldGVzdHNhc2Nvbm5lY3Rpb25zdHJpbmdub2RlMTgBMDFkN2M1NDM3OWM2ZWVmZg--',
+  'Access-Control-Expose-Headers',
+  'x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,X-Content-Type-Options,Cache-Control,x-ms-continuation-NextTableName,Content-Type,Content-Length,Date,Transfer-Encoding',
+  'Access-Control-Allow-Origin',
+  '*',
+  'Date',
+  'Tue, 19 Oct 2021 23:46:03 GMT'
+]);
+
+nock('https://fakeaccount.table.core.windows.net:443', {"encodedQueryParams":true})
+  .get('/Tables')
+  .query(true)
+  .reply(200, {"odata.metadata":"https://fakeaccount.table.core.windows.net/$metadata#Tables","value":[{"TableName":"ListTableTestSASConnectionStringnode18"},{"TableName":"ListTableTestSASConnectionStringnode19"}]}, [
+  'Cache-Control',
+  'no-cache',
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json;odata=minimalmetadata;streaming=true;charset=utf-8',
+  'Server',
+  'Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '10303485-8002-0001-4343-c58042000000',
+  'x-ms-client-request-id',
+  'c8ef179b-7985-425c-bcb5-9345ad978510',
+  'x-ms-version',
+  '2019-02-02',
+  'X-Content-Type-Options',
+  'nosniff',
+  'x-ms-continuation-NextTableName',
+  '1!72!bGlzdHRhYmxldGVzdHNhc2Nvbm5lY3Rpb25zdHJpbmdub2RlMgEwMWQ3YzU0Mzc5NmIyYTJi',
+  'Access-Control-Expose-Headers',
+  'x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,X-Content-Type-Options,Cache-Control,x-ms-continuation-NextTableName,Content-Type,Content-Length,Date,Transfer-Encoding',
+  'Access-Control-Allow-Origin',
+  '*',
+  'Date',
+  'Tue, 19 Oct 2021 23:46:03 GMT'
+]);
+
+nock('https://fakeaccount.table.core.windows.net:443', {"encodedQueryParams":true})
+  .get('/Tables')
+  .query(true)
+  .reply(200, {"odata.metadata":"https://fakeaccount.table.core.windows.net/$metadata#Tables","value":[{"TableName":"ListTableTestSASConnectionStringnode2"},{"TableName":"ListTableTestSASConnectionStringnode3"}]}, [
+  'Cache-Control',
+  'no-cache',
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json;odata=minimalmetadata;streaming=true;charset=utf-8',
+  'Server',
+  'Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '1030348e-8002-0001-4c43-c58042000000',
+  'x-ms-client-request-id',
+  '781c904f-72ae-43ab-bc58-5e174fb9f905',
+  'x-ms-version',
+  '2019-02-02',
+  'X-Content-Type-Options',
+  'nosniff',
+  'x-ms-continuation-NextTableName',
+  '1!72!bGlzdHRhYmxldGVzdHNhc2Nvbm5lY3Rpb25zdHJpbmdub2RlNAEwMWQ3YzU0Mzc5NzViMzU4',
+  'Access-Control-Expose-Headers',
+  'x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,X-Content-Type-Options,Cache-Control,x-ms-continuation-NextTableName,Content-Type,Content-Length,Date,Transfer-Encoding',
+  'Access-Control-Allow-Origin',
+  '*',
+  'Date',
+  'Tue, 19 Oct 2021 23:46:03 GMT'
+]);
+
+nock('https://fakeaccount.table.core.windows.net:443', {"encodedQueryParams":true})
+  .get('/Tables')
+  .query(true)
+  .reply(200, {"odata.metadata":"https://fakeaccount.table.core.windows.net/$metadata#Tables","value":[{"TableName":"ListTableTestSASConnectionStringnode4"},{"TableName":"ListTableTestSASConnectionStringnode5"}]}, [
+  'Cache-Control',
+  'no-cache',
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json;odata=minimalmetadata;streaming=true;charset=utf-8',
+  'Server',
+  'Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '10303496-8002-0001-5443-c58042000000',
+  'x-ms-client-request-id',
+  'd927b604-8e63-47de-a2c1-e4ff7003fd2f',
+  'x-ms-version',
+  '2019-02-02',
+  'X-Content-Type-Options',
+  'nosniff',
+  'x-ms-continuation-NextTableName',
+  '1!72!bGlzdHRhYmxldGVzdHNhc2Nvbm5lY3Rpb25zdHJpbmdub2RlNgEwMWQ3YzU0Mzc5ODBkOGU1',
+  'Access-Control-Expose-Headers',
+  'x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,X-Content-Type-Options,Cache-Control,x-ms-continuation-NextTableName,Content-Type,Content-Length,Date,Transfer-Encoding',
+  'Access-Control-Allow-Origin',
+  '*',
+  'Date',
+  'Tue, 19 Oct 2021 23:46:03 GMT'
+]);
+
+nock('https://fakeaccount.table.core.windows.net:443', {"encodedQueryParams":true})
+  .get('/Tables')
+  .query(true)
+  .reply(200, {"odata.metadata":"https://fakeaccount.table.core.windows.net/$metadata#Tables","value":[{"TableName":"ListTableTestSASConnectionStringnode6"},{"TableName":"ListTableTestSASConnectionStringnode7"}]}, [
+  'Cache-Control',
+  'no-cache',
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json;odata=minimalmetadata;streaming=true;charset=utf-8',
+  'Server',
+  'Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '1030349e-8002-0001-5c43-c58042000000',
+  'x-ms-client-request-id',
+  '266ff38d-6cfd-409d-9586-2ae0ec0a9074',
+  'x-ms-version',
+  '2019-02-02',
+  'X-Content-Type-Options',
+  'nosniff',
+  'x-ms-continuation-NextTableName',
+  '1!72!bGlzdHRhYmxldGVzdHNhc2Nvbm5lY3Rpb25zdHJpbmdub2RlOAEwMWQ3YzU0Mzc5OGU0OGM1',
+  'Access-Control-Expose-Headers',
+  'x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,X-Content-Type-Options,Cache-Control,x-ms-continuation-NextTableName,Content-Type,Content-Length,Date,Transfer-Encoding',
+  'Access-Control-Allow-Origin',
+  '*',
+  'Date',
+  'Tue, 19 Oct 2021 23:46:03 GMT'
+]);
+
+nock('https://fakeaccount.table.core.windows.net:443', {"encodedQueryParams":true})
+  .get('/Tables')
+  .query(true)
+  .reply(200, {"odata.metadata":"https://fakeaccount.table.core.windows.net/$metadata#Tables","value":[{"TableName":"ListTableTestSASConnectionStringnode8"},{"TableName":"ListTableTestSASConnectionStringnode9"}]}, [
+  'Cache-Control',
+  'no-cache',
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json;odata=minimalmetadata;streaming=true;charset=utf-8',
+  'Server',
+  'Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '103034a6-8002-0001-6343-c58042000000',
+  'x-ms-client-request-id',
+  '0eb415b9-e9a4-4d49-930d-4785577f854a',
+  'x-ms-version',
+  '2019-02-02',
+  'X-Content-Type-Options',
+  'nosniff',
+  'x-ms-continuation-NextTableName',
+  '1!64!bGlzdHRhYmxldGVzdHNhc3Rva2VuYnJvd3NlcjABMDFkN2M1NDM2NjZkOGYzMw--',
+  'Access-Control-Expose-Headers',
+  'x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,X-Content-Type-Options,Cache-Control,x-ms-continuation-NextTableName,Content-Type,Content-Length,Date,Transfer-Encoding',
+  'Access-Control-Allow-Origin',
+  '*',
+  'Date',
+  'Tue, 19 Oct 2021 23:46:03 GMT'
+]);
+
+nock('https://fakeaccount.table.core.windows.net:443', {"encodedQueryParams":true})
+  .get('/Tables')
+  .query(true)
+  .reply(200, {"odata.metadata":"https://fakeaccount.table.core.windows.net/$metadata#Tables","value":[{"TableName":"TestChars"},{"TableName":"TestChars2"}]}, [
+  'Cache-Control',
+  'no-cache',
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json;odata=minimalmetadata;streaming=true;charset=utf-8',
+  'Server',
+  'Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '103034ae-8002-0001-6b43-c58042000000',
+  'x-ms-client-request-id',
+  '368d19b6-7a5b-457e-86c5-34396f2d2ba5',
+  'x-ms-version',
+  '2019-02-02',
+  'X-Content-Type-Options',
+  'nosniff',
+  'x-ms-continuation-NextTableName',
+  '1!36!dGVzdGNoYXJzMwEwMWQ3YThkYWYwYjJiYjlj',
+  'Access-Control-Expose-Headers',
+  'x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,X-Content-Type-Options,Cache-Control,x-ms-continuation-NextTableName,Content-Type,Content-Length,Date,Transfer-Encoding',
+  'Access-Control-Allow-Origin',
+  '*',
+  'Date',
+  'Tue, 19 Oct 2021 23:46:03 GMT'
+]);
+
+nock('https://fakeaccount.table.core.windows.net:443', {"encodedQueryParams":true})
+  .get('/Tables')
+  .query(true)
+  .reply(200, {"odata.metadata":"https://fakeaccount.table.core.windows.net/$metadata#Tables","value":[{"TableName":"TestChars3"},{"TableName":"testTable"}]}, [
+  'Cache-Control',
+  'no-cache',
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json;odata=minimalmetadata;streaming=true;charset=utf-8',
+  'Server',
+  'Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '103034b6-8002-0001-7243-c58042000000',
+  'x-ms-client-request-id',
+  'b3905a51-3f9b-4c4e-9d9c-de7a39d58ddc',
+  'x-ms-version',
+  '2019-02-02',
+  'X-Content-Type-Options',
+  'nosniff',
+  'x-ms-continuation-NextTableName',
+  '1!68!dGVzdHRhYmxlc2FzY29ubmVjdGlvbnN0cmluZ25vZGUBMDFkN2M1NDM3OTRmMTFiNw--',
+  'Access-Control-Expose-Headers',
+  'x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,X-Content-Type-Options,Cache-Control,x-ms-continuation-NextTableName,Content-Type,Content-Length,Date,Transfer-Encoding',
+  'Access-Control-Allow-Origin',
+  '*',
+  'Date',
+  'Tue, 19 Oct 2021 23:46:03 GMT'
+]);
+
+nock('https://fakeaccount.table.core.windows.net:443', {"encodedQueryParams":true})
+  .get('/Tables')
+  .query(true)
+  .reply(200, {"odata.metadata":"https://fakeaccount.table.core.windows.net/$metadata#Tables","value":[{"TableName":"TestTestTest"}]}, [
+  'Cache-Control',
+  'no-cache',
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json;odata=minimalmetadata;streaming=true;charset=utf-8',
+  'Server',
+  'Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '103034be-8002-0001-7a43-c58042000000',
+  'x-ms-client-request-id',
+  'f5497646-3e9c-479c-b678-7a290cf7298f',
+  'x-ms-version',
+  '2019-02-02',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Access-Control-Expose-Headers',
+  'x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,X-Content-Type-Options,Cache-Control,Content-Type,Content-Length,Date,Transfer-Encoding',
+  'Access-Control-Allow-Origin',
+  '*',
+  'Date',
+  'Tue, 19 Oct 2021 23:46:03 GMT'
+]);
+
+nock('https://fakeaccount.table.core.windows.net:443', {"encodedQueryParams":true})
+  .get('/Tables')
+  .query(true)
+  .reply(200, {"odata.metadata":"https://fakeaccount.table.core.windows.net/$metadata#Tables","value":[{"TableName":"TestTestTest"}]}, [
+  'Cache-Control',
+  'no-cache',
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json;odata=minimalmetadata;streaming=true;charset=utf-8',
+  'Server',
+  'Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '103034c6-8002-0001-0143-c58042000000',
+  'x-ms-client-request-id',
+  '31d2d514-8206-4107-8819-9314549b72d8',
+  'x-ms-version',
+  '2019-02-02',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Access-Control-Expose-Headers',
+  'x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,X-Content-Type-Options,Cache-Control,Content-Type,Content-Length,Date,Transfer-Encoding',
+  'Access-Control-Allow-Origin',
+  '*',
+  'Date',
+  'Tue, 19 Oct 2021 23:46:03 GMT'
+]);

--- a/sdk/tables/data-tables/recordings/node/tableserviceclient_tokencredential_listtables/recording_should_list_a_specific_page_with_continuationtoken.js
+++ b/sdk/tables/data-tables/recordings/node/tableserviceclient_tokencredential_listtables/recording_should_list_a_specific_page_with_continuationtoken.js
@@ -1,0 +1,617 @@
+let nock = require('nock');
+
+module.exports.hash = "e362ada74cb298d39243b965b65024cc";
+
+module.exports.testInfo = {"uniqueName":{},"newDate":{}}
+
+nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
+  .get('/common/discovery/instance')
+  .query(true)
+  .reply(200, {"tenant_discovery_endpoint":"https://login.microsoftonline.com/88888888-8888-8888-8888-888888888888/v2.0/.well-known/openid-configuration","api-version":"1.1","metadata":[{"preferred_network":"login.microsoftonline.com","preferred_cache":"login.windows.net","aliases":["login.microsoftonline.com","login.windows.net","login.microsoft.com","sts.windows.net"]},{"preferred_network":"login.partner.microsoftonline.cn","preferred_cache":"login.partner.microsoftonline.cn","aliases":["login.partner.microsoftonline.cn","login.chinacloudapi.cn"]},{"preferred_network":"login.microsoftonline.de","preferred_cache":"login.microsoftonline.de","aliases":["login.microsoftonline.de"]},{"preferred_network":"login.microsoftonline.us","preferred_cache":"login.microsoftonline.us","aliases":["login.microsoftonline.us","login.usgovcloudapi.net"]},{"preferred_network":"login-us.microsoftonline.com","preferred_cache":"login-us.microsoftonline.com","aliases":["login-us.microsoftonline.com"]}]}, [
+  'Cache-Control',
+  'max-age=86400, private',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Access-Control-Allow-Origin',
+  '*',
+  'Access-Control-Allow-Methods',
+  'GET, OPTIONS',
+  'P3P',
+  'CP="DSP CUR OTPi IND OTRi ONL FIN"',
+  'x-ms-request-id',
+  '80cc9c8c-299d-49b0-9eaf-768b5ad83e00',
+  'x-ms-ests-server',
+  '2.1.12108.11 - EUS ProdSlices',
+  'Set-Cookie',
+  'fpc=Al0HEYzY2MNAis0gmriyqiw; expires=Thu, 18-Nov-2021 23:46:00 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'Set-Cookie',
+  'esctx=AQABAAAAAAD--DLA3VO7QrddgJg7Wevr3SbWfK7K7DkIIFDoam5ld75kXdJcUA55LQuEseBcDwAaBvtOKTXafppsTuu9KrqVNc4N81hiXQwlA5UWNyVZhx7hMccQrqitL_6g6ChzpWOpRezNelcNjDoA6D-9c-3KiF3KM-ClF4cQHDQOIlZufK_QqeWAL22-s0kirjnFzQMgAA; domain=.login.microsoftonline.com; path=/; secure; HttpOnly; SameSite=None',
+  'Set-Cookie',
+  'x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly',
+  'Set-Cookie',
+  'stsservicecookie=estsfd; path=/; secure; samesite=none; httponly',
+  'Date',
+  'Tue, 19 Oct 2021 23:45:59 GMT',
+  'Content-Length',
+  '980'
+]);
+
+nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
+  .get('/88888888-8888-8888-8888-888888888888/v2.0/.well-known/openid-configuration')
+  .reply(200, {"token_endpoint":"https://login.microsoftonline.com/88888888-8888-8888-8888-888888888888/oauth2/v2.0/token","token_endpoint_auth_methods_supported":["client_secret_post","private_key_jwt","client_secret_basic"],"jwks_uri":"https://login.microsoftonline.com/88888888-8888-8888-8888-888888888888/discovery/v2.0/keys","response_modes_supported":["query","fragment","form_post"],"subject_types_supported":["pairwise"],"id_token_signing_alg_values_supported":["RS256"],"response_types_supported":["code","id_token","code id_token","id_token token"],"scopes_supported":["openid","profile","email","offline_access"],"issuer":"https://login.microsoftonline.com/88888888-8888-8888-8888-888888888888/v2.0","request_uri_parameter_supported":false,"userinfo_endpoint":"https://graph.microsoft.com/oidc/userinfo","authorization_endpoint":"https://login.microsoftonline.com/88888888-8888-8888-8888-888888888888/oauth2/v2.0/authorize","device_authorization_endpoint":"https://login.microsoftonline.com/88888888-8888-8888-8888-888888888888/oauth2/v2.0/devicecode","http_logout_supported":true,"frontchannel_logout_supported":true,"end_session_endpoint":"https://login.microsoftonline.com/88888888-8888-8888-8888-888888888888/oauth2/v2.0/logout","claims_supported":["sub","iss","cloud_instance_name","cloud_instance_host_name","cloud_graph_host_name","msgraph_host","aud","exp","iat","auth_time","acr","nonce","preferred_username","name","tid","ver","at_hash","c_hash","email"],"kerberos_endpoint":"https://login.microsoftonline.com/88888888-8888-8888-8888-888888888888/kerberos","tenant_region_scope":"WW","cloud_instance_name":"microsoftonline.com","cloud_graph_host_name":"graph.windows.net","msgraph_host":"graph.microsoft.com","rbac_url":"https://pas.windows.net"}, [
+  'Cache-Control',
+  'max-age=86400, private',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Access-Control-Allow-Origin',
+  '*',
+  'Access-Control-Allow-Methods',
+  'GET, OPTIONS',
+  'P3P',
+  'CP="DSP CUR OTPi IND OTRi ONL FIN"',
+  'x-ms-request-id',
+  '48297d79-8474-4ac2-a90d-70c4e1540f00',
+  'x-ms-ests-server',
+  '2.1.12158.6 - NCUS ProdSlices',
+  'Set-Cookie',
+  'fpc=AmiMufyHo-pOmkBHdTucYPo; expires=Thu, 18-Nov-2021 23:46:00 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'Set-Cookie',
+  'esctx=AQABAAAAAAD--DLA3VO7QrddgJg7WevrjbtRKkFtPcf_dK9zSzjMoYQN53-cuAgMllRwFxQTxkW5qH5l9cl38rqNinQxGLRdIXob7dcbbTsjNWaGaZGSg5HWoDaza3_TnPj9lTwGrQZCc9KMrH68stiv4cUAqf5-bxM7RIWXxkC8epoyUALyLbnMjBJzib--YyyzlWzANzkgAA; domain=.login.microsoftonline.com; path=/; secure; HttpOnly; SameSite=None',
+  'Set-Cookie',
+  'x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly',
+  'Set-Cookie',
+  'stsservicecookie=estsfd; path=/; secure; samesite=none; httponly',
+  'Date',
+  'Tue, 19 Oct 2021 23:45:59 GMT',
+  'Content-Length',
+  '1753'
+]);
+
+nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
+  .post('/88888888-8888-8888-8888-888888888888/oauth2/v2.0/token', "client_id=azure_client_id&scope=https%3A%2F%2Fsanitized%2F&grant_type=client_credentials&x-client-SKU=msal.js.node&x-client-VER=1.3.2&x-client-OS=linux&x-client-CPU=x64&x-ms-lib-capability=retry-after, h429&x-client-current-telemetry=5|771,2,,,|,&x-client-last-telemetry=5|0|||0,0&client-request-id=87d981f2-c173-49f1-9d21-813f2e950dc6&client_secret=azure_client_secret&claims=%7B%22access_token%22%3A%7B%22xms_cc%22%3A%7B%22values%22%3A%5B%22CP1%22%5D%7D%7D%7D")
+  .reply(200, {"token_type":"Bearer","expires_in":86399,"ext_expires_in":86399,"access_token":"access_token"}, [
+  'Cache-Control',
+  'no-store, no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'P3P',
+  'CP="DSP CUR OTPi IND OTRi ONL FIN"',
+  'x-ms-request-id',
+  '46fed83f-725b-4668-b598-407ec172d900',
+  'x-ms-ests-server',
+  '2.1.12158.6 - WUS2 ProdSlices',
+  'x-ms-clitelem',
+  '1,0,0,,',
+  'Set-Cookie',
+  'fpc=ApABF8dahDNHkTps3xqGWdnJVDEwAQAAALdPAdkOAAAA; expires=Thu, 18-Nov-2021 23:46:00 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'Set-Cookie',
+  'x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly',
+  'Set-Cookie',
+  'stsservicecookie=estsfd; path=/; secure; samesite=none; httponly',
+  'Date',
+  'Tue, 19 Oct 2021 23:45:59 GMT',
+  'Content-Length',
+  '1318'
+]);
+
+nock('https://fakeaccount.table.core.windows.net:443', {"encodedQueryParams":true})
+  .get('/Tables')
+  .query(true)
+  .reply(200, {"odata.metadata":"https://fakeaccount.table.core.windows.net/$metadata#Tables","value":[{"TableName":"byPageTest"},{"TableName":"CreateSimpleEntityBatchPerf"}]}, [
+  'Cache-Control',
+  'no-cache',
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json;odata=minimalmetadata;streaming=true;charset=utf-8',
+  'Server',
+  'Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '1030312d-8002-0001-4b43-c58042000000',
+  'x-ms-client-request-id',
+  '96877570-ee92-42c1-8fc1-b071ef3f29d4',
+  'x-ms-version',
+  '2019-02-02',
+  'X-Content-Type-Options',
+  'nosniff',
+  'x-ms-continuation-NextTableName',
+  '1!44!Y3JlYXRldGFibGVuZXcBMDFkNzY2YmM1MmE5N2JhMA--',
+  'Access-Control-Expose-Headers',
+  'x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,X-Content-Type-Options,Cache-Control,x-ms-continuation-NextTableName,Content-Type,Content-Length,Date,Transfer-Encoding',
+  'Access-Control-Allow-Origin',
+  '*',
+  'Date',
+  'Tue, 19 Oct 2021 23:46:00 GMT'
+]);
+
+nock('https://fakeaccount.table.core.windows.net:443', {"encodedQueryParams":true})
+  .get('/Tables')
+  .query(true)
+  .reply(200, {"odata.metadata":"https://fakeaccount.table.core.windows.net/$metadata#Tables","value":[{"TableName":"createTableNew"},{"TableName":"createTableNew2"}]}, [
+  'Cache-Control',
+  'no-cache',
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json;odata=minimalmetadata;streaming=true;charset=utf-8',
+  'Server',
+  'Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '10303139-8002-0001-5443-c58042000000',
+  'x-ms-client-request-id',
+  '392e7057-7087-4b6f-a438-6a040216b154',
+  'x-ms-version',
+  '2019-02-02',
+  'X-Content-Type-Options',
+  'nosniff',
+  'x-ms-continuation-NextTableName',
+  '1!44!Y3JlYXRldGFibGVvbGQBMDFkNzY2YmQ2ZWMzODZlYQ--',
+  'Access-Control-Expose-Headers',
+  'x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,X-Content-Type-Options,Cache-Control,x-ms-continuation-NextTableName,Content-Type,Content-Length,Date,Transfer-Encoding',
+  'Access-Control-Allow-Origin',
+  '*',
+  'Date',
+  'Tue, 19 Oct 2021 23:46:00 GMT'
+]);
+
+nock('https://fakeaccount.table.core.windows.net:443', {"encodedQueryParams":true})
+  .get('/Tables')
+  .query(true)
+  .reply(200, {"odata.metadata":"https://fakeaccount.table.core.windows.net/$metadata#Tables","value":[{"TableName":"createTableOld"},{"TableName":"doublesTest"}]}, [
+  'Cache-Control',
+  'no-cache',
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json;odata=minimalmetadata;streaming=true;charset=utf-8',
+  'Server',
+  'Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '10303140-8002-0001-5a43-c58042000000',
+  'x-ms-client-request-id',
+  'fd0a0492-388b-42d5-b256-ac6368a67025',
+  'x-ms-version',
+  '2019-02-02',
+  'X-Content-Type-Options',
+  'nosniff',
+  'x-ms-continuation-NextTableName',
+  '1!76!bGlzdHRhYmxldGVzdHNhc2Nvbm5lY3Rpb25zdHJpbmdicm93c2VyMAEwMWQ3YzU0MzY0Y2IyZGYw',
+  'Access-Control-Expose-Headers',
+  'x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,X-Content-Type-Options,Cache-Control,x-ms-continuation-NextTableName,Content-Type,Content-Length,Date,Transfer-Encoding',
+  'Access-Control-Allow-Origin',
+  '*',
+  'Date',
+  'Tue, 19 Oct 2021 23:46:00 GMT'
+]);
+
+nock('https://fakeaccount.table.core.windows.net:443', {"encodedQueryParams":true})
+  .get('/Tables')
+  .query(true)
+  .reply(200, {"odata.metadata":"https://fakeaccount.table.core.windows.net/$metadata#Tables","value":[{"TableName":"ListTableTestTokenCredentialnode0"},{"TableName":"ListTableTestTokenCredentialnode1"}]}, [
+  'Cache-Control',
+  'no-cache',
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json;odata=minimalmetadata;streaming=true;charset=utf-8',
+  'Server',
+  'Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '10303147-8002-0001-6043-c58042000000',
+  'x-ms-client-request-id',
+  '37e5c7bd-63a0-4e04-b3f0-d21af1933a39',
+  'x-ms-version',
+  '2019-02-02',
+  'X-Content-Type-Options',
+  'nosniff',
+  'x-ms-continuation-NextTableName',
+  '1!68!bGlzdHRhYmxldGVzdHRva2VuY3JlZGVudGlhbG5vZGUxMAEwMWQ3YzU0Mzc3MzZjZjU1',
+  'Access-Control-Expose-Headers',
+  'x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,X-Content-Type-Options,Cache-Control,x-ms-continuation-NextTableName,Content-Type,Content-Length,Date,Transfer-Encoding',
+  'Access-Control-Allow-Origin',
+  '*',
+  'Date',
+  'Tue, 19 Oct 2021 23:46:00 GMT'
+]);
+
+nock('https://fakeaccount.table.core.windows.net:443', {"encodedQueryParams":true})
+  .get('/Tables')
+  .query(true)
+  .reply(200, {"odata.metadata":"https://fakeaccount.table.core.windows.net/$metadata#Tables","value":[{"TableName":"ListTableTestTokenCredentialnode10"},{"TableName":"ListTableTestTokenCredentialnode11"}]}, [
+  'Cache-Control',
+  'no-cache',
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json;odata=minimalmetadata;streaming=true;charset=utf-8',
+  'Server',
+  'Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '10303152-8002-0001-6a43-c58042000000',
+  'x-ms-client-request-id',
+  '48c42587-3d71-4a4d-a86c-4c7b18b5a59a',
+  'x-ms-version',
+  '2019-02-02',
+  'X-Content-Type-Options',
+  'nosniff',
+  'x-ms-continuation-NextTableName',
+  '1!68!bGlzdHRhYmxldGVzdHRva2VuY3JlZGVudGlhbG5vZGUxMgEwMWQ3YzU0Mzc3NDUwMmE4',
+  'Access-Control-Expose-Headers',
+  'x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,X-Content-Type-Options,Cache-Control,x-ms-continuation-NextTableName,Content-Type,Content-Length,Date,Transfer-Encoding',
+  'Access-Control-Allow-Origin',
+  '*',
+  'Date',
+  'Tue, 19 Oct 2021 23:46:00 GMT'
+]);
+
+nock('https://fakeaccount.table.core.windows.net:443', {"encodedQueryParams":true})
+  .get('/Tables')
+  .query(true)
+  .reply(200, {"odata.metadata":"https://fakeaccount.table.core.windows.net/$metadata#Tables","value":[{"TableName":"ListTableTestTokenCredentialnode12"},{"TableName":"ListTableTestTokenCredentialnode13"}]}, [
+  'Cache-Control',
+  'no-cache',
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json;odata=minimalmetadata;streaming=true;charset=utf-8',
+  'Server',
+  'Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '10303159-8002-0001-7143-c58042000000',
+  'x-ms-client-request-id',
+  '97ef0933-3e53-40e0-9bda-cca1174f1ced',
+  'x-ms-version',
+  '2019-02-02',
+  'X-Content-Type-Options',
+  'nosniff',
+  'x-ms-continuation-NextTableName',
+  '1!68!bGlzdHRhYmxldGVzdHRva2VuY3JlZGVudGlhbG5vZGUxNAEwMWQ3YzU0Mzc3NTQ2ZWIy',
+  'Access-Control-Expose-Headers',
+  'x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,X-Content-Type-Options,Cache-Control,x-ms-continuation-NextTableName,Content-Type,Content-Length,Date,Transfer-Encoding',
+  'Access-Control-Allow-Origin',
+  '*',
+  'Date',
+  'Tue, 19 Oct 2021 23:46:00 GMT'
+]);
+
+nock('https://fakeaccount.table.core.windows.net:443', {"encodedQueryParams":true})
+  .get('/Tables')
+  .query(true)
+  .reply(200, {"odata.metadata":"https://fakeaccount.table.core.windows.net/$metadata#Tables","value":[{"TableName":"ListTableTestTokenCredentialnode14"},{"TableName":"ListTableTestTokenCredentialnode15"}]}, [
+  'Cache-Control',
+  'no-cache',
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json;odata=minimalmetadata;streaming=true;charset=utf-8',
+  'Server',
+  'Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '1030315f-8002-0001-7743-c58042000000',
+  'x-ms-client-request-id',
+  'ac62f223-79b4-4821-a055-6a8401a4597b',
+  'x-ms-version',
+  '2019-02-02',
+  'X-Content-Type-Options',
+  'nosniff',
+  'x-ms-continuation-NextTableName',
+  '1!68!bGlzdHRhYmxldGVzdHRva2VuY3JlZGVudGlhbG5vZGUxNgEwMWQ3YzU0Mzc3NjIwNWFl',
+  'Access-Control-Expose-Headers',
+  'x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,X-Content-Type-Options,Cache-Control,x-ms-continuation-NextTableName,Content-Type,Content-Length,Date,Transfer-Encoding',
+  'Access-Control-Allow-Origin',
+  '*',
+  'Date',
+  'Tue, 19 Oct 2021 23:46:00 GMT'
+]);
+
+nock('https://fakeaccount.table.core.windows.net:443', {"encodedQueryParams":true})
+  .get('/Tables')
+  .query(true)
+  .reply(200, {"odata.metadata":"https://fakeaccount.table.core.windows.net/$metadata#Tables","value":[{"TableName":"ListTableTestTokenCredentialnode16"},{"TableName":"ListTableTestTokenCredentialnode17"}]}, [
+  'Cache-Control',
+  'no-cache',
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json;odata=minimalmetadata;streaming=true;charset=utf-8',
+  'Server',
+  'Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '1030316d-8002-0001-0343-c58042000000',
+  'x-ms-client-request-id',
+  '93673337-11b1-4434-bd0a-bc278a39116f',
+  'x-ms-version',
+  '2019-02-02',
+  'X-Content-Type-Options',
+  'nosniff',
+  'x-ms-continuation-NextTableName',
+  '1!68!bGlzdHRhYmxldGVzdHRva2VuY3JlZGVudGlhbG5vZGUxOAEwMWQ3YzU0Mzc3NmY5Y2E1',
+  'Access-Control-Expose-Headers',
+  'x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,X-Content-Type-Options,Cache-Control,x-ms-continuation-NextTableName,Content-Type,Content-Length,Date,Transfer-Encoding',
+  'Access-Control-Allow-Origin',
+  '*',
+  'Date',
+  'Tue, 19 Oct 2021 23:46:00 GMT'
+]);
+
+nock('https://fakeaccount.table.core.windows.net:443', {"encodedQueryParams":true})
+  .get('/Tables')
+  .query(true)
+  .reply(200, {"odata.metadata":"https://fakeaccount.table.core.windows.net/$metadata#Tables","value":[{"TableName":"ListTableTestTokenCredentialnode18"},{"TableName":"ListTableTestTokenCredentialnode19"}]}, [
+  'Cache-Control',
+  'no-cache',
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json;odata=minimalmetadata;streaming=true;charset=utf-8',
+  'Server',
+  'Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '10303175-8002-0001-0a43-c58042000000',
+  'x-ms-client-request-id',
+  '33981a8b-19ff-450f-ba29-d3ccad6bd417',
+  'x-ms-version',
+  '2019-02-02',
+  'X-Content-Type-Options',
+  'nosniff',
+  'x-ms-continuation-NextTableName',
+  '1!68!bGlzdHRhYmxldGVzdHRva2VuY3JlZGVudGlhbG5vZGUyATAxZDdjNTQzNzZmYjY5ODM-',
+  'Access-Control-Expose-Headers',
+  'x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,X-Content-Type-Options,Cache-Control,x-ms-continuation-NextTableName,Content-Type,Content-Length,Date,Transfer-Encoding',
+  'Access-Control-Allow-Origin',
+  '*',
+  'Date',
+  'Tue, 19 Oct 2021 23:46:00 GMT'
+]);
+
+nock('https://fakeaccount.table.core.windows.net:443', {"encodedQueryParams":true})
+  .get('/Tables')
+  .query(true)
+  .reply(200, {"odata.metadata":"https://fakeaccount.table.core.windows.net/$metadata#Tables","value":[{"TableName":"ListTableTestTokenCredentialnode2"},{"TableName":"ListTableTestTokenCredentialnode3"}]}, [
+  'Cache-Control',
+  'no-cache',
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json;odata=minimalmetadata;streaming=true;charset=utf-8',
+  'Server',
+  'Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '1030317b-8002-0001-0e43-c58042000000',
+  'x-ms-client-request-id',
+  'c1abbca9-be67-455b-af72-2600315a63eb',
+  'x-ms-version',
+  '2019-02-02',
+  'X-Content-Type-Options',
+  'nosniff',
+  'x-ms-continuation-NextTableName',
+  '1!68!bGlzdHRhYmxldGVzdHRva2VuY3JlZGVudGlhbG5vZGU0ATAxZDdjNTQzNzcwYTM5MzY-',
+  'Access-Control-Expose-Headers',
+  'x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,X-Content-Type-Options,Cache-Control,x-ms-continuation-NextTableName,Content-Type,Content-Length,Date,Transfer-Encoding',
+  'Access-Control-Allow-Origin',
+  '*',
+  'Date',
+  'Tue, 19 Oct 2021 23:46:00 GMT'
+]);
+
+nock('https://fakeaccount.table.core.windows.net:443', {"encodedQueryParams":true})
+  .get('/Tables')
+  .query(true)
+  .reply(200, {"odata.metadata":"https://fakeaccount.table.core.windows.net/$metadata#Tables","value":[{"TableName":"ListTableTestTokenCredentialnode4"},{"TableName":"ListTableTestTokenCredentialnode5"}]}, [
+  'Cache-Control',
+  'no-cache',
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json;odata=minimalmetadata;streaming=true;charset=utf-8',
+  'Server',
+  'Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '1030317e-8002-0001-1143-c58042000000',
+  'x-ms-client-request-id',
+  'eb593d81-2d09-4a6d-9278-a33a42cb6931',
+  'x-ms-version',
+  '2019-02-02',
+  'X-Content-Type-Options',
+  'nosniff',
+  'x-ms-continuation-NextTableName',
+  '1!68!bGlzdHRhYmxldGVzdHRva2VuY3JlZGVudGlhbG5vZGU2ATAxZDdjNTQzNzcxOGJhYjI-',
+  'Access-Control-Expose-Headers',
+  'x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,X-Content-Type-Options,Cache-Control,x-ms-continuation-NextTableName,Content-Type,Content-Length,Date,Transfer-Encoding',
+  'Access-Control-Allow-Origin',
+  '*',
+  'Date',
+  'Tue, 19 Oct 2021 23:46:00 GMT'
+]);
+
+nock('https://fakeaccount.table.core.windows.net:443', {"encodedQueryParams":true})
+  .get('/Tables')
+  .query(true)
+  .reply(200, {"odata.metadata":"https://fakeaccount.table.core.windows.net/$metadata#Tables","value":[{"TableName":"ListTableTestTokenCredentialnode6"},{"TableName":"ListTableTestTokenCredentialnode7"}]}, [
+  'Cache-Control',
+  'no-cache',
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json;odata=minimalmetadata;streaming=true;charset=utf-8',
+  'Server',
+  'Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '10303189-8002-0001-1a43-c58042000000',
+  'x-ms-client-request-id',
+  'a040df9b-69f9-42b6-baa8-a6c26833bf0d',
+  'x-ms-version',
+  '2019-02-02',
+  'X-Content-Type-Options',
+  'nosniff',
+  'x-ms-continuation-NextTableName',
+  '1!68!bGlzdHRhYmxldGVzdHRva2VuY3JlZGVudGlhbG5vZGU4ATAxZDdjNTQzNzcyNjUxYWE-',
+  'Access-Control-Expose-Headers',
+  'x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,X-Content-Type-Options,Cache-Control,x-ms-continuation-NextTableName,Content-Type,Content-Length,Date,Transfer-Encoding',
+  'Access-Control-Allow-Origin',
+  '*',
+  'Date',
+  'Tue, 19 Oct 2021 23:46:00 GMT'
+]);
+
+nock('https://fakeaccount.table.core.windows.net:443', {"encodedQueryParams":true})
+  .get('/Tables')
+  .query(true)
+  .reply(200, {"odata.metadata":"https://fakeaccount.table.core.windows.net/$metadata#Tables","value":[{"TableName":"ListTableTestTokenCredentialnode8"},{"TableName":"ListTableTestTokenCredentialnode9"}]}, [
+  'Cache-Control',
+  'no-cache',
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json;odata=minimalmetadata;streaming=true;charset=utf-8',
+  'Server',
+  'Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '10303192-8002-0001-2243-c58042000000',
+  'x-ms-client-request-id',
+  '8cba8155-5d67-4b62-88d3-1731d149b9dc',
+  'x-ms-version',
+  '2019-02-02',
+  'X-Content-Type-Options',
+  'nosniff',
+  'x-ms-continuation-NextTableName',
+  '1!36!dGVzdGNoYXJzATAxZDdhOGQ0YTAwZTVhZDY-',
+  'Access-Control-Expose-Headers',
+  'x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,X-Content-Type-Options,Cache-Control,x-ms-continuation-NextTableName,Content-Type,Content-Length,Date,Transfer-Encoding',
+  'Access-Control-Allow-Origin',
+  '*',
+  'Date',
+  'Tue, 19 Oct 2021 23:46:00 GMT'
+]);
+
+nock('https://fakeaccount.table.core.windows.net:443', {"encodedQueryParams":true})
+  .get('/Tables')
+  .query(true)
+  .reply(200, {"odata.metadata":"https://fakeaccount.table.core.windows.net/$metadata#Tables","value":[{"TableName":"TestChars"},{"TableName":"TestChars2"}]}, [
+  'Cache-Control',
+  'no-cache',
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json;odata=minimalmetadata;streaming=true;charset=utf-8',
+  'Server',
+  'Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '1030319a-8002-0001-2843-c58042000000',
+  'x-ms-client-request-id',
+  'e9231afe-e695-4f01-ba68-eaed46793774',
+  'x-ms-version',
+  '2019-02-02',
+  'X-Content-Type-Options',
+  'nosniff',
+  'x-ms-continuation-NextTableName',
+  '1!36!dGVzdGNoYXJzMwEwMWQ3YThkYWYwYjJiYjlj',
+  'Access-Control-Expose-Headers',
+  'x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,X-Content-Type-Options,Cache-Control,x-ms-continuation-NextTableName,Content-Type,Content-Length,Date,Transfer-Encoding',
+  'Access-Control-Allow-Origin',
+  '*',
+  'Date',
+  'Tue, 19 Oct 2021 23:46:00 GMT'
+]);
+
+nock('https://fakeaccount.table.core.windows.net:443', {"encodedQueryParams":true})
+  .get('/Tables')
+  .query(true)
+  .reply(200, {"odata.metadata":"https://fakeaccount.table.core.windows.net/$metadata#Tables","value":[{"TableName":"TestChars3"},{"TableName":"testTable"}]}, [
+  'Cache-Control',
+  'no-cache',
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json;odata=minimalmetadata;streaming=true;charset=utf-8',
+  'Server',
+  'Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '103031a5-8002-0001-3343-c58042000000',
+  'x-ms-client-request-id',
+  '443c5f85-4576-412b-b463-edc2ccf938d6',
+  'x-ms-version',
+  '2019-02-02',
+  'X-Content-Type-Options',
+  'nosniff',
+  'x-ms-continuation-NextTableName',
+  '1!56!dGVzdHRhYmxlc2FzdG9rZW5icm93c2VyATAxZDdjNTQzNjY1YWVlNGM-',
+  'Access-Control-Expose-Headers',
+  'x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,X-Content-Type-Options,Cache-Control,x-ms-continuation-NextTableName,Content-Type,Content-Length,Date,Transfer-Encoding',
+  'Access-Control-Allow-Origin',
+  '*',
+  'Date',
+  'Tue, 19 Oct 2021 23:46:00 GMT'
+]);
+
+nock('https://fakeaccount.table.core.windows.net:443', {"encodedQueryParams":true})
+  .get('/Tables')
+  .query(true)
+  .reply(200, {"odata.metadata":"https://fakeaccount.table.core.windows.net/$metadata#Tables","value":[{"TableName":"TestTestTest"}]}, [
+  'Cache-Control',
+  'no-cache',
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json;odata=minimalmetadata;streaming=true;charset=utf-8',
+  'Server',
+  'Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '103031ae-8002-0001-3c43-c58042000000',
+  'x-ms-client-request-id',
+  'd66d432c-539f-40fe-8a12-1e72d79c0d0e',
+  'x-ms-version',
+  '2019-02-02',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Access-Control-Expose-Headers',
+  'x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,X-Content-Type-Options,Cache-Control,Content-Type,Content-Length,Date,Transfer-Encoding',
+  'Access-Control-Allow-Origin',
+  '*',
+  'Date',
+  'Tue, 19 Oct 2021 23:46:00 GMT'
+]);
+
+nock('https://fakeaccount.table.core.windows.net:443', {"encodedQueryParams":true})
+  .get('/Tables')
+  .query(true)
+  .reply(200, {"odata.metadata":"https://fakeaccount.table.core.windows.net/$metadata#Tables","value":[{"TableName":"TestTestTest"}]}, [
+  'Cache-Control',
+  'no-cache',
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json;odata=minimalmetadata;streaming=true;charset=utf-8',
+  'Server',
+  'Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '103031b3-8002-0001-4143-c58042000000',
+  'x-ms-client-request-id',
+  '14a99637-bf4f-4e08-bb98-d618e6409367',
+  'x-ms-version',
+  '2019-02-02',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Access-Control-Expose-Headers',
+  'x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,X-Content-Type-Options,Cache-Control,Content-Type,Content-Length,Date,Transfer-Encoding',
+  'Access-Control-Allow-Origin',
+  '*',
+  'Date',
+  'Tue, 19 Oct 2021 23:46:00 GMT'
+]);

--- a/sdk/tables/data-tables/review/data-tables.api.md
+++ b/sdk/tables/data-tables/review/data-tables.api.md
@@ -323,6 +323,11 @@ export interface TableItem {
 }
 
 // @public
+export interface TableItemResultPage extends Array<TableItem> {
+    continuationToken?: string;
+}
+
+// @public
 export interface TableMergeEntityHeaders {
     clientRequestId?: string;
     date?: Date;
@@ -375,7 +380,7 @@ export class TableServiceClient {
     static fromConnectionString(connectionString: string, options?: TableServiceClientOptions): TableServiceClient;
     getProperties(options?: OperationOptions): Promise<GetPropertiesResponse>;
     getStatistics(options?: OperationOptions): Promise<GetStatisticsResponse>;
-    listTables(options?: ListTableItemsOptions): PagedAsyncIterableIterator<TableItem, TableItem[]>;
+    listTables(options?: ListTableItemsOptions): PagedAsyncIterableIterator<TableItem, TableItemResultPage>;
     pipeline: Pipeline;
     setProperties(properties: ServiceProperties, options?: SetPropertiesOptions): Promise<SetPropertiesResponse>;
     url: string;

--- a/sdk/tables/data-tables/src/models.ts
+++ b/sdk/tables/data-tables/src/models.ts
@@ -245,6 +245,16 @@ export interface TableQueryResponse {
 }
 
 /**
+ * Output page type for table query operations
+ */
+export interface TableItemResultPage extends Array<TableItem> {
+  /**
+   * Continuation token to get the next TableItem page
+   */
+  continuationToken?: string;
+}
+
+/**
  * Represents a sub-response of a Transaction operation
  */
 export interface TableTransactionEntityResponse {


### PR DESCRIPTION
This PR exposes continuation token to the PageResult when listing Tables with `TableServiceClient.listTables().byPage`. This change is similar to what we did in #18179 for `TableClient.listEntities`

This change is simpler than the one in `listEntities` because we just have a single continuationToken so we don't nee to encode the pair as we did for `listEntities`