### PR TITLE
[KeyVault] - Move dom reference to dts file

### DIFF
--- a/sdk/keyvault/keyvault-common/src/dom.d.ts
+++ b/sdk/keyvault/keyvault-common/src/dom.d.ts
@@ -1,0 +1,5 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+// Workaround for https://github.com/DefinitelyTyped/DefinitelyTyped/issues/34960
+/// <reference lib="dom" />

--- a/sdk/keyvault/keyvault-common/src/parseWWWAuthenticate.ts
+++ b/sdk/keyvault/keyvault-common/src/parseWWWAuthenticate.ts
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-/// <reference lib="dom" />
 /**
  * @internal
  *


### PR DESCRIPTION
In order to work around a known typing issue when using the global URL, we added
a reference comment in source code. 

This PR just moves that declaration to a separate dts file in order to stay
consistent with how we're doing it in other packages.
