### PR TITLE
[core-lro] Handle async path requests correctly

### DIFF
--- a/sdk/core/core-lro/src/lroEngine/requestUtils.ts
+++ b/sdk/core/core-lro/src/lroEngine/requestUtils.ts
@@ -41,7 +41,7 @@ export function inferLroMode(
       resourceLocation:
         requestMethod === "PUT"
           ? requestPath
-          : requestMethod === "POST"
+          : ["POST", "PATCH"].includes(requestMethod)
           ? getLocation(rawResponse)
           : undefined
     };

--- a/sdk/core/core-lro/test/engine.spec.ts
+++ b/sdk/core/core-lro/test/engine.spec.ts
@@ -262,6 +262,12 @@ describe("Lro Engine", function() {
       assert.equal(result.id, "100");
     });
 
+    it("should handle patchAsync", async () => {
+      const result = await runMockedLro("PATCH", "/patchasync/202/200");
+      assert.equal(result.name, "sku");
+      assert.equal(result.id, "100");
+    });
+
     it("should handle putAsyncNoHeaderInRetry", async () => {
       const result = await runMockedLro("PUT", "/putasync/noheader/201/200");
       assert.equal(result.name, "foo");

--- a/sdk/core/core-lro/test/utils/router/routesProcesses.ts
+++ b/sdk/core/core-lro/test/utils/router/routesProcesses.ts
@@ -201,8 +201,37 @@ export function getNonresourceAsync202200(request: PipelineRequest): PipelineRes
   return buildResponse(request, 200, `{ "name": "sku" , "id": "100" }`);
 }
 
+export function patchAsync202200(request: PipelineRequest): PipelineResponse {
+  return buildResponse(
+    request,
+    202,
+    undefined,
+    createHttpHeaders({
+      "Azure-AsyncOperation": `/patchasync/operationresults/123`,
+      Location: `/patchasync/succeeded`
+    })
+  );
+}
+
+export function getPatchAsyncSucceeded(request: PipelineRequest): PipelineResponse {
+  return buildResponse(request, 200, `{ "name": "sku" , "id": "100" }`);
+}
+
 export const putNonresourceAsyncOperationresults123 = buildProcessMultipleRequests(
   (req) => buildResponse(req, 200, `{ "status": "InProgress"}`),
+  (req) => buildResponse(req, 200, `{ "status": "Succeeded"}`)
+);
+
+export const patchAsyncOperationresults123 = buildProcessMultipleRequests(
+  (req) =>
+    buildResponse(
+      req,
+      200,
+      `{ "status": "InProgress"}`,
+      createHttpHeaders({
+        "Azure-AsyncOperation": `/patchasync/operationresults/123`
+      })
+    ),
   (req) => buildResponse(req, 200, `{ "status": "Succeeded"}`)
 );
 

--- a/sdk/core/core-lro/test/utils/router/routesTable.ts
+++ b/sdk/core/core-lro/test/utils/router/routesTable.ts
@@ -41,6 +41,7 @@ import {
   getNonretryerrorPost202retry400,
   getNonretryerrorPut201creating400,
   getNonretryerrorPut201creating400invalidjson,
+  getPatchAsyncSucceeded,
   getPayload200,
   getSubresourceAsync202200,
   nonretryerrorDelete202retry400,
@@ -56,6 +57,8 @@ import {
   nonretryerrorPut400,
   nonretryerrorPutasyncRetry400,
   nonretryerrorPutasyncRetryFailedOperationResults400,
+  patchAsync202200,
+  patchAsyncOperationresults123,
   postDoubleHeadersFinalAzureHeaderGet,
   postDoubleHeadersFinalAzureHeaderGetAsyncOperationUrl,
   postDoubleHeadersFinalAzureHeaderGetDefault,
@@ -178,6 +181,13 @@ export const routes: LroRoute[] = [
     process: putNonresourceAsyncOperationresults123
   },
   { method: "GET", path: "/putnonresourceasync/202/200", process: getNonresourceAsync202200 },
+  { method: "PATCH", path: "/patchasync/202/200", process: patchAsync202200 },
+  {
+    method: "GET",
+    path: "/patchasync/operationresults/123",
+    process: patchAsyncOperationresults123
+  },
+  { method: "GET", path: "/patchasync/succeeded", process: getPatchAsyncSucceeded },
   { method: "PUT", path: "/putasync/noheader/201/200", process: putasyncNoheader201200 },
   { method: "GET", path: "/putasync/noheader/201/200", process: getasyncNoheader201200 },
   {


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-sdk-for-js/issues/18818.

PATCH operations could also have a location header URL where the patched results will be located eventually but the LRO engine ignored that header. This PR fixes this issue by treating PATCH the same as POST and adds a test case.