### PR TITLE
[sort-imports] update ```core-lro``` with respect to ```sort-imports``` rule

### DIFF
--- a/sdk/core/core-lro/src/lroEngine/azureAsyncPolling.ts
+++ b/sdk/core/core-lro/src/lroEngine/azureAsyncPolling.ts
@@ -2,14 +2,14 @@
 // Licensed under the MIT license.
 
 import {
-  failureStates,
-  LroResourceLocationConfig,
   LongRunningOperation,
   LroBody,
+  LroResourceLocationConfig,
   LroResponse,
   LroStatus,
-  successStates,
-  RawResponse
+  RawResponse,
+  failureStates,
+  successStates
 } from "./models";
 import { isUnexpectedPollingResponse } from "./requestUtils";
 

--- a/sdk/core/core-lro/src/lroEngine/bodyPolling.ts
+++ b/sdk/core/core-lro/src/lroEngine/bodyPolling.ts
@@ -2,11 +2,11 @@
 // Licensed under the MIT license.
 
 import {
-  failureStates,
   LroBody,
   LroResponse,
   LroStatus,
   RawResponse,
+  failureStates,
   successStates
 } from "./models";
 import { isUnexpectedPollingResponse } from "./requestUtils";

--- a/sdk/core/core-lro/src/lroEngine/lroEngine.ts
+++ b/sdk/core/core-lro/src/lroEngine/lroEngine.ts
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { Poller } from "../poller";
-import { PollOperationState } from "../pollOperation";
 import {
   LongRunningOperation,
   LroEngineOptions,
@@ -10,6 +8,8 @@ import {
   ResumablePollOperationState
 } from "./models";
 import { GenericPollOperation } from "./operation";
+import { PollOperationState } from "../pollOperation";
+import { Poller } from "../poller";
 
 function deserializeState<TResult, TState>(
   serializedState: string

--- a/sdk/core/core-lro/src/lroEngine/operation.ts
+++ b/sdk/core/core-lro/src/lroEngine/operation.ts
@@ -1,21 +1,21 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { AbortSignalLike } from "@azure/abort-controller";
-import { PollOperation, PollOperationState } from "../pollOperation";
-import { logger } from "./logger";
 import {
-  PollerConfig,
-  ResumablePollOperationState,
-  LongRunningOperation,
   GetLroStatusFromResponse,
+  LongRunningOperation,
   LroResourceLocationConfig,
-  LroStatus,
   LroResponse,
-  RawResponse
+  LroStatus,
+  PollerConfig,
+  RawResponse,
+  ResumablePollOperationState
 } from "./models";
-import { getPollingUrl } from "./requestUtils";
+import { PollOperation, PollOperationState } from "../pollOperation";
 import { createGetLroStatusFromResponse, createInitializeState, createPoll } from "./stateMachine";
+import { AbortSignalLike } from "@azure/abort-controller";
+import { getPollingUrl } from "./requestUtils";
+import { logger } from "./logger";
 
 export class GenericPollOperation<TResult, TState extends PollOperationState<TResult>>
   implements PollOperation<TState, TResult> {

--- a/sdk/core/core-lro/src/lroEngine/stateMachine.ts
+++ b/sdk/core/core-lro/src/lroEngine/stateMachine.ts
@@ -1,22 +1,22 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { processAzureAsyncOperationResult } from "./azureAsyncPolling";
-import { isBodyPollingDone, processBodyPollingOperationResult } from "./bodyPolling";
-import { processLocationPollingOperationResult } from "./locationPolling";
-import { logger } from "./logger";
 import {
-  LroResourceLocationConfig,
   GetLroStatusFromResponse,
   LongRunningOperation,
   LroConfig,
-  PollerConfig,
-  ResumablePollOperationState,
+  LroResourceLocationConfig,
   LroResponse,
-  LroStatus
+  LroStatus,
+  PollerConfig,
+  ResumablePollOperationState
 } from "./models";
-import { processPassthroughOperationResult } from "./passthrough";
 import { getPollingUrl, inferLroMode, isUnexpectedInitialResponse } from "./requestUtils";
+import { isBodyPollingDone, processBodyPollingOperationResult } from "./bodyPolling";
+import { logger } from "./logger";
+import { processAzureAsyncOperationResult } from "./azureAsyncPolling";
+import { processLocationPollingOperationResult } from "./locationPolling";
+import { processPassthroughOperationResult } from "./passthrough";
 
 /**
  * creates a stepping function that maps an LRO state to another.

--- a/sdk/core/core-lro/test/abort.spec.ts
+++ b/sdk/core/core-lro/test/abort.spec.ts
@@ -1,12 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { assert } from "chai";
-import { delay, WebResource, HttpHeaders } from "@azure/core-http";
-import { TestClient } from "./utils/testClient";
+import { HttpHeaders, WebResource, delay } from "@azure/core-http";
 import { AbortController } from "@azure/abort-controller";
 import { PollerStoppedError } from "../src";
+import { TestClient } from "./utils/testClient";
 import { TestTokenCredential } from "./utils/testTokenCredential";
+import { assert } from "chai";
 
 const testHttpHeaders: HttpHeaders = new HttpHeaders();
 const testHttpRequest: WebResource = new WebResource();

--- a/sdk/core/core-lro/test/engine.spec.ts
+++ b/sdk/core/core-lro/test/engine.spec.ts
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { assert } from "chai";
-import { RawResponse } from "../src/lroEngine/models";
 import { mockedPoller, runMockedLro } from "./utils/router";
+import { RawResponse } from "../src/lroEngine/models";
+import { assert } from "chai";
 
 describe("Lro Engine", function() {
   it("put201Succeeded", async function() {

--- a/sdk/core/core-lro/test/testClient.spec.ts
+++ b/sdk/core/core-lro/test/testClient.spec.ts
@@ -4,12 +4,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-import {
-  HttpHeaders,
-  WebResource,
-  delay,
-  isNode
-} from "@azure/core-http";
+import { HttpHeaders, WebResource, delay, isNode } from "@azure/core-http";
 import { PollerCancelledError, PollerStoppedError } from "../src";
 import { TestClient } from "./utils/testClient";
 import { TestOperationState } from "./utils/testOperation";

--- a/sdk/core/core-lro/test/testClient.spec.ts
+++ b/sdk/core/core-lro/test/testClient.spec.ts
@@ -4,12 +4,17 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-import { assert } from "chai";
-import { delay, WebResource, HttpHeaders, isNode } from "@azure/core-http";
+import {
+  HttpHeaders,
+  WebResource,
+  delay,
+  isNode
+} from "@azure/core-http";
+import { PollerCancelledError, PollerStoppedError } from "../src";
 import { TestClient } from "./utils/testClient";
-import { PollerStoppedError, PollerCancelledError } from "../src";
-import { TestTokenCredential } from "./utils/testTokenCredential";
 import { TestOperationState } from "./utils/testOperation";
+import { TestTokenCredential } from "./utils/testTokenCredential";
+import { assert } from "chai";
 
 const testHttpHeaders: HttpHeaders = new HttpHeaders();
 const testHttpRequest: WebResource = new WebResource();

--- a/sdk/core/core-lro/test/utils/coreRestPipelineLro.ts
+++ b/sdk/core/core-lro/test/utils/coreRestPipelineLro.ts
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { PipelineRequest } from "@azure/core-rest-pipeline";
 import { LongRunningOperation, LroResponse } from "../../src";
+import { PipelineRequest } from "@azure/core-rest-pipeline";
 
 export type SendOperationFn<T> = (request: PipelineRequest) => Promise<LroResponse<T>>;
 

--- a/sdk/core/core-lro/test/utils/router.ts
+++ b/sdk/core/core-lro/test/utils/router.ts
@@ -2,24 +2,24 @@
 // Licensed under the MIT license.
 
 import {
-  createHttpHeaders,
   HttpClient,
   HttpMethods,
   PipelineRequest,
   PipelineResponse,
-  RestError
+  RestError,
+  createHttpHeaders
 } from "@azure/core-rest-pipeline";
-import { LroEngine, PollerLike, PollOperationState } from "../../src";
 import {
-  LroResourceLocationConfig,
   LroBody,
+  LroResourceLocationConfig,
   LroResponse,
   RawResponse
 } from "../../src/lroEngine/models";
-import { CoreRestPipelineLro } from "./coreRestPipelineLro";
-import { paramRoutes } from "./router/paramRoutes";
+import { LroEngine, PollOperationState, PollerLike } from "../../src";
 import { routes, routesTable } from "./router/routesTable";
+import { CoreRestPipelineLro } from "./coreRestPipelineLro";
 import { applyScenarios } from "./router/utils";
+import { paramRoutes } from "./router/paramRoutes";
 
 /**
  * Re-implementation of the lro routes in Autorest test server located in https://github.com/Azure/autorest.testserver/blob/main/legacy/routes/lros.js

--- a/sdk/core/core-lro/test/utils/router/paramRoutes.ts
+++ b/sdk/core/core-lro/test/utils/router/paramRoutes.ts
@@ -1,8 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { createHttpHeaders, PipelineRequest, PipelineResponse } from "@azure/core-rest-pipeline";
-
+import { PipelineRequest, PipelineResponse, createHttpHeaders } from "@azure/core-rest-pipeline";
 import { buildResponse, getPascalCase, parseUri } from "./utils";
 
 function putBody(request: PipelineRequest): PipelineResponse | undefined {

--- a/sdk/core/core-lro/test/utils/router/routesProcesses.ts
+++ b/sdk/core/core-lro/test/utils/router/routesProcesses.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { createHttpHeaders, PipelineRequest, PipelineResponse } from "@azure/core-rest-pipeline";
+import { PipelineRequest, PipelineResponse, createHttpHeaders } from "@azure/core-rest-pipeline";
 import { buildProcessMultipleRequests, buildResponse } from "./utils";
 
 export function put200Succeeded(request: PipelineRequest): PipelineResponse {

--- a/sdk/core/core-lro/test/utils/router/routesTable.ts
+++ b/sdk/core/core-lro/test/utils/router/routesTable.ts
@@ -4,10 +4,10 @@
 import { PipelineRequest, PipelineResponse } from "@azure/core-rest-pipeline";
 import {
   delete204Succeeded,
-  deleteasyncNoheader202204,
-  deleteasyncNoheaderOperationresults123,
   deleteNoHeader,
   deleteNoHeaderOperationResults,
+  deleteasyncNoheader202204,
+  deleteasyncNoheaderOperationresults123,
   errorDelete202RetryInvalidheader,
   errorDelete204nolocation,
   errorDeleteasyncRetryFailedOperationResultsInvalidjsonpolling,
@@ -15,8 +15,8 @@ import {
   errorDeleteasyncRetryInvalidheader,
   errorDeleteasyncRetryInvalidjsonpolling,
   errorDeleteasyncRetryNostatus,
-  errorPost202nolocation,
   errorPost202RetryInvalidheader,
+  errorPost202nolocation,
   errorPostasyncRetryFailedOperationResultsInvalidjsonpolling,
   errorPostasyncRetryFailedOperationResultsNopayload,
   errorPostasyncRetryInvalidheader,
@@ -31,7 +31,6 @@ import {
   errorPutasyncRetryInvalidjsonpolling,
   errorPutasyncRetryNostatus,
   errorPutasyncRetryNostatuspayload,
-  getasyncNoheader201200,
   getDoubleHeadersFinalAzureHeaderGetDefaultAsyncOperationUrl,
   getDoubleHeadersFinalAzureHeaderGetDefaultLocation,
   getListFinalGet,
@@ -44,6 +43,7 @@ import {
   getPatchAsyncSucceeded,
   getPayload200,
   getSubresourceAsync202200,
+  getasyncNoheader201200,
   nonretryerrorDelete202retry400,
   nonretryerrorDelete400,
   nonretryerrorDeleteasyncRetry400,
@@ -73,8 +73,6 @@ import {
   put201SucceededNoState,
   put202Retry200,
   put202RetryOperationResults200,
-  putasyncNoheader201200,
-  putasyncNoheaderOperationresults123,
   putNoHeader202200,
   putNoHeaderOperationResults,
   putNonresource20200,
@@ -83,8 +81,10 @@ import {
   putNonresourceOperationResults,
   putSubresource202200,
   putSubresourceAsync202200,
+  putSubresourceOperationResults,
   putSubresourceasyncOperationresults123,
-  putSubresourceOperationResults
+  putasyncNoheader201200,
+  putasyncNoheaderOperationresults123
 } from "./routesProcesses";
 
 interface LroRoute {

--- a/sdk/core/core-lro/test/utils/router/utils.ts
+++ b/sdk/core/core-lro/test/utils/router/utils.ts
@@ -2,10 +2,10 @@
 // Licensed under the MIT license.
 
 import {
-  createHttpHeaders,
   HttpHeaders,
   PipelineRequest,
-  PipelineResponse
+  PipelineResponse,
+  createHttpHeaders
 } from "@azure/core-rest-pipeline";
 
 export function buildResponse(

--- a/sdk/core/core-lro/test/utils/testClient.ts
+++ b/sdk/core/core-lro/test/utils/testClient.ts
@@ -2,10 +2,10 @@
 // Licensed under the MIT license.
 
 import { RequestOptionsBase } from "@azure/core-http";
-import { TestServiceClient } from "./testServiceClient";
-import { TestPoller } from "./testPoller";
 import { TestNonCancellablePoller } from "./testNonCancellablePoller";
 import { TestOperationState } from "./testOperation";
+import { TestPoller } from "./testPoller";
+import { TestServiceClient } from "./testServiceClient";
 
 interface StartLROOptions {
   intervalInMs?: number;

--- a/sdk/core/core-lro/test/utils/testNonCancellablePoller.ts
+++ b/sdk/core/core-lro/test/utils/testNonCancellablePoller.ts
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { delay, RequestOptionsBase, HttpOperationResponse } from "@azure/core-http";
+import { HttpOperationResponse, RequestOptionsBase, delay } from "@azure/core-http";
+import { TestOperationState, makeOperation } from "./testOperation";
 import { Poller } from "../../src";
 import { TestServiceClient } from "./testServiceClient";
-import { makeOperation, TestOperationState } from "./testOperation";
 
 export class TestNonCancellablePoller extends Poller<TestOperationState, string> {
   public intervalInMs: number;

--- a/sdk/core/core-lro/test/utils/testOperation.ts
+++ b/sdk/core/core-lro/test/utils/testOperation.ts
@@ -2,8 +2,8 @@
 // Licensed under the MIT license.
 
 import { HttpOperationResponse, RequestOptionsBase } from "@azure/core-http";
+import { PollOperation, PollOperationState } from "../../src";
 import { AbortSignalLike } from "@azure/abort-controller";
-import { PollOperationState, PollOperation } from "../../src";
 import { TestServiceClient } from "./testServiceClient";
 import { TestWebResource } from "./testWebResource";
 

--- a/sdk/core/core-lro/test/utils/testPoller.ts
+++ b/sdk/core/core-lro/test/utils/testPoller.ts
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { delay, RequestOptionsBase, HttpOperationResponse } from "@azure/core-http";
+import { HttpOperationResponse, RequestOptionsBase, delay } from "@azure/core-http";
+import { PublicTestOperationState, TestOperationState, makeOperation } from "./testOperation";
 import { Poller } from "../../src";
 import { TestServiceClient } from "./testServiceClient";
-import { makeOperation, TestOperationState, PublicTestOperationState } from "./testOperation";
 
 export class TestPoller extends Poller<TestOperationState, string> {
   public intervalInMs: number;

--- a/sdk/core/core-lro/test/utils/testServiceClient.ts
+++ b/sdk/core/core-lro/test/utils/testServiceClient.ts
@@ -3,11 +3,11 @@
 
 import {
   HttpOperationResponse,
+  RequestOptionsBase,
   ServiceClient,
   ServiceClientCredentials,
   ServiceClientOptions,
-  TokenCredential,
-  RequestOptionsBase
+  TokenCredential
 } from "@azure/core-http";
 
 interface TestServiceClientOptions extends ServiceClientOptions {}

--- a/sdk/core/core-lro/test/utils/testTokenCredential.ts
+++ b/sdk/core/core-lro/test/utils/testTokenCredential.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { TokenCredential, GetTokenOptions, AccessToken } from "@azure/core-http";
+import { AccessToken, GetTokenOptions, TokenCredential } from "@azure/core-http";
 
 export class TestTokenCredential implements TokenCredential {
   public token: string;

--- a/sdk/core/core-lro/test/utils/testWebResource.ts
+++ b/sdk/core/core-lro/test/utils/testWebResource.ts
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { WebResource } from "@azure/core-http";
 import { AbortSignalLike } from "@azure/abort-controller";
+import { WebResource } from "@azure/core-http";
 
 export class TestWebResource extends WebResource {
   constructor(abortSignal?: AbortSignalLike) {


### PR DESCRIPTION
This PR is working in conjunction with other PRs to fix individual sections of the azure codebase with respect to the new ```sort-imports``` rule, as indicated in #9252.

In this PR, I have fixed all files under ```sdk/core/core-lro```.