### PR TITLE
[cosmosdb] Restore damaged ci.yml

### DIFF
--- a/sdk/cosmosdb/ci.yml
+++ b/sdk/cosmosdb/ci.yml
@@ -3,7 +3,9 @@
 trigger:
   branches:
     include:
-	@@ -9,25 +7,25 @@ trigger:
+      - main
+      - release/*
+      - hotfix/*
   paths:
     include:
       - sdk/cosmosdb/cosmos/


### PR DESCRIPTION
#18667 damaged this file, and this PR restores it. The cosmosdb data-plane CI currently cannot run.

CC @colawwj @qiaozha 