### PR TITLE
[sort-imports] update ```cosmos``` with respect to ```sort-imports``` rule

### DIFF
--- a/sdk/cosmosdb/cosmos/src/ChangeFeedIterator.ts
+++ b/sdk/cosmosdb/cosmos/src/ChangeFeedIterator.ts
@@ -1,12 +1,13 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 /// <reference lib="esnext.asynciterable" />
+
+import { Constants, ResourceType, StatusCodes } from "./common";
 import { ChangeFeedOptions } from "./ChangeFeedOptions";
 import { ChangeFeedResponse } from "./ChangeFeedResponse";
-import { Resource } from "./client";
 import { ClientContext } from "./ClientContext";
-import { Constants, ResourceType, StatusCodes } from "./common";
 import { FeedOptions } from "./request";
+import { Resource } from "./client";
 import { Response } from "./request";
 
 /**

--- a/sdk/cosmosdb/cosmos/src/ClientContext.ts
+++ b/sdk/cosmosdb/cosmos/src/ClientContext.ts
@@ -1,35 +1,33 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
-import { v4 } from "uuid";
-const uuid = v4;
-import {
-  bearerTokenAuthenticationPolicy,
-  createEmptyPipeline,
-  Pipeline
-} from "@azure/core-rest-pipeline";
-import { PartitionKeyRange } from "./client/Container/PartitionKeyRange";
-import { Resource } from "./client/Resource";
-import { Constants, HTTPMethod, OperationType, ResourceType } from "./common/constants";
-import { getIdFromLink, getPathFromLink, parseLink } from "./common/helper";
-import { StatusCodes, SubStatusCodes } from "./common/statusCodes";
-import { CosmosClientOptions } from "./CosmosClientOptions";
+
+import { AzureLogger, createClientLogger } from "@azure/logger";
 import { ConnectionPolicy, ConsistencyLevel, DatabaseAccount, PartitionKey } from "./documents";
-import { GlobalEndpointManager } from "./globalEndpointManager";
-import { executePlugins, PluginOn } from "./plugins/Plugin";
-import { FetchFunctionCallback, SqlQuerySpec } from "./queryExecutionContext";
-import { CosmosHeaders } from "./queryExecutionContext/CosmosHeaders";
-import { QueryIterator } from "./queryIterator";
-import { ErrorResponse } from "./request";
+import { Constants, HTTPMethod, OperationType, ResourceType } from "./common/constants";
 import { FeedOptions, RequestOptions, Response } from "./request";
+import { FetchFunctionCallback, SqlQuerySpec } from "./queryExecutionContext";
+import { Pipeline, bearerTokenAuthenticationPolicy, createEmptyPipeline } from "@azure/core-rest-pipeline";
+import { PluginOn, executePlugins } from "./plugins/Plugin";
+import { StatusCodes, SubStatusCodes } from "./common/statusCodes";
+import { getIdFromLink, getPathFromLink, parseLink } from "./common/helper";
+import { BulkOptions } from "./utils/batch";
+import { CosmosClientOptions } from "./CosmosClientOptions";
+import { CosmosHeaders } from "./queryExecutionContext/CosmosHeaders";
+import { ErrorResponse } from "./request";
+import { GlobalEndpointManager } from "./globalEndpointManager";
+import { PartitionKeyRange } from "./client/Container/PartitionKeyRange";
 import { PartitionedQueryExecutionInfo } from "./request/ErrorResponse";
-import { getHeaders } from "./request/request";
+import { QueryIterator } from "./queryIterator";
 import { RequestContext } from "./request/RequestContext";
-import { request as executeRequest } from "./request/RequestHandler";
+import { Resource } from "./client/Resource";
 import { SessionContainer } from "./session/sessionContainer";
 import { SessionContext } from "./session/SessionContext";
-import { BulkOptions } from "./utils/batch";
+import { request as executeRequest } from "./request/RequestHandler";
+import { getHeaders } from "./request/request";
 import { sanitizeEndpoint } from "./utils/checkURL";
-import { AzureLogger, createClientLogger } from "@azure/logger";
+import { v4 } from "uuid";
+
+const uuid = v4;
 
 const logger: AzureLogger = createClientLogger("ClientContext");
 

--- a/sdk/cosmosdb/cosmos/src/ClientContext.ts
+++ b/sdk/cosmosdb/cosmos/src/ClientContext.ts
@@ -6,7 +6,11 @@ import { ConnectionPolicy, ConsistencyLevel, DatabaseAccount, PartitionKey } fro
 import { Constants, HTTPMethod, OperationType, ResourceType } from "./common/constants";
 import { FeedOptions, RequestOptions, Response } from "./request";
 import { FetchFunctionCallback, SqlQuerySpec } from "./queryExecutionContext";
-import { Pipeline, bearerTokenAuthenticationPolicy, createEmptyPipeline } from "@azure/core-rest-pipeline";
+import {
+  Pipeline,
+  bearerTokenAuthenticationPolicy,
+  createEmptyPipeline
+} from "@azure/core-rest-pipeline";
 import { PluginOn, executePlugins } from "./plugins/Plugin";
 import { StatusCodes, SubStatusCodes } from "./common/statusCodes";
 import { getIdFromLink, getPathFromLink, parseLink } from "./common/helper";

--- a/sdk/cosmosdb/cosmos/src/CosmosClient.ts
+++ b/sdk/cosmosdb/cosmos/src/CosmosClient.ts
@@ -1,16 +1,17 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
+
 import { Database, Databases } from "./client/Database";
-import { Offer, Offers } from "./client/Offer";
-import { ClientContext } from "./ClientContext";
-import { parseConnectionString } from "./common";
-import { Constants } from "./common/constants";
-import { getUserAgent } from "./common/platform";
-import { CosmosClientOptions } from "./CosmosClientOptions";
 import { DatabaseAccount, defaultConnectionPolicy } from "./documents";
-import { GlobalEndpointManager } from "./globalEndpointManager";
+import { Offer, Offers } from "./client/Offer";
 import { RequestOptions, ResourceResponse } from "./request";
+import { ClientContext } from "./ClientContext";
+import { Constants } from "./common/constants";
+import { CosmosClientOptions } from "./CosmosClientOptions";
+import { GlobalEndpointManager } from "./globalEndpointManager";
 import { checkURL } from "./utils/checkURL";
+import { getUserAgent } from "./common/platform";
+import { parseConnectionString } from "./common";
 
 /**
  * Provides a client-side logical representation of the Azure Cosmos DB database account.

--- a/sdk/cosmosdb/cosmos/src/CosmosClientOptions.ts
+++ b/sdk/cosmosdb/cosmos/src/CosmosClientOptions.ts
@@ -1,11 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
+
+import { ConnectionPolicy, ConsistencyLevel } from "./documents";
+import { CosmosHeaders } from "./queryExecutionContext/CosmosHeaders";
+import { PermissionDefinition } from "./client";
+import { PluginConfig } from "./plugins/Plugin";
 import { TokenCredential } from "@azure/core-auth";
 import { TokenProvider } from "./auth";
-import { PermissionDefinition } from "./client";
-import { ConnectionPolicy, ConsistencyLevel } from "./documents";
-import { PluginConfig } from "./plugins/Plugin";
-import { CosmosHeaders } from "./queryExecutionContext/CosmosHeaders";
 
 // We expose our own Agent interface to avoid taking a dependency on and leaking node types. This interface should mirror the node Agent interface
 export interface Agent {

--- a/sdk/cosmosdb/cosmos/src/auth.ts
+++ b/sdk/cosmosdb/cosmos/src/auth.ts
@@ -1,15 +1,16 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
-import { generateHeaders } from "./utils/headers";
+
 import {
   Constants,
-  getResourceIdFromPath,
   HTTPMethod,
   ResourceType,
+  getResourceIdFromPath,
   trimSlashFromLeftAndRight
 } from "./common";
 import { CosmosClientOptions } from "./CosmosClientOptions";
 import { CosmosHeaders } from "./queryExecutionContext";
+import { generateHeaders } from "./utils/headers";
 
 /** @hidden */
 export interface RequestInfo {

--- a/sdk/cosmosdb/cosmos/src/client/Conflict/Conflict.ts
+++ b/sdk/cosmosdb/cosmos/src/client/Conflict/Conflict.ts
@@ -1,13 +1,14 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
+
+import { Constants, ResourceType, getIdFromLink, getPathFromLink } from "../../common";
 import { ClientContext } from "../../ClientContext";
-import { Constants, getIdFromLink, getPathFromLink, ResourceType } from "../../common";
-import { RequestOptions } from "../../request";
-import { Container } from "../Container";
 import { ConflictDefinition } from "./ConflictDefinition";
 import { ConflictResponse } from "./ConflictResponse";
-import { undefinedPartitionKey } from "../../extractPartitionKey";
+import { Container } from "../Container";
 import { PartitionKey } from "../../documents";
+import { RequestOptions } from "../../request";
+import { undefinedPartitionKey } from "../../extractPartitionKey";
 
 /**
  * Use to read or delete a given {@link Conflict} by id.

--- a/sdk/cosmosdb/cosmos/src/client/Conflict/ConflictResponse.ts
+++ b/sdk/cosmosdb/cosmos/src/client/Conflict/ConflictResponse.ts
@@ -1,10 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
-import { CosmosHeaders } from "../../queryExecutionContext";
-import { ResourceResponse } from "../../request";
-import { Resource } from "../Resource";
+
 import { Conflict } from "./Conflict";
 import { ConflictDefinition } from "./ConflictDefinition";
+import { CosmosHeaders } from "../../queryExecutionContext";
+import { Resource } from "../Resource";
+import { ResourceResponse } from "../../request";
 
 export class ConflictResponse extends ResourceResponse<ConflictDefinition & Resource> {
   constructor(

--- a/sdk/cosmosdb/cosmos/src/client/Conflict/Conflicts.ts
+++ b/sdk/cosmosdb/cosmos/src/client/Conflict/Conflicts.ts
@@ -1,13 +1,14 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
+
+import { ResourceType, getIdFromLink, getPathFromLink } from "../../common";
 import { ClientContext } from "../../ClientContext";
-import { getIdFromLink, getPathFromLink, ResourceType } from "../../common";
-import { SqlQuerySpec } from "../../queryExecutionContext";
-import { QueryIterator } from "../../queryIterator";
-import { FeedOptions } from "../../request";
-import { Container } from "../Container";
-import { Resource } from "../Resource";
 import { ConflictDefinition } from "./ConflictDefinition";
+import { Container } from "../Container";
+import { FeedOptions } from "../../request";
+import { QueryIterator } from "../../queryIterator";
+import { Resource } from "../Resource";
+import { SqlQuerySpec } from "../../queryExecutionContext";
 
 /**
  * Use to query or read all conflicts.

--- a/sdk/cosmosdb/cosmos/src/client/Container/Container.ts
+++ b/sdk/cosmosdb/cosmos/src/client/Container/Container.ts
@@ -1,28 +1,29 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
-import { ClientContext } from "../../ClientContext";
+
+import { Conflict, Conflicts } from "../Conflict";
+import { FeedOptions, RequestOptions, ResourceResponse, Response } from "../../request";
+import { Item, Items } from "../Item";
+import { Offer, OfferDefinition } from "../Offer";
+import { PartitionKey, PartitionKeyDefinition } from "../../documents";
 import {
+  ResourceType,
   createDocumentCollectionUri,
   getIdFromLink,
   getPathFromLink,
-  isResourceValid,
-  ResourceType
+  isResourceValid
 } from "../../common";
-import { PartitionKey, PartitionKeyDefinition } from "../../documents";
-import { SqlQuerySpec } from "../../queryExecutionContext";
-import { QueryIterator } from "../../queryIterator";
-import { FeedOptions, RequestOptions, ResourceResponse, Response } from "../../request";
-import { PartitionedQueryExecutionInfo } from "../../request/ErrorResponse";
-import { Conflict, Conflicts } from "../Conflict";
-import { Database } from "../Database";
-import { Item, Items } from "../Item";
-import { Scripts } from "../Script/Scripts";
+import { ClientContext } from "../../ClientContext";
 import { ContainerDefinition } from "./ContainerDefinition";
 import { ContainerResponse } from "./ContainerResponse";
-import { PartitionKeyRange } from "./PartitionKeyRange";
-import { Offer, OfferDefinition } from "../Offer";
+import { Database } from "../Database";
 import { OfferResponse } from "../Offer/OfferResponse";
+import { PartitionKeyRange } from "./PartitionKeyRange";
+import { PartitionedQueryExecutionInfo } from "../../request/ErrorResponse";
+import { QueryIterator } from "../../queryIterator";
 import { Resource } from "../Resource";
+import { Scripts } from "../Script/Scripts";
+import { SqlQuerySpec } from "../../queryExecutionContext";
 
 /**
  * Operations for reading, replacing, or deleting a specific, existing container by id.

--- a/sdk/cosmosdb/cosmos/src/client/Container/ContainerDefinition.ts
+++ b/sdk/cosmosdb/cosmos/src/client/Container/ContainerDefinition.ts
@@ -1,9 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
+
 import { IndexingPolicy, PartitionKeyDefinition } from "../../documents";
 import { ConflictResolutionPolicy } from "../Conflict/ConflictResolutionPolicy";
-import { UniqueKeyPolicy } from "./UniqueKeyPolicy";
 import { GeospatialType } from "../../documents/GeospatialType";
+import { UniqueKeyPolicy } from "./UniqueKeyPolicy";
 
 export interface ContainerDefinition {
   /** The id of the container. */

--- a/sdk/cosmosdb/cosmos/src/client/Container/ContainerResponse.ts
+++ b/sdk/cosmosdb/cosmos/src/client/Container/ContainerResponse.ts
@@ -1,10 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
-import { CosmosHeaders } from "../../queryExecutionContext";
-import { ResourceResponse } from "../../request/ResourceResponse";
-import { Resource } from "../Resource";
-import { ContainerDefinition } from "./ContainerDefinition";
+
 import { Container } from "./index";
+import { ContainerDefinition } from "./ContainerDefinition";
+import { CosmosHeaders } from "../../queryExecutionContext";
+import { Resource } from "../Resource";
+import { ResourceResponse } from "../../request/ResourceResponse";
 
 /** Response object for Container operations */
 export class ContainerResponse extends ResourceResponse<ContainerDefinition & Resource> {

--- a/sdk/cosmosdb/cosmos/src/client/Container/Containers.ts
+++ b/sdk/cosmosdb/cosmos/src/client/Container/Containers.ts
@@ -1,24 +1,25 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
-import { ClientContext } from "../../ClientContext";
+
 import {
   Constants,
+  ResourceType,
+  StatusCodes,
   getIdFromLink,
   getPathFromLink,
-  isResourceValid,
-  ResourceType,
-  StatusCodes
+  isResourceValid
 } from "../../common";
-import { DEFAULT_PARTITION_KEY_PATH } from "../../common/partitionKeys";
-import { mergeHeaders, SqlQuerySpec } from "../../queryExecutionContext";
-import { QueryIterator } from "../../queryIterator";
 import { FeedOptions, RequestOptions } from "../../request";
-import { Database } from "../Database";
-import { Resource } from "../Resource";
+import { SqlQuerySpec, mergeHeaders } from "../../queryExecutionContext";
+import { ClientContext } from "../../ClientContext";
 import { Container } from "./Container";
 import { ContainerDefinition } from "./ContainerDefinition";
 import { ContainerRequest } from "./ContainerRequest";
 import { ContainerResponse } from "./ContainerResponse";
+import { DEFAULT_PARTITION_KEY_PATH } from "../../common/partitionKeys";
+import { Database } from "../Database";
+import { QueryIterator } from "../../queryIterator";
+import { Resource } from "../Resource";
 import { validateOffer } from "../../utils/offers";
 
 /**

--- a/sdk/cosmosdb/cosmos/src/client/Database/Database.ts
+++ b/sdk/cosmosdb/cosmos/src/client/Database/Database.ts
@@ -1,14 +1,15 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
-import { ClientContext } from "../../ClientContext";
-import { createDatabaseUri, getIdFromLink, getPathFromLink, ResourceType } from "../../common";
-import { CosmosClient } from "../../CosmosClient";
-import { RequestOptions } from "../../request";
+
 import { Container, Containers } from "../Container";
+import { Offer, OfferDefinition, OfferResponse } from "../Offer";
+import { ResourceType, createDatabaseUri, getIdFromLink, getPathFromLink } from "../../common";
 import { User, Users } from "../User";
+import { ClientContext } from "../../ClientContext";
+import { CosmosClient } from "../../CosmosClient";
 import { DatabaseDefinition } from "./DatabaseDefinition";
 import { DatabaseResponse } from "./DatabaseResponse";
-import { OfferResponse, OfferDefinition, Offer } from "../Offer";
+import { RequestOptions } from "../../request";
 import { Resource } from "../Resource";
 
 /**

--- a/sdk/cosmosdb/cosmos/src/client/Database/DatabaseResponse.ts
+++ b/sdk/cosmosdb/cosmos/src/client/Database/DatabaseResponse.ts
@@ -1,10 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
+
 import { CosmosHeaders } from "../../queryExecutionContext";
-import { ResourceResponse } from "../../request/ResourceResponse";
-import { Resource } from "../Resource";
 import { Database } from "./Database";
 import { DatabaseDefinition } from "./DatabaseDefinition";
+import { Resource } from "../Resource";
+import { ResourceResponse } from "../../request/ResourceResponse";
 
 /** Response object for Database operations */
 export class DatabaseResponse extends ResourceResponse<DatabaseDefinition & Resource> {

--- a/sdk/cosmosdb/cosmos/src/client/Database/Databases.ts
+++ b/sdk/cosmosdb/cosmos/src/client/Database/Databases.ts
@@ -1,16 +1,17 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
-import { ClientContext } from "../../ClientContext";
-import { Constants, isResourceValid, ResourceType, StatusCodes } from "../../common";
-import { CosmosClient } from "../../CosmosClient";
-import { FetchFunctionCallback, mergeHeaders, SqlQuerySpec } from "../../queryExecutionContext";
-import { QueryIterator } from "../../queryIterator";
+
+import { Constants, ResourceType, StatusCodes, isResourceValid } from "../../common";
 import { FeedOptions, RequestOptions } from "../../request";
-import { Resource } from "../Resource";
+import { FetchFunctionCallback, SqlQuerySpec, mergeHeaders } from "../../queryExecutionContext";
+import { ClientContext } from "../../ClientContext";
+import { CosmosClient } from "../../CosmosClient";
 import { Database } from "./Database";
 import { DatabaseDefinition } from "./DatabaseDefinition";
 import { DatabaseRequest } from "./DatabaseRequest";
 import { DatabaseResponse } from "./DatabaseResponse";
+import { QueryIterator } from "../../queryIterator";
+import { Resource } from "../Resource";
 import { validateOffer } from "../../utils/offers";
 
 /**

--- a/sdk/cosmosdb/cosmos/src/client/Item/Item.ts
+++ b/sdk/cosmosdb/cosmos/src/client/Item/Item.ts
@@ -1,22 +1,23 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
-import { ClientContext } from "../../ClientContext";
+
+import { RequestOptions, Response } from "../../request";
 import {
+  ResourceType,
+  StatusCodes,
   createDocumentUri,
   getIdFromLink,
   getPathFromLink,
-  isResourceValid,
-  ResourceType,
-  StatusCodes
+  isResourceValid
 } from "../../common";
-import { PartitionKey } from "../../documents";
 import { extractPartitionKey, undefinedPartitionKey } from "../../extractPartitionKey";
-import { RequestOptions, Response } from "../../request";
-import { PatchRequestBody } from "../../utils/patch";
+import { ClientContext } from "../../ClientContext";
 import { Container } from "../Container";
-import { Resource } from "../Resource";
 import { ItemDefinition } from "./ItemDefinition";
 import { ItemResponse } from "./ItemResponse";
+import { PartitionKey } from "../../documents";
+import { PatchRequestBody } from "../../utils/patch";
+import { Resource } from "../Resource";
 
 /**
  * Used to perform operations on a specific item.

--- a/sdk/cosmosdb/cosmos/src/client/Item/ItemResponse.ts
+++ b/sdk/cosmosdb/cosmos/src/client/Item/ItemResponse.ts
@@ -1,10 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
+
 import { CosmosHeaders } from "../../queryExecutionContext";
-import { ResourceResponse } from "../../request/ResourceResponse";
-import { Resource } from "../Resource";
 import { Item } from "./Item";
 import { ItemDefinition } from "./ItemDefinition";
+import { Resource } from "../Resource";
+import { ResourceResponse } from "../../request/ResourceResponse";
 
 export class ItemResponse<T extends ItemDefinition> extends ResourceResponse<T & Resource> {
   constructor(

--- a/sdk/cosmosdb/cosmos/src/client/Item/Items.ts
+++ b/sdk/cosmosdb/cosmos/src/client/Item/Items.ts
@@ -1,32 +1,34 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
-import { v4 } from "uuid";
-const uuid = v4;
+
+import {
+  Batch,
+  BulkOptions,
+  Operation,
+  OperationInput,
+  OperationResponse,
+  decorateBatchOperation,
+  decorateOperation,
+  getPartitionKeyToHash,
+  isKeyInRange
+} from "../../utils/batch";
+import { Container, PartitionKeyRange } from "../Container";
+import { FeedOptions, RequestOptions, Response } from "../../request";
+import { FetchFunctionCallback, SqlQuerySpec } from "../../queryExecutionContext";
+import { ResourceType, getIdFromLink, getPathFromLink, isResourceValid } from "../../common";
 import { ChangeFeedIterator } from "../../ChangeFeedIterator";
 import { ChangeFeedOptions } from "../../ChangeFeedOptions";
 import { ClientContext } from "../../ClientContext";
-import { getIdFromLink, getPathFromLink, isResourceValid, ResourceType } from "../../common";
-import { extractPartitionKey } from "../../extractPartitionKey";
-import { FetchFunctionCallback, SqlQuerySpec } from "../../queryExecutionContext";
-import { QueryIterator } from "../../queryIterator";
-import { FeedOptions, RequestOptions, Response } from "../../request";
-import { Container, PartitionKeyRange } from "../Container";
 import { Item } from "./Item";
 import { ItemDefinition } from "./ItemDefinition";
 import { ItemResponse } from "./ItemResponse";
-import {
-  Batch,
-  isKeyInRange,
-  Operation,
-  getPartitionKeyToHash,
-  decorateOperation,
-  OperationResponse,
-  OperationInput,
-  BulkOptions,
-  decorateBatchOperation
-} from "../../utils/batch";
+import { QueryIterator } from "../../queryIterator";
+import { extractPartitionKey } from "../../extractPartitionKey";
 import { hashV1PartitionKey } from "../../utils/hashing/v1";
 import { hashV2PartitionKey } from "../../utils/hashing/v2";
+import { v4 } from "uuid";
+
+const uuid = v4;
 
 /**
  * @hidden

--- a/sdk/cosmosdb/cosmos/src/client/Offer/Offer.ts
+++ b/sdk/cosmosdb/cosmos/src/client/Offer/Offer.ts
@@ -1,11 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
+
+import { Constants, ResourceType, isResourceValid } from "../../common";
 import { ClientContext } from "../../ClientContext";
-import { Constants, isResourceValid, ResourceType } from "../../common";
 import { CosmosClient } from "../../CosmosClient";
-import { RequestOptions } from "../../request";
 import { OfferDefinition } from "./OfferDefinition";
 import { OfferResponse } from "./OfferResponse";
+import { RequestOptions } from "../../request";
 
 /**
  * Use to read or replace an existing {@link Offer} by id.

--- a/sdk/cosmosdb/cosmos/src/client/Offer/OfferResponse.ts
+++ b/sdk/cosmosdb/cosmos/src/client/Offer/OfferResponse.ts
@@ -1,10 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
+
 import { CosmosHeaders } from "../../queryExecutionContext";
-import { ResourceResponse } from "../../request";
-import { Resource } from "../Resource";
 import { Offer } from "./Offer";
 import { OfferDefinition } from "./OfferDefinition";
+import { Resource } from "../Resource";
+import { ResourceResponse } from "../../request";
 
 export class OfferResponse extends ResourceResponse<OfferDefinition & Resource> {
   constructor(

--- a/sdk/cosmosdb/cosmos/src/client/Offer/Offers.ts
+++ b/sdk/cosmosdb/cosmos/src/client/Offer/Offers.ts
@@ -1,13 +1,14 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
+
 import { ClientContext } from "../../ClientContext";
-import { ResourceType } from "../../common";
 import { CosmosClient } from "../../CosmosClient";
-import { SqlQuerySpec } from "../../queryExecutionContext";
-import { QueryIterator } from "../../queryIterator";
 import { FeedOptions } from "../../request";
-import { Resource } from "../Resource";
 import { OfferDefinition } from "./OfferDefinition";
+import { QueryIterator } from "../../queryIterator";
+import { Resource } from "../Resource";
+import { ResourceType } from "../../common";
+import { SqlQuerySpec } from "../../queryExecutionContext";
 
 /**
  * Use to query or read all Offers.

--- a/sdk/cosmosdb/cosmos/src/client/Permission/Permission.ts
+++ b/sdk/cosmosdb/cosmos/src/client/Permission/Permission.ts
@@ -1,18 +1,19 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
-import { ClientContext } from "../../ClientContext";
+
 import {
+  ResourceType,
   createPermissionUri,
   getIdFromLink,
   getPathFromLink,
-  isResourceValid,
-  ResourceType
+  isResourceValid
 } from "../../common";
-import { RequestOptions } from "../../request/RequestOptions";
-import { User } from "../User";
+import { ClientContext } from "../../ClientContext";
 import { PermissionBody } from "./PermissionBody";
 import { PermissionDefinition } from "./PermissionDefinition";
 import { PermissionResponse } from "./PermissionResponse";
+import { RequestOptions } from "../../request/RequestOptions";
+import { User } from "../User";
 
 /**
  * Use to read, replace, or delete a given {@link Permission} by id.

--- a/sdk/cosmosdb/cosmos/src/client/Permission/PermissionResponse.ts
+++ b/sdk/cosmosdb/cosmos/src/client/Permission/PermissionResponse.ts
@@ -1,11 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
+
 import { CosmosHeaders } from "../../queryExecutionContext";
-import { ResourceResponse } from "../../request";
-import { Resource } from "../Resource";
 import { Permission } from "./Permission";
 import { PermissionBody } from "./PermissionBody";
 import { PermissionDefinition } from "./PermissionDefinition";
+import { Resource } from "../Resource";
+import { ResourceResponse } from "../../request";
 
 export class PermissionResponse extends ResourceResponse<
   PermissionDefinition & PermissionBody & Resource

--- a/sdk/cosmosdb/cosmos/src/client/Permission/Permissions.ts
+++ b/sdk/cosmosdb/cosmos/src/client/Permission/Permissions.ts
@@ -1,16 +1,17 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
-import { ClientContext } from "../../ClientContext";
-import { getIdFromLink, getPathFromLink, isResourceValid, ResourceType } from "../../common";
-import { SqlQuerySpec } from "../../queryExecutionContext";
-import { QueryIterator } from "../../queryIterator";
+
 import { FeedOptions, RequestOptions } from "../../request";
-import { Resource } from "../Resource";
-import { User } from "../User";
+import { ResourceType, getIdFromLink, getPathFromLink, isResourceValid } from "../../common";
+import { ClientContext } from "../../ClientContext";
 import { Permission } from "./Permission";
 import { PermissionBody } from "./PermissionBody";
 import { PermissionDefinition } from "./PermissionDefinition";
 import { PermissionResponse } from "./PermissionResponse";
+import { QueryIterator } from "../../queryIterator";
+import { Resource } from "../Resource";
+import { SqlQuerySpec } from "../../queryExecutionContext";
+import { User } from "../User";
 
 /**
  * Use to create, replace, query, and read all Permissions.

--- a/sdk/cosmosdb/cosmos/src/client/Script/Scripts.ts
+++ b/sdk/cosmosdb/cosmos/src/client/Script/Scripts.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
-import { StoredProcedures, StoredProcedure } from "../StoredProcedure";
+
+import { StoredProcedure, StoredProcedures } from "../StoredProcedure";
 import { Trigger, Triggers } from "../Trigger";
 import { UserDefinedFunction, UserDefinedFunctions } from "../UserDefinedFunction";
 import { ClientContext } from "../../ClientContext";

--- a/sdk/cosmosdb/cosmos/src/client/StoredProcedure/StoredProcedure.ts
+++ b/sdk/cosmosdb/cosmos/src/client/StoredProcedure/StoredProcedure.ts
@@ -1,19 +1,20 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
-import { ClientContext } from "../../ClientContext";
+
+import { RequestOptions, ResourceResponse } from "../../request";
 import {
+  ResourceType,
   createStoredProcedureUri,
   getIdFromLink,
   getPathFromLink,
-  isResourceValid,
-  ResourceType
+  isResourceValid
 } from "../../common";
-import { PartitionKey } from "../../documents/PartitionKey";
-import { undefinedPartitionKey } from "../../extractPartitionKey";
-import { RequestOptions, ResourceResponse } from "../../request";
+import { ClientContext } from "../../ClientContext";
 import { Container } from "../Container";
+import { PartitionKey } from "../../documents/PartitionKey";
 import { StoredProcedureDefinition } from "./StoredProcedureDefinition";
 import { StoredProcedureResponse } from "./StoredProcedureResponse";
+import { undefinedPartitionKey } from "../../extractPartitionKey";
 
 /**
  * Operations for reading, replacing, deleting, or executing a specific, existing stored procedure by id.

--- a/sdk/cosmosdb/cosmos/src/client/StoredProcedure/StoredProcedureResponse.ts
+++ b/sdk/cosmosdb/cosmos/src/client/StoredProcedure/StoredProcedureResponse.ts
@@ -1,8 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
+
 import { CosmosHeaders } from "../../queryExecutionContext";
-import { ResourceResponse } from "../../request";
 import { Resource } from "../Resource";
+import { ResourceResponse } from "../../request";
 import { StoredProcedure } from "./StoredProcedure";
 import { StoredProcedureDefinition } from "./StoredProcedureDefinition";
 

--- a/sdk/cosmosdb/cosmos/src/client/StoredProcedure/StoredProcedures.ts
+++ b/sdk/cosmosdb/cosmos/src/client/StoredProcedure/StoredProcedures.ts
@@ -1,12 +1,13 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
-import { ClientContext } from "../../ClientContext";
-import { getIdFromLink, getPathFromLink, isResourceValid, ResourceType } from "../../common";
-import { SqlQuerySpec } from "../../queryExecutionContext";
-import { QueryIterator } from "../../queryIterator";
+
 import { FeedOptions, RequestOptions } from "../../request";
+import { ResourceType, getIdFromLink, getPathFromLink, isResourceValid } from "../../common";
+import { ClientContext } from "../../ClientContext";
 import { Container } from "../Container";
+import { QueryIterator } from "../../queryIterator";
 import { Resource } from "../Resource";
+import { SqlQuerySpec } from "../../queryExecutionContext";
 import { StoredProcedure } from "./StoredProcedure";
 import { StoredProcedureDefinition } from "./StoredProcedureDefinition";
 import { StoredProcedureResponse } from "./StoredProcedureResponse";

--- a/sdk/cosmosdb/cosmos/src/client/Trigger/Trigger.ts
+++ b/sdk/cosmosdb/cosmos/src/client/Trigger/Trigger.ts
@@ -1,15 +1,16 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
-import { ClientContext } from "../../ClientContext";
+
 import {
+  ResourceType,
   createTriggerUri,
   getIdFromLink,
   getPathFromLink,
-  isResourceValid,
-  ResourceType
+  isResourceValid
 } from "../../common";
-import { RequestOptions } from "../../request";
+import { ClientContext } from "../../ClientContext";
 import { Container } from "../Container";
+import { RequestOptions } from "../../request";
 import { TriggerDefinition } from "./TriggerDefinition";
 import { TriggerResponse } from "./TriggerResponse";
 

--- a/sdk/cosmosdb/cosmos/src/client/Trigger/TriggerResponse.ts
+++ b/sdk/cosmosdb/cosmos/src/client/Trigger/TriggerResponse.ts
@@ -1,8 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
+
 import { CosmosHeaders } from "../../queryExecutionContext";
-import { ResourceResponse } from "../../request";
 import { Resource } from "../Resource";
+import { ResourceResponse } from "../../request";
 import { Trigger } from "./index";
 import { TriggerDefinition } from "./TriggerDefinition";
 

--- a/sdk/cosmosdb/cosmos/src/client/Trigger/Triggers.ts
+++ b/sdk/cosmosdb/cosmos/src/client/Trigger/Triggers.ts
@@ -1,12 +1,13 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
-import { ClientContext } from "../../ClientContext";
-import { getIdFromLink, getPathFromLink, isResourceValid, ResourceType } from "../../common";
-import { SqlQuerySpec } from "../../queryExecutionContext";
-import { QueryIterator } from "../../queryIterator";
+
 import { FeedOptions, RequestOptions } from "../../request";
+import { ResourceType, getIdFromLink, getPathFromLink, isResourceValid } from "../../common";
+import { ClientContext } from "../../ClientContext";
 import { Container } from "../Container";
+import { QueryIterator } from "../../queryIterator";
 import { Resource } from "../Resource";
+import { SqlQuerySpec } from "../../queryExecutionContext";
 import { Trigger } from "./Trigger";
 import { TriggerDefinition } from "./TriggerDefinition";
 import { TriggerResponse } from "./TriggerResponse";

--- a/sdk/cosmosdb/cosmos/src/client/User/User.ts
+++ b/sdk/cosmosdb/cosmos/src/client/User/User.ts
@@ -1,16 +1,17 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
-import { ClientContext } from "../../ClientContext";
+
+import { Permission, Permissions } from "../Permission";
 import {
+  ResourceType,
   createUserUri,
   getIdFromLink,
   getPathFromLink,
-  isResourceValid,
-  ResourceType
+  isResourceValid
 } from "../../common";
-import { RequestOptions } from "../../request";
+import { ClientContext } from "../../ClientContext";
 import { Database } from "../Database";
-import { Permission, Permissions } from "../Permission";
+import { RequestOptions } from "../../request";
 import { UserDefinition } from "./UserDefinition";
 import { UserResponse } from "./UserResponse";
 

--- a/sdk/cosmosdb/cosmos/src/client/User/UserResponse.ts
+++ b/sdk/cosmosdb/cosmos/src/client/User/UserResponse.ts
@@ -1,8 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
+
 import { CosmosHeaders } from "../../queryExecutionContext";
-import { ResourceResponse } from "../../request";
 import { Resource } from "../Resource";
+import { ResourceResponse } from "../../request";
 import { User } from "./User";
 import { UserDefinition } from "./UserDefinition";
 

--- a/sdk/cosmosdb/cosmos/src/client/User/Users.ts
+++ b/sdk/cosmosdb/cosmos/src/client/User/Users.ts
@@ -1,12 +1,13 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
-import { ClientContext } from "../../ClientContext";
-import { getIdFromLink, getPathFromLink, isResourceValid, ResourceType } from "../../common";
-import { SqlQuerySpec } from "../../queryExecutionContext";
-import { QueryIterator } from "../../queryIterator";
+
 import { FeedOptions, RequestOptions } from "../../request";
+import { ResourceType, getIdFromLink, getPathFromLink, isResourceValid } from "../../common";
+import { ClientContext } from "../../ClientContext";
 import { Database } from "../Database";
+import { QueryIterator } from "../../queryIterator";
 import { Resource } from "../Resource";
+import { SqlQuerySpec } from "../../queryExecutionContext";
 import { User } from "./User";
 import { UserDefinition } from "./UserDefinition";
 import { UserResponse } from "./UserResponse";

--- a/sdk/cosmosdb/cosmos/src/client/UserDefinedFunction/UserDefinedFunction.ts
+++ b/sdk/cosmosdb/cosmos/src/client/UserDefinedFunction/UserDefinedFunction.ts
@@ -1,15 +1,16 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
-import { ClientContext } from "../../ClientContext";
+
 import {
+  ResourceType,
   createUserDefinedFunctionUri,
   getIdFromLink,
   getPathFromLink,
-  isResourceValid,
-  ResourceType
+  isResourceValid
 } from "../../common";
-import { RequestOptions } from "../../request";
+import { ClientContext } from "../../ClientContext";
 import { Container } from "../Container";
+import { RequestOptions } from "../../request";
 import { UserDefinedFunctionDefinition } from "./UserDefinedFunctionDefinition";
 import { UserDefinedFunctionResponse } from "./UserDefinedFunctionResponse";
 

--- a/sdk/cosmosdb/cosmos/src/client/UserDefinedFunction/UserDefinedFunctionResponse.ts
+++ b/sdk/cosmosdb/cosmos/src/client/UserDefinedFunction/UserDefinedFunctionResponse.ts
@@ -1,8 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
+
 import { CosmosHeaders } from "../../queryExecutionContext";
-import { ResourceResponse } from "../../request";
 import { Resource } from "../Resource";
+import { ResourceResponse } from "../../request";
 import { UserDefinedFunction } from "./UserDefinedFunction";
 import { UserDefinedFunctionDefinition } from "./UserDefinedFunctionDefinition";
 

--- a/sdk/cosmosdb/cosmos/src/client/UserDefinedFunction/UserDefinedFunctions.ts
+++ b/sdk/cosmosdb/cosmos/src/client/UserDefinedFunction/UserDefinedFunctions.ts
@@ -1,12 +1,13 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
-import { ClientContext } from "../../ClientContext";
-import { getIdFromLink, getPathFromLink, isResourceValid, ResourceType } from "../../common";
-import { SqlQuerySpec } from "../../queryExecutionContext";
-import { QueryIterator } from "../../queryIterator";
+
 import { FeedOptions, RequestOptions } from "../../request";
+import { ResourceType, getIdFromLink, getPathFromLink, isResourceValid } from "../../common";
+import { ClientContext } from "../../ClientContext";
 import { Container } from "../Container";
+import { QueryIterator } from "../../queryIterator";
 import { Resource } from "../Resource";
+import { SqlQuerySpec } from "../../queryExecutionContext";
 import { UserDefinedFunction } from "./UserDefinedFunction";
 import { UserDefinedFunctionDefinition } from "./UserDefinedFunctionDefinition";
 import { UserDefinedFunctionResponse } from "./UserDefinedFunctionResponse";

--- a/sdk/cosmosdb/cosmos/src/common/helper.ts
+++ b/sdk/cosmosdb/cosmos/src/common/helper.ts
@@ -1,7 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
-import { CosmosClientOptions } from "../CosmosClientOptions";
+
 import { OperationType, ResourceType } from "./constants";
+import { CosmosClientOptions } from "../CosmosClientOptions";
 
 const trimLeftSlashes = new RegExp("^[/]+");
 const trimRightSlashes = new RegExp("[/]+$");

--- a/sdk/cosmosdb/cosmos/src/common/logger.ts
+++ b/sdk/cosmosdb/cosmos/src/common/logger.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
-import { createClientLogger, AzureLogger } from "@azure/logger";
+
+import { AzureLogger, createClientLogger } from "@azure/logger";
 
 /**
  * The \@azure/logger configuration for this package.

--- a/sdk/cosmosdb/cosmos/src/common/platform.ts
+++ b/sdk/cosmosdb/cosmos/src/common/platform.ts
@@ -1,7 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
-import { getUserAgent as userAgent } from "universal-user-agent";
+
 import { Constants } from "./constants";
+import { getUserAgent as userAgent } from "universal-user-agent";
 
 /**
  * @hidden

--- a/sdk/cosmosdb/cosmos/src/common/uriFactory.ts
+++ b/sdk/cosmosdb/cosmos/src/common/uriFactory.ts
@@ -1,7 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
-import { Constants } from "./constants";
+
 import { trimSlashFromLeftAndRight, validateResourceId } from "./helper";
+import { Constants } from "./constants";
 
 /**
  * Would be used when creating or deleting a DocumentCollection

--- a/sdk/cosmosdb/cosmos/src/documents/ConnectionPolicy.ts
+++ b/sdk/cosmosdb/cosmos/src/documents/ConnectionPolicy.ts
@@ -1,7 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
-import { RetryOptions } from "../retry/retryOptions";
+
 import { ConnectionMode } from "./ConnectionMode";
+import { RetryOptions } from "../retry/retryOptions";
+
 /**
  * Represents the Connection policy associated with a CosmosClient in the Azure Cosmos DB database service.
  */

--- a/sdk/cosmosdb/cosmos/src/documents/DatabaseAccount.ts
+++ b/sdk/cosmosdb/cosmos/src/documents/DatabaseAccount.ts
@@ -1,8 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
+
+import { ConsistencyLevel } from "./ConsistencyLevel";
 import { Constants } from "../common";
 import { CosmosHeaders } from "../queryExecutionContext";
-import { ConsistencyLevel } from "./ConsistencyLevel";
 
 /**
  * Represents a DatabaseAccount in the Azure Cosmos DB database service.

--- a/sdk/cosmosdb/cosmos/src/documents/IndexingPolicy.ts
+++ b/sdk/cosmosdb/cosmos/src/documents/IndexingPolicy.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
-import { DataType, IndexingMode, IndexKind } from "./index";
+
+import { DataType, IndexKind, IndexingMode } from "./index";
 
 export interface IndexingPolicy {
   /** The indexing mode (consistent or lazy) {@link IndexingMode}. */

--- a/sdk/cosmosdb/cosmos/src/extractPartitionKey.ts
+++ b/sdk/cosmosdb/cosmos/src/extractPartitionKey.ts
@@ -1,7 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
-import { parsePath } from "./common";
+
 import { PartitionKey, PartitionKeyDefinition } from "./documents";
+import { parsePath } from "./common";
 
 /**
  * @hidden

--- a/sdk/cosmosdb/cosmos/src/globalEndpointManager.ts
+++ b/sdk/cosmosdb/cosmos/src/globalEndpointManager.ts
@@ -1,8 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
+
+import { DatabaseAccount, Location } from "./documents";
 import { OperationType, ResourceType, isReadRequest } from "./common";
 import { CosmosClientOptions } from "./CosmosClientOptions";
-import { Location, DatabaseAccount } from "./documents";
 import { RequestOptions } from "./index";
 import { ResourceResponse } from "./request";
 

--- a/sdk/cosmosdb/cosmos/src/queryExecutionContext/Aggregators/MaxAggregator.ts
+++ b/sdk/cosmosdb/cosmos/src/queryExecutionContext/Aggregators/MaxAggregator.ts
@@ -1,7 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
-import { OrderByDocumentProducerComparator } from "../orderByDocumentProducerComparator";
+
 import { Aggregator } from "./Aggregator";
+import { OrderByDocumentProducerComparator } from "../orderByDocumentProducerComparator";
 
 interface MaxAggregateResult {
   count: number;

--- a/sdk/cosmosdb/cosmos/src/queryExecutionContext/Aggregators/MinAggregator.ts
+++ b/sdk/cosmosdb/cosmos/src/queryExecutionContext/Aggregators/MinAggregator.ts
@@ -1,7 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
-import { OrderByDocumentProducerComparator } from "../orderByDocumentProducerComparator";
+
 import { Aggregator } from "./Aggregator";
+import { OrderByDocumentProducerComparator } from "../orderByDocumentProducerComparator";
 
 export interface MinAggregateResult {
   min: number;

--- a/sdk/cosmosdb/cosmos/src/queryExecutionContext/Aggregators/index.ts
+++ b/sdk/cosmosdb/cosmos/src/queryExecutionContext/Aggregators/index.ts
@@ -1,12 +1,13 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
+
+import { AggregateType } from "../../request/ErrorResponse";
 import { AverageAggregator } from "./AverageAggregator";
 import { CountAggregator } from "./CountAggregator";
 import { MaxAggregator } from "./MaxAggregator";
 import { MinAggregator } from "./MinAggregator";
-import { SumAggregator } from "./SumAggregator";
 import { StaticValueAggregator } from "./StaticValueAggregator";
-import { AggregateType } from "../../request/ErrorResponse";
+import { SumAggregator } from "./SumAggregator";
 
 export function createAggregator(
   aggregateType: AggregateType

--- a/sdk/cosmosdb/cosmos/src/queryExecutionContext/EndpointComponent/GroupByEndpointComponent.ts
+++ b/sdk/cosmosdb/cosmos/src/queryExecutionContext/EndpointComponent/GroupByEndpointComponent.ts
@@ -1,13 +1,14 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
-import { Response } from "../../request";
-import { ExecutionContext } from "../ExecutionContext";
-import { CosmosHeaders } from "../CosmosHeaders";
-import { QueryInfo } from "../../request/ErrorResponse";
-import { hashObject } from "../../utils/hashObject";
+
 import { Aggregator, createAggregator } from "../Aggregators";
-import { getInitialHeader, mergeHeaders } from "../headerUtils";
 import { emptyGroup, extractAggregateResult } from "./emptyGroup";
+import { getInitialHeader, mergeHeaders } from "../headerUtils";
+import { CosmosHeaders } from "../CosmosHeaders";
+import { ExecutionContext } from "../ExecutionContext";
+import { QueryInfo } from "../../request/ErrorResponse";
+import { Response } from "../../request";
+import { hashObject } from "../../utils/hashObject";
 
 interface GroupByResponse {
   result: GroupByResult;

--- a/sdk/cosmosdb/cosmos/src/queryExecutionContext/EndpointComponent/GroupByValueEndpointComponent.ts
+++ b/sdk/cosmosdb/cosmos/src/queryExecutionContext/EndpointComponent/GroupByValueEndpointComponent.ts
@@ -1,13 +1,14 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
-import { Response } from "../../request";
-import { ExecutionContext } from "../ExecutionContext";
-import { CosmosHeaders } from "../CosmosHeaders";
+
 import { AggregateType, QueryInfo } from "../../request/ErrorResponse";
-import { hashObject } from "../../utils/hashObject";
 import { Aggregator, createAggregator } from "../Aggregators";
-import { getInitialHeader, mergeHeaders } from "../headerUtils";
 import { emptyGroup, extractAggregateResult } from "./emptyGroup";
+import { getInitialHeader, mergeHeaders } from "../headerUtils";
+import { CosmosHeaders } from "../CosmosHeaders";
+import { ExecutionContext } from "../ExecutionContext";
+import { Response } from "../../request";
+import { hashObject } from "../../utils/hashObject";
 
 interface GroupByResponse {
   result: GroupByResult;

--- a/sdk/cosmosdb/cosmos/src/queryExecutionContext/EndpointComponent/OffsetLimitEndpointComponent.ts
+++ b/sdk/cosmosdb/cosmos/src/queryExecutionContext/EndpointComponent/OffsetLimitEndpointComponent.ts
@@ -1,8 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
-import { Response } from "../../request";
-import { ExecutionContext } from "../ExecutionContext";
+
 import { getInitialHeader, mergeHeaders } from "../headerUtils";
+import { ExecutionContext } from "../ExecutionContext";
+import { Response } from "../../request";
 
 /** @hidden */
 export class OffsetLimitEndpointComponent implements ExecutionContext {

--- a/sdk/cosmosdb/cosmos/src/queryExecutionContext/EndpointComponent/OrderByEndpointComponent.ts
+++ b/sdk/cosmosdb/cosmos/src/queryExecutionContext/EndpointComponent/OrderByEndpointComponent.ts
@@ -1,7 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
-import { Response } from "../../request";
+
 import { ExecutionContext } from "../ExecutionContext";
+import { Response } from "../../request";
 
 /** @hidden */
 export class OrderByEndpointComponent implements ExecutionContext {

--- a/sdk/cosmosdb/cosmos/src/queryExecutionContext/EndpointComponent/OrderedDistinctEndpointComponent.ts
+++ b/sdk/cosmosdb/cosmos/src/queryExecutionContext/EndpointComponent/OrderedDistinctEndpointComponent.ts
@@ -1,7 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
-import { Response } from "../../request";
+
 import { ExecutionContext } from "../ExecutionContext";
+import { Response } from "../../request";
 import { hashObject } from "../../utils/hashObject";
 
 /** @hidden */

--- a/sdk/cosmosdb/cosmos/src/queryExecutionContext/EndpointComponent/UnorderedDistinctEndpointComponent.ts
+++ b/sdk/cosmosdb/cosmos/src/queryExecutionContext/EndpointComponent/UnorderedDistinctEndpointComponent.ts
@@ -1,7 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
-import { Response } from "../../request";
+
 import { ExecutionContext } from "../ExecutionContext";
+import { Response } from "../../request";
 import { hashObject } from "../../utils/hashObject";
 
 /** @hidden */

--- a/sdk/cosmosdb/cosmos/src/queryExecutionContext/defaultQueryExecutionContext.ts
+++ b/sdk/cosmosdb/cosmos/src/queryExecutionContext/defaultQueryExecutionContext.ts
@@ -1,11 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
+
 import { AzureLogger, createClientLogger } from "@azure/logger";
-import { Constants } from "../common";
 import { ClientSideMetrics, QueryMetrics } from "../queryMetrics";
 import { FeedOptions, Response } from "../request";
-import { getInitialHeader } from "./headerUtils";
+import { Constants } from "../common";
 import { ExecutionContext } from "./index";
+import { getInitialHeader } from "./headerUtils";
 
 const logger: AzureLogger = createClientLogger("ClientContext");
 /** @hidden */

--- a/sdk/cosmosdb/cosmos/src/queryExecutionContext/documentProducer.ts
+++ b/sdk/cosmosdb/cosmos/src/queryExecutionContext/documentProducer.ts
@@ -1,20 +1,21 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
-import { PartitionKeyRange, Resource } from "../client";
-import { ClientContext } from "../ClientContext";
+
 import {
   Constants,
-  getIdFromLink,
-  getPathFromLink,
   ResourceType,
   StatusCodes,
-  SubStatusCodes
+  SubStatusCodes,
+  getIdFromLink,
+  getPathFromLink
 } from "../common";
+import { CosmosHeaders, getInitialHeader, mergeHeaders } from "./headerUtils";
+import { FetchResult, FetchResultType } from "./FetchResult";
+import { PartitionKeyRange, Resource } from "../client";
+import { ClientContext } from "../ClientContext";
+import { DefaultQueryExecutionContext } from "./defaultQueryExecutionContext";
 import { FeedOptions } from "../request";
 import { Response } from "../request";
-import { DefaultQueryExecutionContext } from "./defaultQueryExecutionContext";
-import { FetchResult, FetchResultType } from "./FetchResult";
-import { CosmosHeaders, getInitialHeader, mergeHeaders } from "./headerUtils";
 import { SqlQuerySpec } from "./index";
 
 /** @hidden */

--- a/sdk/cosmosdb/cosmos/src/queryExecutionContext/orderByQueryExecutionContext.ts
+++ b/sdk/cosmosdb/cosmos/src/queryExecutionContext/orderByQueryExecutionContext.ts
@@ -1,12 +1,13 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
+
 import { ClientContext } from "../ClientContext";
-import { PartitionedQueryExecutionInfo } from "../request/ErrorResponse";
-import { FeedOptions } from "../request/FeedOptions";
 import { DocumentProducer } from "./documentProducer";
 import { ExecutionContext } from "./ExecutionContext";
+import { FeedOptions } from "../request/FeedOptions";
 import { OrderByDocumentProducerComparator } from "./orderByDocumentProducerComparator";
 import { ParallelQueryExecutionContextBase } from "./parallelQueryExecutionContextBase";
+import { PartitionedQueryExecutionInfo } from "../request/ErrorResponse";
 import { SqlQuerySpec } from "./SqlQuerySpec";
 
 /** @hidden */

--- a/sdk/cosmosdb/cosmos/src/queryExecutionContext/parallelQueryExecutionContextBase.ts
+++ b/sdk/cosmosdb/cosmos/src/queryExecutionContext/parallelQueryExecutionContextBase.ts
@@ -1,19 +1,20 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
-import PriorityQueue from "priorityqueuejs";
-import semaphore from "semaphore";
-import { ClientContext } from "../ClientContext";
+
 import { AzureLogger, createClientLogger } from "@azure/logger";
-import { StatusCodes, SubStatusCodes } from "../common/statusCodes";
 import { FeedOptions, Response } from "../request";
-import { PartitionedQueryExecutionInfo } from "../request/ErrorResponse";
-import { QueryRange } from "../routing/QueryRange";
-import { SmartRoutingMapProvider } from "../routing/smartRoutingMapProvider";
+import { StatusCodes, SubStatusCodes } from "../common/statusCodes";
+import { getInitialHeader, mergeHeaders } from "./headerUtils";
+import { ClientContext } from "../ClientContext";
 import { CosmosHeaders } from "./CosmosHeaders";
 import { DocumentProducer } from "./documentProducer";
 import { ExecutionContext } from "./ExecutionContext";
-import { getInitialHeader, mergeHeaders } from "./headerUtils";
+import { PartitionedQueryExecutionInfo } from "../request/ErrorResponse";
+import PriorityQueue from "priorityqueuejs";
+import { QueryRange } from "../routing/QueryRange";
+import { SmartRoutingMapProvider } from "../routing/smartRoutingMapProvider";
 import { SqlQuerySpec } from "./SqlQuerySpec";
+import semaphore from "semaphore";
 
 /** @hidden */
 const logger: AzureLogger = createClientLogger("parallelQueryExecutionContextBase");

--- a/sdk/cosmosdb/cosmos/src/queryExecutionContext/pipelinedQueryExecutionContext.ts
+++ b/sdk/cosmosdb/cosmos/src/queryExecutionContext/pipelinedQueryExecutionContext.ts
@@ -1,20 +1,21 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
+
+import { FeedOptions, Response } from "../request";
+import { getInitialHeader, mergeHeaders } from "./headerUtils";
 import { ClientContext } from "../ClientContext";
-import { Response, FeedOptions } from "../request";
-import { PartitionedQueryExecutionInfo } from "../request/ErrorResponse";
 import { CosmosHeaders } from "./CosmosHeaders";
+import { ExecutionContext } from "./ExecutionContext";
+import { GroupByEndpointComponent } from "./EndpointComponent/GroupByEndpointComponent";
+import { GroupByValueEndpointComponent } from "./EndpointComponent/GroupByValueEndpointComponent";
 import { OffsetLimitEndpointComponent } from "./EndpointComponent/OffsetLimitEndpointComponent";
 import { OrderByEndpointComponent } from "./EndpointComponent/OrderByEndpointComponent";
-import { OrderedDistinctEndpointComponent } from "./EndpointComponent/OrderedDistinctEndpointComponent";
-import { UnorderedDistinctEndpointComponent } from "./EndpointComponent/UnorderedDistinctEndpointComponent";
-import { GroupByEndpointComponent } from "./EndpointComponent/GroupByEndpointComponent";
-import { ExecutionContext } from "./ExecutionContext";
-import { getInitialHeader, mergeHeaders } from "./headerUtils";
 import { OrderByQueryExecutionContext } from "./orderByQueryExecutionContext";
+import { OrderedDistinctEndpointComponent } from "./EndpointComponent/OrderedDistinctEndpointComponent";
 import { ParallelQueryExecutionContext } from "./parallelQueryExecutionContext";
-import { GroupByValueEndpointComponent } from "./EndpointComponent/GroupByValueEndpointComponent";
+import { PartitionedQueryExecutionInfo } from "../request/ErrorResponse";
 import { SqlQuerySpec } from "./SqlQuerySpec";
+import { UnorderedDistinctEndpointComponent } from "./EndpointComponent/UnorderedDistinctEndpointComponent";
 
 /** @hidden */
 export class PipelinedQueryExecutionContext implements ExecutionContext {

--- a/sdk/cosmosdb/cosmos/src/queryIterator.ts
+++ b/sdk/cosmosdb/cosmos/src/queryIterator.ts
@@ -3,22 +3,22 @@
 
 /// <reference lib="esnext.asynciterable" />
 
-import { ClientContext } from "./ClientContext";
-import { getPathFromLink, ResourceType, StatusCodes } from "./common";
 import {
   CosmosHeaders,
   DefaultQueryExecutionContext,
   ExecutionContext,
   FetchFunctionCallback,
-  getInitialHeader,
-  mergeHeaders,
   PipelinedQueryExecutionContext,
-  SqlQuerySpec
+  SqlQuerySpec,
+  getInitialHeader,
+  mergeHeaders
 } from "./queryExecutionContext";
-import { Response } from "./request";
 import { ErrorResponse, PartitionedQueryExecutionInfo } from "./request/ErrorResponse";
+import { ResourceType, StatusCodes, getPathFromLink } from "./common";
+import { ClientContext } from "./ClientContext";
 import { FeedOptions } from "./request/FeedOptions";
 import { FeedResponse } from "./request/FeedResponse";
+import { Response } from "./request";
 
 /**
  * Represents a QueryIterator Object, an implementation of feed or query response that enables

--- a/sdk/cosmosdb/cosmos/src/queryMetrics/queryMetrics.ts
+++ b/sdk/cosmosdb/cosmos/src/queryMetrics/queryMetrics.ts
@@ -1,8 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
+
+import { parseDelimitedString, timeSpanFromMetrics } from "./queryMetricsUtils";
 import { ClientSideMetrics } from "./clientSideMetrics";
 import QueryMetricsConstants from "./queryMetricsConstants";
-import { parseDelimitedString, timeSpanFromMetrics } from "./queryMetricsUtils";
 import { QueryPreparationTimes } from "./queryPreparationTime";
 import { RuntimeExecutionTimes } from "./runtimeExecutionTimes";
 import { TimeSpan } from "./timeSpan";

--- a/sdk/cosmosdb/cosmos/src/queryMetrics/queryPreparationTime.ts
+++ b/sdk/cosmosdb/cosmos/src/queryMetrics/queryPreparationTime.ts
@@ -1,7 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
-import QueryMetricsConstants from "./queryMetricsConstants";
+
 import { parseDelimitedString, timeSpanFromMetrics } from "./queryMetricsUtils";
+import QueryMetricsConstants from "./queryMetricsConstants";
 import { TimeSpan } from "./timeSpan";
 
 export class QueryPreparationTimes {

--- a/sdk/cosmosdb/cosmos/src/queryMetrics/runtimeExecutionTimes.ts
+++ b/sdk/cosmosdb/cosmos/src/queryMetrics/runtimeExecutionTimes.ts
@@ -1,7 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
-import QueryMetricsConstants from "./queryMetricsConstants";
+
 import { parseDelimitedString, timeSpanFromMetrics } from "./queryMetricsUtils";
+import QueryMetricsConstants from "./queryMetricsConstants";
 import { TimeSpan } from "./timeSpan";
 
 export class RuntimeExecutionTimes {

--- a/sdk/cosmosdb/cosmos/src/request/RequestContext.ts
+++ b/sdk/cosmosdb/cosmos/src/request/RequestContext.ts
@@ -1,15 +1,16 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
-import { ClientContext } from "../ClientContext";
+
+import { ConnectionPolicy, PartitionKey } from "../documents";
 import { HTTPMethod, OperationType, ResourceType } from "../common";
 import { Agent } from "../CosmosClientOptions";
-import { ConnectionPolicy, PartitionKey } from "../documents";
-import { GlobalEndpointManager } from "../globalEndpointManager";
-import { PluginConfig } from "../plugins/Plugin";
+import { ClientContext } from "../ClientContext";
 import { CosmosHeaders } from "../queryExecutionContext/CosmosHeaders";
 import { FeedOptions } from "./FeedOptions";
-import { RequestOptions } from "./RequestOptions";
+import { GlobalEndpointManager } from "../globalEndpointManager";
 import { Pipeline } from "@azure/core-rest-pipeline";
+import { PluginConfig } from "../plugins/Plugin";
+import { RequestOptions } from "./RequestOptions";
 
 /**
  * @hidden

--- a/sdk/cosmosdb/cosmos/src/request/RequestHandler.ts
+++ b/sdk/cosmosdb/cosmos/src/request/RequestHandler.ts
@@ -3,7 +3,11 @@
 
 import * as RetryUtility from "../retry/retryUtility";
 import { AzureLogger, createClientLogger } from "@azure/logger";
-import { PipelineResponse, createHttpHeaders, createPipelineRequest } from "@azure/core-rest-pipeline";
+import {
+  PipelineResponse,
+  createHttpHeaders,
+  createPipelineRequest
+} from "@azure/core-rest-pipeline";
 import { PluginOn, executePlugins } from "../plugins/Plugin";
 import { defaultHttpAgent, defaultHttpsAgent } from "./defaultAgent";
 import AbortController from "node-abort-controller";

--- a/sdk/cosmosdb/cosmos/src/request/RequestHandler.ts
+++ b/sdk/cosmosdb/cosmos/src/request/RequestHandler.ts
@@ -1,24 +1,21 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
-import AbortController from "node-abort-controller";
-import {
-  createPipelineRequest,
-  createHttpHeaders,
-  PipelineResponse
-} from "@azure/core-rest-pipeline";
-import { trimSlashes } from "../common";
-import { Constants } from "../common/constants";
-import { executePlugins, PluginOn } from "../plugins/Plugin";
+
 import * as RetryUtility from "../retry/retryUtility";
+import { AzureLogger, createClientLogger } from "@azure/logger";
+import { PipelineResponse, createHttpHeaders, createPipelineRequest } from "@azure/core-rest-pipeline";
+import { PluginOn, executePlugins } from "../plugins/Plugin";
 import { defaultHttpAgent, defaultHttpsAgent } from "./defaultAgent";
-import { ErrorResponse } from "./ErrorResponse";
-import { bodyFromData } from "./request";
-import { RequestContext } from "./RequestContext";
+import AbortController from "node-abort-controller";
+import { Constants } from "../common/constants";
 import { Response as CosmosResponse } from "./Response";
+import { ErrorResponse } from "./ErrorResponse";
+import { RequestContext } from "./RequestContext";
 import { TimeoutError } from "./TimeoutError";
 import { URL } from "../utils/url";
+import { bodyFromData } from "./request";
 import { getCachedDefaultHttpClient } from "../utils/cachedClient";
-import { AzureLogger, createClientLogger } from "@azure/logger";
+import { trimSlashes } from "../common";
 
 const logger: AzureLogger = createClientLogger("RequestHandler");
 

--- a/sdk/cosmosdb/cosmos/src/request/ResourceResponse.ts
+++ b/sdk/cosmosdb/cosmos/src/request/ResourceResponse.ts
@@ -1,8 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
+
+import { StatusCode, SubStatusCode } from "./StatusCodes";
 import { Constants } from "../common";
 import { CosmosHeaders } from "../queryExecutionContext/CosmosHeaders";
-import { StatusCode, SubStatusCode } from "./StatusCodes";
 
 export class ResourceResponse<TResource> {
   constructor(

--- a/sdk/cosmosdb/cosmos/src/request/SharedOptions.ts
+++ b/sdk/cosmosdb/cosmos/src/request/SharedOptions.ts
@@ -1,8 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 /// <reference lib="dom" />
-import { CosmosHeaders } from "../index";
+
 import { AbortSignal } from "node-abort-controller";
+import { CosmosHeaders } from "../index";
 
 /**
  * Options that can be specified for a requested issued to the Azure Cosmos DB servers.=

--- a/sdk/cosmosdb/cosmos/src/request/request.ts
+++ b/sdk/cosmosdb/cosmos/src/request/request.ts
@@ -1,11 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
-import { setAuthorizationHeader } from "../auth";
-import { Constants, HTTPMethod, jsonStringifyAndEscapeNonASCII, ResourceType } from "../common";
-import { CosmosClientOptions } from "../CosmosClientOptions";
-import { PartitionKey } from "../documents";
-import { CosmosHeaders } from "../queryExecutionContext";
+
+import { Constants, HTTPMethod, ResourceType, jsonStringifyAndEscapeNonASCII } from "../common";
 import { FeedOptions, RequestOptions } from "./index";
+import { CosmosClientOptions } from "../CosmosClientOptions";
+import { CosmosHeaders } from "../queryExecutionContext";
+import { PartitionKey } from "../documents";
+import { setAuthorizationHeader } from "../auth";
 
 // ----------------------------------------------------------------------------
 // Utility methods

--- a/sdk/cosmosdb/cosmos/src/retry/defaultRetryPolicy.ts
+++ b/sdk/cosmosdb/cosmos/src/retry/defaultRetryPolicy.ts
@@ -1,9 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
-import { OperationType } from "../common";
+
 import { ErrorResponse } from "../request";
-import { TimeoutErrorCode } from "../request/TimeoutError";
+import { OperationType } from "../common";
 import { RetryPolicy } from "./RetryPolicy";
+import { TimeoutErrorCode } from "../request/TimeoutError";
 
 /**
  * @hidden

--- a/sdk/cosmosdb/cosmos/src/retry/endpointDiscoveryRetryPolicy.ts
+++ b/sdk/cosmosdb/cosmos/src/retry/endpointDiscoveryRetryPolicy.ts
@@ -1,11 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
-import { OperationType } from "../common";
-import { isReadRequest } from "../common/helper";
-import { GlobalEndpointManager } from "../globalEndpointManager";
+
 import { ErrorResponse } from "../request";
+import { GlobalEndpointManager } from "../globalEndpointManager";
+import { OperationType } from "../common";
 import { RetryContext } from "./RetryContext";
 import { RetryPolicy } from "./RetryPolicy";
+import { isReadRequest } from "../common/helper";
 
 /**
  * This class implements the retry policy for endpoint discovery.

--- a/sdk/cosmosdb/cosmos/src/retry/retryUtility.ts
+++ b/sdk/cosmosdb/cosmos/src/retry/retryUtility.ts
@@ -1,16 +1,17 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
-import { Constants } from "../common/constants";
-import { sleep } from "../common/helper";
+
 import { StatusCodes, SubStatusCodes } from "../common/statusCodes";
-import { Response } from "../request";
-import { RequestContext } from "../request/RequestContext";
+import { Constants } from "../common/constants";
 import { DefaultRetryPolicy } from "./defaultRetryPolicy";
 import { EndpointDiscoveryRetryPolicy } from "./endpointDiscoveryRetryPolicy";
+import { RequestContext } from "../request/RequestContext";
 import { ResourceThrottleRetryPolicy } from "./resourceThrottleRetryPolicy";
+import { Response } from "../request";
 import { RetryContext } from "./RetryContext";
 import { RetryPolicy } from "./RetryPolicy";
 import { SessionRetryPolicy } from "./sessionRetryPolicy";
+import { sleep } from "../common/helper";
 
 /**
  * @hidden

--- a/sdk/cosmosdb/cosmos/src/retry/sessionRetryPolicy.ts
+++ b/sdk/cosmosdb/cosmos/src/retry/sessionRetryPolicy.ts
@@ -1,9 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
-import { isReadRequest, OperationType, ResourceType } from "../common";
+
+import { OperationType, ResourceType, isReadRequest } from "../common";
 import { ConnectionPolicy } from "../documents";
-import { GlobalEndpointManager } from "../globalEndpointManager";
 import { ErrorResponse } from "../request";
+import { GlobalEndpointManager } from "../globalEndpointManager";
 import { RetryContext } from "./RetryContext";
 import { RetryPolicy } from "./RetryPolicy";
 

--- a/sdk/cosmosdb/cosmos/src/routing/QueryRange.ts
+++ b/sdk/cosmosdb/cosmos/src/routing/QueryRange.ts
@@ -1,7 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
-import { PartitionKeyRange } from "../client/Container/PartitionKeyRange";
+
 import { Constants } from "../common";
+import { PartitionKeyRange } from "../client/Container/PartitionKeyRange";
 import { QueryRange as ResponseQueryRange } from "../request/ErrorResponse";
 
 /** @hidden */

--- a/sdk/cosmosdb/cosmos/src/routing/inMemoryCollectionRoutingMap.ts
+++ b/sdk/cosmosdb/cosmos/src/routing/inMemoryCollectionRoutingMap.ts
@@ -1,7 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
-import { PartitionKeyRange } from "../client";
+
 import { Constants } from "../common";
+import { PartitionKeyRange } from "../client";
 import { QueryRange } from "./QueryRange";
 
 /** @hidden */

--- a/sdk/cosmosdb/cosmos/src/routing/partitionKeyRangeCache.ts
+++ b/sdk/cosmosdb/cosmos/src/routing/partitionKeyRangeCache.ts
@@ -1,11 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
-import { PartitionKeyRange } from "../client/Container/PartitionKeyRange";
+
 import { ClientContext } from "../ClientContext";
-import { getIdFromLink } from "../common/helper";
-import { createCompleteRoutingMap } from "./CollectionRoutingMapFactory";
 import { InMemoryCollectionRoutingMap } from "./inMemoryCollectionRoutingMap";
+import { PartitionKeyRange } from "../client/Container/PartitionKeyRange";
 import { QueryRange } from "./QueryRange";
+import { createCompleteRoutingMap } from "./CollectionRoutingMapFactory";
+import { getIdFromLink } from "../common/helper";
 
 /** @hidden */
 export class PartitionKeyRangeCache {

--- a/sdk/cosmosdb/cosmos/src/session/sessionContainer.ts
+++ b/sdk/cosmosdb/cosmos/src/session/sessionContainer.ts
@@ -1,13 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import {
-  Constants,
-  OperationType,
-  ResourceType,
-  getContainerLink,
-  trimSlashes
-} from "../common";
+import { Constants, OperationType, ResourceType, getContainerLink, trimSlashes } from "../common";
 import { CosmosHeaders } from "../queryExecutionContext";
 import { SessionContext } from "./SessionContext";
 import { VectorSessionToken } from "./VectorSessionToken";

--- a/sdk/cosmosdb/cosmos/src/session/sessionContainer.ts
+++ b/sdk/cosmosdb/cosmos/src/session/sessionContainer.ts
@@ -1,10 +1,17 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
-import atob from "../utils/atob";
-import { Constants, getContainerLink, OperationType, ResourceType, trimSlashes } from "../common";
+
+import {
+  Constants,
+  OperationType,
+  ResourceType,
+  getContainerLink,
+  trimSlashes
+} from "../common";
 import { CosmosHeaders } from "../queryExecutionContext";
 import { SessionContext } from "./SessionContext";
 import { VectorSessionToken } from "./VectorSessionToken";
+import atob from "../utils/atob";
 
 /** @hidden */
 export class SessionContainer {

--- a/sdk/cosmosdb/cosmos/src/utils/SasToken.ts
+++ b/sdk/cosmosdb/cosmos/src/utils/SasToken.ts
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { SasTokenProperties } from "../client/SasToken/SasTokenProperties";
 import { Constants, CosmosKeyType, SasTokenPermissionKind } from "../common";
+import { SasTokenProperties } from "../client/SasToken/SasTokenProperties";
 import { encodeUTF8 } from "./encode";
 import { hmac } from "./hmac";
 

--- a/sdk/cosmosdb/cosmos/src/utils/batch.ts
+++ b/sdk/cosmosdb/cosmos/src/utils/batch.ts
@@ -2,11 +2,12 @@
 // Licensed under the MIT license.
 
 import { JSONObject } from "../queryExecutionContext";
-import { extractPartitionKey } from "../extractPartitionKey";
 import { PartitionKeyDefinition } from "../documents";
-import { RequestOptions } from "..";
 import { PatchRequestBody } from "./patch";
+import { RequestOptions } from "..";
+import { extractPartitionKey } from "../extractPartitionKey";
 import { v4 } from "uuid";
+
 const uuid = v4;
 
 export type Operation =

--- a/sdk/cosmosdb/cosmos/src/utils/hashing/encoding/number.ts
+++ b/sdk/cosmosdb/cosmos/src/utils/hashing/encoding/number.ts
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import JSBI from "jsbi";
 import { BytePrefix } from "./prefix";
+import JSBI from "jsbi";
 
 export function writeNumberForBinaryEncodingJSBI(hash: number): Buffer {
   let payload = encodeNumberAsUInt64JSBI(hash);

--- a/sdk/cosmosdb/cosmos/src/utils/hashing/v1.ts
+++ b/sdk/cosmosdb/cosmos/src/utils/hashing/v1.ts
@@ -2,9 +2,9 @@
 // Licensed under the MIT license.
 
 import { doubleToByteArrayJSBI, writeNumberForBinaryEncodingJSBI } from "./encoding/number";
-import { writeStringForBinaryEncoding } from "./encoding/string";
 import { BytePrefix } from "./encoding/prefix";
 import MurmurHash from "./murmurHash";
+import { writeStringForBinaryEncoding } from "./encoding/string";
 
 const MAX_STRING_CHARS = 100;
 

--- a/sdk/cosmosdb/cosmos/src/utils/hashing/v2.ts
+++ b/sdk/cosmosdb/cosmos/src/utils/hashing/v2.ts
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { doubleToByteArrayJSBI } from "./encoding/number";
 import { BytePrefix } from "./encoding/prefix";
 import MurmurHash from "./murmurHash";
+import { doubleToByteArrayJSBI } from "./encoding/number";
 
 type v2Key = string | number | boolean | null | Record<string, unknown> | undefined;
 

--- a/sdk/cosmosdb/cosmos/src/utils/headers.ts
+++ b/sdk/cosmosdb/cosmos/src/utils/headers.ts
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+import { Constants, HTTPMethod, ResourceType } from "../common";
 import { hmac } from "./hmac";
-import { HTTPMethod, ResourceType, Constants } from "../common";
 
 export async function generateHeaders(
   masterKey: string,

--- a/sdk/cosmosdb/cosmos/src/utils/hmac.browser.ts
+++ b/sdk/cosmosdb/cosmos/src/utils/hmac.browser.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { encodeUTF8, encodeBase64 } from "./encode";
+import { encodeBase64, encodeUTF8 } from "./encode";
 import atob from "./atob";
 import { globalCrypto } from "./globalCrypto";
 

--- a/sdk/cosmosdb/cosmos/test/internal/session.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/internal/session.spec.ts
@@ -1,18 +1,18 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import assert from "assert";
-import { Suite } from "mocha";
 import { ClientContext, Container, PluginConfig, PluginOn } from "../../src";
 import { OperationType, ResourceType } from "../../src/common";
+import { addEntropy, getTestDatabase, removeAllDatabases } from "../public/common/TestHelpers";
 import { ConsistencyLevel } from "../../src";
 import { CosmosClient } from "../../src";
-import { SessionContainer } from "../../src/session/sessionContainer";
-import { endpoint } from "../public/common/_testConfig";
-import { masterKey } from "../public/common/_fakeTestSecrets";
-import { addEntropy, getTestDatabase, removeAllDatabases } from "../public/common/TestHelpers";
 import { RequestContext } from "../../src";
 import { Response } from "../../src/request/Response";
+import { SessionContainer } from "../../src/session/sessionContainer";
+import { Suite } from "mocha";
+import assert from "assert";
+import { endpoint } from "../public/common/_testConfig";
+import { masterKey } from "../public/common/_fakeTestSecrets";
 
 describe("New session token", function() {
   it("preserves tokens", async function() {

--- a/sdk/cosmosdb/cosmos/test/internal/unit/auth.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/internal/unit/auth.spec.ts
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { getAuthorizationTokenUsingResourceTokens } from "../../../src/auth";
 import { Suite } from "mocha";
 import assert from "assert";
+import { getAuthorizationTokenUsingResourceTokens } from "../../../src/auth";
 
 describe("NodeJS CRUD Tests", function(this: Suite) {
   this.timeout(process.env.MOCHA_TIMEOUT || 10000);

--- a/sdk/cosmosdb/cosmos/test/internal/unit/defaultQueryExecutionContext.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/internal/unit/defaultQueryExecutionContext.spec.ts
@@ -1,7 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { DefaultQueryExecutionContext, FetchFunctionCallback } from "../../../src/queryExecutionContext";
+import {
+  DefaultQueryExecutionContext,
+  FetchFunctionCallback
+} from "../../../src/queryExecutionContext";
 import { FeedOptions } from "../../../src";
 import assert from "assert";
 import { sleep } from "../../../src/common";

--- a/sdk/cosmosdb/cosmos/test/internal/unit/defaultQueryExecutionContext.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/internal/unit/defaultQueryExecutionContext.spec.ts
@@ -1,9 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
-import {
-  FetchFunctionCallback,
-  DefaultQueryExecutionContext
-} from "../../../src/queryExecutionContext";
+
+import { DefaultQueryExecutionContext, FetchFunctionCallback } from "../../../src/queryExecutionContext";
 import { FeedOptions } from "../../../src";
 import assert from "assert";
 import { sleep } from "../../../src/common";

--- a/sdk/cosmosdb/cosmos/test/internal/unit/inMemoryCollectionRoutingMap.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/internal/unit/inMemoryCollectionRoutingMap.spec.ts
@@ -1,7 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
-import assert from "assert";
+
 import { QueryRange } from "../../../src/routing";
+import assert from "assert";
 import { createCompleteRoutingMap } from "../../../src/routing/CollectionRoutingMapFactory";
 
 describe("InMemoryCollectionRoutingMap Tests", function() {

--- a/sdk/cosmosdb/cosmos/test/internal/unit/platform.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/internal/unit/platform.spec.ts
@@ -1,8 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
-import assert from "assert";
+
 import { Constants } from "../../../src/common/constants";
+import assert from "assert";
 import { getUserAgent } from "../../../src/common/platform";
+
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const packageJson = require("../../../package.json");
 const packageVersion = packageJson["version"];

--- a/sdk/cosmosdb/cosmos/test/internal/unit/sasToken.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/internal/unit/sasToken.spec.ts
@@ -1,12 +1,13 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
-import assert from "assert";
-import { CosmosClient } from "../../../src";
-import { endpoint } from "../../public/common/_testConfig";
+
 import { masterKey, userSasTokenKey } from "../../public/common/_fakeTestSecrets";
+import { CosmosClient } from "../../../src";
 import { SasTokenPermissionKind } from "../../../src/common";
-import { createAuthorizationSasToken } from "../../../src/utils/SasToken";
 import { SasTokenProperties } from "../../../src/client/SasToken/SasTokenProperties";
+import assert from "assert";
+import { createAuthorizationSasToken } from "../../../src/utils/SasToken";
+import { endpoint } from "../../public/common/_testConfig";
 
 describe.skip("SAS Token Authorization", function() {
   const sasTokenProperties = <SasTokenProperties>{

--- a/sdk/cosmosdb/cosmos/test/internal/unit/sessionContainer.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/internal/unit/sessionContainer.spec.ts
@@ -1,10 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
-import assert from "assert";
+
 import { Constants, OperationType, ResourceType } from "../../../src/common";
 import { CosmosHeaders } from "../../../src/queryExecutionContext/CosmosHeaders";
 import { SessionContainer } from "../../../src/session/sessionContainer";
 import { SessionContext } from "../../../src/session/SessionContext";
+import assert from "assert";
 
 describe("SessionContainer", function() {
   const collectionLink = "dbs/testDatabase/colls/testCollection";

--- a/sdk/cosmosdb/cosmos/test/internal/unit/smartRoutingMapProvider.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/internal/unit/smartRoutingMapProvider.spec.ts
@@ -1,9 +1,10 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
-import assert from "assert";
-import { ClientContext } from "../../../src/ClientContext";
+
 import { PartitionKeyRangeCache, QueryRange, SmartRoutingMapProvider } from "../../../src/routing";
+import { ClientContext } from "../../../src/ClientContext";
 import { MockedClientContext } from "../../public/common/MockClientContext";
+import assert from "assert";
 
 describe("Smart Routing Map Provider OverlappingRanges", function() {
   const containerLink = "dbs/7JZZAA==/colls/7JZZAOS-JQA=/";

--- a/sdk/cosmosdb/cosmos/test/internal/unit/utils/offer.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/internal/unit/utils/offer.spec.ts
@@ -1,8 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
+
+import { ContainerRequest } from "../../../../src";
 import assert from "assert";
 import { validateOffer } from "../../../../src/utils/offers";
-import { ContainerRequest } from "../../../../src";
 
 describe("Offer utils", function() {
   describe("validateOffer", function() {

--- a/sdk/cosmosdb/cosmos/test/public/common/TestHelpers.ts
+++ b/sdk/cosmosdb/cosmos/test/public/common/TestHelpers.ts
@@ -11,13 +11,7 @@ import {
   Response,
   UserDefinition
 } from "../../../src";
-import {
-  ItemDefinition,
-  ItemResponse,
-  PermissionResponse,
-  Resource,
-  User
-} from "../../../src";
+import { ItemDefinition, ItemResponse, PermissionResponse, Resource, User } from "../../../src";
 import { ContainerRequest } from "../../../src";
 import { DatabaseRequest } from "../../../src";
 import { UserResponse } from "../../../src";

--- a/sdk/cosmosdb/cosmos/test/public/common/TestHelpers.ts
+++ b/sdk/cosmosdb/cosmos/test/public/common/TestHelpers.ts
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
-import assert from "assert";
+
 import {
   Container,
   CosmosClient,
@@ -11,12 +11,19 @@ import {
   Response,
   UserDefinition
 } from "../../../src";
-import { ItemDefinition, ItemResponse, PermissionResponse, Resource, User } from "../../../src";
+import {
+  ItemDefinition,
+  ItemResponse,
+  PermissionResponse,
+  Resource,
+  User
+} from "../../../src";
+import { ContainerRequest } from "../../../src";
+import { DatabaseRequest } from "../../../src";
 import { UserResponse } from "../../../src";
+import assert from "assert";
 import { endpoint } from "../common/_testConfig";
 import { masterKey } from "../common/_fakeTestSecrets";
-import { DatabaseRequest } from "../../../src";
-import { ContainerRequest } from "../../../src";
 
 const defaultClient = new CosmosClient({
   endpoint,

--- a/sdk/cosmosdb/cosmos/test/public/functional/authorization.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/public/functional/authorization.spec.ts
@@ -2,7 +2,12 @@
 // Licensed under the MIT license.
 
 import { CosmosClient, PermissionMode } from "../../../src";
-import { createOrUpsertPermission, getTestContainer, getTestDatabase, removeAllDatabases } from "../common/TestHelpers";
+import {
+  createOrUpsertPermission,
+  getTestContainer,
+  getTestDatabase,
+  removeAllDatabases
+} from "../common/TestHelpers";
 import { PermissionDefinition } from "../../../src/";
 import { Suite } from "mocha";
 import assert from "assert";

--- a/sdk/cosmosdb/cosmos/test/public/functional/authorization.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/public/functional/authorization.spec.ts
@@ -1,17 +1,13 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
-import assert from "assert";
-import { Suite } from "mocha";
+
 import { CosmosClient, PermissionMode } from "../../../src";
+import { createOrUpsertPermission, getTestContainer, getTestDatabase, removeAllDatabases } from "../common/TestHelpers";
 import { PermissionDefinition } from "../../../src/";
+import { Suite } from "mocha";
+import assert from "assert";
 import { endpoint } from "../common/_testConfig";
 import { masterKey } from "../common/_fakeTestSecrets";
-import {
-  createOrUpsertPermission,
-  getTestContainer,
-  getTestDatabase,
-  removeAllDatabases
-} from "../common/TestHelpers";
 
 describe("NodeJS CRUD Tests", function(this: Suite) {
   this.timeout(process.env.MOCHA_TIMEOUT || 10000);

--- a/sdk/cosmosdb/cosmos/test/public/functional/client.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/public/functional/client.spec.ts
@@ -1,7 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { bulkInsertItems, generateDocuments, getTestContainer, getTestDatabase } from "../common/TestHelpers";
+import {
+  bulkInsertItems,
+  generateDocuments,
+  getTestContainer,
+  getTestDatabase
+} from "../common/TestHelpers";
 import AbortController from "node-abort-controller";
 import { Agent } from "http";
 import { CosmosClient } from "../../../src";

--- a/sdk/cosmosdb/cosmos/test/public/functional/client.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/public/functional/client.spec.ts
@@ -1,20 +1,16 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
-import assert from "assert";
-import { Suite } from "mocha";
+
+import { bulkInsertItems, generateDocuments, getTestContainer, getTestDatabase } from "../common/TestHelpers";
+import AbortController from "node-abort-controller";
 import { Agent } from "http";
 import { CosmosClient } from "../../../src";
+import { Suite } from "mocha";
+import { UsernamePasswordCredential } from "@azure/identity";
+import assert from "assert";
+import { defaultConnectionPolicy } from "../../../src/documents";
 import { endpoint } from "../common/_testConfig";
 import { masterKey } from "../common/_fakeTestSecrets";
-import {
-  getTestDatabase,
-  getTestContainer,
-  generateDocuments,
-  bulkInsertItems
-} from "../common/TestHelpers";
-import AbortController from "node-abort-controller";
-import { UsernamePasswordCredential } from "@azure/identity";
-import { defaultConnectionPolicy } from "../../../src/documents";
 
 describe("Client Tests", function(this: Suite) {
   this.timeout(process.env.MOCHA_TIMEOUT || 20000);

--- a/sdk/cosmosdb/cosmos/test/public/functional/conflict.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/public/functional/conflict.spec.ts
@@ -1,8 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
-import assert from "assert";
+
+import { getTestContainer, removeAllDatabases } from "../common/TestHelpers";
 import { Suite } from "mocha";
-import { removeAllDatabases, getTestContainer } from "../common/TestHelpers";
+import assert from "assert";
 
 describe("Conflicts", function(this: Suite) {
   this.timeout(process.env.MOCHA_TIMEOUT || 10000);

--- a/sdk/cosmosdb/cosmos/test/public/functional/container.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/public/functional/container.spec.ts
@@ -1,19 +1,21 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
-import assert from "assert";
-import { Suite } from "mocha";
+
 import { Constants, ContainerResponse } from "../../../src";
-import { ContainerDefinition, Database, Container } from "../../../src";
-import { ContainerRequest } from "../../../src";
-import { DataType, IndexedPath, IndexingMode, IndexingPolicy, IndexKind } from "../../../src";
+import { Container, ContainerDefinition, Database } from "../../../src";
 import {
-  getTestDatabase,
-  removeAllDatabases,
-  getTestContainer,
-  assertThrowsAsync
-} from "../common/TestHelpers";
-import { SpatialType } from "../../../src";
+  DataType,
+  IndexKind,
+  IndexedPath,
+  IndexingMode,
+  IndexingPolicy
+} from "../../../src";
+import { assertThrowsAsync, getTestContainer, getTestDatabase, removeAllDatabases } from "../common/TestHelpers";
+import { ContainerRequest } from "../../../src";
 import { GeospatialType } from "../../../src";
+import { SpatialType } from "../../../src";
+import { Suite } from "mocha";
+import assert from "assert";
 
 describe("Containers", function(this: Suite) {
   this.timeout(process.env.MOCHA_TIMEOUT || 10000);

--- a/sdk/cosmosdb/cosmos/test/public/functional/container.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/public/functional/container.spec.ts
@@ -3,14 +3,13 @@
 
 import { Constants, ContainerResponse } from "../../../src";
 import { Container, ContainerDefinition, Database } from "../../../src";
+import { DataType, IndexKind, IndexedPath, IndexingMode, IndexingPolicy } from "../../../src";
 import {
-  DataType,
-  IndexKind,
-  IndexedPath,
-  IndexingMode,
-  IndexingPolicy
-} from "../../../src";
-import { assertThrowsAsync, getTestContainer, getTestDatabase, removeAllDatabases } from "../common/TestHelpers";
+  assertThrowsAsync,
+  getTestContainer,
+  getTestDatabase,
+  removeAllDatabases
+} from "../common/TestHelpers";
 import { ContainerRequest } from "../../../src";
 import { GeospatialType } from "../../../src";
 import { SpatialType } from "../../../src";

--- a/sdk/cosmosdb/cosmos/test/public/functional/database.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/public/functional/database.spec.ts
@@ -2,7 +2,12 @@
 // Licensed under the MIT license.
 
 import { CosmosClient, Database, DatabaseDefinition } from "../../../src";
-import { addEntropy, assertThrowsAsync, getTestDatabase, removeAllDatabases } from "../common/TestHelpers";
+import {
+  addEntropy,
+  assertThrowsAsync,
+  getTestDatabase,
+  removeAllDatabases
+} from "../common/TestHelpers";
 import { DatabaseRequest } from "../../../src";
 import { Suite } from "mocha";
 import assert from "assert";

--- a/sdk/cosmosdb/cosmos/test/public/functional/database.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/public/functional/database.spec.ts
@@ -1,17 +1,13 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
-import assert from "assert";
+
+import { CosmosClient, Database, DatabaseDefinition } from "../../../src";
+import { addEntropy, assertThrowsAsync, getTestDatabase, removeAllDatabases } from "../common/TestHelpers";
+import { DatabaseRequest } from "../../../src";
 import { Suite } from "mocha";
-import { CosmosClient, DatabaseDefinition, Database } from "../../../src";
+import assert from "assert";
 import { endpoint } from "../common/_testConfig";
 import { masterKey } from "../common/_fakeTestSecrets";
-import {
-  addEntropy,
-  removeAllDatabases,
-  getTestDatabase,
-  assertThrowsAsync
-} from "../common/TestHelpers";
-import { DatabaseRequest } from "../../../src";
 
 const client = new CosmosClient({
   endpoint,

--- a/sdk/cosmosdb/cosmos/test/public/functional/databaseaccount.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/public/functional/databaseaccount.spec.ts
@@ -1,9 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
-import assert from "assert";
+
 import { Context } from "mocha";
-import { Suite } from "mocha";
 import { CosmosClient } from "../../../src";
+import { Suite } from "mocha";
+import assert from "assert";
 import { endpoint } from "../common/_testConfig";
 import { masterKey } from "../common/_fakeTestSecrets";
 

--- a/sdk/cosmosdb/cosmos/test/public/functional/globalEndpointManager.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/public/functional/globalEndpointManager.spec.ts
@@ -1,11 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
-import { DatabaseAccount, ResourceResponse } from "../../../src";
-import { masterKey } from "../common/_fakeTestSecrets";
-import { GlobalEndpointManager } from "../../../src";
-import { OperationType, ResourceType } from "../../../src";
 
+import { DatabaseAccount, ResourceResponse } from "../../../src";
+import { OperationType, ResourceType } from "../../../src";
+import { GlobalEndpointManager } from "../../../src";
 import assert from "assert";
+import { masterKey } from "../common/_fakeTestSecrets";
+
 
 const headers = {
   "access-control-allow-credentials": "true",

--- a/sdk/cosmosdb/cosmos/test/public/functional/globalEndpointManager.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/public/functional/globalEndpointManager.spec.ts
@@ -7,7 +7,6 @@ import { GlobalEndpointManager } from "../../../src";
 import assert from "assert";
 import { masterKey } from "../common/_fakeTestSecrets";
 
-
 const headers = {
   "access-control-allow-credentials": "true",
   "access-control-allow-origin": "",

--- a/sdk/cosmosdb/cosmos/test/public/functional/item.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/public/functional/item.spec.ts
@@ -1,23 +1,24 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
-import assert from "assert";
-import { Suite } from "mocha";
+
+import { BulkOperationType, OperationInput } from "../../../src";
 import { Container, CosmosClient, PatchOperation, PatchOperationType } from "../../../src";
-import { ItemDefinition } from "../../../src";
 import {
+  addEntropy,
   bulkDeleteItems,
   bulkInsertItems,
   bulkQueryItemsWithPartitionKey,
   bulkReadItems,
   bulkReplaceItems,
   createOrUpsertItem,
+  getTestContainer,
   getTestDatabase,
   removeAllDatabases,
-  replaceOrUpsertItem,
-  addEntropy,
-  getTestContainer
+  replaceOrUpsertItem
 } from "../common/TestHelpers";
-import { BulkOperationType, OperationInput } from "../../../src";
+import { ItemDefinition } from "../../../src";
+import { Suite } from "mocha";
+import assert from "assert";
 import { endpoint } from "../common/_testConfig";
 import { masterKey } from "../common/_fakeTestSecrets";
 

--- a/sdk/cosmosdb/cosmos/test/public/functional/npcontainer.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/public/functional/npcontainer.spec.ts
@@ -1,17 +1,18 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
-import assert from "assert";
+
 import {
-  CosmosClient,
   Constants,
   Container,
-  PluginConfig,
-  CosmosClientOptions
+  CosmosClient,
+  CosmosClientOptions,
+  PluginConfig
 } from "../../../src";
-import { removeAllDatabases, getTestContainer } from "../common/TestHelpers";
+import { HTTPMethod, ResourceType, StatusCodes } from "../../../src";
+import { getTestContainer, removeAllDatabases } from "../common/TestHelpers";
+import assert from "assert";
 import { endpoint } from "../common/_testConfig";
 import { masterKey } from "../common/_fakeTestSecrets";
-import { ResourceType, HTTPMethod, StatusCodes } from "../../../src";
 
 const plugins: PluginConfig[] = [
   {

--- a/sdk/cosmosdb/cosmos/test/public/functional/offer.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/public/functional/offer.spec.ts
@@ -1,12 +1,13 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
-import assert from "assert";
+
+import { Constants, CosmosClient } from "../../../src";
+import { getTestContainer, removeAllDatabases } from "../common/TestHelpers";
 import { Context } from "mocha";
 import { Suite } from "mocha";
-import { Constants, CosmosClient } from "../../../src";
+import assert from "assert";
 import { endpoint } from "../common/_testConfig";
 import { masterKey } from "../common/_fakeTestSecrets";
-import { getTestContainer, removeAllDatabases } from "../common/TestHelpers";
 
 const client = new CosmosClient({
   endpoint,

--- a/sdk/cosmosdb/cosmos/test/public/functional/permission.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/public/functional/permission.spec.ts
@@ -1,7 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { createOrUpsertPermission, getTestContainer, removeAllDatabases, replaceOrUpsertPermission } from "../common/TestHelpers";
+import {
+  createOrUpsertPermission,
+  getTestContainer,
+  removeAllDatabases,
+  replaceOrUpsertPermission
+} from "../common/TestHelpers";
 import { PermissionDefinition } from "../../../src";
 import { PermissionMode } from "../../../src";
 import { Suite } from "mocha";

--- a/sdk/cosmosdb/cosmos/test/public/functional/permission.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/public/functional/permission.spec.ts
@@ -1,15 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
-import assert from "assert";
-import { Suite } from "mocha";
-import { PermissionMode } from "../../../src";
+
+import { createOrUpsertPermission, getTestContainer, removeAllDatabases, replaceOrUpsertPermission } from "../common/TestHelpers";
 import { PermissionDefinition } from "../../../src";
-import {
-  createOrUpsertPermission,
-  getTestContainer,
-  removeAllDatabases,
-  replaceOrUpsertPermission
-} from "../common/TestHelpers";
+import { PermissionMode } from "../../../src";
+import { Suite } from "mocha";
+import assert from "assert";
 
 describe("NodeJS CRUD Tests", function(this: Suite) {
   this.timeout(process.env.MOCHA_TIMEOUT || 10000);

--- a/sdk/cosmosdb/cosmos/test/public/functional/plugin.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/public/functional/plugin.spec.ts
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
-import { CosmosClient, CosmosClientOptions } from "../../../src";
-import { RequestContext } from "../../../src";
-import { Plugin, Next, PluginConfig } from "../../../src";
 
 import * as assert from "assert";
+import { CosmosClient, CosmosClientOptions } from "../../../src";
+import { Next, Plugin, PluginConfig } from "../../../src";
+import { RequestContext } from "../../../src";
 
 describe("Plugin", function() {
   it("should handle all requests", async function() {

--- a/sdk/cosmosdb/cosmos/test/public/functional/query.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/public/functional/query.spec.ts
@@ -1,12 +1,13 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
-import assert from "assert";
-import { Suite } from "mocha";
-import { CosmosClient } from "../../../src";
+
+import { getTestContainer, getTestDatabase, removeAllDatabases } from "../common/TestHelpers";
 import { Container } from "../../../src/";
+import { CosmosClient } from "../../../src";
+import { Suite } from "mocha";
+import assert from "assert";
 import { endpoint } from "../common/_testConfig";
 import { masterKey } from "../common/_fakeTestSecrets";
-import { getTestContainer, getTestDatabase, removeAllDatabases } from "../common/TestHelpers";
 
 const client = new CosmosClient({
   endpoint,

--- a/sdk/cosmosdb/cosmos/test/public/functional/spatial.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/public/functional/spatial.spec.ts
@@ -1,9 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
-import assert from "assert";
-import { Suite } from "mocha";
-import { Database, DataType, IndexKind } from "../../../src";
+
+import { DataType, Database, IndexKind } from "../../../src";
 import { createOrUpsertItem, getTestDatabase, removeAllDatabases } from "../common/TestHelpers";
+import { Suite } from "mocha";
+import assert from "assert";
 
 describe("Spatial Indexes", function(this: Suite) {
   this.timeout(process.env.MOCHA_TIMEOUT || 10000);

--- a/sdk/cosmosdb/cosmos/test/public/functional/sproc.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/public/functional/sproc.spec.ts
@@ -2,7 +2,12 @@
 // Licensed under the MIT license.
 
 import { Container, StoredProcedureDefinition } from "../../../src/";
-import { bulkInsertItems, getTestContainer, getTestDatabase, removeAllDatabases } from "../common/TestHelpers";
+import {
+  bulkInsertItems,
+  getTestContainer,
+  getTestDatabase,
+  removeAllDatabases
+} from "../common/TestHelpers";
 import { Constants } from "../../../src";
 import { Context } from "mocha";
 import { Suite } from "mocha";

--- a/sdk/cosmosdb/cosmos/test/public/functional/sproc.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/public/functional/sproc.spec.ts
@@ -1,16 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
-import assert from "assert";
+
+import { Container, StoredProcedureDefinition } from "../../../src/";
+import { bulkInsertItems, getTestContainer, getTestDatabase, removeAllDatabases } from "../common/TestHelpers";
+import { Constants } from "../../../src";
 import { Context } from "mocha";
 import { Suite } from "mocha";
-import { Constants } from "../../../src";
-import { Container, StoredProcedureDefinition } from "../../../src/";
-import {
-  bulkInsertItems,
-  getTestContainer,
-  getTestDatabase,
-  removeAllDatabases
-} from "../common/TestHelpers";
+import assert from "assert";
 
 // Used for sproc
 declare let getContext: any;

--- a/sdk/cosmosdb/cosmos/test/public/functional/trigger.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/public/functional/trigger.spec.ts
@@ -1,10 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
-import assert from "assert";
-import { Suite } from "mocha";
+
+import { Container, TriggerDefinition } from "../../../src";
 import { TriggerOperation, TriggerType } from "../../../src";
-import { TriggerDefinition, Container } from "../../../src";
 import { getTestContainer, removeAllDatabases } from "../common/TestHelpers";
+import { Suite } from "mocha";
+import assert from "assert";
 
 const notFoundErrorCode = 404;
 

--- a/sdk/cosmosdb/cosmos/test/public/functional/ttl.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/public/functional/ttl.spec.ts
@@ -1,10 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
-import assert from "assert";
-import { Suite } from "mocha";
+
 import { Container, ContainerDefinition, Database } from "../../../src";
 import { getTestDatabase, removeAllDatabases } from "../common/TestHelpers";
 import { StatusCodes } from "../../../src";
+import { Suite } from "mocha";
+import assert from "assert";
 
 async function sleep(time: number): Promise<unknown> {
   return new Promise((resolve) => {

--- a/sdk/cosmosdb/cosmos/test/public/functional/udf.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/public/functional/udf.spec.ts
@@ -1,9 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
-import assert from "assert";
+
+import { Container, UserDefinedFunctionDefinition } from "../../../src";
+import { getTestContainer, removeAllDatabases } from "../common/TestHelpers";
 import { Suite } from "mocha";
-import { UserDefinedFunctionDefinition, Container } from "../../../src";
-import { removeAllDatabases, getTestContainer } from "../common/TestHelpers";
+import assert from "assert";
 
 describe("User Defined Function", function(this: Suite) {
   this.timeout(process.env.MOCHA_TIMEOUT || 10000);

--- a/sdk/cosmosdb/cosmos/test/public/functional/user.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/public/functional/user.spec.ts
@@ -1,9 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
-import assert from "assert";
+
+import { createOrUpsertUser, getTestDatabase, removeAllDatabases } from "../common/TestHelpers";
 import { Suite } from "mocha";
 import { UserDefinition } from "../../../src";
-import { createOrUpsertUser, getTestDatabase, removeAllDatabases } from "../common/TestHelpers";
+import assert from "assert";
 
 describe("NodeJS CRUD Tests", function(this: Suite) {
   this.timeout(process.env.MOCHA_TIMEOUT || 10000);

--- a/sdk/cosmosdb/cosmos/test/public/integration/aggregateQuery.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/public/integration/aggregateQuery.spec.ts
@@ -1,14 +1,15 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
-import assert from "assert";
-import { Suite } from "mocha";
+
 import { Container, ContainerDefinition } from "../../../src";
 import { DataType, IndexKind } from "../../../src";
+import { bulkInsertItems, getTestContainer, removeAllDatabases } from "../common/TestHelpers";
+import { FeedOptions } from "../../../src";
 import { QueryIterator } from "../../../src";
 import { SqlQuerySpec } from "../../../src";
-import { FeedOptions } from "../../../src";
+import { Suite } from "mocha";
 import { TestData } from "../common/TestData";
-import { bulkInsertItems, getTestContainer, removeAllDatabases } from "../common/TestHelpers";
+import assert from "assert";
 
 describe("Aggregate Query", function(this: Suite) {
   this.timeout(process.env.MOCHA_TIMEOUT || 20000);

--- a/sdk/cosmosdb/cosmos/test/public/integration/aggregates/groupBy.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/public/integration/aggregates/groupBy.spec.ts
@@ -1,9 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
+
 import { Container, ContainerDefinition } from "../../../../src";
 import { bulkInsertItems, getTestContainer, removeAllDatabases } from "../../common/TestHelpers";
-import snapshot from "snap-shot-it";
 import assert from "assert";
+import snapshot from "snap-shot-it";
 
 const options = {
   maxItemCount: 100

--- a/sdk/cosmosdb/cosmos/test/public/integration/authorization.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/public/integration/authorization.spec.ts
@@ -1,11 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
-import assert from "assert";
-import { Suite } from "mocha";
+
 import { Container, CosmosClient, PermissionMode } from "../../../src";
-import { Database } from "../../../src";
-import { endpoint } from "../common/_testConfig";
 import { getTestContainer, removeAllDatabases } from "../common/TestHelpers";
+import { Database } from "../../../src";
+import { Suite } from "mocha";
+import assert from "assert";
+import { endpoint } from "../common/_testConfig";
 
 describe("Authorization", function(this: Suite) {
   this.timeout(process.env.MOCHA_TIMEOUT || 10000);

--- a/sdk/cosmosdb/cosmos/test/public/integration/changeFeed.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/public/integration/changeFeed.spec.ts
@@ -1,10 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
-import assert from "assert";
-import { Suite } from "mocha";
-import { RequestOptions } from "../../../src";
+
 import { Container, ContainerDefinition } from "../../../src";
 import { getTestContainer, removeAllDatabases } from "../common/TestHelpers";
+import { RequestOptions } from "../../../src";
+import { Suite } from "mocha";
+import assert from "assert";
 
 describe("Change Feed Iterator", function(this: Suite) {
   this.timeout(process.env.MOCHA_TIMEOUT || 20000);

--- a/sdk/cosmosdb/cosmos/test/public/integration/crossPartition.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/public/integration/crossPartition.spec.ts
@@ -1,19 +1,15 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
-import assert from "assert";
-import { Suite } from "mocha";
+
 import * as util from "util";
 import { Container, ContainerDefinition } from "../../../src";
 import { DataType, IndexKind } from "../../../src";
-import { SqlQuerySpec } from "../../../src";
+import { FeedOptions, FeedResponse } from "../../../src";
+import { bulkInsertItems, generateDocuments, getTestContainer, removeAllDatabases } from "../common/TestHelpers";
 import { QueryIterator } from "../../../src";
-import {
-  bulkInsertItems,
-  getTestContainer,
-  removeAllDatabases,
-  generateDocuments
-} from "../common/TestHelpers";
-import { FeedResponse, FeedOptions } from "../../../src";
+import { SqlQuerySpec } from "../../../src";
+import { Suite } from "mocha";
+import assert from "assert";
 
 function compare(key: string) {
   return function(a: any, b: any): number {

--- a/sdk/cosmosdb/cosmos/test/public/integration/crossPartition.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/public/integration/crossPartition.spec.ts
@@ -5,7 +5,12 @@ import * as util from "util";
 import { Container, ContainerDefinition } from "../../../src";
 import { DataType, IndexKind } from "../../../src";
 import { FeedOptions, FeedResponse } from "../../../src";
-import { bulkInsertItems, generateDocuments, getTestContainer, removeAllDatabases } from "../common/TestHelpers";
+import {
+  bulkInsertItems,
+  generateDocuments,
+  getTestContainer,
+  removeAllDatabases
+} from "../common/TestHelpers";
 import { QueryIterator } from "../../../src";
 import { SqlQuerySpec } from "../../../src";
 import { Suite } from "mocha";

--- a/sdk/cosmosdb/cosmos/test/public/integration/encoding.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/public/integration/encoding.spec.ts
@@ -1,9 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
-import assert from "assert";
-import { Suite } from "mocha";
-import { IndexingMode } from "../../../src";
+
 import { getTestDatabase, removeAllDatabases } from "../common/TestHelpers";
+import { IndexingMode } from "../../../src";
+import { Suite } from "mocha";
+import assert from "assert";
 
 const testDoc = {
   id: "ABC",

--- a/sdk/cosmosdb/cosmos/test/public/integration/failover.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/public/integration/failover.spec.ts
@@ -1,8 +1,9 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
-import { CosmosClient, PluginOn, CosmosClientOptions, PluginConfig } from "../../../src";
-import { masterKey } from "../common/_fakeTestSecrets";
+
+import { CosmosClient, CosmosClientOptions, PluginConfig, PluginOn } from "../../../src";
 import assert from "assert";
+import { masterKey } from "../common/_fakeTestSecrets";
 
 const endpoint = "https://failovertest.documents.azure.com/";
 

--- a/sdk/cosmosdb/cosmos/test/public/integration/multiregion.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/public/integration/multiregion.spec.ts
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
-import assert from "assert";
-import { Suite } from "mocha";
 
+import { CosmosClientOptions, PluginConfig, PluginOn } from "../../../src";
 import { CosmosClient } from "../../../src";
+import { Suite } from "mocha";
+import assert from "assert";
 import { masterKey } from "../common/_fakeTestSecrets";
-import { PluginOn, PluginConfig, CosmosClientOptions } from "../../../src";
 
 const endpoint = "https://failovertest.documents.azure.com/";
 

--- a/sdk/cosmosdb/cosmos/test/public/integration/query.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/public/integration/query.spec.ts
@@ -1,9 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
-import assert from "assert";
-import { Suite } from "mocha";
-import { FeedOptions } from "../../../src";
+
 import { getTestContainer, getTestDatabase, removeAllDatabases } from "../common/TestHelpers";
+import { FeedOptions } from "../../../src";
+import { Suite } from "mocha";
+import assert from "assert";
 
 const doc = { id: "myId", pk: "pk" };
 

--- a/sdk/cosmosdb/cosmos/test/public/integration/queryMetrics.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/public/integration/queryMetrics.spec.ts
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
-import assert from "assert";
+
 import {
   ClientSideMetrics,
   QueryMetrics,
@@ -8,6 +8,7 @@ import {
   RuntimeExecutionTimes,
   TimeSpan
 } from "../../../src";
+import assert from "assert";
 
 describe("QueryMetrics", function() {
   // Properties

--- a/sdk/cosmosdb/cosmos/test/public/integration/split.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/public/integration/split.spec.ts
@@ -1,12 +1,19 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
-import { Container } from "../../../src";
+
+import {
+  Constants,
+  CosmosClient,
+  CosmosClientOptions,
+  PluginConfig,
+  PluginOn
+} from "../../../src";
 import { bulkInsertItems, getTestContainer, removeAllDatabases } from "../common/TestHelpers";
-import { Constants, CosmosClient, PluginOn, CosmosClientOptions, PluginConfig } from "../../../src";
-import { endpoint } from "../common/_testConfig";
-import { masterKey } from "../common/_fakeTestSecrets";
+import { Container } from "../../../src";
 import { SubStatusCodes } from "../../../src/common";
 import assert from "assert";
+import { endpoint } from "../common/_testConfig";
+import { masterKey } from "../common/_fakeTestSecrets";
 
 const splitError = new Error("Fake Partition Split") as any;
 splitError.code = 410;

--- a/sdk/cosmosdb/cosmos/test/public/integration/split.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/public/integration/split.spec.ts
@@ -1,13 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import {
-  Constants,
-  CosmosClient,
-  CosmosClientOptions,
-  PluginConfig,
-  PluginOn
-} from "../../../src";
+import { Constants, CosmosClient, CosmosClientOptions, PluginConfig, PluginOn } from "../../../src";
 import { bulkInsertItems, getTestContainer, removeAllDatabases } from "../common/TestHelpers";
 import { Container } from "../../../src";
 import { SubStatusCodes } from "../../../src/common";

--- a/sdk/cosmosdb/cosmos/test/public/integration/sslVerification.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/public/integration/sslVerification.spec.ts
@@ -1,7 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
-import assert from "assert";
+
 import { CosmosClient } from "../../../src";
+import assert from "assert";
 import { getTestDatabase } from "../common/TestHelpers";
 import https from "https";
 

--- a/sdk/cosmosdb/cosmos/test/public/integration/timeout.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/public/integration/timeout.spec.ts
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import assert from "assert";
 import { Container, CosmosClient } from "../../../src";
 import { addEntropy, removeAllDatabases } from "../common/TestHelpers";
+import assert from "assert";
 import { endpoint } from "../common/_testConfig";
 import { masterKey } from "../common/_fakeTestSecrets";
 


### PR DESCRIPTION
This PR is working in conjunction with other PRs to fix individual sections of the azure codebase with respect to the new ```sort-imports``` rule, as indicated in #9252.

In this PR, I have fixed all files under ```sdk/cosmosdb/cosmos```.