### PR TITLE
[Tables] Fix quote encoding for Filter expressions in the URL

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -714,6 +714,31 @@ packages:
       tslib: 2.3.1
     dev: false
 
+  /@azure/core-xml/1.0.0:
+    resolution: {integrity: sha512-VSM3wQomzRZk4SnDK5vKaROON/d3hgfl+D/pfLjpGR8gxRGuO0I8R+Rp/qj6Cq3x7HPgUqrii3/s/RRwDWWdvQ==}
+    engines: {node: '>=12.0.0'}
+    dependencies:
+      tslib: 2.3.1
+      xml2js: 0.4.23
+    dev: false
+
+  /@azure/data-tables/12.1.2:
+    resolution: {integrity: sha512-eGldbkw9UjzrAXzy28/raKauQEjspG1FAHxWI/kEInkFm9mvs5uR2KGEGlQNYfz6pzcCOrsxHlh+pmWKuIgPSQ==}
+    engines: {node: '>=12.0.0'}
+    dependencies:
+      '@azure/core-auth': 1.3.2
+      '@azure/core-client': 1.3.2
+      '@azure/core-paging': 1.2.0
+      '@azure/core-rest-pipeline': 1.3.1
+      '@azure/core-tracing': 1.0.0-preview.13
+      '@azure/core-xml': 1.0.0
+      '@azure/logger': 1.0.3
+      tslib: 2.3.1
+      uuid: 8.3.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   /@azure/event-hubs/2.1.4:
     resolution: {integrity: sha512-CxaMaEjwtsmIhWtjHyGimKO7RmES0YxPqGQ9+jKqGygNlhG5NYHktDaiQu6w7k3g+I51VaLXtVSt+BVFd6VWfQ==}
     dependencies:
@@ -1623,6 +1648,7 @@ packages:
   /@opentelemetry/node/0.22.0_@opentelemetry+api@1.0.3:
     resolution: {integrity: sha512-+HhGbDruQ7cwejVOIYyxRa28uosnG8W95NiQZ6qE8PXXPsDSyGeftAPbtYpGit0H2f5hrVcMlwmWHeAo9xkSLA==}
     engines: {node: '>=8.0.0'}
+    deprecated: Package renamed to @opentelemetry/sdk-trace-node
     peerDependencies:
       '@opentelemetry/api': ^1.0.0
     dependencies:
@@ -9806,7 +9832,7 @@ packages:
     dev: false
 
   file:projects/communication-short-codes.tgz:
-    resolution: {integrity: sha512-W7c8tFK44EglMtWOPtXRO9IFBNqWuePxkwoeezqHp12J3IbkmKWQBxaTPGLJc7u9vKfmletUyc1fa0ARsAQ31A==, tarball: file:projects/communication-short-codes.tgz}
+    resolution: {integrity: sha512-imnt2527n581p0dFDDFF7OPOEw5E2SwUpBU2O7fKnkLO2xf3umZ3kpxXNDlIe59pv9X0HK3oR37PaW06i4j8vw==, tarball: file:projects/communication-short-codes.tgz}
     name: '@rush-temp/communication-short-codes'
     version: 0.0.0
     dependencies:
@@ -11181,10 +11207,11 @@ packages:
     dev: false
 
   file:projects/eventhubs-checkpointstore-table.tgz:
-    resolution: {integrity: sha512-xsIGobaWeiDmYlvBXAQmAZ/fmL/mOBPPUBO74Ed7BJv9cYZ1tP6inNyXsJOt0CpUjh5hj88lW057appUKA5xEg==, tarball: file:projects/eventhubs-checkpointstore-table.tgz}
+    resolution: {integrity: sha512-IhmHN33M9hQqwZ716hAQESqAMrKkMV44b/PLCHLKB/HmYodMkI8YHGb9IDcelw6FoAzVarZtyTyfhrvP8sn+MQ==, tarball: file:projects/eventhubs-checkpointstore-table.tgz}
     name: '@rush-temp/eventhubs-checkpointstore-table'
     version: 0.0.0
     dependencies:
+      '@azure/data-tables': 12.1.2
       '@azure/event-hubs': 5.6.0
       '@microsoft/api-extractor': 7.18.17
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
@@ -12070,10 +12097,11 @@ packages:
     dev: false
 
   file:projects/perf-data-tables.tgz:
-    resolution: {integrity: sha512-nnf36UaqbvZtpzM4/bE/A4NrGEuVpNnJ1pUBonlhGJ/ziUJkwztNvQ59vyvoYjz3nWKmVCbfBO6Ic5MHoaaQyA==, tarball: file:projects/perf-data-tables.tgz}
+    resolution: {integrity: sha512-apNC948J1ppaBLAz9gNALEAzb0aMyos+Gnbe9UfU/arGRMnraju1PKslj3867fbC8um2V+Z3W/TWJhsF45dBOw==, tarball: file:projects/perf-data-tables.tgz}
     name: '@rush-temp/perf-data-tables'
     version: 0.0.0
     dependencies:
+      '@azure/data-tables': 12.1.2
       '@types/node': 12.20.36
       '@types/uuid': 8.3.1
       dotenv: 8.6.0
@@ -13722,10 +13750,11 @@ packages:
     dev: false
 
   file:projects/testing-recorder-new.tgz:
-    resolution: {integrity: sha512-aXWcH+zp0ffSDNjWDAAFIQaFBkBRzvWxmFa6D/L8y5EsfIm66bDa6Mu0GcbptpIR8EICXuRI4qsDlcMgHPUWpg==, tarball: file:projects/testing-recorder-new.tgz}
+    resolution: {integrity: sha512-LXRqL0apMO4Z5E2uKKeJNTvmCkCaED00uH2MBWZ3RqjfuZFGIDgcKUpZ4RmmA6mbOSTUjm30eAwuhmycDxpVrg==, tarball: file:projects/testing-recorder-new.tgz}
     name: '@rush-temp/testing-recorder-new'
     version: 0.0.0
     dependencies:
+      '@azure/data-tables': 12.1.2
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
       '@rollup/plugin-node-resolve': 8.4.0_rollup@1.32.1

--- a/sdk/tables/data-tables/CHANGELOG.md
+++ b/sdk/tables/data-tables/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 12.2.0 (Unreleased)
+## 13.0.0 (Unreleased)
 
 ### Features Added
 
@@ -8,6 +8,8 @@
 - TableServiceClient `listTables` expose and can take PageSetting `continuationToken` as a `PageSetting` when using `byPage`. [#18277](https://github.com/Azure/azure-sdk-for-js/pull/18277)
 
 ### Breaking Changes
+
+- Encode single quote where the partition/row key is used to format the URL - i.e. upsert, update and delete. For more details see [#3356](https://github.com/Azure/azure-sdk/issues/3356)
 
 ### Bugs Fixed
 

--- a/sdk/tables/data-tables/package.json
+++ b/sdk/tables/data-tables/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/data-tables",
-  "version": "12.2.0",
+  "version": "13.0.0",
   "description": "An isomorphic client library for the Azure Tables service.",
   "sdk-type": "client",
   "main": "dist/index.js",

--- a/sdk/tables/data-tables/src/TableClient.ts
+++ b/sdk/tables/data-tables/src/TableClient.ts
@@ -67,6 +67,7 @@ import { tablesSASTokenPolicy } from "./tablesSASTokenPolicy";
 import { isCosmosEndpoint } from "./utils/isCosmosEndpoint";
 import { cosmosPatchPolicy } from "./cosmosPathPolicy";
 import { decodeContinuationToken, encodeContinuationToken } from "./utils/continuationToken";
+import { escapeQuotes } from "./odata";
 
 /**
  * A TableClient represents a Client to the Azure Tables service allowing you
@@ -391,8 +392,8 @@ export class TableClient {
       const { disableTypeConversion, queryOptions, ...getEntityOptions } = updatedOptions || {};
       await this.table.queryEntitiesWithPartitionAndRowKey(
         this.tableName,
-        escapeString(partitionKey),
-        escapeString(rowKey),
+        escapeQuotes(partitionKey),
+        escapeQuotes(rowKey),
         {
           ...getEntityOptions,
           queryOptions: serializeQueryOptions(queryOptions || {}),
@@ -646,8 +647,8 @@ export class TableClient {
       };
       return await this.table.deleteEntity(
         this.tableName,
-        escapeString(partitionKey),
-        escapeString(rowKey),
+        escapeQuotes(partitionKey),
+        escapeQuotes(rowKey),
         etag,
         deleteOptions
       );
@@ -711,8 +712,8 @@ export class TableClient {
         throw new Error("partitionKey and rowKey must be defined");
       }
 
-      const partitionKey = escapeString(entity.partitionKey);
-      const rowKey = escapeString(entity.rowKey);
+      const partitionKey = escapeQuotes(entity.partitionKey);
+      const rowKey = escapeQuotes(entity.rowKey);
 
       const { etag = "*", ...updateEntityOptions } = updatedOptions || {};
       if (mode === "Merge") {
@@ -787,8 +788,8 @@ export class TableClient {
         throw new Error("partitionKey and rowKey must be defined");
       }
 
-      const partitionKey = escapeString(entity.partitionKey);
-      const rowKey = escapeString(entity.rowKey);
+      const partitionKey = escapeQuotes(entity.partitionKey);
+      const rowKey = escapeQuotes(entity.rowKey);
 
       if (mode === "Merge") {
         return await this.table.mergeEntity(this.tableName, partitionKey, rowKey, {
@@ -973,8 +974,4 @@ interface InternalListTableEntitiesOptions extends ListTableEntitiesOptions {
    * This option applies for all the properties
    */
   disableTypeConversion?: boolean;
-}
-
-function escapeString(value: string) {
-  return value.replace(/'/g, "''");
 }

--- a/sdk/tables/data-tables/src/generated/generatedClientContext.ts
+++ b/sdk/tables/data-tables/src/generated/generatedClientContext.ts
@@ -32,7 +32,7 @@ export class GeneratedClientContext extends coreClient.ServiceClient {
       requestContentType: "application/json; charset=utf-8"
     };
 
-    const packageDetails = `azsdk-js-data-tables/12.2.0`;
+    const packageDetails = `azsdk-js-data-tables/13.0.0`;
     const userAgentPrefix =
       options.userAgentOptions && options.userAgentOptions.userAgentPrefix
         ? `${options.userAgentOptions.userAgentPrefix} ${packageDetails}`

--- a/sdk/tables/data-tables/src/odata.ts
+++ b/sdk/tables/data-tables/src/odata.ts
@@ -5,13 +5,17 @@ function escapeQuotesIfString(input: unknown, previous: string): string | unknow
   let result = input;
 
   if (typeof input === "string") {
-    result = input.replace(/'/g, "''");
+    result = escapeQuotes(input);
     // check if we need to escape this literal
     if (!previous.trim().endsWith("'")) {
       result = `'${result}'`;
     }
   }
   return result;
+}
+
+export function escapeQuotes(input: string): string {
+  return input.replace(/'/g, "''");
 }
 
 /**

--- a/sdk/tables/data-tables/swagger/README.md
+++ b/sdk/tables/data-tables/swagger/README.md
@@ -6,7 +6,7 @@
 
 ```yaml
 v3: true
-package-version: 12.2.0
+package-version: 13.0.0
 package-name: "@azure/data-tables"
 title: TablesClient
 description: Tables Client
@@ -29,7 +29,9 @@ directive:
     transform: >
       $["description"] = "Geo-Replication information for the Secondary Storage Service";
 ```
+
 ### Fix additionalProperties type, it should be any not AnyObject. True defaults to AnyObject
+
 ```yaml
 directive:
   - from: swagger-document

--- a/sdk/tables/data-tables/test/public/specialCharacters.spec.ts
+++ b/sdk/tables/data-tables/test/public/specialCharacters.spec.ts
@@ -1,53 +1,65 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
 import { odata, TableClient, TableEntityResult, TransactionAction } from "../../src";
 import { assert } from "chai";
 import { createTableClient, recordedEnvironmentSetup } from "./utils/recordedClient";
 import { isNode } from "@azure/test-utils";
-import { record, Recorder } from "@azure-tools/test-recorder";
+import { isLiveMode, record, Recorder } from "@azure-tools/test-recorder";
+import { Context } from "mocha";
 
-describe("TableClient", () => {
+describe("SpecialCharacters", function() {
+  before(function(this: Context) {
+    if (!isLiveMode()) {
+      // Currently the recorder is having issues with the encoding of single qoutes in the
+      // query request and generates invalid JS code. Disabling this test on playback mode
+      // while these issues are resolved
+      this.skip();
+    }
+  });
   let client: TableClient;
   let recorder: Recorder;
   const suffix = isNode ? "Node" : "Browser";
   const tableName = `SpecialCharacterTest${suffix}`;
   const specialCharacters = [
-    `'`,
-    `"`,
-    `{}`,
-    `[]`,
-    `()`,
-    `:`,
-    `@`,
-    `&`,
-    `=`,
-    `+`,
-    `,`,
-    `$`,
-    `-`,
-    `_`,
-    `<>`,
-    `;`,
-    `~`,
-    `^`,
-    `!`,
-    `%`,
-    `*`
+    { char: `'`, name: "single quote" },
+    { char: `"`, name: "double quote" },
+    { char: `{}`, name: "curly braces" },
+    { char: `[]`, name: "square braces" },
+    { char: `()`, name: "parenthesis braces" },
+    { char: `:`, name: "colon braces" },
+    { char: `@`, name: "at" },
+    { char: `&`, name: "ampersand" },
+    { char: `=`, name: "equals" },
+    { char: `+`, name: "plus" },
+    { char: `,`, name: "comma" },
+    { char: `$`, name: "dollar sing" },
+    { char: `-`, name: "dash" },
+    { char: `_`, name: "underscore" },
+    { char: `<>`, name: "gt and lt" },
+    { char: `;`, name: "semi-colon" },
+    { char: `~`, name: "tilde" },
+    { char: `^`, name: "hat" },
+    { char: `!`, name: "bang" },
+    { char: `%`, name: "percentage" },
+    { char: `*`, name: "star" }
   ];
 
   describe("Single operations", () => {
-    beforeEach(function() {
+    beforeEach(function(this: Context) {
       recorder = record(this, recordedEnvironmentSetup);
-      client = createTableClient(tableName);
+      client = createTableClient(tableName, "TokenCredential");
     });
 
     afterEach(async function() {
       await recorder.stop();
     });
 
-    specialCharacters.forEach((testChar) => {
-      describe(`${testChar} roundtrip`, () => {
-        const partitionKey = `foo${testChar}`;
-        const rowKey = `${testChar}bar`;
-        const value = `test${testChar}`;
+    specialCharacters.forEach(({ char, name }) => {
+      describe(`${name} roundtrip`, () => {
+        const partitionKey = `foo${char}`;
+        const rowKey = `${char}bar`;
+        const value = `test${char}`;
 
         it("should create entity with single quote in the partitionKey and rowKey", async () => {
           await client.createTable();
@@ -120,9 +132,9 @@ describe("TableClient", () => {
   });
 
   describe("Batch", () => {
-    beforeEach(function() {
+    beforeEach(function(this: Context) {
       recorder = record(this, recordedEnvironmentSetup);
-      client = createTableClient(`${tableName}Batch`);
+      client = createTableClient(`${tableName}Batch`, "TokenCredential");
     });
 
     afterEach(async function() {
@@ -131,9 +143,9 @@ describe("TableClient", () => {
     const partitionKey = `foo'`;
     it("should create entity with single quote in the partitionKey and rowKey", async () => {
       await client.createTable();
-      const actions: TransactionAction[] = specialCharacters.map((testChar) => {
-        const rowKey = `${testChar}bar`;
-        const value = `test${testChar}`;
+      const actions: TransactionAction[] = specialCharacters.map(({ char }) => {
+        const rowKey = `${char}bar`;
+        const value = `test${char}`;
         const action: TransactionAction = ["create", { partitionKey, rowKey, value }];
         return action;
       });
@@ -142,9 +154,9 @@ describe("TableClient", () => {
     });
 
     it("should upsert merge entity with single quote in the partitionKey and rowKey", async () => {
-      const actions: TransactionAction[] = specialCharacters.map((testChar) => {
-        const rowKey = `${testChar}bar`;
-        const value = `test${testChar}`;
+      const actions: TransactionAction[] = specialCharacters.map(({ char }) => {
+        const rowKey = `${char}bar`;
+        const value = `test${char}`;
         const action: TransactionAction = ["upsert", { partitionKey, rowKey, value }, "Merge"];
         return action;
       });
@@ -153,9 +165,9 @@ describe("TableClient", () => {
     });
 
     it("should upsert replace entity with single quote in the partitionKey and rowKey", async () => {
-      const actions: TransactionAction[] = specialCharacters.map((testChar) => {
-        const rowKey = `${testChar}bar`;
-        const value = `test${testChar}`;
+      const actions: TransactionAction[] = specialCharacters.map(({ char }) => {
+        const rowKey = `${char}bar`;
+        const value = `test${char}`;
         const action: TransactionAction = ["upsert", { partitionKey, rowKey, value }, "Replace"];
         return action;
       });
@@ -164,9 +176,9 @@ describe("TableClient", () => {
     });
 
     it("should update merge entity with single quote in the partitionKey and rowKey", async () => {
-      const actions: TransactionAction[] = specialCharacters.map((testChar) => {
-        const rowKey = `${testChar}bar`;
-        const value = `test${testChar}`;
+      const actions: TransactionAction[] = specialCharacters.map(({ char }) => {
+        const rowKey = `${char}bar`;
+        const value = `test${char}`;
         const action: TransactionAction = ["update", { partitionKey, rowKey, value }, "Merge"];
         return action;
       });
@@ -175,9 +187,9 @@ describe("TableClient", () => {
     });
 
     it("should update replace entity with single quote in the partitionKey and rowKey", async () => {
-      const actions: TransactionAction[] = specialCharacters.map((testChar) => {
-        const rowKey = `${testChar}bar`;
-        const value = `test${testChar}`;
+      const actions: TransactionAction[] = specialCharacters.map(({ char }) => {
+        const rowKey = `${char}bar`;
+        const value = `test${char}`;
         const action: TransactionAction = ["update", { partitionKey, rowKey, value }, "Replace"];
         return action;
       });
@@ -199,10 +211,10 @@ describe("TableClient", () => {
       assert.lengthOf(results, 21);
     });
 
-    specialCharacters.forEach((testChar) => {
-      const rowKey = `${testChar}bar`;
-      const value = `test${testChar}`;
-      it(`should get entity with ${testChar}`, async () => {
+    specialCharacters.forEach(({ char, name }) => {
+      const rowKey = `${char}bar`;
+      const value = `test${char}`;
+      it(`should get entity with ${name}`, async () => {
         const entity = await client.getEntity(partitionKey, rowKey);
 
         assert.equal(entity.partitionKey, partitionKey);
@@ -210,7 +222,7 @@ describe("TableClient", () => {
         assert.equal(entity.value, value);
       });
 
-      it(`should filter entity by row key with ${testChar}`, async () => {
+      it(`should filter entity by row key with ${name}`, async () => {
         const entities = client.listEntities({
           queryOptions: { filter: odata`RowKey eq ${rowKey}` }
         });
@@ -236,8 +248,8 @@ describe("TableClient", () => {
     });
 
     it(`should delete in batch`, async () => {
-      const actions: TransactionAction[] = specialCharacters.map((testChar) => {
-        const rowKey = `${testChar}bar`;
+      const actions: TransactionAction[] = specialCharacters.map(({ char }) => {
+        const rowKey = `${char}bar`;
         const action: TransactionAction = ["delete", { partitionKey, rowKey }];
         return action;
       });

--- a/sdk/tables/data-tables/test/public/specialCharacters.spec.ts
+++ b/sdk/tables/data-tables/test/public/specialCharacters.spec.ts
@@ -1,0 +1,251 @@
+import { odata, TableClient, TableEntityResult, TransactionAction } from "../../src";
+import { assert } from "chai";
+import { createTableClient, recordedEnvironmentSetup } from "./utils/recordedClient";
+import { isNode } from "@azure/test-utils";
+import { record, Recorder } from "@azure-tools/test-recorder";
+
+describe("TableClient", () => {
+  let client: TableClient;
+  let recorder: Recorder;
+  const suffix = isNode ? "Node" : "Browser";
+  const tableName = `SpecialCharacterTest${suffix}`;
+  const specialCharacters = [
+    `'`,
+    `"`,
+    `{}`,
+    `[]`,
+    `()`,
+    `:`,
+    `@`,
+    `&`,
+    `=`,
+    `+`,
+    `,`,
+    `$`,
+    `-`,
+    `_`,
+    `<>`,
+    `;`,
+    `~`,
+    `^`,
+    `!`,
+    `%`,
+    `*`
+  ];
+
+  describe("Single operations", () => {
+    beforeEach(function() {
+      recorder = record(this, recordedEnvironmentSetup);
+      client = createTableClient(tableName);
+    });
+
+    afterEach(async function() {
+      await recorder.stop();
+    });
+
+    specialCharacters.forEach((testChar) => {
+      describe(`${testChar} roundtrip`, () => {
+        const partitionKey = `foo${testChar}`;
+        const rowKey = `${testChar}bar`;
+        const value = `test${testChar}`;
+
+        it("should create entity with single quote in the partitionKey and rowKey", async () => {
+          await client.createTable();
+          const entity = await client.createEntity({ partitionKey, rowKey, value });
+          assert.isDefined(entity);
+        });
+
+        it("should upsert merge entity", async () => {
+          const result = await client.upsertEntity({ partitionKey, rowKey, value }, "Merge");
+          assert.isDefined(result.etag);
+        });
+
+        it("should upsert replace entity", async () => {
+          const result = await client.upsertEntity({ partitionKey, rowKey, value }, "Replace");
+          assert.isDefined(result.etag);
+        });
+
+        it("should update replace entity", async () => {
+          const result = await client.updateEntity({ partitionKey, rowKey, value }, "Replace");
+          assert.isDefined(result.etag);
+        });
+
+        it("should update merge entity", async () => {
+          const result = await client.updateEntity({ partitionKey, rowKey, value }, "Merge");
+          assert.isDefined(result.etag);
+        });
+
+        it("should get entity", async () => {
+          const entity = await client.getEntity(partitionKey, rowKey);
+
+          assert.equal(entity.partitionKey, partitionKey);
+          assert.equal(entity.rowKey, rowKey);
+          assert.equal(entity.value, value);
+        });
+
+        it("should filter entity by partition key", async () => {
+          const entities = client.listEntities({
+            queryOptions: { filter: odata`PartitionKey eq ${partitionKey}` }
+          });
+
+          for await (const entity of entities) {
+            assert.equal(entity.partitionKey, partitionKey);
+            assert.equal(entity.rowKey, rowKey);
+            assert.equal(entity.value, value);
+          }
+        });
+
+        it("should filter entity by row key", async () => {
+          const entities = client.listEntities({
+            queryOptions: { filter: odata`RowKey eq ${rowKey}` }
+          });
+
+          for await (const entity of entities) {
+            assert.equal(entity.partitionKey, partitionKey);
+            assert.equal(entity.rowKey, rowKey);
+            assert.equal(entity.value, value);
+          }
+        });
+
+        it("should delete entity", async () => {
+          const result = await client.deleteEntity(partitionKey, rowKey);
+          assert.ok(result);
+        });
+      });
+    });
+
+    after(async () => {
+      await client.deleteTable();
+    });
+  });
+
+  describe("Batch", () => {
+    beforeEach(function() {
+      recorder = record(this, recordedEnvironmentSetup);
+      client = createTableClient(`${tableName}Batch`);
+    });
+
+    afterEach(async function() {
+      await recorder.stop();
+    });
+    const partitionKey = `foo'`;
+    it("should create entity with single quote in the partitionKey and rowKey", async () => {
+      await client.createTable();
+      const actions: TransactionAction[] = specialCharacters.map((testChar) => {
+        const rowKey = `${testChar}bar`;
+        const value = `test${testChar}`;
+        const action: TransactionAction = ["create", { partitionKey, rowKey, value }];
+        return action;
+      });
+      const result = await client.submitTransaction(actions);
+      assert.equal(result.status, 202);
+    });
+
+    it("should upsert merge entity with single quote in the partitionKey and rowKey", async () => {
+      const actions: TransactionAction[] = specialCharacters.map((testChar) => {
+        const rowKey = `${testChar}bar`;
+        const value = `test${testChar}`;
+        const action: TransactionAction = ["upsert", { partitionKey, rowKey, value }, "Merge"];
+        return action;
+      });
+      const result = await client.submitTransaction(actions);
+      assert.equal(result.status, 202);
+    });
+
+    it("should upsert replace entity with single quote in the partitionKey and rowKey", async () => {
+      const actions: TransactionAction[] = specialCharacters.map((testChar) => {
+        const rowKey = `${testChar}bar`;
+        const value = `test${testChar}`;
+        const action: TransactionAction = ["upsert", { partitionKey, rowKey, value }, "Replace"];
+        return action;
+      });
+      const result = await client.submitTransaction(actions);
+      assert.equal(result.status, 202);
+    });
+
+    it("should update merge entity with single quote in the partitionKey and rowKey", async () => {
+      const actions: TransactionAction[] = specialCharacters.map((testChar) => {
+        const rowKey = `${testChar}bar`;
+        const value = `test${testChar}`;
+        const action: TransactionAction = ["update", { partitionKey, rowKey, value }, "Merge"];
+        return action;
+      });
+      const result = await client.submitTransaction(actions);
+      assert.equal(result.status, 202);
+    });
+
+    it("should update replace entity with single quote in the partitionKey and rowKey", async () => {
+      const actions: TransactionAction[] = specialCharacters.map((testChar) => {
+        const rowKey = `${testChar}bar`;
+        const value = `test${testChar}`;
+        const action: TransactionAction = ["update", { partitionKey, rowKey, value }, "Replace"];
+        return action;
+      });
+      const result = await client.submitTransaction(actions);
+      assert.equal(result.status, 202);
+    });
+
+    it(`should filter entity by partition key`, async () => {
+      const entities = client.listEntities({
+        queryOptions: { filter: odata`PartitionKey eq ${partitionKey}` }
+      });
+
+      const results = [];
+
+      for await (const entity of entities) {
+        results.push(entity);
+      }
+
+      assert.lengthOf(results, 21);
+    });
+
+    specialCharacters.forEach((testChar) => {
+      const rowKey = `${testChar}bar`;
+      const value = `test${testChar}`;
+      it(`should get entity with ${testChar}`, async () => {
+        const entity = await client.getEntity(partitionKey, rowKey);
+
+        assert.equal(entity.partitionKey, partitionKey);
+        assert.equal(entity.rowKey, rowKey);
+        assert.equal(entity.value, value);
+      });
+
+      it(`should filter entity by row key with ${testChar}`, async () => {
+        const entities = client.listEntities({
+          queryOptions: { filter: odata`RowKey eq ${rowKey}` }
+        });
+
+        const results: TableEntityResult<Record<string, unknown>>[] = [];
+
+        for await (const entity of entities) {
+          results.push(entity);
+          assert.equal(entity.partitionKey, partitionKey);
+          assert.equal(entity.rowKey, rowKey);
+          assert.equal(entity.value, value);
+        }
+
+        const hasEntity = results.some(
+          (e) => e.partitionKey === partitionKey && e.rowKey === rowKey && e.value === value
+        );
+
+        assert.isTrue(
+          hasEntity,
+          `Couldn't find entity with partitionKey: ${partitionKey} and rowKey: ${rowKey}`
+        );
+      });
+    });
+
+    it(`should delete in batch`, async () => {
+      const actions: TransactionAction[] = specialCharacters.map((testChar) => {
+        const rowKey = `${testChar}bar`;
+        const action: TransactionAction = ["delete", { partitionKey, rowKey }];
+        return action;
+      });
+      const result = await client.submitTransaction(actions);
+      assert.equal(result.status, 202);
+    });
+    after(async () => {
+      await client.deleteTable();
+    });
+  });
+});

--- a/sdk/tables/data-tables/test/public/specialCharacters.spec.ts
+++ b/sdk/tables/data-tables/test/public/specialCharacters.spec.ts
@@ -13,7 +13,7 @@ describe("SpecialCharacters", function() {
     if (!isLiveMode()) {
       // Currently the recorder is having issues with the encoding of single qoutes in the
       // query request and generates invalid JS code. Disabling this test on playback mode
-      // while these issues are resolved
+      // while these issues are resolved. #18534
       this.skip();
     }
   });

--- a/sdk/tables/data-tables/test/public/tableclient.spec.ts
+++ b/sdk/tables/data-tables/test/public/tableclient.spec.ts
@@ -30,7 +30,7 @@ describe("special characters", () => {
     if (!isLiveMode()) {
       // Currently the recorder is having issues with the encoding of single qoutes in the
       // query request and generates invalid JS code. Disabling this test on playback mode
-      // while these issues are resolved
+      // while these issues are resolved. #18534
       this.skip();
     }
     const client = createTableClient(`SpecialChars`);

--- a/sdk/tables/data-tables/test/public/tableclient.spec.ts
+++ b/sdk/tables/data-tables/test/public/tableclient.spec.ts
@@ -25,6 +25,38 @@ if (isLiveMode()) {
   authModes.push("SASToken");
 }
 
+describe("special characters", () => {
+  it("should handle partition and row keys with special chars", async () => {
+    const client = createTableClient(`SpecialChars`);
+    await client.createTable();
+
+    try {
+      const partitionKey = "A'aaa_bbbb2\"";
+      const rowKey = `"A'aaa_bbbb2`;
+      const expectedValue = `"A'aaa_bbbb2`;
+      await client.createEntity({
+        partitionKey,
+        rowKey,
+        test: expectedValue
+      });
+      const entities = client.listEntities();
+      for await (const entity of entities) {
+        console.log(`${entity.partitionKey}:${entity.rowKey}`);
+      }
+
+      const entity = await client.getEntity(partitionKey, rowKey);
+
+      assert.equal(entity.partitionKey, partitionKey);
+      assert.equal(entity.rowKey, rowKey);
+      assert.equal(entity.test, expectedValue);
+    } catch (e) {
+      throw e;
+    } finally {
+      await client.deleteTable();
+    }
+  });
+});
+
 // Run the test against each of the supported auth modes
 authModes.forEach((authMode) => {
   describe(`TableClient ${authMode}`, () => {

--- a/sdk/tables/data-tables/test/public/tableclient.spec.ts
+++ b/sdk/tables/data-tables/test/public/tableclient.spec.ts
@@ -26,7 +26,13 @@ if (isLiveMode()) {
 }
 
 describe("special characters", () => {
-  it("should handle partition and row keys with special chars", async () => {
+  it("should handle partition and row keys with special chars", async function(this: Context) {
+    if (!isLiveMode()) {
+      // Currently the recorder is having issues with the encoding of single qoutes in the
+      // query request and generates invalid JS code. Disabling this test on playback mode
+      // while these issues are resolved
+      this.skip();
+    }
     const client = createTableClient(`SpecialChars`);
     await client.createTable();
 
@@ -39,18 +45,11 @@ describe("special characters", () => {
         rowKey,
         test: expectedValue
       });
-      const entities = client.listEntities();
-      for await (const entity of entities) {
-        console.log(`${entity.partitionKey}:${entity.rowKey}`);
-      }
 
       const entity = await client.getEntity(partitionKey, rowKey);
-
       assert.equal(entity.partitionKey, partitionKey);
       assert.equal(entity.rowKey, rowKey);
       assert.equal(entity.test, expectedValue);
-    } catch (e) {
-      throw e;
     } finally {
       await client.deleteTable();
     }


### PR DESCRIPTION
Across languages in the Tables SDK, [a bug was reported](https://github.com/Azure/azure-sdk-for-python/issues/20301) which causes round-tripping issues for table entities where the `PartitionKey` or `RowKey` values contain a single quote character.

This bug impacts any API where the partition/row key is used to format the URL - i.e. upsert, update and delete (note: not​ create, where these values only live in the payload).

For more information on the issue please see Azure/azure-sdk#3356

This fix introduces a runtime **breaking change** as the way we construct request URL when single quotes are present in the `partitionKey` or `rowKey`. Hence bumping the major version