### PR TITLE
[ESLint Plugin] Fix list of rules

### DIFF
--- a/common/tools/eslint-plugin-azure-sdk/tests/plugin.ts
+++ b/common/tools/eslint-plugin-azure-sdk/tests/plugin.ts
@@ -39,7 +39,6 @@ const ruleList = [
   "ts-naming-options",
   "ts-naming-subclients",
   "ts-no-const-enums",
-  "ts-no-namespaces",
   "ts-no-window",
   "ts-package-json-author",
   "ts-package-json-bugs",


### PR DESCRIPTION
`ts-no-namespaces` has been deleted so this PR removes it from the list of the rules to be tested.