### PR TITLE
Update key vault secrets to enable live testing in sovereign clouds for multiple services

### DIFF
--- a/sdk/keyvault/keyvault-keys/tests.yml
+++ b/sdk/keyvault/keyvault-keys/tests.yml
@@ -29,6 +29,7 @@ stages:
           Selection: sparse
           GenerateVMJobs: true
       EnvVars:
-        AZURE_CLIENT_ID: $(aad-azure-sdk-test-client-id)
-        AZURE_TENANT_ID: $(aad-azure-sdk-test-tenant-id)
-        AZURE_CLIENT_SECRET: $(aad-azure-sdk-test-client-secret)
+        AZURE_CLIENT_ID: $(KEYVAULT_CLIENT_ID)
+        AZURE_TENANT_ID: $(KEYVAULT_TENANT_ID)
+        AZURE_CLIENT_SECRET: $(KEYVAULT_CLIENT_SECRET)
+        AZURE_SUBSCRIPTION_ID: $(KEYVAULT_SUBSCRIPTION_ID) 

--- a/sdk/keyvault/keyvault-keys/tests.yml
+++ b/sdk/keyvault/keyvault-keys/tests.yml
@@ -10,26 +10,13 @@ stages:
       # against multiple platforms in parallel (we're limited to a single
       # instance per region per subscription) so we're only running
       # live tests against a single instance.
-      SupportedClouds: 'Public,UsGov,China'
-      CloudConfig:
-        Public:
-          SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
-          Location: 'eastus2'
-        UsGov:
-          SubscriptionConfiguration: $(sub-config-gov-test-resources)
-          MatrixFilters:
-            - ArmTemplateParameters=^(?!.*enableHsm.*true)
-        China:
-          SubscriptionConfiguration: $(sub-config-cn-test-resources)
-          MatrixFilters:
-            - ArmTemplateParameters=^(?!.*enableHsm.*true)
+      Location: eastus2
       AdditionalMatrixConfigs:
         - Name: Keyvault_live_test_base
           Path: sdk/keyvault/keyvault-keys/platform-matrix.json
           Selection: sparse
           GenerateVMJobs: true
       EnvVars:
-        AZURE_CLIENT_ID: $(KEYVAULT_CLIENT_ID)
-        AZURE_TENANT_ID: $(KEYVAULT_TENANT_ID)
-        AZURE_CLIENT_SECRET: $(KEYVAULT_CLIENT_SECRET)
-        AZURE_SUBSCRIPTION_ID: $(KEYVAULT_SUBSCRIPTION_ID) 
+        AZURE_CLIENT_ID: $(aad-azure-sdk-test-client-id)
+        AZURE_TENANT_ID: $(aad-azure-sdk-test-tenant-id)
+        AZURE_CLIENT_SECRET: $(aad-azure-sdk-test-client-secret)

--- a/sdk/keyvault/keyvault-keys/tests.yml
+++ b/sdk/keyvault/keyvault-keys/tests.yml
@@ -10,7 +10,19 @@ stages:
       # against multiple platforms in parallel (we're limited to a single
       # instance per region per subscription) so we're only running
       # live tests against a single instance.
-      Location: eastus2
+      SupportedClouds: 'Public,UsGov,China,Canary'
+      CloudConfig:
+        Public:
+          SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
+          Location: 'eastus2'
+        UsGov:
+          SubscriptionConfiguration: $(sub-config-gov-test-resources)
+          MatrixFilters:
+            - ArmTemplateParameters=^(?!.*enableHsm.*true)
+        China:
+          SubscriptionConfiguration: $(sub-config-cn-test-resources)
+          MatrixFilters:
+            - ArmTemplateParameters=^(?!.*enableHsm.*true)
       AdditionalMatrixConfigs:
         - Name: Keyvault_live_test_base
           Path: sdk/keyvault/keyvault-keys/platform-matrix.json

--- a/sdk/keyvault/keyvault-keys/tests.yml
+++ b/sdk/keyvault/keyvault-keys/tests.yml
@@ -10,7 +10,7 @@ stages:
       # against multiple platforms in parallel (we're limited to a single
       # instance per region per subscription) so we're only running
       # live tests against a single instance.
-      SupportedClouds: 'Public,UsGov,China,Canary'
+      SupportedClouds: 'Public,UsGov,China'
       CloudConfig:
         Public:
           SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)

--- a/sdk/keyvault/keyvault-secrets/tests.yml
+++ b/sdk/keyvault/keyvault-secrets/tests.yml
@@ -6,7 +6,9 @@ stages:
       PackageName: "@azure/keyvault-secrets"
       ServiceDirectory: keyvault
       TimeoutInMinutes: 59
+      SupportedClouds: 'Public,UsGov,China'
       EnvVars:
-        AZURE_CLIENT_ID: $(aad-azure-sdk-test-client-id)
-        AZURE_TENANT_ID: $(aad-azure-sdk-test-tenant-id)
-        AZURE_CLIENT_SECRET: $(aad-azure-sdk-test-client-secret)
+        AZURE_CLIENT_ID: $(KEYVAULT_CLIENT_ID)
+        AZURE_TENANT_ID: $(KEYVAULT_TENANT_ID)
+        AZURE_CLIENT_SECRET: $(KEYVAULT_CLIENT_SECRET)
+        AZURE_SUBSCRIPTION_ID: $(KEYVAULT_SUBSCRIPTION_ID)


### PR DESCRIPTION
1.These changes enable key vault secrets to run live tests against Public, UsGov and China.

2.Update file: sdk/keyvault/keyvault-secrets/tests.yml
 Update to enable key vault secrets to run live tests against UsGov and China.

Pipeline results:
https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1167867&view=results

@benbp, @ramya-rao-a, @AlexGhiondea, @maorleger for notification.
