### PR TITLE
[Tables] Honor expiresOn and permissions optionality

### DIFF
--- a/sdk/tables/data-tables/CHANGELOG.md
+++ b/sdk/tables/data-tables/CHANGELOG.md
@@ -8,6 +8,9 @@
 
 ### Bugs Fixed
 
+- Fix issue where optionality of expiresOn and permissions is not respected when signedIdentifier is provided.
+- Fix `createTable` not calling `onResponse` callback when the service returns `TableAlreadyExists`. [#18914](https://github.com/Azure/azure-sdk-for-js/pull/18914)
+
 ### Other Changes
 
 ## 13.0.0 (2021-11-11)
@@ -37,7 +40,9 @@ Thank you to our developer community members who helped to make the Azure Tables
 - Issue #18521 - `upsertEntity` doesn't work with "" for partition or row keys. [#18586](https://github.com/Azure/azure-sdk-for-js/pull/18586)
 
 ### Other Changes
+
 - Export RestError [#18635](https://github.com/Azure/azure-sdk-for-js/pull/18635). (A community contribution, courtesy of _[dhensby](https://github.com/dhensby))_
+
 ## 12.1.2 (2021-09-07)
 
 ### Bugs Fixed

--- a/sdk/tables/data-tables/package.json
+++ b/sdk/tables/data-tables/package.json
@@ -37,7 +37,7 @@
     "format": "prettier --write --config ../../../.prettierrc.json --ignore-path ../../../.prettierignore \"src/**/*.ts\" \"test/**/*.ts\" \"samples-dev/**/*.ts\" \"*.{js,json}\"",
     "generate:client": "autorest --typescript ./swagger/README.md",
     "integration-test:browser": "karma start --single-run",
-    "integration-test:node": "nyc mocha -r esm --require source-map-support/register --reporter ../../../common/tools/mocha-multi-reporter.js --timeout 5000000 --full-trace \"dist-esm/test/{,!(browser)/**/}*.spec.js\"",
+    "integration-test:node": "nyc mocha -r esm --require source-map-support/register --reporter ../../../common/tools/mocha-multi-reporter.js --timeout 5000000 --full-trace --exclude \"dist-esm/test/**/browser/**/*.spec.js\" \"dist-esm/test/**/*.spec.js\"",
     "integration-test": "npm run integration-test:node && npm run integration-test:browser",
     "lint:fix": "eslint package.json api-extractor.json src test --ext .ts --fix --fix-type [problem,suggestion]",
     "lint": "eslint package.json api-extractor.json src test --ext .ts",
@@ -46,7 +46,7 @@
     "test:node": "npm run build:test && npm run unit-test:node && npm run integration-test:node",
     "test": "npm run clean && npm run build:test && npm run unit-test",
     "unit-test:browser": "karma start --single-run",
-    "unit-test:node": "mocha -r esm --require ts-node/register --reporter ../../../common/tools/mocha-multi-reporter.js --timeout 1200000 --full-trace \"test/{,!(browser)/**/}*.spec.ts\"",
+    "unit-test:node": "mocha -r esm --require ts-node/register --reporter ../../../common/tools/mocha-multi-reporter.js --timeout 1200000 --full-trace --exclude \"test/**/browser/**/*.spec.ts\" \"test/**/*.spec.ts\"",
     "unit-test": "npm run unit-test:node && npm run unit-test:browser",
     "docs": "typedoc --excludePrivate --excludeNotExported --excludeExternals --stripInternal --mode file --out ./dist/docs ./src"
   },

--- a/sdk/tables/data-tables/src/sas/tableSasSignatureValues.ts
+++ b/sdk/tables/data-tables/src/sas/tableSasSignatureValues.ts
@@ -38,12 +38,13 @@ export interface TableSasSignatureValues {
   startsOn?: Date;
 
   /**
-   * Optional only when identifier is provided. The time after which the SAS will no longer work.
+   * Optional. If identifier is not provided has a default value of one hour from the time the token is generated.
+   * The time after which the SAS will no longer work.
    */
   expiresOn?: Date;
 
   /**
-   * Optional only when identifier is provided.
+   * Optional. If identifier is not provided has a default value of "read"
    * Please refer to {@link TableSasPermissions} depending on the resource
    * being accessed for help constructing the permissions string.
    */
@@ -95,12 +96,7 @@ export interface TableSasSignatureValues {
  *
  * Creates an instance of SASQueryParameters.
  *
- * Only accepts required settings needed to create a SAS. For optional settings please
- * set corresponding properties directly, such as permissions, startsOn and identifier.
- *
- * WARNING: When identifier is not provided, permissions and expiresOn are required.
- * You MUST assign value to identifier or expiresOn & permissions manually if you initial with
- * this constructor.
+ * **Note**: When identifier is not provided, permissions has a default value of "read" and expiresOn of one hour from the time the token is generated.
  */
 export function generateTableSasQueryParameters(
   tableName: string,

--- a/sdk/tables/data-tables/test/internal/browser/generateSas.browser.spec.ts
+++ b/sdk/tables/data-tables/test/internal/browser/generateSas.browser.spec.ts
@@ -1,0 +1,17 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { assert } from "chai";
+import { AzureNamedKeyCredential, generateTableSas } from "../../../src";
+
+// This file is empty as sas generation is not supported in browsers
+describe("generateSas Browser", () => {
+  it("should throw", function() {
+    try {
+      generateTableSas("testTable", new AzureNamedKeyCredential("keyName", "keySecret"));
+      assert.fail("`Expected generateTableSas to throw when running in the browser");
+    } catch (error) {
+      assert.equal((error as Error)?.message, "computeHMACSHA256 is not supported in the browser");
+    }
+  });
+});

--- a/sdk/tables/data-tables/test/internal/node/generateSas.spec.ts
+++ b/sdk/tables/data-tables/test/internal/node/generateSas.spec.ts
@@ -1,0 +1,136 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { assert } from "chai";
+import { AzureNamedKeyCredential, generateAccountSas, generateTableSas } from "../../../src";
+import * as sinon from "sinon";
+
+describe("SAS generation", function() {
+  describe("generateTableSAS", () => {
+    let clock: sinon.SinonFakeTimers;
+    beforeEach(() => {
+      clock = sinon.useFakeTimers(new Date("2021-12-12"));
+    });
+
+    afterEach(() => {
+      if (clock) {
+        clock.reset();
+      }
+    });
+
+    it("should generate a SAS token with default values", async () => {
+      // Create the table SAS token
+      const tableSas = generateTableSas(
+        "testTable",
+        new AzureNamedKeyCredential("keyName", "keySecret")
+      );
+
+      assert.equal(
+        tableSas,
+        "sv=2019-02-02&se=2021-12-12T01%3A00%3A00Z&sp=r&sig=lZxPmk%2BpMuu2MRXxeTZoBV6m3eobZKuIkYcHLDdDt2Q%3D&tn=testTable"
+      );
+    });
+
+    it("should generate a SAS token with explicit permissions", async () => {
+      // Create the table SAS token
+      const tableSas = generateTableSas(
+        "testTable",
+        new AzureNamedKeyCredential("keyName", "keySecret"),
+        {
+          permissions: {
+            add: true,
+            delete: true
+          }
+        }
+      );
+
+      assert.equal(
+        tableSas,
+        "sv=2019-02-02&se=2021-12-12T01%3A00%3A00Z&sp=ad&sig=bf2oeXb%2FVL9hzbd5ZWngdNJoR%2BkyDp0vPZz%2FDGJt1d4%3D&tn=testTable"
+      );
+    });
+
+    it("should generate a SAS token with explicit expiry", async () => {
+      // Create the table SAS token
+      const tableSas = generateTableSas(
+        "testTable",
+        new AzureNamedKeyCredential("keyName", "keySecret"),
+        {
+          expiresOn: new Date("2022-12-12")
+        }
+      );
+
+      assert.equal(
+        tableSas,
+        "sv=2019-02-02&se=2022-12-12T00%3A00%3A00Z&sp=r&sig=Jm1wKNTA0%2FHH8u9S8dSjqdZKtFKYr7whXnxDy3RKsxU%3D&tn=testTable"
+      );
+    });
+
+    it("should generate a SAS token with identifier", async () => {
+      // Create the table SAS token
+      const tableSas = generateTableSas(
+        "testTable",
+        new AzureNamedKeyCredential("keyName", "keySecret"),
+        {
+          identifier: "MyAccessPolicy",
+          version: "2019-02-02"
+        }
+      );
+
+      assert.equal(
+        tableSas,
+        "sv=2019-02-02&si=MyAccessPolicy&sig=bXpQx%2FOSDR8oGiqi1QJekrwS5MBf%2Bdi6x%2FClf9QVKgg%3D&tn=testTable"
+      );
+    });
+  });
+
+  describe("generateAccountSAS", () => {
+    let clock: sinon.SinonFakeTimers;
+    beforeEach(() => {
+      clock = sinon.useFakeTimers(new Date("2021-12-12"));
+    });
+
+    afterEach(() => {
+      if (clock) {
+        clock.reset();
+      }
+    });
+
+    it("should generate account SAS token with default values", async () => {
+      // Create the table SAS token
+      const tableSas = generateAccountSas(new AzureNamedKeyCredential("keyName", "keySecret"));
+
+      assert.equal(
+        tableSas,
+        "sv=2019-02-02&ss=t&srt=sco&se=2021-12-12T01%3A00%3A00Z&sp=rl&sig=Yuhy3%2BSpfj%2BFWmSoxa1GAxtX6IOKvX6qGnHIKn%2FLHD0%3D"
+      );
+    });
+
+    it("should generate a SAS token with explicit permissions", async () => {
+      // Create the table SAS token
+      const tableSas = generateAccountSas(new AzureNamedKeyCredential("keyName", "keySecret"), {
+        permissions: {
+          add: true,
+          delete: true
+        }
+      });
+
+      assert.equal(
+        tableSas,
+        "sv=2019-02-02&ss=t&srt=sco&se=2021-12-12T01%3A00%3A00Z&sp=da&sig=TmE8AOQFacynVIVR5ljBYqY3Y3K6olfdDMLl09iRvvs%3D"
+      );
+    });
+
+    it("should generate a SAS token with explicit expiry", async () => {
+      // Create the table SAS token
+      const tableSas = generateAccountSas(new AzureNamedKeyCredential("keyName", "keySecret"), {
+        expiresOn: new Date("2022-12-12")
+      });
+
+      assert.equal(
+        tableSas,
+        "sv=2019-02-02&ss=t&srt=sco&se=2022-12-12T00%3A00%3A00Z&sp=rl&sig=y42pmN9E%2FgA2O3nGn25lx%2B%2BqQmhvh0WqFi4%2BkOPitwA%3D"
+      );
+    });
+  });
+});


### PR DESCRIPTION
When creating a SAS token with using a `signedIdentifier` the access policy is stored in the service making `expiresOn` and `permissions` optional.

**Problem**

As reported in #18985, we are always setting default values for these, plus we were setting an invalid value for table level permissions "rl".

**Fix**
Only set defaults if the values were not provided and `signedIdentifier` was not provided either 