### PR TITLE
[Schema Registry] Regenerate with improved swagger

### DIFF
--- a/sdk/schemaregistry/schema-registry/samples-dev/schemaRegistrySample.ts
+++ b/sdk/schemaregistry/schema-registry/samples-dev/schemaRegistrySample.ts
@@ -21,7 +21,7 @@ const group = process.env["SCHEMA_REGISTRY_GROUP"] || "AzureSdkSampleGroup";
 const schemaObject = {
   type: "record",
   name: "User",
-  namespace: "com.azure.schemaregistry.samples",
+  namespace: "com-azure-schemaregistry-samples",
   fields: [
     {
       name: "firstName",
@@ -36,7 +36,7 @@ const schemaObject = {
 
 // Description of the schema for registration
 const schemaDescription: SchemaDescription = {
-  name: `${schemaObject.namespace}.${schemaObject.name}`,
+  name: `${schemaObject.namespace}-${schemaObject.name}`,
   groupName: group,
   format: "Avro",
   definition: JSON.stringify(schemaObject)

--- a/sdk/schemaregistry/schema-registry/src/generated/models/index.ts
+++ b/sdk/schemaregistry/schema-registry/src/generated/models/index.ts
@@ -42,12 +42,6 @@ export interface SchemaId {
   id?: string;
 }
 
-/** Defines headers for SchemaGroups_list operation. */
-export interface SchemaGroupsListExceptionHeaders {
-  /** Error code for specific error that occurred. */
-  xMsErrorCode?: string;
-}
-
 /** Defines headers for Schema_getById operation. */
 export interface SchemaGetByIdHeaders {
   /** URL location of schema, identified by schema group, schema name, and version. */
@@ -66,18 +60,6 @@ export interface SchemaGetByIdHeaders {
   schemaVersion?: number;
 }
 
-/** Defines headers for Schema_getById operation. */
-export interface SchemaGetByIdExceptionHeaders {
-  /** Error code for specific error that occurred. */
-  xMsErrorCode?: string;
-}
-
-/** Defines headers for Schema_getVersions operation. */
-export interface SchemaGetVersionsExceptionHeaders {
-  /** Error code for specific error that occurred. */
-  xMsErrorCode?: string;
-}
-
 /** Defines headers for Schema_queryIdByContent operation. */
 export interface SchemaQueryIdByContentHeaders {
   /** URL location of schema, identified by schema group, schema name, and version. */
@@ -94,12 +76,6 @@ export interface SchemaQueryIdByContentHeaders {
   schemaVersion?: number;
 }
 
-/** Defines headers for Schema_queryIdByContent operation. */
-export interface SchemaQueryIdByContentExceptionHeaders {
-  /** Error code for specific error that occurred. */
-  xMsErrorCode?: string;
-}
-
 /** Defines headers for Schema_register operation. */
 export interface SchemaRegisterHeaders {
   /** URL location of schema, identified by schema group, schema name, and version. */
@@ -114,12 +90,6 @@ export interface SchemaRegisterHeaders {
   schemaName?: string;
   /** Version of the returned schema. */
   schemaVersion?: number;
-}
-
-/** Defines headers for Schema_register operation. */
-export interface SchemaRegisterExceptionHeaders {
-  /** Error code for specific error that occurred. */
-  xMsErrorCode?: string;
 }
 
 /** Optional parameters. */

--- a/sdk/schemaregistry/schema-registry/src/generated/models/mappers.ts
+++ b/sdk/schemaregistry/schema-registry/src/generated/models/mappers.ts
@@ -114,21 +114,6 @@ export const SchemaId: coreClient.CompositeMapper = {
   }
 };
 
-export const SchemaGroupsListExceptionHeaders: coreClient.CompositeMapper = {
-  type: {
-    name: "Composite",
-    className: "SchemaGroupsListExceptionHeaders",
-    modelProperties: {
-      xMsErrorCode: {
-        serializedName: "x-ms-error-code",
-        type: {
-          name: "String"
-        }
-      }
-    }
-  }
-};
-
 export const SchemaGetByIdHeaders: coreClient.CompositeMapper = {
   type: {
     name: "Composite",
@@ -180,36 +165,6 @@ export const SchemaGetByIdHeaders: coreClient.CompositeMapper = {
   }
 };
 
-export const SchemaGetByIdExceptionHeaders: coreClient.CompositeMapper = {
-  type: {
-    name: "Composite",
-    className: "SchemaGetByIdExceptionHeaders",
-    modelProperties: {
-      xMsErrorCode: {
-        serializedName: "x-ms-error-code",
-        type: {
-          name: "String"
-        }
-      }
-    }
-  }
-};
-
-export const SchemaGetVersionsExceptionHeaders: coreClient.CompositeMapper = {
-  type: {
-    name: "Composite",
-    className: "SchemaGetVersionsExceptionHeaders",
-    modelProperties: {
-      xMsErrorCode: {
-        serializedName: "x-ms-error-code",
-        type: {
-          name: "String"
-        }
-      }
-    }
-  }
-};
-
 export const SchemaQueryIdByContentHeaders: coreClient.CompositeMapper = {
   type: {
     name: "Composite",
@@ -255,21 +210,6 @@ export const SchemaQueryIdByContentHeaders: coreClient.CompositeMapper = {
   }
 };
 
-export const SchemaQueryIdByContentExceptionHeaders: coreClient.CompositeMapper = {
-  type: {
-    name: "Composite",
-    className: "SchemaQueryIdByContentExceptionHeaders",
-    modelProperties: {
-      xMsErrorCode: {
-        serializedName: "x-ms-error-code",
-        type: {
-          name: "String"
-        }
-      }
-    }
-  }
-};
-
 export const SchemaRegisterHeaders: coreClient.CompositeMapper = {
   type: {
     name: "Composite",
@@ -309,21 +249,6 @@ export const SchemaRegisterHeaders: coreClient.CompositeMapper = {
         serializedName: "schema-version",
         type: {
           name: "Number"
-        }
-      }
-    }
-  }
-};
-
-export const SchemaRegisterExceptionHeaders: coreClient.CompositeMapper = {
-  type: {
-    name: "Composite",
-    className: "SchemaRegisterExceptionHeaders",
-    modelProperties: {
-      xMsErrorCode: {
-        serializedName: "x-ms-error-code",
-        type: {
-          name: "String"
         }
       }
     }

--- a/sdk/schemaregistry/schema-registry/src/generated/operations/schema.ts
+++ b/sdk/schemaregistry/schema-registry/src/generated/operations/schema.ts
@@ -132,8 +132,7 @@ const getByIdOperationSpec: coreClient.OperationSpec = {
       headersMapper: Mappers.SchemaGetByIdHeaders
     },
     default: {
-      bodyMapper: Mappers.ErrorModel,
-      headersMapper: Mappers.SchemaGetByIdExceptionHeaders
+      bodyMapper: Mappers.ErrorModel
     }
   },
   queryParameters: [Parameters.apiVersion],
@@ -149,8 +148,7 @@ const getVersionsOperationSpec: coreClient.OperationSpec = {
       bodyMapper: Mappers.SchemaVersions
     },
     default: {
-      bodyMapper: Mappers.ErrorModel,
-      headersMapper: Mappers.SchemaGetVersionsExceptionHeaders
+      bodyMapper: Mappers.ErrorModel
     }
   },
   queryParameters: [Parameters.apiVersion],
@@ -169,9 +167,12 @@ const queryIdByContentOperationSpec: coreClient.OperationSpec = {
     204: {
       headersMapper: Mappers.SchemaQueryIdByContentHeaders
     },
-    default: {
+    415: {
       bodyMapper: Mappers.ErrorModel,
-      headersMapper: Mappers.SchemaQueryIdByContentExceptionHeaders
+      isError: true
+    },
+    default: {
+      bodyMapper: Mappers.ErrorModel
     }
   },
   requestBody: Parameters.schemaContent,
@@ -192,9 +193,12 @@ const registerOperationSpec: coreClient.OperationSpec = {
     204: {
       headersMapper: Mappers.SchemaRegisterHeaders
     },
-    default: {
+    415: {
       bodyMapper: Mappers.ErrorModel,
-      headersMapper: Mappers.SchemaRegisterExceptionHeaders
+      isError: true
+    },
+    default: {
+      bodyMapper: Mappers.ErrorModel
     }
   },
   requestBody: Parameters.schemaContent,

--- a/sdk/schemaregistry/schema-registry/src/generated/operations/schemaGroupsOperations.ts
+++ b/sdk/schemaregistry/schema-registry/src/generated/operations/schemaGroupsOperations.ts
@@ -49,8 +49,7 @@ const listOperationSpec: coreClient.OperationSpec = {
       bodyMapper: Mappers.SchemaGroups
     },
     default: {
-      bodyMapper: Mappers.ErrorModel,
-      headersMapper: Mappers.SchemaGroupsListExceptionHeaders
+      bodyMapper: Mappers.ErrorModel
     }
   },
   queryParameters: [Parameters.apiVersion],

--- a/sdk/schemaregistry/schema-registry/swagger/README.md
+++ b/sdk/schemaregistry/schema-registry/swagger/README.md
@@ -24,7 +24,7 @@ typescript: true
 
 ## Swagger workarounds
 
-### Add Content-Type header to GetById operation and mark 415 as error
+### Add Content-Type header to GetById operation
 
 ``` yaml
 directive:
@@ -37,10 +37,9 @@ directive:
       "description": "Content type of the schema.",
       "required": true,
       "type": "string"});
-    delete $.responses["415"];
 ```
 
-### Add Content-Type header to Register operation and mark 415 as error
+### Add Content-Type header to Register operation
 
 ``` yaml
 directive:
@@ -53,6 +52,4 @@ directive:
       "description": "Content type of the schema.",
       "required": true,
       "type": "string"});
-    delete $.responses["415"];
-
 ```

--- a/sdk/schemaregistry/schema-registry/test/public/schemaRegistry.spec.ts
+++ b/sdk/schemaregistry/schema-registry/test/public/schemaRegistry.spec.ts
@@ -119,7 +119,7 @@ describe("SchemaRegistryClient", function() {
   });
 
   it("fails to get schema by ID when given invalid ID", async () => {
-    await assert.isRejected(client.getSchema(null!), /null/);
+    await isRejected(client.getSchema(null!), undefined, /null/);
   });
 
   it("fails to get schema when no schema exists with given ID", async () => {

--- a/sdk/schemaregistry/schema-registry/test/public/schemaRegistry.spec.ts
+++ b/sdk/schemaregistry/schema-registry/test/public/schemaRegistry.spec.ts
@@ -40,19 +40,19 @@ async function isRejected<T>(
   } catch (e) {
     assert.equal(e.statusCode, expectedStatusCode);
     assert.match(e.message, expectedMessage);
+    /**
+     * The SDK does not currently parse the error response body because it
+     * does not have a compliant error codes yet. The SDK will start to parse
+     * them once the codes become compliant text that follows:
+     *
+     * "Unlocalized string which can be used to programmatically identify the
+     * error.The code should be Pascal-cased, and should serve to uniquely
+     * identify a particular class of error, for example "BadArgument"."
+     *
+     * Right now, the service returns the response status code in the Code field.
+     */
     assert.isUndefined(e.code);
     if (expectedStatusCode !== undefined) {
-      /**
-       * The SDK does not currently parse the error response body because it
-       * does not have a compliant error codes yet. The SDK will start to parse
-       * them once the codes become compliant text that follows:
-       *
-       * "Unlocalized string which can be used to programmatically identify the
-       * error.The code should be Pascal-cased, and should serve to uniquely
-       * identify a particular class of error, for example "BadArgument"."
-       *
-       * Right now, the service returns the response status code in the Code field.
-       */
       assert.equal(JSON.parse(e.message).Code, e.statusCode);
     }
   }

--- a/sdk/schemaregistry/schema-registry/test/public/schemaRegistry.spec.ts
+++ b/sdk/schemaregistry/schema-registry/test/public/schemaRegistry.spec.ts
@@ -52,6 +52,7 @@ async function isRejected<T>(
      * Right now, the service returns the response status code in the Code field.
      */
     assert.isUndefined(e.code);
+    assert.isUndefined(e.Code);
     if (expectedStatusCode !== undefined) {
       assert.equal(JSON.parse(e.message).Code, e.statusCode);
     }

--- a/sdk/schemaregistry/schema-registry/test/public/schemaRegistry.spec.ts
+++ b/sdk/schemaregistry/schema-registry/test/public/schemaRegistry.spec.ts
@@ -40,6 +40,7 @@ async function isRejected<T>(
   } catch (e) {
     assert.equal(e.statusCode, expectedStatusCode);
     assert.match(e.message, expectedMessage);
+    assert.isUndefined(e.code);
     if (expectedStatusCode !== undefined) {
       /**
        * The SDK does not currently parse the error response body because it


### PR DESCRIPTION
- Regenerate using the swagger in https://github.com/Azure/azure-rest-api-specs/pull/16738
- Update samples so the schema name does not include `.`s, as enforced by client-side validation specified by the swagger