### PR TITLE
[Schema Registry] Prepare patch release

### DIFF
--- a/sdk/schemaregistry/schema-registry-avro/CHANGELOG.md
+++ b/sdk/schemaregistry/schema-registry-avro/CHANGELOG.md
@@ -1,14 +1,10 @@
 # Release History
 
-## 1.0.0-beta.5 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
-
-### Bugs Fixed
+## 1.0.0-beta.5 (2021-11-17)
 
 ### Other Changes
+
+- Depends on @azure/schema-registry@1.0.1.
 
 ## 1.0.0-beta.4 (2021-11-11)
 

--- a/sdk/schemaregistry/schema-registry/CHANGELOG.md
+++ b/sdk/schemaregistry/schema-registry/CHANGELOG.md
@@ -1,16 +1,10 @@
 # Release History
 
-## 1.0.1 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
+## 1.0.1 (2021-11-17)
 
 ### Bugs Fixed
 
 - Disable client-side validation of schema names and leave that to the service.
-
-### Other Changes
 
 ## 1.0.0 (2021-11-10)
 


### PR DESCRIPTION
To release a patch that does not have client-side validation of schema names. See https://github.com/Azure/azure-sdk-for-js/pull/18666/ for more details.