### PR TITLE
Remove Node.js 10 from test matrix

### DIFF
--- a/eng/pipelines/templates/jobs/smoke.tests.yml
+++ b/eng/pipelines/templates/jobs/smoke.tests.yml
@@ -79,7 +79,7 @@ jobs:
           SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
           ArmTemplateParameters: $(AzureCloudArmTemplateParameters)
           NodeTestVersion: "16.x"
-#        Linux Node10 (AzureUSGovernment):
+#        Linux Node12 (AzureUSGovernment):
 #          Pool: Azure Pipelines
 #          OSVmImage: "ubuntu-18.04"
 #          SubscriptionConfiguration: $(sub-config-gov-test-resources)
@@ -97,7 +97,7 @@ jobs:
 #          SubscriptionConfiguration: $(sub-config-cn-test-resources)
 #          ArmTemplateParameters: $(AzureChinaCloudArmTemplateParameters)
 #          NodeTestVersion: "12.x"
-#        Windows Node10 (AzureChinaCloud):
+#        Windows Node12 (AzureChinaCloud):
 #          Pool: Azure Pipelines
 #          OSVmImage: "windows-2019"
 #          SubscriptionConfiguration: $(sub-config-cn-test-resources)

--- a/eng/pipelines/templates/jobs/smoke.tests.yml
+++ b/eng/pipelines/templates/jobs/smoke.tests.yml
@@ -84,7 +84,7 @@ jobs:
 #          OSVmImage: "ubuntu-18.04"
 #          SubscriptionConfiguration: $(sub-config-gov-test-resources)
 #          ArmTemplateParameters: $(AzureUSGovernmentArmTemplateParameters)
-#          NodeTestVersion: "10.x"
+#          NodeTestVersion: "12.x"
 #        Windows Node14 (AzureUSGovernment):
 #          Pool: Azure Pipelines
 #          OSVmImage: "windows-2019"
@@ -102,7 +102,7 @@ jobs:
 #          OSVmImage: "windows-2019"
 #          SubscriptionConfiguration: $(sub-config-cn-test-resources)
 #          ArmTemplateParameters: $(AzureChinaCloudArmTemplateParameters)
-#          NodeTestVersion: "10.x"
+#          NodeTestVersion: "12.x"
 
     pool:
       name: $(Pool)

--- a/eng/pipelines/templates/stages/platform-matrix.json
+++ b/eng/pipelines/templates/stages/platform-matrix.json
@@ -17,7 +17,7 @@
         "Pool": "Azure Pipelines"
       }
     },
-    "NodeTestVersion": ["10.x", "12.x", "14.x", "16.x"],
+    "NodeTestVersion": ["12.x", "14.x", "16.x"],
     "TestType": "node",
     "TestResultsFiles": "**/test-results.xml"
   },

--- a/sdk/keyvault/keyvault-admin/platform-matrix.json
+++ b/sdk/keyvault/keyvault-admin/platform-matrix.json
@@ -9,7 +9,7 @@
         }
       },
       "TestType": "node",
-      "NodeTestVersion": "10.x"
+      "NodeTestVersion": "12.x"
     }
   ]
 }

--- a/sdk/keyvault/keyvault-keys/platform-matrix.json
+++ b/sdk/keyvault/keyvault-keys/platform-matrix.json
@@ -9,7 +9,7 @@
         }
       },
       "TestType": "node",
-      "NodeTestVersion": "10.x"
+      "NodeTestVersion": "12.x"
     },
     {
       "Agent": {


### PR DESCRIPTION
Similar to #7022 where we dropped support for Node.js 8, it is now time to drop support for Node.js 10
For more on this, please see our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/master/SUPPORT.md#microsoft-support-policy)


