### PR TITLE
[Tables] Call onResponse when handling TalbeAlreadyExists response

### DIFF
--- a/sdk/tables/data-tables/README.md
+++ b/sdk/tables/data-tables/README.md
@@ -204,7 +204,7 @@ main();
 #### Create a new table
 
 You can create a table through a `TableServiceClient` instance calling the `createTable` function. This function takes the name of the table to create as a parameter.
-Note that `createTable` won't throw an error when the table already exist.
+Note that `createTable` won't throw an error when the table already exists.
 
 ```javascript
 const { TableServiceClient, AzureNamedKeyCredential } = require("@azure/data-tables");
@@ -219,14 +219,15 @@ const serviceClient = new TableServiceClient(
 );
 
 async function main() {
-  const tableName = `newtable${new Date().getTime()}`;
+  const tableName = `newtable`;
+  // If the table 'newTable' already exists, createTable doesn' throw
   await serviceClient.createTable(tableName);
 }
 
 main();
 ```
 
-Here is a sample that checks if the table already existed
+Here is a sample that demonstrates how to test if the table already exists when attempting to create it:
 
 ```javascript
 const { TableServiceClient, AzureNamedKeyCredential } = require("@azure/data-tables");

--- a/sdk/tables/data-tables/README.md
+++ b/sdk/tables/data-tables/README.md
@@ -17,6 +17,7 @@ Azure Cosmos DB provides a Table API for applications that are written for Azure
 - The Azure Tables client library can seamlessly target either Azure table storage or Azure Cosmos DB table service endpoints with no code changes.
 
 Key links:
+
 - [Source code](https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/tables/data-tables/)
 - [Package (NPM)](https://www.npmjs.com/package/@azure/data-tables)
 - [API reference documentation](https://docs.microsoft.com/javascript/api/@azure/data-tables)
@@ -123,6 +124,7 @@ const { TableServiceClient, AzureNamedKeyCredential } = require("@azure/data-tab
 The `TableServiceClient` requires a URL to the table service and an access credential. It also optionally accepts some settings in the `options` parameter.
 
 #### `TableServiceClient` with TokenCredential (AAD)
+
 Azure Tables provides integration with Azure Active Directory (Azure AD) for identity-based authentication of requests
 to the Table service when targeting a Storage endpoint. With Azure AD, you can use role-based access control (RBAC) to
 grant access to your Azure Table resources to users, groups, or applications.
@@ -202,6 +204,7 @@ main();
 #### Create a new table
 
 You can create a table through a `TableServiceClient` instance calling the `createTable` function. This function takes the name of the table to create as a parameter.
+Note that `createTable` won't throw an error when the table already exist.
 
 ```javascript
 const { TableServiceClient, AzureNamedKeyCredential } = require("@azure/data-tables");
@@ -218,6 +221,34 @@ const serviceClient = new TableServiceClient(
 async function main() {
   const tableName = `newtable${new Date().getTime()}`;
   await serviceClient.createTable(tableName);
+}
+
+main();
+```
+
+Here is a sample that checks if the table already existed
+
+```javascript
+const { TableServiceClient, AzureNamedKeyCredential } = require("@azure/data-tables");
+
+const account = "<account>";
+const accountKey = "<accountkey>";
+
+const credential = new AzureNamedKeyCredential(account, accountKey);
+const serviceClient = new TableServiceClient(
+  `https://${account}.table.core.windows.net`,
+  credential
+);
+
+async function main() {
+  const tableName = `newtable${new Date().getTime()}`;
+  await serviceClient.createTable(tableName, {
+    onResponse: (response) => {
+      if (response.status === 409) {
+        console.log(`Table ${tableName} already exists`);
+      }
+    }
+  });
 }
 
 main();
@@ -247,6 +278,7 @@ const client = new TableClient(`https://${account}.table.core.windows.net`, tabl
 ```
 
 #### `TableClient` with `TokenCredential` (Azure Active Directory)
+
 Azure Tables provides integration with Azure Active Directory (Azure AD) for identity-based authentication of requests
 to the Table service when targeting a Storage endpoint. With Azure AD, you can use role-based access control (RBAC) to
 grant access to your Azure Table resources to users, groups, or applications.
@@ -356,32 +388,30 @@ main();
 The Azure Tables Client SDK also works with Azurite, an Azure Storage and Tables API compatible server emulator. Please refer to the ([Azurite repository](https://github.com/Azure/Azurite#azurite-v3)) on how to get started using it.
 
 ### Connecting to Azurite with Connection String shortcut
+
 The easiest way to connect to Azurite from your application is to configure a connection string that references the shortcut `UseDevelopmentStorage=true`. The shortcut is equivalent to the full connection string for the emulator, which specifies the account name, the account key, and the emulator endpoints for each of the Azure Storage services: ([see more](https://github.com/Azure/Azurite#http-connection-strings)). Using this shortcut, the Azure Tables Client SDK would setup the default connection string and `allowInsecureConnection` in the client options.
 
 ```typescript
-import { TableClient } from "@azure/data-tables"
+import { TableClient } from "@azure/data-tables";
 
 const connectionString = "UseDevelopmentStorage=true";
 const client = TableClient.fromConnectionString(connectionString, "myTable");
 ```
 
 ### Connecting to Azurite without Connection String shortcut
+
 You can connect to azurite manually without using the connection string shortcut by specifying the service URL and `AzureNamedKeyCredential` or a custom connection string. However, `allowInsecureConnection` will need to be set manually in case Azurite runs in an `http` endpoint.
 
 ```typescript
-import { TableClient, AzureNamedKeyCredential } from "@azure/data-tables"
+import { TableClient, AzureNamedKeyCredential } from "@azure/data-tables";
 
 const client = new TableClient(
   "<Azurite-http-table-endpoint>",
   "myTable",
-  new AzureNamedKeyCredential(
-    "<Azurite-account-name>",
-    "<Azurite-account-key>"
-  ),
+  new AzureNamedKeyCredential("<Azurite-account-name>", "<Azurite-account-key>"),
   { allowInsecureConnection: true }
 );
 ```
-
 
 ## Troubleshooting
 

--- a/sdk/tables/data-tables/src/TableClient.ts
+++ b/sdk/tables/data-tables/src/TableClient.ts
@@ -2,38 +2,38 @@
 // Licensed under the MIT license.
 
 import {
-  TableEntity,
-  ListTableEntitiesOptions,
-  GetTableEntityResponse,
-  UpdateTableEntityOptions,
-  DeleteTableEntityOptions,
-  GetTableEntityOptions,
-  UpdateMode,
   CreateTableEntityResponse,
-  TableEntityQueryOptions,
-  TableServiceClientOptions as TableClientOptions,
-  TableEntityResult,
-  TransactionAction,
-  TableTransactionResponse,
-  SignedIdentifier,
+  DeleteTableEntityOptions,
   GetAccessPolicyResponse,
-  TableEntityResultPage
+  GetTableEntityOptions,
+  GetTableEntityResponse,
+  ListTableEntitiesOptions,
+  SignedIdentifier,
+  TableServiceClientOptions as TableClientOptions,
+  TableEntity,
+  TableEntityQueryOptions,
+  TableEntityResult,
+  TableEntityResultPage,
+  TableTransactionResponse,
+  TransactionAction,
+  UpdateMode,
+  UpdateTableEntityOptions
 } from "./models";
 import {
-  UpdateEntityResponse,
-  UpsertEntityResponse,
   DeleteTableEntityResponse,
-  SetAccessPolicyResponse
+  SetAccessPolicyResponse,
+  UpdateEntityResponse,
+  UpsertEntityResponse
 } from "./generatedModels";
 import { TableQueryEntitiesOptionalParams } from "./generated/models";
 import { getClientParamsFromConnectionString } from "./utils/connectionString";
 import {
-  isNamedKeyCredential,
-  isSASCredential,
-  isTokenCredential,
   NamedKeyCredential,
   SASCredential,
-  TokenCredential
+  TokenCredential,
+  isNamedKeyCredential,
+  isSASCredential,
+  isTokenCredential
 } from "@azure/core-auth";
 import { tablesNamedKeyCredentialPolicy } from "./tablesNamedCredentialPolicy";
 import "@azure/core-paging";
@@ -68,7 +68,7 @@ import { isCosmosEndpoint } from "./utils/isCosmosEndpoint";
 import { cosmosPatchPolicy } from "./cosmosPathPolicy";
 import { decodeContinuationToken, encodeContinuationToken } from "./utils/continuationToken";
 import { escapeQuotes } from "./odata";
-import { handleTableAlreadyExist } from "./utils/errorHelpers";
+import { handleTableAlreadyExists } from "./utils/errorHelpers";
 
 /**
  * A TableClient represents a Client to the Azure Tables service allowing you
@@ -335,7 +335,7 @@ export class TableClient {
     try {
       await this.table.create({ name: this.tableName }, updatedOptions);
     } catch (e) {
-      handleTableAlreadyExist(e, { ...updatedOptions, span, logger });
+      handleTableAlreadyExists(e, { ...updatedOptions, span, logger, tableName: this.tableName });
     } finally {
       span.end();
     }

--- a/sdk/tables/data-tables/src/TablePolicies.ts
+++ b/sdk/tables/data-tables/src/TablePolicies.ts
@@ -2,10 +2,10 @@
 // Licensed under the MIT license.
 
 import {
-  PipelineResponse,
-  PipelineRequest,
-  SendRequest,
   PipelinePolicy,
+  PipelineRequest,
+  PipelineResponse,
+  SendRequest,
   createHttpHeaders,
   createPipelineRequest
 } from "@azure/core-rest-pipeline";

--- a/sdk/tables/data-tables/src/TableServiceClient.ts
+++ b/sdk/tables/data-tables/src/TableServiceClient.ts
@@ -5,24 +5,24 @@ import { GeneratedClient } from "./generated/generatedClient";
 import { Service, Table } from "./generated";
 import {
   ListTableItemsOptions,
-  TableServiceClientOptions,
+  TableItem,
   TableQueryOptions,
-  TableItem
+  TableServiceClientOptions
 } from "./models";
 import {
-  GetStatisticsResponse,
   GetPropertiesResponse,
-  SetPropertiesOptions,
+  GetStatisticsResponse,
   ServiceProperties,
+  SetPropertiesOptions,
   SetPropertiesResponse
 } from "./generatedModels";
 import { getClientParamsFromConnectionString } from "./utils/connectionString";
 import {
-  isNamedKeyCredential,
   NamedKeyCredential,
   SASCredential,
-  isSASCredential,
   TokenCredential,
+  isNamedKeyCredential,
+  isSASCredential,
   isTokenCredential
 } from "@azure/core-auth";
 import "@azure/core-paging";
@@ -38,7 +38,7 @@ import { Pipeline } from "@azure/core-rest-pipeline";
 import { isCredential } from "./utils/isCredential";
 import { tablesSASTokenPolicy } from "./tablesSASTokenPolicy";
 import { TableItemResultPage } from "./models";
-import { handleTableAlreadyExist } from "./utils/errorHelpers";
+import { handleTableAlreadyExists } from "./utils/errorHelpers";
 
 /**
  * A TableServiceClient represents a Client to the Azure Tables service allowing you
@@ -249,7 +249,7 @@ export class TableServiceClient {
     try {
       await this.table.create({ name }, { ...updatedOptions });
     } catch (e) {
-      handleTableAlreadyExist(e, { ...updatedOptions, span, logger });
+      handleTableAlreadyExists(e, { ...updatedOptions, span, logger, tableName: name });
     } finally {
       span.end();
     }

--- a/sdk/tables/data-tables/src/TableTransaction.ts
+++ b/sdk/tables/data-tables/src/TableTransaction.ts
@@ -2,36 +2,36 @@
 // Licensed under the MIT license.
 
 import {
-  createHttpHeaders,
-  createPipelineRequest,
+  Pipeline,
+  PipelineRequest,
   PipelineResponse,
   RestError,
-  Pipeline,
-  PipelineRequest
+  createHttpHeaders,
+  createPipelineRequest
 } from "@azure/core-rest-pipeline";
 import {
-  ServiceClient,
   OperationOptions,
+  ServiceClient,
+  ServiceClientOptions,
   serializationPolicy,
-  serializationPolicyName,
-  ServiceClientOptions
+  serializationPolicyName
 } from "@azure/core-client";
 import {
   DeleteTableEntityOptions,
   TableEntity,
-  UpdateMode,
-  UpdateTableEntityOptions,
-  TableTransactionResponse,
   TableTransactionEntityResponse,
-  TransactionAction
+  TableTransactionResponse,
+  TransactionAction,
+  UpdateMode,
+  UpdateTableEntityOptions
 } from "./models";
 import {
-  isNamedKeyCredential,
-  isSASCredential,
-  isTokenCredential,
   NamedKeyCredential,
   SASCredential,
-  TokenCredential
+  TokenCredential,
+  isNamedKeyCredential,
+  isSASCredential,
+  isTokenCredential
 } from "@azure/core-auth";
 import { getAuthorizationHeader } from "./tablesNamedCredentialPolicy";
 import { TableClientLike } from "./utils/internalModels";
@@ -40,14 +40,14 @@ import { SpanStatusCode } from "@azure/core-tracing";
 import { TableServiceErrorOdataError } from "./generated";
 import { getTransactionHeaders } from "./utils/transactionHeaders";
 import {
-  getTransactionHttpRequestBody,
-  getInitialTransactionBody
+  getInitialTransactionBody,
+  getTransactionHttpRequestBody
 } from "./utils/transactionHelpers";
 import { signURLWithSAS } from "./tablesSASTokenPolicy";
 import {
   transactionHeaderFilterPolicy,
-  transactionRequestAssemblePolicy,
   transactionHeaderFilterPolicyName,
+  transactionRequestAssemblePolicy,
   transactionRequestAssemblePolicyName
 } from "./TablePolicies";
 import { isCosmosEndpoint } from "./utils/isCosmosEndpoint";

--- a/sdk/tables/data-tables/src/logger.ts
+++ b/sdk/tables/data-tables/src/logger.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { createClientLogger, AzureLogger } from "@azure/logger";
+import { AzureLogger, createClientLogger } from "@azure/logger";
 
 /**
  * The \@azure/logger configuration for this package.

--- a/sdk/tables/data-tables/src/models.ts
+++ b/sdk/tables/data-tables/src/models.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 
 import { TableGetAccessPolicyHeaders, TableInsertEntityHeaders } from "./generated/models";
-import { OperationOptions, CommonClientOptions } from "@azure/core-client";
+import { CommonClientOptions, OperationOptions } from "@azure/core-client";
 
 /**
  * Represents the Create or Delete Entity operation to be included in a Transaction request

--- a/sdk/tables/data-tables/src/sas/accountSasSignatureValues.ts
+++ b/sdk/tables/data-tables/src/sas/accountSasSignatureValues.ts
@@ -11,7 +11,7 @@ import {
   accountSasResourceTypesToString
 } from "./accountSasResourceTypes";
 import { accountSasServicesFromString, accountSasServicesToString } from "./accountSasServices";
-import { ipRangeToString, SasIPRange } from "./sasIPRange";
+import { SasIPRange, ipRangeToString } from "./sasIPRange";
 import { SasProtocol, SasQueryParameters } from "./sasQueryParameters";
 
 /**

--- a/sdk/tables/data-tables/src/sas/generateAccountSas.ts
+++ b/sdk/tables/data-tables/src/sas/generateAccountSas.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { isNamedKeyCredential, NamedKeyCredential } from "@azure/core-auth";
+import { NamedKeyCredential, isNamedKeyCredential } from "@azure/core-auth";
 import { AccountSasPermissions, accountSasPermissionsFromString } from "./accountSasPermissions";
 import {
   AccountSasServices,

--- a/sdk/tables/data-tables/src/sas/generateTableSas.ts
+++ b/sdk/tables/data-tables/src/sas/generateTableSas.ts
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { isNamedKeyCredential, NamedKeyCredential } from "@azure/core-auth";
+import { NamedKeyCredential, isNamedKeyCredential } from "@azure/core-auth";
 import { tableSasPermissionsFromString } from "./tableSasPermisions";
 import {
-  generateTableSasQueryParameters,
-  TableSasSignatureValues
+  TableSasSignatureValues,
+  generateTableSasQueryParameters
 } from "./tableSasSignatureValues";
 
 /**

--- a/sdk/tables/data-tables/src/sas/sasQueryParameters.ts
+++ b/sdk/tables/data-tables/src/sas/sasQueryParameters.ts
@@ -3,7 +3,7 @@
 
 import { truncatedISO8061Date } from "../utils/truncateISO8061Date";
 import { UserDelegationKey } from "./models";
-import { ipRangeToString, SasIPRange } from "./sasIPRange";
+import { SasIPRange, ipRangeToString } from "./sasIPRange";
 
 /**
  * Protocols for generated SAS.

--- a/sdk/tables/data-tables/src/sas/tableSasSignatureValues.ts
+++ b/sdk/tables/data-tables/src/sas/tableSasSignatureValues.ts
@@ -11,7 +11,7 @@ import { NamedKeyCredential } from "@azure/core-auth";
 import { computeHMACSHA256 } from "../utils/computeHMACSHA256";
 import { SERVICE_VERSION } from "../utils/constants";
 import { truncatedISO8061Date } from "../utils/truncateISO8061Date";
-import { ipRangeToString, SasIPRange } from "./sasIPRange";
+import { SasIPRange, ipRangeToString } from "./sasIPRange";
 import { SasProtocol, SasQueryParameters } from "./sasQueryParameters";
 import { TableSasPermissions, tableSasPermissionsToString } from "./tableSasPermisions";
 

--- a/sdk/tables/data-tables/src/serialization.ts
+++ b/sdk/tables/data-tables/src/serialization.ts
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
-import { base64Encode, base64Decode } from "./utils/bufferSerializer";
+import { base64Decode, base64Encode } from "./utils/bufferSerializer";
 import { EdmTypes, SignedIdentifier, TableEntityQueryOptions } from "./models";
 import { truncatedISO8061Date } from "./utils/truncateISO8061Date";
 import {
-  SignedIdentifier as GeneratedSignedIdentifier,
-  QueryOptions as GeneratedQueryOptions
+  QueryOptions as GeneratedQueryOptions,
+  SignedIdentifier as GeneratedSignedIdentifier
 } from "./generated/models";
 
 const propertyCaseMap: Map<string, string> = new Map<string, string>([

--- a/sdk/tables/data-tables/src/tablesNamedCredentialPolicy.ts
+++ b/sdk/tables/data-tables/src/tablesNamedCredentialPolicy.ts
@@ -2,10 +2,10 @@
 // Licensed under the MIT license.
 
 import {
-  PipelineResponse,
+  PipelinePolicy,
   PipelineRequest,
-  SendRequest,
-  PipelinePolicy
+  PipelineResponse,
+  SendRequest
 } from "@azure/core-rest-pipeline";
 import { NamedKeyCredential } from "@azure/core-auth";
 import { HeaderConstants } from "./utils/constants";

--- a/sdk/tables/data-tables/src/tablesSASTokenPolicy.ts
+++ b/sdk/tables/data-tables/src/tablesSASTokenPolicy.ts
@@ -2,10 +2,10 @@
 // Licensed under the MIT license.
 
 import {
-  PipelineResponse,
+  PipelinePolicy,
   PipelineRequest,
-  SendRequest,
-  PipelinePolicy
+  PipelineResponse,
+  SendRequest
 } from "@azure/core-rest-pipeline";
 import { SASCredential } from "@azure/core-auth";
 import { URL, URLSearchParams } from "./utils/url";

--- a/sdk/tables/data-tables/src/utils/continuationToken.ts
+++ b/sdk/tables/data-tables/src/utils/continuationToken.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { base64Encode, base64Decode } from "./bufferSerializer";
+import { base64Decode, base64Encode } from "./bufferSerializer";
 
 export interface ContinuationToken {
   nextPartitionKey: string;

--- a/sdk/tables/data-tables/src/utils/errorHelpers.ts
+++ b/sdk/tables/data-tables/src/utils/errorHelpers.ts
@@ -1,0 +1,62 @@
+import { OperationOptions, OperationRequest } from "@azure/core-client";
+import { PipelineResponse, RestError } from "@azure/core-rest-pipeline";
+import { SpanStatusCode } from "@azure/core-tracing";
+import { AzureLogger } from "@azure/logger";
+import { TableServiceError } from "../generated";
+
+export type TableServiceErrorResponse = PipelineResponse & {
+  /**
+   * The parsed HTTP response headers.
+   */
+  parsedHeaders?: Record<string, unknown>;
+  /**
+   * The response body as parsed JSON or XML.
+   */
+  parsedBody: TableServiceError;
+  /**
+   * The request that generated the response.
+   */
+  request: OperationRequest;
+};
+
+export function handleTableAlreadyExist(
+  error: unknown,
+  options: OperationOptions & { span?: any; logger?: AzureLogger } = {}
+) {
+  const responseError = getErrorResponse(error);
+  if (
+    responseError &&
+    responseError.status === 409 &&
+    responseError.parsedBody.odataError?.code === "TableAlreadyExists"
+  ) {
+    options.logger?.info("Table Already Exists");
+    options.onResponse && options.onResponse(responseError, {});
+  } else {
+    options?.span.setStatus({ code: SpanStatusCode.ERROR, message: (error as Error)?.message });
+    throw error;
+  }
+}
+
+function getErrorResponse(error: unknown): TableServiceErrorResponse | undefined {
+  if (!isRestError(error)) {
+    return undefined;
+  }
+
+  const errorResponse: TableServiceErrorResponse = error.response as TableServiceErrorResponse;
+
+  if (!errorResponse || !isTableServiceErrorResponse(errorResponse.parsedBody)) {
+    return undefined;
+  }
+
+  return errorResponse;
+}
+
+function isRestError(error: unknown): error is RestError {
+  return (error as RestError).name === "RestError";
+}
+
+function isTableServiceErrorResponse(
+  errorResponseBody: any
+): errorResponseBody is TableServiceError {
+  return Boolean(errorResponseBody?.odataError);
+}

--- a/sdk/tables/data-tables/src/utils/errorHelpers.ts
+++ b/sdk/tables/data-tables/src/utils/errorHelpers.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
 import { OperationOptions, OperationRequest } from "@azure/core-client";
 import { PipelineResponse, RestError } from "@azure/core-rest-pipeline";
 import { SpanStatusCode } from "@azure/core-tracing";
@@ -19,18 +22,21 @@ export type TableServiceErrorResponse = PipelineResponse & {
   request: OperationRequest;
 };
 
-export function handleTableAlreadyExist(
+export function handleTableAlreadyExists(
   error: unknown,
-  options: OperationOptions & { span?: any; logger?: AzureLogger } = {}
-) {
+  options: OperationOptions & { tableName?: string; span?: any; logger?: AzureLogger } = {}
+): void {
   const responseError = getErrorResponse(error);
   if (
     responseError &&
     responseError.status === 409 &&
     responseError.parsedBody.odataError?.code === "TableAlreadyExists"
   ) {
-    options.logger?.info("Table Already Exists");
-    options.onResponse && options.onResponse(responseError, {});
+    options.logger?.info(`Table ${options.tableName} already Exists`);
+
+    if (options.onResponse) {
+      options.onResponse(responseError, {});
+    }
   } else {
     options?.span.setStatus({ code: SpanStatusCode.ERROR, message: (error as Error)?.message });
     throw error;

--- a/sdk/tables/data-tables/src/utils/internalModels.ts
+++ b/sdk/tables/data-tables/src/utils/internalModels.ts
@@ -2,19 +2,19 @@
 // Licensed under the MIT license.
 
 import {
-  TableServiceClientOptions,
-  TableEntity,
   CreateTableEntityResponse,
   DeleteTableEntityOptions,
   GetTableEntityOptions,
   GetTableEntityResponse,
   ListTableEntitiesOptions,
-  UpdateMode,
-  UpdateTableEntityOptions,
+  TableEntity,
   TableEntityResult,
   TableItem,
+  TableServiceClientOptions,
+  TableTransactionResponse,
   TransactionAction,
-  TableTransactionResponse
+  UpdateMode,
+  UpdateTableEntityOptions
 } from "../models";
 import { Pipeline, PipelineRequest } from "@azure/core-rest-pipeline";
 import { NamedKeyCredential } from "@azure/core-auth";

--- a/sdk/tables/data-tables/src/utils/isCredential.ts
+++ b/sdk/tables/data-tables/src/utils/isCredential.ts
@@ -2,12 +2,12 @@
 // Licensed under the MIT license.
 
 import {
-  isNamedKeyCredential,
-  isSASCredential,
-  isTokenCredential,
   NamedKeyCredential,
   SASCredential,
-  TokenCredential
+  TokenCredential,
+  isNamedKeyCredential,
+  isSASCredential,
+  isTokenCredential
 } from "@azure/core-auth";
 
 export function isCredential(

--- a/sdk/tables/data-tables/test/internal/serialization.spec.ts
+++ b/sdk/tables/data-tables/test/internal/serialization.spec.ts
@@ -5,10 +5,10 @@ import { assert } from "chai";
 
 import { Edm } from "../../src";
 import {
-  serialize,
   deserialize,
-  serializeSignedIdentifiers,
-  deserializeSignedIdentifier
+  deserializeSignedIdentifier,
+  serialize,
+  serializeSignedIdentifiers
 } from "../../src/serialization";
 import { isNode8 } from "@azure/test-utils";
 

--- a/sdk/tables/data-tables/test/internal/sharedKeyCredential.spec.ts
+++ b/sdk/tables/data-tables/test/internal/sharedKeyCredential.spec.ts
@@ -3,9 +3,9 @@
 
 import { Context } from "mocha";
 import {
-  SendRequest,
   PipelineRequest,
   PipelineResponse,
+  SendRequest,
   createHttpHeaders,
   createPipelineRequest
 } from "@azure/core-rest-pipeline";

--- a/sdk/tables/data-tables/test/internal/utils.spec.ts
+++ b/sdk/tables/data-tables/test/internal/utils.spec.ts
@@ -3,7 +3,7 @@
 
 import { extractConnectionStringParts } from "../../src/utils/connectionString";
 import { Context } from "mocha";
-import { base64Encode, base64Decode } from "../../src/utils/bufferSerializer";
+import { base64Decode, base64Encode } from "../../src/utils/bufferSerializer";
 import { isNode } from "@azure/test-utils";
 import { assert } from "chai";
 import { ConnectionString } from "../../src/utils/internalModels";

--- a/sdk/tables/data-tables/test/public/accessPolicy.spec.ts
+++ b/sdk/tables/data-tables/test/public/accessPolicy.spec.ts
@@ -3,8 +3,8 @@
 
 import { TableClient } from "../../src";
 import { Context } from "mocha";
-import { record, Recorder, isPlaybackMode } from "@azure-tools/test-recorder";
-import { recordedEnvironmentSetup, createTableClient } from "./utils/recordedClient";
+import { Recorder, isPlaybackMode, record } from "@azure-tools/test-recorder";
+import { createTableClient, recordedEnvironmentSetup } from "./utils/recordedClient";
 import { isNode } from "@azure/test-utils";
 import { assert } from "chai";
 

--- a/sdk/tables/data-tables/test/public/createTable.spec.ts
+++ b/sdk/tables/data-tables/test/public/createTable.spec.ts
@@ -1,0 +1,136 @@
+import { TableClient, RestError, TableServiceClient } from "../../src";
+import { Context } from "mocha";
+import { assert } from "chai";
+import { createTableClient, createTableServiceClient } from "./utils/recordedClient";
+import { createHttpHeaders } from "@azure/core-rest-pipeline";
+import { TableServiceErrorResponse } from "../../src/utils/errorHelpers";
+
+describe("TableClient CreationHandling", () => {
+  let client: TableClient;
+  beforeEach(function(this: Context) {
+    client = createTableClient("testTable");
+  });
+
+  it("should not thorw if table already exists", async function() {
+    // Mock core-client throwing on error to verify consistenty that don't throw the error
+    client.pipeline.addPolicy({
+      name: "TableAlreadyExists",
+      sendRequest: async (req) => {
+        const mockedResponse: TableServiceErrorResponse = {
+          headers: createHttpHeaders(),
+          request: req,
+          status: 409,
+          bodyAsText: "",
+          parsedBody: {
+            odataError: {
+              code: "TableAlreadyExists"
+            }
+          }
+        };
+        throw new RestError("TableAlreadyExists", {
+          statusCode: 409,
+          response: mockedResponse
+        });
+      }
+    });
+
+    await client.createTable({
+      onResponse: (response) => {
+        assert.equal(response.status, 409);
+      }
+    });
+  });
+
+  it("should throw when 409 and not TableAlreadyExists", async function() {
+    // Mock core-client throwing on error to verify consistenty that we surface the error
+    client.pipeline.addPolicy({
+      name: "Other409Error",
+      sendRequest: async (req) => {
+        const mockedResponse: TableServiceErrorResponse = {
+          headers: createHttpHeaders(),
+          request: req,
+          status: 409,
+          bodyAsText: "",
+          parsedBody: { odataError: { code: "TableBeingDeleted" } }
+        };
+        throw new RestError("TableBeingDeleted", { statusCode: 409, response: mockedResponse });
+      }
+    });
+
+    try {
+      await client.createTable();
+      assert.fail("Expected error");
+    } catch (error) {
+      assert.equal((error as RestError).statusCode, 409);
+    }
+  });
+});
+
+describe("TableServiceClient CreationHandling", () => {
+  let client: TableServiceClient;
+  beforeEach(function(this: Context) {
+    client = createTableServiceClient();
+  });
+
+  it("should not thorw if table already exists", async function() {
+    const tableName = `tableExists`;
+    // Mock core-client throwing on error to verify consistenty that don't throw the error
+    client.pipeline.addPolicy({
+      name: "TableAlreadyExists",
+      sendRequest: async (req) => {
+        const mockedResponse: TableServiceErrorResponse = {
+          headers: createHttpHeaders(),
+          request: req,
+          status: 409,
+          bodyAsText: "",
+          parsedBody: {
+            odataError: {
+              code: "TableAlreadyExists"
+            }
+          }
+        };
+        throw new RestError("TableAlreadyExists", {
+          statusCode: 409,
+          response: mockedResponse
+        });
+      }
+    });
+
+    await client.createTable(tableName, {
+      onResponse: (response) => {
+        assert.equal(response.status, 409);
+      }
+    });
+  });
+
+  it("should throw when 409 and not TableAlreadyExists", async function() {
+    const tableName = `throwError`;
+    // Mock core-client throwing on error to verify consistenty that we surface the error
+    client.pipeline.addPolicy({
+      name: "Other409Error",
+      sendRequest: async (req) => {
+        const mockedResponse: TableServiceErrorResponse = {
+          headers: createHttpHeaders(),
+          request: req,
+          status: 409,
+          bodyAsText: "",
+          parsedBody: {
+            odataError: {
+              code: "TableBeingDeleted"
+            }
+          }
+        };
+        throw new RestError("TableBeingDeleted", {
+          statusCode: 409,
+          response: mockedResponse
+        });
+      }
+    });
+    try {
+      await client.createTable(tableName);
+      assert.fail("Expected error");
+    } catch (error) {
+      assert.equal((error as RestError).statusCode, 409);
+    }
+  });
+});

--- a/sdk/tables/data-tables/test/public/createTable.spec.ts
+++ b/sdk/tables/data-tables/test/public/createTable.spec.ts
@@ -1,4 +1,7 @@
-import { TableClient, RestError, TableServiceClient } from "../../src";
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { RestError, TableClient, TableServiceClient } from "../../src";
 import { Context } from "mocha";
 import { assert } from "chai";
 import { createTableClient, createTableServiceClient } from "./utils/recordedClient";

--- a/sdk/tables/data-tables/test/public/specialCharacters.spec.ts
+++ b/sdk/tables/data-tables/test/public/specialCharacters.spec.ts
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { odata, TableClient, TableEntityResult, TransactionAction } from "../../src";
+import { TableClient, TableEntityResult, TransactionAction, odata } from "../../src";
 import { assert } from "chai";
 import { createTableClient, recordedEnvironmentSetup } from "./utils/recordedClient";
 import { isNode } from "@azure/test-utils";
-import { isLiveMode, record, Recorder } from "@azure-tools/test-recorder";
+import { Recorder, isLiveMode, record } from "@azure-tools/test-recorder";
 import { Context } from "mocha";
 
 describe("SpecialCharacters", function() {

--- a/sdk/tables/data-tables/test/public/tableclient.spec.ts
+++ b/sdk/tables/data-tables/test/public/tableclient.spec.ts
@@ -1,14 +1,14 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { TableClient, TableEntity, Edm, odata, TableEntityResult } from "../../src";
+import { Edm, TableClient, TableEntity, TableEntityResult, odata } from "../../src";
 import { Context } from "mocha";
 import { assert } from "chai";
-import { record, Recorder, isPlaybackMode, isLiveMode } from "@azure-tools/test-recorder";
+import { Recorder, isLiveMode, isPlaybackMode, record } from "@azure-tools/test-recorder";
 import {
-  recordedEnvironmentSetup,
+  CreateClientMode,
   createTableClient,
-  CreateClientMode
+  recordedEnvironmentSetup
 } from "./utils/recordedClient";
 import { isNode, isNode8 } from "@azure/test-utils";
 import { FullOperationResponse } from "@azure/core-client";

--- a/sdk/tables/data-tables/test/public/tableserviceclient.spec.ts
+++ b/sdk/tables/data-tables/test/public/tableserviceclient.spec.ts
@@ -3,11 +3,11 @@
 
 import { TableItem, TableItemResultPage, TableServiceClient } from "../../src";
 import { Context } from "mocha";
-import { record, Recorder, isPlaybackMode, isLiveMode } from "@azure-tools/test-recorder";
+import { Recorder, isLiveMode, isPlaybackMode, record } from "@azure-tools/test-recorder";
 import {
-  recordedEnvironmentSetup,
+  CreateClientMode,
   createTableServiceClient,
-  CreateClientMode
+  recordedEnvironmentSetup
 } from "./utils/recordedClient";
 import { isNode } from "@azure/test-utils";
 import { assert } from "chai";

--- a/sdk/tables/data-tables/test/public/transaction.spec.ts
+++ b/sdk/tables/data-tables/test/public/transaction.spec.ts
@@ -1,14 +1,14 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { TableClient, odata, TransactionAction, TableTransaction } from "../../src";
+import { TableClient, TableTransaction, TransactionAction, odata } from "../../src";
 import { Context } from "mocha";
 import { assert } from "chai";
-import { record, Recorder, isPlaybackMode, isLiveMode } from "@azure-tools/test-recorder";
+import { Recorder, isLiveMode, isPlaybackMode, record } from "@azure-tools/test-recorder";
 import {
-  recordedEnvironmentSetup,
+  CreateClientMode,
   createTableClient,
-  CreateClientMode
+  recordedEnvironmentSetup
 } from "./utils/recordedClient";
 import { isNode } from "@azure/test-utils";
 import { Uuid } from "../../src/utils/uuid";

--- a/sdk/tables/data-tables/test/public/utils/recordedClient.ts
+++ b/sdk/tables/data-tables/test/public/utils/recordedClient.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { env, RecorderEnvironmentSetup } from "@azure-tools/test-recorder";
+import { RecorderEnvironmentSetup, env } from "@azure-tools/test-recorder";
 
 import { ClientSecretCredential } from "@azure/identity";
 import { TableClient, TableServiceClient } from "../../../src";


### PR DESCRIPTION
This PR fixes 3 issues around `createTable`

* Adds documentation noting that `createTable` doesn't throw on `TableAlreadyExists` response. And document a sample on how to check for such a response.
* `onResponse` callback was not executed when handling `TableAlreadyExists`
* `TableBeingDeleted` errors were sneaking into the `TableAlreadyExists` handling. Explicitly check for error code and statusCode to make sure we only no-throw for `TableAlreadyExists`

Related to #18865