### PR TITLE
[Identity] Better default troubleshooting link

### DIFF
--- a/sdk/identity/identity/src/msal/utils.ts
+++ b/sdk/identity/identity/src/msal/utils.ts
@@ -158,7 +158,7 @@ export class MsalBaseUtilities {
    * Handles MSAL errors.
    */
   protected handleError(scopes: string[], error: Error, getTokenOptions?: GetTokenOptions): Error {
-    const troubleshoot = `To troubleshoot, visit https://aka.ms/azsdk/js/identity/usernamepasswordcredential/troubleshoot.`;
+    const troubleshoot = `To troubleshoot, visit https://aka.ms/azsdk/js/identity/defaultazurecredential/troubleshoot`;
     if (
       error.name === "AuthError" ||
       error.name === "ClientAuthError" ||

--- a/sdk/identity/identity/test/internal/identityClient.spec.ts
+++ b/sdk/identity/identity/test/internal/identityClient.spec.ts
@@ -147,7 +147,7 @@ describe("IdentityClient", function() {
       assert.strictEqual(error?.name, "AuthenticationRequiredError");
       assert.strictEqual(
         error?.message,
-        `Response had no "expiresOn" property.\nTo troubleshoot, visit https://aka.ms/azsdk/js/identity/usernamepasswordcredential/troubleshoot.`
+        `Response had no "expiresOn" property.\nTo troubleshoot, visit https://aka.ms/azsdk/js/identity/defaultazurecredential/troubleshoot`
       );
     } else {
       // The browser version of this credential uses a legacy approach.


### PR DESCRIPTION
The previous PR related to this link: https://github.com/Azure/azure-sdk-for-js/pull/18296 didn’t take in consideration to point to a generic link to the troubleshooting guide. The code affected is used by many credentials so it would be rather hard to specify a section of this guide.

This PR changes this link to the troubleshooting of the `DefaultAzureCredential`. Is there a better link? Perhaps we could make a new aka.ms link just to the troubleshooting guide, without a specific section.