### PR TITLE
Use working region/subscription for search deployments

### DIFF
--- a/sdk/search/search-documents/tests.yml
+++ b/sdk/search/search-documents/tests.yml
@@ -5,4 +5,6 @@ stages:
     parameters:
       PackageName: "@azure/search-documents"
       ServiceDirectory: search
-      SupportedClouds: 'Public,UsGov,China'
+      # TODO: change 'Preview' cloud back to public after search RP fixes deletion metadata issue
+      Clouds: 'Preview'
+      SupportedClouds: 'Preview,UsGov,China'


### PR DESCRIPTION
We are running into deployment issues with the search RP and deletion metadata. This switches our search deployments to a working region/subscription until their fix rolls out