### PR TITLE
Update key vault admin to enable live testing in sovereign clouds for multiple services

### DIFF
--- a/sdk/keyvault/keyvault-admin/tests.yml
+++ b/sdk/keyvault/keyvault-admin/tests.yml
@@ -5,17 +5,29 @@ stages:
     parameters:
       PackageName: "@azure/keyvault-admin"
       ServiceDirectory: keyvault
+      SupportedClouds: 'Public,UsGov,China'
+      CloudConfig:
+        Public:
+          SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
+          Location: 'eastus2'
+        UsGov:
+          SubscriptionConfiguration: $(sub-config-gov-test-resources)
+          MatrixFilters:
+            - ArmTemplateParameters=^(?!.*enableHsm.*true)
+        China:
+          SubscriptionConfiguration: $(sub-config-cn-test-resources)
+          MatrixFilters:
+            - ArmTemplateParameters=^(?!.*enableHsm.*true)
       # KV HSM limitation prevents us from running live tests
       # against multiple platforms in parallel (we're limited to a single
       # instance per region per subscription) so we're only running
       # live tests against a single instance.
-      Location: eastus2
       MatrixConfigs:
         - Name: Keyvault_live_test_base
           Path: sdk/keyvault/keyvault-admin/platform-matrix.json
           Selection: sparse
           GenerateVMJobs: true
       EnvVars:
-        AZURE_CLIENT_ID: $(aad-azure-sdk-test-client-id)
-        AZURE_TENANT_ID: $(aad-azure-sdk-test-tenant-id)
-        AZURE_CLIENT_SECRET: $(aad-azure-sdk-test-client-secret)
+        AZURE_CLIENT_ID: $(KEYVAULT_CLIENT_ID)
+        AZURE_TENANT_ID: $(KEYVAULT_TENANT_ID)
+        AZURE_CLIENT_SECRET: $(KEYVAULT_CLIENT_SECRET)


### PR DESCRIPTION
1.These changes enable key vault secrets to run live tests against Public, UsGov and China.

2.Update file: sdk/keyvault/keyvault-admin/tests.yml
Update to enable key vault admin to run live tests against UsGov and China.

Pipeline results:
https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1197180&view=results

@benbp, @ramya-rao-a, @AlexGhiondea, @dw511214992 for notification.