### PR TITLE
[KeyVault] - Use RBAC for permissions

### DIFF
--- a/sdk/keyvault/test-resources.json
+++ b/sdk/keyvault/test-resources.json
@@ -82,6 +82,8 @@
     "mgmtApiVersion": "2019-04-01",
     "blobContainerName": "hsmbackups",
     "primaryAccountName": "[concat(replace(parameters('baseName'), '-', ''), 'prim')]",
+    "kvAdminDefinitionId": "00482a5a-887f-4fb3-b363-3b7fe8e74483",
+    "kvAdminAssignmentName": "[guid(resourceGroup().id, variables('kvAdminDefinitionId'), parameters('testApplicationOid'))]",
     "encryption": {
       "services": {
         "blob": {
@@ -117,57 +119,22 @@
           "name": "[parameters('keyVaultSku')]"
         },
         "tenantId": "[parameters('tenantId')]",
-        "accessPolicies": [
-          {
-            "tenantId": "[parameters('tenantId')]",
-            "objectId": "[parameters('testApplicationOid')]",
-            "permissions": {
-              "keys": [
-                "get",
-                "list",
-                "update",
-                "create",
-                "import",
-                "delete",
-                "recover",
-                "backup",
-                "restore",
-                "decrypt",
-                "encrypt",
-                "unwrapKey",
-                "wrapKey",
-                "verify",
-                "sign",
-                "purge",
-                "rotate"
-              ],
-              "secrets": ["get", "list", "set", "delete", "recover", "backup", "restore", "purge"],
-              "certificates": [
-                "get",
-                "list",
-                "update",
-                "create",
-                "import",
-                "delete",
-                "recover",
-                "backup",
-                "restore",
-                "managecontacts",
-                "manageissuers",
-                "getissuers",
-                "listissuers",
-                "setissuers",
-                "deleteissuers",
-                "purge"
-              ]
-            }
-          }
-        ],
         "enabledForDeployment": false,
         "enabledForDiskEncryption": false,
         "enabledForTemplateDeployment": false,
         "enableSoftDelete": true,
+        "enableRbacAuthorization": true,
         "softDeleteRetentionInDays": 7
+      }
+    },
+    {
+      "type": "Microsoft.Authorization/roleAssignments",
+      "apiVersion": "2020-04-01-preview",
+      "name": "[variables('kvAdminAssignmentName')]",
+      "properties": {
+        "roleDefinitionId": "[resourceId('Microsoft.Authorization/roleDefinitions', variables('kvAdminDefinitionId'))]",
+        "principalId": "[parameters('testApplicationOid')]",
+        "scope": "[resourceGroup().id]"
       }
     },
     {


### PR DESCRIPTION
## What

- Remove access permissions from ARM template
- Switch to RBAC based permission model for KV

## Why

Due to a recent permission that was added on the service side, our nightly tests
started failing as the ARM template has not been updated with the new
permission. Instead of adding the permissions, Heath noticed that we can switch
to RBAC roles now and avoid having to chase these things are they're added.

This commit just ports that over to Azure SDK for JS.
