### PR TITLE
Revert "[Identity] Pointing to troubleshooting guide on more credentials"

### DIFF
--- a/sdk/identity/identity/CHANGELOG.md
+++ b/sdk/identity/identity/CHANGELOG.md
@@ -12,8 +12,6 @@
 
 ### Other Changes
 
-- Added a reference to the troubleshooting guide on the error cases of the credentials that use MSAL directly.
-
 ## 2.0.0 (2021-10-15)
 
 After multiple beta releases over the past year, we're proud to announce the general availability of version 2 of the `@azure/identity` package. This version includes the best parts of v1, plus several improvements.

--- a/sdk/identity/identity/src/msal/utils.ts
+++ b/sdk/identity/identity/src/msal/utils.ts
@@ -158,7 +158,6 @@ export class MsalBaseUtilities {
    * Handles MSAL errors.
    */
   protected handleError(scopes: string[], error: Error, getTokenOptions?: GetTokenOptions): Error {
-    const troubleshoot = `To troubleshoot, visit https://aka.ms/azsdk/js/identity/usernamepasswordcredential/troubleshoot.`;
     if (
       error.name === "AuthError" ||
       error.name === "ClientAuthError" ||
@@ -168,11 +167,9 @@ export class MsalBaseUtilities {
       switch (msalError.errorCode) {
         case "endpoints_resolution_error":
           this.logger.info(formatError(scopes, error.message));
-          return new CredentialUnavailableError(`${error.message}\n${troubleshoot}`);
+          return new CredentialUnavailableError(error.message);
         case "device_code_polling_cancelled":
-          return new AbortError(
-            `The authentication has been aborted by the caller. ${troubleshoot}`
-          );
+          return new AbortError("The authentication has been aborted by the caller.");
         case "consent_required":
         case "interaction_required":
         case "login_required":
@@ -190,10 +187,8 @@ export class MsalBaseUtilities {
       error.name === "BrowserConfigurationAuthError" ||
       error.name === "AbortError"
     ) {
-      error.message = `${error.message}\n${troubleshoot}`;
       return error;
     }
-    error.message = `${error.message}\n${troubleshoot}`;
     return new AuthenticationRequiredError({ scopes, getTokenOptions, message: error.message });
   }
 }

--- a/sdk/identity/identity/test/internal/identityClient.spec.ts
+++ b/sdk/identity/identity/test/internal/identityClient.spec.ts
@@ -145,10 +145,7 @@ describe("IdentityClient", function() {
     });
     if (isNode) {
       assert.strictEqual(error?.name, "AuthenticationRequiredError");
-      assert.strictEqual(
-        error?.message,
-        `Response had no "expiresOn" property.\nTo troubleshoot, visit https://aka.ms/azsdk/js/identity/usernamepasswordcredential/troubleshoot.`
-      );
+      assert.strictEqual(error?.message, `Response had no "expiresOn" property.`);
     } else {
       // The browser version of this credential uses a legacy approach.
       // While the Node version uses MSAL, the browser version does the network requests directly.


### PR DESCRIPTION
After further conversations with the identity crew, we have decided to not have generic references to the troubleshooting guide.

Reverts Azure/azure-sdk-for-js#18296