### PR TITLE
[sort-imports] update ```core-tracing``` with respect to ```sort-imports``` rule

### DIFF
--- a/sdk/core/core-tracing/src/createSpan.ts
+++ b/sdk/core/core-tracing/src/createSpan.ts
@@ -2,16 +2,16 @@
 // Licensed under the MIT license.
 
 import {
+  Context,
   OperationTracingOptions,
   Span,
+  SpanKind,
   SpanOptions,
-  setSpan,
-  context as otContext,
   getTracer,
-  Context,
-  SpanKind
+  context as otContext,
+  setSpan
 } from "./interfaces";
-import { trace, INVALID_SPAN_CONTEXT } from "@opentelemetry/api";
+import { INVALID_SPAN_CONTEXT, trace } from "@opentelemetry/api";
 
 /**
  * Arguments for `createSpanFunction` that allow you to specify the

--- a/sdk/core/core-tracing/test/createSpan.spec.ts
+++ b/sdk/core/core-tracing/test/createSpan.spec.ts
@@ -1,19 +1,18 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { assert } from "chai";
 import {
-  setSpan,
+  Context,
   SpanKind,
-  context as otContext,
   getSpanContext,
-  Context
+  context as otContext,
+  setSpan
 } from "../src/interfaces";
-
-import { TestSpan } from "./util/testSpan";
 import { createSpanFunction, isTracingDisabled, knownSpanAttributes } from "../src/createSpan";
 import { OperationTracingOptions } from "../src/interfaces";
+import { TestSpan } from "./util/testSpan";
 import { TestTracerProvider } from "./util/testTracerProvider";
+import { assert } from "chai";
 
 describe("createSpan", () => {
   let createSpan: ReturnType<typeof createSpanFunction>;

--- a/sdk/core/core-tracing/test/interfaces.spec.ts
+++ b/sdk/core/core-tracing/test/interfaces.spec.ts
@@ -1,12 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import * as openTelemetry from "@opentelemetry/api";
 import * as coreAuth from "@azure/core-auth";
 import * as coreTracing from "../src/interfaces";
+import * as openTelemetry from "@opentelemetry/api";
+import { TestTracer } from "./util/testTracer";
 import { assert } from "chai";
 import { getTracer } from "../src/interfaces";
-import { TestTracer } from "./util/testTracer";
 
 type coreAuthTracingOptions = Required<coreAuth.GetTokenOptions>["tracingOptions"];
 

--- a/sdk/core/core-tracing/test/traceParentHeader.spec.ts
+++ b/sdk/core/core-tracing/test/traceParentHeader.spec.ts
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { assert } from "chai";
+import { SpanContext, TraceFlags } from "@opentelemetry/api";
 import { extractSpanContextFromTraceParentHeader, getTraceParentHeader } from "../src";
-import { TraceFlags, SpanContext } from "@opentelemetry/api";
+import { assert } from "chai";
 
 describe("traceParentHeader", () => {
   describe("#extractSpanContextFromTraceParentHeader", () => {

--- a/sdk/core/core-tracing/test/util/testSpan.ts
+++ b/sdk/core/core-tracing/test/util/testSpan.ts
@@ -2,16 +2,16 @@
 // Licensed under the MIT license.
 
 import {
-  TimeInput,
-  Tracer,
-  SpanKind,
-  SpanStatus,
-  SpanContext,
-  SpanAttributes,
-  SpanStatusCode,
-  SpanAttributeValue,
   Span,
-  SpanOptions
+  SpanAttributeValue,
+  SpanAttributes,
+  SpanContext,
+  SpanKind,
+  SpanOptions,
+  SpanStatus,
+  SpanStatusCode,
+  TimeInput,
+  Tracer
 } from "../../src/interfaces";
 
 /**

--- a/sdk/core/core-tracing/test/util/testTracer.ts
+++ b/sdk/core/core-tracing/test/util/testTracer.ts
@@ -1,16 +1,16 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { TestSpan } from "./testSpan";
 import {
+  Context as OTContext,
   SpanContext,
   SpanOptions,
   TraceFlags,
-  Context as OTContext,
-  context as otContext,
+  Tracer,
   getSpanContext,
-  Tracer
+  context as otContext
 } from "../../src/interfaces";
+import { TestSpan } from "./testSpan";
 
 /**
  * Simple representation of a Span that only has name and child relationships.


### PR DESCRIPTION
This PR is working in conjunction with other PRs to fix individual sections of the azure codebase with respect to the new ```sort-imports``` rule, as indicated in #9252 

In this PR, I have fixed all files under ```sdk/core/core-tracing```.