### PR TITLE
Fix aggregate-reports.yml

### DIFF
--- a/eng/pipelines/aggregate-reports.yml
+++ b/eng/pipelines/aggregate-reports.yml
@@ -1,5 +1,5 @@
 trigger: none
-hbadershy: haberdashery
+
 pr:
   branches:
     include:


### PR DESCRIPTION
This looks like it came out of a spelling error test commit somewhere in a rebase. Not sure why [the PR checks for the original PR didn't include `js - aggregate-reports`](https://github.com/Azure/azure-sdk-for-js/pull/17142/checks) given that `aggregate-reports.yml` was included in the list of changes and there is a trigger condition which includes that file. 

There was a run of [`js - aggregate-reports`](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1232234&view=results) but it does not appear to have gone into the checks. 