### PR TITLE
[core-client] Prepare v1.3.2 release

### DIFF
--- a/sdk/core/core-client/CHANGELOG.md
+++ b/sdk/core/core-client/CHANGELOG.md
@@ -1,16 +1,10 @@
 # Release History
 
-## 1.3.2 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
+## 1.3.2 (2021-10-25)
 
 ### Bugs Fixed
 
 - Skip query parameter replacement for absolute URLs. [PR #18310](https://github.com/Azure/azure-sdk-for-js/pull/18310)
-
-### Other Changes
 
 ## 1.3.1 (2021-09-30)
 


### PR DESCRIPTION
To be released today. This release has a critical fix that affects how LROs behave in management-plane libraries which will be released as GAs this week.