### PR TITLE
Build and test predefined set of packages only in identity pipelines

### DIFF
--- a/eng/tools/rush-runner.js
+++ b/eng/tools/rush-runner.js
@@ -35,7 +35,8 @@ const reducedDependencyTestMatrix = {
     '@azure/storage-file-share',
     '@azure/template'
   ],
-  'identity': ['@azure-rest/core-client',
+  'identity': [
+    '@azure-rest/core-client',
     '@azure-rest/core-client-lro',
     '@azure-rest/core-client-paging',
     '@azure-rest/purview-account',

--- a/eng/tools/rush-runner.js
+++ b/eng/tools/rush-runner.js
@@ -34,7 +34,21 @@ const reducedDependencyTestMatrix = {
     '@azure/identity-vscode',
     '@azure/storage-file-share',
     '@azure/template'
-  ]
+  ],
+  'identity': ['@azure-rest/core-client',
+    '@azure-rest/core-client-lro',
+    '@azure-rest/core-client-paging',
+    '@azure-rest/purview-account',
+    '@azure-tests/perf-storage-blob',
+    '@azure/ai-text-analytics',
+    '@azure/arm-compute',
+    '@azure/identity-cache-persistence',
+    '@azure/identity-vscode',
+    '@azure/service-bus',
+    '@azure/storage-blob',
+    '@azure/template',
+    '@azure/synapse-monitoring'
+  ],
 };
 
 const parseArgs = () => {


### PR DESCRIPTION
Identity pipeline is timing out after 1 hour since it tries to build and test every packages in the repo.