### PR TITLE
[App Config] Secret reference sample update

### DIFF
--- a/sdk/appconfiguration/app-configuration/samples-dev/secretReference.ts
+++ b/sdk/appconfiguration/app-configuration/samples-dev/secretReference.ts
@@ -13,7 +13,7 @@ import {
   ConfigurationSetting,
   parseSecretReference
 } from "@azure/app-configuration";
-import { SecretClient } from "@azure/keyvault-secrets";
+import { parseKeyVaultSecretIdentifier, SecretClient } from "@azure/keyvault-secrets";
 import { DefaultAzureCredential } from "@azure/identity";
 
 // Load the .env file if it exists
@@ -22,67 +22,95 @@ dotenv.config();
 
 export async function main() {
   console.log(`Running secretReference sample`);
-  const secretReference: ConfigurationSetting<SecretReferenceValue> = {
-    key: `secret${new Date().getTime()}`,
-    value: {
-      secretId: `secret-key${Math.ceil(100 + Math.random() * 900)}`
-    },
-    isReadOnly: false,
-    contentType: secretReferenceContentType
-  };
 
+  const key = `secret${new Date().getTime()}`;
+
+  // setup
+  // - creates a secret using `@azure/keyvault-secrets`
+  // and
+  // - a corresponding secret reference config setting with `@azure/app-configuration`
+  await setup(key);
+
+  console.log(`Get the added secretReference from App Config with key: ${key}`);
+  // Set the following environment variable or edit the value on the following line.
+  const connectionString = process.env["APPCONFIG_CONNECTION_STRING"] || "";
+  const appConfigClient = new AppConfigurationClient(connectionString);
+  const getResponse = await appConfigClient.getConfigurationSetting({
+    key
+  });
+  // You can use the `isSecretReference` global method to check if the content type is secretReferenceContentType ("application/vnd.microsoft.appconfig.keyvaultref+json;charset=utf-8")
+
+  const parsedSecretReference = parseSecretReference(getResponse);
+
+  // Get the name and vaultUrl from the secretId
+  const { name: secretName, vaultUrl } = parseKeyVaultSecretIdentifier(
+    parsedSecretReference.value.secretId
+  );
+
+  const secretClient = new SecretClient(vaultUrl, new DefaultAzureCredential());
+
+  // Read the secret we created
+  const secret = await secretClient.getSecret(secretName);
+  console.log(`Get the secret from keyvault key: ${secretName}, value: ${secret.value}`);
+
+  console.log(`Deleting the secret from keyvault`);
+  await secretClient.beginDeleteSecret(secretName);
+
+  await cleanupSampleValues([key], appConfigClient);
+}
+
+async function setup(key: string) {
   if (
     !process.env["AZURE_TENANT_ID"] ||
     !process.env["AZURE_CLIENT_ID"] ||
     !process.env["AZURE_CLIENT_SECRET"] ||
-    !process.env["KEYVAULT_URI"]
+    !process.env["KEYVAULT_URI"] ||
+    !process.env["APPCONFIG_CONNECTION_STRING"]
   ) {
     console.log(
-      `At least one of the AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET, and KEYVAULT_URI variables is not present, 
+      `At least one of the AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET, APPCONFIG_CONNECTION_STRING and KEYVAULT_URI variables is not present, 
       please add the missing ones in your environment and rerun the sample.`
     );
     return;
   }
+
+  let uri = process.env["KEYVAULT_URI"] || "<keyvault-uri>";
+  uri = !uri.endsWith("/") ? `${uri}/` : uri;
+  const secretId = `${uri}secrets/secret-key${Math.ceil(100 + Math.random() * 900)}`;
+
   // DefaultAzureCredential expects the following three environment variables:
   // - AZURE_TENANT_ID: The tenant ID in Azure Active Directory
   // - AZURE_CLIENT_ID: The application (client) ID registered in the AAD tenant
   // - AZURE_CLIENT_SECRET: The client secret for the registered application
-  const credential = new DefaultAzureCredential();
-  const url = process.env["KEYVAULT_URI"] || "<keyvault-url>";
+  const secretClient = new SecretClient(uri, new DefaultAzureCredential());
 
-  const secretClient = new SecretClient(url, credential);
+  const secretName = parseKeyVaultSecretIdentifier(secretId).name;
   // Create a secret
-  console.log(
-    `Create a keyvault secret with key: ${secretReference.value.secretId} and value: "MySecretValue"`
-  );
-  await secretClient.setSecret(secretReference.value.secretId, "MySecretValue");
+  console.log(`Create a keyvault secret with key: ${secretName} and value: "MySecretValue"`);
+  await secretClient.setSecret(secretName, "MySecretValue");
 
+  // creates the secret reference config setting
+  await createConfigSetting(key, secretId);
+}
+
+async function createConfigSetting(key: string, secretId: string) {
   // Set the following environment variable or edit the value on the following line.
   const connectionString = process.env["APPCONFIG_CONNECTION_STRING"] || "<connection string>";
   const appConfigClient = new AppConfigurationClient(connectionString);
 
-  await cleanupSampleValues([secretReference.key], appConfigClient);
+  const secretReference: ConfigurationSetting<SecretReferenceValue> = {
+    key,
+    value: { secretId },
+    isReadOnly: false,
+    contentType: secretReferenceContentType
+  };
+
+  await cleanupSampleValues([key], appConfigClient);
 
   console.log(
-    `Add a new secretReference with key: ${secretReference.key} and secretId: ${secretReference.value.secretId}`
+    `Add a new secretReference with key: ${key} and secretId: ${secretReference.value.secretId}`
   );
   await appConfigClient.addConfigurationSetting(secretReference);
-
-  console.log(`Get the added secretReference from App Config with key: ${secretReference.key}`);
-  const getResponse = await appConfigClient.getConfigurationSetting({
-    key: secretReference.key
-  });
-
-  // You can use the `isSecretReference` global method to check if the content type is secretReferenceContentType ("application/vnd.microsoft.appconfig.keyvaultref+json;charset=utf-8")
-  const parsedSecretReference = parseSecretReference(getResponse);
-  // Read the secret we created
-  const secret = await secretClient.getSecret(parsedSecretReference.value.secretId);
-  console.log(`Get the secret from keyvault key: ${secret.name}, value: ${secret.value}`);
-
-  console.log(`Deleting the secret from keyvault`);
-  await secretClient.beginDeleteSecret(parsedSecretReference.value.secretId);
-
-  await cleanupSampleValues([secretReference.key], appConfigClient);
 }
 
 async function cleanupSampleValues(keys: string[], client: AppConfigurationClient) {

--- a/sdk/appconfiguration/app-configuration/samples-dev/secretReference.ts
+++ b/sdk/appconfiguration/app-configuration/samples-dev/secretReference.ts
@@ -47,10 +47,20 @@ export async function main() {
   );
 
   const secretClient = new SecretClient(vaultUrl, new DefaultAzureCredential());
-
-  // Read the secret we created
-  const secret = await secretClient.getSecret(secretName);
-  console.log(`Get the secret from keyvault key: ${secretName}, value: ${secret.value}`);
+  try {
+    // Read the secret we created
+    const secret = await secretClient.getSecret(secretName);
+    console.log(`Get the secret from keyvault key: ${secretName}, value: ${secret.value}`);
+  } catch (err) {
+    const error = err as { code: string; statusCode: number };
+    if (error.code === "SecretNotFound" && error.statusCode === 404) {
+      throw new Error(
+        `\n Secret is not found, make sure the secret ${parsedSecretReference.value.secretId} is present in your keyvault account;\n Original error - ${error}`
+      );
+    } else {
+      throw err;
+    }
+  }
 
   console.log(`Deleting the secret from keyvault`);
   await secretClient.beginDeleteSecret(secretName);

--- a/sdk/appconfiguration/app-configuration/samples-dev/secretReference.ts
+++ b/sdk/appconfiguration/app-configuration/samples-dev/secretReference.ts
@@ -27,7 +27,7 @@ export async function main() {
 
   // setup method creates
   // - a secret using `@azure/keyvault-secrets`
-  // - and a corresponding secret reference config setting with `@azure/app-configuration`
+  // - a corresponding secret reference config setting with `@azure/app-configuration`
   await setup(key);
 
   console.log(`Get the added secretReference from App Config with key: ${key}`);

--- a/sdk/appconfiguration/app-configuration/samples-dev/secretReference.ts
+++ b/sdk/appconfiguration/app-configuration/samples-dev/secretReference.ts
@@ -25,7 +25,7 @@ export async function main() {
 
   const key = `secret${new Date().getTime()}`;
 
-  // setup method creates 
+  // setup method creates
   // - a secret using `@azure/keyvault-secrets`
   // - and a corresponding secret reference config setting with `@azure/app-configuration`
   await setup(key);
@@ -73,23 +73,22 @@ async function setup(key: string) {
     return;
   }
 
-  let uri = process.env["KEYVAULT_URI"] || "<keyvault-uri>";
-  uri = !uri.endsWith("/") ? `${uri}/` : uri;
-  const secretId = `${uri}secrets/secret-key${Math.ceil(100 + Math.random() * 900)}`;
-
   // DefaultAzureCredential expects the following three environment variables:
   // - AZURE_TENANT_ID: The tenant ID in Azure Active Directory
   // - AZURE_CLIENT_ID: The application (client) ID registered in the AAD tenant
   // - AZURE_CLIENT_SECRET: The client secret for the registered application
-  const secretClient = new SecretClient(uri, new DefaultAzureCredential());
-
-  const secretName = parseKeyVaultSecretIdentifier(secretId).name;
+  const secretClient = new SecretClient(process.env["KEYVAULT_URI"], new DefaultAzureCredential());
+  const secretName = `secret-${Date.now()}`;
   // Create a secret
-  console.log(`Create a keyvault secret with key: ${secretName} and value: "MySecretValue"`);
-  await secretClient.setSecret(secretName, "MySecretValue");
+  console.log(`Create a keyvault secret with key: ${secretName}  and value: "MySecretValue"`);
+  const secret = await secretClient.setSecret(secretName, "MySecretValue");
+
+  if (!secret.properties.id) {
+    throw new Error("Something went wrong - secret id is undefined");
+  }
 
   // creates the secret reference config setting
-  await createConfigSetting(key, secretId);
+  await createConfigSetting(key, secret.properties.id);
 }
 
 async function createConfigSetting(key: string, secretId: string) {

--- a/sdk/appconfiguration/app-configuration/samples-dev/secretReference.ts
+++ b/sdk/appconfiguration/app-configuration/samples-dev/secretReference.ts
@@ -25,10 +25,9 @@ export async function main() {
 
   const key = `secret${new Date().getTime()}`;
 
-  // setup
-  // - creates a secret using `@azure/keyvault-secrets`
-  // and
-  // - a corresponding secret reference config setting with `@azure/app-configuration`
+  // setup method creates 
+  // - a secret using `@azure/keyvault-secrets`
+  // - and a corresponding secret reference config setting with `@azure/app-configuration`
   await setup(key);
 
   console.log(`Get the added secretReference from App Config with key: ${key}`);

--- a/sdk/appconfiguration/app-configuration/samples/v1/javascript/secretReference.js
+++ b/sdk/appconfiguration/app-configuration/samples/v1/javascript/secretReference.js
@@ -23,7 +23,7 @@ async function main() {
 
   // setup method creates
   // - a secret using `@azure/keyvault-secrets`
-  // - and a corresponding secret reference config setting with `@azure/app-configuration`
+  // - a corresponding secret reference config setting with `@azure/app-configuration`
   await setup(key);
 
   console.log(`Get the added secretReference from App Config with key: ${key}`);

--- a/sdk/appconfiguration/app-configuration/samples/v1/javascript/secretReference.js
+++ b/sdk/appconfiguration/app-configuration/samples/v1/javascript/secretReference.js
@@ -43,10 +43,20 @@ async function main() {
   );
 
   const secretClient = new SecretClient(vaultUrl, new DefaultAzureCredential());
-
-  // Read the secret we created
-  const secret = await secretClient.getSecret(secretName);
-  console.log(`Get the secret from keyvault key: ${secretName}, value: ${secret.value}`);
+  try {
+    // Read the secret we created
+    const secret = await secretClient.getSecret(secretName);
+    console.log(`Get the secret from keyvault key: ${secretName}, value: ${secret.value}`);
+  } catch (err) {
+    const error = err;
+    if (error.code === "SecretNotFound" && error.statusCode === 404) {
+      throw new Error(
+        `\n Secret is not found, make sure the secret ${parsedSecretReference.value.secretId} is present in your keyvault account;\n Original error - ${error}`
+      );
+    } else {
+      throw err;
+    }
+  }
 
   console.log(`Deleting the secret from keyvault`);
   await secretClient.beginDeleteSecret(secretName);

--- a/sdk/appconfiguration/app-configuration/samples/v1/javascript/secretReference.js
+++ b/sdk/appconfiguration/app-configuration/samples/v1/javascript/secretReference.js
@@ -21,10 +21,9 @@ async function main() {
 
   const key = `secret${new Date().getTime()}`;
 
-  // setup
-  // - creates a secret using `@azure/keyvault-secrets`
-  // and
-  // - a corresponding secret reference config setting with `@azure/app-configuration`
+  // setup method creates
+  // - a secret using `@azure/keyvault-secrets`
+  // - and a corresponding secret reference config setting with `@azure/app-configuration`
   await setup(key);
 
   console.log(`Get the added secretReference from App Config with key: ${key}`);

--- a/sdk/appconfiguration/app-configuration/samples/v1/javascript/secretReference.js
+++ b/sdk/appconfiguration/app-configuration/samples/v1/javascript/secretReference.js
@@ -67,23 +67,22 @@ async function setup(key) {
     return;
   }
 
-  let uri = process.env["KEYVAULT_URI"] || "<keyvault-uri>";
-  uri = !uri.endsWith("/") ? `${uri}/` : uri;
-  const secretId = `${uri}secrets/secret-key${Math.ceil(100 + Math.random() * 900)}`;
-
   // DefaultAzureCredential expects the following three environment variables:
   // - AZURE_TENANT_ID: The tenant ID in Azure Active Directory
   // - AZURE_CLIENT_ID: The application (client) ID registered in the AAD tenant
   // - AZURE_CLIENT_SECRET: The client secret for the registered application
-  const secretClient = new SecretClient(uri, new DefaultAzureCredential());
-
-  const secretName = parseKeyVaultSecretIdentifier(secretId).name;
+  const secretClient = new SecretClient(process.env["KEYVAULT_URI"], new DefaultAzureCredential());
+  const secretName = `secret-${Date.now()}`;
   // Create a secret
-  console.log(`Create a keyvault secret with key: ${secretName} and value: "MySecretValue"`);
-  await secretClient.setSecret(secretName, "MySecretValue");
+  console.log(`Create a keyvault secret with key: ${secretName}  and value: "MySecretValue"`);
+  const secret = await secretClient.setSecret(secretName, "MySecretValue");
+
+  if (!secret.properties.id) {
+    throw new Error("Something went wrong - secret id is undefined");
+  }
 
   // creates the secret reference config setting
-  await createConfigSetting(key, secretId);
+  await createConfigSetting(key, secret.properties.id);
 }
 
 async function createConfigSetting(key, secretId) {

--- a/sdk/appconfiguration/app-configuration/samples/v1/javascript/secretReference.js
+++ b/sdk/appconfiguration/app-configuration/samples/v1/javascript/secretReference.js
@@ -9,7 +9,7 @@ const {
   secretReferenceContentType,
   parseSecretReference
 } = require("@azure/app-configuration");
-const { SecretClient } = require("@azure/keyvault-secrets");
+const { parseKeyVaultSecretIdentifier, SecretClient } = require("@azure/keyvault-secrets");
 const { DefaultAzureCredential } = require("@azure/identity");
 
 // Load the .env file if it exists
@@ -18,65 +18,93 @@ dotenv.config();
 
 async function main() {
   console.log(`Running secretReference sample`);
-  const secretReference = {
-    key: `secret${new Date().getTime()}`,
-    value: {
-      secretId: `secret-key${Math.ceil(100 + Math.random() * 900)}`
-    },
-    isReadOnly: false,
-    contentType: secretReferenceContentType
-  };
 
+  const key = `secret${new Date().getTime()}`;
+
+  // setup
+  // - creates a secret using `@azure/keyvault-secrets`
+  // and
+  // - a corresponding secret reference config setting with `@azure/app-configuration`
+  await setup(key);
+
+  console.log(`Get the added secretReference from App Config with key: ${key}`);
+  // Set the following environment variable or edit the value on the following line.
+  const connectionString = process.env["APPCONFIG_CONNECTION_STRING"] || "";
+  const appConfigClient = new AppConfigurationClient(connectionString);
+  const getResponse = await appConfigClient.getConfigurationSetting({
+    key
+  });
+  // You can use the `isSecretReference` global method to check if the content type is secretReferenceContentType ("application/vnd.microsoft.appconfig.keyvaultref+json;charset=utf-8")
+
+  const parsedSecretReference = parseSecretReference(getResponse);
+
+  // Get the name and vaultUrl from the secretId
+  const { name: secretName, vaultUrl } = parseKeyVaultSecretIdentifier(
+    parsedSecretReference.value.secretId
+  );
+
+  const secretClient = new SecretClient(vaultUrl, new DefaultAzureCredential());
+
+  // Read the secret we created
+  const secret = await secretClient.getSecret(secretName);
+  console.log(`Get the secret from keyvault key: ${secretName}, value: ${secret.value}`);
+
+  console.log(`Deleting the secret from keyvault`);
+  await secretClient.beginDeleteSecret(secretName);
+
+  await cleanupSampleValues([key], appConfigClient);
+}
+
+async function setup(key) {
   if (
     !process.env["AZURE_TENANT_ID"] ||
     !process.env["AZURE_CLIENT_ID"] ||
     !process.env["AZURE_CLIENT_SECRET"] ||
-    !process.env["KEYVAULT_URI"]
+    !process.env["KEYVAULT_URI"] ||
+    !process.env["APPCONFIG_CONNECTION_STRING"]
   ) {
-    console.log(`At least one of the AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET, and KEYVAULT_URI variables is not present, 
+    console.log(`At least one of the AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET, APPCONFIG_CONNECTION_STRING and KEYVAULT_URI variables is not present, 
       please add the missing ones in your environment and rerun the sample.`);
     return;
   }
+
+  let uri = process.env["KEYVAULT_URI"] || "<keyvault-uri>";
+  uri = !uri.endsWith("/") ? `${uri}/` : uri;
+  const secretId = `${uri}secrets/secret-key${Math.ceil(100 + Math.random() * 900)}`;
+
   // DefaultAzureCredential expects the following three environment variables:
   // - AZURE_TENANT_ID: The tenant ID in Azure Active Directory
   // - AZURE_CLIENT_ID: The application (client) ID registered in the AAD tenant
   // - AZURE_CLIENT_SECRET: The client secret for the registered application
-  const credential = new DefaultAzureCredential();
-  const url = process.env["KEYVAULT_URI"] || "<keyvault-url>";
+  const secretClient = new SecretClient(uri, new DefaultAzureCredential());
 
-  const secretClient = new SecretClient(url, credential);
+  const secretName = parseKeyVaultSecretIdentifier(secretId).name;
   // Create a secret
-  console.log(
-    `Create a keyvault secret with key: ${secretReference.value.secretId} and value: "MySecretValue"`
-  );
-  await secretClient.setSecret(secretReference.value.secretId, "MySecretValue");
+  console.log(`Create a keyvault secret with key: ${secretName} and value: "MySecretValue"`);
+  await secretClient.setSecret(secretName, "MySecretValue");
 
+  // creates the secret reference config setting
+  await createConfigSetting(key, secretId);
+}
+
+async function createConfigSetting(key, secretId) {
   // Set the following environment variable or edit the value on the following line.
   const connectionString = process.env["APPCONFIG_CONNECTION_STRING"] || "<connection string>";
   const appConfigClient = new AppConfigurationClient(connectionString);
 
-  await cleanupSampleValues([secretReference.key], appConfigClient);
+  const secretReference = {
+    key,
+    value: { secretId },
+    isReadOnly: false,
+    contentType: secretReferenceContentType
+  };
+
+  await cleanupSampleValues([key], appConfigClient);
 
   console.log(
-    `Add a new secretReference with key: ${secretReference.key} and secretId: ${secretReference.value.secretId}`
+    `Add a new secretReference with key: ${key} and secretId: ${secretReference.value.secretId}`
   );
   await appConfigClient.addConfigurationSetting(secretReference);
-
-  console.log(`Get the added secretReference from App Config with key: ${secretReference.key}`);
-  const getResponse = await appConfigClient.getConfigurationSetting({
-    key: secretReference.key
-  });
-
-  // You can use the `isSecretReference` global method to check if the content type is secretReferenceContentType ("application/vnd.microsoft.appconfig.keyvaultref+json;charset=utf-8")
-  const parsedSecretReference = parseSecretReference(getResponse);
-  // Read the secret we created
-  const secret = await secretClient.getSecret(parsedSecretReference.value.secretId);
-  console.log(`Get the secret from keyvault key: ${secret.name}, value: ${secret.value}`);
-
-  console.log(`Deleting the secret from keyvault`);
-  await secretClient.beginDeleteSecret(parsedSecretReference.value.secretId);
-
-  await cleanupSampleValues([secretReference.key], appConfigClient);
 }
 
 async function cleanupSampleValues(keys, client) {

--- a/sdk/appconfiguration/app-configuration/samples/v1/typescript/src/secretReference.ts
+++ b/sdk/appconfiguration/app-configuration/samples/v1/typescript/src/secretReference.ts
@@ -23,10 +23,9 @@ export async function main() {
 
   const key = `secret${new Date().getTime()}`;
 
-  // setup
-  // - creates a secret using `@azure/keyvault-secrets`
-  // and
-  // - a corresponding secret reference config setting with `@azure/app-configuration`
+  // setup method creates 
+  // - a secret using `@azure/keyvault-secrets`
+  // - and a corresponding secret reference config setting with `@azure/app-configuration`
   await setup(key);
 
   console.log(`Get the added secretReference from App Config with key: ${key}`);

--- a/sdk/appconfiguration/app-configuration/samples/v1/typescript/src/secretReference.ts
+++ b/sdk/appconfiguration/app-configuration/samples/v1/typescript/src/secretReference.ts
@@ -45,10 +45,20 @@ export async function main() {
   );
 
   const secretClient = new SecretClient(vaultUrl, new DefaultAzureCredential());
-
-  // Read the secret we created
-  const secret = await secretClient.getSecret(secretName);
-  console.log(`Get the secret from keyvault key: ${secretName}, value: ${secret.value}`);
+  try {
+    // Read the secret we created
+    const secret = await secretClient.getSecret(secretName);
+    console.log(`Get the secret from keyvault key: ${secretName}, value: ${secret.value}`);
+  } catch (err) {
+    const error = err as { code: string; statusCode: number };
+    if (error.code === "SecretNotFound" && error.statusCode === 404) {
+      throw new Error(
+        `\n Secret is not found, make sure the secret ${parsedSecretReference.value.secretId} is present in your keyvault account;\n Original error - ${error}`
+      );
+    } else {
+      throw err;
+    }
+  }
 
   console.log(`Deleting the secret from keyvault`);
   await secretClient.beginDeleteSecret(secretName);

--- a/sdk/appconfiguration/app-configuration/samples/v1/typescript/src/secretReference.ts
+++ b/sdk/appconfiguration/app-configuration/samples/v1/typescript/src/secretReference.ts
@@ -25,7 +25,7 @@ export async function main() {
 
   // setup method creates
   // - a secret using `@azure/keyvault-secrets`
-  // - and a corresponding secret reference config setting with `@azure/app-configuration`
+  // - a corresponding secret reference config setting with `@azure/app-configuration`
   await setup(key);
 
   console.log(`Get the added secretReference from App Config with key: ${key}`);

--- a/sdk/appconfiguration/app-configuration/samples/v1/typescript/src/secretReference.ts
+++ b/sdk/appconfiguration/app-configuration/samples/v1/typescript/src/secretReference.ts
@@ -11,7 +11,7 @@ import {
   ConfigurationSetting,
   parseSecretReference
 } from "@azure/app-configuration";
-import { SecretClient } from "@azure/keyvault-secrets";
+import { parseKeyVaultSecretIdentifier, SecretClient } from "@azure/keyvault-secrets";
 import { DefaultAzureCredential } from "@azure/identity";
 
 // Load the .env file if it exists
@@ -20,67 +20,95 @@ dotenv.config();
 
 export async function main() {
   console.log(`Running secretReference sample`);
-  const secretReference: ConfigurationSetting<SecretReferenceValue> = {
-    key: `secret${new Date().getTime()}`,
-    value: {
-      secretId: `secret-key${Math.ceil(100 + Math.random() * 900)}`
-    },
-    isReadOnly: false,
-    contentType: secretReferenceContentType
-  };
 
+  const key = `secret${new Date().getTime()}`;
+
+  // setup
+  // - creates a secret using `@azure/keyvault-secrets`
+  // and
+  // - a corresponding secret reference config setting with `@azure/app-configuration`
+  await setup(key);
+
+  console.log(`Get the added secretReference from App Config with key: ${key}`);
+  // Set the following environment variable or edit the value on the following line.
+  const connectionString = process.env["APPCONFIG_CONNECTION_STRING"] || "";
+  const appConfigClient = new AppConfigurationClient(connectionString);
+  const getResponse = await appConfigClient.getConfigurationSetting({
+    key
+  });
+  // You can use the `isSecretReference` global method to check if the content type is secretReferenceContentType ("application/vnd.microsoft.appconfig.keyvaultref+json;charset=utf-8")
+
+  const parsedSecretReference = parseSecretReference(getResponse);
+
+  // Get the name and vaultUrl from the secretId
+  const { name: secretName, vaultUrl } = parseKeyVaultSecretIdentifier(
+    parsedSecretReference.value.secretId
+  );
+
+  const secretClient = new SecretClient(vaultUrl, new DefaultAzureCredential());
+
+  // Read the secret we created
+  const secret = await secretClient.getSecret(secretName);
+  console.log(`Get the secret from keyvault key: ${secretName}, value: ${secret.value}`);
+
+  console.log(`Deleting the secret from keyvault`);
+  await secretClient.beginDeleteSecret(secretName);
+
+  await cleanupSampleValues([key], appConfigClient);
+}
+
+async function setup(key: string) {
   if (
     !process.env["AZURE_TENANT_ID"] ||
     !process.env["AZURE_CLIENT_ID"] ||
     !process.env["AZURE_CLIENT_SECRET"] ||
-    !process.env["KEYVAULT_URI"]
+    !process.env["KEYVAULT_URI"] ||
+    !process.env["APPCONFIG_CONNECTION_STRING"]
   ) {
     console.log(
-      `At least one of the AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET, and KEYVAULT_URI variables is not present, 
+      `At least one of the AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET, APPCONFIG_CONNECTION_STRING and KEYVAULT_URI variables is not present, 
       please add the missing ones in your environment and rerun the sample.`
     );
     return;
   }
+
+  let uri = process.env["KEYVAULT_URI"] || "<keyvault-uri>";
+  uri = !uri.endsWith("/") ? `${uri}/` : uri;
+  const secretId = `${uri}secrets/secret-key${Math.ceil(100 + Math.random() * 900)}`;
+
   // DefaultAzureCredential expects the following three environment variables:
   // - AZURE_TENANT_ID: The tenant ID in Azure Active Directory
   // - AZURE_CLIENT_ID: The application (client) ID registered in the AAD tenant
   // - AZURE_CLIENT_SECRET: The client secret for the registered application
-  const credential = new DefaultAzureCredential();
-  const url = process.env["KEYVAULT_URI"] || "<keyvault-url>";
+  const secretClient = new SecretClient(uri, new DefaultAzureCredential());
 
-  const secretClient = new SecretClient(url, credential);
+  const secretName = parseKeyVaultSecretIdentifier(secretId).name;
   // Create a secret
-  console.log(
-    `Create a keyvault secret with key: ${secretReference.value.secretId} and value: "MySecretValue"`
-  );
-  await secretClient.setSecret(secretReference.value.secretId, "MySecretValue");
+  console.log(`Create a keyvault secret with key: ${secretName} and value: "MySecretValue"`);
+  await secretClient.setSecret(secretName, "MySecretValue");
 
+  // creates the secret reference config setting
+  await createConfigSetting(key, secretId);
+}
+
+async function createConfigSetting(key: string, secretId: string) {
   // Set the following environment variable or edit the value on the following line.
   const connectionString = process.env["APPCONFIG_CONNECTION_STRING"] || "<connection string>";
   const appConfigClient = new AppConfigurationClient(connectionString);
 
-  await cleanupSampleValues([secretReference.key], appConfigClient);
+  const secretReference: ConfigurationSetting<SecretReferenceValue> = {
+    key,
+    value: { secretId },
+    isReadOnly: false,
+    contentType: secretReferenceContentType
+  };
+
+  await cleanupSampleValues([key], appConfigClient);
 
   console.log(
-    `Add a new secretReference with key: ${secretReference.key} and secretId: ${secretReference.value.secretId}`
+    `Add a new secretReference with key: ${key} and secretId: ${secretReference.value.secretId}`
   );
   await appConfigClient.addConfigurationSetting(secretReference);
-
-  console.log(`Get the added secretReference from App Config with key: ${secretReference.key}`);
-  const getResponse = await appConfigClient.getConfigurationSetting({
-    key: secretReference.key
-  });
-
-  // You can use the `isSecretReference` global method to check if the content type is secretReferenceContentType ("application/vnd.microsoft.appconfig.keyvaultref+json;charset=utf-8")
-  const parsedSecretReference = parseSecretReference(getResponse);
-  // Read the secret we created
-  const secret = await secretClient.getSecret(parsedSecretReference.value.secretId);
-  console.log(`Get the secret from keyvault key: ${secret.name}, value: ${secret.value}`);
-
-  console.log(`Deleting the secret from keyvault`);
-  await secretClient.beginDeleteSecret(parsedSecretReference.value.secretId);
-
-  await cleanupSampleValues([secretReference.key], appConfigClient);
 }
 
 async function cleanupSampleValues(keys: string[], client: AppConfigurationClient) {

--- a/sdk/appconfiguration/app-configuration/test/public/secretReference.spec.ts
+++ b/sdk/appconfiguration/app-configuration/test/public/secretReference.spec.ts
@@ -33,7 +33,7 @@ describe("AppConfigurationClient - SecretReference", () => {
       return {
         value: {
           secretId: `https://vault_name.vault.azure.net/secrets/${recorder.getUniqueName("name-2")}`
-        }, // TODO: It's a URL in .NET, should we leave it as a string input?
+        },
         isReadOnly: false,
         key: recorder.getUniqueName("name-3"),
         label: "label-s",


### PR DESCRIPTION
## Fixes #18669 

The main change is that the `secretId` in the sample is updated from `random_string` to `https://vault_name.vault.azure.net/secrets/random_string`
- Updated the generated samples too
- Leveraging `parseKeyVaultSecretIdentifier` to parse the `secretId` to get the name and vault url
- This makes the sample consistent with .NET
- Did some refactoring as the sample became huge