### PR TITLE
Check is value is undefined in appendQueryParams

### DIFF
--- a/sdk/core/core-client/src/urlHelpers.ts
+++ b/sdk/core/core-client/src/urlHelpers.ts
@@ -215,8 +215,11 @@ function calculateQueryParameters(
   };
 }
 
-function simpleParseQueryParams(queryString: string): Map<string, string | string[]> {
-  const result: Map<string, string | string[]> = new Map<string, string | string[]>();
+function simpleParseQueryParams(queryString: string): Map<string, string | string[] | undefined> {
+  const result: Map<string, string | string[] | undefined> = new Map<
+    string,
+    string | string[] | undefined
+  >();
   if (!queryString || queryString[0] !== "?") {
     return result;
   }
@@ -294,6 +297,8 @@ export function appendQueryParams(
         for (const subValue of value) {
           searchPieces.push(`${name}=${subValue}`);
         }
+      } else {
+        searchPieces.push(`${name}=${value}`);
       }
     }
   }

--- a/sdk/core/core-client/src/urlHelpers.ts
+++ b/sdk/core/core-client/src/urlHelpers.ts
@@ -291,7 +291,7 @@ export function appendQueryParams(
   for (const [name, value] of combinedParams) {
     if (typeof value === "string") {
       searchPieces.push(`${name}=${value}`);
-    } else {
+    } else if(Array.isArray(value)) {
       if (value) {
         // QUIRK: If we get an array of values, include multiple key/value pairs
         for (const subValue of value) {

--- a/sdk/core/core-client/src/urlHelpers.ts
+++ b/sdk/core/core-client/src/urlHelpers.ts
@@ -289,7 +289,7 @@ export function appendQueryParams(
     if (typeof value === "string") {
       searchPieces.push(`${name}=${value}`);
     } else {
-      if (value != undefined) {
+      if (value) {
         // QUIRK: If we get an array of values, include multiple key/value pairs
         for (const subValue of value) {
           searchPieces.push(`${name}=${subValue}`);

--- a/sdk/core/core-client/src/urlHelpers.ts
+++ b/sdk/core/core-client/src/urlHelpers.ts
@@ -289,9 +289,11 @@ export function appendQueryParams(
     if (typeof value === "string") {
       searchPieces.push(`${name}=${value}`);
     } else {
-      // QUIRK: If we get an array of values, include multiple key/value pairs
-      for (const subValue of value) {
-        searchPieces.push(`${name}=${subValue}`);
+      if (value != undefined) {
+        // QUIRK: If we get an array of values, include multiple key/value pairs
+        for (const subValue of value) {
+          searchPieces.push(`${name}=${subValue}`);
+        }
       }
     }
   }

--- a/sdk/core/core-client/src/urlHelpers.ts
+++ b/sdk/core/core-client/src/urlHelpers.ts
@@ -291,15 +291,13 @@ export function appendQueryParams(
   for (const [name, value] of combinedParams) {
     if (typeof value === "string") {
       searchPieces.push(`${name}=${value}`);
-    } else if(Array.isArray(value)) {
-      if (value) {
-        // QUIRK: If we get an array of values, include multiple key/value pairs
-        for (const subValue of value) {
-          searchPieces.push(`${name}=${subValue}`);
-        }
-      } else {
-        searchPieces.push(`${name}=${value}`);
+    } else if (Array.isArray(value)) {
+      // QUIRK: If we get an array of values, include multiple key/value pairs
+      for (const subValue of value) {
+        searchPieces.push(`${name}=${subValue}`);
       }
+    } else {
+      searchPieces.push(`${name}=${value}`);
     }
   }
 


### PR DESCRIPTION
@qiaozha has recently reported that during the testing of `beginCreateOrUpdateAndWait` operation in the `@azure/arm-iothub` library. During the testing, the code is erroring out with the message:

```
(node:17412) UnhandledPromiseRejectionWarning: TypeError: value is not iterable
    at appendQueryParams (C:\Users\sarajama\Projects\temp\node_modules\@azure\core-client\dist\index.js:1343:40)
```

On analysis, I found that the value is undefined which is causing the error. Adding a check resolves the issue. 

@xirzec Could you please review and approve the PR? TIA