### PR TITLE
[sort-imports] update ```keyvault-secrets``` with respect to ```sort-imports``` rule

### DIFF
--- a/sdk/keyvault/keyvault-secrets/package.json
+++ b/sdk/keyvault/keyvault-secrets/package.json
@@ -20,7 +20,7 @@
     "url": "https://github.com/Azure/azure-sdk-for-js/issues"
   },
   "main": "./dist/index.js",
-  "module": "dist-esm/keyvault-secrets/src/index.js",
+  "module": "dist-esm/src/index.js",
   "types": "./types/keyvault-secrets.d.ts",
   "engines": {
     "node": ">=12.0.0"

--- a/sdk/keyvault/keyvault-secrets/src/index.ts
+++ b/sdk/keyvault/keyvault-secrets/src/index.ts
@@ -3,56 +3,52 @@
 /* eslint @typescript-eslint/member-ordering: 0 */
 /// <reference lib="esnext.asynciterable" />
 
-import {
-  TokenCredential,
-  isTokenCredential,
-  signingPolicy,
-  PipelineOptions,
-  createPipelineFromOptions
-} from "@azure/core-http";
-
-import { logger } from "./log";
-
 import "@azure/core-paging";
-import { PageSettings, PagedAsyncIterableIterator } from "@azure/core-paging";
-import { PollerLike, PollOperationState } from "@azure/core-lro";
 import {
-  DeletionRecoveryLevel,
-  KnownDeletionRecoveryLevel,
-  KeyVaultClientGetSecretsOptionalParams,
-  SecretBundle,
-  DeletedSecretBundle
-} from "./generated/models";
-import { KeyVaultClient } from "./generated/keyVaultClient";
-import { SDK_VERSION } from "./constants";
-import { challengeBasedAuthenticationPolicy } from "../../keyvault-common/src";
-
-import { DeleteSecretPoller } from "./lro/delete/poller";
-import { RecoverDeletedSecretPoller } from "./lro/recover/poller";
-
-import {
-  KeyVaultSecret,
-  DeletedSecret,
-  SecretPollerOptions,
+  BackupSecretOptions,
   BeginDeleteSecretOptions,
   BeginRecoverDeletedSecretOptions,
-  SetSecretOptions,
-  UpdateSecretPropertiesOptions,
-  GetSecretOptions,
+  DeletedSecret,
   GetDeletedSecretOptions,
-  PurgeDeletedSecretOptions,
-  BackupSecretOptions,
-  RestoreSecretBackupOptions,
+  GetSecretOptions,
+  KeyVaultSecret,
+  LATEST_API_VERSION,
+  ListDeletedSecretsOptions,
   ListPropertiesOfSecretVersionsOptions,
   ListPropertiesOfSecretsOptions,
-  ListDeletedSecretsOptions,
-  SecretProperties,
+  PurgeDeletedSecretOptions,
+  RestoreSecretBackupOptions,
   SecretClientOptions,
-  LATEST_API_VERSION
+  SecretPollerOptions,
+  SecretProperties,
+  SetSecretOptions,
+  UpdateSecretPropertiesOptions
 } from "./secretsModels";
+import {
+  DeletedSecretBundle,
+  DeletionRecoveryLevel,
+  KeyVaultClientGetSecretsOptionalParams,
+  KnownDeletionRecoveryLevel,
+  SecretBundle
+} from "./generated/models";
 import { KeyVaultSecretIdentifier, parseKeyVaultSecretIdentifier } from "./identifier";
-import { getSecretFromSecretBundle } from "./transformations";
+import { PageSettings, PagedAsyncIterableIterator } from "@azure/core-paging";
+import {
+  PipelineOptions,
+  TokenCredential,
+  createPipelineFromOptions,
+  isTokenCredential,
+  signingPolicy
+} from "@azure/core-http";
+import { PollOperationState, PollerLike } from "@azure/core-lro";
+import { DeleteSecretPoller } from "./lro/delete/poller";
+import { KeyVaultClient } from "./generated/keyVaultClient";
+import { RecoverDeletedSecretPoller } from "./lro/recover/poller";
+import { SDK_VERSION } from "./constants";
+import { challengeBasedAuthenticationPolicy } from "../../keyvault-common/src";
 import { createTraceFunction } from "../../keyvault-common/src";
+import { getSecretFromSecretBundle } from "./transformations";
+import { logger } from "./log";
 
 export {
   SecretClientOptions,

--- a/sdk/keyvault/keyvault-secrets/src/lro/delete/operation.ts
+++ b/sdk/keyvault/keyvault-secrets/src/lro/delete/operation.ts
@@ -1,16 +1,13 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+import { DeleteSecretOptions, DeletedSecret, GetDeletedSecretOptions } from "../../secretsModels";
+import { KeyVaultSecretPollOperation, KeyVaultSecretPollOperationState } from "../keyVaultSecretPoller";
 import { AbortSignalLike } from "@azure/abort-controller";
-import { DeletedSecret, DeleteSecretOptions, GetDeletedSecretOptions } from "../../secretsModels";
-import {
-  KeyVaultSecretPollOperation,
-  KeyVaultSecretPollOperationState
-} from "../keyVaultSecretPoller";
 import { KeyVaultClient } from "../../generated/keyVaultClient";
-import { getSecretFromSecretBundle } from "../../transformations";
 import { OperationOptions } from "@azure/core-http";
 import { createTraceFunction } from "../../../../keyvault-common/src";
+import { getSecretFromSecretBundle } from "../../transformations";
 
 /**
  * @internal

--- a/sdk/keyvault/keyvault-secrets/src/lro/delete/poller.ts
+++ b/sdk/keyvault/keyvault-secrets/src/lro/delete/poller.ts
@@ -2,8 +2,8 @@
 // Licensed under the MIT license.
 
 import { DeleteSecretPollOperation, DeleteSecretPollOperationState } from "./operation";
-import { DeletedSecret } from "../../secretsModels";
 import { KeyVaultSecretPoller, KeyVaultSecretPollerOptions } from "../keyVaultSecretPoller";
+import { DeletedSecret } from "../../secretsModels";
 
 /**
  * Class that creates a poller that waits until a secret finishes being deleted.

--- a/sdk/keyvault/keyvault-secrets/src/lro/keyVaultSecretPoller.ts
+++ b/sdk/keyvault/keyvault-secrets/src/lro/keyVaultSecretPoller.ts
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { delay, OperationOptions } from "@azure/core-http";
-import { Poller, PollOperation, PollOperationState } from "@azure/core-lro";
+import { OperationOptions, delay } from "@azure/core-http";
+import { PollOperation, PollOperationState, Poller } from "@azure/core-lro";
 import { KeyVaultClient } from "../generated/keyVaultClient";
 
 /**

--- a/sdk/keyvault/keyvault-secrets/src/lro/recover/operation.ts
+++ b/sdk/keyvault/keyvault-secrets/src/lro/recover/operation.ts
@@ -1,22 +1,13 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+import { DeletedSecret, GetSecretOptions, KeyVaultSecret, SecretProperties } from "../../secretsModels";
+import { KeyVaultSecretPollOperation, KeyVaultSecretPollOperationState } from "../keyVaultSecretPoller";
 import { AbortSignalLike } from "@azure/abort-controller";
-import {
-  DeletedSecret,
-  GetSecretOptions,
-  KeyVaultSecret,
-  SecretProperties
-} from "../../secretsModels";
-import {
-  KeyVaultSecretPollOperation,
-  KeyVaultSecretPollOperationState
-} from "../keyVaultSecretPoller";
 import { KeyVaultClient } from "../../generated/keyVaultClient";
-import { getSecretFromSecretBundle } from "../../transformations";
 import { OperationOptions } from "@azure/core-http";
-
 import { createTraceFunction } from "../../../../keyvault-common/src";
+import { getSecretFromSecretBundle } from "../../transformations";
 
 /**
  * @internal

--- a/sdk/keyvault/keyvault-secrets/src/lro/recover/poller.ts
+++ b/sdk/keyvault/keyvault-secrets/src/lro/recover/poller.ts
@@ -2,11 +2,14 @@
 // Licensed under the MIT license.
 
 import {
+  KeyVaultSecretPoller,
+  KeyVaultSecretPollerOptions
+} from "../keyVaultSecretPoller";
+import {
   RecoverDeletedSecretPollOperation,
   RecoverDeletedSecretPollOperationState
 } from "./operation";
 import { SecretProperties } from "../../secretsModels";
-import { KeyVaultSecretPoller, KeyVaultSecretPollerOptions } from "../keyVaultSecretPoller";
 
 /**
  * Class that deletes a poller that waits until a secret finishes being deleted

--- a/sdk/keyvault/keyvault-secrets/src/transformations.ts
+++ b/sdk/keyvault/keyvault-secrets/src/transformations.ts
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+import { DeletedSecret, KeyVaultSecret } from "./secretsModels";
 import { DeletedSecretBundle, SecretBundle } from "./generated/models";
 import { parseKeyVaultSecretIdentifier } from "./identifier";
-import { DeletedSecret, KeyVaultSecret } from "./secretsModels";
 
 /**
  * @internal

--- a/sdk/keyvault/keyvault-secrets/test/internal/challengeBasedAuthenticationPolicy.spec.ts
+++ b/sdk/keyvault/keyvault-secrets/test/internal/challengeBasedAuthenticationPolicy.spec.ts
@@ -1,22 +1,21 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { assert } from "chai";
-import { Context } from "mocha";
-import { env, Recorder } from "@azure-tools/test-recorder";
-import { createSandbox } from "sinon";
-
 import {
-  AuthenticationChallengeCache,
   AuthenticationChallenge,
-  parseWWWAuthenticate,
-  challengeBasedAuthenticationPolicy
+  AuthenticationChallengeCache,
+  challengeBasedAuthenticationPolicy,
+  parseWWWAuthenticate
 } from "../../../keyvault-common/src";
-import { SecretClient } from "../../src";
-import { authenticate } from "../utils/testAuthentication";
-import TestClient from "../utils/testClient";
+import { Recorder, env } from "@azure-tools/test-recorder";
 import { ClientSecretCredential } from "@azure/identity";
+import { Context } from "mocha";
+import { SecretClient } from "../../src";
+import TestClient from "../utils/testClient";
 import { WebResource } from "@azure/core-http";
+import { assert } from "chai";
+import { authenticate } from "../utils/testAuthentication";
+import { createSandbox } from "sinon";
 
 // Following the philosophy of not testing the insides if we can test the outsides...
 // I present you with this "Get Out of Jail Free" card (in reference to Monopoly).

--- a/sdk/keyvault/keyvault-secrets/test/internal/lroUnexpectedErrors.spec.ts
+++ b/sdk/keyvault/keyvault-secrets/test/internal/lroUnexpectedErrors.spec.ts
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { assert } from "chai";
-import { RestError } from "@azure/core-http";
 import { DeleteSecretPoller } from "../../src/lro/delete/poller";
 import { RecoverDeletedSecretPoller } from "../../src/lro/recover/poller";
+import { RestError } from "@azure/core-http";
+import { assert } from "chai";
 
 describe("The LROs properly throw on unexpected errors", () => {
   const vaultUrl = `https://keyVaultName.vault.azure.net`;

--- a/sdk/keyvault/keyvault-secrets/test/internal/serviceVersionParameter.spec.ts
+++ b/sdk/keyvault/keyvault-secrets/test/internal/serviceVersionParameter.spec.ts
@@ -2,11 +2,11 @@
 // Licensed under the MIT license.
 
 import * as assert from "assert";
-import { createSandbox, SinonSandbox, SinonSpy } from "sinon";
-import { SecretClient } from "../../src";
-import { LATEST_API_VERSION } from "../../src/secretsModels";
-import { HttpClient, WebResourceLike, HttpOperationResponse, HttpHeaders } from "@azure/core-http";
+import { HttpClient, HttpHeaders, HttpOperationResponse, WebResourceLike } from "@azure/core-http";
+import { SinonSandbox, SinonSpy, createSandbox } from "sinon";
 import { ClientSecretCredential } from "@azure/identity";
+import { LATEST_API_VERSION } from "../../src/secretsModels";
+import { SecretClient } from "../../src";
 import { env } from "@azure-tools/test-recorder";
 
 describe("The Secrets client should set the serviceVersion", () => {

--- a/sdk/keyvault/keyvault-secrets/test/internal/transformations.spec.ts
+++ b/sdk/keyvault/keyvault-secrets/test/internal/transformations.spec.ts
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { assert } from "chai";
 import { DeletedSecret, KeyVaultSecret } from "../../src";
 import { DeletedSecretBundle, SecretBundle } from "../../src/generated";
+import { assert } from "chai";
 import { getSecretFromSecretBundle } from "../../src/transformations";
 
 describe("Transformations", () => {

--- a/sdk/keyvault/keyvault-secrets/test/internal/userAgent.spec.ts
+++ b/sdk/keyvault/keyvault-secrets/test/internal/userAgent.spec.ts
@@ -4,10 +4,10 @@
 import * as assert from "assert";
 import { Context } from "mocha";
 import { SDK_VERSION } from "../../src/constants";
-import { packageVersion } from "../../src/generated/keyVaultClientContext";
-import { isNode } from "@azure/core-http";
-import path from "path";
 import fs from "fs";
+import { isNode } from "@azure/core-http";
+import { packageVersion } from "../../src/generated/keyVaultClientContext";
+import path from "path";
 
 describe("Secrets client's user agent (only in Node, because of fs)", () => {
   it("SDK_VERSION and packageVersion should match", async function() {

--- a/sdk/keyvault/keyvault-secrets/test/public/CRUD.spec.ts
+++ b/sdk/keyvault/keyvault-secrets/test/public/CRUD.spec.ts
@@ -1,17 +1,16 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { Context } from "mocha";
-import { assert } from "chai";
-import { supportsTracing } from "../../../keyvault-common/test/utils/supportsTracing";
-import { env, Recorder } from "@azure-tools/test-recorder";
+import { Recorder, env } from "@azure-tools/test-recorder";
 import { AbortController } from "@azure/abort-controller";
-
+import { Context } from "mocha";
 import { SecretClient } from "../../src";
-import { assertThrowsAbortError } from "../utils/utils.common";
-import { testPollerProperties } from "../utils/recorderUtils";
-import { authenticate } from "../utils/testAuthentication";
 import TestClient from "../utils/testClient";
+import { assert } from "chai";
+import { assertThrowsAbortError } from "../utils/utils.common";
+import { authenticate } from "../utils/testAuthentication";
+import { supportsTracing } from "../../../keyvault-common/test/utils/supportsTracing";
+import { testPollerProperties } from "../utils/recorderUtils";
 
 describe("Secret client - create, read, update and delete operations", () => {
   const secretValue = "SECRET_VALUE";

--- a/sdk/keyvault/keyvault-secrets/test/public/identifier.spec.ts
+++ b/sdk/keyvault/keyvault-secrets/test/public/identifier.spec.ts
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { parseKeyVaultSecretIdentifier } from "../../src/identifier";
 import * as assert from "assert";
+import { parseKeyVaultSecretIdentifier } from "../../src/identifier";
 
 describe("Key Vault Secrets Identifier", () => {
   it("It should work with a URI of a secret before it gets a version", async function() {

--- a/sdk/keyvault/keyvault-secrets/test/public/list.spec.ts
+++ b/sdk/keyvault/keyvault-secrets/test/public/list.spec.ts
@@ -2,15 +2,14 @@
 // Licensed under the MIT license.
 
 import * as assert from "assert";
+import { Recorder, env, isRecordMode } from "@azure-tools/test-recorder";
 import { Context } from "mocha";
-import chai from "chai";
-import { env, Recorder, isRecordMode } from "@azure-tools/test-recorder";
-
 import { SecretClient } from "../../src";
-import { assertThrowsAbortError } from "../utils/utils.common";
-import { testPollerProperties } from "../utils/recorderUtils";
-import { authenticate } from "../utils/testAuthentication";
 import TestClient from "../utils/testClient";
+import { assertThrowsAbortError } from "../utils/utils.common";
+import { authenticate } from "../utils/testAuthentication";
+import chai from "chai";
+import { testPollerProperties } from "../utils/recorderUtils";
 
 const { expect } = chai;
 

--- a/sdk/keyvault/keyvault-secrets/test/public/lro.delete.spec.ts
+++ b/sdk/keyvault/keyvault-secrets/test/public/lro.delete.spec.ts
@@ -2,15 +2,14 @@
 // Licensed under the MIT license.
 
 import * as assert from "assert";
+import { DeletedSecret, SecretClient } from "../../src";
+import { Recorder, env } from "@azure-tools/test-recorder";
 import { Context } from "mocha";
-import { env, Recorder } from "@azure-tools/test-recorder";
 import { PollerStoppedError } from "@azure/core-lro";
-
-import { SecretClient, DeletedSecret } from "../../src";
-import { assertThrowsAbortError } from "../utils/utils.common";
-import { testPollerProperties } from "../utils/recorderUtils";
-import { authenticate } from "../utils/testAuthentication";
 import TestClient from "../utils/testClient";
+import { assertThrowsAbortError } from "../utils/utils.common";
+import { authenticate } from "../utils/testAuthentication";
+import { testPollerProperties } from "../utils/recorderUtils";
 
 describe("Secrets client - Long Running Operations - delete", () => {
   const secretPrefix = `lroDelete${env.CERTIFICATE_NAME || "SecretName"}`;

--- a/sdk/keyvault/keyvault-secrets/test/public/lro.recover.spec.ts
+++ b/sdk/keyvault/keyvault-secrets/test/public/lro.recover.spec.ts
@@ -2,15 +2,14 @@
 // Licensed under the MIT license.
 
 import * as assert from "assert";
-import { Context } from "mocha";
-import { env, Recorder } from "@azure-tools/test-recorder";
-import { PollerStoppedError } from "@azure/core-lro";
-
+import { Recorder, env } from "@azure-tools/test-recorder";
 import { SecretClient, SecretProperties } from "../../src";
-import { assertThrowsAbortError } from "../utils/utils.common";
-import { testPollerProperties } from "../utils/recorderUtils";
-import { authenticate } from "../utils/testAuthentication";
+import { Context } from "mocha";
+import { PollerStoppedError } from "@azure/core-lro";
 import TestClient from "../utils/testClient";
+import { assertThrowsAbortError } from "../utils/utils.common";
+import { authenticate } from "../utils/testAuthentication";
+import { testPollerProperties } from "../utils/recorderUtils";
 
 describe("Secrets client - Long Running Operations - recoverDelete", () => {
   const secretPrefix = `lroRecover${env.CERTIFICATE_NAME || "SecretName"}`;

--- a/sdk/keyvault/keyvault-secrets/test/public/recoverBackupRestore.spec.ts
+++ b/sdk/keyvault/keyvault-secrets/test/public/recoverBackupRestore.spec.ts
@@ -2,15 +2,14 @@
 // Licensed under the MIT license.
 
 import * as assert from "assert";
+import { Recorder, env, isPlaybackMode, isRecordMode } from "@azure-tools/test-recorder";
 import { Context } from "mocha";
-import { isNode } from "@azure/core-http";
-import { env, isPlaybackMode, Recorder, isRecordMode } from "@azure-tools/test-recorder";
-
 import { SecretClient } from "../../src";
-import { assertThrowsAbortError } from "../utils/utils.common";
-import { testPollerProperties } from "../utils/recorderUtils";
-import { authenticate } from "../utils/testAuthentication";
 import TestClient from "../utils/testClient";
+import { assertThrowsAbortError } from "../utils/utils.common";
+import { authenticate } from "../utils/testAuthentication";
+import { isNode } from "@azure/core-http";
+import { testPollerProperties } from "../utils/recorderUtils";
 
 describe("Secret client - restore secrets and recover backups", () => {
   const secretPrefix = `backupRestore${env.SECRET_NAME || "SecretName"}`;

--- a/sdk/keyvault/keyvault-secrets/test/utils/lro/restore/operation.ts
+++ b/sdk/keyvault/keyvault-secrets/test/utils/lro/restore/operation.ts
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { AbortSignalLike } from "@azure/abort-controller";
-import { PollOperationState, PollOperation } from "@azure/core-lro";
-import { OperationOptions } from "@azure/core-http";
+import { PollOperation, PollOperationState } from "@azure/core-lro";
 import { SecretPollerOptions, SecretProperties } from "../../../../src/secretsModels";
+import { AbortSignalLike } from "@azure/abort-controller";
+import { OperationOptions } from "@azure/core-http";
 
 /**
  * Options sent to the beginRestoreSecretBackup method.

--- a/sdk/keyvault/keyvault-secrets/test/utils/lro/restore/poller.ts
+++ b/sdk/keyvault/keyvault-secrets/test/utils/lro/restore/poller.ts
@@ -1,13 +1,13 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { delay, OperationOptions } from "@azure/core-http";
-import { Poller } from "@azure/core-lro";
+import { OperationOptions, delay } from "@azure/core-http";
 import {
   RestoreSecretBackupPollOperationState,
-  makeRestoreSecretBackupPollOperation,
-  TestSecretClientInterface
+  TestSecretClientInterface,
+  makeRestoreSecretBackupPollOperation
 } from "./operation";
+import { Poller } from "@azure/core-lro";
 import { SecretProperties } from "../../../../src/secretsModels";
 
 export interface RestoreSecretBackupPollerOptions {

--- a/sdk/keyvault/keyvault-secrets/test/utils/recorderUtils.ts
+++ b/sdk/keyvault/keyvault-secrets/test/utils/recorderUtils.ts
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { isPlaybackMode } from "@azure-tools/test-recorder";
-import { isNode } from "@azure/core-http";
 import * as dotenv from "dotenv";
+import { isNode } from "@azure/core-http";
+import { isPlaybackMode } from "@azure-tools/test-recorder";
 
 if (isNode) {
   dotenv.config();

--- a/sdk/keyvault/keyvault-secrets/test/utils/testAuthentication.ts
+++ b/sdk/keyvault/keyvault-secrets/test/utils/testAuthentication.ts
@@ -1,12 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+import { RecorderEnvironmentSetup, env, record } from "@azure-tools/test-recorder";
 import { ClientSecretCredential } from "@azure/identity";
-import { SecretClient } from "../../src";
-import { env, record, RecorderEnvironmentSetup } from "@azure-tools/test-recorder";
-import { uniqueString } from "./recorderUtils";
-import TestClient from "./testClient";
 import { Context } from "mocha";
+import { SecretClient } from "../../src";
+import TestClient from "./testClient";
+import { uniqueString } from "./recorderUtils";
 
 export async function authenticate(that: Context): Promise<any> {
   const secretSuffix = uniqueString();

--- a/sdk/keyvault/keyvault-secrets/test/utils/testClient.ts
+++ b/sdk/keyvault/keyvault-secrets/test/utils/testClient.ts
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { testPollerProperties } from "./recorderUtils";
+import { PollOperationState, PollerLike } from "@azure/core-lro";
 import { SecretClient, SecretProperties } from "../../src";
-import { PollerLike, PollOperationState } from "@azure/core-lro";
-import { RestoreSecretBackupPoller } from "./lro/restore/poller";
 import { BeginRestoreSecretBackupOptions } from "./lro/restore/operation";
+import { RestoreSecretBackupPoller } from "./lro/restore/poller";
+import { testPollerProperties } from "./recorderUtils";
 
 export default class TestClient {
   public readonly client: SecretClient;


### PR DESCRIPTION
This PR is working in conjunction with other PRs to solve #9252.
As per my previous PR #18598, I will be making multiple PRs to fix individual sections of the azure codebase with respect to the new ```sort-imports``` rule.

In this PR, I have fixed all files under ```sdk/keyvault/keyvault-secrets```.