### PR TITLE
[core-http] preserve header key casing

### DIFF
--- a/sdk/core/core-http/CHANGELOG.md
+++ b/sdk/core/core-http/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Fix `HttpHeaders.rawHeaders()` to preserve header name case. As a result HttpClient now sends requests with their original header names. `HttpHeaders.toJson()` now has an option to preserve header key casing.
+
 ### Other Changes
 
 ## 2.2.2 (2021-11-03)

--- a/sdk/core/core-http/review/core-http.api.md
+++ b/sdk/core/core-http/review/core-http.api.md
@@ -296,7 +296,9 @@ export class HttpHeaders implements HttpHeadersLike {
     rawHeaders(): RawHttpHeaders;
     remove(headerName: string): boolean;
     set(headerName: string, headerValue: string | number): void;
-    toJson(): RawHttpHeaders;
+    toJson(options?: {
+        preserveCase?: boolean;
+    }): RawHttpHeaders;
     toString(): string;
 }
 
@@ -311,7 +313,9 @@ export interface HttpHeadersLike {
     rawHeaders(): RawHttpHeaders;
     remove(headerName: string): boolean;
     set(headerName: string, headerValue: string | number): void;
-    toJson(): RawHttpHeaders;
+    toJson(options?: {
+        preserveCase?: boolean;
+    }): RawHttpHeaders;
 }
 
 // @public (undocumented)

--- a/sdk/core/core-http/src/httpHeaders.ts
+++ b/sdk/core/core-http/src/httpHeaders.ts
@@ -79,7 +79,7 @@ export interface HttpHeadersLike {
    * Get the JSON object representation of this HTTP header collection.
    * The result is the same as `rawHeaders()`.
    */
-  toJson(): RawHttpHeaders;
+  toJson(options?: { preserveCase?: boolean }): RawHttpHeaders;
 }
 
 export function isHttpHeadersLike(object?: unknown): object is HttpHeadersLike {
@@ -175,12 +175,7 @@ export class HttpHeaders implements HttpHeadersLike {
    * Get the headers that are contained this collection as an object.
    */
   public rawHeaders(): RawHttpHeaders {
-    const result: RawHttpHeaders = {};
-    for (const headerKey in this._headersMap) {
-      const header: HttpHeader = this._headersMap[headerKey];
-      result[header.name.toLowerCase()] = header.value;
-    }
-    return result;
+    return this.toJson({ preserveCase: true });
   }
 
   /**
@@ -221,15 +216,27 @@ export class HttpHeaders implements HttpHeadersLike {
   /**
    * Get the JSON object representation of this HTTP header collection.
    */
-  public toJson(): RawHttpHeaders {
-    return this.rawHeaders();
+  public toJson(options: { preserveCase?: boolean } = {}): RawHttpHeaders {
+    const result: RawHttpHeaders = {};
+    if (options.preserveCase) {
+      for (const headerKey in this._headersMap) {
+        const header: HttpHeader = this._headersMap[headerKey];
+        result[header.name] = header.value;
+      }
+    } else {
+      for (const headerKey in this._headersMap) {
+        const header: HttpHeader = this._headersMap[headerKey];
+        result[getHeaderKey(header.name)] = header.value;
+      }
+    }
+    return result;
   }
 
   /**
    * Get the string representation of this HTTP header collection.
    */
   public toString(): string {
-    return JSON.stringify(this.toJson());
+    return JSON.stringify(this.toJson({ preserveCase: true }));
   }
 
   /**

--- a/sdk/core/core-http/test/httpHeadersTests.ts
+++ b/sdk/core/core-http/test/httpHeadersTests.ts
@@ -16,4 +16,54 @@ describe("HttpHeaders", () => {
 
     assert.deepStrictEqual(cloned.headersArray(), headers.headersArray());
   });
+
+  it("toJson() should use normalized header names", () => {
+    const rawHeaders = {
+      lowercase: "lower case value",
+      camelCase: "camel case value",
+      ALLUPPERCASE: "all upper case value"
+    };
+    const normalizedHeaders = {
+      lowercase: "lower case value",
+      camelcase: "camel case value",
+      alluppercase: "all upper case value"
+    };
+    const headers = new HttpHeaders(rawHeaders);
+
+    assert.deepStrictEqual(headers.toJson(), normalizedHeaders);
+  });
+
+  it("toJson({preserveCase: true}) should keep the original header names", () => {
+    const rawHeaders = {
+      lowercase: "lower case value",
+      camelCase: "camel case value",
+      ALLUPPERCASE: "all upper case value"
+    };
+    const headers = new HttpHeaders(rawHeaders);
+
+    assert.deepStrictEqual(headers.toJson({ preserveCase: true }), rawHeaders);
+  });
+
+  it("rawHeaders() should keep the original header names", () => {
+    const rawHeaders = {
+      lowercase: "lower case value",
+      camelCase: "camel case value",
+      ALLUPPERCASE: "all upper case value"
+    };
+    const headers = new HttpHeaders(rawHeaders);
+
+    assert.deepStrictEqual(headers.rawHeaders(), rawHeaders);
+  });
+
+  it("iteration should use original header names", () => {
+    const rawHeaders = {
+      lowercase: "lower case value",
+      camelCase: "camel case value",
+      ALLUPPERCASE: "all upper case value"
+    };
+    const headers = new HttpHeaders(rawHeaders);
+    headers.headersArray().forEach((pair) => {
+      assert.include(rawHeaders, { [pair.name]: pair.value });
+    });
+  });
 });

--- a/sdk/core/core-http/test/proxyAgent.node.ts
+++ b/sdk/core/core-http/test/proxyAgent.node.ts
@@ -60,7 +60,7 @@ describe("proxyAgent", () => {
 
       const agent = proxyAgent.agent as HttpsAgent;
       should().exist(agent.proxyOptions.headers);
-      agent.proxyOptions.headers!.should.contain({ "user-agent": "Node.js" });
+      agent.proxyOptions.headers!.should.contain({ "User-Agent": "Node.js" });
       done();
     });
 


### PR DESCRIPTION
Porting fix from core-rest-pipeline #18517

- Add an option to `HttpHeaders.toJson()` allowing keeping the original header
key casing
- Fix `HttpHeaders.rawHeaders()` to preserve header key casing