### PR TITLE
Remove assert dev dependency from Web-pubsub

### DIFF
--- a/sdk/web-pubsub/web-pubsub-express/package.json
+++ b/sdk/web-pubsub/web-pubsub-express/package.json
@@ -77,7 +77,6 @@
     "@types/mocha": "^7.0.2",
     "@types/node": "^12.0.0",
     "@types/sinon": "^9.0.4",
-    "assert": "^1.4.1",
     "chai": "^4.2.0",
     "cross-env": "^7.0.2",
     "dotenv": "^8.2.0",


### PR DESCRIPTION
Solves https://github.com/Azure/azure-sdk-for-js/issues/17110#issuecomment-985076005.

Removing `assert` dev dependency since it is no longer needed when using `chai` and it is introducing a circular dependency issue when upgrading it to the latest version.