### PR TITLE
[KeyVault] - Clarify certificate version properties

### DIFF
--- a/sdk/keyvault/keyvault-certificates/src/certificatesModels.ts
+++ b/sdk/keyvault/keyvault-certificates/src/certificatesModels.ts
@@ -439,6 +439,7 @@ export interface CertificateProperties {
   readonly vaultUrl?: string;
   /**
    * The version of certificate. May be undefined.
+   * **NOTE: This property will not be serialized. It can only be populated by the server.**
    */
   readonly version?: string;
   /**

--- a/sdk/keyvault/keyvault-certificates/src/index.ts
+++ b/sdk/keyvault/keyvault-certificates/src/index.ts
@@ -1111,6 +1111,9 @@ export class CertificateClient {
    *   issuerName: "Self",
    *   subject: "cn=MyCert"
    * });
+   *
+   * // You may pass an empty string for version which will update
+   * // the latest version of the certificate
    * await client.updateCertificateProperties("MyCertificate", "", {
    *   tags: {
    *     customTag: "value"
@@ -1119,7 +1122,7 @@ export class CertificateClient {
    * ```
    * Updates a certificate
    * @param certificateName - The name of the certificate
-   * @param version - The version of the certificate to update
+   * @param version - The version of the certificate to update (an empty string will update the latest version)
    * @param options - The options, including what to update
    */
   public updateCertificateProperties(


### PR DESCRIPTION
## What

- Add comment about CertificateProperties#version which can only be populated by
the service
- Add explanation for updating the latest version of a certificate using an
empty version string

## Why

When updating some of our samples, Dina noticed a few things that can lead to
confusion. 

The first is that `version` is both a positional param _and_ part of
the `CertificateProperties` param. It's not clear which to use and its due to us
using the same model for both input and output types here.

The second is that version is technically required but not really - a user can
pass an empty string to update the latest version of a certificate. This is
common across all KV APIs but we did not make it truly optional.

Since these would be breaking changes, and no customers have yet to complain
about this, we decided a good middle-ground would be to update the documentation
to make it clearer.

Fixes #18886 