### PR TITLE
Add NodeJS version 17.x to test matrix

### DIFF
--- a/eng/pipelines/templates/stages/platform-matrix.json
+++ b/eng/pipelines/templates/stages/platform-matrix.json
@@ -17,7 +17,12 @@
         "Pool": "Azure Pipelines"
       }
     },
-    "NodeTestVersion": ["12.x", "14.x", "16.x"],
+    "NodeTestVersion": [
+      "12.x",
+      "14.x",
+      "16.x",
+      "17.x"
+    ],
     "TestType": "node",
     "TestResultsFiles": "**/test-results.xml"
   },
@@ -55,7 +60,10 @@
       },
       "TestType": "node",
       "NodeTestVersion": "12.x",
-      "DependencyVersion": ["max", "min"],
+      "DependencyVersion": [
+        "max",
+        "min"
+      ],
       "TestResultsFiles": "**/test-results.xml"
     }
   ]


### PR DESCRIPTION
Solves https://github.com/Azure/azure-sdk-for-js/issues/18447

Added `17.x` to the `NodeTestVersion` array.

Creating this PR to ensure that all the tests pass