### PR TITLE
[Unified Recorder] NoOp AAD Credential in playback

### DIFF
--- a/sdk/test-utils/recorder-new/CHANGELOG.md
+++ b/sdk/test-utils/recorder-new/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## 1.0.0 (Unreleased)
 
+## 2021-11-30
+
+- Adds NoOp AAD Credential for playback `NoOpCredential`. Using this as your AAD credential in playback mode would avoid the AAD traffic in playback.
+  [#18904](https://github.com/Azure/azure-sdk-for-js/pull/18904)
+
 ## 2021-11-08
 
 - Allows storing dynamically created variables in record mode. The recorder registers the variables as part of the recording and stores their values in the recording file. Using the `variables` in playback mode produces the key-value pairs that were stored in the recording file.

--- a/sdk/test-utils/recorder-new/package.json
+++ b/sdk/test-utils/recorder-new/package.json
@@ -67,7 +67,8 @@
     "@azure-tools/test-recorder": "^1.0.0",
     "@azure/core-http": "^2.0.0",
     "@azure/core-rest-pipeline": "^1.1.0",
-    "@azure/test-utils": "^1.0.0"
+    "@azure/test-utils": "^1.0.0",
+    "@azure/core-auth": "^1.3.2"
   },
   "devDependencies": {
     "@azure/core-client": "^1.0.0",

--- a/sdk/test-utils/recorder-new/src/index.ts
+++ b/sdk/test-utils/recorder-new/src/index.ts
@@ -5,3 +5,4 @@ export { recorderHttpPolicy, TestProxyHttpClient } from "./core-v2-recorder";
 export { TestProxyHttpClientCoreV1 } from "./core-v1-recorder";
 export { relativeRecordingsPath } from "./utils/relativePathCalculator";
 export { SanitizerOptions, RecorderStartOptions } from "./utils/utils";
+export { NoOpCredential } from "./recorderAADCredential";

--- a/sdk/test-utils/recorder-new/src/recorderAADCredential.ts
+++ b/sdk/test-utils/recorder-new/src/recorderAADCredential.ts
@@ -1,0 +1,17 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { AccessToken, TokenCredential } from "@azure/core-auth";
+
+/**
+ * `TokenCredential` implementation for playback.
+ * If your regular AAD credentials don't take the recorder httpClient option, the AAD traffic won't be recorded.
+ * In this case, you'll need to bypass the AAD requests with no-op.
+ *
+ * Using this NoOpCredential as your credential in playback mode would help you bypass the AAD traffic.
+ */
+export class NoOpCredential implements TokenCredential {
+  async getToken(): Promise<AccessToken> {
+    return { token: "TEST TOKEN PLAYBACK", expiresOnTimestamp: 86400 * 1000 };
+  }
+}

--- a/sdk/test-utils/recorder-new/src/recorderAADCredential.ts
+++ b/sdk/test-utils/recorder-new/src/recorderAADCredential.ts
@@ -12,6 +12,9 @@ import { AccessToken, TokenCredential } from "@azure/core-auth";
  */
 export class NoOpCredential implements TokenCredential {
   getToken(): Promise<AccessToken> {
-    return Promise.resolve({ token: "SecretPlaceholder", expiresOnTimestamp: 86400 * 1000 });
+    return Promise.resolve({
+      token: "SecretPlaceholder",
+      expiresOnTimestamp: Date.now() + 86400 * 1000
+    });
   }
 }

--- a/sdk/test-utils/recorder-new/src/recorderAADCredential.ts
+++ b/sdk/test-utils/recorder-new/src/recorderAADCredential.ts
@@ -12,6 +12,6 @@ import { AccessToken, TokenCredential } from "@azure/core-auth";
  */
 export class NoOpCredential implements TokenCredential {
   getToken(): Promise<AccessToken> {
-    return Promise.resolve({ token: "TEST TOKEN PLAYBACK", expiresOnTimestamp: 86400 * 1000 });
+    return Promise.resolve({ token: "SecretPlaceholder", expiresOnTimestamp: 86400 * 1000 });
   }
 }

--- a/sdk/test-utils/recorder-new/src/recorderAADCredential.ts
+++ b/sdk/test-utils/recorder-new/src/recorderAADCredential.ts
@@ -11,7 +11,7 @@ import { AccessToken, TokenCredential } from "@azure/core-auth";
  * Using this NoOpCredential as your credential in playback mode would help you bypass the AAD traffic.
  */
 export class NoOpCredential implements TokenCredential {
-  async getToken(): Promise<AccessToken> {
-    return { token: "TEST TOKEN PLAYBACK", expiresOnTimestamp: 86400 * 1000 };
+  getToken(): Promise<AccessToken> {
+    return Promise.resolve({ token: "TEST TOKEN PLAYBACK", expiresOnTimestamp: 86400 * 1000 });
   }
 }

--- a/sdk/test-utils/testing-recorder-new/karma.conf.js
+++ b/sdk/test-utils/testing-recorder-new/karma.conf.js
@@ -53,7 +53,11 @@ module.exports = function(config) {
     envPreprocessor: [
       "TEST_MODE",
       "STORAGE_SAS_URL",
+      "TABLES_URL",
       "TABLES_SAS_CONNECTION_STRING",
+      "AZURE_CLIENT_ID",
+      "AZURE_CLIENT_SECRET",
+      "AZURE_TENANT_ID",
       "RECORDINGS_RELATIVE_PATH"
     ],
 
@@ -99,7 +103,13 @@ module.exports = function(config) {
     // start these browsers
     // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
     // 'ChromeHeadless', 'Chrome', 'Firefox', 'Edge', 'IE'
-    browsers: ["ChromeHeadless"],
+    browsers: ["ChromeHeadlessNoSandbox"],
+    customLaunchers: {
+      ChromeHeadlessNoSandbox: {
+        base: "ChromeHeadless",
+        flags: ["--no-sandbox", "--disable-web-security"]
+      }
+    },
 
     // Continuous Integration mode
     // if true, Karma captures browsers, runs the tests and exits

--- a/sdk/test-utils/testing-recorder-new/package.json
+++ b/sdk/test-utils/testing-recorder-new/package.json
@@ -58,8 +58,10 @@
   "private": true,
   "devDependencies": {
     "@azure/core-util": "^1.0.0-beta.1",
+    "@azure/identity": "^2.0.1",
     "@azure-tools/test-recorder": "^1.0.0",
     "@azure-tools/test-recorder-new": "^1.0.0",
+    "@azure/core-auth": "^1.3.2",
     "@azure/storage-queue": "^12.6.0",
     "@azure/dev-tool": "^1.0.0",
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",

--- a/sdk/test-utils/testing-recorder-new/recordings/browsers/noop_credential_with_tables/recording_should_create_new_table_then_delete.json
+++ b/sdk/test-utils/testing-recorder-new/recordings/browsers/noop_credential_with_tables/recording_should_create_new_table_then_delete.json
@@ -1,0 +1,95 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://fakeaccount.table.core.windows.net/Tables",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json;odata=minimalmetadata",
+        "Accept-Encoding": "gzip, deflate, br",
+        "Accept-Language": "en-US",
+        "Authorization": "Sanitized",
+        "Connection": "keep-alive",
+        "Content-Length": "25",
+        "Content-Type": "application/json;odata=nometadata",
+        "dataserviceversion": "3.0",
+        "prefer": "return-content",
+        "Referer": "http://localhost:9328/",
+        "sec-ch-ua": "",
+        "sec-ch-ua-mobile": "?0",
+        "sec-ch-ua-platform": "",
+        "Sec-Fetch-Dest": "empty",
+        "Sec-Fetch-Mode": "cors",
+        "Sec-Fetch-Site": "same-site",
+        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/93.0.4577.0 Safari/537.36",
+        "x-ms-client-request-id": "73505eb1-249a-4907-a923-31a56ecb6ab2",
+        "x-ms-useragent": "azsdk-js-data-tables/12.1.2 core-rest-pipeline/1.3.2 OS/Linuxx86_64",
+        "x-ms-version": "2019-02-02"
+      },
+      "RequestBody": {
+        "TableName": "table1678"
+      },
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Type": "application/json; odata=minimalmetadata; streaming=true; charset=utf-8",
+        "Date": "Wed, 01 Dec 2021 03:33:59 GMT",
+        "Location": "https://fakeaccount.table.core.windows.net/Tables(\u0027table1678\u0027)",
+        "Preference-Applied": "return-content",
+        "Server": [
+          "Windows-Azure-Table/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "73505eb1-249a-4907-a923-31a56ecb6ab2",
+        "x-ms-request-id": "f4a38afa-9002-0015-7164-e64326000000",
+        "x-ms-version": "2019-02-02"
+      },
+      "ResponseBody": {
+        "odata.metadata": "https://fakeaccount.table.core.windows.net/$metadata#Tables/@Element",
+        "TableName": "table1678"
+      }
+    },
+    {
+      "RequestUri": "https://fakeaccount.table.core.windows.net/Tables(\u0027table1678\u0027)",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip, deflate, br",
+        "Accept-Language": "en-US",
+        "Authorization": "Sanitized",
+        "Connection": "keep-alive",
+        "Referer": "http://localhost:9328/",
+        "sec-ch-ua": "",
+        "sec-ch-ua-mobile": "?0",
+        "sec-ch-ua-platform": "",
+        "Sec-Fetch-Dest": "empty",
+        "Sec-Fetch-Mode": "cors",
+        "Sec-Fetch-Site": "same-site",
+        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/93.0.4577.0 Safari/537.36",
+        "x-ms-client-request-id": "4a1c3793-6746-42a4-9c4c-24957e49217d",
+        "x-ms-useragent": "azsdk-js-data-tables/12.1.2 core-rest-pipeline/1.3.2 OS/Linuxx86_64",
+        "x-ms-version": "2019-02-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "0",
+        "Date": "Wed, 01 Dec 2021 03:33:59 GMT",
+        "Server": [
+          "Windows-Azure-Table/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "4a1c3793-6746-42a4-9c4c-24957e49217d",
+        "x-ms-request-id": "f4a38b1c-9002-0015-1164-e64326000000",
+        "x-ms-version": "2019-02-02"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "table-name": "table1678"
+  }
+}

--- a/sdk/test-utils/testing-recorder-new/recordings/node/noop_credential_with_tables/recording_should_create_new_table_then_delete.json
+++ b/sdk/test-utils/testing-recorder-new/recordings/node/noop_credential_with_tables/recording_should_create_new_table_then_delete.json
@@ -1,0 +1,77 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://fakeaccount.table.core.windows.net/Tables",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json;odata=minimalmetadata",
+        "Accept-Encoding": "gzip,deflate",
+        "Authorization": "Sanitized",
+        "Connection": "keep-alive",
+        "Content-Length": "25",
+        "Content-Type": "application/json;odata=nometadata",
+        "dataserviceversion": "3.0",
+        "prefer": "return-content",
+        "User-Agent": "azsdk-js-data-tables/12.1.2 core-rest-pipeline/1.3.2 Node/v14.17.6 OS/(x64-Linux-5.4.0-1063-azure)",
+        "x-ms-client-request-id": "32ba8e90-d7e1-493f-96b3-8f4e85e0683b",
+        "x-ms-version": "2019-02-02"
+      },
+      "RequestBody": {
+        "TableName": "table1869"
+      },
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Type": "application/json; odata=minimalmetadata; streaming=true; charset=utf-8",
+        "Date": "Wed, 01 Dec 2021 03:33:54 GMT",
+        "Location": "https://fakeaccount.table.core.windows.net/Tables(\u0027table1869\u0027)",
+        "Preference-Applied": "return-content",
+        "Server": [
+          "Windows-Azure-Table/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "32ba8e90-d7e1-493f-96b3-8f4e85e0683b",
+        "x-ms-request-id": "76817f31-4002-007a-8064-e6ebf2000000",
+        "x-ms-version": "2019-02-02"
+      },
+      "ResponseBody": {
+        "odata.metadata": "https://fakeaccount.table.core.windows.net/$metadata#Tables/@Element",
+        "TableName": "table1869"
+      }
+    },
+    {
+      "RequestUri": "https://fakeaccount.table.core.windows.net/Tables(\u0027table1869\u0027)",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip,deflate",
+        "Authorization": "Sanitized",
+        "Connection": "keep-alive",
+        "User-Agent": "azsdk-js-data-tables/12.1.2 core-rest-pipeline/1.3.2 Node/v14.17.6 OS/(x64-Linux-5.4.0-1063-azure)",
+        "x-ms-client-request-id": "1289757b-56ab-4e6f-87a7-eee3c49f498b",
+        "x-ms-version": "2019-02-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "0",
+        "Date": "Wed, 01 Dec 2021 03:33:54 GMT",
+        "Server": [
+          "Windows-Azure-Table/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "1289757b-56ab-4e6f-87a7-eee3c49f498b",
+        "x-ms-request-id": "76817f46-4002-007a-1464-e6ebf2000000",
+        "x-ms-version": "2019-02-02"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "table-name": "table1869"
+  }
+}

--- a/sdk/test-utils/testing-recorder-new/test/noOpCredentialTest.spec.ts
+++ b/sdk/test-utils/testing-recorder-new/test/noOpCredentialTest.spec.ts
@@ -1,0 +1,62 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import {
+  RecorderStartOptions,
+  NoOpCredential,
+  recorderHttpPolicy,
+  TestProxyHttpClient
+} from "@azure-tools/test-recorder-new";
+import { env, isPlaybackMode } from "@azure-tools/test-recorder";
+import { TokenCredential } from "@azure/core-auth";
+import { ClientSecretCredential } from "@azure/identity";
+import { TableServiceClient } from "@azure/data-tables";
+
+const recorderStartOptions: RecorderStartOptions = {
+  envSetupForPlayback: {
+    TABLES_URL: "https://fakeaccount.table.core.windows.net",
+    AZURE_CLIENT_ID: "azure_client_id",
+    AZURE_CLIENT_SECRET: "azure_client_secret",
+    AZURE_TENANT_ID: "azuretenantid"
+  },
+  sanitizerOptions: {
+    bodyRegexSanitizers: [
+      {
+        regex: encodeURIComponent(env.TABLES_URL),
+        value: encodeURIComponent(`https://fakeaccount.table.core.windows.net`)
+      }
+    ]
+  }
+};
+
+describe(`NoOp credential with Tables`, () => {
+  let recorder: TestProxyHttpClient;
+  let credential: TokenCredential;
+
+  beforeEach(async function() {
+    recorder = new TestProxyHttpClient(this.currentTest);
+    await recorder.start(recorderStartOptions);
+    credential = isPlaybackMode()
+      ? new NoOpCredential()
+      : new ClientSecretCredential(
+          env["AZURE_TENANT_ID"],
+          env["AZURE_CLIENT_ID"],
+          env["AZURE_CLIENT_SECRET"]
+        );
+  });
+
+  afterEach(async function() {
+    await recorder.stop();
+  });
+
+  it("should create new table, then delete", async () => {
+    if (!isPlaybackMode()) {
+      recorder.variables["table-name"] = `table${Math.ceil(Math.random() * 1000 + 1000)}`;
+    }
+    const tableName = recorder.variables["table-name"];
+    const client = new TableServiceClient(env.TABLES_URL, credential);
+    client.pipeline.addPolicy(recorderHttpPolicy(recorder));
+    await client.createTable(tableName);
+    await client.deleteTable(tableName);
+  });
+});


### PR DESCRIPTION
## Fixes #18897

## Background
If the AAD credentials don't take the recorder httpClient option, the AAD traffic won't be recorded.
In this case, we'll need to bypass the AAD requests with no-ops in playback(since there are no recorded requests to match).
This PR provides the No-op AAD credential for playback as part of recorder-new.

## The plan
The current plan is to provide both ways of recording the AAD tests - with and without recording AAD traffic
- NoOp credential  https://github.com/Azure/azure-sdk-for-js/pull/18896 - where the services/SDKs don't care about the AAD traffic
  - .NET and Python follow this model for all their services/SDKs 
- RecorderHttpClient for AAD - https://github.com/Azure/azure-sdk-for-js/pull/18898 - for the Services/SDKs that would want to see the AAD traffic in their tests
  - We had seen some value in recording the AAD traffic with the old recorder(in JS). 
  - This has particularly helped us uncover multiple bugs in the token refreshing space where we regressed and started making more requests than expected. 
  - Also helped us see how the msal has been changing over time w.r.t its request bodies.
  - We are waiting for a special kind of matcher from the proxy tool side to complete the missing pieces in this area.
  - This is exclusive for JS.

## What's in the PR?
- Adds the NoOp credential in recorder-new and exports it
- Adds a test in testing-recorder-new by showing how it can be used with data-tables
- Showing how the recordings look like - without AAD traffic
- Changelog