### PR TITLE
Fix aggregate-reports.yml

### DIFF
--- a/eng/pipelines/aggregate-reports.yml
+++ b/eng/pipelines/aggregate-reports.yml
@@ -1,5 +1,5 @@
 trigger: none
-hbadershy: haberdashery
+
 pr:
   branches:
     include:


### PR DESCRIPTION
Moving https://github.com/Azure/azure-sdk-for-js/pull/19004 to a branch off the main repo. 

The `aggregate-reports.yml` pipeline restricts usage of some service connections and will fail if not run from a branch off the main repo. 