### PR TITLE
Update rush and pnpm

### DIFF
--- a/rush.json
+++ b/rush.json
@@ -14,7 +14,7 @@
    * path segment in the "$schema" field for all your Rush config files.  This will ensure
    * correct error-underlining and tab-completion for editors such as VS Code.
    */
-  "rushVersion": "5.54.0",
+  "rushVersion": "5.55.1",
   /**
    * The next field selects which package manager should be installed and determines its version.
    * Rush installs its own local copy of the package manager to ensure that your build process
@@ -23,7 +23,7 @@
    * Specify one of: "pnpmVersion", "npmVersion", or "yarnVersion".  See the Rush documentation
    * for details about these alternatives.
    */
-  "pnpmVersion": "6.14.2",
+  "pnpmVersion": "6.19.1",
   // "npmVersion": "4.5.0",
   // "yarnVersion": "1.9.4",
   /**


### PR DESCRIPTION
- The fix in https://github.com/pnpm/pnpm/pull/3768 might address the mac build reliability issues we've been seeing