### PR TITLE
[Text Analytics] Postprocess recordings

### DIFF
--- a/sdk/textanalytics/ai-text-analytics/scripts/escapeNonAsciiRecordings/package.json
+++ b/sdk/textanalytics/ai-text-analytics/scripts/escapeNonAsciiRecordings/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "internalms/ta-dev-scripts",
+  "author": "Microsoft Corporation",
+  "description": "Utility scripts to help with the development of the Text Analytics SDK",
+  "license": "MIT",
+  "main": "./dist/index.js",
+  "module": "./dist-esm/src/index.js",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/textanalytics/ai-text-analytics/README.md",
+  "repository": "github:Azure/azure-sdk-for-js",
+  "bugs": {
+    "url": "https://github.com/Azure/azure-sdk-for-js/issues"
+  },
+  "engines": {
+    "node": ">=12.0.0"
+  },
+  "scripts": {
+    "format": "prettier --write --config ../../../../../.prettierrc.json --ignore-path ../../../../../.prettierignore \"src/**/*.ts\" \"test/**/*.ts\" \"samples-dev/**/*.ts\" \"*.{js,json}\"",
+    "pack": "npm pack 2>&1",
+    "test": "mocha -r esm --require ts-node/register --reporter ../../../../../common/tools/mocha-multi-reporter.js --timeout 1200000 --full-trace \"test/*.spec.ts\""
+  },
+  "sideEffects": false,
+  "autoPublish": false,
+  "dependencies": {
+    "isbinaryfile": "latest",
+    "tslib": "latest"
+  },
+  "devDependencies": {
+    "@types/chai": "^4.1.6",
+    "@types/chai-as-promised": "^7.1.0",
+    "@types/mocha": "^7.0.2",
+    "@types/node": "^12.0.0",
+    "chai": "^4.2.0",
+    "chai-as-promised": "^7.1.1",
+    "mocha": "^7.1.1",
+    "prettier": "^1.16.4",
+    "rimraf": "^3.0.0",
+    "ts-node": "^10.0.0",
+    "typescript": "~4.2.0"
+  }
+}

--- a/sdk/textanalytics/ai-text-analytics/scripts/escapeNonAsciiRecordings/src/index.ts
+++ b/sdk/textanalytics/ai-text-analytics/scripts/escapeNonAsciiRecordings/src/index.ts
@@ -1,0 +1,63 @@
+
+import * as fs from "fs";
+import * as path from "path";
+import { isBinaryFile } from "isbinaryfile";
+
+function padWithLeadingZeros(text: string): string {
+    return new Array(5 - text.length).join("0") + text;
+}
+
+function unicodeCharEscape(charCode: number): string {
+    return `\\u${padWithLeadingZeros(charCode.toString(16))}`;
+}
+
+function unicodeEscape(text: string): string {
+    return text.split("")
+        .map(function (char) {
+            var charCode = char.charCodeAt(0);
+            return charCode > 127 ? unicodeCharEscape(charCode) : char;
+        })
+        .join("");
+}
+
+function updateRecording(recording: string): string {
+  const parsedRecording: { recordings: { requestBody: string, response: string }[] } = JSON.parse(recording);
+  parsedRecording.recordings.map((recording) => {
+    recording.requestBody = unicodeEscape(recording.requestBody);
+    recording.response = unicodeEscape(recording.response);
+  })
+  return JSON.stringify(parsedRecording, null, " ");
+}
+
+function getAllFiles(dirPath: string, arrayOfFiles: string[]) {
+  const currentDirPath = path.join(__dirname, dirPath);
+  const files = fs.readdirSync(currentDirPath)
+
+  files.forEach(function(file) {
+    console.log(path.join(__dirname, dirPath, path.sep, file))
+    if (fs.statSync(path.join(__dirname, dirPath, path.sep, file)).isDirectory()) {
+      arrayOfFiles = getAllFiles(dirPath + path.sep + file, arrayOfFiles)
+    } else {
+      arrayOfFiles.push(path.join(currentDirPath, path.sep, file))
+    }
+  })
+
+  return arrayOfFiles
+}
+
+function getRecordingsList(): string[] {
+    return getAllFiles("../../../recordings/browsers", []);
+}
+
+async function main() {
+    for (const filePath of getRecordingsList()) {
+        if (await isBinaryFile(filePath)) {
+          const fileContent = fs.readFileSync(filePath);
+          const contentString = typeof fileContent === "string" ? fileContent : fileContent.toString();
+          const updatedRecording = updateRecording(contentString);
+          fs.writeFileSync(filePath, updatedRecording);
+        }
+    }
+}
+
+main()

--- a/sdk/textanalytics/ai-text-analytics/scripts/escapeNonAsciiRecordings/tsconfig.json
+++ b/sdk/textanalytics/ai-text-analytics/scripts/escapeNonAsciiRecordings/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../../../../tsconfig.package",
+  "compilerOptions": {
+    "module": "CommonJS",
+    "lib": ["ES6", "ESNext.AsyncIterable"],
+    "noEmit": true
+  },
+  "compileOnSave": true,
+  "include": ["./src/**/*.ts"]
+}


### PR DESCRIPTION
Some recordings are flagged as binary files by the [`isbinaryfile`](https://www.npmjs.com/package/isbinaryfile) package that karma uses. This causes karma to fail to run the test suite. This flagging happened because of some the request and response bodies contain non-ascii characters.

To fix this issue, we need to escape the hex codes for these unicode characters. I used to do this manually (see https://github.com/Azure/azure-sdk-for-js/pull/16126) but this PR automates this process by providing a script that does so.

WIP