### PR TITLE
Remove assert dev dependency from Service Bus

### DIFF
--- a/sdk/servicebus/service-bus/package.json
+++ b/sdk/servicebus/service-bus/package.json
@@ -144,7 +144,6 @@
     "@types/mocha": "^7.0.2",
     "@types/node": "^12.0.0",
     "@types/ws": "^7.2.4",
-    "assert": "^1.4.1",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
     "chai-exclude": "^2.0.2",


### PR DESCRIPTION
Solves https://github.com/Azure/azure-sdk-for-js/issues/17110#issuecomment-985076005.

Removing `assert` dev dependency since it is no longer needed when using `chai` and it is introducing a circular dependency issue when upgrading it to the latest version.