### PR TITLE
Update all samples to use Identity v2

### DIFF
--- a/samples/cors/ts/server/package.json
+++ b/samples/cors/ts/server/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@azure/identity": "^1.2.0",
+    "@azure/identity": "^2.0.1",
     "@azure/keyvault-secrets": "^4.1.0",
     "@types/node": "^14.14.19",
     "axios": "^0.21.1",

--- a/samples/frameworks/electron/ts/package.json
+++ b/samples/frameworks/electron/ts/package.json
@@ -23,7 +23,7 @@
     "webpack": "^5.6.0"
   },
   "dependencies": {
-    "@azure/identity": "^1.2.0",
+    "@azure/identity": "^2.0.1",
     "@azure/logger": "^1.0.0",
     "@azure/service-bus": "^7.0.0",
     "@azure/storage-blob": "^12.3.0",

--- a/samples/frameworks/react/ts/package.json
+++ b/samples/frameworks/react/ts/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "@azure/event-hubs": "^5.3.1",
-    "@azure/identity": "^1.2.0",
+    "@azure/identity": "^2.0.1",
     "@azure/storage-blob": "^12.3.0",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",

--- a/sdk/agrifood/agrifood-farming-rest/samples/v1/javascript/package.json
+++ b/sdk/agrifood/agrifood-farming-rest/samples/v1/javascript/package.json
@@ -28,6 +28,6 @@
   "dependencies": {
     "@azure-rest/agrifood-farming": "next",
     "dotenv": "latest",
-    "@azure/identity": "^1.1.0"
+    "@azure/identity": "^2.0.1"
   }
 }

--- a/sdk/agrifood/agrifood-farming-rest/samples/v1/typescript/package.json
+++ b/sdk/agrifood/agrifood-farming-rest/samples/v1/typescript/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "@azure-rest/agrifood-farming": "next",
     "dotenv": "latest",
-    "@azure/identity": "^1.1.0"
+    "@azure/identity": "^2.0.1"
   },
   "devDependencies": {
     "typescript": "~4.2.0",

--- a/sdk/appconfiguration/app-configuration/samples/v1/javascript/package.json
+++ b/sdk/appconfiguration/app-configuration/samples/v1/javascript/package.json
@@ -29,6 +29,6 @@
     "@azure/app-configuration": "latest",
     "dotenv": "latest",
     "@azure/keyvault-secrets": "^4.2.0",
-    "@azure/identity": "2.0.0-beta.6"
+    "@azure/identity": "^2.0.1"
   }
 }

--- a/sdk/appconfiguration/app-configuration/samples/v1/typescript/package.json
+++ b/sdk/appconfiguration/app-configuration/samples/v1/typescript/package.json
@@ -33,7 +33,7 @@
     "@azure/app-configuration": "latest",
     "dotenv": "latest",
     "@azure/keyvault-secrets": "^4.2.0",
-    "@azure/identity": "2.0.0-beta.6"
+    "@azure/identity": "^2.0.1"
   },
   "devDependencies": {
     "typescript": "~4.4.0",

--- a/sdk/communication/communication-identity/samples/v1/javascript/package.json
+++ b/sdk/communication/communication-identity/samples/v1/javascript/package.json
@@ -25,6 +25,6 @@
   "dependencies": {
     "@azure/communication-identity": "next",
     "dotenv": "latest",
-    "@azure/identity": "2.0.0-beta.6"
+    "@azure/identity": "^2.0.1"
   }
 }

--- a/sdk/communication/communication-identity/samples/v1/typescript/package.json
+++ b/sdk/communication/communication-identity/samples/v1/typescript/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "@azure/communication-identity": "next",
     "dotenv": "latest",
-    "@azure/identity": "2.0.0-beta.6"
+    "@azure/identity": "^2.0.1"
   },
   "devDependencies": {
     "typescript": "~4.4.0",

--- a/sdk/communication/communication-sms/samples/v1/javascript/package.json
+++ b/sdk/communication/communication-sms/samples/v1/javascript/package.json
@@ -29,6 +29,6 @@
     "dotenv": "latest",
     "@azure/communication-common": "^1.1.0",
     "@azure/core-http": "^2.0.0",
-    "@azure/identity": "2.0.0-beta.6"
+    "@azure/identity": "^2.0.1"
   }
 }

--- a/sdk/communication/communication-sms/samples/v1/typescript/package.json
+++ b/sdk/communication/communication-sms/samples/v1/typescript/package.json
@@ -33,7 +33,7 @@
     "dotenv": "latest",
     "@azure/communication-common": "^1.1.0",
     "@azure/core-http": "^2.0.0",
-    "@azure/identity": "2.0.0-beta.6"
+    "@azure/identity": "^2.0.1"
   },
   "devDependencies": {
     "typescript": "~4.4.0",

--- a/sdk/confidentialledger/confidential-ledger-rest/samples/v1/javascript/package.json
+++ b/sdk/confidentialledger/confidential-ledger-rest/samples/v1/javascript/package.json
@@ -28,6 +28,6 @@
   "dependencies": {
     "@azure-rest/confidential-ledger": "next",
     "dotenv": "latest",
-    "@azure/identity": "^1.1.0"
+    "@azure/identity": "^2.0.1"
   }
 }

--- a/sdk/confidentialledger/confidential-ledger-rest/samples/v1/typescript/package.json
+++ b/sdk/confidentialledger/confidential-ledger-rest/samples/v1/typescript/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "@azure-rest/confidential-ledger": "next",
     "dotenv": "latest",
-    "@azure/identity": "^1.1.0"
+    "@azure/identity": "^2.0.1"
   },
   "devDependencies": {
     "typescript": "~4.2.0",

--- a/sdk/containerregistry/container-registry/samples/v1/javascript/package.json
+++ b/sdk/containerregistry/container-registry/samples/v1/javascript/package.json
@@ -25,6 +25,6 @@
   "dependencies": {
     "@azure/container-registry": "next",
     "dotenv": "latest",
-    "@azure/identity": "^1.3.0"
+    "@azure/identity": "^2.0.1"
   }
 }

--- a/sdk/containerregistry/container-registry/samples/v1/typescript/package.json
+++ b/sdk/containerregistry/container-registry/samples/v1/typescript/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "@azure/container-registry": "next",
     "dotenv": "latest",
-    "@azure/identity": "^1.3.0"
+    "@azure/identity": "^2.0.1"
   },
   "devDependencies": {
     "typescript": "~4.2.0",

--- a/sdk/cosmosdb/cosmos/samples/v3/javascript/package.json
+++ b/sdk/cosmosdb/cosmos/samples/v3/javascript/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "@azure/cosmos": "latest",
     "dotenv": "latest",
-    "@azure/identity": "^1.1.0",
+    "@azure/identity": "^2.0.1",
     "uuid": "^8.3.0"
   }
 }

--- a/sdk/cosmosdb/cosmos/samples/v3/typescript/package.json
+++ b/sdk/cosmosdb/cosmos/samples/v3/typescript/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "@azure/cosmos": "latest",
     "dotenv": "latest",
-    "@azure/identity": "^1.1.0",
+    "@azure/identity": "^2.0.1",
     "uuid": "^8.3.0"
   },
   "devDependencies": {

--- a/sdk/deviceupdate/iot-device-update/samples/v1/javascript/package.json
+++ b/sdk/deviceupdate/iot-device-update/samples/v1/javascript/package.json
@@ -28,6 +28,6 @@
   "dependencies": {
     "@azure/iot-device-update": "next",
     "dotenv": "latest",
-    "@azure/identity": "^1.1.0"
+    "@azure/identity": "^2.0.1"
   }
 }

--- a/sdk/deviceupdate/iot-device-update/samples/v1/typescript/package.json
+++ b/sdk/deviceupdate/iot-device-update/samples/v1/typescript/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "@azure/iot-device-update": "next",
     "dotenv": "latest",
-    "@azure/identity": "^1.1.0"
+    "@azure/identity": "^2.0.1"
   },
   "devDependencies": {
     "typescript": "~4.2.0",

--- a/sdk/digitaltwins/digital-twins-core/samples/v1/javascript/package.json
+++ b/sdk/digitaltwins/digital-twins-core/samples/v1/javascript/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "@azure/digital-twins-core": "latest",
     "dotenv": "latest",
-    "@azure/identity": "^1.1.0",
+    "@azure/identity": "^2.0.1",
     "uuid": "^8.3.0"
   }
 }

--- a/sdk/digitaltwins/digital-twins-core/samples/v1/typescript/package.json
+++ b/sdk/digitaltwins/digital-twins-core/samples/v1/typescript/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "@azure/digital-twins-core": "latest",
     "dotenv": "latest",
-    "@azure/identity": "^1.1.0",
+    "@azure/identity": "^2.0.1",
     "uuid": "^8.3.0"
   },
   "devDependencies": {

--- a/sdk/eventhub/event-hubs/samples-browser/package.json
+++ b/sdk/eventhub/event-hubs/samples-browser/package.json
@@ -29,7 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@azure/event-hubs": "^5.0.0",
-    "@azure/identity": "^1.0.2"
+    "@azure/identity": "^2.0.1"
   },
   "devDependencies": {
     "http-server": "^0.12.1",

--- a/sdk/eventhub/event-hubs/samples/v5/browser/package.json
+++ b/sdk/eventhub/event-hubs/samples/v5/browser/package.json
@@ -29,7 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@azure/event-hubs": "^5.0.0",
-    "@azure/identity": "^1.0.2"
+    "@azure/identity": "^2.0.1"
   },
   "devDependencies": {
     "http-server": "^0.12.1",

--- a/sdk/eventhub/event-hubs/samples/v5/javascript/package.json
+++ b/sdk/eventhub/event-hubs/samples/v5/javascript/package.json
@@ -28,7 +28,7 @@
     "@azure/event-hubs": "latest",
     "dotenv": "latest",
     "rhea-promise": "^2.1.0",
-    "@azure/identity": "^1.5.1",
+    "@azure/identity": "^2.0.1",
     "ws": "^7.1.1",
     "https-proxy-agent": "^5.0.0"
   }

--- a/sdk/eventhub/event-hubs/samples/v5/typescript/package.json
+++ b/sdk/eventhub/event-hubs/samples/v5/typescript/package.json
@@ -32,7 +32,7 @@
     "@azure/event-hubs": "latest",
     "dotenv": "latest",
     "rhea-promise": "^2.1.0",
-    "@azure/identity": "^1.5.1",
+    "@azure/identity": "^2.0.1",
     "ws": "^7.1.1",
     "https-proxy-agent": "^5.0.0"
   },

--- a/sdk/formrecognizer/ai-form-recognizer/samples/v3/javascript/package.json
+++ b/sdk/formrecognizer/ai-form-recognizer/samples/v3/javascript/package.json
@@ -28,6 +28,6 @@
   "dependencies": {
     "@azure/ai-form-recognizer": "latest",
     "dotenv": "latest",
-    "@azure/identity": "2.0.0-beta.5"
+    "@azure/identity": "^2.0.1"
   }
 }

--- a/sdk/formrecognizer/ai-form-recognizer/samples/v3/typescript/package.json
+++ b/sdk/formrecognizer/ai-form-recognizer/samples/v3/typescript/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "@azure/ai-form-recognizer": "latest",
     "dotenv": "latest",
-    "@azure/identity": "2.0.0-beta.5"
+    "@azure/identity": "^2.0.1"
   },
   "devDependencies": {
     "typescript": "~4.2.0",

--- a/sdk/identity/identity/samples/typescript/package.json
+++ b/sdk/identity/identity/samples/typescript/package.json
@@ -29,7 +29,7 @@
   "homepage": "https://github.com/Azure/azure-sdk-for-js#readme",
   "sideEffects": false,
   "dependencies": {
-    "@azure/identity": "2.0.0-beta.5",
+    "@azure/identity": "^2.0.1",
     "@azure/keyvault-keys": "4.1.0",
     "@azure/keyvault-secrets": "4.2.0",
     "@azure/keyvault-certificates": "4.2.0",

--- a/sdk/keyvault/keyvault-admin/samples/v4/javascript/package.json
+++ b/sdk/keyvault/keyvault-admin/samples/v4/javascript/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "@azure/keyvault-admin": "next",
     "dotenv": "latest",
-    "@azure/identity": "2.0.0-beta.5",
+    "@azure/identity": "^2.0.1",
     "uuid": "^8.3.0",
     "@azure/keyvault-keys": "^4.2.1"
   }

--- a/sdk/keyvault/keyvault-admin/samples/v4/typescript/package.json
+++ b/sdk/keyvault/keyvault-admin/samples/v4/typescript/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "@azure/keyvault-admin": "next",
     "dotenv": "latest",
-    "@azure/identity": "2.0.0-beta.5",
+    "@azure/identity": "^2.0.1",
     "uuid": "^8.3.0",
     "@azure/keyvault-keys": "^4.2.1"
   },

--- a/sdk/keyvault/keyvault-certificates/samples/v4/javascript/package.json
+++ b/sdk/keyvault/keyvault-certificates/samples/v4/javascript/package.json
@@ -29,6 +29,6 @@
   "dependencies": {
     "@azure/keyvault-certificates": "next",
     "dotenv": "latest",
-    "@azure/identity": "2.0.0-beta.6"
+    "@azure/identity": "^2.0.1"
   }
 }

--- a/sdk/keyvault/keyvault-certificates/samples/v4/typescript/package.json
+++ b/sdk/keyvault/keyvault-certificates/samples/v4/typescript/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "@azure/keyvault-certificates": "next",
     "dotenv": "latest",
-    "@azure/identity": "2.0.0-beta.6"
+    "@azure/identity": "^2.0.1"
   },
   "devDependencies": {
     "typescript": "~4.2.0",

--- a/sdk/keyvault/keyvault-keys/samples/v4/javascript/package.json
+++ b/sdk/keyvault/keyvault-keys/samples/v4/javascript/package.json
@@ -29,6 +29,6 @@
   "dependencies": {
     "@azure/keyvault-keys": "next",
     "dotenv": "latest",
-    "@azure/identity": "^1.1.0"
+    "@azure/identity": "^2.0.1"
   }
 }

--- a/sdk/keyvault/keyvault-keys/samples/v4/typescript/package.json
+++ b/sdk/keyvault/keyvault-keys/samples/v4/typescript/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "@azure/keyvault-keys": "next",
     "dotenv": "latest",
-    "@azure/identity": "^1.1.0"
+    "@azure/identity": "^2.0.1"
   },
   "devDependencies": {
     "typescript": "~4.2.0",

--- a/sdk/keyvault/keyvault-secrets/samples/v4/javascript/package.json
+++ b/sdk/keyvault/keyvault-secrets/samples/v4/javascript/package.json
@@ -29,6 +29,6 @@
   "dependencies": {
     "@azure/keyvault-secrets": "next",
     "dotenv": "latest",
-    "@azure/identity": "2.0.0-beta.6"
+    "@azure/identity": "^2.0.1"
   }
 }

--- a/sdk/keyvault/keyvault-secrets/samples/v4/typescript/package.json
+++ b/sdk/keyvault/keyvault-secrets/samples/v4/typescript/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "@azure/keyvault-secrets": "next",
     "dotenv": "latest",
-    "@azure/identity": "2.0.0-beta.6"
+    "@azure/identity": "^2.0.1"
   },
   "devDependencies": {
     "typescript": "~4.2.0",

--- a/sdk/purview/purview-account-rest/samples/v1/javascript/package.json
+++ b/sdk/purview/purview-account-rest/samples/v1/javascript/package.json
@@ -28,6 +28,6 @@
   "dependencies": {
     "@azure-rest/purview-account": "next",
     "dotenv": "latest",
-    "@azure/identity": "^1.1.0"
+    "@azure/identity": "^2.0.1"
   }
 }

--- a/sdk/purview/purview-account-rest/samples/v1/typescript/package.json
+++ b/sdk/purview/purview-account-rest/samples/v1/typescript/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "@azure-rest/purview-account": "next",
     "dotenv": "latest",
-    "@azure/identity": "^1.1.0"
+    "@azure/identity": "^2.0.1"
   },
   "devDependencies": {
     "typescript": "~4.2.0",

--- a/sdk/purview/purview-administration-rest/samples/v1/javascript/package.json
+++ b/sdk/purview/purview-administration-rest/samples/v1/javascript/package.json
@@ -28,6 +28,6 @@
   "dependencies": {
     "@azure-rest/purview-administration": "next",
     "dotenv": "latest",
-    "@azure/identity": "^1.1.0"
+    "@azure/identity": "^2.0.1"
   }
 }

--- a/sdk/purview/purview-administration-rest/samples/v1/typescript/package.json
+++ b/sdk/purview/purview-administration-rest/samples/v1/typescript/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "@azure-rest/purview-administration": "next",
     "dotenv": "latest",
-    "@azure/identity": "^1.1.0"
+    "@azure/identity": "^2.0.1"
   },
   "devDependencies": {
     "typescript": "~4.4.0",

--- a/sdk/purview/purview-catalog-rest/samples/v1/javascript/package.json
+++ b/sdk/purview/purview-catalog-rest/samples/v1/javascript/package.json
@@ -28,6 +28,6 @@
   "dependencies": {
     "@azure-rest/purview-catalog": "next",
     "dotenv": "latest",
-    "@azure/identity": "^1.1.0"
+    "@azure/identity": "^2.0.1"
   }
 }

--- a/sdk/purview/purview-catalog-rest/samples/v1/typescript/package.json
+++ b/sdk/purview/purview-catalog-rest/samples/v1/typescript/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "@azure-rest/purview-catalog": "next",
     "dotenv": "latest",
-    "@azure/identity": "^1.1.0"
+    "@azure/identity": "^2.0.1"
   },
   "devDependencies": {
     "typescript": "~4.4.0",

--- a/sdk/purview/purview-scanning-rest/samples/v1/javascript/package.json
+++ b/sdk/purview/purview-scanning-rest/samples/v1/javascript/package.json
@@ -29,6 +29,6 @@
     "@azure-rest/purview-scanning": "next",
     "dotenv": "latest",
     "@azure/core-paging": "^1.1.1",
-    "@azure/identity": "^1.1.0"
+    "@azure/identity": "^2.0.1"
   }
 }

--- a/sdk/purview/purview-scanning-rest/samples/v1/typescript/package.json
+++ b/sdk/purview/purview-scanning-rest/samples/v1/typescript/package.json
@@ -33,7 +33,7 @@
     "@azure-rest/purview-scanning": "next",
     "dotenv": "latest",
     "@azure/core-paging": "^1.1.1",
-    "@azure/identity": "^1.1.0"
+    "@azure/identity": "^2.0.1"
   },
   "devDependencies": {
     "typescript": "~4.4.0",

--- a/sdk/quantum/quantum-jobs/samples/package.json
+++ b/sdk/quantum/quantum-jobs/samples/package.json
@@ -9,6 +9,6 @@
   "dependencies": {
     "@azure/core-http": "latest",
     "@azure/storage-blob": "latest",
-    "@azure/identity": "2.0.0-beta.5"
+    "@azure/identity": "^2.0.1"
   }
 }

--- a/sdk/schemaregistry/schema-registry-avro/samples/v1/javascript/package.json
+++ b/sdk/schemaregistry/schema-registry-avro/samples/v1/javascript/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "@azure/schema-registry-avro": "next",
     "dotenv": "latest",
-    "@azure/identity": "2.0.0-beta.6",
+    "@azure/identity": "^2.0.1",
     "@azure/schema-registry": "1.0.0-beta.3"
   }
 }

--- a/sdk/schemaregistry/schema-registry-avro/samples/v1/typescript/package.json
+++ b/sdk/schemaregistry/schema-registry-avro/samples/v1/typescript/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "@azure/schema-registry-avro": "next",
     "dotenv": "latest",
-    "@azure/identity": "2.0.0-beta.6",
+    "@azure/identity": "^2.0.1",
     "@azure/schema-registry": "1.0.0-beta.3"
   },
   "devDependencies": {

--- a/sdk/schemaregistry/schema-registry/samples/v1/javascript/package.json
+++ b/sdk/schemaregistry/schema-registry/samples/v1/javascript/package.json
@@ -25,6 +25,6 @@
   "dependencies": {
     "@azure/schema-registry": "next",
     "dotenv": "latest",
-    "@azure/identity": "2.0.0-beta.6"
+    "@azure/identity": "^2.0.1"
   }
 }

--- a/sdk/schemaregistry/schema-registry/samples/v1/typescript/package.json
+++ b/sdk/schemaregistry/schema-registry/samples/v1/typescript/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "@azure/schema-registry": "next",
     "dotenv": "latest",
-    "@azure/identity": "2.0.0-beta.6"
+    "@azure/identity": "^2.0.1"
   },
   "devDependencies": {
     "typescript": "~4.4.0",

--- a/sdk/servicebus/service-bus/samples/v7/javascript/package.json
+++ b/sdk/servicebus/service-bus/samples/v7/javascript/package.json
@@ -29,7 +29,7 @@
     "dotenv": "latest",
     "ws": "^7.1.1",
     "https-proxy-agent": "^5.0.0",
-    "@azure/identity": "^1.1.0",
+    "@azure/identity": "^2.0.1",
     "@azure/abort-controller": "^1.0.0"
   }
 }

--- a/sdk/servicebus/service-bus/samples/v7/typescript/package.json
+++ b/sdk/servicebus/service-bus/samples/v7/typescript/package.json
@@ -33,7 +33,7 @@
     "dotenv": "latest",
     "ws": "^7.1.1",
     "https-proxy-agent": "^5.0.0",
-    "@azure/identity": "^1.1.0",
+    "@azure/identity": "^2.0.1",
     "@azure/abort-controller": "^1.0.0"
   },
   "devDependencies": {

--- a/sdk/storage/storage-blob/samples/javascript/package.json
+++ b/sdk/storage/storage-blob/samples/javascript/package.json
@@ -26,7 +26,7 @@
   "sideEffects": false,
   "dependencies": {
     "@azure/abort-controller": "latest",
-    "@azure/identity": "2.0.0-beta.5",
+    "@azure/identity": "^2.0.1",
     "@azure/storage-blob": "latest",
     "dotenv": "^8.2.0"
   },

--- a/sdk/tables/data-tables/samples/v12/javascript/package.json
+++ b/sdk/tables/data-tables/samples/v12/javascript/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "@azure/data-tables": "latest",
     "dotenv": "latest",
-    "@azure/identity": "2.0.0-beta.6",
+    "@azure/identity": "^2.0.1",
     "uuid": "^8.3.0",
     "@azure/core-auth": "^1.3.0"
   }

--- a/sdk/tables/data-tables/samples/v12/typescript/package.json
+++ b/sdk/tables/data-tables/samples/v12/typescript/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "@azure/data-tables": "latest",
     "dotenv": "latest",
-    "@azure/identity": "2.0.0-beta.6",
+    "@azure/identity": "^2.0.1",
     "uuid": "^8.3.0",
     "@azure/core-auth": "^1.3.0"
   },

--- a/sdk/template/template/samples/v1/javascript/package.json
+++ b/sdk/template/template/samples/v1/javascript/package.json
@@ -25,6 +25,6 @@
   "dependencies": {
     "@azure/template": "next",
     "dotenv": "latest",
-    "@azure/identity": "^1.1.0"
+    "@azure/identity": "^2.0.1"
   }
 }

--- a/sdk/template/template/samples/v1/typescript/package.json
+++ b/sdk/template/template/samples/v1/typescript/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "@azure/template": "next",
     "dotenv": "latest",
-    "@azure/identity": "^1.1.0"
+    "@azure/identity": "^2.0.1"
   },
   "devDependencies": {
     "typescript": "~4.1.2",

--- a/sdk/textanalytics/ai-text-analytics/samples/v5/javascript/package.json
+++ b/sdk/textanalytics/ai-text-analytics/samples/v5/javascript/package.json
@@ -27,7 +27,7 @@
   "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/textanalytics/ai-text-analytics",
   "dependencies": {
     "@azure/ai-text-analytics": "latest",
-    "@azure/identity": "2.0.0-beta.5",
+    "@azure/identity": "^2.0.1",
     "dotenv": "latest"
   }
 }

--- a/sdk/textanalytics/ai-text-analytics/samples/v5/typescript/package.json
+++ b/sdk/textanalytics/ai-text-analytics/samples/v5/typescript/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "@azure/ai-text-analytics": "latest",
     "dotenv": "latest",
-    "@azure/identity": "2.0.0-beta.5"
+    "@azure/identity": "^2.0.1"
   },
   "devDependencies": {
     "typescript": "~4.2.0",


### PR DESCRIPTION
Related to #14581

Since we want to encourage the use of latest version of `@azure/identity` among our customers, we should update our samples to do the same.

Since none of the samples used VSCodeCredential, no code changes are part of this PR, only version updates