### PR TITLE
Revert "Use working region/subscription for search deployments"

### DIFF
--- a/sdk/search/search-documents/tests.yml
+++ b/sdk/search/search-documents/tests.yml
@@ -5,6 +5,4 @@ stages:
     parameters:
       PackageName: "@azure/search-documents"
       ServiceDirectory: search
-      # TODO: change 'Preview' cloud back to public after search RP fixes deletion metadata issue
-      Clouds: 'Preview'
-      SupportedClouds: 'Preview,UsGov,China'
+      SupportedClouds: 'Public,UsGov,China'


### PR DESCRIPTION
Reverts Azure/azure-sdk-for-js#18512

The above PR was a temporary workaround fix for an RP deletion metadata issue. Checking to see if it is resolved now.