### PR TITLE
Release For Face Recognition Quality Score

### DIFF
--- a/sdk/cognitiveservices/cognitiveservices-face/package.json
+++ b/sdk/cognitiveservices/cognitiveservices-face/package.json
@@ -2,7 +2,7 @@
   "name": "@azure/cognitiveservices-face",
   "author": "Microsoft Corporation",
   "description": "FaceClient Library with typescript type definitions for node.js and browser.",
-  "version": "4.2.0",
+  "version": "5.0.0",
   "dependencies": {
     "@azure/ms-rest-js": "^2.0.4",
     "tslib": "^1.10.0"

--- a/sdk/cognitiveservices/cognitiveservices-face/src/faceClientContext.ts
+++ b/sdk/cognitiveservices/cognitiveservices-face/src/faceClientContext.ts
@@ -11,7 +11,7 @@
 import * as msRest from "@azure/ms-rest-js";
 
 const packageName = "@azure/cognitiveservices-face";
-const packageVersion = "4.2.0";
+const packageVersion = "5.0.0";
 
 export class FaceClientContext extends msRest.ServiceClient {
   endpoint: string;

--- a/sdk/cognitiveservices/cognitiveservices-face/src/models/faceListOperationsMappers.ts
+++ b/sdk/cognitiveservices/cognitiveservices-face/src/models/faceListOperationsMappers.ts
@@ -15,6 +15,7 @@ export {
   LargePersonGroup,
   MetaDataContract,
   NameAndUserDataContract,
+  NonNullableNameAndNullableUserDataContract,
   PersistedFace,
   Person,
   PersonGroup

--- a/sdk/cognitiveservices/cognitiveservices-face/src/models/index.ts
+++ b/sdk/cognitiveservices/cognitiveservices-face/src/models/index.ts
@@ -330,6 +330,12 @@ export interface FaceAttributes {
    * Properties describing the presence of a mask on a given face.
    */
   mask?: Mask;
+  /**
+   * Properties describing the overall image quality regarding whether the image being used in the
+   * detection is of sufficient quality to attempt face recognition on. Possible values include:
+   * 'Low', 'Medium', 'High'
+   */
+  qualityForRecognition?: QualityForRecognition;
 }
 
 /**
@@ -454,7 +460,7 @@ export interface IdentifyRequest {
    */
   largePersonGroupId?: string;
   /**
-   * The range of maxNumOfCandidatesReturned is between 1 and 5 (default is 1). Default value: 1.
+   * The range of maxNumOfCandidatesReturned is between 1 and 100 (default is 1). Default value: 1.
    */
   maxNumOfCandidatesReturned?: number;
   /**
@@ -574,11 +580,11 @@ export interface PersistedFace {
  * A combination of user defined name and user specified data for the person,
  * largePersonGroup/personGroup, and largeFaceList/faceList.
  */
-export interface NameAndUserDataContract {
+export interface NonNullableNameAndNullableUserDataContract {
   /**
    * User defined name, maximum length is 128.
    */
-  name?: string;
+  name: string;
   /**
    * User specified data. Length should not exceed 16KB.
    */
@@ -589,7 +595,7 @@ export interface NameAndUserDataContract {
  * A combination of user defined name and user specified data and recognition model name for
  * largePersonGroup/personGroup, and largeFaceList/faceList.
  */
-export interface MetaDataContract extends NameAndUserDataContract {
+export interface MetaDataContract extends NonNullableNameAndNullableUserDataContract {
   /**
    * Possible values include: 'recognition_01', 'recognition_02', 'recognition_03',
    * 'recognition_04'. Default value: 'recognition_01'.
@@ -619,6 +625,21 @@ export interface PersonGroup extends MetaDataContract {
    * PersonGroupId of the target person group.
    */
   personGroupId: string;
+}
+
+/**
+ * A combination of user defined name and user specified data for the person,
+ * largePersonGroup/personGroup, and largeFaceList/faceList.
+ */
+export interface NameAndUserDataContract {
+  /**
+   * User defined name, maximum length is 128.
+   */
+  name?: string;
+  /**
+   * User specified data. Length should not exceed 16KB.
+   */
+  userData?: string;
 }
 
 /**
@@ -903,7 +924,7 @@ export interface FaceIdentifyOptionalParams extends msRest.RequestOptionsBase {
    */
   largePersonGroupId?: string;
   /**
-   * The range of maxNumOfCandidatesReturned is between 1 and 5 (default is 1). Default value: 1.
+   * The range of maxNumOfCandidatesReturned is between 1 and 100 (default is 1). Default value: 1.
    */
   maxNumOfCandidatesReturned?: number;
   /**
@@ -931,9 +952,11 @@ export interface FaceDetectWithUrlOptionalParams extends msRest.RequestOptionsBa
    * Analyze and return the one or more specified face attributes in the comma-separated string
    * like "returnFaceAttributes=age,gender". The available attributes depends on the
    * 'detectionModel' specified. 'detection_01' supports age, gender, headPose, smile, facialHair,
-   * glasses, emotion, hair, makeup, occlusion, accessories, blur, exposure, and noise. While
-   * 'detection_02' does not support any attributes and 'detection_03' only supports mask. Note
-   * that each face attribute analysis has additional computational and time cost.
+   * glasses, emotion, hair, makeup, occlusion, accessories, blur, exposure, noise, and
+   * qualityForRecognition. While 'detection_02' does not support any attributes and 'detection_03'
+   * only supports mask and qualityForRecognition. Additionally, qualityForRecognition is only
+   * supported when the 'recognitionModel' is specified as 'recognition_03' or 'recognition_04'.
+   * Note that each face attribute analysis has additional computational and time cost.
    */
   returnFaceAttributes?: FaceAttributeType[];
   /**
@@ -1001,9 +1024,11 @@ export interface FaceDetectWithStreamOptionalParams extends msRest.RequestOption
    * Analyze and return the one or more specified face attributes in the comma-separated string
    * like "returnFaceAttributes=age,gender". The available attributes depends on the
    * 'detectionModel' specified. 'detection_01' supports age, gender, headPose, smile, facialHair,
-   * glasses, emotion, hair, makeup, occlusion, accessories, blur, exposure, and noise. While
-   * 'detection_02' does not support any attributes and 'detection_03' only supports mask. Note
-   * that each face attribute analysis has additional computational and time cost.
+   * glasses, emotion, hair, makeup, occlusion, accessories, blur, exposure, noise, and
+   * qualityForRecognition. While 'detection_02' does not support any attributes and 'detection_03'
+   * only supports mask and qualityForRecognition. Additionally, qualityForRecognition is only
+   * supported when the 'recognitionModel' is specified as 'recognition_03' or 'recognition_04'.
+   * Note that each face attribute analysis has additional computational and time cost.
    */
   returnFaceAttributes?: FaceAttributeType[];
   /**
@@ -1142,10 +1167,6 @@ export interface PersonGroupPersonAddFaceFromStreamOptionalParams extends msRest
  */
 export interface PersonGroupCreateOptionalParams extends msRest.RequestOptionsBase {
   /**
-   * User defined name, maximum length is 128.
-   */
-  name?: string;
-  /**
    * User specified data. Length should not exceed 16KB.
    */
   userData?: string;
@@ -1204,10 +1225,6 @@ export interface PersonGroupListOptionalParams extends msRest.RequestOptionsBase
  * Optional Parameters.
  */
 export interface FaceListCreateOptionalParams extends msRest.RequestOptionsBase {
-  /**
-   * User defined name, maximum length is 128.
-   */
-  name?: string;
   /**
    * User specified data. Length should not exceed 16KB.
    */
@@ -1412,10 +1429,6 @@ export interface LargePersonGroupPersonAddFaceFromStreamOptionalParams extends m
  */
 export interface LargePersonGroupCreateOptionalParams extends msRest.RequestOptionsBase {
   /**
-   * User defined name, maximum length is 128.
-   */
-  name?: string;
-  /**
    * User specified data. Length should not exceed 16KB.
    */
   userData?: string;
@@ -1475,10 +1488,6 @@ export interface LargePersonGroupListOptionalParams extends msRest.RequestOption
  */
 export interface LargeFaceListCreateOptionalParams extends msRest.RequestOptionsBase {
   /**
-   * User defined name, maximum length is 128.
-   */
-  name?: string;
-  /**
    * User specified data. Length should not exceed 16KB.
    */
   userData?: string;
@@ -1523,6 +1532,15 @@ export interface LargeFaceListListOptionalParams extends msRest.RequestOptionsBa
    * value: false.
    */
   returnRecognitionModel?: boolean;
+  /**
+   * Starting large face list id to return (used to list a range of large face lists).
+   */
+  start?: string;
+  /**
+   * Number of large face lists to return starting with the large face list id indicated by the
+   * 'start' parameter.
+   */
+  top?: number;
 }
 
 /**
@@ -1751,6 +1769,14 @@ export type NoiseLevel = 'Low' | 'Medium' | 'High';
 export type MaskType = 'noMask' | 'faceMask' | 'otherMaskOrOcclusion' | 'uncertain';
 
 /**
+ * Defines values for QualityForRecognition.
+ * Possible values include: 'Low', 'Medium', 'High'
+ * @readonly
+ * @enum {string}
+ */
+export type QualityForRecognition = 'Low' | 'Medium' | 'High';
+
+/**
  * Defines values for FindSimilarMatchMode.
  * Possible values include: 'matchPerson', 'matchFace'
  * @readonly
@@ -1793,11 +1819,12 @@ export type OperationStatusType = 'notstarted' | 'running' | 'succeeded' | 'fail
 /**
  * Defines values for FaceAttributeType.
  * Possible values include: 'age', 'gender', 'headPose', 'smile', 'facialHair', 'glasses',
- * 'emotion', 'hair', 'makeup', 'occlusion', 'accessories', 'blur', 'exposure', 'noise', 'mask'
+ * 'emotion', 'hair', 'makeup', 'occlusion', 'accessories', 'blur', 'exposure', 'noise', 'mask',
+ * 'qualityForRecognition'
  * @readonly
  * @enum {string}
  */
-export type FaceAttributeType = 'age' | 'gender' | 'headPose' | 'smile' | 'facialHair' | 'glasses' | 'emotion' | 'hair' | 'makeup' | 'occlusion' | 'accessories' | 'blur' | 'exposure' | 'noise' | 'mask';
+export type FaceAttributeType = 'age' | 'gender' | 'headPose' | 'smile' | 'facialHair' | 'glasses' | 'emotion' | 'hair' | 'makeup' | 'occlusion' | 'accessories' | 'blur' | 'exposure' | 'noise' | 'mask' | 'qualityForRecognition';
 
 /**
  * Defines values for DetectionModel.

--- a/sdk/cognitiveservices/cognitiveservices-face/src/models/largeFaceListOperationsMappers.ts
+++ b/sdk/cognitiveservices/cognitiveservices-face/src/models/largeFaceListOperationsMappers.ts
@@ -15,6 +15,7 @@ export {
   LargePersonGroup,
   MetaDataContract,
   NameAndUserDataContract,
+  NonNullableNameAndNullableUserDataContract,
   PersistedFace,
   Person,
   PersonGroup,

--- a/sdk/cognitiveservices/cognitiveservices-face/src/models/largePersonGroupOperationsMappers.ts
+++ b/sdk/cognitiveservices/cognitiveservices-face/src/models/largePersonGroupOperationsMappers.ts
@@ -14,6 +14,7 @@ export {
   LargePersonGroup,
   MetaDataContract,
   NameAndUserDataContract,
+  NonNullableNameAndNullableUserDataContract,
   PersistedFace,
   Person,
   PersonGroup,

--- a/sdk/cognitiveservices/cognitiveservices-face/src/models/largePersonGroupPersonMappers.ts
+++ b/sdk/cognitiveservices/cognitiveservices-face/src/models/largePersonGroupPersonMappers.ts
@@ -9,14 +9,9 @@
 export {
   APIError,
   ErrorModel,
-  FaceList,
   ImageUrl,
-  LargeFaceList,
-  LargePersonGroup,
-  MetaDataContract,
   NameAndUserDataContract,
   PersistedFace,
   Person,
-  PersonGroup,
   UpdateFaceRequest
 } from "../models/mappers";

--- a/sdk/cognitiveservices/cognitiveservices-face/src/models/mappers.ts
+++ b/sdk/cognitiveservices/cognitiveservices-face/src/models/mappers.ts
@@ -829,6 +829,17 @@ export const FaceAttributes: msRest.CompositeMapper = {
           name: "Composite",
           className: "Mask"
         }
+      },
+      qualityForRecognition: {
+        serializedName: "qualityForRecognition",
+        type: {
+          name: "Enum",
+          allowedValues: [
+            "Low",
+            "Medium",
+            "High"
+          ]
+        }
       }
     }
   }
@@ -1091,7 +1102,7 @@ export const IdentifyRequest: msRest.CompositeMapper = {
         serializedName: "maxNumOfCandidatesReturned",
         defaultValue: 1,
         constraints: {
-          InclusiveMaximum: 5,
+          InclusiveMaximum: 100,
           InclusiveMinimum: 1
         },
         type: {
@@ -1280,16 +1291,18 @@ export const PersistedFace: msRest.CompositeMapper = {
   }
 };
 
-export const NameAndUserDataContract: msRest.CompositeMapper = {
-  serializedName: "NameAndUserDataContract",
+export const NonNullableNameAndNullableUserDataContract: msRest.CompositeMapper = {
+  serializedName: "NonNullableNameAndNullableUserDataContract",
   type: {
     name: "Composite",
-    className: "NameAndUserDataContract",
+    className: "NonNullableNameAndNullableUserDataContract",
     modelProperties: {
       name: {
+        required: true,
         serializedName: "name",
         constraints: {
-          MaxLength: 128
+          MaxLength: 128,
+          MinLength: 1
         },
         type: {
           name: "String"
@@ -1314,7 +1327,7 @@ export const MetaDataContract: msRest.CompositeMapper = {
     name: "Composite",
     className: "MetaDataContract",
     modelProperties: {
-      ...NameAndUserDataContract.type.modelProperties,
+      ...NonNullableNameAndNullableUserDataContract.type.modelProperties,
       recognitionModel: {
         nullable: false,
         serializedName: "recognitionModel",
@@ -1374,6 +1387,34 @@ export const PersonGroup: msRest.CompositeMapper = {
         constraints: {
           MaxLength: 64,
           Pattern: /^[a-z0-9-_]+$/
+        },
+        type: {
+          name: "String"
+        }
+      }
+    }
+  }
+};
+
+export const NameAndUserDataContract: msRest.CompositeMapper = {
+  serializedName: "NameAndUserDataContract",
+  type: {
+    name: "Composite",
+    className: "NameAndUserDataContract",
+    modelProperties: {
+      name: {
+        serializedName: "name",
+        constraints: {
+          MaxLength: 128
+        },
+        type: {
+          name: "String"
+        }
+      },
+      userData: {
+        serializedName: "userData",
+        constraints: {
+          MaxLength: 16384
         },
         type: {
           name: "String"

--- a/sdk/cognitiveservices/cognitiveservices-face/src/models/parameters.ts
+++ b/sdk/cognitiveservices/cognitiveservices-face/src/models/parameters.ts
@@ -196,7 +196,8 @@ export const returnFaceAttributes: msRest.OperationQueryParameter = {
             "blur",
             "exposure",
             "noise",
-            "mask"
+            "mask",
+            "qualityForRecognition"
           ]
         }
       }

--- a/sdk/cognitiveservices/cognitiveservices-face/src/models/personGroupOperationsMappers.ts
+++ b/sdk/cognitiveservices/cognitiveservices-face/src/models/personGroupOperationsMappers.ts
@@ -14,6 +14,7 @@ export {
   LargePersonGroup,
   MetaDataContract,
   NameAndUserDataContract,
+  NonNullableNameAndNullableUserDataContract,
   PersistedFace,
   Person,
   PersonGroup,

--- a/sdk/cognitiveservices/cognitiveservices-face/src/models/personGroupPersonMappers.ts
+++ b/sdk/cognitiveservices/cognitiveservices-face/src/models/personGroupPersonMappers.ts
@@ -9,14 +9,9 @@
 export {
   APIError,
   ErrorModel,
-  FaceList,
   ImageUrl,
-  LargeFaceList,
-  LargePersonGroup,
-  MetaDataContract,
   NameAndUserDataContract,
   PersistedFace,
   Person,
-  PersonGroup,
   UpdateFaceRequest
 } from "../models/mappers";

--- a/sdk/cognitiveservices/cognitiveservices-face/src/operations/face.ts
+++ b/sdk/cognitiveservices/cognitiveservices-face/src/operations/face.ts
@@ -222,8 +222,8 @@ export class Face {
    * original detection call.
    * * Optional parameters include faceId, landmarks, and attributes. Attributes include age, gender,
    * headPose, smile, facialHair, glasses, emotion, hair, makeup, occlusion, accessories, blur,
-   * exposure, noise, and mask. Some of the results returned for specific attributes may not be
-   * highly accurate.
+   * exposure, noise, mask, and qualityForRecognition. Some of the results returned for specific
+   * attributes may not be highly accurate.
    * * JPEG, PNG, GIF (the first frame), and BMP format are supported. The allowed image file size is
    * from 1KB to 6MB.
    * * Up to 100 faces can be returned for an image. Faces are ranked by face rectangle size from
@@ -321,8 +321,8 @@ export class Face {
    * original detection call.
    * * Optional parameters include faceId, landmarks, and attributes. Attributes include age, gender,
    * headPose, smile, facialHair, glasses, emotion, hair, makeup, occlusion, accessories, blur,
-   * exposure, noise, and mask. Some of the results returned for specific attributes may not be
-   * highly accurate.
+   * exposure, noise, mask, and qualityForRecognition. Some of the results returned for specific
+   * attributes may not be highly accurate.
    * * JPEG, PNG, GIF (the first frame), and BMP format are supported. The allowed image file size is
    * from 1KB to 6MB.
    * * Up to 100 faces can be returned for an image. Faces are ranked by face rectangle size from

--- a/sdk/cognitiveservices/cognitiveservices-face/src/operations/faceListOperations.ts
+++ b/sdk/cognitiveservices/cognitiveservices-face/src/operations/faceListOperations.ts
@@ -52,25 +52,29 @@ export class FaceListOperations {
    * Please Refer to [Specify a face recognition
    * model](https://docs.microsoft.com/azure/cognitive-services/face/face-api-how-to-topics/specify-recognition-model).
    * @param faceListId Id referencing a particular face list.
+   * @param name User defined name, maximum length is 128.
    * @param [options] The optional parameters
    * @returns Promise<msRest.RestResponse>
    */
-  create(faceListId: string, options?: Models.FaceListCreateOptionalParams): Promise<msRest.RestResponse>;
+  create(faceListId: string, name: string, options?: Models.FaceListCreateOptionalParams): Promise<msRest.RestResponse>;
   /**
    * @param faceListId Id referencing a particular face list.
+   * @param name User defined name, maximum length is 128.
    * @param callback The callback
    */
-  create(faceListId: string, callback: msRest.ServiceCallback<void>): void;
+  create(faceListId: string, name: string, callback: msRest.ServiceCallback<void>): void;
   /**
    * @param faceListId Id referencing a particular face list.
+   * @param name User defined name, maximum length is 128.
    * @param options The optional parameters
    * @param callback The callback
    */
-  create(faceListId: string, options: Models.FaceListCreateOptionalParams, callback: msRest.ServiceCallback<void>): void;
-  create(faceListId: string, options?: Models.FaceListCreateOptionalParams | msRest.ServiceCallback<void>, callback?: msRest.ServiceCallback<void>): Promise<msRest.RestResponse> {
+  create(faceListId: string, name: string, options: Models.FaceListCreateOptionalParams, callback: msRest.ServiceCallback<void>): void;
+  create(faceListId: string, name: string, options?: Models.FaceListCreateOptionalParams | msRest.ServiceCallback<void>, callback?: msRest.ServiceCallback<void>): Promise<msRest.RestResponse> {
     return this.client.sendOperationRequest(
       {
         faceListId,
+        name,
         options
       },
       createOperationSpec,
@@ -349,10 +353,7 @@ const createOperationSpec: msRest.OperationSpec = {
   ],
   requestBody: {
     parameterPath: {
-      name: [
-        "options",
-        "name"
-      ],
+      name: "name",
       userData: [
         "options",
         "userData"

--- a/sdk/cognitiveservices/cognitiveservices-face/src/operations/largeFaceListOperations.ts
+++ b/sdk/cognitiveservices/cognitiveservices-face/src/operations/largeFaceListOperations.ts
@@ -55,25 +55,29 @@ export class LargeFaceListOperations {
    * * Free-tier subscription quota: 64 large face lists.
    * * S0-tier subscription quota: 1,000,000 large face lists.
    * @param largeFaceListId Id referencing a particular large face list.
+   * @param name User defined name, maximum length is 128.
    * @param [options] The optional parameters
    * @returns Promise<msRest.RestResponse>
    */
-  create(largeFaceListId: string, options?: Models.LargeFaceListCreateOptionalParams): Promise<msRest.RestResponse>;
+  create(largeFaceListId: string, name: string, options?: Models.LargeFaceListCreateOptionalParams): Promise<msRest.RestResponse>;
   /**
    * @param largeFaceListId Id referencing a particular large face list.
+   * @param name User defined name, maximum length is 128.
    * @param callback The callback
    */
-  create(largeFaceListId: string, callback: msRest.ServiceCallback<void>): void;
+  create(largeFaceListId: string, name: string, callback: msRest.ServiceCallback<void>): void;
   /**
    * @param largeFaceListId Id referencing a particular large face list.
+   * @param name User defined name, maximum length is 128.
    * @param options The optional parameters
    * @param callback The callback
    */
-  create(largeFaceListId: string, options: Models.LargeFaceListCreateOptionalParams, callback: msRest.ServiceCallback<void>): void;
-  create(largeFaceListId: string, options?: Models.LargeFaceListCreateOptionalParams | msRest.ServiceCallback<void>, callback?: msRest.ServiceCallback<void>): Promise<msRest.RestResponse> {
+  create(largeFaceListId: string, name: string, options: Models.LargeFaceListCreateOptionalParams, callback: msRest.ServiceCallback<void>): void;
+  create(largeFaceListId: string, name: string, options?: Models.LargeFaceListCreateOptionalParams | msRest.ServiceCallback<void>, callback?: msRest.ServiceCallback<void>): Promise<msRest.RestResponse> {
     return this.client.sendOperationRequest(
       {
         largeFaceListId,
+        name,
         options
       },
       createOperationSpec,
@@ -523,10 +527,7 @@ const createOperationSpec: msRest.OperationSpec = {
   ],
   requestBody: {
     parameterPath: {
-      name: [
-        "options",
-        "name"
-      ],
+      name: "name",
       userData: [
         "options",
         "userData"
@@ -644,7 +645,9 @@ const listOperationSpec: msRest.OperationSpec = {
     Parameters.endpoint
   ],
   queryParameters: [
-    Parameters.returnRecognitionModel
+    Parameters.returnRecognitionModel,
+    Parameters.start0,
+    Parameters.top0
   ],
   responses: {
     200: {

--- a/sdk/cognitiveservices/cognitiveservices-face/src/operations/largePersonGroupOperations.ts
+++ b/sdk/cognitiveservices/cognitiveservices-face/src/operations/largePersonGroupOperations.ts
@@ -54,25 +54,29 @@ export class LargePersonGroupOperations {
    * * Free-tier subscription quota: 1,000 large person groups.
    * * S0-tier subscription quota: 1,000,000 large person groups.
    * @param largePersonGroupId Id referencing a particular large person group.
+   * @param name User defined name, maximum length is 128.
    * @param [options] The optional parameters
    * @returns Promise<msRest.RestResponse>
    */
-  create(largePersonGroupId: string, options?: Models.LargePersonGroupCreateOptionalParams): Promise<msRest.RestResponse>;
+  create(largePersonGroupId: string, name: string, options?: Models.LargePersonGroupCreateOptionalParams): Promise<msRest.RestResponse>;
   /**
    * @param largePersonGroupId Id referencing a particular large person group.
+   * @param name User defined name, maximum length is 128.
    * @param callback The callback
    */
-  create(largePersonGroupId: string, callback: msRest.ServiceCallback<void>): void;
+  create(largePersonGroupId: string, name: string, callback: msRest.ServiceCallback<void>): void;
   /**
    * @param largePersonGroupId Id referencing a particular large person group.
+   * @param name User defined name, maximum length is 128.
    * @param options The optional parameters
    * @param callback The callback
    */
-  create(largePersonGroupId: string, options: Models.LargePersonGroupCreateOptionalParams, callback: msRest.ServiceCallback<void>): void;
-  create(largePersonGroupId: string, options?: Models.LargePersonGroupCreateOptionalParams | msRest.ServiceCallback<void>, callback?: msRest.ServiceCallback<void>): Promise<msRest.RestResponse> {
+  create(largePersonGroupId: string, name: string, options: Models.LargePersonGroupCreateOptionalParams, callback: msRest.ServiceCallback<void>): void;
+  create(largePersonGroupId: string, name: string, options?: Models.LargePersonGroupCreateOptionalParams | msRest.ServiceCallback<void>, callback?: msRest.ServiceCallback<void>): Promise<msRest.RestResponse> {
     return this.client.sendOperationRequest(
       {
         largePersonGroupId,
+        name,
         options
       },
       createOperationSpec,
@@ -273,10 +277,7 @@ const createOperationSpec: msRest.OperationSpec = {
   ],
   requestBody: {
     parameterPath: {
-      name: [
-        "options",
-        "name"
-      ],
+      name: "name",
       userData: [
         "options",
         "userData"

--- a/sdk/cognitiveservices/cognitiveservices-face/src/operations/personGroupOperations.ts
+++ b/sdk/cognitiveservices/cognitiveservices-face/src/operations/personGroupOperations.ts
@@ -53,25 +53,29 @@ export class PersonGroupOperations {
    * * to handle larger scale face identification problem, please consider using
    * [LargePersonGroup](https://docs.microsoft.com/rest/api/faceapi/largepersongroup).
    * @param personGroupId Id referencing a particular person group.
+   * @param name User defined name, maximum length is 128.
    * @param [options] The optional parameters
    * @returns Promise<msRest.RestResponse>
    */
-  create(personGroupId: string, options?: Models.PersonGroupCreateOptionalParams): Promise<msRest.RestResponse>;
+  create(personGroupId: string, name: string, options?: Models.PersonGroupCreateOptionalParams): Promise<msRest.RestResponse>;
   /**
    * @param personGroupId Id referencing a particular person group.
+   * @param name User defined name, maximum length is 128.
    * @param callback The callback
    */
-  create(personGroupId: string, callback: msRest.ServiceCallback<void>): void;
+  create(personGroupId: string, name: string, callback: msRest.ServiceCallback<void>): void;
   /**
    * @param personGroupId Id referencing a particular person group.
+   * @param name User defined name, maximum length is 128.
    * @param options The optional parameters
    * @param callback The callback
    */
-  create(personGroupId: string, options: Models.PersonGroupCreateOptionalParams, callback: msRest.ServiceCallback<void>): void;
-  create(personGroupId: string, options?: Models.PersonGroupCreateOptionalParams | msRest.ServiceCallback<void>, callback?: msRest.ServiceCallback<void>): Promise<msRest.RestResponse> {
+  create(personGroupId: string, name: string, options: Models.PersonGroupCreateOptionalParams, callback: msRest.ServiceCallback<void>): void;
+  create(personGroupId: string, name: string, options?: Models.PersonGroupCreateOptionalParams | msRest.ServiceCallback<void>, callback?: msRest.ServiceCallback<void>): Promise<msRest.RestResponse> {
     return this.client.sendOperationRequest(
       {
         personGroupId,
+        name,
         options
       },
       createOperationSpec,
@@ -270,10 +274,7 @@ const createOperationSpec: msRest.OperationSpec = {
   ],
   requestBody: {
     parameterPath: {
-      name: [
-        "options",
-        "name"
-      ],
+      name: "name",
       userData: [
         "options",
         "userData"


### PR DESCRIPTION
A new `data-plane` SDK release request for the Face SDK has been created at https://github.com/Azure/sdk-release-request/issues/2251. This PR is to support that request. 

The following command has been used to generate the SDK:

```
autorest --version:2.0.4417 --typescript --license-header=MICROSOFT_MIT_NO_VERSION --typescript-sdks-folder=. --use=@microsoft.azure/autorest.typescript@4.2.2 --package-version=5.0.0 https://raw.githubusercontent.com/Azure/azure-rest-api-specs/b280ba25a2cc02d8174b43ed6a84ea1953a83f27/specification/cognitiveservices/data-plane/Face/readme.md
AutoRest code generation utility [cli version: 3.0.6339; node: v14.15.4, max-memory: 4096 MB]
(C) 2018 Microsoft Corporation.
https://aka.ms/autorest

There is a new version of AutoRest available (3.5.1).
 > You can install the newer version with with npm install -g autorest@latest

   Loading AutoRest core      'C:\Users\sarajama\.autorest\@microsoft.azure_autorest-core@2.0.4417\node_modules\@microsoft.azure\autorest-core\dist' (2.0.4417)
   Loading AutoRest extension '@microsoft.azure/autorest.typescript' (4.2.2->4.2.2)
   Loading AutoRest extension '@microsoft.azure/autorest.modeler' (2.3.51->2.3.51)
```

This release has a breaking change. So, I have updated the major version. 

@ramya-rao-a Please review and approve the PR. 
