### PR TITLE
[sort-imports] update ```core-util``` with respect to ```sort-imports``` rule

### DIFF
--- a/sdk/core/core-util/test/browser/isNode.spec.ts
+++ b/sdk/core/core-util/test/browser/isNode.spec.ts
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { isNode } from "../../src";
 import { assert } from "chai";
+import { isNode } from "../../src";
 
 describe("isNode (browser)", function() {
   it("should return false", async function() {

--- a/sdk/core/core-util/test/delay.spec.ts
+++ b/sdk/core/core-util/test/delay.spec.ts
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { delay } from "../src";
-import { assert } from "chai";
 import * as sinon from "sinon";
+import { assert } from "chai";
+import { delay } from "../src";
 
 describe("delay", function() {
   afterEach(function() {

--- a/sdk/core/core-util/test/node/isNode.spec.ts
+++ b/sdk/core/core-util/test/node/isNode.spec.ts
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { isNode } from "../../src";
 import { assert } from "chai";
+import { isNode } from "../../src";
 
 describe("isNode (node)", function() {
   it("should return true", async function() {


### PR DESCRIPTION
This PR is working in conjunction with other PRs to fix individual sections of the azure codebase with respect to the new ```sort-imports``` rule, as indicated in #9252.

In this PR, I have fixed all files under ```sdk/core/core-util```.