### PR TITLE
Update key vault keys to enable live testing in sovereign clouds for multiple services

### DIFF
--- a/sdk/keyvault/keyvault-keys/tests.yml
+++ b/sdk/keyvault/keyvault-keys/tests.yml
@@ -29,6 +29,7 @@ stages:
           Selection: sparse
           GenerateVMJobs: true
       EnvVars:
-        AZURE_CLIENT_ID: $(aad-azure-sdk-test-client-id)
-        AZURE_TENANT_ID: $(aad-azure-sdk-test-tenant-id)
-        AZURE_CLIENT_SECRET: $(aad-azure-sdk-test-client-secret)
+        AZURE_CLIENT_ID: $(KEYVAULT_CLIENT_ID)
+        AZURE_TENANT_ID: $(KEYVAULT_TENANT_ID)
+        AZURE_CLIENT_SECRET: $(KEYVAULT_CLIENT_SECRET)
+        AZURE_SUBSCRIPTION_ID: $(KEYVAULT_SUBSCRIPTION_ID) 

--- a/sdk/keyvault/keyvault-keys/tests.yml
+++ b/sdk/keyvault/keyvault-keys/tests.yml
@@ -7,9 +7,6 @@ stages:
       ServiceDirectory: keyvault
       TimeoutInMinutes: 90
       # KV HSM limitation prevents us from running live tests
-      # against multiple platforms in parallel (we're limited to a single
-      # instance per region per subscription) so we're only running
-      # live tests against a single instance.
       SupportedClouds: 'Public,UsGov,China'
       CloudConfig:
         Public:
@@ -23,6 +20,9 @@ stages:
           SubscriptionConfiguration: $(sub-config-cn-test-resources)
           MatrixFilters:
             - ArmTemplateParameters=^(?!.*enableHsm.*true)
+      # against multiple platforms in parallel (we're limited to a single
+      # instance per region per subscription) so we're only running
+      # live tests against a single instance.
       AdditionalMatrixConfigs:
         - Name: Keyvault_live_test_base
           Path: sdk/keyvault/keyvault-keys/platform-matrix.json

--- a/sdk/keyvault/keyvault-keys/tests.yml
+++ b/sdk/keyvault/keyvault-keys/tests.yml
@@ -10,7 +10,19 @@ stages:
       # against multiple platforms in parallel (we're limited to a single
       # instance per region per subscription) so we're only running
       # live tests against a single instance.
-      Location: eastus2
+      SupportedClouds: 'Public,UsGov,China,Canary'
+      CloudConfig:
+        Public:
+          SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
+          Location: 'eastus2'
+        UsGov:
+          SubscriptionConfiguration: $(sub-config-gov-test-resources)
+          MatrixFilters:
+            - ArmTemplateParameters=^(?!.*enableHsm.*true)
+        China:
+          SubscriptionConfiguration: $(sub-config-cn-test-resources)
+          MatrixFilters:
+            - ArmTemplateParameters=^(?!.*enableHsm.*true)
       AdditionalMatrixConfigs:
         - Name: Keyvault_live_test_base
           Path: sdk/keyvault/keyvault-keys/platform-matrix.json

--- a/sdk/keyvault/keyvault-keys/tests.yml
+++ b/sdk/keyvault/keyvault-keys/tests.yml
@@ -6,7 +6,6 @@ stages:
       PackageName: "@azure/keyvault-keys"
       ServiceDirectory: keyvault
       TimeoutInMinutes: 90
-      # KV HSM limitation prevents us from running live tests
       SupportedClouds: 'Public,UsGov,China'
       CloudConfig:
         Public:
@@ -20,6 +19,7 @@ stages:
           SubscriptionConfiguration: $(sub-config-cn-test-resources)
           MatrixFilters:
             - ArmTemplateParameters=^(?!.*enableHsm.*true)
+      # KV HSM limitation prevents us from running live tests
       # against multiple platforms in parallel (we're limited to a single
       # instance per region per subscription) so we're only running
       # live tests against a single instance.

--- a/sdk/keyvault/keyvault-keys/tests.yml
+++ b/sdk/keyvault/keyvault-keys/tests.yml
@@ -10,7 +10,7 @@ stages:
       # against multiple platforms in parallel (we're limited to a single
       # instance per region per subscription) so we're only running
       # live tests against a single instance.
-      SupportedClouds: 'Public,UsGov,China,Canary'
+      SupportedClouds: 'Public,UsGov,China'
       CloudConfig:
         Public:
           SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)


### PR DESCRIPTION
1. These changes enable key vault keys to run live tests against Public, UsGov and China.
2. Fix https://github.com/Azure/azure-sdk-for-js/issues/18414
3. Update file: keyvault-keys/tests.yml
    Update to manage HSM tests in sovereign clouds

Pipeline results:
https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1167620&view=results

@benbp, @ramya-rao-a, @AlexGhiondea, @maorleger for notification.