### PR TITLE
[ai-form-recognizer] Use CommonClientOptions

### DIFF
--- a/sdk/formrecognizer/ai-form-recognizer/CHANGELOG.md
+++ b/sdk/formrecognizer/ai-form-recognizer/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Other Changes
 
+- Changed `FormRecognizerCommonClientOptions` to extend `CommonClientOptions` from `@azure/core-client` instead of `PipelineOptions`. `CommonClientOptions` itself extends `PipelineOptions`, so no fields are removed, but `CommonClientOptions` also includes `httpClient` and `allowInsecureConnection` fields to allow overriding the default HTTP client and using insecure connections (without SSL/TLS) respectively.
+
 ## 4.0.0-beta.2 (2021-11-09)
 
 ### Features Added

--- a/sdk/formrecognizer/ai-form-recognizer/review/ai-form-recognizer.api.md
+++ b/sdk/formrecognizer/ai-form-recognizer/review/ai-form-recognizer.api.md
@@ -7,10 +7,10 @@
 /// <reference types="node" />
 
 import { AzureKeyCredential } from '@azure/core-auth';
+import { CommonClientOptions } from '@azure/core-client';
 import { KeyCredential } from '@azure/core-auth';
 import { OperationOptions } from '@azure/core-client';
 import { PagedAsyncIterableIterator } from '@azure/core-paging';
-import { PipelineOptions } from '@azure/core-rest-pipeline';
 import { PollerLike } from '@azure/core-lro';
 import { PollOperationState } from '@azure/core-lro';
 import { TokenCredential } from '@azure/core-auth';
@@ -502,7 +502,7 @@ export const FormRecognizerApiVersion: {
 };
 
 // @public
-export interface FormRecognizerCommonClientOptions extends PipelineOptions {
+export interface FormRecognizerCommonClientOptions extends CommonClientOptions {
     apiVersion?: FormRecognizerApiVersion;
 }
 

--- a/sdk/formrecognizer/ai-form-recognizer/src/options/FormRecognizerClientOptions.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/src/options/FormRecognizerClientOptions.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { PipelineOptions } from "@azure/core-rest-pipeline";
+import { CommonClientOptions } from "@azure/core-client";
 import { GeneratedClientOptionalParams } from "../generated";
 
 /**
@@ -60,7 +60,7 @@ export const DEFAULT_GENERATED_CLIENT_OPTIONS: GeneratedClientOptionalParams = {
  * Configurable options for the Form Recognizer service clients (DocumentAnalysisClient and
  * DocumentModelAdministrationClient).
  */
-export interface FormRecognizerCommonClientOptions extends PipelineOptions {
+export interface FormRecognizerCommonClientOptions extends CommonClientOptions {
   /**
    * The version of the Form Recognizer REST API to call. Service versions 2.1 and lower (non-date-based versions) are
    * not supported by this client. To use API version 2.1, please use version 3 of the Azure Form Recognizer SDK for


### PR DESCRIPTION
This changes `FormRecognizerCommonClientOptions` to inherit from `CommonClientOptions` instead of `PipelineOptions`. This gives us a couple more options in the client constructor that were missing.