### PR TITLE
Use docker to validate packages in js docindex

### DIFF
--- a/eng/pipelines/docindex.yml
+++ b/eng/pipelines/docindex.yml
@@ -10,7 +10,7 @@ jobs:
       DocRepoLocation: $(Pipeline.Workspace)/docs
       DocRepoOwner: MicrosoftDocs
       DocRepoName: azure-docs-sdk-node
-      ImageId: azuresdkimages.azurecr.io/jsrefautocr:latest
+      DocValidationImageId: azuresdkimages.azurecr.io/jsrefautocr:latest
     steps:
       # Sync docs repo (this can be sparse)
       - template: /eng/common/pipelines/templates/steps/sparse-checkout.yml
@@ -28,7 +28,7 @@ jobs:
         parameters:
           ContainerRegistryClientId: $(azuresdkimages-cr-clientid)
           ContainerRegistryClientSecret: $(azuresdkimages-cr-clientsecret)
-          ImageId: '$(ImageId)'
+          ImageId: '$(DocValidationImageId)'
           
 
       # Call update docs ci script to onboard packages
@@ -36,7 +36,7 @@ jobs:
         inputs:
           pwsh: true
           filePath: eng/common/scripts/Update-DocsMsPackages.ps1
-          arguments: -DocRepoLocation $(DocRepoLocation) -ImageId '$(ImageId)'
+          arguments: -DocRepoLocation $(DocRepoLocation) -ImageId '$(DocValidationImageId)'
         displayName: Update Docs Onboarding
         condition: and(succeeded(), or(eq(variables['Build.Reason'], 'Schedule'), eq(variables['Force.MainUpdate'], 'true')))
           
@@ -69,7 +69,7 @@ jobs:
         inputs:
           pwsh: true
           filePath: eng/common/scripts/Update-DocsMsPackages.ps1
-          arguments: -DocRepoLocation $(DocRepoLocation) -ImageId '$(ImageId)'
+          arguments: -DocRepoLocation $(DocRepoLocation) -ImageId '$(DocValidationImageId)'
         displayName: Update Docs Onboarding for Daily branch
 
       - template: /eng/common/pipelines/templates/steps/git-push-changes.yml

--- a/eng/pipelines/docindex.yml
+++ b/eng/pipelines/docindex.yml
@@ -10,6 +10,7 @@ jobs:
       DocRepoLocation: $(Pipeline.Workspace)/docs
       DocRepoOwner: MicrosoftDocs
       DocRepoName: azure-docs-sdk-node
+      ImageId: azuresdkimages.azurecr.io/jsrefautocr:latest
     steps:
       # Sync docs repo (this can be sparse)
       - template: /eng/common/pipelines/templates/steps/sparse-checkout.yml
@@ -22,15 +23,23 @@ jobs:
           Repositories:
             - Name: $(DocRepoOwner)/$(DocRepoName)
               WorkingDirectory: $(DocRepoLocation)
+      # Pull and build the docker image. 
+      - template: /eng/common/pipelines/templates/steps/docker-pull-image.yml
+        parameters:
+          ContainerRegistryClientId: $(azuresdkimages-cr-clientid)
+          ContainerRegistryClientSecret: $(azuresdkimages-cr-clientsecret)
+          ImageId: '$(ImageId)'
+          
 
       # Call update docs ci script to onboard packages
       - task: Powershell@2
         inputs:
           pwsh: true
           filePath: eng/common/scripts/Update-DocsMsPackages.ps1
-          arguments: -DocRepoLocation $(DocRepoLocation)
+          arguments: -DocRepoLocation $(DocRepoLocation) -ImageId '$(ImageId)'
         displayName: Update Docs Onboarding
-
+        condition: and(succeeded(), or(eq(variables['Build.Reason'], 'Schedule'), eq(variables['Force.MainUpdate'], 'true')))
+          
       # Push changes to docs repo
       - template: /eng/common/pipelines/templates/steps/set-default-branch.yml
         parameters:
@@ -60,8 +69,9 @@ jobs:
         inputs:
           pwsh: true
           filePath: eng/common/scripts/Update-DocsMsPackages.ps1
-          arguments: -DocRepoLocation $(DocRepoLocation)
+          arguments: -DocRepoLocation $(DocRepoLocation) -ImageId '$(ImageId)'
         displayName: Update Docs Onboarding for Daily branch
+
       - template: /eng/common/pipelines/templates/steps/git-push-changes.yml
         parameters:
           BaseRepoBranch: $(DailyDocsBranchName)

--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -243,8 +243,7 @@ function ValidatePackagesForDocs($packages) {
   $validationOutput = $packages | Foreach-Object -Parallel {
     # Get value for variables outside of the Foreach-Object scope
     $scriptRoot = "$using:scriptRoot"
-    $workingDirectory = "$using:tempDirectory"
-    return ."$scriptRoot\validate-docs-package.ps1" -Package $_ -WorkingDirectory $workingDirectory
+    return ."$scriptRoot\validate-docs-package.ps1" -Package $_ -DocValidationImageId "$using:imageId"
   }
 
   # Clean up temp folder

--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -244,7 +244,7 @@ function ValidatePackagesForDocs($packages) {
     # Get value for variables outside of the Foreach-Object scope
     $scriptRoot = "$using:scriptRoot"
     $workingDirectory = "$using:tempDirectory"
-    return ."$scriptRoot\validate-docs-package.ps1" -Package $_ -DocValidationImageId "$using:imageId" -WorkDirectory $workingDirectory 
+    return ."$scriptRoot\validate-docs-package.ps1" -Package $_ -DocValidationImageId "$using:ImageId" -WorkDirectory $workingDirectory 
   }
 
   # Clean up temp folder

--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -244,7 +244,7 @@ function ValidatePackagesForDocs($packages) {
     # Get value for variables outside of the Foreach-Object scope
     $scriptRoot = "$using:scriptRoot"
     $workingDirectory = "$using:tempDirectory"
-    return ."$scriptRoot\validate-docs-package.ps1" -Package $_ -DocValidationImageId "$using:ImageId" -WorkDirectory $workingDirectory 
+    return ."$scriptRoot\validate-docs-package.ps1" -Package $_ -DocValidationImageId "$using:ImageId" -WorkingDirectory $workingDirectory 
   }
 
   # Clean up temp folder

--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -243,7 +243,8 @@ function ValidatePackagesForDocs($packages) {
   $validationOutput = $packages | Foreach-Object -Parallel {
     # Get value for variables outside of the Foreach-Object scope
     $scriptRoot = "$using:scriptRoot"
-    return ."$scriptRoot\validate-docs-package.ps1" -Package $_ -DocValidationImageId "$using:imageId"
+    $workingDirectory = "$using:tempDirectory"
+    return ."$scriptRoot\validate-docs-package.ps1" -Package $_ -DocValidationImageId "$using:imageId" -WorkDirectory $workingDirectory 
   }
 
   # Clean up temp folder

--- a/eng/scripts/validate-docs-package.ps1
+++ b/eng/scripts/validate-docs-package.ps1
@@ -17,7 +17,7 @@ Example:
   registry = "<url>";
   ...
 }
-.PARAMETER docValidationImageId
+.PARAMETER DocValidationImageId
 The image name for package validation in format of '$containerRegistry/$imageName:$tag'. 
 e.g. azuresdkimages.azurecr.io/jsrefautocr:latest
 #>

--- a/eng/scripts/validate-docs-package.ps1
+++ b/eng/scripts/validate-docs-package.ps1
@@ -31,8 +31,8 @@ param(
 function GetResult($success, $package, $output) { 
   return @{ Success = $success; Package = $package; Output = $output }
 }
-$registry = "TARGET_REGISTRY=$($Package.registry)"
-$folder = "TARGET_FOLDER=$($Package.folder)"
+$registry = " -e TARGET_REGISTRY=$($Package.registry)"
+$folder = " -e TARGET_FOLDER=$($Package.folder)"
 $commandLine = "docker run --restart=on-failure:3 -e TARGET_PACKAGE='$($Package.name)'"
 if ("$($Package.registry)") {
   $commandLine = "$commandLine$registry"

--- a/eng/scripts/validate-docs-package.ps1
+++ b/eng/scripts/validate-docs-package.ps1
@@ -28,7 +28,8 @@ node_modules folder is created and the package is installed
 
 param(
   [object] $Package,
-  [string] $DocValidationImageId
+  [string] $DocValidationImageId,
+  [string] $WorkingDirectory
 )
 ."$PSScriptRoot\..\common\scripts\common.ps1"
 

--- a/eng/scripts/validate-docs-package.ps1
+++ b/eng/scripts/validate-docs-package.ps1
@@ -31,9 +31,10 @@ param(
 function GetResult($success, $package, $output) { 
   return @{ Success = $success; Package = $package; Output = $output }
 }
-
-Write-Host "docker run --restart=on-failure:3 -e TARGET_PACKAGE='$($Package.name)' TARGET_REGISTRY='$($Package.registry)'' TARGET_FOLDER='$($Package.folder)'' $DocValidationImageId"
-$installOutput = docker run --restart=on-failure:3 -e TARGET_PACKAGE=$($Package.name) TARGET_REGISTRY="$($Package.registry)" TARGET_FOLDER="$($Package.folder)" $DocValidationImageId 2>&1
+$registry = "$($Package.registry)"
+$folder = "$($Package.folder)"
+Write-Host "docker run --restart=on-failure:3 -e TARGET_PACKAGE='$($Package.name)' TARGET_REGISTRY=$registry TARGET_FOLDER=$folder $DocValidationImageId"
+$installOutput = docker run --restart=on-failure:3 -e TARGET_PACKAGE=$($Package.name) TARGET_REGISTRY=$registry TARGET_FOLDER=$folder $DocValidationImageId 2>&1
 
 # The docker exit codes: https://docs.docker.com/engine/reference/run/#exit-status
 # If the docker failed because of docker itself instead of the application, 

--- a/eng/scripts/validate-docs-package.ps1
+++ b/eng/scripts/validate-docs-package.ps1
@@ -40,17 +40,18 @@ if ("$($Package.registry)") {
 if ("$($Package.folder)") {
   $commandLine = "$commandLine$folder"
 }
-$commandLine = "$commandLine $DocValidationImageId 2>&1" 
-Write-Host $commandLine
+$commandLine = "$commandLine $DocValidationImageId 2>&1"
 $installOutput = Invoke-Expression $commandLine
 
 # The docker exit codes: https://docs.docker.com/engine/reference/run/#exit-status
 # If the docker failed because of docker itself instead of the application, 
 # we should skip the validation and keep the packages. 
-if ($LASTEXITCODE -eq 125 -Or $LASTEXITCODE -eq 126 -Or $LASTEXITCODE -eq 127) {
+if ($LASTEXITCODE -eq 125 -Or $LASTEXITCODE -eq 126 -Or $LASTEXITCODE -eq 127) { 
+  Write-Host $commandLine
   LogWarning "The `docker` command does not work with exit code $LASTEXITCODE. Skipvalidation of $($Package.name)."
 }
-elseif ($LASTEXITCODE -ne 0) {
+elseif ($LASTEXITCODE -ne 0) { 
+  Write-Host $commandLine
   LogWarning "Package $($Package.name) ref docs validation failed."
   return GetResult $false $package $installOutput
 }

--- a/eng/scripts/validate-docs-package.ps1
+++ b/eng/scripts/validate-docs-package.ps1
@@ -31,10 +31,18 @@ param(
 function GetResult($success, $package, $output) { 
   return @{ Success = $success; Package = $package; Output = $output }
 }
-$registry = "$($Package.registry)"
-$folder = "$($Package.folder)"
-Write-Host "docker run --restart=on-failure:3 -e TARGET_PACKAGE='$($Package.name)' TARGET_REGISTRY=$registry TARGET_FOLDER=$folder $DocValidationImageId"
-$installOutput = docker run --restart=on-failure:3 -e TARGET_PACKAGE=$($Package.name) TARGET_REGISTRY=$registry TARGET_FOLDER=$folder $DocValidationImageId 2>&1
+$registry = "TARGET_REGISTRY=$($Package.registry)"
+$folder = "TARGET_FOLDER=$($Package.folder)"
+$commandLine = "docker run --restart=on-failure:3 -e TARGET_PACKAGE='$($Package.name)'"
+if ("$($Package.registry)") {
+  $commandLine = "$commandLine$registry"
+}
+if ("$($Package.folder)") {
+  $commandLine = "$commandLine$folder"
+}
+$commandLine = "$commandLine $DocValidationImageId 2>&1" 
+Write-Host $commandLine
+$installOutput = Invoke-Expression $commandLine
 
 # The docker exit codes: https://docs.docker.com/engine/reference/run/#exit-status
 # If the docker failed because of docker itself instead of the application, 

--- a/eng/scripts/validate-docs-package.ps1
+++ b/eng/scripts/validate-docs-package.ps1
@@ -82,7 +82,7 @@ function DockerValidation() {
 }
 
 
-if (-not $DocValidationImageId) {
+if (!$DocValidationImageId) {
   FallbackValidation
 } 
 else {

--- a/eng/scripts/validate-docs-package.ps1
+++ b/eng/scripts/validate-docs-package.ps1
@@ -31,8 +31,8 @@ param(
 function GetResult($success, $package, $output) { 
   return @{ Success = $success; Package = $package; Output = $output }
 }
-$registry = " -e TARGET_REGISTRY=$($Package.registry)"
-$folder = " -e TARGET_FOLDER=$($Package.folder)"
+$registry = " -e TARGET_REGISTRY=`'$($Package.registry)`'"
+$folder = " -e TARGET_FOLDER=`'$($Package.folder)`'"
 $commandLine = "docker run --restart=on-failure:3 -e TARGET_PACKAGE='$($Package.name)'"
 if ("$($Package.registry)") {
   $commandLine = "$commandLine$registry"

--- a/eng/scripts/validate-docs-package.ps1
+++ b/eng/scripts/validate-docs-package.ps1
@@ -20,6 +20,10 @@ Example:
 .PARAMETER DocValidationImageId
 The image name for package validation in format of '$containerRegistry/$imageName:$tag'. 
 e.g. azuresdkimages.azurecr.io/jsrefautocr:latest
+
+.PARAMETER WorkingDirectory
+Supplied to `npm install ... --prefix $WorkingDirectory`. The place where the 
+node_modules folder is created and the package is installed
 #>
 
 param(
@@ -31,28 +35,55 @@ param(
 function GetResult($success, $package, $output) { 
   return @{ Success = $success; Package = $package; Output = $output }
 }
-$registry = " -e TARGET_REGISTRY=`'$($Package.registry)`'"
-$folder = " -e TARGET_FOLDER=`'$($Package.folder)`'"
-$commandLine = "docker run --restart=on-failure:3 -e TARGET_PACKAGE='$($Package.name)'"
-if ("$($Package.registry)") {
-  $commandLine = "$commandLine$registry"
-}
-if ("$($Package.folder)") {
-  $commandLine = "$commandLine$folder"
-}
-$commandLine = "$commandLine $DocValidationImageId 2>&1"
-$installOutput = Invoke-Expression $commandLine
+function FallbackValidation() {
+  $additionalParameters = @()
+  $prefixDirectory = New-Item -ItemType Directory -Force -Path "$WorkingDirectory\$($Package.name)"
+  if ($Package.registry) {
+    Write-Host $Package.registry
+    $additionalParameters += @("--registry", $Package.registry)
+  }
 
-# The docker exit codes: https://docs.docker.com/engine/reference/run/#exit-status
-# If the docker failed because of docker itself instead of the application, 
-# we should skip the validation and keep the packages. 
-if ($LASTEXITCODE -eq 125 -Or $LASTEXITCODE -eq 126 -Or $LASTEXITCODE -eq 127) { 
-  Write-Host $commandLine
-  LogWarning "The `docker` command does not work with exit code $LASTEXITCODE. Skipvalidation of $($Package.name)."
+  Write-Host "npm install $($Package.name) --prefix $prefixDirectory $additionalParameters"
+  $installOutput = npm install $Package.name --prefix $prefixDirectory @additionalParameters 2>&1
+  if ($LASTEXITCODE -ne 0) {
+    LogWarning "Package install failed: $($Package.name)"
+    return GetResult $false $Package $installOutput
+  }
+  return GetResult $true $Package $installOutput
 }
-elseif ($LASTEXITCODE -ne 0) { 
-  Write-Host $commandLine
-  LogWarning "Package $($Package.name) ref docs validation failed."
-  return GetResult $false $package $installOutput
+function DockerValidation() {
+  $registry = " -e TARGET_REGISTRY=`'$($Package.registry)`'"
+  $folder = " -e TARGET_FOLDER=`'$($Package.folder)`'"
+  $commandLine = "docker run --restart=on-failure:3 -e TARGET_PACKAGE='$($Package.name)'"
+  if ("$($Package.registry)") {
+    $commandLine = "$commandLine$registry"
+  }
+  if ("$($Package.folder)") {
+    $commandLine = "$commandLine$folder"
+  }
+  $commandLine = "$commandLine $DocValidationImageId 2>&1"
+  $installOutput = Invoke-Expression $commandLine
+
+  # The docker exit codes: https://docs.docker.com/engine/reference/run/#exit-status
+  # If the docker failed because of docker itself instead of the application, 
+  # we should skip the validation and keep the packages. 
+  if ($LASTEXITCODE -eq 125 -Or $LASTEXITCODE -eq 126 -Or $LASTEXITCODE -eq 127) { 
+    Write-Host $commandLine
+    LogWarning "The `docker` command does not work with exit code $LASTEXITCODE. Fall back to npm install $($Package.name) directly."
+    FallbackValidation
+  }
+  elseif ($LASTEXITCODE -ne 0) { 
+    Write-Host $commandLine
+    LogWarning "Package $($Package.name) ref docs validation failed."
+    return GetResult $false $Package $installOutput
+  }
+  return GetResult $true $Package $installOutput
 }
-return GetResult $true $package $installOutput
+
+
+if (-not $DocValidationImageId) {
+  FallbackValidation
+} 
+else {
+  DockerValidation
+}


### PR DESCRIPTION
We plan to wrap the CI build command into docker image and use it to validate packages in docker. 

The PR is to replace the sanity check first. Will have a follow up PR for creating issues whenever the package got filtered out.

Here is the testing pipeline:
https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1174856&view=logs&j=dc056dfc-c0cf-5958-c8c4-8da4f91a3739

Test on no image id:
https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1180723&view=logs&j=dc056dfc-c0cf-5958-c8c4-8da4f91a3739&t=bfb6cede-7671-5504-0a11-79b13ef63703