### PR TITLE
[ServiceBus] Use `Promise.all()` when closing connection context.

### DIFF
--- a/sdk/servicebus/service-bus/CHANGELOG.md
+++ b/sdk/servicebus/service-bus/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### Bugs Fixed
 
+- Resolves an issue ([#17932](https://github.com/Azure/azure-sdk-for-js/issues/17932)) of receivers not being closed correctly when service bus client is closed.
+
 ### Other Changes
 
 ## 7.4.0-beta.1 (2021-10-04)

--- a/sdk/servicebus/service-bus/src/connectionContext.ts
+++ b/sdk/servicebus/service-bus/src/connectionContext.ts
@@ -620,11 +620,10 @@ export namespace ConnectionContext {
       const senderNames = Object.keys(context.senders);
       const messageReceiverNames = Object.keys(context.messageReceivers);
       const messageSessionNames = Object.keys(context.messageSessions);
-
-      logger.verbose(
-        `${logPrefix} Permanently closing all the senders, MessageReceivers, MessageSessions, and ManagementClients.`
-      );
       const managementClientsEntityPaths = Object.keys(context.managementClients);
+      logger.verbose(
+        `${logPrefix} Permanently closing all the senders(${senderNames.length}), MessageReceivers(${messageReceiverNames.length}), MessageSessions(${messageSessionNames.length}), and ManagementClients(${managementClientsEntityPaths.length}).`
+      );
       await Promise.all([
         ...senderNames.map((n) => context.senders[n].close()),
         ...messageReceiverNames.map((n) => context.messageReceivers[n].close()),

--- a/sdk/servicebus/service-bus/src/connectionContext.ts
+++ b/sdk/servicebus/service-bus/src/connectionContext.ts
@@ -620,34 +620,26 @@ export namespace ConnectionContext {
       // Close all the senders.
       const senderNames = Object.keys(context.senders);
       logger.verbose(`${logPrefix} Permanently closing ${senderNames.length} senders.`);
-      for (const senderName of senderNames) {
-        await context.senders[senderName].close();
-      }
+      await Promise.all(senderNames.map(n => context.senders[n].close()));
 
       // Close all MessageReceiver instances
       const messageReceiverNames = Object.keys(context.messageReceivers);
       logger.verbose(`${logPrefix} Permanently closing ${messageReceiverNames.length} receivers.`);
-      for (const receiverName of messageReceiverNames) {
-        await context.messageReceivers[receiverName].close();
-      }
+      await Promise.all(messageReceiverNames.map(n => context.messageReceivers[n].close()));
 
       // Close all MessageSession instances
       const messageSessionNames = Object.keys(context.messageSessions);
       logger.verbose(
         `${logPrefix} Permanently closing ${messageSessionNames.length} session receivers.`
       );
-      for (const messageSessionName of messageSessionNames) {
-        await context.messageSessions[messageSessionName].close();
-      }
+      await Promise.all(messageSessionNames.map(n => context.messageSessions[n].close()));
 
       // Close all the ManagementClients.
       const managementClientsEntityPaths = Object.keys(context.managementClients);
       logger.verbose(
         `${logPrefix} Permanently closing ${managementClientsEntityPaths.length} session receivers.`
       );
-      for (const entityPath of managementClientsEntityPaths) {
-        await context.managementClients[entityPath].close();
-      }
+      await Promise.all(managementClientsEntityPaths.map(p => context.managementClients[p].close()));
 
       logger.verbose(`${logPrefix} Permanently closing cbsSession`);
       await context.cbsSession.close();

--- a/sdk/servicebus/service-bus/src/connectionContext.ts
+++ b/sdk/servicebus/service-bus/src/connectionContext.ts
@@ -617,29 +617,20 @@ export namespace ConnectionContext {
     try {
       logger.verbose(`${logPrefix} Permanently closing the amqp connection on the client.`);
 
-      // Close all the senders.
       const senderNames = Object.keys(context.senders);
-      logger.verbose(`${logPrefix} Permanently closing ${senderNames.length} senders.`);
-      await Promise.all(senderNames.map(n => context.senders[n].close()));
-
-      // Close all MessageReceiver instances
       const messageReceiverNames = Object.keys(context.messageReceivers);
-      logger.verbose(`${logPrefix} Permanently closing ${messageReceiverNames.length} receivers.`);
-      await Promise.all(messageReceiverNames.map(n => context.messageReceivers[n].close()));
-
-      // Close all MessageSession instances
       const messageSessionNames = Object.keys(context.messageSessions);
-      logger.verbose(
-        `${logPrefix} Permanently closing ${messageSessionNames.length} session receivers.`
-      );
-      await Promise.all(messageSessionNames.map(n => context.messageSessions[n].close()));
 
-      // Close all the ManagementClients.
-      const managementClientsEntityPaths = Object.keys(context.managementClients);
       logger.verbose(
-        `${logPrefix} Permanently closing ${managementClientsEntityPaths.length} session receivers.`
+        `${logPrefix} Permanently closing all the senders, MessageReceivers, MessageSessions, and ManagementClients.`
       );
-      await Promise.all(managementClientsEntityPaths.map(p => context.managementClients[p].close()));
+      const managementClientsEntityPaths = Object.keys(context.managementClients);
+      await Promise.all([
+        ...senderNames.map((n) => context.senders[n].close()),
+        ...messageReceiverNames.map((n) => context.messageReceivers[n].close()),
+        ...messageSessionNames.map((n) => context.messageSessions[n].close()),
+        ...managementClientsEntityPaths.map((p) => context.managementClients[p].close())
+      ]);
 
       logger.verbose(`${logPrefix} Permanently closing cbsSession`);
       await context.cbsSession.close();


### PR DESCRIPTION
so that closing requests are fired immediately.