### PR TITLE
[sort-imports] update ```eslint-plugin-azure-sdk``` with respect to ```sort-imports``` rule

### DIFF
--- a/common/tools/eslint-plugin-azure-sdk/src/rules/github-source-headers.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/rules/github-source-headers.ts
@@ -6,8 +6,8 @@
  * @author Arpan Laha
  */
 
-import { Rule } from "eslint";
 import { Comment, Node } from "estree";
+import { Rule } from "eslint";
 import { getRuleMetaData } from "../utils";
 
 //------------------------------------------------------------------------------

--- a/common/tools/eslint-plugin-azure-sdk/src/rules/ts-apiextractor-json-types.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/rules/ts-apiextractor-json-types.ts
@@ -7,9 +7,9 @@
  * @author Will Temple
  */
 
-import { Rule } from "eslint";
-import { Property } from "estree";
 import { getRuleMetaData, getVerifiers, stripPath } from "../utils";
+import { Property } from "estree";
+import { Rule } from "eslint";
 import { stripFileName } from "../utils/verifiers";
 
 //------------------------------------------------------------------------------

--- a/common/tools/eslint-plugin-azure-sdk/src/rules/ts-apisurface-standardized-verbs.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/rules/ts-apisurface-standardized-verbs.ts
@@ -6,9 +6,9 @@
  * @author Arpan Laha
  */
 
-import { Rule } from "eslint";
 import { ClassDeclaration, Identifier, MethodDefinition } from "estree";
 import { getPublicMethods, getRuleMetaData } from "../utils";
+import { Rule } from "eslint";
 
 //------------------------------------------------------------------------------
 // Rule Definition

--- a/common/tools/eslint-plugin-azure-sdk/src/rules/ts-apisurface-supportcancellation.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/rules/ts-apisurface-supportcancellation.ts
@@ -6,12 +6,12 @@
  * @author Arpan Laha
  */
 
-import { ParserServices, TSESTree } from "@typescript-eslint/experimental-utils";
-import { ParserWeakMapESTreeToTSNode } from "@typescript-eslint/typescript-estree/dist/parser-options";
-import { Rule } from "eslint";
 import { ClassDeclaration, Identifier, MethodDefinition } from "estree";
+import { ParserServices, TSESTree } from "@typescript-eslint/experimental-utils";
 import { Symbol as TSSymbol, Type, TypeChecker, TypeFlags } from "typescript";
 import { getPublicMethods, getRuleMetaData } from "../utils";
+import { ParserWeakMapESTreeToTSNode } from "@typescript-eslint/typescript-estree/dist/parser-options";
+import { Rule } from "eslint";
 
 //------------------------------------------------------------------------------
 // Rule Definition

--- a/common/tools/eslint-plugin-azure-sdk/src/rules/ts-config-include.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/rules/ts-config-include.ts
@@ -6,9 +6,9 @@
  * @author Wei Jun Tan
  */
 
-import { Rule } from "eslint";
 import { ArrayExpression, Literal, Property } from "estree";
 import { arrayToString, getRuleMetaData, getVerifiers, stripPath } from "../utils";
+import { Rule } from "eslint";
 
 //------------------------------------------------------------------------------
 // Rule Definition

--- a/common/tools/eslint-plugin-azure-sdk/src/rules/ts-doc-internal.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/rules/ts-doc-internal.ts
@@ -7,14 +7,14 @@
  */
 
 import { ParserServices, TSESTree } from "@typescript-eslint/experimental-utils";
+import { getLocalExports, getRuleMetaData } from "../utils";
+import { Node } from "estree";
 import { ParserWeakMapESTreeToTSNode } from "@typescript-eslint/typescript-estree/dist/parser-options";
 import { Rule } from "eslint";
-import { Node } from "estree";
-import { readFileSync } from "fs";
-import { sync as globSync } from "glob";
-import { relative } from "path";
 import { TypeChecker } from "typescript";
-import { getLocalExports, getRuleMetaData } from "../utils";
+import { sync as globSync } from "glob";
+import { readFileSync } from "fs";
+import { relative } from "path";
 
 //------------------------------------------------------------------------------
 // Rule Definition

--- a/common/tools/eslint-plugin-azure-sdk/src/rules/ts-error-handling.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/rules/ts-error-handling.ts
@@ -6,9 +6,9 @@
  * @author Arpan Laha
  */
 
+import { Identifier, NewExpression, ThrowStatement } from "estree";
 import { ParserServices, TSESTree } from "@typescript-eslint/experimental-utils";
 import { Rule } from "eslint";
-import { Identifier, NewExpression, ThrowStatement } from "estree";
 import { getRuleMetaData } from "../utils";
 
 //------------------------------------------------------------------------------

--- a/common/tools/eslint-plugin-azure-sdk/src/rules/ts-modules-only-named.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/rules/ts-modules-only-named.ts
@@ -6,9 +6,9 @@
  * @author Arpan Laha
  */
 
-import { Rule } from "eslint";
-import { ExportDefaultDeclaration } from "estree";
 import { normalize, relative } from "path";
+import { ExportDefaultDeclaration } from "estree";
+import { Rule } from "eslint";
 import { getRuleMetaData } from "../utils";
 
 //------------------------------------------------------------------------------

--- a/common/tools/eslint-plugin-azure-sdk/src/rules/ts-naming-drop-noun.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/rules/ts-naming-drop-noun.ts
@@ -6,10 +6,10 @@
  * @author Arpan Laha
  */
 
-import { TSESTree } from "@typescript-eslint/experimental-utils";
-import { Rule } from "eslint";
 import { ClassDeclaration, Identifier, MethodDefinition } from "estree";
 import { getPublicMethods, getRuleMetaData } from "../utils";
+import { Rule } from "eslint";
+import { TSESTree } from "@typescript-eslint/experimental-utils";
 
 //------------------------------------------------------------------------------
 // Rule Definition

--- a/common/tools/eslint-plugin-azure-sdk/src/rules/ts-naming-options.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/rules/ts-naming-options.ts
@@ -6,10 +6,10 @@
  * @author Arpan Laha
  */
 
-import { ParserServices, TSESTree } from "@typescript-eslint/experimental-utils";
-import { Rule } from "eslint";
 import { ClassDeclaration, Identifier, MethodDefinition } from "estree";
+import { ParserServices, TSESTree } from "@typescript-eslint/experimental-utils";
 import { getPublicMethods, getRuleMetaData } from "../utils";
+import { Rule } from "eslint";
 
 //------------------------------------------------------------------------------
 // Rule Definition

--- a/common/tools/eslint-plugin-azure-sdk/src/rules/ts-naming-subclients.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/rules/ts-naming-subclients.ts
@@ -6,10 +6,10 @@
  * @author Arpan Laha
  */
 
-import { TSESTree } from "@typescript-eslint/experimental-utils";
-import { Rule } from "eslint";
 import { ClassDeclaration, Identifier, MethodDefinition } from "estree";
 import { getPublicMethods, getRuleMetaData } from "../utils";
+import { Rule } from "eslint";
+import { TSESTree } from "@typescript-eslint/experimental-utils";
 
 //------------------------------------------------------------------------------
 // Rule Definition

--- a/common/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-author.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-author.ts
@@ -6,8 +6,8 @@
  * @author Arpan Laha
  */
 
-import { Rule } from "eslint";
 import { getRuleMetaData, getVerifiers, stripPath } from "../utils";
+import { Rule } from "eslint";
 
 //------------------------------------------------------------------------------
 // Rule Definition

--- a/common/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-bugs.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-bugs.ts
@@ -6,8 +6,8 @@
  * @author Arpan Laha
  */
 
-import { Rule } from "eslint";
 import { getRuleMetaData, getVerifiers, stripPath } from "../utils";
+import { Rule } from "eslint";
 
 //------------------------------------------------------------------------------
 // Rule Definition

--- a/common/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-engine-is-present.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-engine-is-present.ts
@@ -6,8 +6,8 @@
  * @author Arpan Laha
  */
 
-import { Rule } from "eslint";
 import { getRuleMetaData, getVerifiers, stripPath } from "../utils";
+import { Rule } from "eslint";
 
 /**
  * definition of LTS Node versions

--- a/common/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-files-required.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-files-required.ts
@@ -6,9 +6,9 @@
  * @author Arpan Laha
  */
 
-import { Rule } from "eslint";
 import { Literal, Property } from "estree";
 import { arrayToString, getRuleMetaData, getVerifiers, stripPath } from "../utils";
+import { Rule } from "eslint";
 
 //------------------------------------------------------------------------------
 // Rule Definition

--- a/common/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-homepage.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-homepage.ts
@@ -6,9 +6,9 @@
  * @author Arpan Laha
  */
 
+import { Literal, Property } from "estree";
 import { getRuleMetaData, getVerifiers, stripPath } from "../utils";
 import { Rule } from "eslint";
-import { Literal, Property } from "estree";
 
 //------------------------------------------------------------------------------
 // Rule Definition

--- a/common/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-keywords.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-keywords.ts
@@ -6,8 +6,8 @@
  * @author Arpan Laha
  */
 
-import { Rule } from "eslint";
 import { getRuleMetaData, getVerifiers, stripPath } from "../utils";
+import { Rule } from "eslint";
 
 //------------------------------------------------------------------------------
 // Rule Definition

--- a/common/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-license.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-license.ts
@@ -6,8 +6,8 @@
  * @license Arpan Laha
  */
 
-import { Rule } from "eslint";
 import { getRuleMetaData, getVerifiers, stripPath } from "../utils";
+import { Rule } from "eslint";
 
 //------------------------------------------------------------------------------
 // Rule Definition

--- a/common/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-main-is-cjs.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-main-is-cjs.ts
@@ -6,9 +6,9 @@
  * @author Arpan Laha
  */
 
-import { Rule } from "eslint";
 import { Literal, Property } from "estree";
 import { getRuleMetaData, getVerifiers, stripPath } from "../utils";
+import { Rule } from "eslint";
 
 //------------------------------------------------------------------------------
 // Rule Definition

--- a/common/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-module.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-module.ts
@@ -6,9 +6,9 @@
  * @author Arpan Laha
  */
 
-import { Rule } from "eslint";
 import { Literal, Property } from "estree";
 import { getRuleMetaData, getVerifiers, stripPath } from "../utils";
+import { Rule } from "eslint";
 
 //------------------------------------------------------------------------------
 // Rule Definition

--- a/common/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-name.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-name.ts
@@ -6,9 +6,9 @@
  * @author Arpan Laha
  */
 
-import { Rule } from "eslint";
 import { Literal, Property } from "estree";
 import { getRuleMetaData, getVerifiers, stripPath } from "../utils";
+import { Rule } from "eslint";
 import { stripFileName } from "../utils/verifiers";
 
 //------------------------------------------------------------------------------

--- a/common/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-repo.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-repo.ts
@@ -6,8 +6,8 @@
  * @author Arpan Laha
  */
 
-import { Rule } from "eslint";
 import { getRuleMetaData, getVerifiers, stripPath } from "../utils";
+import { Rule } from "eslint";
 
 //------------------------------------------------------------------------------
 // Rule Definition

--- a/common/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-required-scripts.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-required-scripts.ts
@@ -6,9 +6,9 @@
  * @author Arpan Laha
  */
 
-import { Rule } from "eslint";
-import { Property } from "estree";
 import { getRuleMetaData, getVerifiers, stripPath } from "../utils";
+import { Property } from "estree";
+import { Rule } from "eslint";
 
 //------------------------------------------------------------------------------
 // Rule Definition

--- a/common/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-sdktype.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-sdktype.ts
@@ -7,9 +7,9 @@
  * @author Ben Zhang
  */
 
-import { Rule } from "eslint";
-import { Property } from "estree";
 import { getRuleMetaData, getVerifiers, stripPath } from "../utils";
+import { Property } from "estree";
+import { Rule } from "eslint";
 
 //------------------------------------------------------------------------------
 // Rule Definition

--- a/common/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-sideeffects.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-sideeffects.ts
@@ -6,8 +6,8 @@
  * @author Arpan Laha
  */
 
-import { Rule } from "eslint";
 import { getRuleMetaData, getVerifiers, stripPath } from "../utils";
+import { Rule } from "eslint";
 
 //------------------------------------------------------------------------------
 // Rule Definition

--- a/common/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-types.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-types.ts
@@ -6,9 +6,9 @@
  * @author Arpan Laha
  */
 
-import { Rule } from "eslint";
-import { Property } from "estree";
 import { getRuleMetaData, getVerifiers, stripPath } from "../utils";
+import { Property } from "estree";
+import { Rule } from "eslint";
 import { stripFileName } from "../utils/verifiers";
 
 //------------------------------------------------------------------------------

--- a/common/tools/eslint-plugin-azure-sdk/src/rules/ts-pagination-list.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/rules/ts-pagination-list.ts
@@ -6,9 +6,9 @@
  * @author Arpan Laha
  */
 
-import { TSESTree } from "@typescript-eslint/experimental-utils";
-import { Rule } from "eslint";
 import { Identifier, MethodDefinition } from "estree";
+import { Rule } from "eslint";
+import { TSESTree } from "@typescript-eslint/experimental-utils";
 import { getRuleMetaData } from "../utils";
 
 //------------------------------------------------------------------------------

--- a/common/tools/eslint-plugin-azure-sdk/src/rules/ts-use-interface-parameters.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/rules/ts-use-interface-parameters.ts
@@ -6,12 +6,20 @@
  * @author Arpan Laha
  */
 
-import { ParserServices, TSESTree } from "@typescript-eslint/experimental-utils";
 import {
-  ParserWeakMapESTreeToTSNode,
-  ParserWeakMap
-} from "@typescript-eslint/typescript-estree/dist/parser-options";
-import { Rule } from "eslint";
+  Declaration,
+  Modifier,
+  PropertySignature,
+  SymbolFlags,
+  SyntaxKind,
+  Node as TSNode,
+  Symbol as TSSymbol,
+  Type,
+  TypeChecker,
+  TypeReference,
+  TypeReferenceNode,
+  isArrayTypeNode
+} from "typescript";
 import {
   FunctionDeclaration,
   FunctionExpression,
@@ -19,20 +27,9 @@ import {
   MethodDefinition,
   Pattern
 } from "estree";
-import {
-  Declaration,
-  isArrayTypeNode,
-  Node as TSNode,
-  PropertySignature,
-  Symbol as TSSymbol,
-  SymbolFlags,
-  Type,
-  TypeChecker,
-  TypeReferenceNode,
-  TypeReference,
-  Modifier,
-  SyntaxKind
-} from "typescript";
+import { ParserServices, TSESTree } from "@typescript-eslint/experimental-utils";
+import { ParserWeakMap, ParserWeakMapESTreeToTSNode } from "@typescript-eslint/typescript-estree/dist/parser-options";
+import { Rule } from "eslint";
 import { getRuleMetaData } from "../utils";
 
 //------------------------------------------------------------------------------

--- a/common/tools/eslint-plugin-azure-sdk/src/rules/ts-use-promises.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/rules/ts-use-promises.ts
@@ -8,8 +8,8 @@
 
 import { ParserServices } from "@typescript-eslint/experimental-utils";
 import { Rule } from "eslint";
-import { isExternalModule } from "typescript";
 import { getRuleMetaData } from "../utils";
+import { isExternalModule } from "typescript";
 
 //------------------------------------------------------------------------------
 // Rule Definition

--- a/common/tools/eslint-plugin-azure-sdk/src/rules/ts-versioning-semver.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/rules/ts-versioning-semver.ts
@@ -6,9 +6,9 @@
  * @author Arpan Laha
  */
 
-import { Rule } from "eslint";
-import { Property } from "estree";
 import { getRuleMetaData, getVerifiers, stripPath } from "../utils";
+import { Property } from "estree";
+import { Rule } from "eslint";
 
 //------------------------------------------------------------------------------
 // Rule Definition

--- a/common/tools/eslint-plugin-azure-sdk/src/utils/exports.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/utils/exports.ts
@@ -6,10 +6,10 @@
  * @author Arpan Laha
  */
 
-import { ParserServices, TSESTree } from "@typescript-eslint/experimental-utils";
-import { Rule } from "eslint";
-import { SourceFile, Symbol as TSSymbol } from "typescript";
 import { ClassDeclaration, MethodDefinition } from "estree";
+import { ParserServices, TSESTree } from "@typescript-eslint/experimental-utils";
+import { SourceFile, Symbol as TSSymbol } from "typescript";
+import { Rule } from "eslint";
 
 /**
  * Gets all Symbols of Types of all top-level exports from a package.

--- a/common/tools/eslint-plugin-azure-sdk/src/utils/metadata.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/utils/metadata.ts
@@ -6,8 +6,8 @@
  * @author Arpan Laha
  */
 
-import { Rule } from "eslint";
 import { JSONSchema4 } from "json-schema";
+import { Rule } from "eslint";
 
 export const getRuleMetaData = (
   ruleName: string,

--- a/common/tools/eslint-plugin-azure-sdk/src/utils/verifiers.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/utils/verifiers.ts
@@ -6,8 +6,8 @@
  * @author Arpan Laha
  */
 
-import { Rule } from "eslint";
 import { ArrayExpression, Literal, ObjectExpression, Property, SpreadElement } from "estree";
+import { Rule } from "eslint";
 
 interface StructureData {
   outer: string;

--- a/common/tools/eslint-plugin-azure-sdk/tests/plugin.ts
+++ b/common/tools/eslint-plugin-azure-sdk/tests/plugin.ts
@@ -6,9 +6,9 @@
  * @author Arpan Laha
  */
 
-import plugin from "../src";
 import { describe, it } from "mocha";
 import { assert } from "chai";
+import plugin from "../src";
 
 /**
  * A list of all currently supported rules

--- a/common/tools/eslint-plugin-azure-sdk/tests/rules/github-source-headers.ts
+++ b/common/tools/eslint-plugin-azure-sdk/tests/rules/github-source-headers.ts
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import rule from "../../src/rules/github-source-headers";
 import { RuleTester } from "eslint";
+import rule from "../../src/rules/github-source-headers";
 
 //------------------------------------------------------------------------------
 // Tests

--- a/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-apiextractor-json-types.ts
+++ b/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-apiextractor-json-types.ts
@@ -7,8 +7,8 @@
  * @author Will Temple
  */
 
-import rule from "../../src/rules/ts-apiextractor-json-types";
 import { RuleTester } from "eslint";
+import rule from "../../src/rules/ts-apiextractor-json-types";
 
 //------------------------------------------------------------------------------
 // Example files

--- a/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-apisurface-standardized-verbs.ts
+++ b/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-apisurface-standardized-verbs.ts
@@ -6,8 +6,8 @@
  * @author Arpan Laha
  */
 
-import rule from "../../src/rules/ts-apisurface-standardized-verbs";
 import { RuleTester } from "eslint";
+import rule from "../../src/rules/ts-apisurface-standardized-verbs";
 
 //------------------------------------------------------------------------------
 // Tests

--- a/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-apisurface-supportcancellation.ts
+++ b/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-apisurface-supportcancellation.ts
@@ -6,8 +6,8 @@
  * @author Arpan Laha
  */
 
-import rule from "../../src/rules/ts-apisurface-supportcancellation";
 import { RuleTester } from "eslint";
+import rule from "../../src/rules/ts-apisurface-supportcancellation";
 
 //------------------------------------------------------------------------------
 // Tests

--- a/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-config-include.ts
+++ b/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-config-include.ts
@@ -6,8 +6,8 @@
  * @author Wei Jun Tan
  */
 
-import rule from "../../src/rules/ts-config-include";
 import { RuleTester } from "eslint";
+import rule from "../../src/rules/ts-config-include";
 
 //------------------------------------------------------------------------------
 // Example files

--- a/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-doc-internal.ts
+++ b/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-doc-internal.ts
@@ -6,8 +6,8 @@
  * @author Arpan Laha
  */
 
-import rule from "../../src/rules/ts-doc-internal";
 import { RuleTester } from "eslint";
+import rule from "../../src/rules/ts-doc-internal";
 
 //------------------------------------------------------------------------------
 // Tests

--- a/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-error-handling.ts
+++ b/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-error-handling.ts
@@ -6,8 +6,8 @@
  * @author Arpan Laha
  */
 
-import rule from "../../src/rules/ts-error-handling";
 import { RuleTester } from "eslint";
+import rule from "../../src/rules/ts-error-handling";
 
 //------------------------------------------------------------------------------
 // Tests

--- a/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-modules-only-named.ts
+++ b/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-modules-only-named.ts
@@ -6,8 +6,8 @@
  * @author Arpan Laha
  */
 
-import rule from "../../src/rules/ts-modules-only-named";
 import { RuleTester } from "eslint";
+import rule from "../../src/rules/ts-modules-only-named";
 
 //------------------------------------------------------------------------------
 // Tests

--- a/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-naming-drop-noun.ts
+++ b/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-naming-drop-noun.ts
@@ -6,8 +6,8 @@
  * @author Arpan Laha
  */
 
-import rule from "../../src/rules/ts-naming-drop-noun";
 import { RuleTester } from "eslint";
+import rule from "../../src/rules/ts-naming-drop-noun";
 
 //------------------------------------------------------------------------------
 // Tests

--- a/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-naming-options.ts
+++ b/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-naming-options.ts
@@ -6,8 +6,8 @@
  * @author Arpan Laha
  */
 
-import rule from "../../src/rules/ts-naming-options";
 import { RuleTester } from "eslint";
+import rule from "../../src/rules/ts-naming-options";
 
 //------------------------------------------------------------------------------
 // Tests

--- a/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-naming-subclients.ts
+++ b/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-naming-subclients.ts
@@ -6,8 +6,8 @@
  * @author Arpan Laha
  */
 
-import rule from "../../src/rules/ts-naming-subclients";
 import { RuleTester } from "eslint";
+import rule from "../../src/rules/ts-naming-subclients";
 
 //------------------------------------------------------------------------------
 // Tests

--- a/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-no-const-enums.ts
+++ b/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-no-const-enums.ts
@@ -6,8 +6,8 @@
  * @author Arpan Laha
  */
 
-import rule from "../../src/rules/ts-no-const-enums";
 import { RuleTester } from "eslint";
+import rule from "../../src/rules/ts-no-const-enums";
 
 //------------------------------------------------------------------------------
 // Tests

--- a/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-no-window.ts
+++ b/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-no-window.ts
@@ -6,8 +6,8 @@
  * @author Maor Leger
  */
 
-import rule from "../../src/rules/ts-no-window";
 import { RuleTester } from "eslint";
+import rule from "../../src/rules/ts-no-window";
 
 //------------------------------------------------------------------------------
 // Tests

--- a/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-package-json-author.ts
+++ b/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-package-json-author.ts
@@ -6,8 +6,8 @@
  * @author Arpan Laha
  */
 
-import rule from "../../src/rules/ts-package-json-author";
 import { RuleTester } from "eslint";
+import rule from "../../src/rules/ts-package-json-author";
 
 //------------------------------------------------------------------------------
 // Example files
@@ -80,7 +80,7 @@ const examplePackageGood = `{
     "eslint-detailed-reporter": "^0.8.0",
     "eslint-plugin-no-null": "^1.0.2",
     "eslint-plugin-no-only-tests": "^2.3.0",
-    "eslint-plugin-promise": "^4.1.1",    
+    "eslint-plugin-promise": "^4.1.1",
     "https-proxy-agent": "^2.2.1",
     "karma": "^4.0.1",
     "karma-chrome-launcher": "^2.2.0",
@@ -193,7 +193,7 @@ const examplePackageBad = `{
     "eslint-detailed-reporter": "^0.8.0",
     "eslint-plugin-no-null": "^1.0.2",
     "eslint-plugin-no-only-tests": "^2.3.0",
-    "eslint-plugin-promise": "^4.1.1",    
+    "eslint-plugin-promise": "^4.1.1",
     "https-proxy-agent": "^2.2.1",
     "karma": "^4.0.1",
     "karma-chrome-launcher": "^2.2.0",

--- a/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-package-json-bugs.ts
+++ b/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-package-json-bugs.ts
@@ -6,8 +6,8 @@
  * @author Arpan Laha
  */
 
-import rule from "../../src/rules/ts-package-json-bugs";
 import { RuleTester } from "eslint";
+import rule from "../../src/rules/ts-package-json-bugs";
 
 //------------------------------------------------------------------------------
 // Example files
@@ -80,7 +80,7 @@ const examplePackageGood = `{
     "eslint-detailed-reporter": "^0.8.0",
     "eslint-plugin-no-null": "^1.0.2",
     "eslint-plugin-no-only-tests": "^2.3.0",
-    "eslint-plugin-promise": "^4.1.1",    
+    "eslint-plugin-promise": "^4.1.1",
     "https-proxy-agent": "^2.2.1",
     "karma": "^4.0.1",
     "karma-chrome-launcher": "^2.2.0",
@@ -193,7 +193,7 @@ const examplePackageBad = `{
     "eslint-detailed-reporter": "^0.8.0",
     "eslint-plugin-no-null": "^1.0.2",
     "eslint-plugin-no-only-tests": "^2.3.0",
-    "eslint-plugin-promise": "^4.1.1",    
+    "eslint-plugin-promise": "^4.1.1",
     "https-proxy-agent": "^2.2.1",
     "karma": "^4.0.1",
     "karma-chrome-launcher": "^2.2.0",

--- a/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-package-json-engine-is-present.ts
+++ b/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-package-json-engine-is-present.ts
@@ -8,8 +8,8 @@
 
 "use strict";
 
-import rule from "../../src/rules/ts-package-json-engine-is-present";
 import { RuleTester } from "eslint";
+import rule from "../../src/rules/ts-package-json-engine-is-present";
 
 //------------------------------------------------------------------------------
 // Example files

--- a/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-package-json-files-required.ts
+++ b/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-package-json-files-required.ts
@@ -6,8 +6,8 @@
  * @author Arpan Laha
  */
 
-import rule from "../../src/rules/ts-package-json-files-required";
 import { RuleTester } from "eslint";
+import rule from "../../src/rules/ts-package-json-files-required";
 
 //------------------------------------------------------------------------------
 // Example files
@@ -80,7 +80,7 @@ const examplePackageGood = `{
     "eslint-detailed-reporter": "^0.8.0",
     "eslint-plugin-no-null": "^1.0.2",
     "eslint-plugin-no-only-tests": "^2.3.0",
-    "eslint-plugin-promise": "^4.1.1",    
+    "eslint-plugin-promise": "^4.1.1",
     "https-proxy-agent": "^2.2.1",
     "karma": "^4.0.1",
     "karma-chrome-launcher": "^2.2.0",
@@ -192,7 +192,7 @@ const examplePackageBad = `{
     "eslint-detailed-reporter": "^0.8.0",
     "eslint-plugin-no-null": "^1.0.2",
     "eslint-plugin-no-only-tests": "^2.3.0",
-    "eslint-plugin-promise": "^4.1.1",    
+    "eslint-plugin-promise": "^4.1.1",
     "https-proxy-agent": "^2.2.1",
     "karma": "^4.0.1",
     "karma-chrome-launcher": "^2.2.0",
@@ -302,7 +302,7 @@ const examplePackageBadFixed = `{
     "eslint-detailed-reporter": "^0.8.0",
     "eslint-plugin-no-null": "^1.0.2",
     "eslint-plugin-no-only-tests": "^2.3.0",
-    "eslint-plugin-promise": "^4.1.1",    
+    "eslint-plugin-promise": "^4.1.1",
     "https-proxy-agent": "^2.2.1",
     "karma": "^4.0.1",
     "karma-chrome-launcher": "^2.2.0",

--- a/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-package-json-homepage.ts
+++ b/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-package-json-homepage.ts
@@ -6,8 +6,8 @@
  * @author Arpan Laha
  */
 
-import rule from "../../src/rules/ts-package-json-homepage";
 import { RuleTester } from "eslint";
+import rule from "../../src/rules/ts-package-json-homepage";
 
 //------------------------------------------------------------------------------
 // Example files
@@ -80,7 +80,7 @@ const examplePackageGood = `{
     "eslint-detailed-reporter": "^0.8.0",
     "eslint-plugin-no-null": "^1.0.2",
     "eslint-plugin-no-only-tests": "^2.3.0",
-    "eslint-plugin-promise": "^4.1.1",    
+    "eslint-plugin-promise": "^4.1.1",
     "https-proxy-agent": "^2.2.1",
     "karma": "^4.0.1",
     "karma-chrome-launcher": "^2.2.0",
@@ -193,7 +193,7 @@ const examplePackageBad = `{
     "eslint-detailed-reporter": "^0.8.0",
     "eslint-plugin-no-null": "^1.0.2",
     "eslint-plugin-no-only-tests": "^2.3.0",
-    "eslint-plugin-promise": "^4.1.1",    
+    "eslint-plugin-promise": "^4.1.1",
     "https-proxy-agent": "^2.2.1",
     "karma": "^4.0.1",
     "karma-chrome-launcher": "^2.2.0",

--- a/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-package-json-keywords.ts
+++ b/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-package-json-keywords.ts
@@ -6,8 +6,8 @@
  * @author Arpan Laha
  */
 
-import rule from "../../src/rules/ts-package-json-keywords";
 import { RuleTester } from "eslint";
+import rule from "../../src/rules/ts-package-json-keywords";
 
 //------------------------------------------------------------------------------
 // Example files
@@ -78,7 +78,7 @@ const examplePackageGood = `{
     "eslint-detailed-reporter": "^0.8.0",
     "eslint-plugin-no-null": "^1.0.2",
     "eslint-plugin-no-only-tests": "^2.3.0",
-    "eslint-plugin-promise": "^4.1.1",    
+    "eslint-plugin-promise": "^4.1.1",
     "https-proxy-agent": "^2.2.1",
     "karma": "^4.0.1",
     "karma-chrome-launcher": "^2.2.0",
@@ -186,7 +186,7 @@ const examplePackageBad = `{
     "eslint-detailed-reporter": "^0.8.0",
     "eslint-plugin-no-null": "^1.0.2",
     "eslint-plugin-no-only-tests": "^2.3.0",
-    "eslint-plugin-promise": "^4.1.1",    
+    "eslint-plugin-promise": "^4.1.1",
     "https-proxy-agent": "^2.2.1",
     "karma": "^4.0.1",
     "karma-chrome-launcher": "^2.2.0",
@@ -294,7 +294,7 @@ const examplePackageBadFixed = `{
     "eslint-detailed-reporter": "^0.8.0",
     "eslint-plugin-no-null": "^1.0.2",
     "eslint-plugin-no-only-tests": "^2.3.0",
-    "eslint-plugin-promise": "^4.1.1",    
+    "eslint-plugin-promise": "^4.1.1",
     "https-proxy-agent": "^2.2.1",
     "karma": "^4.0.1",
     "karma-chrome-launcher": "^2.2.0",

--- a/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-package-json-license.ts
+++ b/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-package-json-license.ts
@@ -6,8 +6,8 @@
  * @author Arpan Laha
  */
 
-import rule from "../../src/rules/ts-package-json-license";
 import { RuleTester } from "eslint";
+import rule from "../../src/rules/ts-package-json-license";
 
 //------------------------------------------------------------------------------
 // Example files
@@ -80,7 +80,7 @@ const examplePackageGood = `{
     "eslint-detailed-reporter": "^0.8.0",
     "eslint-plugin-no-null": "^1.0.2",
     "eslint-plugin-no-only-tests": "^2.3.0",
-    "eslint-plugin-promise": "^4.1.1",    
+    "eslint-plugin-promise": "^4.1.1",
     "https-proxy-agent": "^2.2.1",
     "karma": "^4.0.1",
     "karma-chrome-launcher": "^2.2.0",
@@ -193,7 +193,7 @@ const examplePackageBad = `{
     "eslint-detailed-reporter": "^0.8.0",
     "eslint-plugin-no-null": "^1.0.2",
     "eslint-plugin-no-only-tests": "^2.3.0",
-    "eslint-plugin-promise": "^4.1.1",    
+    "eslint-plugin-promise": "^4.1.1",
     "https-proxy-agent": "^2.2.1",
     "karma": "^4.0.1",
     "karma-chrome-launcher": "^2.2.0",

--- a/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-package-json-main-is-cjs.ts
+++ b/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-package-json-main-is-cjs.ts
@@ -6,8 +6,8 @@
  * @author Arpan Laha
  */
 
-import rule from "../../src/rules/ts-package-json-main-is-cjs";
 import { RuleTester } from "eslint";
+import rule from "../../src/rules/ts-package-json-main-is-cjs";
 
 //------------------------------------------------------------------------------
 // Example files
@@ -80,7 +80,7 @@ const examplePackageGood = `{
     "eslint-detailed-reporter": "^0.8.0",
     "eslint-plugin-no-null": "^1.0.2",
     "eslint-plugin-no-only-tests": "^2.3.0",
-    "eslint-plugin-promise": "^4.1.1",    
+    "eslint-plugin-promise": "^4.1.1",
     "https-proxy-agent": "^2.2.1",
     "karma": "^4.0.1",
     "karma-chrome-launcher": "^2.2.0",
@@ -193,7 +193,7 @@ const examplePackageBad = `{
     "eslint-detailed-reporter": "^0.8.0",
     "eslint-plugin-no-null": "^1.0.2",
     "eslint-plugin-no-only-tests": "^2.3.0",
-    "eslint-plugin-promise": "^4.1.1",    
+    "eslint-plugin-promise": "^4.1.1",
     "https-proxy-agent": "^2.2.1",
     "karma": "^4.0.1",
     "karma-chrome-launcher": "^2.2.0",

--- a/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-package-json-module.ts
+++ b/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-package-json-module.ts
@@ -6,8 +6,8 @@
  * @author Arpan Laha
  */
 
-import rule from "../../src/rules/ts-package-json-module";
 import { RuleTester } from "eslint";
+import rule from "../../src/rules/ts-package-json-module";
 
 //------------------------------------------------------------------------------
 // Example files
@@ -80,7 +80,7 @@ const examplePackageGood = `{
     "eslint-detailed-reporter": "^0.8.0",
     "eslint-plugin-no-null": "^1.0.2",
     "eslint-plugin-no-only-tests": "^2.3.0",
-    "eslint-plugin-promise": "^4.1.1",    
+    "eslint-plugin-promise": "^4.1.1",
     "https-proxy-agent": "^2.2.1",
     "karma": "^4.0.1",
     "karma-chrome-launcher": "^2.2.0",
@@ -193,7 +193,7 @@ const examplePackageBad = `{
     "eslint-detailed-reporter": "^0.8.0",
     "eslint-plugin-no-null": "^1.0.2",
     "eslint-plugin-no-only-tests": "^2.3.0",
-    "eslint-plugin-promise": "^4.1.1",    
+    "eslint-plugin-promise": "^4.1.1",
     "https-proxy-agent": "^2.2.1",
     "karma": "^4.0.1",
     "karma-chrome-launcher": "^2.2.0",

--- a/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-package-json-name.ts
+++ b/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-package-json-name.ts
@@ -6,8 +6,8 @@
  * @author Arpan Laha
  */
 
-import rule from "../../src/rules/ts-package-json-name";
 import { RuleTester } from "eslint";
+import rule from "../../src/rules/ts-package-json-name";
 
 //------------------------------------------------------------------------------
 // Example files
@@ -80,7 +80,7 @@ const examplePackageGood = `{
     "eslint-detailed-reporter": "^0.8.0",
     "eslint-plugin-no-null": "^1.0.2",
     "eslint-plugin-no-only-tests": "^2.3.0",
-    "eslint-plugin-promise": "^4.1.1",    
+    "eslint-plugin-promise": "^4.1.1",
     "https-proxy-agent": "^2.2.1",
     "karma": "^4.0.1",
     "karma-chrome-launcher": "^2.2.0",
@@ -193,7 +193,7 @@ const examplePackageBad = `{
     "eslint-detailed-reporter": "^0.8.0",
     "eslint-plugin-no-null": "^1.0.2",
     "eslint-plugin-no-only-tests": "^2.3.0",
-    "eslint-plugin-promise": "^4.1.1",    
+    "eslint-plugin-promise": "^4.1.1",
     "https-proxy-agent": "^2.2.1",
     "karma": "^4.0.1",
     "karma-chrome-launcher": "^2.2.0",

--- a/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-package-json-repo.ts
+++ b/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-package-json-repo.ts
@@ -6,8 +6,8 @@
  * @author Arpan Laha
  */
 
-import rule from "../../src/rules/ts-package-json-repo";
 import { RuleTester } from "eslint";
+import rule from "../../src/rules/ts-package-json-repo";
 
 //------------------------------------------------------------------------------
 // Example files
@@ -80,7 +80,7 @@ const examplePackageGood = `{
     "eslint-detailed-reporter": "^0.8.0",
     "eslint-plugin-no-null": "^1.0.2",
     "eslint-plugin-no-only-tests": "^2.3.0",
-    "eslint-plugin-promise": "^4.1.1",    
+    "eslint-plugin-promise": "^4.1.1",
     "https-proxy-agent": "^2.2.1",
     "karma": "^4.0.1",
     "karma-chrome-launcher": "^2.2.0",
@@ -193,7 +193,7 @@ const examplePackageBad = `{
     "eslint-detailed-reporter": "^0.8.0",
     "eslint-plugin-no-null": "^1.0.2",
     "eslint-plugin-no-only-tests": "^2.3.0",
-    "eslint-plugin-promise": "^4.1.1",    
+    "eslint-plugin-promise": "^4.1.1",
     "https-proxy-agent": "^2.2.1",
     "karma": "^4.0.1",
     "karma-chrome-launcher": "^2.2.0",

--- a/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-package-json-required-scripts.ts
+++ b/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-package-json-required-scripts.ts
@@ -6,8 +6,8 @@
  * @author Arpan Laha
  */
 
-import rule from "../../src/rules/ts-package-json-required-scripts";
 import { RuleTester } from "eslint";
+import rule from "../../src/rules/ts-package-json-required-scripts";
 
 //------------------------------------------------------------------------------
 // Example files
@@ -80,7 +80,7 @@ const examplePackageGood = `{
     "eslint-detailed-reporter": "^0.8.0",
     "eslint-plugin-no-null": "^1.0.2",
     "eslint-plugin-no-only-tests": "^2.3.0",
-    "eslint-plugin-promise": "^4.1.1",    
+    "eslint-plugin-promise": "^4.1.1",
     "https-proxy-agent": "^2.2.1",
     "karma": "^4.0.1",
     "karma-chrome-launcher": "^2.2.0",
@@ -199,7 +199,7 @@ const examplePackageBad = `{
     "eslint-detailed-reporter": "^0.8.0",
     "eslint-plugin-no-null": "^1.0.2",
     "eslint-plugin-no-only-tests": "^2.3.0",
-    "eslint-plugin-promise": "^4.1.1",    
+    "eslint-plugin-promise": "^4.1.1",
     "https-proxy-agent": "^2.2.1",
     "karma": "^4.0.1",
     "karma-chrome-launcher": "^2.2.0",

--- a/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-package-json-sideeffects.ts
+++ b/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-package-json-sideeffects.ts
@@ -6,8 +6,8 @@
  * @author Arpan Laha
  */
 
-import rule from "../../src/rules/ts-package-json-sideeffects";
 import { RuleTester } from "eslint";
+import rule from "../../src/rules/ts-package-json-sideeffects";
 
 //------------------------------------------------------------------------------
 // Example files
@@ -80,7 +80,7 @@ const examplePackageGood = `{
     "eslint-detailed-reporter": "^0.8.0",
     "eslint-plugin-no-null": "^1.0.2",
     "eslint-plugin-no-only-tests": "^2.3.0",
-    "eslint-plugin-promise": "^4.1.1",    
+    "eslint-plugin-promise": "^4.1.1",
     "https-proxy-agent": "^2.2.1",
     "karma": "^4.0.1",
     "karma-chrome-launcher": "^2.2.0",
@@ -193,7 +193,7 @@ const examplePackageBad = `{
     "eslint-detailed-reporter": "^0.8.0",
     "eslint-plugin-no-null": "^1.0.2",
     "eslint-plugin-no-only-tests": "^2.3.0",
-    "eslint-plugin-promise": "^4.1.1",    
+    "eslint-plugin-promise": "^4.1.1",
     "https-proxy-agent": "^2.2.1",
     "karma": "^4.0.1",
     "karma-chrome-launcher": "^2.2.0",

--- a/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-package-json-types.ts
+++ b/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-package-json-types.ts
@@ -6,8 +6,8 @@
  * @author Arpan Laha
  */
 
-import rule from "../../src/rules/ts-package-json-types";
 import { RuleTester } from "eslint";
+import rule from "../../src/rules/ts-package-json-types";
 
 //------------------------------------------------------------------------------
 // Example files
@@ -80,7 +80,7 @@ const examplePackageGood = `{
     "eslint-detailed-reporter": "^0.8.0",
     "eslint-plugin-no-null": "^1.0.2",
     "eslint-plugin-no-only-tests": "^2.3.0",
-    "eslint-plugin-promise": "^4.1.1",    
+    "eslint-plugin-promise": "^4.1.1",
     "https-proxy-agent": "^2.2.1",
     "karma": "^4.0.1",
     "karma-chrome-launcher": "^2.2.0",
@@ -193,7 +193,7 @@ const examplePackageBad = `{
     "eslint-detailed-reporter": "^0.8.0",
     "eslint-plugin-no-null": "^1.0.2",
     "eslint-plugin-no-only-tests": "^2.3.0",
-    "eslint-plugin-promise": "^4.1.1",    
+    "eslint-plugin-promise": "^4.1.1",
     "https-proxy-agent": "^2.2.1",
     "karma": "^4.0.1",
     "karma-chrome-launcher": "^2.2.0",

--- a/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-pagination-list.ts
+++ b/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-pagination-list.ts
@@ -6,8 +6,8 @@
  * @author Arpan Laha
  */
 
-import rule from "../../src/rules/ts-pagination-list";
 import { RuleTester } from "eslint";
+import rule from "../../src/rules/ts-pagination-list";
 
 //------------------------------------------------------------------------------
 // Tests

--- a/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-use-interface-parameters.ts
+++ b/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-use-interface-parameters.ts
@@ -6,8 +6,8 @@
  * @author Arpan Laha
  */
 
-import rule from "../../src/rules/ts-use-interface-parameters";
 import { RuleTester } from "eslint";
+import rule from "../../src/rules/ts-use-interface-parameters";
 
 //------------------------------------------------------------------------------
 // Example class & interface

--- a/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-use-promises.ts
+++ b/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-use-promises.ts
@@ -6,8 +6,8 @@
  * @author Arpan Laha
  */
 
-import rule from "../../src/rules/ts-use-promises";
 import { RuleTester } from "eslint";
+import rule from "../../src/rules/ts-use-promises";
 
 //------------------------------------------------------------------------------
 // Example files

--- a/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-versioning-semver.ts
+++ b/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-versioning-semver.ts
@@ -6,8 +6,8 @@
  * @author Arpan Laha
  */
 
-import rule from "../../src/rules/ts-versioning-semver";
 import { RuleTester } from "eslint";
+import rule from "../../src/rules/ts-versioning-semver";
 
 //------------------------------------------------------------------------------
 // Example files
@@ -80,7 +80,7 @@ const examplePackageGood = `{
     "eslint-detailed-reporter": "^0.8.0",
     "eslint-plugin-no-null": "^1.0.2",
     "eslint-plugin-no-only-tests": "^2.3.0",
-    "eslint-plugin-promise": "^4.1.1",    
+    "eslint-plugin-promise": "^4.1.1",
     "https-proxy-agent": "^2.2.1",
     "karma": "^4.0.1",
     "karma-chrome-launcher": "^2.2.0",
@@ -193,7 +193,7 @@ const examplePackageBad = `{
     "eslint-detailed-reporter": "^0.8.0",
     "eslint-plugin-no-null": "^1.0.2",
     "eslint-plugin-no-only-tests": "^2.3.0",
-    "eslint-plugin-promise": "^4.1.1",    
+    "eslint-plugin-promise": "^4.1.1",
     "https-proxy-agent": "^2.2.1",
     "karma": "^4.0.1",
     "karma-chrome-launcher": "^2.2.0",


### PR DESCRIPTION
This PR is working in conjunction with other PRs to solve #9252.
As per my previous PR #18598, I will be making multiple PRs to fix individual sections of the azure codebase with respect to the new ```sort-imports``` rule.

In this PR, I have fixed all files under ```common/tools/eslint-plugin-azure-sdk```.