### PR TITLE
[Identity] Update core-client to ^1.4.0

### DIFF
--- a/sdk/identity/identity/package.json
+++ b/sdk/identity/identity/package.json
@@ -95,7 +95,7 @@
     "@azure/core-util": "^1.0.0-beta.1",
     "@azure/core-tracing": "1.0.0-preview.13",
     "@azure/core-auth": "^1.3.0",
-    "@azure/core-client": "^1.3.3",
+    "@azure/core-client": "^1.4.0",
     "@azure/core-rest-pipeline": "^1.1.0",
     "@azure/logger": "^1.0.0",
     "@azure/abort-controller": "^1.0.0",

--- a/sdk/identity/identity/package.json
+++ b/sdk/identity/identity/package.json
@@ -95,7 +95,7 @@
     "@azure/core-util": "^1.0.0-beta.1",
     "@azure/core-tracing": "1.0.0-preview.13",
     "@azure/core-auth": "^1.3.0",
-    "@azure/core-client": "^1.0.0",
+    "@azure/core-client": "^1.3.3",
     "@azure/core-rest-pipeline": "^1.1.0",
     "@azure/logger": "^1.0.0",
     "@azure/abort-controller": "^1.0.0",


### PR DESCRIPTION
Our internal tests will only pass if we point to 1.4.0

The caveat of this PR is that we won’t be able to release Identity before @azure/core-client, but that should be fine according to our plans anyway.

Please let me know if I’m wrong. Feedback always appreciated!