### PR TITLE
Remove assert dev dependency from Communication

### DIFF
--- a/sdk/communication/communication-chat/package.json
+++ b/sdk/communication/communication-chat/package.json
@@ -93,7 +93,6 @@
     "@types/node": "^12.0.0",
     "@types/sinon": "^9.0.4",
     "@types/uuid": "^8.0.0",
-    "assert": "^1.4.1",
     "chai": "^4.2.0",
     "cross-env": "^7.0.2",
     "dotenv": "^8.2.0",

--- a/sdk/communication/communication-common/package.json
+++ b/sdk/communication/communication-common/package.json
@@ -85,7 +85,6 @@
     "@types/mocha": "^7.0.2",
     "@types/node": "^12.0.0",
     "@types/sinon": "^9.0.4",
-    "assert": "^1.4.1",
     "chai-as-promised": "^7.1.1",
     "chai": "^4.2.0",
     "cross-env": "^7.0.2",

--- a/sdk/communication/communication-identity/package.json
+++ b/sdk/communication/communication-identity/package.json
@@ -99,7 +99,6 @@
     "@types/mocha": "^7.0.2",
     "@types/sinon": "^9.0.4",
     "@types/node": "^12.0.0",
-    "assert": "^1.4.1",
     "chai": "^4.2.0",
     "cross-env": "^7.0.2",
     "dotenv": "^8.2.0",

--- a/sdk/communication/communication-network-traversal/package.json
+++ b/sdk/communication/communication-network-traversal/package.json
@@ -98,7 +98,6 @@
     "@types/mocha": "^7.0.2",
     "@types/node": "^12.0.0",
     "@types/sinon": "^9.0.4",
-    "assert": "^1.4.1",
     "chai": "^4.2.0",
     "cross-env": "^7.0.2",
     "dotenv": "^8.2.0",

--- a/sdk/communication/communication-phone-numbers/package.json
+++ b/sdk/communication/communication-phone-numbers/package.json
@@ -87,7 +87,6 @@
     "@types/mocha": "^7.0.2",
     "@types/sinon": "^9.0.4",
     "@types/node": "^12.0.0",
-    "assert": "^1.4.1",
     "chai": "^4.2.0",
     "cross-env": "^7.0.2",
     "dotenv": "^8.2.0",

--- a/sdk/communication/communication-short-codes/package.json
+++ b/sdk/communication/communication-short-codes/package.json
@@ -87,7 +87,6 @@
     "@types/mocha": "^7.0.2",
     "@types/node": "^12.0.0",
     "@types/sinon": "^9.0.4",
-    "assert": "^1.4.1",
     "chai": "^4.2.0",
     "cross-env": "^7.0.2",
     "dotenv": "^8.2.0",

--- a/sdk/communication/communication-sms/package.json
+++ b/sdk/communication/communication-sms/package.json
@@ -89,7 +89,6 @@
     "@types/mocha": "^7.0.2",
     "@types/node": "^12.0.0",
     "@types/sinon": "^9.0.4",
-    "assert": "^1.4.1",
     "chai": "^4.2.0",
     "cross-env": "^7.0.2",
     "dotenv": "^8.2.0",


### PR DESCRIPTION
Solves https://github.com/Azure/azure-sdk-for-js/issues/17110#issuecomment-985076005.

Removing `assert` dev dependency since it is no longer needed when using `chai` and it is introducing a circular dependency issue when upgrading it to the latest version.