### PR TITLE
Move Identity dependency from v2 beta to v2 GA

### DIFF
--- a/sdk/anomalydetector/ai-anomaly-detector/package.json
+++ b/sdk/anomalydetector/ai-anomaly-detector/package.json
@@ -70,7 +70,7 @@
   },
   "devDependencies": {
     "@azure/dev-tool": "^1.0.0",
-    "@azure/identity": "2.0.0-beta.6",
+    "@azure/identity": "^2.0.1",
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
     "@microsoft/api-extractor": "^7.18.11",
     "@rollup/plugin-commonjs": "11.0.2",

--- a/sdk/appconfiguration/app-configuration/package.json
+++ b/sdk/appconfiguration/app-configuration/package.json
@@ -96,7 +96,7 @@
   "devDependencies": {
     "@azure/dev-tool": "^1.0.0",
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
-    "@azure/identity": "2.0.0-beta.6",
+    "@azure/identity": "^2.0.1",
     "@azure/keyvault-secrets": "^4.2.0",
     "@azure-tools/test-recorder": "^1.0.0",
     "@microsoft/api-extractor": "^7.18.11",

--- a/sdk/attestation/attestation/package.json
+++ b/sdk/attestation/attestation/package.json
@@ -103,7 +103,7 @@
   "devDependencies": {
     "@azure/dev-tool": "^1.0.0",
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
-    "@azure/identity": "2.0.0-beta.6",
+    "@azure/identity": "^2.0.1",
     "@azure-tools/test-recorder": "^1.0.0",
     "@microsoft/api-extractor": "^7.18.11",
     "@types/chai": "^4.1.6",

--- a/sdk/batch/batch/package.json
+++ b/sdk/batch/batch/package.json
@@ -50,7 +50,7 @@
     "karma-junit-reporter": "^2.0.1",
     "karma-mocha": "^2.0.1",
     "karma-mocha-reporter": "^2.2.5",
-    "@azure/identity": "2.0.0-beta.5",
+    "@azure/identity": "^2.0.1",
     "mocha": "^8.3.0",
     "mocha-junit-reporter": "^2.0.0",
     "moment": "^2.29.1",

--- a/sdk/communication/communication-identity/package.json
+++ b/sdk/communication/communication-identity/package.json
@@ -88,7 +88,7 @@
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
     "@azure/test-utils": "^1.0.0",
     "@azure-tools/test-recorder": "^1.0.0",
-    "@azure/identity": "2.0.0-beta.6",
+    "@azure/identity": "^2.0.1",
     "@microsoft/api-extractor": "^7.18.11",
     "@rollup/plugin-commonjs": "11.0.2",
     "@rollup/plugin-json": "^4.0.0",

--- a/sdk/communication/communication-network-traversal/package.json
+++ b/sdk/communication/communication-network-traversal/package.json
@@ -85,7 +85,7 @@
     "@azure/communication-identity": "^1.0.0",
     "@azure/dev-tool": "^1.0.0",
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
-    "@azure/identity": "2.0.0-beta.6",
+    "@azure/identity": "^2.0.1",
     "@azure/test-utils": "^1.0.0",
     "@azure-tools/test-recorder": "^1.0.0",
     "@microsoft/api-extractor": "^7.18.11",

--- a/sdk/communication/communication-phone-numbers/package.json
+++ b/sdk/communication/communication-phone-numbers/package.json
@@ -76,7 +76,7 @@
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
     "@azure/test-utils": "^1.0.0",
     "@azure-tools/test-recorder": "^1.0.0",
-    "@azure/identity": "2.0.0-beta.6",
+    "@azure/identity": "^2.0.1",
     "@microsoft/api-extractor": "^7.18.11",
     "@rollup/plugin-commonjs": "11.0.2",
     "@rollup/plugin-json": "^4.0.0",

--- a/sdk/communication/communication-sms/package.json
+++ b/sdk/communication/communication-sms/package.json
@@ -76,7 +76,7 @@
   "devDependencies": {
     "@azure/dev-tool": "^1.0.0",
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
-    "@azure/identity": "2.0.0-beta.6",
+    "@azure/identity": "^2.0.1",
     "@azure/test-utils": "^1.0.0",
     "@azure-tools/test-recorder": "^1.0.0",
     "@microsoft/api-extractor": "^7.18.11",

--- a/sdk/containerregistry/container-registry/package.json
+++ b/sdk/containerregistry/container-registry/package.json
@@ -86,7 +86,7 @@
   "devDependencies": {
     "@azure/dev-tool": "^1.0.0",
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
-    "@azure/identity": "2.0.0-beta.6",
+    "@azure/identity": "^2.0.1",
     "@azure/test-utils": "^1.0.0",
     "@azure-tools/test-recorder": "^1.0.0",
     "@microsoft/api-extractor": "^7.18.11",

--- a/sdk/deviceupdate/iot-device-update/package.json
+++ b/sdk/deviceupdate/iot-device-update/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@azure/dev-tool": "^1.0.0",
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
-    "@azure/identity": "2.0.0-beta.6",
+    "@azure/identity": "^2.0.1",
     "@microsoft/api-extractor": "^7.18.11",
     "@types/node": "^12.0.0",
     "@types/uuid": "^8.0.0",

--- a/sdk/digitaltwins/digital-twins-core/package.json
+++ b/sdk/digitaltwins/digital-twins-core/package.json
@@ -74,7 +74,7 @@
   "devDependencies": {
     "@azure/dev-tool": "^1.0.0",
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
-    "@azure/identity": "2.0.0-beta.6",
+    "@azure/identity": "^2.0.1",
     "@azure-tools/test-recorder": "^1.0.0",
     "@microsoft/api-extractor": "^7.18.11",
     "@rollup/plugin-commonjs": "11.0.2",

--- a/sdk/eventhub/event-hubs/package.json
+++ b/sdk/eventhub/event-hubs/package.json
@@ -127,7 +127,7 @@
   "devDependencies": {
     "@azure/dev-tool": "^1.0.0",
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
-    "@azure/identity": "2.0.0-beta.6",
+    "@azure/identity": "^2.0.1",
     "@azure/mock-hub": "^1.0.0",
     "@azure/test-utils": "^1.0.0",
     "@azure/test-utils-perf": "^1.0.0",

--- a/sdk/formrecognizer/ai-form-recognizer/package.json
+++ b/sdk/formrecognizer/ai-form-recognizer/package.json
@@ -94,7 +94,7 @@
   "devDependencies": {
     "@azure/dev-tool": "^1.0.0",
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
-    "@azure/identity": "2.0.0-beta.6",
+    "@azure/identity": "^2.0.1",
     "@azure/test-utils": "^1.0.0",
     "@azure-tools/test-recorder": "^1.0.0",
     "@microsoft/api-extractor": "^7.18.11",

--- a/sdk/formrecognizer/perf-tests/ai-form-recognizer/package.json
+++ b/sdk/formrecognizer/perf-tests/ai-form-recognizer/package.json
@@ -10,7 +10,7 @@
   "license": "ISC",
   "dependencies": {
     "@azure/ai-form-recognizer": "3.1.0-beta.3",
-    "@azure/identity": "2.0.0-beta.5",
+    "@azure/identity": "^2.0.1",
     "@azure/test-utils-perf": "^1.0.0",
     "dotenv": "^8.2.0",
     "tslib": "^2.2.0"

--- a/sdk/identity/identity/test/manual-integration/AzureArc/package.json
+++ b/sdk/identity/identity/test/manual-integration/AzureArc/package.json
@@ -9,7 +9,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@azure/identity": "2.0.0-beta.6",
+    "@azure/identity": "^2.0.1",
     "@azure/keyvault-secrets": "^4.1.0",
     "typescript": "^4.2.4"
   }

--- a/sdk/identity/identity/test/manual-integration/AzureFunctions/IdentityTest/package.json
+++ b/sdk/identity/identity/test/manual-integration/AzureFunctions/IdentityTest/package.json
@@ -14,7 +14,7 @@
   "description": "",
   "devDependencies": {
     "@azure/functions": "1.2.3",
-    "@azure/identity": "2.0.0-beta.5",
+    "@azure/identity": "^2.0.1",
     "@azure/keyvault-secrets": "^4.1.0",
     "npm-run-all": "^4.1.5",
     "typescript": "^3.3.3"

--- a/sdk/identity/identity/test/manual-integration/AzureVM/package.json
+++ b/sdk/identity/identity/test/manual-integration/AzureVM/package.json
@@ -9,7 +9,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@azure/identity": "2.0.0-beta.6",
+    "@azure/identity": "^2.0.1",
     "@azure/keyvault-secrets": "^4.0.2"
   }
 }

--- a/sdk/identity/identity/test/manual-integration/Cloudshell/package.json
+++ b/sdk/identity/identity/test/manual-integration/Cloudshell/package.json
@@ -9,7 +9,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@azure/identity": "2.0.0-beta.5",
+    "@azure/identity": "^2.0.1",
     "@azure/keyvault-secrets": "^4.0.2"
   }
 }

--- a/sdk/identity/identity/test/manual-integration/Kubernetes/package.json
+++ b/sdk/identity/identity/test/manual-integration/Kubernetes/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "yargs": "15.1.0",
     "@types/yargs": "15.0.3",
-    "@azure/identity": "2.0.0-beta.6",
+    "@azure/identity": "^2.0.1",
     "@azure/keyvault-secrets": "^4.0.2"
   },
   "devDependencies": {

--- a/sdk/identity/identity/test/manual-integration/webjobs/App_Data/jobs/triggered/AzureTestJob/package.json
+++ b/sdk/identity/identity/test/manual-integration/webjobs/App_Data/jobs/triggered/AzureTestJob/package.json
@@ -9,7 +9,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@azure/identity": "2.0.0-beta.5",
+    "@azure/identity": "^2.0.1",
     "@azure/keyvault-secrets": "^4.0.2",
     "tslib": "^1.10.0"
   }

--- a/sdk/identity/identity/test/manual/package.json
+++ b/sdk/identity/identity/test/manual/package.json
@@ -12,7 +12,7 @@
   "author": "Microsoft Corporation",
   "license": "MIT",
   "dependencies": {
-    "@azure/identity": "2.0.0-beta.6",
+    "@azure/identity": "^2.0.1",
     "@azure/service-bus": "^7.0.3",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",

--- a/sdk/keyvault/perf-tests/keyvault-certificates/package.json
+++ b/sdk/keyvault/perf-tests/keyvault-certificates/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@azure/test-utils-perf": "^1.0.0",
     "dotenv": "^8.2.0",
-    "@azure/identity": "2.0.0-beta.5",
+    "@azure/identity": "^2.0.1",
     "uuid": "^8.3.0",
     "@azure/keyvault-certificates": "^4.2.0"
   },

--- a/sdk/keyvault/perf-tests/keyvault-keys/package.json
+++ b/sdk/keyvault/perf-tests/keyvault-keys/package.json
@@ -11,7 +11,7 @@
     "@azure/test-utils-perf": "^1.0.0",
     "@azure/keyvault-keys": "^4.2.1",
     "dotenv": "^8.2.0",
-    "@azure/identity": "2.0.0-beta.6",
+    "@azure/identity": "^2.0.1",
     "uuid": "^8.3.0"
   },
   "devDependencies": {

--- a/sdk/keyvault/perf-tests/keyvault-secrets/package.json
+++ b/sdk/keyvault/perf-tests/keyvault-secrets/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@azure/test-utils-perf": "^1.0.0",
     "dotenv": "^8.2.0",
-    "@azure/identity": "2.0.0-beta.5",
+    "@azure/identity": "^2.0.1",
     "uuid": "^8.3.0",
     "@azure/keyvault-secrets": "4.4.0-beta.2"
   },

--- a/sdk/quantum/quantum-jobs/package.json
+++ b/sdk/quantum/quantum-jobs/package.json
@@ -72,7 +72,7 @@
     "@azure/storage-blob": "^12.8.0",
     "@azure/dev-tool": "^1.0.0",
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
-    "@azure/identity": "2.0.0-beta.6",
+    "@azure/identity": "^2.0.1",
     "@azure-tools/test-recorder": "^1.0.0",
     "@microsoft/api-extractor": "^7.18.11",
     "@rollup/plugin-commonjs": "11.0.2",

--- a/sdk/schemaregistry/schema-registry-avro/package.json
+++ b/sdk/schemaregistry/schema-registry-avro/package.json
@@ -80,7 +80,7 @@
   "devDependencies": {
     "@azure/dev-tool": "^1.0.0",
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
-    "@azure/identity": "2.0.0-beta.6",
+    "@azure/identity": "^2.0.1",
     "@azure-tools/test-recorder": "^1.0.0",
     "@microsoft/api-extractor": "^7.18.11",
     "@rollup/plugin-commonjs": "11.0.2",

--- a/sdk/schemaregistry/schema-registry/package.json
+++ b/sdk/schemaregistry/schema-registry/package.json
@@ -89,7 +89,7 @@
   "devDependencies": {
     "@azure/dev-tool": "^1.0.0",
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
-    "@azure/identity": "2.0.0-beta.6",
+    "@azure/identity": "^2.0.1",
     "@azure-tools/test-recorder": "^1.0.0",
     "@microsoft/api-extractor": "^7.18.11",
     "@types/chai": "^4.1.6",

--- a/sdk/search/perf-tests/search-documents/package.json
+++ b/sdk/search/perf-tests/search-documents/package.json
@@ -8,7 +8,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@azure/identity": "2.0.0-beta.5",
+    "@azure/identity": "^2.0.1",
     "@azure/search-documents": "11.3.0-beta.4",
     "@azure/test-utils-perf": "^1.0.0",
     "dotenv": "^8.2.0"

--- a/sdk/servicebus/service-bus/package.json
+++ b/sdk/servicebus/service-bus/package.json
@@ -130,7 +130,7 @@
   "devDependencies": {
     "@azure/dev-tool": "^1.0.0",
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
-    "@azure/identity": "2.0.0-beta.6",
+    "@azure/identity": "^2.0.1",
     "@azure/test-utils": "^1.0.0",
     "@azure/test-utils-perf": "^1.0.0",
     "@microsoft/api-extractor": "^7.18.11",

--- a/sdk/storage/storage-blob/package.json
+++ b/sdk/storage/storage-blob/package.json
@@ -138,7 +138,7 @@
     "@azure/core-rest-pipeline": "^1.1.0",
     "@azure/dev-tool": "^1.0.0",
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
-    "@azure/identity": "2.0.0-beta.6",
+    "@azure/identity": "^2.0.1",
     "@azure/test-utils": "^1.0.0",
     "@azure-tools/test-recorder": "^1.0.0",
     "@azure/test-utils-perf": "^1.0.0",

--- a/sdk/storage/storage-file-datalake/package.json
+++ b/sdk/storage/storage-file-datalake/package.json
@@ -117,7 +117,7 @@
   "devDependencies": {
     "@azure/dev-tool": "^1.0.0",
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
-    "@azure/identity": "2.0.0-beta.6",
+    "@azure/identity": "^2.0.1",
     "@azure/test-utils": "^1.0.0",
     "@azure-tools/test-recorder": "^1.0.0",
     "@azure/test-utils-perf": "^1.0.0",

--- a/sdk/storage/storage-queue/package.json
+++ b/sdk/storage/storage-queue/package.json
@@ -118,7 +118,7 @@
   "devDependencies": {
     "@azure/dev-tool": "^1.0.0",
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
-    "@azure/identity": "2.0.0-beta.6",
+    "@azure/identity": "^2.0.1",
     "@azure/test-utils": "^1.0.0",
     "@azure-tools/test-recorder": "^1.0.0",
     "@microsoft/api-extractor": "^7.18.11",

--- a/sdk/synapse/synapse-access-control/package.json
+++ b/sdk/synapse/synapse-access-control/package.json
@@ -45,7 +45,7 @@
   "devDependencies": {
     "@azure/dev-tool": "^1.0.0",
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
-    "@azure/identity": "2.0.0-beta.6",
+    "@azure/identity": "^2.0.1",
     "@azure-tools/test-recorder": "^1.0.0",
     "@microsoft/api-extractor": "^7.18.11",
     "@types/chai": "^4.1.6",

--- a/sdk/synapse/synapse-artifacts/package.json
+++ b/sdk/synapse/synapse-artifacts/package.json
@@ -36,7 +36,7 @@
   "devDependencies": {
     "@azure/dev-tool": "^1.0.0",
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
-    "@azure/identity": "2.0.0-beta.6",
+    "@azure/identity": "^2.0.1",
     "@azure-tools/test-recorder": "^1.0.0",
     "@microsoft/api-extractor": "^7.18.11",
     "@types/chai": "^4.1.6",

--- a/sdk/synapse/synapse-managed-private-endpoints/package.json
+++ b/sdk/synapse/synapse-managed-private-endpoints/package.json
@@ -45,7 +45,7 @@
   "types": "./types/synapse-managed-private-endpoints.d.ts",
   "devDependencies": {
     "@azure-tools/test-recorder": "^1.0.0",
-    "@azure/identity": "2.0.0-beta.6",
+    "@azure/identity": "^2.0.1",
     "typescript": "~4.2.0",
     "eslint": "^7.15.0",
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",

--- a/sdk/synapse/synapse-spark/package.json
+++ b/sdk/synapse/synapse-spark/package.json
@@ -38,7 +38,7 @@
     "@microsoft/api-extractor": "^7.18.11",
     "typedoc": "0.15.2",
     "@azure-tools/test-recorder": "^1.0.0",
-    "@azure/identity": "2.0.0-beta.6",
+    "@azure/identity": "^2.0.1",
     "@types/chai": "^4.1.6",
     "@types/mocha": "^7.0.2",
     "chai": "^4.2.0",

--- a/sdk/tables/data-tables/package.json
+++ b/sdk/tables/data-tables/package.json
@@ -87,7 +87,7 @@
     "uuid": "^8.3.0"
   },
   "devDependencies": {
-    "@azure/identity": "2.0.0-beta.6",
+    "@azure/identity": "^2.0.1",
     "@azure/dev-tool": "^1.0.0",
     "@microsoft/api-extractor": "^7.18.11",
     "@rollup/plugin-commonjs": "11.0.2",

--- a/sdk/template/template/package.json
+++ b/sdk/template/template/package.json
@@ -87,7 +87,7 @@
   "devDependencies": {
     "@azure/dev-tool": "^1.0.0",
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
-    "@azure/identity": "2.0.0-beta.5",
+    "@azure/identity": "^2.0.1",
     "@azure-tools/test-recorder": "^1.0.0",
     "@microsoft/api-extractor": "^7.18.11",
     "@types/chai": "^4.1.6",

--- a/sdk/textanalytics/ai-text-analytics/package.json
+++ b/sdk/textanalytics/ai-text-analytics/package.json
@@ -100,7 +100,7 @@
   "devDependencies": {
     "@azure/dev-tool": "^1.0.0",
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
-    "@azure/identity": "2.0.0-beta.6",
+    "@azure/identity": "^2.0.1",
     "@azure/test-utils": "^1.0.0",
     "@azure-tools/test-recorder": "^1.0.0",
     "@microsoft/api-extractor": "^7.18.11",

--- a/sdk/textanalytics/perf-tests/text-analytics/package.json
+++ b/sdk/textanalytics/perf-tests/text-analytics/package.json
@@ -9,7 +9,7 @@
   "license": "ISC",
   "dependencies": {
     "@azure/ai-text-analytics": "^5.1.0-beta.5",
-    "@azure/identity": "2.0.0-beta.6",
+    "@azure/identity": "^2.0.1",
     "@azure/test-utils-perf": "^1.0.0",
     "dotenv": "^8.2.0"
   },


### PR DESCRIPTION
Related to #14581

In #18463, we attempt to update all our samples to use latest v2 of `@azure/identity` so that our customers don't end up on older versions when using the samples. We came across a problem of these versions getting overridden the next time the samples are published via dev-tool as the version in the corresponding package are different.

This PR attempts to solve this problem by updating the devDependency on `@azure/identity` v2 beta version to GA version. There are no changes between the v2 beta and GA that should affect the packages in their use of the package in their tests. Therefore, this PR has changes only to the package.json files


There are still packages that are still on v1 of `@azure/identity`. They are out of scope of this PR as they would require their recordings to be re-generated to work with v2 of `@azure/identity`
