### PR TITLE
Nit: Change ~ to ^ in @types/mock-fs dev dependency version

### DIFF
--- a/sdk/test-utils/recorder-new/package.json
+++ b/sdk/test-utils/recorder-new/package.json
@@ -85,7 +85,7 @@
     "@types/nise": "^1.4.0",
     "@types/node": "^12.0.0",
     "@types/mock-require": "~2.0.0",
-    "@types/mock-fs": "~4.13.1",
+    "@types/mock-fs": "^4.13.1",
     "@types/uuid": "^8.3.1",
     "chai": "^4.2.0",
     "concurrently": "^6.2.1",

--- a/sdk/test-utils/recorder/package.json
+++ b/sdk/test-utils/recorder/package.json
@@ -83,7 +83,7 @@
     "@types/nise": "^1.4.0",
     "@types/node": "^12.0.0",
     "@types/mock-require": "~2.0.0",
-    "@types/mock-fs": "~4.13.1",
+    "@types/mock-fs": "^4.13.1",
     "chai": "^4.2.0",
     "dotenv": "^8.2.0",
     "eslint": "^7.15.0",

--- a/sdk/test-utils/testing-recorder-new/package.json
+++ b/sdk/test-utils/testing-recorder-new/package.json
@@ -74,7 +74,7 @@
     "@types/nise": "^1.4.0",
     "@types/node": "^12.0.0",
     "@types/mock-require": "~2.0.0",
-    "@types/mock-fs": "~4.13.1",
+    "@types/mock-fs": "^4.13.1",
     "chai": "^4.2.0",
     "dotenv": "^8.2.0",
     "eslint": "^7.15.0",


### PR DESCRIPTION
Resolving [this comment](https://github.com/Azure/azure-sdk-for-js/pull/18707#discussion_r750815462) from PR #18707.

Minor change in @types/mock-fs dependency version, changing `~4.13.1` to `^4.13.1`.