### PR TITLE
[Identity] Fixing wrong expiration date on the tokenExchangeMsi

### DIFF
--- a/sdk/identity/identity/CHANGELOG.md
+++ b/sdk/identity/identity/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Bugs Fixed
 
 - Challenge claims now are properly being passed through to the outgoing token requests.
+- The `ManagedIdentityCredential` now properly parses expiration dates from token exchange requests.
 
 ### Other Changes
 

--- a/sdk/identity/identity/src/credentials/managedIdentityCredential/tokenExchangeMsi.ts
+++ b/sdk/identity/identity/src/credentials/managedIdentityCredential/tokenExchangeMsi.ts
@@ -9,7 +9,6 @@ import {
 } from "@azure/core-rest-pipeline";
 import { AccessToken, GetTokenOptions } from "@azure/core-auth";
 import { promisify } from "util";
-import { TokenResponseParsedBody } from "../../client/identityClient";
 import { DefaultAuthorityHost } from "../../constants";
 import { credentialLogger } from "../../util/logging";
 import { MSI, MSIConfiguration } from "./models";
@@ -18,14 +17,6 @@ const msiName = "ManagedIdentityCredential - Token Exchange";
 const logger = credentialLogger(msiName);
 
 const readFileAsync = promisify(fs.readFile);
-
-/**
- * Formats the expiration date of the received token into the number of milliseconds between that date and midnight, January 1, 1970.
- */
-function expiresOnParser(requestBody: TokenResponseParsedBody): number {
-  // Parses a string representation of the seconds since epoch into a number value
-  return Number(requestBody.expires_on);
-}
 
 /**
  * Generates the options used on the request for an access token.
@@ -124,7 +115,7 @@ export function tokenExchangeMsi(): MSI {
         // Generally, MSI endpoints use the HTTP protocol, without transport layer security (TLS).
         allowInsecureConnection: true
       });
-      const tokenResponse = await identityClient.sendTokenRequest(request, expiresOnParser);
+      const tokenResponse = await identityClient.sendTokenRequest(request);
       return (tokenResponse && tokenResponse.accessToken) || null;
     }
   };

--- a/sdk/identity/identity/test/internal/node/managedIdentityCredential.spec.ts
+++ b/sdk/identity/identity/test/internal/node/managedIdentityCredential.spec.ts
@@ -516,7 +516,7 @@ describe("ManagedIdentityCredential", function() {
         secureResponses: [
           createResponse(200, {
             access_token: "token",
-            expires_on: 1
+            expires_in: 1
           })
         ]
       });
@@ -538,6 +538,7 @@ describe("ManagedIdentityCredential", function() {
       );
       assert.strictEqual(decodeURIComponent(body.get("scope")!), "https://service/.default");
       assert.strictEqual(authDetails.result!.token, "token");
+      assert.strictEqual(authDetails.result!.expiresOnTimestamp, 1000);
     });
 
     it("reads from the token file again only after 5 minutes have passed", async function(this: Mocha.Context) {


### PR DESCRIPTION
A customer recently reported that their AKS application was failing because the token being used became expired after a while. After inspecting their code and logs, I thought that perhaps it was that the expiration date that we were providing from Identity to the HTTP pipelines was wrong.

The `tokenExchangeMsi` is special because it first reads from `AZURE_FEDERATED_TOKEN_FILE`’s in order to retrieve an assertion that then gets used to retrieve a token from AAD. While developing this MSI, I assumed the expiration date would come similarly to other MSIs, however other MSIs retrieve the tokens from the MSI service, which is different from the AAD service.

- Other MSIs, like the `imdsMsi`, use the IMDS endpoint https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/identity/identity/src/credentials/managedIdentityCredential/imdsMsi.ts#L78
- However, the `tokenExchangeMsi` uses the AAD service https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/identity/identity/src/credentials/managedIdentityCredential/tokenExchangeMsi.ts#L48

Generally, we assume that for MSI requests, the expiration date will come from the `expires_on` property, while the default AAD token request assumes the expiration date will be available through the received `expires_in` property.

- MSIs using the `expires_on` property: https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/identity/identity/src/credentials/managedIdentityCredential/fabricMsi.ts#L36
- The Identity client using `expires_in` by default: https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/identity/identity/src/client/identityClient.ts#L114

This PR ensures that the `tokenExchangeMsi` fulfills the `expiresOnTimestamp` property based on the default approach provided by the Identity client’s `sendTokenRequest`, which is to use the `expires_in` property received from the AAD service.

Once this is merged, we will be able to confirm with the customer that the update works via our nightly releases. After that, we will be able to make a hotfix.

Feedback appreciated ❤️