### PR TITLE
[Text Analytics] Delete unused URL parsing helper

### DIFF
--- a/sdk/textanalytics/ai-text-analytics/package.json
+++ b/sdk/textanalytics/ai-text-analytics/package.json
@@ -55,7 +55,6 @@
     }
   },
   "browser": {
-    "./dist-esm/src/utils/url.js": "./dist-esm/src/utils/url.browser.js",
     "./dist-esm/test/public/utils/env.js": "./dist-esm/test/public/utils/env.browser.js"
   },
   "scripts": {

--- a/sdk/textanalytics/ai-text-analytics/src/util.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/util.ts
@@ -4,7 +4,6 @@
 import { RestError } from "@azure/core-rest-pipeline";
 import { FullOperationResponse, OperationOptions, OperationSpec } from "@azure/core-client";
 import { SpanStatusCode } from "@azure/core-tracing";
-import { URL, URLSearchParams } from "./utils/url";
 import { logger } from "./logger";
 import { GeneratedClient, StringIndexType as GeneratedStringIndexType } from "./generated";
 import { TextAnalyticsAction } from "./textAnalyticsAction";
@@ -184,30 +183,6 @@ export function setModelVersionParam<X extends { modelVersion?: string }>(
 export interface PageParam {
   top: number;
   skip: number;
-}
-
-/**
- * @internal
- */
-export function nextLinkToTopAndSkip(nextLink: string): PageParam {
-  const url = new URL(nextLink);
-  const searchParams = new URLSearchParams(url.searchParams);
-  let top: number;
-  if (searchParams.has("$top")) {
-    top = parseInt(searchParams.get("$top")!);
-  } else {
-    throw new Error(`nextLink URL does not have the $top param: ${nextLink}`);
-  }
-  let skip: number;
-  if (searchParams.has("$skip")) {
-    skip = parseInt(searchParams.get("$skip")!);
-  } else {
-    throw new Error(`nextLink URL does not have the $skip param: ${nextLink}`);
-  }
-  return {
-    skip: skip,
-    top: top
-  };
 }
 
 /**

--- a/sdk/textanalytics/ai-text-analytics/src/utils/url.browser.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/utils/url.browser.ts
@@ -1,7 +1,0 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT license.
-
-const url = URL;
-const urlSearchParams = URLSearchParams;
-
-export { url as URL, urlSearchParams as URLSearchParams };

--- a/sdk/textanalytics/ai-text-analytics/src/utils/url.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/utils/url.ts
@@ -1,4 +1,0 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT license.
-
-export { URL, URLSearchParams } from "url";

--- a/sdk/textanalytics/ai-text-analytics/test/internal/util.spec.ts
+++ b/sdk/textanalytics/ai-text-analytics/test/internal/util.spec.ts
@@ -3,7 +3,7 @@
 
 import { assert } from "chai";
 import { parseActionError } from "../../src/analyzeActionsResult";
-import { sortResponseIdObjects, nextLinkToTopAndSkip } from "../../src/util";
+import { sortResponseIdObjects } from "../../src/util";
 
 describe("util.sortByPreviousOrder", () => {
   it("should sort outputs correctly", () => {
@@ -11,15 +11,6 @@ describe("util.sortByPreviousOrder", () => {
     const output = [{ id: "3" }, { id: "1" }, { id: "2" }];
     const result = sortResponseIdObjects(input, output);
     assert.deepEqual(result, input);
-  });
-});
-
-describe("util.nextLinkToTopAndSkip", () => {
-  it("should return top and skip correctly", () => {
-    const nextLink =
-      "https://somehost/text/analytics/v3.2-preview.1/entities/health/jobs/1ef2876d-a815-4927-9fc9-e6d5fbc6ce95?$skip=10&$top=5";
-    const result = nextLinkToTopAndSkip(nextLink);
-    assert.deepEqual(result, { skip: 10, top: 5 });
   });
 });
 


### PR DESCRIPTION
This helper were used to parse `nextLink` URLs but it is no longer used.