### PR TITLE
[KeyVault] - Update duration sample and doc comments

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -1591,6 +1591,7 @@ packages:
   /@opentelemetry/node/0.22.0_@opentelemetry+api@1.0.3:
     resolution: {integrity: sha512-+HhGbDruQ7cwejVOIYyxRa28uosnG8W95NiQZ6qE8PXXPsDSyGeftAPbtYpGit0H2f5hrVcMlwmWHeAo9xkSLA==}
     engines: {node: '>=8.0.0'}
+    deprecated: Package renamed to @opentelemetry/sdk-trace-node
     peerDependencies:
       '@opentelemetry/api': ^1.0.0
     dependencies:
@@ -3186,6 +3187,10 @@ packages:
   /date-utils/1.2.21:
     resolution: {integrity: sha1-YfsWzcEnSzyayq/+n8ad+HIKK2Q=}
     engines: {node: '>0.4.0'}
+    dev: false
+
+  /dayjs/1.10.7:
+    resolution: {integrity: sha512-P6twpd70BcPK34K26uJ1KT3wlhpuOAPoMwJzpsIWUxHZ7wpmbdZL/hQqBDfz7hGurYSa5PhzdhDHtt319hL3ig==}
     dev: false
 
   /debounce/1.2.1:
@@ -9364,7 +9369,7 @@ packages:
     dev: false
 
   file:projects/arm-streamanalytics.tgz:
-    resolution: {integrity: sha512-GYtEbWFfsmbKa168tVMSugSMPWBxtmxwU2f3gxq5cWOXbkP3EdUf5cTnPvWELOHwGifKuKiyC29W7YWiOWhfmQ==, tarball: file:projects/arm-streamanalytics.tgz}
+    resolution: {integrity: sha512-MhbiHP5ZomEoVlRa9KOHteLHqPOvxZfszSEZ0JgUowO9APTWrir2HLd1R+bHBpX3myNuOGV0yRtk1x661KVLgg==, tarball: file:projects/arm-streamanalytics.tgz}
     name: '@rush-temp/arm-streamanalytics'
     version: 0.0.0
     dependencies:
@@ -9382,9 +9387,6 @@ packages:
       tslib: 2.3.1
       typescript: 4.2.4
       uglify-js: 3.14.2
-    transitivePeerDependencies:
-      - debug
-      - supports-color
     dev: false
 
   file:projects/arm-templatespecs.tgz:
@@ -11511,7 +11513,7 @@ packages:
     dev: false
 
   file:projects/keyvault-keys.tgz:
-    resolution: {integrity: sha512-jM7GDoaLV4A6QVyuIgtTRI8mG6i9eQYfH+xpYwnS5FS5jlLaO8HI7r1WDtUHt/0O13Vjlel+rVy5cTCsoSc48Q==, tarball: file:projects/keyvault-keys.tgz}
+    resolution: {integrity: sha512-bItJqRLx3j4rrZpKyTCxI18P4YCErPnlR6O4semzo0ufXijFot8yXhaKPvdb+H2E5toFvTqwtqSEegLK57pyfg==, tarball: file:projects/keyvault-keys.tgz}
     name: '@rush-temp/keyvault-keys'
     version: 0.0.0
     dependencies:
@@ -11532,6 +11534,7 @@ packages:
       chai-as-promised: 7.1.1_chai@4.3.4
       chai-exclude: 2.1.0_chai@4.3.4
       cross-env: 7.0.3
+      dayjs: 1.10.7
       dotenv: 8.6.0
       eslint: 7.32.0
       esm: 3.2.25

--- a/sdk/keyvault/keyvault-keys/package.json
+++ b/sdk/keyvault/keyvault-keys/package.json
@@ -133,6 +133,7 @@
     "chai-as-promised": "^7.1.1",
     "chai-exclude": "^2.0.2",
     "cross-env": "^7.0.2",
+    "dayjs": "^1.10.7",
     "dotenv": "^8.2.0",
     "eslint": "^7.15.0",
     "esm": "^3.2.18",

--- a/sdk/keyvault/keyvault-keys/samples-dev/keyRotation.ts
+++ b/sdk/keyvault/keyvault-keys/samples-dev/keyRotation.ts
@@ -7,6 +7,9 @@
 
 import { KeyClient } from "@azure/keyvault-keys";
 import { DefaultAzureCredential } from "@azure/identity";
+import dayjs from "dayjs";
+import duration from "dayjs/plugin/duration";
+dayjs.extend(duration);
 
 // Load the .env file if it exists
 import * as dotenv from "dotenv";
@@ -43,11 +46,15 @@ export async function main(): Promise<void> {
   console.log("fetched policy", currentPolicy);
 
   // Update the key's automated rotation policy to notify 30 days before the key expires.
+  // By using the ISO8601 duration standard, interoperability with any 3rd party library that supports Durations is supported.
+  // In this example, we'll use Day.js (documented in https://day.js.org) to create the duration.
+  // For more information on the ISO 8601 Duration standard, please refer to the Wikipedia page on Durations:
+  // https://wikipedia.org/wiki/ISO_8601#Durations
   const updatedPolicy = await client.updateKeyRotationPolicy(key.name, {
     lifetimeActions: [
       {
         action: "Notify",
-        timeBeforeExpiry: "P30D"
+        timeBeforeExpiry: dayjs.duration({ days: 30 }).toISOString()
       }
     ],
     expiresIn: "P90D"

--- a/sdk/keyvault/keyvault-keys/src/index.ts
+++ b/sdk/keyvault/keyvault-keys/src/index.ts
@@ -773,6 +773,7 @@ export class KeyClient {
 
   /**
    * Gets the requested number of bytes containing random values from a managed HSM.
+   * This operation requires the managedHsm/rng permission.
    *
    * Example usage:
    * ```ts
@@ -848,11 +849,12 @@ export class KeyClient {
 
   /**
    * Gets the rotation policy of a Key Vault Key.
+   * By default, all keys have a policy that will notify 30 days before expiry.
    *
+   * This operation requires the keys/get permission.
    * Example usage:
    * ```ts
    * let client = new KeyClient(vaultUrl, credentials);
-   * await client.updateKeyRotationPolicy("MyKey", myPolicy);
    * let result = await client.getKeyRotationPolicy("myKey");
    * ```
    *
@@ -871,6 +873,7 @@ export class KeyClient {
 
   /**
    * Updates the rotation policy of a Key Vault Key.
+   * This operation requires the keys/update permission.
    *
    * Example usage:
    * ```ts


### PR DESCRIPTION
## What

- Use Day.js in the Key Rotation sample
- Update the doc comments for Key Rotation

## Why

We discussed adding updating the API of Key Rotation to take an object instead
of a raw string for ISO8601 durations; however, with Temporal adding support for
Durations we want to avoid duplicating the type for now. Instead, we decided to
demonstrate interop with an existing 3rd party library. I chose Day.js for this
sample as it has a nice clean API.
