### PR TITLE
Adding "sdk-type": "utility" for `sdk/test-utils/*` packages

### DIFF
--- a/common/tools/dev-tool/package.json
+++ b/common/tools/dev-tool/package.json
@@ -2,6 +2,7 @@
   "name": "@azure/dev-tool",
   "version": "1.0.0",
   "description": "A helpful command for azure-sdk-for-js developers",
+  "sdk-type": "utility",
   "bin": {
     "dev-tool": "launch.js"
   },

--- a/common/tools/eslint-plugin-azure-sdk/package.json
+++ b/common/tools/eslint-plugin-azure-sdk/package.json
@@ -2,6 +2,7 @@
   "name": "@azure/eslint-plugin-azure-sdk",
   "version": "3.0.0",
   "description": "An ESLint plugin enforcing design guidelines for the JavaScript/TypeScript Azure SDK",
+  "sdk-type": "utility",
   "private": true,
   "keywords": [
     "eslint",

--- a/eng/tools/rush-runner.js
+++ b/eng/tools/rush-runner.js
@@ -111,7 +111,8 @@ const getServicePackages = (baseDir, serviceDirs) => {
     const packageJsons = getPackageJsons(searchDir);
     for (const filePath of packageJsons) {
       const contents = JSON.parse(fs.readFileSync(filePath, "utf8"));
-      if (contents["sdk-type"] === "client" || contents["sdk-type"] === "mgmt" || contents["sdk-type"] === "perf-test" || contents["sdk-type"] === "utility") {
+      const sdkType = contents["sdk-type"];
+      if (sdkType === "client" || sdkType === "mgmt" || sdkType === "perf-test" || sdkType === "utility") {
         packageNames.push(contents.name);
         packageDirs.push(path.dirname(filePath));
       }

--- a/eng/tools/rush-runner.js
+++ b/eng/tools/rush-runner.js
@@ -111,7 +111,7 @@ const getServicePackages = (baseDir, serviceDirs) => {
     const packageJsons = getPackageJsons(searchDir);
     for (const filePath of packageJsons) {
       const contents = JSON.parse(fs.readFileSync(filePath, "utf8"));
-      if (contents["sdk-type"] === "client" || contents["sdk-type"] === "mgmt" || contents["sdk-type"] === "perf-test") {
+      if (contents["sdk-type"] === "client" || contents["sdk-type"] === "mgmt" || contents["sdk-type"] === "perf-test" || contents["sdk-type"] === "utility") {
         packageNames.push(contents.name);
         packageDirs.push(path.dirname(filePath));
       }

--- a/eng/tools/rush-runner.js
+++ b/eng/tools/rush-runner.js
@@ -90,14 +90,15 @@ const getPackageJsons = (searchDir) => {
 };
 
 const getServicePackages = (baseDir, serviceDirs) => {
-  const packageNames = [],
-    packageDirs = [];
+  const packageNames = [];
+  const packageDirs = [];
+  const validSdkTypes =  ["client", "mgmt", "perf-test", "utility"]; // valid "sdk-type"s that we are looking for, to be able to apply rush-runner jobs on
   for (const serviceDir of serviceDirs) {
     const searchDir = path.resolve(path.join(baseDir, "sdk", serviceDir));
     const packageJsons = getPackageJsons(searchDir);
     for (const filePath of packageJsons) {
       const contents = JSON.parse(fs.readFileSync(filePath, "utf8"));
-      if (["client", "mgmt", "perf-test", "utility"].includes(contents["sdk-type"])) {
+      if (validSdkTypes.includes(contents["sdk-type"])) {
         packageNames.push(contents.name);
         packageDirs.push(path.dirname(filePath));
       }

--- a/eng/tools/rush-runner.js
+++ b/eng/tools/rush-runner.js
@@ -97,11 +97,8 @@ const getServicePackages = (baseDir, serviceDirs) => {
     const packageJsons = getPackageJsons(searchDir);
     for (const filePath of packageJsons) {
       const contents = JSON.parse(fs.readFileSync(filePath, "utf8"));
-      const sdkType = contents["sdk-type"];
-      if (sdkType === "client" || sdkType === "mgmt" || sdkType === "perf-test" || sdkType === "utility") {
-        packageNames.push(contents.name);
-        packageDirs.push(path.dirname(filePath));
-      }
+      packageNames.push(contents.name);
+      packageDirs.push(path.dirname(filePath));
     }
   }
 

--- a/eng/tools/rush-runner.js
+++ b/eng/tools/rush-runner.js
@@ -70,20 +70,6 @@ const parseArgs = () => {
   return [baseDir, action, services, flags];
 };
 
-const getAllPackageJsonPaths = (baseDir) => {
-  // Find and return path to all packages in repo
-  const packagePaths = [];
-  const serviceDirs = fs
-    .readdirSync(path.resolve(path.join(baseDir, "sdk")))
-    .filter((f) => !f.startsWith("."))
-    .map((f) => path.resolve(path.join(baseDir, "sdk", f)));
-
-  for (const serviceDir of serviceDirs) {
-    for (const pkgPath of getPackageJsons(serviceDir)) packagePaths.push(pkgPath);
-  }
-  return packagePaths;
-};
-
 const getPackageJsons = (searchDir) => {
   // This gets all the directories with package.json at the `sdk/<service>/<service-sdk>` level excluding "arm-" packages
   const sdkDirectories = fs

--- a/eng/tools/rush-runner.js
+++ b/eng/tools/rush-runner.js
@@ -97,8 +97,10 @@ const getServicePackages = (baseDir, serviceDirs) => {
     const packageJsons = getPackageJsons(searchDir);
     for (const filePath of packageJsons) {
       const contents = JSON.parse(fs.readFileSync(filePath, "utf8"));
-      packageNames.push(contents.name);
-      packageDirs.push(path.dirname(filePath));
+      if (["client", "mgmt", "perf-test", "utility"].includes(contents["sdk-type"])) {
+        packageNames.push(contents.name);
+        packageDirs.push(path.dirname(filePath));
+      }
     }
   }
 

--- a/sdk/test-utils/perf/package.json
+++ b/sdk/test-utils/perf/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@azure/test-utils-perf",
   "version": "1.0.0",
-  "sdk-type": "client",
+  "sdk-type": "utility",
   "description": "Performance and stress test framework for the Azure SDK for JavaScript and TypeScript",
   "main": "dist-esm/src/index.js",
   "module": "dist-esm/src/index.js",

--- a/sdk/test-utils/recorder/package.json
+++ b/sdk/test-utils/recorder/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@azure-tools/test-recorder",
   "version": "1.0.2",
-  "sdk-type": "client",
+  "sdk-type": "utility",
   "description": "This library provides interfaces and helper methods to provide recording and playback capabilities for the tests in Azure JS/TS SDKs",
   "main": "dist/index.js",
   "module": "dist-esm/src/index.js",

--- a/sdk/test-utils/test-utils/package.json
+++ b/sdk/test-utils/test-utils/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@azure/test-utils",
   "version": "1.0.0",
+  "sdk-type": "utility",
   "description": "Test utilities library for the Azure SDK for JavaScript and TypeScript",
   "main": "dist/index.js",
   "module": "dist-esm/src/index.js",

--- a/sdk/test-utils/testing-recorder-new/package.json
+++ b/sdk/test-utils/testing-recorder-new/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@azure-tools/testing-recorder-new",
   "version": "1.0.0",
-  "sdk-type": "test",
+  "sdk-type": "utility",
   "description": "This library uses the interfaces and helper methods from @azure-tools/test-recorder-new in the tests to show an example",
   "main": "dist/index.js",
   "module": "dist-esm/src/index.js",


### PR DESCRIPTION
Issue #18401 

`js - test-utils - ci` is not building/running tests for `sdk/test-utils/test-utils` and `sdk/test-utils/recorder-new`.


This PR 
- adds "utility" sdk-type check in the rush-runner to allow building/testing these packages, 
- distinguishes the packages under `sdk/test-utils` as "utility"

Fixes #18401