### PR TITLE
[core-rest-pipeline] Allow specifying any status response to get stream

### DIFF
--- a/sdk/core/core-rest-pipeline/CHANGELOG.md
+++ b/sdk/core/core-rest-pipeline/CHANGELOG.md
@@ -1,14 +1,10 @@
 # Release History
 
-## 1.3.2 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
-
-### Bugs Fixed
+## 1.3.2 (2021-11-4)
 
 ### Other Changes
+
+- Allow specifying any status response to get a raw stream as response content. [#18492](https://github.com/Azure/azure-sdk-for-js/pull/18492)
 
 ## 1.3.1 (2021-09-30)
 

--- a/sdk/core/core-rest-pipeline/review/core-rest-pipeline.api.md
+++ b/sdk/core/core-rest-pipeline/review/core-rest-pipeline.api.md
@@ -199,6 +199,7 @@ export interface PipelineRequest {
     onUploadProgress?: (progress: TransferProgressEvent) => void;
     proxySettings?: ProxySettings;
     requestId: string;
+    responseAsStream?: boolean;
     streamResponseStatusCodes?: Set<number>;
     timeout: number;
     tracingOptions?: OperationTracingOptions;
@@ -219,6 +220,7 @@ export interface PipelineRequestOptions {
     onUploadProgress?: (progress: TransferProgressEvent) => void;
     proxySettings?: ProxySettings;
     requestId?: string;
+    responseAsStream?: boolean;
     streamResponseStatusCodes?: Set<number>;
     timeout?: number;
     tracingOptions?: OperationTracingOptions;

--- a/sdk/core/core-rest-pipeline/review/core-rest-pipeline.api.md
+++ b/sdk/core/core-rest-pipeline/review/core-rest-pipeline.api.md
@@ -199,7 +199,6 @@ export interface PipelineRequest {
     onUploadProgress?: (progress: TransferProgressEvent) => void;
     proxySettings?: ProxySettings;
     requestId: string;
-    responseAsStream?: boolean;
     streamResponseStatusCodes?: Set<number>;
     timeout: number;
     tracingOptions?: OperationTracingOptions;
@@ -220,7 +219,6 @@ export interface PipelineRequestOptions {
     onUploadProgress?: (progress: TransferProgressEvent) => void;
     proxySettings?: ProxySettings;
     requestId?: string;
-    responseAsStream?: boolean;
     streamResponseStatusCodes?: Set<number>;
     timeout?: number;
     tracingOptions?: OperationTracingOptions;

--- a/sdk/core/core-rest-pipeline/src/interfaces.ts
+++ b/sdk/core/core-rest-pipeline/src/interfaces.ts
@@ -138,13 +138,9 @@ export interface PipelineRequest {
 
   /**
    * A list of response status codes whose corresponding PipelineResponse body should be treated as a stream.
+   * When streamResponseStatusCodes contains the value Number.POSITIVE_INFINITY any status would be treated as a stream.
    */
   streamResponseStatusCodes?: Set<number>;
-
-  /**
-   * If set, body will be returned as a raw stream.
-   */
-  responseAsStream?: boolean;
 
   /**
    * Proxy configuration.

--- a/sdk/core/core-rest-pipeline/src/interfaces.ts
+++ b/sdk/core/core-rest-pipeline/src/interfaces.ts
@@ -142,6 +142,11 @@ export interface PipelineRequest {
   streamResponseStatusCodes?: Set<number>;
 
   /**
+   * If set, body will be returned as a raw stream.
+   */
+  responseAsStream?: boolean;
+
+  /**
    * Proxy configuration.
    */
   proxySettings?: ProxySettings;

--- a/sdk/core/core-rest-pipeline/src/nodeHttpClient.ts
+++ b/sdk/core/core-rest-pipeline/src/nodeHttpClient.ts
@@ -151,7 +151,7 @@ class NodeHttpClient implements HttpClient {
         responseStream = downloadReportStream;
       }
 
-      if (request.streamResponseStatusCodes?.has(response.status)) {
+      if (request.responseAsStream || request.streamResponseStatusCodes?.has(response.status)) {
         response.readableStreamBody = responseStream;
       } else {
         response.bodyAsText = await streamToText(responseStream);

--- a/sdk/core/core-rest-pipeline/src/nodeHttpClient.ts
+++ b/sdk/core/core-rest-pipeline/src/nodeHttpClient.ts
@@ -151,7 +151,11 @@ class NodeHttpClient implements HttpClient {
         responseStream = downloadReportStream;
       }
 
-      if (request.responseAsStream || request.streamResponseStatusCodes?.has(response.status)) {
+      if (
+        // Value of POSITIVE_INFINITY in streamResponseStatusCodes is considered as any status code
+        request.streamResponseStatusCodes?.has(Number.POSITIVE_INFINITY) ||
+        request.streamResponseStatusCodes?.has(response.status)
+      ) {
         response.readableStreamBody = responseStream;
       } else {
         response.bodyAsText = await streamToText(responseStream);

--- a/sdk/core/core-rest-pipeline/src/pipelineRequest.ts
+++ b/sdk/core/core-rest-pipeline/src/pipelineRequest.ts
@@ -109,7 +109,6 @@ class PipelineRequestImpl implements PipelineRequest {
   public body?: RequestBodyType;
   public formData?: FormDataMap;
   public streamResponseStatusCodes?: Set<number>;
-  public responseAsStream?: boolean;
 
   public proxySettings?: ProxySettings;
   public disableKeepAlive: boolean;

--- a/sdk/core/core-rest-pipeline/src/pipelineRequest.ts
+++ b/sdk/core/core-rest-pipeline/src/pipelineRequest.ts
@@ -69,11 +69,6 @@ export interface PipelineRequestOptions {
   streamResponseStatusCodes?: Set<number>;
 
   /**
-   * If set, body will be returned as a raw stream.
-   */
-  responseAsStream?: boolean;
-
-  /**
    * Proxy configuration.
    */
   proxySettings?: ProxySettings;
@@ -135,7 +130,6 @@ class PipelineRequestImpl implements PipelineRequest {
     this.disableKeepAlive = options.disableKeepAlive ?? false;
     this.proxySettings = options.proxySettings;
     this.streamResponseStatusCodes = options.streamResponseStatusCodes;
-    this.responseAsStream = options.responseAsStream;
     this.withCredentials = options.withCredentials ?? false;
     this.abortSignal = options.abortSignal;
     this.tracingOptions = options.tracingOptions;

--- a/sdk/core/core-rest-pipeline/src/pipelineRequest.ts
+++ b/sdk/core/core-rest-pipeline/src/pipelineRequest.ts
@@ -69,6 +69,11 @@ export interface PipelineRequestOptions {
   streamResponseStatusCodes?: Set<number>;
 
   /**
+   * If set, body will be returned as a raw stream.
+   */
+  responseAsStream?: boolean;
+
+  /**
    * Proxy configuration.
    */
   proxySettings?: ProxySettings;
@@ -109,6 +114,8 @@ class PipelineRequestImpl implements PipelineRequest {
   public body?: RequestBodyType;
   public formData?: FormDataMap;
   public streamResponseStatusCodes?: Set<number>;
+  public responseAsStream?: boolean;
+
   public proxySettings?: ProxySettings;
   public disableKeepAlive: boolean;
   public abortSignal?: AbortSignalLike;
@@ -128,6 +135,7 @@ class PipelineRequestImpl implements PipelineRequest {
     this.disableKeepAlive = options.disableKeepAlive ?? false;
     this.proxySettings = options.proxySettings;
     this.streamResponseStatusCodes = options.streamResponseStatusCodes;
+    this.responseAsStream = options.responseAsStream;
     this.withCredentials = options.withCredentials ?? false;
     this.abortSignal = options.abortSignal;
     this.tracingOptions = options.tracingOptions;

--- a/sdk/core/core-rest-pipeline/src/xhrHttpClient.ts
+++ b/sdk/core/core-rest-pipeline/src/xhrHttpClient.ts
@@ -67,8 +67,13 @@ class XhrHttpClient implements HttpClient {
     for (const [name, value] of request.headers) {
       xhr.setRequestHeader(name, value);
     }
+
     xhr.responseType =
-      request.responseAsStream || request.streamResponseStatusCodes?.size ? "blob" : "text";
+      // Value of POSITIVE_INFINITY in streamResponseStatusCodes is considered as any status code
+      request.streamResponseStatusCodes?.has(Number.POSITIVE_INFINITY) ||
+      request.streamResponseStatusCodes?.size
+        ? "blob"
+        : "text";
 
     if (isReadableStream(request.body)) {
       throw new Error("Node streams are not supported in browser environment.");
@@ -106,7 +111,11 @@ function handleBlobResponse(
   xhr.addEventListener("readystatechange", () => {
     // Resolve as soon as headers are loaded
     if (xhr.readyState === XMLHttpRequest.HEADERS_RECEIVED) {
-      if (request.responseAsStream || request.streamResponseStatusCodes?.has(xhr.status)) {
+      if (
+        // Value of POSITIVE_INFINITY in streamResponseStatusCodes is considered as any status code
+        request.streamResponseStatusCodes?.has(Number.POSITIVE_INFINITY) ||
+        request.streamResponseStatusCodes?.has(xhr.status)
+      ) {
         const blobBody = new Promise<Blob>((resolve, reject) => {
           xhr.addEventListener("load", () => {
             resolve(xhr.response);

--- a/sdk/core/core-rest-pipeline/src/xhrHttpClient.ts
+++ b/sdk/core/core-rest-pipeline/src/xhrHttpClient.ts
@@ -67,7 +67,8 @@ class XhrHttpClient implements HttpClient {
     for (const [name, value] of request.headers) {
       xhr.setRequestHeader(name, value);
     }
-    xhr.responseType = request.streamResponseStatusCodes?.size ? "blob" : "text";
+    xhr.responseType =
+      request.responseAsStream || request.streamResponseStatusCodes?.size ? "blob" : "text";
 
     if (isReadableStream(request.body)) {
       throw new Error("Node streams are not supported in browser environment.");
@@ -105,7 +106,7 @@ function handleBlobResponse(
   xhr.addEventListener("readystatechange", () => {
     // Resolve as soon as headers are loaded
     if (xhr.readyState === XMLHttpRequest.HEADERS_RECEIVED) {
-      if (request.streamResponseStatusCodes?.has(xhr.status)) {
+      if (request.responseAsStream || request.streamResponseStatusCodes?.has(xhr.status)) {
         const blobBody = new Promise<Blob>((resolve, reject) => {
           xhr.addEventListener("load", () => {
             resolve(xhr.response);

--- a/sdk/core/core-rest-pipeline/src/xhrHttpClient.ts
+++ b/sdk/core/core-rest-pipeline/src/xhrHttpClient.ts
@@ -68,12 +68,7 @@ class XhrHttpClient implements HttpClient {
       xhr.setRequestHeader(name, value);
     }
 
-    xhr.responseType =
-      // Value of POSITIVE_INFINITY in streamResponseStatusCodes is considered as any status code
-      request.streamResponseStatusCodes?.has(Number.POSITIVE_INFINITY) ||
-      request.streamResponseStatusCodes?.size
-        ? "blob"
-        : "text";
+    xhr.responseType = request.streamResponseStatusCodes?.size ? "blob" : "text";
 
     if (isReadableStream(request.body)) {
       throw new Error("Node streams are not supported in browser environment.");

--- a/sdk/core/core-rest-pipeline/test/browser/xhrHttpClient.spec.ts
+++ b/sdk/core/core-rest-pipeline/test/browser/xhrHttpClient.spec.ts
@@ -153,6 +153,21 @@ describe("XhrHttpClient", function() {
     assert.ok(response.blobBody, "Expect streaming body");
   });
 
+  it("should stream response body on responseAsStream", async function() {
+    const client = createDefaultHttpClient();
+    const request = createPipelineRequest({
+      url: "https://example.com",
+      responseAsStream: true
+    });
+    const promise = client.sendRequest(request);
+    assert.equal(requests.length, 1);
+    requests[0].respond(200, {}, "body");
+    const response = await promise;
+    assert.strictEqual(response.status, 200);
+    assert.equal(response.bodyAsText, undefined);
+    assert.ok(response.blobBody, "Expect streaming body");
+  });
+
   it("should not stream response body on non-matching status code", async function() {
     const client = createDefaultHttpClient();
     const request = createPipelineRequest({

--- a/sdk/core/core-rest-pipeline/test/browser/xhrHttpClient.spec.ts
+++ b/sdk/core/core-rest-pipeline/test/browser/xhrHttpClient.spec.ts
@@ -157,7 +157,7 @@ describe("XhrHttpClient", function() {
     const client = createDefaultHttpClient();
     const request = createPipelineRequest({
       url: "https://example.com",
-      responseAsStream: true
+      streamResponseStatusCodes: new Set([Number.POSITIVE_INFINITY])
     });
     const promise = client.sendRequest(request);
     assert.equal(requests.length, 1);

--- a/sdk/core/core-rest-pipeline/test/browser/xhrHttpClient.spec.ts
+++ b/sdk/core/core-rest-pipeline/test/browser/xhrHttpClient.spec.ts
@@ -153,7 +153,7 @@ describe("XhrHttpClient", function() {
     assert.ok(response.blobBody, "Expect streaming body");
   });
 
-  it("should stream response body on responseAsStream", async function() {
+  it("should stream response body on any status code", async function() {
     const client = createDefaultHttpClient();
     const request = createPipelineRequest({
       url: "https://example.com",
@@ -161,9 +161,9 @@ describe("XhrHttpClient", function() {
     });
     const promise = client.sendRequest(request);
     assert.equal(requests.length, 1);
-    requests[0].respond(200, {}, "body");
+    requests[0].respond(201, {}, "body");
     const response = await promise;
-    assert.strictEqual(response.status, 200);
+    assert.strictEqual(response.status, 201);
     assert.equal(response.bodyAsText, undefined);
     assert.ok(response.blobBody, "Expect streaming body");
   });

--- a/sdk/core/core-rest-pipeline/test/node/nodeHttpClient.spec.ts
+++ b/sdk/core/core-rest-pipeline/test/node/nodeHttpClient.spec.ts
@@ -200,7 +200,7 @@ describe("NodeHttpClient", function() {
     stubbedHttpsRequest.returns(clientRequest);
     const request = createPipelineRequest({
       url: "https://example.com",
-      responseAsStream: true
+      streamResponseStatusCodes: new Set([Number.POSITIVE_INFINITY])
     });
     const promise = client.sendRequest(request);
     stubbedHttpsRequest.yield(createResponse(200, "body"));

--- a/sdk/core/core-rest-pipeline/test/node/nodeHttpClient.spec.ts
+++ b/sdk/core/core-rest-pipeline/test/node/nodeHttpClient.spec.ts
@@ -194,6 +194,21 @@ describe("NodeHttpClient", function() {
     assert.ok(response.readableStreamBody);
   });
 
+  it("should stream response body on responseAsStream", async function() {
+    const client = createDefaultHttpClient();
+    const clientRequest = createRequest();
+    stubbedHttpsRequest.returns(clientRequest);
+    const request = createPipelineRequest({
+      url: "https://example.com",
+      responseAsStream: true
+    });
+    const promise = client.sendRequest(request);
+    stubbedHttpsRequest.yield(createResponse(200, "body"));
+    const response = await promise;
+    assert.equal(response.bodyAsText, undefined);
+    assert.ok(response.readableStreamBody);
+  });
+
   it("should not stream response body on non-matching status code", async function() {
     const client = createDefaultHttpClient();
     const clientRequest = createRequest();

--- a/sdk/core/core-rest-pipeline/test/node/nodeHttpClient.spec.ts
+++ b/sdk/core/core-rest-pipeline/test/node/nodeHttpClient.spec.ts
@@ -194,7 +194,7 @@ describe("NodeHttpClient", function() {
     assert.ok(response.readableStreamBody);
   });
 
-  it("should stream response body on responseAsStream", async function() {
+  it("should stream response body on any status code", async function() {
     const client = createDefaultHttpClient();
     const clientRequest = createRequest();
     stubbedHttpsRequest.returns(clientRequest);
@@ -203,7 +203,7 @@ describe("NodeHttpClient", function() {
       streamResponseStatusCodes: new Set([Number.POSITIVE_INFINITY])
     });
     const promise = client.sendRequest(request);
-    stubbedHttpsRequest.yield(createResponse(200, "body"));
+    stubbedHttpsRequest.yield(createResponse(201, "body"));
     const response = await promise;
     assert.equal(response.bodyAsText, undefined);
     assert.ok(response.readableStreamBody);


### PR DESCRIPTION
In preparation to adding support for handling streams manually in @azure-rest/core-client, this PR adds an option to PipelineRequest to always get the raw stream