### PR TITLE
[KeyVault] - Move MHSM to resource group location

### DIFF
--- a/sdk/keyvault/test-resources.json
+++ b/sdk/keyvault/test-resources.json
@@ -37,10 +37,9 @@
     },
     "hsmLocation": {
       "type": "string",
-      "defaultValue": "eastus",
-      "allowedValues": ["eastus", "eastus2", "southcentralus", "northeurope", "westeurope"],
+      "defaultValue": "[resourceGroup().location]",
       "metadata": {
-        "description": "The location of the Managed HSM. By default, this is 'eastus'."
+        "description": "The location of the Managed HSM. By default, this is the same as the resource group."
       }
     },
     "enableHsm": {


### PR DESCRIPTION
Moving the Managed HSM to the same location as our resource group now that the
limits have been expanded.
