### PR TITLE
Upgrade assert version from 1.4.1 to 2.0.0

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -1585,6 +1585,7 @@ packages:
   /@opentelemetry/node/0.22.0_@opentelemetry+api@1.0.3:
     resolution: {integrity: sha512-+HhGbDruQ7cwejVOIYyxRa28uosnG8W95NiQZ6qE8PXXPsDSyGeftAPbtYpGit0H2f5hrVcMlwmWHeAo9xkSLA==}
     engines: {node: '>=8.0.0'}
+    deprecated: Package renamed to @opentelemetry/sdk-trace-node
     peerDependencies:
       '@opentelemetry/api': ^1.0.0
     dependencies:
@@ -2460,11 +2461,13 @@ packages:
     engines: {node: '>=0.8'}
     dev: false
 
-  /assert/1.5.0:
-    resolution: {integrity: sha512-EDsgawzwoun2CZkCgtxJbv392v4nbk9XDD06zI+kQYoBM/3RBWLlEyJARDOmhAAosBjWACEkKL6S+lIZtcAubA==}
+  /assert/2.0.0:
+    resolution: {integrity: sha512-se5Cd+js9dXJnu6Ag2JFc00t+HmHOen+8Q+L7O9zI0PqQXr20uk2J0XQqMxZEeo5U50o8Nvmmx7dZrl+Ufr35A==}
     dependencies:
-      object-assign: 4.1.1
-      util: 0.10.3
+      es6-object-assign: 1.1.0
+      is-nan: 1.3.2
+      object-is: 1.1.5
+      util: 0.12.4
     dev: false
 
   /assertion-error/1.1.0:
@@ -3535,6 +3538,10 @@ packages:
 
   /es6-error/4.1.1:
     resolution: {integrity: sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==}
+    dev: false
+
+  /es6-object-assign/1.1.0:
+    resolution: {integrity: sha1-wsNYJlYkfDnqEHyx5mUrb58kUjw=}
     dev: false
 
   /es6-promise/4.2.8:
@@ -4616,10 +4623,6 @@ packages:
       wrappy: 1.0.2
     dev: false
 
-  /inherits/2.0.1:
-    resolution: {integrity: sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=}
-    dev: false
-
   /inherits/2.0.3:
     resolution: {integrity: sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=}
     dev: false
@@ -4774,6 +4777,14 @@ packages:
 
   /is-module/1.0.0:
     resolution: {integrity: sha1-Mlj7afeMFNW4FdZkM2tM/7ZEFZE=}
+    dev: false
+
+  /is-nan/1.3.2:
+    resolution: {integrity: sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      call-bind: 1.0.2
+      define-properties: 1.1.3
     dev: false
 
   /is-negative-zero/2.0.1:
@@ -6003,6 +6014,14 @@ packages:
 
   /object-inspect/1.11.0:
     resolution: {integrity: sha512-jp7ikS6Sd3GxQfZJPyH3cjcbJF6GZPClgdV+EFygjFLQ5FmW/dRUnTd9PQ9k0JhoNDabWFbpF1yCdSWCC6gexg==}
+    dev: false
+
+  /object-is/1.1.5:
+    resolution: {integrity: sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      call-bind: 1.0.2
+      define-properties: 1.1.3
     dev: false
 
   /object-keys/1.1.1:
@@ -7820,12 +7839,6 @@ packages:
     resolution: {integrity: sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=}
     dev: false
 
-  /util/0.10.3:
-    resolution: {integrity: sha1-evsa/lCAUkZInj23/g7TeTNqwPk=}
-    dependencies:
-      inherits: 2.0.1
-    dev: false
-
   /util/0.11.1:
     resolution: {integrity: sha512-HShAsny+zS2TZfaXxD9tYj4HQGlBezXZMZuM/S5PKLLoZkShZiGk9o5CzukI1LVHZvjdvZ2Sj1aW/Ndn2NB/HQ==}
     dependencies:
@@ -8548,7 +8561,7 @@ packages:
     dev: false
 
   file:projects/app-configuration.tgz:
-    resolution: {integrity: sha512-sPvElpc5bwIabAIHZpBTOonPqylTX7uXmivK1G6IpNS1aHtZhPJbcKWQ2Q6/1s0lDTOEhKPt5z09czDk4h2FJQ==, tarball: file:projects/app-configuration.tgz}
+    resolution: {integrity: sha512-jRlWIppDtMPkY1GZI7Nt1YnVWSb4GSGzMcBJ9oyiTuKaCnBJqiGYKnm8E9SFyq1ot/MblEYP2r2/MAFnMeomRw==, tarball: file:projects/app-configuration.tgz}
     name: '@rush-temp/app-configuration'
     version: 0.0.0
     dependencies:
@@ -8565,7 +8578,7 @@ packages:
       '@types/mocha': 7.0.2
       '@types/node': 12.20.37
       '@types/sinon': 9.0.11
-      assert: 1.5.0
+      assert: 2.0.0
       chai: 4.3.4
       cross-env: 7.0.3
       dotenv: 8.6.0
@@ -9591,7 +9604,7 @@ packages:
     dev: false
 
   file:projects/communication-chat.tgz:
-    resolution: {integrity: sha512-3mBDemL2PvS7+J1J+I6rvF0FDpoN5BKfpISDGwz+7vbCTKOBa1Wrnp6OfdaXyT7clZ0vTdzAxbz0JN/MdWnM7w==, tarball: file:projects/communication-chat.tgz}
+    resolution: {integrity: sha512-lPy2OwLEPk6w9/gd5a2hYzBj1aXlO17UwT/Hng4+TAWS6t5iU7u7P0EB4A+kmRFxx1I3zkfYrqQqxX1nDCTI2Q==, tarball: file:projects/communication-chat.tgz}
     name: '@rush-temp/communication-chat'
     version: 0.0.0
     dependencies:
@@ -9609,7 +9622,7 @@ packages:
       '@types/node': 12.20.37
       '@types/sinon': 9.0.11
       '@types/uuid': 8.3.1
-      assert: 1.5.0
+      assert: 2.0.0
       chai: 4.3.4
       cross-env: 7.0.3
       dotenv: 8.6.0
@@ -9653,7 +9666,7 @@ packages:
     dev: false
 
   file:projects/communication-common.tgz:
-    resolution: {integrity: sha512-fwGyN4Eqeo8BLJIXXrRwk7ZsugwP93sZTBIMQyVX/Sbd0J6f1FZI0df2R4Nwtmw7OD2SjnngCbwL+uX+X5KfPQ==, tarball: file:projects/communication-common.tgz}
+    resolution: {integrity: sha512-VWZyiY3hpLu1c9uuZjVR0n52urSiyFh+rsAmNG6s3fSHqtp7/Dh9dFAFbRZsPrRLiUHPqADnx8aLJQ+MWNw8rQ==, tarball: file:projects/communication-common.tgz}
     name: '@rush-temp/communication-common'
     version: 0.0.0
     dependencies:
@@ -9670,7 +9683,7 @@ packages:
       '@types/mocha': 7.0.2
       '@types/node': 12.20.37
       '@types/sinon': 9.0.11
-      assert: 1.5.0
+      assert: 2.0.0
       chai: 4.3.4
       chai-as-promised: 7.1.1_chai@4.3.4
       cross-env: 7.0.3
@@ -9711,7 +9724,7 @@ packages:
     dev: false
 
   file:projects/communication-identity.tgz:
-    resolution: {integrity: sha512-naYVfcc4DaPxq/vl1CtRPuqrvMDxE3dZSOSPpLgp48ZH6rgGjXp9UY0Jz2DS9/uPr20rFfIyjvprfvbZ5zs+RA==, tarball: file:projects/communication-identity.tgz}
+    resolution: {integrity: sha512-nUTci/30Rhy8ND6Wy1k40i70+q35LTJhXAjO/7BluS/6o1Dz/e2RyXytfGreM7f1o3owOOh/CK8p7fJHpCJJLQ==, tarball: file:projects/communication-identity.tgz}
     name: '@rush-temp/communication-identity'
     version: 0.0.0
     dependencies:
@@ -9726,7 +9739,7 @@ packages:
       '@types/mocha': 7.0.2
       '@types/node': 12.20.37
       '@types/sinon': 9.0.11
-      assert: 1.5.0
+      assert: 2.0.0
       chai: 4.3.4
       cross-env: 7.0.3
       dotenv: 8.6.0
@@ -9768,7 +9781,7 @@ packages:
     dev: false
 
   file:projects/communication-network-traversal.tgz:
-    resolution: {integrity: sha512-JXTNG52bxAFRcTo1kAVKSRqvLnZqtkLHJXBXc1VlynQ7zpChO9k/ixq5ys7NiKCxlte8RsMhe9sRM1TRSxCJfw==, tarball: file:projects/communication-network-traversal.tgz}
+    resolution: {integrity: sha512-LWKuzT2Al0OakAuUr++sol/eUDhx1U5kjxSh0d1xmXLbqDLKs6cjFbfUwJyDyJ4HVmyEc8ZX1zyGLKEV6PMARg==, tarball: file:projects/communication-network-traversal.tgz}
     name: '@rush-temp/communication-network-traversal'
     version: 0.0.0
     dependencies:
@@ -9784,7 +9797,7 @@ packages:
       '@types/mocha': 7.0.2
       '@types/node': 12.20.37
       '@types/sinon': 9.0.11
-      assert: 1.5.0
+      assert: 2.0.0
       chai: 4.3.4
       cross-env: 7.0.3
       dotenv: 8.6.0
@@ -9826,7 +9839,7 @@ packages:
     dev: false
 
   file:projects/communication-phone-numbers.tgz:
-    resolution: {integrity: sha512-H8X0AA9SgMlTlvkUReOytTon/R6E1EHAcecVbzLrplFpW3jglss1bC2SymppdT5ruSfGmMT/RGDpxqDvzExkaA==, tarball: file:projects/communication-phone-numbers.tgz}
+    resolution: {integrity: sha512-2oCxUErEXCra2geEzN1VkJkewxlFwYCvIZHqkVIPLdG30eMC5S6NyO9sRfn8rJrbirxJBNFZEz/Zc9EnGQDrUQ==, tarball: file:projects/communication-phone-numbers.tgz}
     name: '@rush-temp/communication-phone-numbers'
     version: 0.0.0
     dependencies:
@@ -9841,7 +9854,7 @@ packages:
       '@types/mocha': 7.0.2
       '@types/node': 12.20.37
       '@types/sinon': 9.0.11
-      assert: 1.5.0
+      assert: 2.0.0
       chai: 4.3.4
       cross-env: 7.0.3
       dotenv: 8.6.0
@@ -9883,7 +9896,7 @@ packages:
     dev: false
 
   file:projects/communication-short-codes.tgz:
-    resolution: {integrity: sha512-imnt2527n581p0dFDDFF7OPOEw5E2SwUpBU2O7fKnkLO2xf3umZ3kpxXNDlIe59pv9X0HK3oR37PaW06i4j8vw==, tarball: file:projects/communication-short-codes.tgz}
+    resolution: {integrity: sha512-NRkiPfhKNT5Wg09jonyd3I7cAqpelt34z8Gg5RSOd5Kfgq+SkDeLwkxy3qsDDL0HfS/vM9/DKLqy9L0RUk8ojQ==, tarball: file:projects/communication-short-codes.tgz}
     name: '@rush-temp/communication-short-codes'
     version: 0.0.0
     dependencies:
@@ -9899,7 +9912,7 @@ packages:
       '@types/mocha': 7.0.2
       '@types/node': 12.20.37
       '@types/sinon': 9.0.11
-      assert: 1.5.0
+      assert: 2.0.0
       chai: 4.3.4
       cross-env: 7.0.3
       dotenv: 8.6.0
@@ -9941,7 +9954,7 @@ packages:
     dev: false
 
   file:projects/communication-sms.tgz:
-    resolution: {integrity: sha512-XX2890G/sqzluIVyahS7ajPY4Np66iKjf8U9dXXnAwsHUDiD1xI0r/+QRk6gtaA/+HUHcCU08BI9jUZQmqjVRA==, tarball: file:projects/communication-sms.tgz}
+    resolution: {integrity: sha512-jVakTqWKBIWZiXMzKOcBci3Tj7/S53JAUzgdlewgo4+AtCRyAcxcDqW2yfOkQNvL0qwyctWuCclRAcaZQ85Tjw==, tarball: file:projects/communication-sms.tgz}
     name: '@rush-temp/communication-sms'
     version: 0.0.0
     dependencies:
@@ -9956,7 +9969,7 @@ packages:
       '@types/mocha': 7.0.2
       '@types/node': 12.20.37
       '@types/sinon': 9.0.11
-      assert: 1.5.0
+      assert: 2.0.0
       chai: 4.3.4
       cross-env: 7.0.3
       dotenv: 8.6.0
@@ -10989,7 +11002,7 @@ packages:
     dev: false
 
   file:projects/event-hubs.tgz:
-    resolution: {integrity: sha512-u60wc48AXg1Ak1a9ZKCtkoUsltHwtjcDcc+Z0EshNKTBqTHMpLug9YiQQJ0RX9LeYLzI4CTOO0STVvs2Jeoskw==, tarball: file:projects/event-hubs.tgz}
+    resolution: {integrity: sha512-c2zHGRWa/zR+v+LfTHi05xONu4JYK4xQa731vJIEzozjl5HCuVvXR567JTTgjPFo47UPYlr6Y0Twe9DxS5o9mQ==, tarball: file:projects/event-hubs.tgz}
     name: '@rush-temp/event-hubs'
     version: 0.0.0
     dependencies:
@@ -11012,7 +11025,7 @@ packages:
       '@types/sinon': 9.0.11
       '@types/uuid': 8.3.1
       '@types/ws': 7.4.7
-      assert: 1.5.0
+      assert: 2.0.0
       buffer: 6.0.3
       chai: 4.3.4
       chai-as-promised: 7.1.1_chai@4.3.4
@@ -11184,7 +11197,7 @@ packages:
     dev: false
 
   file:projects/eventhubs-checkpointstore-blob.tgz:
-    resolution: {integrity: sha512-zlmANI3IQuRtUDLzP2EGMCG793uIgXFNl9BiChwo8KJKgd5wuAiSdKNI/E59mNCHG8TZM1cuDPHB7GrCASUXKg==, tarball: file:projects/eventhubs-checkpointstore-blob.tgz}
+    resolution: {integrity: sha512-KA0KajJu1kDDLcPbnXUg8+dBA7Vcu1isQZrms4sgqOkmGhKsjtEm7b6hULb9DGbb1HjVp/oNpdAAl9SGBJRXkQ==, tarball: file:projects/eventhubs-checkpointstore-blob.tgz}
     name: '@rush-temp/eventhubs-checkpointstore-blob'
     version: 0.0.0
     dependencies:
@@ -11203,7 +11216,7 @@ packages:
       '@types/debug': 4.1.7
       '@types/mocha': 7.0.2
       '@types/node': 12.20.37
-      assert: 1.5.0
+      assert: 2.0.0
       chai: 4.3.4
       chai-as-promised: 7.1.1_chai@4.3.4
       chai-string: 1.5.0_chai@4.3.4
@@ -11250,7 +11263,7 @@ packages:
     dev: false
 
   file:projects/eventhubs-checkpointstore-table.tgz:
-    resolution: {integrity: sha512-IhmHN33M9hQqwZ716hAQESqAMrKkMV44b/PLCHLKB/HmYodMkI8YHGb9IDcelw6FoAzVarZtyTyfhrvP8sn+MQ==, tarball: file:projects/eventhubs-checkpointstore-table.tgz}
+    resolution: {integrity: sha512-t1pLtglN8KVgvM/OQd0RyCf4TdJV0RFfCzqW2UaTJcS6KJGgwd0ukEZpe0y3vxALPb2KyjwdQlB7AamM7x6mzg==, tarball: file:projects/eventhubs-checkpointstore-table.tgz}
     name: '@rush-temp/eventhubs-checkpointstore-table'
     version: 0.0.0
     dependencies:
@@ -11269,7 +11282,7 @@ packages:
       '@types/debug': 4.1.7
       '@types/mocha': 7.0.2
       '@types/node': 12.20.37
-      assert: 1.5.0
+      assert: 2.0.0
       chai: 4.3.4
       chai-as-promised: 7.1.1_chai@4.3.4
       chai-string: 1.5.0_chai@4.3.4
@@ -11315,7 +11328,7 @@ packages:
     dev: false
 
   file:projects/identity-cache-persistence.tgz:
-    resolution: {integrity: sha512-bn+kJWfekz/K7QAoZCaYhBkLGk5NJXqJxcc9I3MpirMbvqoe3bImtYW7MvbvXJjBcDEdBKCYZVM0Bjv62Juhmw==, tarball: file:projects/identity-cache-persistence.tgz}
+    resolution: {integrity: sha512-1ZohvGLk3UD9Tp5IxQK22XrOC7BCkvGQdHRg8N02BHuuDnpu72Q2ZAQvY4w/ezdfjViIHnIXkGNCq2Ezwu88RA==, tarball: file:projects/identity-cache-persistence.tgz}
     name: '@rush-temp/identity-cache-persistence'
     version: 0.0.0
     dependencies:
@@ -11327,7 +11340,7 @@ packages:
       '@types/node': 12.20.37
       '@types/qs': 6.9.7
       '@types/sinon': 9.0.11
-      assert: 1.5.0
+      assert: 2.0.0
       cross-env: 7.0.3
       dotenv: 8.6.0
       eslint: 7.32.0
@@ -11352,7 +11365,7 @@ packages:
     dev: false
 
   file:projects/identity-vscode.tgz:
-    resolution: {integrity: sha512-IvmWVktnEJpap3ZPqEue4f3T806qVYjhfAM+Y6jFdt/rC/SPPO5ST2/kfxNC/Pr/Xz2etkCoWvgEO+4z9X8htQ==, tarball: file:projects/identity-vscode.tgz}
+    resolution: {integrity: sha512-IljTKwwCEOzWJEu3BEvImx/L5k+0/fWSB8QrnwKjUGZ1KQ102yqxASWLToySUUNf0Ki2h8g4MoW+dHiAXepQvw==, tarball: file:projects/identity-vscode.tgz}
     name: '@rush-temp/identity-vscode'
     version: 0.0.0
     dependencies:
@@ -11363,7 +11376,7 @@ packages:
       '@types/qs': 6.9.7
       '@types/sinon': 9.0.11
       '@types/uuid': 8.3.1
-      assert: 1.5.0
+      assert: 2.0.0
       cross-env: 7.0.3
       dotenv: 8.6.0
       eslint: 7.32.0
@@ -11387,7 +11400,7 @@ packages:
     dev: false
 
   file:projects/identity.tgz:
-    resolution: {integrity: sha512-eCD9KQuFyyjZeb0kS077iCU4UDl5M8OLnndQsn0z11tRhRVHXLtdekSjiYbOcbCXUY9QFePX2ogJ7jdesrfqlg==, tarball: file:projects/identity.tgz}
+    resolution: {integrity: sha512-gzddBHu10CYusWY0CFlxdLFL5rMFYsZYoOiCI1W9w7a40HmWQy9uhsaQkM5i00wyqANalEL5ss0NVOIUlXyNaw==, tarball: file:projects/identity.tgz}
     name: '@rush-temp/identity'
     version: 0.0.0
     dependencies:
@@ -11403,7 +11416,7 @@ packages:
       '@types/sinon': 9.0.11
       '@types/stoppable': 1.1.1
       '@types/uuid': 8.3.1
-      assert: 1.5.0
+      assert: 2.0.0
       chai: 4.3.4
       cross-env: 7.0.3
       dotenv: 8.6.0
@@ -11525,7 +11538,7 @@ packages:
     dev: false
 
   file:projects/keyvault-admin.tgz:
-    resolution: {integrity: sha512-iVMo9LqkOfoBXihdqtxPmSvoQmPi9zFZ4fFpL0h1M9TpOP08eeRAmA5TFp4Cxcy7qZly3F6IHz8lRe3LNC7usA==, tarball: file:projects/keyvault-admin.tgz}
+    resolution: {integrity: sha512-vCBiC3lsTxY/QlGEcsWDpQ1mRItPR/kCvcRnYBfjt0a8g6Xr0kq7UZZD6kPotDM2Sg4kKVkXTQZcS8rrjjnr4Q==, tarball: file:projects/keyvault-admin.tgz}
     name: '@rush-temp/keyvault-admin'
     version: 0.0.0
     dependencies:
@@ -11543,7 +11556,7 @@ packages:
       '@types/node': 12.20.37
       '@types/sinon': 9.0.11
       '@types/uuid': 8.3.1
-      assert: 1.5.0
+      assert: 2.0.0
       chai: 4.3.4
       chai-as-promised: 7.1.1_chai@4.3.4
       cross-env: 7.0.3
@@ -11571,7 +11584,7 @@ packages:
     dev: false
 
   file:projects/keyvault-certificates.tgz:
-    resolution: {integrity: sha512-uwcMmHEi/l1kaX+RqQp+sEtSDUIYorlZ/j40KdXYwcys53250GDtEH888EzydWqdN8d6bLHG6bbVKIMPNGhcqg==, tarball: file:projects/keyvault-certificates.tgz}
+    resolution: {integrity: sha512-oWq+MPRNQ5K8wQosamWckvVBwpFKknKJSbMtL5BjUkxh3I0dAIwVEW1VfLLOe/gLJH+I+Z3GiIW5fhV//JkDqA==, tarball: file:projects/keyvault-certificates.tgz}
     name: '@rush-temp/keyvault-certificates'
     version: 0.0.0
     dependencies:
@@ -11587,7 +11600,7 @@ packages:
       '@types/mocha': 7.0.2
       '@types/node': 12.20.37
       '@types/sinon': 9.0.11
-      assert: 1.5.0
+      assert: 2.0.0
       chai: 4.3.4
       cross-env: 7.0.3
       dotenv: 8.6.0
@@ -11646,7 +11659,7 @@ packages:
     dev: false
 
   file:projects/keyvault-keys.tgz:
-    resolution: {integrity: sha512-lB2NNpBNlKc+zxXdpmP+QVhTk/E5Vpk1Rs4stsDAxfEcyDna4byDIh2ZfRZ+A77UB+Ye7nM7slOs5KK+pPrDzw==, tarball: file:projects/keyvault-keys.tgz}
+    resolution: {integrity: sha512-jJuRrInZYe/M+/Iz+QDbuqMyvHsBAFpPCby+Hiqj2jWThjZFtSSWshMncZIOGENSN138IWqE3iUe+j2RB/QrvQ==, tarball: file:projects/keyvault-keys.tgz}
     name: '@rush-temp/keyvault-keys'
     version: 0.0.0
     dependencies:
@@ -11662,7 +11675,7 @@ packages:
       '@types/mocha': 7.0.2
       '@types/node': 12.20.37
       '@types/sinon': 9.0.11
-      assert: 1.5.0
+      assert: 2.0.0
       chai: 4.3.4
       chai-as-promised: 7.1.1_chai@4.3.4
       chai-exclude: 2.1.0_chai@4.3.4
@@ -11709,7 +11722,7 @@ packages:
     dev: false
 
   file:projects/keyvault-secrets.tgz:
-    resolution: {integrity: sha512-+kqhTFsA8yXm5MOJt/Yb5KW84zhfTGfx5qAOqAqc+SNVBNSCvCom/LeT9xjr26fi8kKQl9Gh6AoU2RcmgHMmuQ==, tarball: file:projects/keyvault-secrets.tgz}
+    resolution: {integrity: sha512-kDN/CHaqMiqw0U2OfOESJWyWoil2Q9chxtqo1VWnRo8Q2gxPsbJ1zm2P9NeAh1A+Nqxgx/e6kUxKnv6HTKXeiw==, tarball: file:projects/keyvault-secrets.tgz}
     name: '@rush-temp/keyvault-secrets'
     version: 0.0.0
     dependencies:
@@ -11724,7 +11737,7 @@ packages:
       '@types/mocha': 7.0.2
       '@types/node': 12.20.37
       '@types/sinon': 9.0.11
-      assert: 1.5.0
+      assert: 2.0.0
       chai: 4.3.4
       cross-env: 7.0.3
       dotenv: 8.6.0
@@ -12653,7 +12666,7 @@ packages:
     dev: false
 
   file:projects/schema-registry-avro.tgz:
-    resolution: {integrity: sha512-es1wTz4ESP2fxE8Wky3jiVQdorQHXzokj57HKP5pNkP4WnDy+0p20f6dQZAgH1abgNsYYha8yK+vK/i2txJ+AQ==, tarball: file:projects/schema-registry-avro.tgz}
+    resolution: {integrity: sha512-35agTFs5ffVjxETd28kTXTFaPA1IKu6rGeGKxb0mBeIN44hPM96P2uLG/+MPGjhvYAtJmVHjB/1sHn2HLE/Kew==, tarball: file:projects/schema-registry-avro.tgz}
     name: '@rush-temp/schema-registry-avro'
     version: 0.0.0
     dependencies:
@@ -12811,7 +12824,7 @@ packages:
     dev: false
 
   file:projects/service-bus.tgz:
-    resolution: {integrity: sha512-O0Fzn9c6IdZdNX8eOqwh+o6KelkxkcBZD9womwBijoPxqd0kAWdtnzV9sq+kbBNDXb7j+WAo3lKOQ6ZyUMuPww==, tarball: file:projects/service-bus.tgz}
+    resolution: {integrity: sha512-jvrtFCllOTTjJht9CcrcLye9HCe/HBQbbhiNrWlfDq9EJy5j/qLAIq+wQ2lqmQD7eXjKIbhZTr+RFflKBRWIqw==, tarball: file:projects/service-bus.tgz}
     name: '@rush-temp/service-bus'
     version: 0.0.0
     dependencies:
@@ -12833,7 +12846,7 @@ packages:
       '@types/node': 12.20.37
       '@types/sinon': 9.0.11
       '@types/ws': 7.4.7
-      assert: 1.5.0
+      assert: 2.0.0
       buffer: 6.0.3
       chai: 4.3.4
       chai-as-promised: 7.1.1_chai@4.3.4
@@ -12890,7 +12903,7 @@ packages:
     dev: false
 
   file:projects/storage-blob-changefeed.tgz:
-    resolution: {integrity: sha512-VGsLe3QuXI6wbkiphVieGfv4MUpLKi+iXU2zHDACCIMqqmPlQCOfxFy/dVySDLfBZWFyuW/IXeY2LYSypwBklg==, tarball: file:projects/storage-blob-changefeed.tgz}
+    resolution: {integrity: sha512-8S/GipKP4QzBT4zTEvHnvJ5KukjI5N59hpNoZdwqsH1HvQTTPu9gRPZ3lEJIP0x5RdnydKD3M99vX6KnE1IrOg==, tarball: file:projects/storage-blob-changefeed.tgz}
     name: '@rush-temp/storage-blob-changefeed'
     version: 0.0.0
     dependencies:
@@ -12904,7 +12917,7 @@ packages:
       '@types/mocha': 7.0.2
       '@types/node': 12.20.37
       '@types/sinon': 9.0.11
-      assert: 1.5.0
+      assert: 2.0.0
       cross-env: 7.0.3
       dotenv: 8.6.0
       downlevel-dts: 0.4.0
@@ -12954,7 +12967,7 @@ packages:
     dev: false
 
   file:projects/storage-blob.tgz:
-    resolution: {integrity: sha512-b1nHoHla4RKc9OA/lfyeQEddBfNSxy7HpP1YRZuhQw7QFZysNv9WVjdMywiHMaP+bnGHiaHoCOVBJa/Yk2Ilkg==, tarball: file:projects/storage-blob.tgz}
+    resolution: {integrity: sha512-7YWTpRKxFwEFn/M0PhueyTCxPMGfWeLmBAdPWX17RpcQUG1VyxUpabYRuSiJsyTPQfh/sgbxXLfwV1CJ8dcXXg==, tarball: file:projects/storage-blob.tgz}
     name: '@rush-temp/storage-blob'
     version: 0.0.0
     dependencies:
@@ -12968,7 +12981,7 @@ packages:
       '@types/mocha': 7.0.2
       '@types/node': 12.20.37
       '@types/node-fetch': 2.5.12
-      assert: 1.5.0
+      assert: 2.0.0
       cross-env: 7.0.3
       dotenv: 8.6.0
       downlevel-dts: 0.4.0
@@ -13018,7 +13031,7 @@ packages:
     dev: false
 
   file:projects/storage-file-datalake.tgz:
-    resolution: {integrity: sha512-QPJrLbmZqRY28DrDri/iF0R2yFimNq7qH2tQk9WuhztNeudzfxV+shKdIwDBiBRmVNMH3WHLIbQISkpoR1IkAQ==, tarball: file:projects/storage-file-datalake.tgz}
+    resolution: {integrity: sha512-VO/uuj9UcXkB1aWolpScgugf7aoNROYnqSCudlktldrW/qey1htMT0wHYnk7hJgW+afg7uv0htXp1EccI2jxwg==, tarball: file:projects/storage-file-datalake.tgz}
     name: '@rush-temp/storage-file-datalake'
     version: 0.0.0
     dependencies:
@@ -13031,7 +13044,7 @@ packages:
       '@rollup/plugin-replace': 2.4.2_rollup@1.32.1
       '@types/mocha': 7.0.2
       '@types/node': 12.20.37
-      assert: 1.5.0
+      assert: 2.0.0
       cross-env: 7.0.3
       dotenv: 8.6.0
       downlevel-dts: 0.4.0
@@ -13081,7 +13094,7 @@ packages:
     dev: false
 
   file:projects/storage-file-share.tgz:
-    resolution: {integrity: sha512-p7dhiAVH8TV/4KJQG/VvNUeQCwanCueE7Jfk2zjWOSAQvxEGuwyXnqbfISaj5D1UuL/UgJ9ue31JJycZYYvRRA==, tarball: file:projects/storage-file-share.tgz}
+    resolution: {integrity: sha512-qgneL6ncQSdoFVBEfNKD8TriwdCtcxxUlsmyHaUj4VPQ8u8ObHKqBWZkiO0uNKc8CRcBiGduBzGb0mKJRoyZJQ==, tarball: file:projects/storage-file-share.tgz}
     name: '@rush-temp/storage-file-share'
     version: 0.0.0
     dependencies:
@@ -13093,7 +13106,7 @@ packages:
       '@rollup/plugin-replace': 2.4.2_rollup@1.32.1
       '@types/mocha': 7.0.2
       '@types/node': 12.20.37
-      assert: 1.5.0
+      assert: 2.0.0
       cross-env: 7.0.3
       dotenv: 8.6.0
       downlevel-dts: 0.4.0
@@ -13142,7 +13155,7 @@ packages:
     dev: false
 
   file:projects/storage-internal-avro.tgz:
-    resolution: {integrity: sha512-h4R5NafhZZvBq8OM9gK3/YFjhV7gSzIMWbQMy8FYpF8psshzU9pHkWGwpIEkJuGNiDzAacOdbHub5i0sKRqHdA==, tarball: file:projects/storage-internal-avro.tgz}
+    resolution: {integrity: sha512-26HSBCyPxXnHGiIJ7mUCHzGT2RLBtCFVmsuHoQjt8pxzvgyVCstMDYQ2+Qcizvlv7omMCS9NaoSerd3Syc41Gw==, tarball: file:projects/storage-internal-avro.tgz}
     name: '@rush-temp/storage-internal-avro'
     version: 0.0.0
     dependencies:
@@ -13153,7 +13166,7 @@ packages:
       '@rollup/plugin-replace': 2.4.2_rollup@1.32.1
       '@types/mocha': 7.0.2
       '@types/node': 12.20.37
-      assert: 1.5.0
+      assert: 2.0.0
       dotenv: 8.6.0
       downlevel-dts: 0.4.0
       es6-promise: 4.2.8
@@ -13199,7 +13212,7 @@ packages:
     dev: false
 
   file:projects/storage-queue.tgz:
-    resolution: {integrity: sha512-g1EWancq1sqsOP/UZLutMo2pqaIe13Wk0LJ996sJSrDpgGt9GFN0iTeM8JXxV48U41Ze/nPVrXy0yWFQjT16wA==, tarball: file:projects/storage-queue.tgz}
+    resolution: {integrity: sha512-shDa4FjmRHxpve8Dm1DGqAjdorFeL6P4DMOA8dOBiXhT+3VBQW+xTsX/oQgKBL+4WYHEhfezv4fMGz6J6gVuaA==, tarball: file:projects/storage-queue.tgz}
     name: '@rush-temp/storage-queue'
     version: 0.0.0
     dependencies:
@@ -13211,7 +13224,7 @@ packages:
       '@rollup/plugin-replace': 2.4.2_rollup@1.32.1
       '@types/mocha': 7.0.2
       '@types/node': 12.20.37
-      assert: 1.5.0
+      assert: 2.0.0
       cross-env: 7.0.3
       dotenv: 8.6.0
       downlevel-dts: 0.4.0
@@ -13583,7 +13596,7 @@ packages:
     dev: false
 
   file:projects/test-recorder-new.tgz:
-    resolution: {integrity: sha512-w/Zii/SpFvK01jA/kmC4Fwy29GlhBeBe9R9WP6d7p0yT2ENP0sCYc8an2dmyhOuwA+QFIoMZI1f59Awmx4hggA==, tarball: file:projects/test-recorder-new.tgz}
+    resolution: {integrity: sha512-2ZpucefoPAPvOYedg2rkAYe5kKIpSgxPd+7vTYfkm4oz6bLtxES+fvECqktN+J2Zk8gGmZohSvTSSfV+RBc4zg==, tarball: file:projects/test-recorder-new.tgz}
     name: '@rush-temp/test-recorder-new'
     version: 0.0.0
     dependencies:
@@ -13646,7 +13659,7 @@ packages:
     dev: false
 
   file:projects/test-recorder.tgz:
-    resolution: {integrity: sha512-uZ1ALIuLgV6XWWo4MBQ+nLfbw4txKZYJfJ8/GYWQfNyCQi6nEg4Bo0kfOUk0cvSqZRwUNM/+mND9qqmHps2RBg==, tarball: file:projects/test-recorder.tgz}
+    resolution: {integrity: sha512-bm6Rx6QWOzW0aNv8lVTKvBX1QlWE0nuVdIdZWb1wFhtEbDAZksRkWq5xFgnaNDgxpILM/IhZmS5Su68XytwNWg==, tarball: file:projects/test-recorder.tgz}
     name: '@rush-temp/test-recorder'
     version: 0.0.0
     dependencies:
@@ -13766,7 +13779,7 @@ packages:
     dev: false
 
   file:projects/testing-recorder-new.tgz:
-    resolution: {integrity: sha512-H8ns2GLWDfXpV5dtOh7Kxhg0YMVje5oFFzcD+4aGF4erEIjQsmkBE09mmjNnTaJdELb4LQcVhq5HOQ8wxRbPRQ==, tarball: file:projects/testing-recorder-new.tgz}
+    resolution: {integrity: sha512-LQ9WLbbCZ1vVpj7fzrWF+ql1zI6qElwBWHHRSBQc3YQHrkQ7TOFBL5ke4iBcbxaJFsrRT55jzIohJJHuo2sGXg==, tarball: file:projects/testing-recorder-new.tgz}
     name: '@rush-temp/testing-recorder-new'
     version: 0.0.0
     dependencies:
@@ -13872,7 +13885,7 @@ packages:
     dev: false
 
   file:projects/web-pubsub-express.tgz:
-    resolution: {integrity: sha512-Lo9UvjD8tDlR/EFi5d4mIezt9UuwSChzouW/PbvTxVr61oCNFPPgR5d/52fLh2lPe0OFtofBV0C/IviZg89weA==, tarball: file:projects/web-pubsub-express.tgz}
+    resolution: {integrity: sha512-8iURk25tNKZUPQHmsDhNxjgnD5coG+74AnTPKKrI6b996p6vvpUTEJtM1+xCpeF+MrvLiN10OYc3zHk/vCy0qw==, tarball: file:projects/web-pubsub-express.tgz}
     name: '@rush-temp/web-pubsub-express'
     version: 0.0.0
     dependencies:
@@ -13889,7 +13902,7 @@ packages:
       '@types/mocha': 7.0.2
       '@types/node': 12.20.37
       '@types/sinon': 9.0.11
-      assert: 1.5.0
+      assert: 2.0.0
       chai: 4.3.4
       cloudevents: 4.0.3
       cross-env: 7.0.3

--- a/sdk/appconfiguration/app-configuration/package.json
+++ b/sdk/appconfiguration/app-configuration/package.json
@@ -110,7 +110,7 @@
     "@types/mocha": "^7.0.2",
     "@types/node": "^12.0.0",
     "@types/sinon": "^9.0.4",
-    "assert": "^1.4.1",
+    "assert": "^2.0.0",
     "chai": "^4.2.0",
     "dotenv": "^8.2.0",
     "eslint": "^7.15.0",

--- a/sdk/communication/communication-chat/package.json
+++ b/sdk/communication/communication-chat/package.json
@@ -93,7 +93,7 @@
     "@types/node": "^12.0.0",
     "@types/sinon": "^9.0.4",
     "@types/uuid": "^8.0.0",
-    "assert": "^1.4.1",
+    "assert": "^2.0.0",
     "chai": "^4.2.0",
     "cross-env": "^7.0.2",
     "dotenv": "^8.2.0",

--- a/sdk/communication/communication-common/package.json
+++ b/sdk/communication/communication-common/package.json
@@ -85,7 +85,7 @@
     "@types/mocha": "^7.0.2",
     "@types/node": "^12.0.0",
     "@types/sinon": "^9.0.4",
-    "assert": "^1.4.1",
+    "assert": "^2.0.0",
     "chai-as-promised": "^7.1.1",
     "chai": "^4.2.0",
     "cross-env": "^7.0.2",

--- a/sdk/communication/communication-identity/package.json
+++ b/sdk/communication/communication-identity/package.json
@@ -99,7 +99,7 @@
     "@types/mocha": "^7.0.2",
     "@types/sinon": "^9.0.4",
     "@types/node": "^12.0.0",
-    "assert": "^1.4.1",
+    "assert": "^2.0.0",
     "chai": "^4.2.0",
     "cross-env": "^7.0.2",
     "dotenv": "^8.2.0",

--- a/sdk/communication/communication-network-traversal/package.json
+++ b/sdk/communication/communication-network-traversal/package.json
@@ -98,7 +98,7 @@
     "@types/mocha": "^7.0.2",
     "@types/node": "^12.0.0",
     "@types/sinon": "^9.0.4",
-    "assert": "^1.4.1",
+    "assert": "^2.0.0",
     "chai": "^4.2.0",
     "cross-env": "^7.0.2",
     "dotenv": "^8.2.0",

--- a/sdk/communication/communication-phone-numbers/package.json
+++ b/sdk/communication/communication-phone-numbers/package.json
@@ -87,7 +87,7 @@
     "@types/mocha": "^7.0.2",
     "@types/sinon": "^9.0.4",
     "@types/node": "^12.0.0",
-    "assert": "^1.4.1",
+    "assert": "^2.0.0",
     "chai": "^4.2.0",
     "cross-env": "^7.0.2",
     "dotenv": "^8.2.0",

--- a/sdk/communication/communication-short-codes/package.json
+++ b/sdk/communication/communication-short-codes/package.json
@@ -87,7 +87,7 @@
     "@types/mocha": "^7.0.2",
     "@types/node": "^12.0.0",
     "@types/sinon": "^9.0.4",
-    "assert": "^1.4.1",
+    "assert": "^2.0.0",
     "chai": "^4.2.0",
     "cross-env": "^7.0.2",
     "dotenv": "^8.2.0",

--- a/sdk/communication/communication-sms/package.json
+++ b/sdk/communication/communication-sms/package.json
@@ -89,7 +89,7 @@
     "@types/mocha": "^7.0.2",
     "@types/node": "^12.0.0",
     "@types/sinon": "^9.0.4",
-    "assert": "^1.4.1",
+    "assert": "^2.0.0",
     "chai": "^4.2.0",
     "cross-env": "^7.0.2",
     "dotenv": "^8.2.0",

--- a/sdk/eventhub/event-hubs/package.json
+++ b/sdk/eventhub/event-hubs/package.json
@@ -146,7 +146,7 @@
     "@types/sinon": "^9.0.4",
     "@types/uuid": "^8.0.0",
     "@types/ws": "^7.2.4",
-    "assert": "^1.4.1",
+    "assert": "^2.0.0",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
     "chai-exclude": "^2.0.2",

--- a/sdk/eventhub/eventhubs-checkpointstore-blob/package.json
+++ b/sdk/eventhub/eventhubs-checkpointstore-blob/package.json
@@ -82,7 +82,7 @@
     "@types/debug": "^4.1.4",
     "@types/mocha": "^7.0.2",
     "@types/node": "^12.0.0",
-    "assert": "^1.4.1",
+    "assert": "^2.0.0",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
     "chai-string": "^1.5.0",

--- a/sdk/eventhub/eventhubs-checkpointstore-table/package.json
+++ b/sdk/eventhub/eventhubs-checkpointstore-table/package.json
@@ -81,7 +81,7 @@
     "@types/debug": "^4.1.4",
     "@types/mocha": "^7.0.2",
     "@types/node": "^12.0.0",
-    "assert": "^1.4.1",
+    "assert": "^2.0.0",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
     "chai-string": "^1.5.0",

--- a/sdk/identity/identity-cache-persistence/package.json
+++ b/sdk/identity/identity-cache-persistence/package.json
@@ -77,7 +77,7 @@
     "@types/mocha": "^7.0.2",
     "@types/node": "^12.0.0",
     "@types/qs": "^6.5.3",
-    "assert": "^1.4.1",
+    "assert": "^2.0.0",
     "cross-env": "^7.0.2",
     "dotenv": "^8.2.0",
     "eslint": "^7.15.0",

--- a/sdk/identity/identity-vscode/package.json
+++ b/sdk/identity/identity-vscode/package.json
@@ -76,7 +76,7 @@
     "@types/qs": "^6.5.3",
     "@types/sinon": "^9.0.4",
     "@types/uuid": "^8.0.0",
-    "assert": "^1.4.1",
+    "assert": "^2.0.0",
     "cross-env": "^7.0.2",
     "dotenv": "^8.2.0",
     "eslint": "^7.15.0",

--- a/sdk/identity/identity/package.json
+++ b/sdk/identity/identity/package.json
@@ -122,7 +122,7 @@
     "@types/uuid": "^8.0.0",
     "@types/chai": "^4.1.6",
     "chai": "^4.2.0",
-    "assert": "^1.4.1",
+    "assert": "^2.0.0",
     "cross-env": "^7.0.2",
     "dotenv": "^8.2.0",
     "eslint": "^7.15.0",

--- a/sdk/keyvault/keyvault-admin/package.json
+++ b/sdk/keyvault/keyvault-admin/package.json
@@ -135,7 +135,7 @@
     "@types/mocha": "^7.0.2",
     "@types/node": "^12.0.0",
     "@types/sinon": "^9.0.4",
-    "assert": "^1.4.1",
+    "assert": "^2.0.0",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
     "cross-env": "^7.0.2",

--- a/sdk/keyvault/keyvault-certificates/package.json
+++ b/sdk/keyvault/keyvault-certificates/package.json
@@ -131,7 +131,7 @@
     "@types/mocha": "^7.0.2",
     "@types/node": "^12.0.0",
     "@types/sinon": "^9.0.4",
-    "assert": "^1.4.1",
+    "assert": "^2.0.0",
     "chai": "^4.2.0",
     "cross-env": "^7.0.2",
     "dotenv": "^8.2.0",

--- a/sdk/keyvault/keyvault-keys/package.json
+++ b/sdk/keyvault/keyvault-keys/package.json
@@ -128,7 +128,7 @@
     "@types/mocha": "^7.0.2",
     "@types/node": "^12.0.0",
     "@types/sinon": "^9.0.4",
-    "assert": "^1.4.1",
+    "assert": "^2.0.0",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
     "chai-exclude": "^2.0.2",

--- a/sdk/keyvault/keyvault-secrets/package.json
+++ b/sdk/keyvault/keyvault-secrets/package.json
@@ -126,7 +126,7 @@
     "@types/mocha": "^7.0.2",
     "@types/node": "^12.0.0",
     "@types/sinon": "^9.0.4",
-    "assert": "^1.4.1",
+    "assert": "^2.0.0",
     "chai": "^4.2.0",
     "cross-env": "^7.0.2",
     "dotenv": "^8.2.0",

--- a/sdk/servicebus/service-bus/package.json
+++ b/sdk/servicebus/service-bus/package.json
@@ -144,7 +144,7 @@
     "@types/mocha": "^7.0.2",
     "@types/node": "^12.0.0",
     "@types/ws": "^7.2.4",
-    "assert": "^1.4.1",
+    "assert": "^2.0.0",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
     "chai-exclude": "^2.0.2",

--- a/sdk/storage/storage-blob-changefeed/package.json
+++ b/sdk/storage/storage-blob-changefeed/package.json
@@ -114,7 +114,7 @@
     "@types/mocha": "^7.0.2",
     "@types/node": "^12.0.0",
     "@types/sinon": "^9.0.4",
-    "assert": "^1.4.1",
+    "assert": "^2.0.0",
     "cross-env": "^7.0.2",
     "dotenv": "^8.2.0",
     "downlevel-dts": "~0.4.0",

--- a/sdk/storage/storage-blob/package.json
+++ b/sdk/storage/storage-blob/package.json
@@ -149,7 +149,7 @@
     "@types/mocha": "^7.0.2",
     "@types/node": "^12.0.0",
     "@types/node-fetch": "^2.5.0",
-    "assert": "^1.4.1",
+    "assert": "^2.0.0",
     "cross-env": "^7.0.2",
     "dotenv": "^8.2.0",
     "downlevel-dts": "~0.4.0",

--- a/sdk/storage/storage-file-datalake/package.json
+++ b/sdk/storage/storage-file-datalake/package.json
@@ -129,7 +129,7 @@
     "@rollup/plugin-replace": "^2.2.0",
     "@types/mocha": "^7.0.2",
     "@types/node": "^12.0.0",
-    "assert": "^1.4.1",
+    "assert": "^2.0.0",
     "cross-env": "^7.0.2",
     "dotenv": "^8.2.0",
     "downlevel-dts": "~0.4.0",

--- a/sdk/storage/storage-file-share/package.json
+++ b/sdk/storage/storage-file-share/package.json
@@ -135,7 +135,7 @@
     "@rollup/plugin-replace": "^2.2.0",
     "@types/mocha": "^7.0.2",
     "@types/node": "^12.0.0",
-    "assert": "^1.4.1",
+    "assert": "^2.0.0",
     "cross-env": "^7.0.2",
     "dotenv": "^8.2.0",
     "downlevel-dts": "~0.4.0",

--- a/sdk/storage/storage-internal-avro/package.json
+++ b/sdk/storage/storage-internal-avro/package.json
@@ -76,7 +76,7 @@
     "@rollup/plugin-replace": "^2.2.0",
     "@types/mocha": "^7.0.2",
     "@types/node": "^12.0.0",
-    "assert": "^1.4.1",
+    "assert": "^2.0.0",
     "dotenv": "^8.2.0",
     "downlevel-dts": "~0.4.0",
     "es6-promise": "^4.2.5",

--- a/sdk/storage/storage-queue/package.json
+++ b/sdk/storage/storage-queue/package.json
@@ -128,7 +128,7 @@
     "@rollup/plugin-replace": "^2.2.0",
     "@types/mocha": "^7.0.2",
     "@types/node": "^12.0.0",
-    "assert": "^1.4.1",
+    "assert": "^2.0.0",
     "cross-env": "^7.0.2",
     "dotenv": "^8.2.0",
     "downlevel-dts": "~0.4.0",

--- a/sdk/web-pubsub/web-pubsub-express/package.json
+++ b/sdk/web-pubsub/web-pubsub-express/package.json
@@ -77,7 +77,7 @@
     "@types/mocha": "^7.0.2",
     "@types/node": "^12.0.0",
     "@types/sinon": "^9.0.4",
-    "assert": "^1.4.1",
+    "assert": "^2.0.0",
     "chai": "^4.2.0",
     "cross-env": "^7.0.2",
     "dotenv": "^8.2.0",


### PR DESCRIPTION
Solves https://github.com/Azure/azure-sdk-for-js/issues/17110.
Upgrading [assert](https://www.npmjs.com/package/assert/v/2.0.0) dev dependency from `1.4.1` to `2.0.0`. 

Looking at the changelog, there should not be any breaking changes. It is worth mentioning that support for IE9 and IE10 has been dropped.

Draft PR to run the tests and discard any breaking changes.
