### PR TITLE
Update remaining beta dependencies on identity

### DIFF
--- a/sdk/identity/identity/test/manual/package.json
+++ b/sdk/identity/identity/test/manual/package.json
@@ -19,7 +19,7 @@
     "tslib": "1.9.3"
   },
   "devDependencies": {
-    "@azure/identity-cache-persistence": "^1.0.0-beta.2",
+    "@azure/identity-cache-persistence": "^1.0.0",
     "@types/express": "^4.16.0",
     "@types/node": "12.0.0",
     "@types/react": "^16.8.24",

--- a/sdk/identity/perf-tests/identity/package.json
+++ b/sdk/identity/perf-tests/identity/package.json
@@ -8,8 +8,8 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@azure/identity": "^2.0.0-beta.6",
-    "@azure/identity-cache-persistence": "~1.0.0-beta.1",
+    "@azure/identity": "^2.0.1",
+    "@azure/identity-cache-persistence": "^1.0.0",
     "@azure/test-utils-perf": "^1.0.0",
     "dotenv": "^8.2.0"
   },


### PR DESCRIPTION
Related to #14581

A few cases of beta dependencies were missed in #18470 as they were not pinned as expected. This PR covers these cases and updates the Identity dependencies to use the GA versions