### PR TITLE
[core] - Ensure package information is provided for traces

### DIFF
--- a/sdk/core/core-tracing/review/core-tracing.api.md
+++ b/sdk/core/core-tracing/review/core-tracing.api.md
@@ -5,13 +5,13 @@
 ```ts
 
 // @public
-export function createTracingClient(namespace: string, packageInformation: PackageInformation): TracingClient;
+export function createTracingClient(options: TracingClientOptions): TracingClient;
 
 // @public
 export interface Instrumenter {
     createRequestHeaders(spanContext: TracingSpanContext): Record<string, string>;
     parseTraceparentHeader(traceparentHeader: string): TracingSpanContext | undefined;
-    startSpan(name: string, packageInformation: PackageInformation, spanOptions?: InstrumenterSpanOptions): {
+    startSpan(name: string, spanOptions: InstrumenterSpanOptions): {
         span: TracingSpan;
         tracingContext: TracingContext;
     };
@@ -20,18 +20,14 @@ export interface Instrumenter {
 
 // @public
 export interface InstrumenterSpanOptions extends TracingSpanOptions {
+    packageName: string;
+    packageVersion?: string;
     tracingContext?: TracingContext;
 }
 
 // @public
 export interface OperationTracingOptions {
     tracingContext?: TracingContext;
-}
-
-// @public
-export interface PackageInformation {
-    name: string;
-    version?: string;
 }
 
 // @public
@@ -57,6 +53,13 @@ export interface TracingClient {
     withSpan<Options extends {
         tracingOptions?: OperationTracingOptions;
     }, Callback extends (updatedOptions: Options, span: Omit<TracingSpan, "end">) => ReturnType<Callback>>(name: string, operationOptions: Options, callback: Callback, spanOptions?: TracingSpanOptions, callbackThis?: ThisParameterType<Callback>): Promise<ReturnType<Callback>>;
+}
+
+// @public
+export interface TracingClientOptions {
+    namespace: string;
+    packageName: string;
+    packageVersion?: string;
 }
 
 // @public

--- a/sdk/core/core-tracing/review/core-tracing.api.md
+++ b/sdk/core/core-tracing/review/core-tracing.api.md
@@ -5,13 +5,13 @@
 ```ts
 
 // @public
-export function createTracingClient(options: TracingClientOptions): TracingClient;
+export function createTracingClient(namespace: string, packageInformation: PackageInformation): TracingClient;
 
 // @public
 export interface Instrumenter {
     createRequestHeaders(spanContext: TracingSpanContext): Record<string, string>;
     parseTraceparentHeader(traceparentHeader: string): TracingSpanContext | undefined;
-    startSpan(name: string, spanOptions?: InstrumenterSpanOptions): {
+    startSpan(name: string, packageInformation: PackageInformation, spanOptions?: InstrumenterSpanOptions): {
         span: TracingSpan;
         tracingContext: TracingContext;
     };
@@ -20,16 +20,18 @@ export interface Instrumenter {
 
 // @public
 export interface InstrumenterSpanOptions extends TracingSpanOptions {
-    packageInformation: {
-        name: string;
-        version?: string;
-    };
     tracingContext?: TracingContext;
 }
 
 // @public
 export interface OperationTracingOptions {
     tracingContext?: TracingContext;
+}
+
+// @public
+export interface PackageInformation {
+    name: string;
+    version?: string;
 }
 
 // @public
@@ -55,15 +57,6 @@ export interface TracingClient {
     withSpan<Options extends {
         tracingOptions?: OperationTracingOptions;
     }, Callback extends (updatedOptions: Options, span: Omit<TracingSpan, "end">) => ReturnType<Callback>>(name: string, operationOptions: Options, callback: Callback, spanOptions?: TracingSpanOptions, callbackThis?: ThisParameterType<Callback>): Promise<ReturnType<Callback>>;
-}
-
-// @public
-export interface TracingClientOptions {
-    namespace: string;
-    packageInformation: {
-        name: string;
-        version?: string;
-    };
 }
 
 // @public

--- a/sdk/core/core-tracing/src/instrumenter.ts
+++ b/sdk/core/core-tracing/src/instrumenter.ts
@@ -6,8 +6,7 @@ import {
   TracingSpan,
   TracingContext,
   TracingSpanContext,
-  InstrumenterSpanOptions,
-  PackageInformation
+  InstrumenterSpanOptions
 } from "./interfaces";
 import { createTracingContext } from "./tracingContext";
 
@@ -15,12 +14,11 @@ import { createTracingContext } from "./tracingContext";
 export class NoOpInstrumenter implements Instrumenter {
   startSpan(
     _name: string,
-    _packageInformation: PackageInformation,
-    spanOptions?: InstrumenterSpanOptions
+    spanOptions: InstrumenterSpanOptions
   ): { span: TracingSpan; tracingContext: TracingContext } {
     return {
       span: new NoOpSpan(),
-      tracingContext: createTracingContext({ parentContext: spanOptions?.tracingContext })
+      tracingContext: createTracingContext({ parentContext: spanOptions.tracingContext })
     };
   }
   withContext<

--- a/sdk/core/core-tracing/src/instrumenter.ts
+++ b/sdk/core/core-tracing/src/instrumenter.ts
@@ -6,14 +6,16 @@ import {
   TracingSpan,
   TracingContext,
   TracingSpanContext,
-  InstrumenterSpanOptions
+  InstrumenterSpanOptions,
+  PackageInformation
 } from "./interfaces";
 import { createTracingContext } from "./tracingContext";
 
 /** @internal */
 export class NoOpInstrumenter implements Instrumenter {
   startSpan(
-    _name?: string,
+    _name: string,
+    _packageInformation: PackageInformation,
     spanOptions?: InstrumenterSpanOptions
   ): { span: TracingSpan; tracingContext: TracingContext } {
     return {

--- a/sdk/core/core-tracing/src/interfaces.ts
+++ b/sdk/core/core-tracing/src/interfaces.ts
@@ -92,18 +92,13 @@ export interface TracingClient {
 }
 
 /**
- * Options that can be passed to {@link createTracingClient}.
+ * Information about the package invoking this trace.
  */
-export interface TracingClientOptions {
-  /** The value of the az.namespace tracing attribute on any given spans */
-  namespace: string;
-  /** Information about the package invoking this trace. */
-  packageInformation: {
-    /** The name of the package. */
-    name: string;
-    /** An optional package version. */
-    version?: string;
-  };
+export interface PackageInformation {
+  /** The name of the package. */
+  name: string;
+  /** An optional package version. */
+  version?: string;
 }
 
 /** The kind of span. */
@@ -158,6 +153,7 @@ export interface Instrumenter {
    */
   startSpan(
     name: string,
+    packageInformation: PackageInformation,
     spanOptions?: InstrumenterSpanOptions
   ): { span: TracingSpan; tracingContext: TracingContext };
   /**
@@ -197,13 +193,6 @@ export interface Instrumenter {
 export interface InstrumenterSpanOptions extends TracingSpanOptions {
   /** The current tracing context. Defaults to an implementation-specific "active" context. */
   tracingContext?: TracingContext;
-  /** Information about the package invoking this trace. */
-  packageInformation: {
-    /** The name of the package. */
-    name: string;
-    /** An optional package version. */
-    version?: string;
-  };
 }
 
 /**

--- a/sdk/core/core-tracing/src/interfaces.ts
+++ b/sdk/core/core-tracing/src/interfaces.ts
@@ -92,13 +92,15 @@ export interface TracingClient {
 }
 
 /**
- * Information about the package invoking this trace.
+ * Options that can be passed to {@link createTracingClient}
  */
-export interface PackageInformation {
-  /** The name of the package. */
-  name: string;
-  /** An optional package version. */
-  version?: string;
+export interface TracingClientOptions {
+  /** The value of the az.namespace tracing attribute on newly created spans. */
+  namespace: string;
+  /** The name of the package invoking this trace. */
+  packageName: string;
+  /** An optional version of the package invoking this trace. */
+  packageVersion?: string;
 }
 
 /** The kind of span. */
@@ -153,8 +155,7 @@ export interface Instrumenter {
    */
   startSpan(
     name: string,
-    packageInformation: PackageInformation,
-    spanOptions?: InstrumenterSpanOptions
+    spanOptions: InstrumenterSpanOptions
   ): { span: TracingSpan; tracingContext: TracingContext };
   /**
    * Wraps a callback with an active context and calls the callback.
@@ -191,6 +192,10 @@ export interface Instrumenter {
  * Options passed to {@link Instrumenter.startSpan} as a superset of {@link TracingSpanOptions}.
  */
 export interface InstrumenterSpanOptions extends TracingSpanOptions {
+  /** The name of the package invoking this trace. */
+  packageName: string;
+  /** The version of the package invoking this trace. */
+  packageVersion?: string;
   /** The current tracing context. Defaults to an implementation-specific "active" context. */
   tracingContext?: TracingContext;
 }

--- a/sdk/core/core-tracing/src/tracingClient.ts
+++ b/sdk/core/core-tracing/src/tracingClient.ts
@@ -9,7 +9,7 @@ import {
   TracingContext,
   TracingSpanOptions,
   TracingSpanContext,
-  PackageInformation
+  TracingClientOptions
 } from "./interfaces";
 import { getInstrumenter } from "./instrumenter";
 import { knownContextKeys } from "./tracingContext";
@@ -18,12 +18,14 @@ import { knownContextKeys } from "./tracingContext";
 export class TracingClientImpl implements TracingClient {
   private _namespace: string;
   private _instrumenter: Instrumenter;
-  private _packageInformation: PackageInformation;
+  private _packageName: string;
+  private _packageVersion?: string;
 
-  constructor(namespace: string, packageInformation: PackageInformation) {
-    this._namespace = namespace;
+  constructor(options: TracingClientOptions) {
+    this._namespace = options.namespace;
+    this._packageName = options.packageName;
+    this._packageVersion = options.packageVersion;
     this._instrumenter = getInstrumenter();
-    this._packageInformation = packageInformation;
   }
   startSpan<Options extends { tracingOptions?: OperationTracingOptions }>(
     name: string,
@@ -34,8 +36,10 @@ export class TracingClientImpl implements TracingClient {
     tracingContext: TracingContext;
     updatedOptions: Options;
   } {
-    const startSpanResult = this._instrumenter.startSpan(name, this._packageInformation, {
+    const startSpanResult = this._instrumenter.startSpan(name, {
       ...spanOptions,
+      packageName: this._packageName,
+      packageVersion: this._packageVersion,
       tracingContext: operationOptions?.tracingOptions?.tracingContext
     });
     let tracingContext = startSpanResult.tracingContext;
@@ -123,13 +127,10 @@ export class TracingClientImpl implements TracingClient {
 
 /**
  * Creates a new tracing client.
- * @param namespace - The Azure namespace to set on spans.
- * @param packageInformation - Name and version of the package invoking this trace.
+ *
+ * @param options - Options used to configure the tracing client.
  * @returns - An instance of {@link TracingClient}.
  */
-export function createTracingClient(
-  namespace: string,
-  packageInformation: PackageInformation
-): TracingClient {
-  return new TracingClientImpl(namespace, packageInformation);
+export function createTracingClient(options: TracingClientOptions): TracingClient {
+  return new TracingClientImpl(options);
 }

--- a/sdk/core/core-tracing/test/instrumenter.spec.ts
+++ b/sdk/core/core-tracing/test/instrumenter.spec.ts
@@ -17,19 +17,17 @@ describe("Instrumenter", () => {
     });
 
     describe("#startSpan", () => {
-      const startSpanOptions = {
-        packageInformation: {
-          name: "test-package"
-        }
+      const packageInformation = {
+        name: "test-package"
       };
 
       it("return no-op span", () => {
-        const { span } = instrumenter.startSpan(name, startSpanOptions);
+        const { span } = instrumenter.startSpan(name, packageInformation);
         assert.instanceOf(span, NoOpSpan);
       });
 
       it("returns a new context", () => {
-        const { tracingContext } = instrumenter.startSpan(name, startSpanOptions);
+        const { tracingContext } = instrumenter.startSpan(name, packageInformation);
         assert.exists(tracingContext);
       });
 
@@ -37,9 +35,8 @@ describe("Instrumenter", () => {
         const [key, value] = [Symbol.for("key"), "value"];
         const context = createTracingContext().setValue(key, value);
 
-        const { tracingContext } = instrumenter.startSpan(name, {
-          tracingContext: context,
-          ...startSpanOptions
+        const { tracingContext } = instrumenter.startSpan(name, packageInformation, {
+          tracingContext: context
         });
         assert.strictEqual(tracingContext.getValue(key), value);
       });

--- a/sdk/core/core-tracing/test/instrumenter.spec.ts
+++ b/sdk/core/core-tracing/test/instrumenter.spec.ts
@@ -17,17 +17,15 @@ describe("Instrumenter", () => {
     });
 
     describe("#startSpan", () => {
-      const packageInformation = {
-        name: "test-package"
-      };
+      const packageName = "test-package";
 
       it("return no-op span", () => {
-        const { span } = instrumenter.startSpan(name, packageInformation);
+        const { span } = instrumenter.startSpan(name, { packageName });
         assert.instanceOf(span, NoOpSpan);
       });
 
       it("returns a new context", () => {
-        const { tracingContext } = instrumenter.startSpan(name, packageInformation);
+        const { tracingContext } = instrumenter.startSpan(name, { packageName });
         assert.exists(tracingContext);
       });
 
@@ -35,8 +33,9 @@ describe("Instrumenter", () => {
         const [key, value] = [Symbol.for("key"), "value"];
         const context = createTracingContext().setValue(key, value);
 
-        const { tracingContext } = instrumenter.startSpan(name, packageInformation, {
-          tracingContext: context
+        const { tracingContext } = instrumenter.startSpan(name, {
+          tracingContext: context,
+          packageName
         });
         assert.strictEqual(tracingContext.getValue(key), value);
       });

--- a/sdk/core/core-tracing/test/tracingClient.spec.ts
+++ b/sdk/core/core-tracing/test/tracingClient.spec.ts
@@ -22,9 +22,10 @@ describe("TracingClient", () => {
     context = createTracingContext();
 
     useInstrumenter(instrumenter);
-    client = createTracingClient(expectedNamespace, {
-      name: "test-package",
-      version: "1.0.0"
+    client = createTracingClient({
+      namespace: expectedNamespace,
+      packageName: "test-package",
+      packageVersion: "1.0.0"
     });
   });
 
@@ -57,8 +58,8 @@ describe("TracingClient", () => {
       const args = instrumenterStartSpanSpy.getCall(0).args;
 
       assert.equal(args[0], "test");
-      assert.equal(args[1].name, "test-package");
-      assert.equal(args[1].version, "1.0.0");
+      assert.equal(args[1]?.packageName, "test-package");
+      assert.equal(args[1]?.packageVersion, "1.0.0");
     });
 
     it("sets namespace on context", () => {

--- a/sdk/core/core-tracing/test/tracingClient.spec.ts
+++ b/sdk/core/core-tracing/test/tracingClient.spec.ts
@@ -22,12 +22,9 @@ describe("TracingClient", () => {
     context = createTracingContext();
 
     useInstrumenter(instrumenter);
-    client = createTracingClient({
-      namespace: expectedNamespace,
-      packageInformation: {
-        name: "test-package",
-        version: "1.0.0"
-      }
+    client = createTracingClient(expectedNamespace, {
+      name: "test-package",
+      version: "1.0.0"
     });
   });
 
@@ -60,8 +57,8 @@ describe("TracingClient", () => {
       const args = instrumenterStartSpanSpy.getCall(0).args;
 
       assert.equal(args[0], "test");
-      assert.equal(args[1]?.packageInformation?.name, "test-package");
-      assert.equal(args[1]?.packageInformation?.version, "1.0.0");
+      assert.equal(args[1].name, "test-package");
+      assert.equal(args[1].version, "1.0.0");
     });
 
     it("sets namespace on context", () => {

--- a/sdk/core/core-tracing/test/tracingContext.spec.ts
+++ b/sdk/core/core-tracing/test/tracingContext.spec.ts
@@ -96,7 +96,7 @@ describe("TracingContext", () => {
     });
 
     it("can add known attributes", () => {
-      const client = createTracingClient("test", { name: "test" });
+      const client = createTracingClient({ namespace: "test", packageName: "test" });
       const span = new NoOpSpan();
       const namespace = "test-namespace";
       const newContext = createTracingContext({

--- a/sdk/core/core-tracing/test/tracingContext.spec.ts
+++ b/sdk/core/core-tracing/test/tracingContext.spec.ts
@@ -96,10 +96,7 @@ describe("TracingContext", () => {
     });
 
     it("can add known attributes", () => {
-      const client = createTracingClient({
-        namespace: "test",
-        packageInformation: { name: "test" }
-      });
+      const client = createTracingClient("test", { name: "test" });
       const span = new NoOpSpan();
       const namespace = "test-namespace";
       const newContext = createTracingContext({

--- a/sdk/instrumentation/instrumentation-opentelemetry/src/instrumenter.ts
+++ b/sdk/instrumentation/instrumentation-opentelemetry/src/instrumenter.ts
@@ -6,8 +6,7 @@ import {
   InstrumenterSpanOptions,
   TracingContext,
   TracingSpan,
-  TracingSpanContext,
-  PackageInformation
+  TracingSpanContext
 } from "@azure/core-tracing";
 
 import { trace, context } from "@opentelemetry/api";
@@ -23,11 +22,10 @@ import {
 export class OpenTelemetryInstrumenter implements Instrumenter {
   startSpan(
     name: string,
-    packageInformation: PackageInformation,
-    spanOptions?: InstrumenterSpanOptions
+    spanOptions: InstrumenterSpanOptions
   ): { span: TracingSpan; tracingContext: TracingContext } {
     const span = trace
-      .getTracer(packageInformation.name, packageInformation.version)
+      .getTracer(spanOptions.packageName, spanOptions.packageVersion)
       .startSpan(name, toSpanOptions(spanOptions));
 
     const ctx = spanOptions?.tracingContext || context.active();

--- a/sdk/instrumentation/instrumentation-opentelemetry/src/instrumenter.ts
+++ b/sdk/instrumentation/instrumentation-opentelemetry/src/instrumenter.ts
@@ -6,7 +6,8 @@ import {
   InstrumenterSpanOptions,
   TracingContext,
   TracingSpan,
-  TracingSpanContext
+  TracingSpanContext,
+  PackageInformation
 } from "@azure/core-tracing";
 
 import { trace, context } from "@opentelemetry/api";
@@ -22,18 +23,11 @@ import {
 export class OpenTelemetryInstrumenter implements Instrumenter {
   startSpan(
     name: string,
+    packageInformation: PackageInformation,
     spanOptions?: InstrumenterSpanOptions
   ): { span: TracingSpan; tracingContext: TracingContext } {
-    if (!spanOptions) {
-      spanOptions = {
-        packageInformation: {
-          name: "@azure/instrumentation-opentelemetry"
-        }
-      };
-    }
-
     const span = trace
-      .getTracer(spanOptions.packageInformation.name, spanOptions.packageInformation.version)
+      .getTracer(packageInformation.name, packageInformation.version)
       .startSpan(name, toSpanOptions(spanOptions));
 
     const ctx = spanOptions?.tracingContext || context.active();

--- a/sdk/instrumentation/instrumentation-opentelemetry/src/transformations.ts
+++ b/sdk/instrumentation/instrumentation-opentelemetry/src/transformations.ts
@@ -88,8 +88,8 @@ function toOpenTelemetrySpanAttributes(
  * @param spanOptions - The {@link InstrumenterSpanOptions} to convert.
  * @returns An OpenTelemetry {@link SpanOptions} that can be used when creating a span.
  */
-export function toSpanOptions(spanOptions: InstrumenterSpanOptions): SpanOptions {
-  const { spanAttributes, spanLinks, spanKind } = spanOptions;
+export function toSpanOptions(spanOptions?: InstrumenterSpanOptions): SpanOptions {
+  const { spanAttributes, spanLinks, spanKind } = spanOptions || {};
 
   const attributes: SpanAttributes = toOpenTelemetrySpanAttributes(spanAttributes);
   const kind = toOpenTelemetrySpanKind(spanKind);

--- a/sdk/instrumentation/instrumentation-opentelemetry/test/public/instrumenter.spec.ts
+++ b/sdk/instrumentation/instrumentation-opentelemetry/test/public/instrumenter.spec.ts
@@ -181,10 +181,8 @@ describe("OpenTelemetryInstrumenter", () => {
       return (span as OpenTelemetrySpanWrapper).unwrap() as TestSpan;
     }
     let tracer: TestTracer;
-    const packageInformation = {
-      name: "test-package",
-      version: "test-version"
-    };
+    const packageName = "test-package";
+    const packageVersion = "test-version";
     beforeEach(() => {
       tracer = setTracer(tracer);
     });
@@ -194,7 +192,7 @@ describe("OpenTelemetryInstrumenter", () => {
     });
 
     it("returns a newly started TracingSpan", () => {
-      const { span } = instrumenter.startSpan("test", packageInformation);
+      const { span } = instrumenter.startSpan("test", { packageName, packageVersion });
       const otSpan = unwrap(span);
       assert.equal(otSpan, tracer.getActiveSpans()[0]);
       assert.equal(otSpan.kind, SpanKind.INTERNAL);
@@ -202,17 +200,18 @@ describe("OpenTelemetryInstrumenter", () => {
 
     it("passes package information to the tracer", () => {
       const getTracerSpy = sinon.spy(trace, "getTracer");
-      instrumenter.startSpan("test", packageInformation);
+      instrumenter.startSpan("test", { packageName, packageVersion });
 
-      assert.isTrue(getTracerSpy.calledWith(packageInformation.name, packageInformation.version));
+      assert.isTrue(getTracerSpy.calledWith(packageName, packageVersion));
     });
 
     describe("with an existing context", () => {
       it("returns a context that contains all existing fields", () => {
         const currentContext = context.active().setValue(Symbol.for("foo"), "bar");
 
-        const { tracingContext } = instrumenter.startSpan("test", packageInformation, {
-          tracingContext: currentContext
+        const { tracingContext } = instrumenter.startSpan("test", {
+          tracingContext: currentContext,
+          packageName
         });
 
         assert.equal(tracingContext.getValue(Symbol.for("foo")), "bar");
@@ -221,8 +220,9 @@ describe("OpenTelemetryInstrumenter", () => {
       it("sets span on the context", () => {
         const currentContext = context.active().setValue(Symbol.for("foo"), "bar");
 
-        const { span, tracingContext } = instrumenter.startSpan("test", packageInformation, {
-          tracingContext: currentContext
+        const { span, tracingContext } = instrumenter.startSpan("test", {
+          tracingContext: currentContext,
+          packageName
         });
 
         assert.equal(trace.getSpan(tracingContext), unwrap(span));
@@ -233,13 +233,16 @@ describe("OpenTelemetryInstrumenter", () => {
       it("uses the active context", () => {
         const contextSpy = sinon.spy(context, "active");
 
-        instrumenter.startSpan("test", packageInformation);
+        instrumenter.startSpan("test", { packageName, packageVersion });
 
         assert.isTrue(contextSpy.called);
       });
 
       it("sets span on the context", () => {
-        const { span, tracingContext } = instrumenter.startSpan("test", packageInformation);
+        const { span, tracingContext } = instrumenter.startSpan("test", {
+          packageName,
+          packageVersion
+        });
 
         assert.equal(trace.getSpan(tracingContext), unwrap(span));
       });
@@ -251,8 +254,10 @@ describe("OpenTelemetryInstrumenter", () => {
           attr1: "val1",
           attr2: "val2"
         };
-        const { span } = instrumenter.startSpan("test", packageInformation, {
-          spanAttributes
+        const { span } = instrumenter.startSpan("test", {
+          spanAttributes,
+          packageName,
+          packageVersion
         });
 
         assert.deepEqual(unwrap(span).attributes, spanAttributes);
@@ -260,20 +265,22 @@ describe("OpenTelemetryInstrumenter", () => {
 
       describe("spanKind", () => {
         it("maps spanKind correctly", () => {
-          const { span } = instrumenter.startSpan("test", packageInformation, {
+          const { span } = instrumenter.startSpan("test", {
+            packageName,
             spanKind: "client"
           });
           assert.equal(unwrap(span).kind, SpanKind.CLIENT);
         });
 
         it("defaults spanKind to INTERNAL if omitted", () => {
-          const { span } = instrumenter.startSpan("test", packageInformation);
+          const { span } = instrumenter.startSpan("test", { packageName });
           assert.equal(unwrap(span).kind, SpanKind.INTERNAL);
         });
 
         // TODO: what's the right behavior? throw? log and continue?
         it("defaults spanKind to INTERNAL if an invalid spanKind is provided", () => {
-          const { span } = instrumenter.startSpan("test", packageInformation, {
+          const { span } = instrumenter.startSpan("test", {
+            packageName,
             spanKind: "foo" as TracingSpanKind
           });
           assert.equal(unwrap(span).kind, SpanKind.INTERNAL);
@@ -281,8 +288,9 @@ describe("OpenTelemetryInstrumenter", () => {
       });
 
       it("supports spanLinks", () => {
-        const { span: linkedSpan } = instrumenter.startSpan("linked", packageInformation);
-        const { span } = instrumenter.startSpan("test", packageInformation, {
+        const { span: linkedSpan } = instrumenter.startSpan("linked", { packageName });
+        const { span } = instrumenter.startSpan("test", {
+          packageName,
           spanLinks: [
             {
               spanContext: linkedSpan.spanContext,


### PR DESCRIPTION
## What

- Add a type for PackageInformation
- Pass namespace and packageInformation as positional params to createTracingClient
- Pass packageInformation as a positional param to `Instrumenter#startSpan`

## Why

When we discussed the API design for this, @lmolkova mentioned that ideally we'd require information about the package 
invoking the trace to ensure that data is passed along correctly to AZ Monitor. It was originally optional, and as part of the 
options bag for `createTracingClient` function.

But I accidentally made it "optionally required" on the Instrumenter level. Example:

```ts
instrumenter.startSpan("name") // OK
instrumenter.startSpan("name", {}) // Error: missing required packageInformation or something like that
```

Correcting this now. Also, required params should be positional right? A required options bag with required params seemed 
wrong, but let me know if you disagree!