### PR TITLE
Remove assert dev dependency from Identity

### DIFF
--- a/sdk/identity/identity-cache-persistence/package.json
+++ b/sdk/identity/identity-cache-persistence/package.json
@@ -77,7 +77,6 @@
     "@types/mocha": "^7.0.2",
     "@types/node": "^12.0.0",
     "@types/qs": "^6.5.3",
-    "assert": "^1.4.1",
     "cross-env": "^7.0.2",
     "dotenv": "^8.2.0",
     "eslint": "^7.15.0",

--- a/sdk/identity/identity-vscode/package.json
+++ b/sdk/identity/identity-vscode/package.json
@@ -76,7 +76,6 @@
     "@types/qs": "^6.5.3",
     "@types/sinon": "^9.0.4",
     "@types/uuid": "^8.0.0",
-    "assert": "^1.4.1",
     "cross-env": "^7.0.2",
     "dotenv": "^8.2.0",
     "eslint": "^7.15.0",

--- a/sdk/identity/identity/package.json
+++ b/sdk/identity/identity/package.json
@@ -122,7 +122,6 @@
     "@types/uuid": "^8.0.0",
     "@types/chai": "^4.1.6",
     "chai": "^4.2.0",
-    "assert": "^1.4.1",
     "cross-env": "^7.0.2",
     "dotenv": "^8.2.0",
     "eslint": "^7.15.0",


### PR DESCRIPTION
Solves https://github.com/Azure/azure-sdk-for-js/issues/17110#issuecomment-985076005.

Removing `assert` dev dependency since it is no longer needed when using `chai` and it is introducing a circular dependency issue when upgrading it to the latest version.