### PR TITLE
[storage] Add migration guide for storage packages

### DIFF
--- a/sdk/storage/storage-blob/MigrationGuide.md
+++ b/sdk/storage/storage-blob/MigrationGuide.md
@@ -1,6 +1,6 @@
 # Guide for migrating to `@azure/storage-blob` v12 from `azure-storage`
 
-This guide is intended to assist in the migration to `@azure/storage-blob` from the legacy `azure-storage` package. It will focus on side-by-side comparisons for similar operations between the two packages.
+This guide is intended to assist in the migration to version 12 of `@azure/storage-blob` from the legacy `azure-storage` package. It will focus on side-by-side comparisons for similar operations between the two packages.
 
 We assume that you are familiar with `azure-storage`. If you are new to the Azure Storage Blob client library for JavaScript, please refer to the [README](https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/storage/storage-blob/README.md) and [samples](https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/storage/storage-blob/samples) rather than this guide.
 
@@ -11,6 +11,8 @@ We assume that you are familiar with `azure-storage`. If you are new to the Azur
 - [Important changes](#important-changes)
   - [Package name and structure](#package-name-and-structure)
   - [Constructing the clients](#constructing-the-clients)
+    - [Constructing the clients with connection string](#constructing-the-clients-with-connection-string)
+    - [Constructing the clients with AAD token credentials](#constructing-the-clients-with-aad-token-credentials)
   - [Creating a container](#creating-a-container)
   - [Uploading a blob to the container](#uploading-a-blob-to-the-container)
   - [Fetching properties of a blob](#fetching-properties-of-a-blob)
@@ -38,29 +40,31 @@ The modern `@azure/storage-blob` client library is also benefited from the cross
 
 ### Package name and structure
 
-The modern client library is named `@azure/storage-blob` . The legacy client library is named `azure-storage`.
+The modern client library is named `@azure/storage-blob` following the [naming conventions](https://azure.github.io/azure-sdk/typescript_design.html) for the new libraries across all Azure services. The legacy client library was named `azure-storage`.
 
-The legacy library `azure-storage` grouped functionality to work with multiple services in the same package such as `Blob`, `Queue`, `Files` and `Tables`. The new `@azure/storage-blob` is dedicated to `Blob` service. New generation packages are available for the other storage services as well: `@azure/data-tables`, `@azure/storage-queue`, `@azure/storage-blob-changefeed`, `@azure/storage-file-datalake` and `@azure/storage-file-share`. This provides more granular control on which dependencies to take on your project.
+The legacy library `azure-storage` grouped functionality to work with multiple services such as `Blob`, `Queue`, `Files` and `Tables` in the same package. The new `@azure/storage-blob` package is dedicated to `Blob` service. Similary, dedicated packages are available for the other storage services as well: `@azure/data-tables`, `@azure/storage-queue`, `@azure/storage-blob-changefeed`, `@azure/storage-file-datalake` and `@azure/storage-file-share`. This reduces the bundle size if you were to use any of these packages in browser applications and provides more granular control on which dependencies to take on your project.
 
-### Constructing the clients with connection string
+### Constructing the clients
 
-Previously in `azure-storage`, you would use `createBlobService` which can be used to get an instance of the `BlobService` in order to perform service level operations.
+#### Constructing the clients with connection string
+
+Previously in `azure-storage`, you can pass the connection string to the function `createBlobService` get an instance of the `BlobService` in order to perform operations on blobs and containers.
 
 ```javascript
 const azure = require("azure-storage");
 const blobService = azure.createBlobService("<connection-string>");
 ```
 
-Now, in `@azure/storage-blob`, we will be creating an instance of `BlobServiceClient` for service level operations.
+Now, in `@azure/storage-blob`, you can pass the connection string to the static method `BlobServiceClient.fromConnectionString` to create an instance of `BlobServiceClient` to perform operations on blobs and containers.
 
 ```javascript
 const { BlobServiceClient } = require("@azure/storage-blob");
 const blobService = BlobServiceClient.fromConnectionString("<connection-string>");
 ```
 
-### Constructing the clients with AAD token credentials
+#### Constructing the clients with AAD token credentials
 
-`azure-storage` or `@azure/storage-blob` supports to access `Blob` service with different types of credentials: anonymous, account key credentials, sas token, and AAD token credentials. This section shows samples to construct blob service clients with AAD token credentials.
+Both `azure-storage` and `@azure/storage-blob` supports to access `Blob` service by creating the client with different types of credentials: anonymous, account key credentials, sas token, and AAD token credentials. This section shows the use of AAD token credentials.
 
 Previously in `azure-storage`, you can invoke method `createBlobServiceWithTokenCredential` to get an instance of the `BlobService` with access token for your AAD credentials.
 
@@ -73,7 +77,7 @@ const blobService = azure.createBlobServiceWithTokenCredential(
 );
 ```
 
-Now, for `@azure/storage-blob`, you can use a constructor of `BlobServiceClient` which accepts token credential classes provided in `@azure/identity` package to get a `BlobServiceClient` instance with AAD token credentials. In following sample, it creates an instance of `DefaultAzureCredential` which reads credentials from environment variables `AZURE_TENANT_ID`, `AZURE_CLIENT_ID` and `AZURE_CLIENT_SECRET`, and creates a `BlobServiceClient` to consume the credential instance.
+Now, for `@azure/storage-blob`, you can pass any of the [credentials from the `@azure/identity` package](https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/identity/identity/samples/AzureIdentityExamples.md) to the constructor of `BlobServiceClient` to make use of your AAD credentials. In following sample, it creates an instance of `DefaultAzureCredential` which reads credentials from environment variables `AZURE_TENANT_ID`, `AZURE_CLIENT_ID` and `AZURE_CLIENT_SECRET`, and creates a `BlobServiceClient` to consume the credential instance.
 
 ```javascript
 const { BlobServiceClient } = require("@azure/storage-blob");

--- a/sdk/storage/storage-blob/MigrationGuide.md
+++ b/sdk/storage/storage-blob/MigrationGuide.md
@@ -24,11 +24,11 @@ As Azure has matured and been embraced by a more diverse group of developers, we
 
 There were several areas of consistent feedback expressed across the Azure client library ecosystem. One of the most important is that the client libraries for different Azure services have not had a consistent approach to organization, naming, and API structure. Additionally, many developers have felt that the learning curve was difficult, and the APIs did not offer a good, approachable, and consistent onboarding story for those learning Azure or exploring a specific Azure service.
 
-To improve the development experience across Azure services, a set of uniform [design guidelines](https://azure.github.io/azure-sdk/general_introduction.html) was created for all languages to drive a consistent experience with established API patterns for all services. A set of [TypeScript & JavaScript Guidelines](https://azure.github.io/azure-sdk/typescript_introduction.html) was also introduced to ensure that TypeScript clients have a natural and idiomatic feel with respect to the TypeScript and JavaScript ecosystems. The new `@azure/storage-blob` follows these guidelines.
+To improve the development experience across Azure services, a set of uniform [design guidelines](https://azure.github.io/azure-sdk/general_introduction.html) was created for all languages to drive a consistent experience with established API patterns for all services. A set of [TypeScript & JavaScript Guidelines](https://azure.github.io/azure-sdk/typescript_introduction.html) was also introduced to ensure that TypeScript clients have a natural and idiomatic feel with respect to the TypeScript and JavaScript ecosystems. The new `@azure/storage-blob` client library follows these guidelines.
 
 ### Cross Service SDK improvements
 
-The modern `@azure/storage-blob` client library also provides the ability to share in some of the cross-service improvements made to the Azure development experience, such as
+The modern `@azure/storage-blob` client library is also benefited from the cross-service improvements made to the Azure development experience, such as
 
 - A unified logging and diagnostics pipeline offering a common view of the activities across each of the client libraries
 - Use of promises rather than callbacks for a simplified programming experience
@@ -40,7 +40,7 @@ The modern `@azure/storage-blob` client library also provides the ability to sha
 
 The modern client library is named `@azure/storage-blob` and was released beginning with version 10. The legacy client library is named `azure-storage` with version of 2.x.x or below.
 
-The legacy library `azure-storage` grouped functionality to work with multiple services in the same package such as `Blob`, `Queue`, `Files` and `Tables`. The new `@azure/storage-blob` is dedicated to `Blob` there are new generation packages for the other storage services `@azure/data-tables`, `@azure/storage-queue`, `@azure/storage-file-share` this provides more granular control on which dependencies to take on your project.
+The legacy library `azure-storage` grouped functionality to work with multiple services in the same package such as `Blob`, `Queue`, `Files` and `Tables`. The new `@azure/storage-blob` is dedicated to `Blob` service. New generation packages are available for the other storage services as well: `@azure/data-tables`, `@azure/storage-queue` and `@azure/storage-file-share`. This provides more granular control on which dependencies to take on your project.
 
 ### Constructing the clients
 
@@ -107,7 +107,7 @@ console.log(`Container created`);
 
 ### Uploading a blob to the container
 
-Previously in `azure-storage`, A `BlobService` instance would be used for blob operations. `BlobService` has methods for blob operations for each blob type. `createBlockBlobFromLocalFile` would be used to upload from a local file to a block blob.
+Previously in `azure-storage`, A `BlobService` instance would be used for blob operations. `BlobService` has methods for blob operations for each blob type. For example, `createBlockBlobFromLocalFile` would be used to upload from a local file to a block blob.
 
 ```javascript
 const azure = require("azure-storage");
@@ -171,7 +171,7 @@ console.log(blobProperties);
 
 ### Listing blobs from the container
 
-Previously in `azure-storage`, listing a container didn't provide a built in way to handle pagination, looking as follows.
+Previously in `azure-storage`, there is no built-in way to handle pagination when listing blobs in a container. Users have to use `continuationToken` to get the next page of result then retrieve the items.
 
 ```javascript
 const azure = require("azure-storage");

--- a/sdk/storage/storage-file-share/MigrationGuide.md
+++ b/sdk/storage/storage-file-share/MigrationGuide.md
@@ -25,11 +25,11 @@ As Azure has matured and been embraced by a more diverse group of developers, we
 
 There were several areas of consistent feedback expressed across the Azure client library ecosystem. One of the most important is that the client libraries for different Azure services have not had a consistent approach to organization, naming, and API structure. Additionally, many developers have felt that the learning curve was difficult, and the APIs did not offer a good, approachable, and consistent onboarding story for those learning Azure or exploring a specific Azure service.
 
-To improve the development experience across Azure services, a set of uniform [design guidelines](https://azure.github.io/azure-sdk/general_introduction.html) was created for all languages to drive a consistent experience with established API patterns for all services. A set of [TypeScript & JavaScript Guidelines](https://azure.github.io/azure-sdk/typescript_introduction.html) was also introduced to ensure that TypeScript clients have a natural and idiomatic feel with respect to the TypeScript and JavaScript ecosystems. The new `@azure/storage-file-share` follows these guidelines.
+To improve the development experience across Azure services, a set of uniform [design guidelines](https://azure.github.io/azure-sdk/general_introduction.html) was created for all languages to drive a consistent experience with established API patterns for all services. A set of [TypeScript & JavaScript Guidelines](https://azure.github.io/azure-sdk/typescript_introduction.html) was also introduced to ensure that TypeScript clients have a natural and idiomatic feel with respect to the TypeScript and JavaScript ecosystems. The new `@azure/storage-file-share` client library follows these guidelines.
 
 ### Cross Service SDK improvements
 
-The modern `@azure/storage-file-share` client library also provides the ability to share in some of the cross-service improvements made to the Azure development experience, such as
+The modern `@azure/storage-file-share` client library is also benefited from the cross-service improvements made to the Azure development experience, such as
 
 - A unified logging and diagnostics pipeline offering a common view of the activities across each of the client libraries
 - Use of promises rather than callbacks for a simplified programming experience
@@ -41,7 +41,7 @@ The modern `@azure/storage-file-share` client library also provides the ability 
 
 The modern client library is named `@azure/storage-file-share` and was released beginning with version 10. The legacy client library is named `azure-storage` with version of 2.x.x or below.
 
-The legacy library `azure-storage` grouped functionality to work with multiple services in the same package such as `Blob`, `Queue`, `Files` and `Tables`. The new `@azure/storage-file-share` is dedicated to `Files` there are new generation packages for the other storage services `@azure/data-tables`, `@azure/storage-queue`, `@azure/storage-blob` this provides more granular control on which dependencies to take on your project.
+The legacy library `azure-storage` grouped functionality to work with multiple services in the same package such as `Blob`, `Queue`, `Files` and `Tables`. The new `@azure/storage-file-share` is dedicated to `Files` service. New generation packages are available for the other storage services as well: `@azure/data-tables`, `@azure/storage-queue` and `@azure/storage-blob`. This provides more granular control on which dependencies to take on your project.
 
 ### Constructing the clients
 
@@ -226,7 +226,7 @@ console.log(fileProperties);
 
 ### Listing files and directories from a directory
 
-Previously in `azure-storage`, listing a directory didn't provide a built in way to handle pagination, looking as follows.
+Previously in `azure-storage`, there is no built-in way to handle pagination when listing files and directories in a directory. Users have to use `continuationToken` to get the next page of result then retrieve the items.
 
 ```javascript
 const azure = require("azure-storage");

--- a/sdk/storage/storage-file-share/MigrationGuide.md
+++ b/sdk/storage/storage-file-share/MigrationGuide.md
@@ -1,4 +1,4 @@
-# Guide for migrating to `@azure/storage-file-share` from `azure-storage`
+# Guide for migrating to `@azure/storage-file-share` v12 from `azure-storage`
 
 This guide is intended to assist in the migration to `@azure/storage-file-share` from the legacy `azure-storage` package. It will focus on side-by-side comparisons for similar operations between the two packages.
 
@@ -39,11 +39,11 @@ The modern `@azure/storage-file-share` client library is also benefited from the
 
 ### Package name and structure
 
-The modern client library is named `@azure/storage-file-share` and was released beginning with version 10. The legacy client library is named `azure-storage` with version of 2.x.x or below.
+The modern client library is named `@azure/storage-file-share`. The legacy client library is named `azure-storage`.
 
-The legacy library `azure-storage` grouped functionality to work with multiple services in the same package such as `Blob`, `Queue`, `Files` and `Tables`. The new `@azure/storage-file-share` is dedicated to `Files` service. New generation packages are available for the other storage services as well: `@azure/data-tables`, `@azure/storage-queue` and `@azure/storage-blob`. This provides more granular control on which dependencies to take on your project.
+The legacy library `azure-storage` grouped functionality to work with multiple services in the same package such as `Blob`, `Queue`, `Files` and `Tables`. The new `@azure/storage-file-share` is dedicated to `Files` service. New generation packages are available for the other storage services as well: `@azure/data-tables`, `@azure/storage-queue`, `@azure/storage-blob-changefeed`, `@azure/storage-file-datalake` and `@azure/storage-blob`. This provides more granular control on which dependencies to take on your project.
 
-### Constructing the clients
+### Constructing the clients with connection string
 
 Previously in `azure-storage`, you would use `createFileService` which can be used to get an instance of the `FileService` in order to perform service level operations.
 
@@ -52,11 +52,34 @@ const azure = require("azure-storage");
 const fileService = azure.createFileService("<connection-string>");
 ```
 
-Now, in `@azure/storage-file-share`, we need a `ShareServiceClient` for service level operations.
+Now, in `@azure/storage-file-share`, we will be creating an instance of `ShareServiceClient` for service level operations.
 
 ```javascript
 const { ShareServiceClient } = require("@azure/storage-file-share");
 const shareService = ShareServiceClient.fromConnectionString("<connection-string>");
+```
+
+### Constructing the clients with SAS token
+
+`azure-storage` or `@azure/storage-file-share` supports to access `Files` service with different types of credentials: anonymous, account key credentials and SAS token. This section shows samples to construct blob service clients with SAS token credentials.
+
+Previously in `azure-storage`, you can invoke method `createFileServiceWithSas` to get an instance of the `FileService` with SAS token credentials.
+
+```javascript
+const azure = require("azure-storage");
+const fileService = azure.createFileServiceWithSas(
+  "https://<account-name>.file.core.windows.net",
+  "<sas-token>"
+);
+```
+
+Now, in `@azure/storage-file-share`, you can invoke `ShareServiceClient` constructor with URL with SAS token to create a `ShareServiceClient` instance with SAS token credentials.
+
+```javascript
+const { ShareServiceClient } = require("@azure/storage-file-share");
+const shareService = new ShareServiceClient(
+  "https://<account-name>.file.core.windows.net<sas-token>"
+);
 ```
 
 ### Creating a file share
@@ -73,7 +96,7 @@ fileService.createShare(shareName, function() {
 });
 ```
 
-With `@azure/storage-file-share` you have access to all share level operations directly from the `ShareServiceClient`. Because the file share service client is not affinitized to any one share, it is ideal for scenarios where you need to create, delete, or list more than one share.
+With `@azure/storage-file-share` you can access to all share level operations directly from the `ShareServiceClient`. Because the file share service client is not affinitized to any one share, it is ideal for scenarios where you need to create, delete, or list more than one share.
 
 ```javascript
 const { ShareServiceClient, StorageSharedKeyCredential } = require("@azure/storage-file-share");
@@ -108,7 +131,7 @@ console.log(`Share created`);
 
 ### Creating a directory in the share
 
-Previously in `azure-storage`, A `FileService` instance would be used for all directory or file operations. The `createDirectory` method would take a callback to execute once the directory has been created. This forces sequential operations to be inside the callback, potentially creating a callback chain
+Previously in `azure-storage`, the `FileService` class would have methods for operations for all directory or file operations. The `createDirectory` method would take a callback to execute once the directory has been created. This forces sequential operations to be inside the callback, potentially creating a callback chain.
 
 ```javascript
 const azure = require("azure-storage");

--- a/sdk/storage/storage-file-share/MigrationGuide.md
+++ b/sdk/storage/storage-file-share/MigrationGuide.md
@@ -1,6 +1,6 @@
 # Guide for migrating to `@azure/storage-file-share` v12 from `azure-storage`
 
-This guide is intended to assist in the migration to `@azure/storage-file-share` from the legacy `azure-storage` package. It will focus on side-by-side comparisons for similar operations between the two packages.
+This guide is intended to assist in the migration to version 12 of `@azure/storage-file-share` from the legacy `azure-storage` package. It will focus on side-by-side comparisons for similar operations between the two packages.
 
 We assume that you are familiar with `azure-storage`. If you are new to the Azure Storage File client library for JavaScript, please refer to the [README](https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/storage/storage-file-share/README.md) and [samples](https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/storage/storage-file-share/samples) rather than this guide.
 
@@ -11,6 +11,8 @@ We assume that you are familiar with `azure-storage`. If you are new to the Azur
 - [Important changes](#important-changes)
   - [Package name and structure](#package-name-and-structure)
   - [Constructing the clients](#constructing-the-clients)
+    - [Constructing the clients with connection string](#constructing-the-clients-with-connection-string)
+    - [Constructing the clients with SAS token](#constructing-the-clients-with-sas-token)
   - [Creating a file share](#creating-a-file-share)
   - [Creating a directory in the share](#creating-a-directory-in-the-share)
   - [Uploading file to a directory](#uploading-file-to-a-directory)
@@ -39,29 +41,31 @@ The modern `@azure/storage-file-share` client library is also benefited from the
 
 ### Package name and structure
 
-The modern client library is named `@azure/storage-file-share`. The legacy client library is named `azure-storage`.
+The modern client library is named `@azure/storage-file-share` following the [naming conventions](https://azure.github.io/azure-sdk/typescript_design.html) for the new libraries across all Azure services. The legacy client library was named `azure-storage`.
 
-The legacy library `azure-storage` grouped functionality to work with multiple services in the same package such as `Blob`, `Queue`, `Files` and `Tables`. The new `@azure/storage-file-share` is dedicated to `Files` service. New generation packages are available for the other storage services as well: `@azure/data-tables`, `@azure/storage-queue`, `@azure/storage-blob-changefeed`, `@azure/storage-file-datalake` and `@azure/storage-blob`. This provides more granular control on which dependencies to take on your project.
+The legacy library `azure-storage` grouped functionality to work with multiple services such as `Blob`, `Queue`, `Files` and `Tables` in the same package . The new `@azure/storage-file-share` package is dedicated to `Files` service. Similary, dedicated packages are available for the other storage services as well: `@azure/data-tables`, `@azure/storage-queue`, `@azure/storage-blob-changefeed`, `@azure/storage-file-datalake` and `@azure/storage-blob`. This reduces the bundle size if you were to use any of these packages in browser applications and provides more granular control on which dependencies to take on your project.
 
-### Constructing the clients with connection string
+### Constructing the clients
 
-Previously in `azure-storage`, you would use `createFileService` which can be used to get an instance of the `FileService` in order to perform service level operations.
+#### Constructing the clients with connection string
+
+Previously in `azure-storage`, you can pass the connection string to the function `createFileService` get an instance of the `FileService` in order to perform operations on files and shares.
 
 ```javascript
 const azure = require("azure-storage");
 const fileService = azure.createFileService("<connection-string>");
 ```
 
-Now, in `@azure/storage-file-share`, we will be creating an instance of `ShareServiceClient` for service level operations.
+Now, in `@azure/storage-file-share`, you can pass the connection string to the static method `ShareServiceClient.fromConnectionString` to create an instance of `ShareServiceClient` to perform operations on files and shares.
 
 ```javascript
 const { ShareServiceClient } = require("@azure/storage-file-share");
 const shareService = ShareServiceClient.fromConnectionString("<connection-string>");
 ```
 
-### Constructing the clients with SAS token
+#### Constructing the clients with SAS token
 
-`azure-storage` or `@azure/storage-file-share` supports to access `Files` service with different types of credentials: anonymous, account key credentials and SAS token. This section shows samples to construct blob service clients with SAS token credentials.
+Both `azure-storage` and `@azure/storage-file-share` supports to access `Files` service by creating the client with different types of credentials: anonymous, account key credentials and SAS token. This section shows the use of SAS token credentials.
 
 Previously in `azure-storage`, you can invoke method `createFileServiceWithSas` to get an instance of the `FileService` with SAS token credentials.
 
@@ -73,7 +77,7 @@ const fileService = azure.createFileServiceWithSas(
 );
 ```
 
-Now, in `@azure/storage-file-share`, you can invoke `ShareServiceClient` constructor with URL with SAS token to create a `ShareServiceClient` instance with SAS token credentials.
+Now, in `@azure/storage-file-share`, you can pass URL with SAS token to the constructor of `ShareServiceClient` to make use of your SAS token credentials.
 
 ```javascript
 const { ShareServiceClient } = require("@azure/storage-file-share");

--- a/sdk/storage/storage-file-share/MigrationGuide.md
+++ b/sdk/storage/storage-file-share/MigrationGuide.md
@@ -1,0 +1,343 @@
+# Guide for migrating to `@azure/storage-file-share` from `azure-storage`
+
+This guide is intended to assist in the migration to `@azure/storage-file-share` from the legacy `azure-storage` package. It will focus on side-by-side comparisons for similar operations between the two packages.
+
+We assume that you are familiar with `azure-storage`. If you are new to the Azure Storage File client library for JavaScript, please refer to the [README](https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/storage/storage-file-share/README.md) and [samples](https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/storage/storage-file-share/samples) rather than this guide.
+
+## Table of contents
+
+- [Migration benefits](#migration-benefits)
+  - [Cross Service SDK improvements](#cross-service-sdk-improvements)
+- [Important changes](#important-changes)
+  - [Package name and structure](#package-name-and-structure)
+  - [Constructing the clients](#constructing-the-clients)
+  - [Creating a file share](#creating-a-file-share)
+  - [Creating a directory in the share](#creating-a-directory-in-the-share)
+  - [Uploading file to a directory](#uploading-file-to-a-directory)
+  - [Fetching properties of a file](#fetching-properties-of-a-file)
+  - [Listing files and directories from a directory](#listing-files-and-directories-from-a-directory)
+  - [Sequential actions](#sequential-actions)
+- [Additional samples](#additional-samples)
+
+## Migration benefits
+
+As Azure has matured and been embraced by a more diverse group of developers, we have been focused on learning the patterns and practices to best support developer productivity and to understand the gaps that the JavaScript client libraries have.
+
+There were several areas of consistent feedback expressed across the Azure client library ecosystem. One of the most important is that the client libraries for different Azure services have not had a consistent approach to organization, naming, and API structure. Additionally, many developers have felt that the learning curve was difficult, and the APIs did not offer a good, approachable, and consistent onboarding story for those learning Azure or exploring a specific Azure service.
+
+To improve the development experience across Azure services, a set of uniform [design guidelines](https://azure.github.io/azure-sdk/general_introduction.html) was created for all languages to drive a consistent experience with established API patterns for all services. A set of [TypeScript & JavaScript Guidelines](https://azure.github.io/azure-sdk/typescript_introduction.html) was also introduced to ensure that TypeScript clients have a natural and idiomatic feel with respect to the TypeScript and JavaScript ecosystems. The new `@azure/storage-file-share` follows these guidelines.
+
+### Cross Service SDK improvements
+
+The modern `@azure/storage-file-share` client library also provides the ability to share in some of the cross-service improvements made to the Azure development experience, such as
+
+- A unified logging and diagnostics pipeline offering a common view of the activities across each of the client libraries
+- Use of promises rather than callbacks for a simplified programming experience
+- Use of async iterators in paging APIs
+
+## Important changes
+
+### Package name and structure
+
+The modern client library is named `@azure/storage-file-share` and was released beginning with version 10. The legacy client library is named `azure-storage` with version of 2.x.x or below.
+
+The legacy library `azure-storage` grouped functionality to work with multiple services in the same package such as `Blob`, `Queue`, `Files` and `Tables`. The new `@azure/storage-file-share` is dedicated to `Files` there are new generation packages for the other storage services `@azure/data-tables`, `@azure/storage-queue`, `@azure/storage-blob` this provides more granular control on which dependencies to take on your project.
+
+### Constructing the clients
+
+Previously in `azure-storage`, you would use `createFileService` which can be used to get an instance of the `FileService` in order to perform service level operations.
+
+```javascript
+const azure = require("azure-storage");
+const fileService = azure.createFileService("<connection-string>");
+```
+
+Now, in `@azure/storage-file-share`, we need a `ShareServiceClient` for service level operations.
+
+```javascript
+const { ShareServiceClient } = require("@azure/storage-file-share");
+const shareService = ShareServiceClient.fromConnectionString("<connection-string>");
+```
+
+### Creating a file share
+
+Previously in `azure-storage`, you would use a `FileService` instance to create a file share.
+
+```javascript
+const azure = require("azure-storage");
+const fileService = azure.createFileService("<connection-string>");
+
+const shareName = "<share-name>";
+fileService.createShare(shareName, function() {
+  console.log(`Share created`);
+});
+```
+
+With `@azure/storage-file-share` you have access to all share level operations directly from the `ShareServiceClient`. Because the file share service client is not affinitized to any one share, it is ideal for scenarios where you need to create, delete, or list more than one share.
+
+```javascript
+const { ShareServiceClient, StorageSharedKeyCredential } = require("@azure/storage-file-share");
+const shareName = "<share-name>";
+const fileEndpoint = "https://<account-name>.file.core.windows.net";
+
+const shareService = new ShareServiceClient(
+  fileEndpoint,
+  new StorageSharedKeyCredential("<accountName>", "<accountKey>")
+);
+
+// Creates the Share with `<share-name>`
+const shareClient = await shareService.createShare(shareName);
+console.log(`Share created`);
+```
+
+If your intention is to work only in the context of a single share, it's also possible to create a share from the `ShareClient`.
+
+```javascript
+const { ShareClient, StorageSharedKeyCredential } = require("@azure/storage-file-share");
+const shareUrl = "https://<account-name>.file.core.windows.net/<share-name>";
+
+const shareClient = new ShareClient(
+  shareUrl,
+  new StorageSharedKeyCredential("<accountName>", "<accountKey>")
+);
+
+// Creates the share with `<share-name>`
+const response = await shareClient.create();
+console.log(`Share created`);
+```
+
+### Creating a directory in the share
+
+Previously in `azure-storage`, A `FileService` instance would be used for all directory or file operations. The `createDirectory` method would take a callback to execute once the directory has been created. This forces sequential operations to be inside the callback, potentially creating a callback chain
+
+```javascript
+const azure = require("azure-storage");
+const shareName = "<share-name>";
+const directoryName = "<directory-name>";
+const fileService = azure.createFileService("<connection-string>");
+
+fileService.createDirectory(shareName, directoryName, function() {
+  console.log("Directory created");
+});
+```
+
+There's a implicit root directory under a share. Now in the new `@azure/storage-file-share` SDK, an instance of `ShareClient` could also be used to preresent the root directory. The instance can be used to create or delete directories or files under the root directory. Following code can be used to create a directory under the share.
+
+```javascript
+const { ShareClient, StorageSharedKeyCredential } = require("@azure/storage-file-share");
+const directoryName = "<directory-name>";
+const shareUrl = "https://<account-name>.file.core.windows.net/<share-name>";
+
+const shareClient = new ShareClient(
+  shareUrl,
+  new StorageSharedKeyCredential("<accountName>", "<accountKey>")
+);
+
+await shareClient.createDirectory(directoryName);
+console.log("Directory created");
+```
+
+If your intention is to work only in the context of a single directory, it's also possible to create a directory from the `ShareDirectoryClient`.
+
+```javascript
+const { ShareDirectoryClient, StorageSharedKeyCredential } = require("@azure/storage-file-share");
+const directoryUrl = "https://<account-name>.file.core.windows.net/<share-name>/<directory-name>";
+
+const directoryClient = new ShareDirectoryClient(
+  directoryUrl,
+  new StorageSharedKeyCredential("<accountName>", "<accountKey>")
+);
+
+await directoryClient.create();
+console.log("Directory created");
+```
+
+### Uploading file to a directory
+
+Previously in `azure-storage`, method `createFileFromLocalFile` in a `FileService` instance can be used to upload a local file to a file in Azure Storage.
+
+```javascript
+const azure = require("azure-storage");
+const shareName = "<share-name>";
+const directoryName = "<directory-name>";
+const fileName = "<file-name>";
+const localFilePath = "<local-file-path>";
+
+const fileService = azure.createFileService("<connection-string>");
+
+fileService.createFileFromLocalFile(shareName, directoryName, fileName, localFilePath, function() {
+  console.log("File uploaded");
+});
+```
+
+Now with `@azure/storage-file-share`, an instance of `ShareFileClient` is used for operations on a file. Following is code to upload a local file to a file in Azure Storage.
+
+```javascript
+const { ShareFileClient, StorageSharedKeyCredential } = require("@azure/storage-file-share");
+const fileUrl =
+  "https://<account-name>.file.core.windows.net/<container-name>/<directory-name>/<file-name>";
+const localFilePath = "<local-file-path>";
+
+const fileClient = new ShareFileClient(
+  fileUrl,
+  new StorageSharedKeyCredential("<accountName>", "<accountKey>")
+);
+
+await fileClient.uploadFile(localFilePath);
+console.log("File uploaded");
+```
+
+### Fetching properties of a file
+
+Previously in `azure-storage`, method `getBlobProperties` in a `BlobService` instance can be used to fetch properties of a blob.
+
+```javascript
+const azure = require("azure-storage");
+const fileService = azure.createFileService("<connection-string>");
+const shareName = "<container-name>";
+const directoryName = "<directoryName>";
+const fileName = "<file-name>";
+
+const fileService = azure.createFileService("<connection-string>");
+
+fileService.getFileProperties(shareName, directoryName, fileName, function(error, result) {
+  if (!error) {
+    // result contains the blob properties
+    console.log(result);
+  }
+});
+```
+
+Now with `@azure/storage-file-share`, we use method `getProperties` in an instance of `ShareFileClient`, the return type is a Promise of the properties which can be awaited, making the code cleaner.
+
+```javascript
+const { ShareFileClient, StorageSharedKeyCredential } = require("@azure/storage-blob");
+const fileUrl =
+  "https://<account-name>.blob.core.windows.net/<share-name>/<directory-name>/<file-name>";
+
+const fileClient = new ShareFileClient(
+  fileUrl,
+  new StorageSharedKeyCredential("<accountName>", "<accountKey>")
+);
+
+const fileProperties = await fileClient.getProperties();
+console.log(fileProperties);
+```
+
+### Listing files and directories from a directory
+
+Previously in `azure-storage`, listing a directory didn't provide a built in way to handle pagination, looking as follows.
+
+```javascript
+const azure = require("azure-storage");
+const fileService = azure.createFileService("<connection-string>");
+const shareName = "<share-name>";
+const directoryName = "<directory-name>";
+
+let files = [];
+let directories = [];
+
+function listFilesAndDirectories(continuationToken, callback) {
+  fileService.listFilesAndDirectoriesSegmented(
+    shareName,
+    directoryName,
+    continuationToken,
+    function(error, result) {
+      files.push.apply(files, result.entries.files);
+      directories.push.apply(directories, result.entries.directories);
+      const continuationToken = result.continuationToken;
+      if (continuationToken) {
+        listFilesAndDirectories(continuationToken, callback);
+      } else {
+        console.log("completed listing all files and directories");
+        callback();
+      }
+    }
+  );
+}
+
+listFilesAndDirectories(null, function() {
+  console.log(files);
+  console.log(directories);
+});
+```
+
+In the new `@azure/storage-file-share` we return a `PagedAsyncIterableIterator` that handles the details of pagination internally, simplifying the task of iteration.
+
+```javascript
+const { ShareDirectoryClient, StorageSharedKeyCredential } = require("@azure/storage-file-share");
+const directoryUrl = "https://<account-name>.file.core.windows.net/<share-name>/<directory-name>";
+
+const directoryClient = new ShareDirectoryClient(
+  containerUrl,
+  new StorageSharedKeyCredential("<accountName>", "<accountKey>")
+);
+
+const iterator = directoryClient.listFilesAndDirectories();
+let listItem = await iterator.next();
+while (!listItem.done) {
+  if (listItem.value.kind === "file") {
+    console.log("Got a file: " + listItem.value.name);
+  } else if (listItem.value.kind === "directory") {
+    console.log("Got a directory: " + listItem.value.name);
+  }
+
+  listItem = await iterator.next();
+}
+```
+
+### Sequential actions
+
+Previously in `azure-storage`, all the operations took a callback which would be executed once the operation completed. For example, to create a share and then create a directory and upload a file we would like to write the following nested code
+
+```javascript
+const azure = require("azure-storage");
+const fileService = azure.createFileService("<connection-string>");
+
+const shareName = "<share-name>";
+const directoryName = "<directory-name>";
+const fileName = "<file-name>";
+const localFilePath = "<local-file-path>";
+
+fileService.createShare(shareName, function() {
+  fileService.createDirectory(shareName, directoryName, function() {
+    fileService.createFileFromLocalFile(
+      shareName,
+      directoryName,
+      fileName,
+      localFilePath,
+      function() {
+        console.log("File uploaded");
+      }
+    );
+  });
+});
+```
+
+With `@azure/storage-file-share` we work with promises which makes the programming experience better, leveraging async/await we no longer need nested code blocks to perform sequential actions
+
+```javascript
+const { ShareClient, StorageSharedKeyCredential } = require("@azure/storage-file-share");
+const directoryName = "<directory-name>";
+const fileName = "<file-name>";
+const localFilePath = "<local-file-path>";
+const shareUrl = "https://<account-name>.file.core.windows.net/<share-name>";
+
+const shareClient = new ShareClient(
+  shareUrl,
+  new StorageSharedKeyCredential("<accountName>", "<accountKey>")
+);
+
+await shareClient.create();
+
+const directoryClient = shareClient.getDirectoryClient(directoryName);
+await directoryClient.create();
+
+const fileClient = directoryClient.getFileClient(fileName);
+await fileClient.uploadFile(localFilePath);
+console.log("File uploaded");
+```
+
+## Additional samples
+
+More samples can be found [here](https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/storage/storage-file-share/samples)

--- a/sdk/storage/storage-queue/MigrationGuide.md
+++ b/sdk/storage/storage-queue/MigrationGuide.md
@@ -1,6 +1,6 @@
 # Guide for migrating to `@azure/storage-queue` v12 from `azure-storage`
 
-This guide is intended to assist in the migration to `@azure/storage-queue` from the legacy `azure-storage` package. It will focus on side-by-side comparisons for similar operations between the two packages.
+This guide is intended to assist in the migration to version 12 of `@azure/storage-queue` from the legacy `azure-storage` package. It will focus on side-by-side comparisons for similar operations between the two packages.
 
 We assume that you are familiar with `azure-storage`. If you are new to the Azure Storage Queue client library for JavaScript, please refer to the [README](https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/storage/storage-queue/README.md) and [samples](https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/storage/storage-queue/samples) rather than this guide.
 
@@ -11,6 +11,8 @@ We assume that you are familiar with `azure-storage`. If you are new to the Azur
 - [Important changes](#important-changes)
   - [Package name and structure](#package-name-and-structure)
   - [Constructing the clients](#constructing-the-clients)
+    - [Constructing the clients with connection string](#constructing-the-clients-with-connection-string)
+    - [Constructing the clients with AAD token credentials](#constructing-the-clients-with-aad-token-credentials)
   - [Creating a queue](#creating-a-queue)
   - [Adding a message to the queue](#adding-a-message-to-the-queue)
   - [Retrieving message from a queue](#retrieving-message-from-a-queue)
@@ -37,29 +39,31 @@ The modern `@azure/storage-queue` client library is also benefited from the cros
 
 ### Package name and structure
 
-The modern client library is named `@azure/storage-queue`. The legacy client library is named `azure-storage`.
+The modern client library is named `@azure/storage-queue` following the [naming conventions](https://azure.github.io/azure-sdk/typescript_design.html) for the new libraries across all Azure services. The legacy client library was named `azure-storage`.
 
-The legacy library `azure-storage` grouped functionality to work with multiple services in the same package such as `Blob`, `Queue`, `Files` and `Tables`. The new `@azure/storage-queue` is dedicated to `Queue` service. New generation packages are available for the other storage services as well: `@azure/data-tables`, `@azure/storage-blob`, `@azure/storage-blob-changefeed`, `@azure/storage-file-datalake` and `@azure/storage-file-share`. This provides more granular control on which dependencies to take on your project.
+The legacy library `azure-storage` grouped functionality to work with multiple services such as `Blob`, `Queue`, `Files` and `Tables` in the same package. The new `@azure/storage-queue` package is dedicated to `Queue` service. Similary, dedicated packages are available for the other storage services as well: `@azure/data-tables`, `@azure/storage-blob`, `@azure/storage-blob-changefeed`, `@azure/storage-file-datalake` and `@azure/storage-file-share`. This reduces the bundle size if you were to use any of these packages in browser applications and provides more granular control on which dependencies to take on your project.
 
-### Constructing the clients with connection string
+### Constructing the clients
 
-Previously in `azure-storage`, you would use `createQueueService` which can be used to get an instance of the `QueueService` in order to perform service level operations.
+#### Constructing the clients with connection string
+
+Previously in `azure-storage`, you can pass the connection string to the function `createQueueService` get an instance of the `QueueService` in order to perform operations on queues.
 
 ```javascript
 const azure = require("azure-storage");
 const queueService = azure.createQueueService("<connection-string>");
 ```
 
-Now, in `@azure/storage-queue`, we will be creating an instance of `QueueServiceClient` for service level operations.
+Now, in `@azure/storage-queue`, you can pass the connection string to the static method `QueueServiceClient.fromConnectionString` to create an instance of `QueueServiceClient` to perform operations on queues.
 
 ```javascript
 const { QueueServiceClient } = require("@azure/storage-queue");
 const queueService = QueueServiceClient.fromConnectionString("<connection-string>");
 ```
 
-### Constructing the clients with AAD token credentials
+#### Constructing the clients with AAD token credentials
 
-`azure-storage` or `@azure/storage-queue` supports to access `Queue` service with different types of credentials: anonymous, account key credentials, sas token, and AAD token credentials. This section shows samples to construct queue service clients with AAD token credentials.
+Both `azure-storage` and `@azure/storage-queue` supports to access `Queue` service by creating the client with different types of credentials: anonymous, account key credentials, sas token, and AAD token credentials. This section shows the use of AAD token credentials.
 
 Previously in `azure-storage`, you can invoke method `createQueueServiceWithTokenCredential` to get an instance of the `QueueService` with access token for your AAD credentials.
 
@@ -72,7 +76,7 @@ const queueService = azure.createQueueServiceWithTokenCredential(
 );
 ```
 
-Now, for `@azure/storage-queue`, you can use a constructor of `QueueServiceClient` which accepts token credential classes provided in `@azure/identity` package to get a `BlobServiceClient` instance with AAD token credentials. In following sample, it creates an instance of `DefaultAzureCredential` which reads credentials from environment variables `AZURE_TENANT_ID`, `AZURE_CLIENT_ID` and `AZURE_CLIENT_SECRET`, and creates a `QueueServiceClient` to consume the credential instance.
+Now, for `@azure/storage-queue`, you can pass any of the [credentials from the `@azure/identity` package](https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/identity/identity/samples/AzureIdentityExamples.md) to the constructor of `QueueServiceClient` to make use of your AAD credentials. In following sample, it creates an instance of `DefaultAzureCredential` which reads credentials from environment variables `AZURE_TENANT_ID`, `AZURE_CLIENT_ID` and `AZURE_CLIENT_SECRET`, and creates a `QueueServiceClient` to consume the credential instance.
 
 ```javascript
 const { QueueServiceClient } = require("@azure/storage-queue");

--- a/sdk/storage/storage-queue/MigrationGuide.md
+++ b/sdk/storage/storage-queue/MigrationGuide.md
@@ -1,0 +1,220 @@
+# Guide for migrating to `@azure/storage-queue` from `azure-storage`
+
+This guide is intended to assist in the migration to `@azure/storage-queue` from the legacy `azure-storage` package. It will focus on side-by-side comparisons for similar operations between the two packages.
+
+We assume that you are familiar with `azure-storage`. If you are new to the Azure Storage Queue client library for JavaScript, please refer to the [README](https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/storage/storage-queue/README.md) and [samples](https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/storage/storage-queue/samples) rather than this guide.
+
+## Table of contents
+
+- [Migration benefits](#migration-benefits)
+  - [Cross Service SDK improvements](#cross-service-sdk-improvements)
+- [Important changes](#important-changes)
+  - [Package name and structure](#package-name-and-structure)
+  - [Constructing the clients](#constructing-the-clients)
+  - [Creating a queue](#creating-a-queue)
+  - [Adding a message to the queue](#adding-a-message-to-the-queue)
+  - [Retrieving message from a queue](#retrieving-message-from-a-queue)
+  - [Sequential actions](#sequential-actions)
+- [Additional samples](#additional-samples)
+
+## Migration benefits
+
+As Azure has matured and been embraced by a more diverse group of developers, we have been focused on learning the patterns and practices to best support developer productivity and to understand the gaps that the JavaScript client libraries have.
+
+There were several areas of consistent feedback expressed across the Azure client library ecosystem. One of the most important is that the client libraries for different Azure services have not had a consistent approach to organization, naming, and API structure. Additionally, many developers have felt that the learning curve was difficult, and the APIs did not offer a good, approachable, and consistent onboarding story for those learning Azure or exploring a specific Azure service.
+
+To improve the development experience across Azure services, a set of uniform [design guidelines](https://azure.github.io/azure-sdk/general_introduction.html) was created for all languages to drive a consistent experience with established API patterns for all services. A set of [TypeScript & JavaScript Guidelines](https://azure.github.io/azure-sdk/typescript_introduction.html) was also introduced to ensure that TypeScript clients have a natural and idiomatic feel with respect to the TypeScript and JavaScript ecosystems. The new `@azure/storage-queue` follows these guidelines.
+
+### Cross Service SDK improvements
+
+The modern `@azure/storage-queue` client library also provides the ability to share in some of the cross-service improvements made to the Azure development experience, such as
+
+- A unified logging and diagnostics pipeline offering a common view of the activities across each of the client libraries
+- Use of promises rather than callbacks for a simplified programming experience
+- Use of async iterators in paging APIs
+
+## Important changes
+
+### Package name and structure
+
+The modern client library is named `@azure/storage-queue` and was released beginning with version 10. The legacy client library is named `azure-storage` with version of 2.x.x or below.
+
+The legacy library `azure-storage` grouped functionality to work with multiple services in the same package such as `Blob`, `Queue`, `Files` and `Tables`. The new `@azure/storage-queue` is dedicated to `Queue` there are new generation packages for the other storage services `@azure/data-tables`, `@azure/storage-blob`, `@azure/storage-file-share` this provides more granular control on which dependencies to take on your project.
+
+### Constructing the clients
+
+Previously in `azure-storage`, you would use `createQueueService` which can be used to get an instance of the `QueueService` in order to perform service level operations.
+
+```javascript
+const azure = require("azure-storage");
+const queueService = azure.createQueueService("<connection-string>");
+```
+
+Now, in `@azure/storage-queue`, we need a `QueueServiceClient` for service level operations.
+
+```javascript
+const { QueueServiceClient } = require("@azure/storage-queue");
+const queueService = QueueServiceClient.fromConnectionString("<connection-string>");
+```
+
+### Creating a queue
+
+Previously in `azure-storage`, you would use a `QueueService` instance to create a queue. The `createQueue` method would take a callback to execute once the queue has been created. This forces sequential operations to be inside the callback, potentially creating a callback chain
+
+```javascript
+const azure = require("azure-storage");
+const queueService = azure.createQueueService("<connection-string>");
+
+const queueName = "<queue-name>";
+queueService.createQueue(queueName, function() {
+  console.log(`Queue created`);
+});
+```
+
+With `@azure/storage-queue` you have access to all queue level operations directly from the `QueueServiceClient`. Because the queue service client is not affinitized to any one queue, it is ideal for scenarios where you need to create, delete, or list more than one queue.
+
+```javascript
+const { QueueServiceClient, StorageSharedKeyCredential } = require("@azure/storage-queue");
+const queueName = "queue2";
+const queueEndpoint = "https://<account-name>.queue.core.windows.net";
+
+const queueService = new QueueServiceClient(
+  queueEndpoint,
+  new StorageSharedKeyCredential("<accountName>", "<accountKey>")
+);
+
+// Creates the queue with `<queue-name>`
+const queueClient = await queueService.createQueue(queueName);
+console.log(`Queue created`);
+```
+
+If your intention is to work only in the context of a single queue, it's also possible to create a queue from the `QueueClient`.
+
+```javascript
+const { QueueClient, StorageSharedKeyCredential } = require("@azure/storage-queue");
+const queueUrl = "https://<account-name>.queue.core.windows.net/<queue-name>";
+
+const queueClient = new QueueClient(
+  queueUrl,
+  new StorageSharedKeyCredential("<accountName>", "<accountKey>")
+);
+
+// Creates the queue with `<queue-name>`
+const response = await queueClient.create();
+console.log(`Queue created`);
+```
+
+### Adding a message to the queue
+
+Previously in `azure-storage`, A `QueueService` instance would be used for queue operations. Method `createMessage` can be used to add a new message to the back of the queue.
+
+```javascript
+const azure = require("azure-storage");
+const queueService = azure.createQueueService("<connection-string>");
+const queueName = "<queue-name>";
+const messageContent = "<message-content>";
+
+queueService.createMessage(queueName, messageContent, function() {
+  console.log(`Message sent`);
+});
+```
+
+Now in the new `@azure/storage-queue` SDK, instances of `QueueClient` would be used for queue operations. Method `sendMessage` can be used to add a new message to the back of the queue.
+
+```javascript
+const { QueueClient, StorageSharedKeyCredential } = require("@azure/storage-queue");
+const queueUrl = "https://<account-name>.queue.core.windows.net/<queue-name>";
+const messageContent = "<message-content>";
+
+const queueClient = new QueueClient(
+  queueUrl,
+  new StorageSharedKeyCredential("<accountName>", "<accountKey>")
+);
+
+await queueClient.sendMessage(messageContent);
+console.log(`Message sent`);
+```
+
+### Retrieving message from a queue
+
+Previously in `azure-storage`, method `getMessages` in a `QueueService` instance can be used to retrieve one or more message from the front of a queue
+
+```javascript
+const azure = require("azure-storage");
+const queueService = azure.createQueueService("<connection-string>");
+const queueName = "<queue-name>";
+
+queueService.getMessages(queueName, function(error, result) {
+  if (!error) {
+    console.log(result);
+  }
+});
+```
+
+Now with `@azure/storage-queue`, we use method `receiveMessages` in an instance of `QueueClient`, the return type is a Promise of the messages which can be awaited, making the code cleaner.
+
+```javascript
+const { QueueClient, StorageSharedKeyCredential } = require("@azure/storage-queue");
+const queueUrl = "https://<account-name>.queue.core.windows.net/<queue-name>";
+const messageContent = "<message-content>";
+
+const queueClient = new QueueClient(
+  queueUrl,
+  new StorageSharedKeyCredential("<accountName>", "<accountKey>")
+);
+
+const result = await queueClient.receiveMessages();
+console.log(result.receivedMessageItems);
+```
+
+### Sequential actions
+
+Previously in `azure-storage`, all the operations took a callback which would be executed once the operation completed. For example, to create a queue, add a message to the it, retrieve a message from it and then delete the message we would like to write the following nested code
+
+```javascript
+const azure = require("azure-storage");
+const queueService = azure.createQueueService("<connection-string>");
+const queueName = "<queue-name>";
+const messageContent = "<message-content>";
+
+queueService.createQueue(queueName, function() {
+  queueService.createMessage(queueName, messageContent, function() {
+    queueService.getMessages(queueName, function(error, result) {
+      if (!error) {
+        queueService.deleteMessage(queueName, result[0].messageId, result[0].popReceipt, function(
+          error,
+          result
+        ) {
+          console.log("Retrieved and deleted a message");
+        });
+      }
+    });
+  });
+});
+```
+
+With `@azure/storage-queue` we work with promises which makes the programming experience better, leveraging async/await we no longer need nested code blocks to perform sequential actions
+
+```javascript
+const { QueueClient, StorageSharedKeyCredential } = require("@azure/storage-queue");
+const queueUrl = "https://<account-name>.queue.core.windows.net/<queue-name>";
+const messageContent = "<message-content>";
+
+const queueClient = new QueueClient(
+  queueUrl,
+  new StorageSharedKeyCredential("<accountName>", "<accountKey>")
+);
+
+await queueClient.create();
+await queueClient.sendMessage("Hello, world!!111");
+const result = await queueClient.receiveMessages();
+await queueClient.deleteMessage(
+  result.receivedMessageItems[0].messageId,
+  result.receivedMessageItems[0].popReceipt
+);
+console.log("Retrieved and deleted a message");
+```
+
+## Additional samples
+
+More samples can be found [here](https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/storage/storage-queue/samples)

--- a/sdk/storage/storage-queue/MigrationGuide.md
+++ b/sdk/storage/storage-queue/MigrationGuide.md
@@ -23,11 +23,11 @@ As Azure has matured and been embraced by a more diverse group of developers, we
 
 There were several areas of consistent feedback expressed across the Azure client library ecosystem. One of the most important is that the client libraries for different Azure services have not had a consistent approach to organization, naming, and API structure. Additionally, many developers have felt that the learning curve was difficult, and the APIs did not offer a good, approachable, and consistent onboarding story for those learning Azure or exploring a specific Azure service.
 
-To improve the development experience across Azure services, a set of uniform [design guidelines](https://azure.github.io/azure-sdk/general_introduction.html) was created for all languages to drive a consistent experience with established API patterns for all services. A set of [TypeScript & JavaScript Guidelines](https://azure.github.io/azure-sdk/typescript_introduction.html) was also introduced to ensure that TypeScript clients have a natural and idiomatic feel with respect to the TypeScript and JavaScript ecosystems. The new `@azure/storage-queue` follows these guidelines.
+To improve the development experience across Azure services, a set of uniform [design guidelines](https://azure.github.io/azure-sdk/general_introduction.html) was created for all languages to drive a consistent experience with established API patterns for all services. A set of [TypeScript & JavaScript Guidelines](https://azure.github.io/azure-sdk/typescript_introduction.html) was also introduced to ensure that TypeScript clients have a natural and idiomatic feel with respect to the TypeScript and JavaScript ecosystems. The new `@azure/storage-queue` client library follows these guidelines.
 
 ### Cross Service SDK improvements
 
-The modern `@azure/storage-queue` client library also provides the ability to share in some of the cross-service improvements made to the Azure development experience, such as
+The modern `@azure/storage-queue` client library is also benefited from the cross-service improvements made to the Azure development experience, such as
 
 - A unified logging and diagnostics pipeline offering a common view of the activities across each of the client libraries
 - Use of promises rather than callbacks for a simplified programming experience
@@ -39,7 +39,7 @@ The modern `@azure/storage-queue` client library also provides the ability to sh
 
 The modern client library is named `@azure/storage-queue` and was released beginning with version 10. The legacy client library is named `azure-storage` with version of 2.x.x or below.
 
-The legacy library `azure-storage` grouped functionality to work with multiple services in the same package such as `Blob`, `Queue`, `Files` and `Tables`. The new `@azure/storage-queue` is dedicated to `Queue` there are new generation packages for the other storage services `@azure/data-tables`, `@azure/storage-blob`, `@azure/storage-file-share` this provides more granular control on which dependencies to take on your project.
+The legacy library `azure-storage` grouped functionality to work with multiple services in the same package such as `Blob`, `Queue`, `Files` and `Tables`. The new `@azure/storage-queue` is dedicated to `Queue` service. New generation packages are available for the other storage services as well: `@azure/data-tables`, `@azure/storage-blob` and `@azure/storage-file-share`. This provides more granular control on which dependencies to take on your project.
 
 ### Constructing the clients
 


### PR DESCRIPTION
Add migration guide from v2 to v12 storage packages: @azure/storage-blob, @azure/storage-file-share, @azure/storage-queue.