### PR TITLE
Remove generate:client script

### DIFF
--- a/sdk/batch/batch/package.json
+++ b/sdk/batch/batch/package.json
@@ -92,7 +92,6 @@
     "execute:samples": "dev-tool samples run samples-dev",
     "extract-api": "tsc -p . && api-extractor run --local",
     "format": "prettier --write --config ../../../.prettierrc.json --ignore-path ../../../.prettierignore \"src/**/*.ts\" \"test/**/*.ts\" \"samples-dev/**/*.ts\" \"*.{js,json}\"",
-    "generate:client": "autorest --typescript swagger",
     "integration-test:browser": "karma start --single-run",
     "integration-test:node": "nyc mocha -r esm --require source-map-support/register --reporter ../../../common/tools/mocha-multi-reporter.js --timeout 5000000 --full-trace \"dist-esm/test/{,!(browser)/**/}/*.spec.js\"",
     "integration-test": "npm run integration-test:node && npm run integration-test:browser",


### PR DESCRIPTION
Solves https://github.com/Azure/azure-sdk-for-js/issues/18428

Given that batch is a track 1 SDK and this script had caused problems before, as [mentioned here](https://github.com/Azure/azure-sdk-for-js/pull/18398#discussion_r738854204), `generate:client` has been removed from the package.json

CC: @deyaaeldeen 