### PR TITLE
[EventGrid] Fix link in README.md

### DIFF
--- a/sdk/eventgrid/eventgrid/README.md
+++ b/sdk/eventgrid/eventgrid/README.md
@@ -328,5 +328,5 @@ If you'd like to contribute to this library, please read the [contributing guide
 [event_grid]: https://docs.microsoft.com/azure/event-grid
 [azure_portal]: https://portal.azure.com
 [azure-core-tracing-github]: https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/core/core-tracing
-[cloud-events-distributed-tracing-spec]: https://github.com/cloudevents/spec/blob/master/extensions/distributed-tracing.md
+[cloud-events-distributed-tracing-spec]: https://github.com/cloudevents/spec/blob/v1.0.1/extensions/distributed-tracing.md
 [eventgrid-on-kubernetes-using-azure-arc]: https://docs.microsoft.com/azure/event-grid/kubernetes/


### PR DESCRIPTION
The CNCF moved some files around in their specs repository, which
broken this link. Use a versioned URL instead of pointing at their
main development branch so this doesn't happen again in the future.