### PR TITLE
Remove dependency overrides for Identity

### DIFF
--- a/sdk/containerregistry/container-registry/package.json
+++ b/sdk/containerregistry/container-registry/package.json
@@ -132,9 +132,6 @@
     ],
     "requiredResources": {
       "Azure Container Registry": "https://docs.microsoft.com/azure/container-registry/container-registry-get-started-portal"
-    },
-    "dependencyOverrides": {
-      "@azure/identity": "^1.3.0"
     }
   }
 }

--- a/sdk/eventhub/event-hubs/package.json
+++ b/sdk/eventhub/event-hubs/package.json
@@ -83,9 +83,6 @@
     ]
   },
   "//sampleConfiguration": {
-    "dependencyOverrides": {
-      "@azure/identity": "^1.5.1"
-    },
     "extraFiles": {
       "./samples-browser": [
         "browser"

--- a/sdk/servicebus/service-bus/package.json
+++ b/sdk/servicebus/service-bus/package.json
@@ -92,9 +92,6 @@
     "requiredResources": {
       "Azure Service Bus": "https://docs.microsoft.com/azure/service-bus-messaging"
     },
-    "dependencyOverrides": {
-      "@azure/identity": "^1.1.0"
-    },
     "skip": [
       "receiveMessagesLoop.js",
       "receiveMessagesStreaming.js",


### PR DESCRIPTION
Related to #14581

In https://github.com/Azure/azure-sdk-for-js/pull/18463, we updated all samples to use GA of Identity v2
In https://github.com/Azure/azure-sdk-for-js/pull/18470, we updated devDependencies of Identity v2 beta to use Identity v2 GA

This PR removes the dependency overrides put in place for the reason (am guessing) that we wanted tests to use the beta v2 Identity, but not samples

Now that the samples are using v2, we no longer need the dependency overrides