### PR TITLE
[core-client] Version to 1.4.0

### DIFF
--- a/sdk/core/core-client/CHANGELOG.md
+++ b/sdk/core/core-client/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.3.3 (Unreleased)
+## 1.3.3 (2021-11-22)
 
 ### Features Added
 

--- a/sdk/core/core-client/CHANGELOG.md
+++ b/sdk/core/core-client/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.3.3 (2021-11-22)
+## 1.4.0 (Unreleased)
 
 ### Features Added
 

--- a/sdk/core/core-client/package.json
+++ b/sdk/core/core-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/core-client",
-  "version": "1.3.3",
+  "version": "1.4.0",
   "description": "Core library for interfacing with AutoRest generated code",
   "sdk-type": "client",
   "main": "dist/index.js",


### PR DESCRIPTION
~What if we release @azure/core-client 1.3.3 tomorrow? 🙂~
Changed this PR to upgrade the version of core-client to 1.4.0 since CAE support is a new thing entirely, not a patch to something already in this package.