### PR TITLE
[core-http] use the original header name when returning raw headers

### DIFF
--- a/sdk/core/core-http/src/httpHeaders.ts
+++ b/sdk/core/core-http/src/httpHeaders.ts
@@ -178,7 +178,7 @@ export class HttpHeaders implements HttpHeadersLike {
     const result: RawHttpHeaders = {};
     for (const headerKey in this._headersMap) {
       const header: HttpHeader = this._headersMap[headerKey];
-      result[header.name.toLowerCase()] = header.value;
+      result[header.name] = header.value;
     }
     return result;
   }

--- a/sdk/core/core-http/test/httpHeaderTests.ts
+++ b/sdk/core/core-http/test/httpHeaderTests.ts
@@ -1,0 +1,34 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { assert } from "chai";
+import { HttpHeaders } from "../src/httpHeaders";
+
+describe("HttpHeaders", () => {
+  it("rawHeaders() preserves casing of raw header names from constructor", () => {
+    const rawHeaders = {
+      lowercase: "lower case value",
+      camelCase: "camel case value",
+      ALLUPPERCASE: "all upper case value"
+    };
+    const headers = new HttpHeaders(rawHeaders);
+
+    const actual = headers.rawHeaders();
+    assert.deepStrictEqual(actual, rawHeaders);
+  });
+
+  it("preserves casing of raw header names from set() calls", () => {
+    const expected = {
+      lowercase: "lower case value",
+      camelCase: "camel case value",
+      ALLUPPERCASE: "all upper case value"
+    };
+    const headers = new HttpHeaders();
+    headers.set("lowercase", "lower case value");
+    headers.set("camelCase", "camel case value");
+    headers.set("ALLUPPERCASE", "all upper case value");
+
+    const actual = headers.rawHeaders();
+    assert.deepStrictEqual(actual, expected);
+  });
+});

--- a/sdk/core/core-http/test/proxyAgent.node.ts
+++ b/sdk/core/core-http/test/proxyAgent.node.ts
@@ -60,7 +60,7 @@ describe("proxyAgent", () => {
 
       const agent = proxyAgent.agent as HttpsAgent;
       should().exist(agent.proxyOptions.headers);
-      agent.proxyOptions.headers!.should.contain({ "user-agent": "Node.js" });
+      agent.proxyOptions.headers!.should.contain({ "User-Agent": "Node.js" });
       done();
     });
 


### PR DESCRIPTION
so that the casing of header names is preserved in the result of `rawHeaders()`.

Relevant issue: #8117