### PR TITLE
[tables] Add RestError export

### DIFF
--- a/sdk/tables/data-tables/review/data-tables.api.md
+++ b/sdk/tables/data-tables/review/data-tables.api.md
@@ -12,6 +12,7 @@ import { NamedKeyCredential } from '@azure/core-auth';
 import { OperationOptions } from '@azure/core-client';
 import { PagedAsyncIterableIterator } from '@azure/core-paging';
 import { Pipeline } from '@azure/core-rest-pipeline';
+import { RestError } from '@azure/core-rest-pipeline';
 import { SASCredential } from '@azure/core-auth';
 import { TokenCredential } from '@azure/core-auth';
 
@@ -161,6 +162,8 @@ export interface Metrics {
 
 // @public
 export function odata(strings: TemplateStringsArray, ...values: unknown[]): string;
+
+export { RestError }
 
 // @public
 export interface RetentionPolicy {

--- a/sdk/tables/data-tables/src/index.ts
+++ b/sdk/tables/data-tables/src/index.ts
@@ -10,3 +10,4 @@ export { TableTransaction } from "./TableTransaction";
 export { TableClient } from "./TableClient";
 export { odata } from "./odata";
 export { AzureNamedKeyCredential, AzureSASCredential } from "@azure/core-auth";
+export { RestError } from "@azure/core-rest-pipeline";


### PR DESCRIPTION
This adds the `RestError` class that can be thrown by the library to the exports so that consumers can more easily catch and perform `instanceof` checks on thrown errors.

This is the convention with [@azure/storage-blob](https://github.com/Azure/azure-sdk-for-js/blob/681c9b9e364d9bc2cbc7a7cbf418165bde02fc84/sdk/storage/storage-blob/src/index.ts#L59) and [@azure/storage-queue](https://github.com/Azure/azure-sdk-for-js/blob/681c9b9e364d9bc2cbc7a7cbf418165bde02fc84/sdk/storage/storage-queue/src/index.ts#L28)