### PR TITLE
Remove assert dev dependency from Event Hubs

### DIFF
--- a/sdk/eventhub/event-hubs/package.json
+++ b/sdk/eventhub/event-hubs/package.json
@@ -146,7 +146,6 @@
     "@types/sinon": "^9.0.4",
     "@types/uuid": "^8.0.0",
     "@types/ws": "^7.2.4",
-    "assert": "^1.4.1",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
     "chai-exclude": "^2.0.2",

--- a/sdk/eventhub/eventhubs-checkpointstore-blob/package.json
+++ b/sdk/eventhub/eventhubs-checkpointstore-blob/package.json
@@ -82,7 +82,6 @@
     "@types/debug": "^4.1.4",
     "@types/mocha": "^7.0.2",
     "@types/node": "^12.0.0",
-    "assert": "^1.4.1",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
     "chai-string": "^1.5.0",

--- a/sdk/eventhub/eventhubs-checkpointstore-table/package.json
+++ b/sdk/eventhub/eventhubs-checkpointstore-table/package.json
@@ -81,7 +81,6 @@
     "@types/debug": "^4.1.4",
     "@types/mocha": "^7.0.2",
     "@types/node": "^12.0.0",
-    "assert": "^1.4.1",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
     "chai-string": "^1.5.0",


### PR DESCRIPTION
Solves https://github.com/Azure/azure-sdk-for-js/issues/17110#issuecomment-985076005.

Removing `assert` dev dependency since it is no longer needed when using `chai` and it is introducing a circular dependency issue when upgrading it to the latest version.