### PR TITLE
[sort-imports] update ```data-tables``` with respect to ```sort-imports``` rule

### DIFF
--- a/sdk/tables/data-tables/src/TableClient.ts
+++ b/sdk/tables/data-tables/src/TableClient.ts
@@ -20,8 +20,17 @@ import {
   UpdateMode,
   UpdateTableEntityOptions
 } from "./models";
-import { DeleteTableEntityResponse, SetAccessPolicyResponse, UpdateEntityResponse, UpsertEntityResponse } from "./generatedModels";
-import { FullOperationResponse, InternalClientPipelineOptions, OperationOptions } from "@azure/core-client";
+import {
+  DeleteTableEntityResponse,
+  SetAccessPolicyResponse,
+  UpdateEntityResponse,
+  UpsertEntityResponse
+} from "./generatedModels";
+import {
+  FullOperationResponse,
+  InternalClientPipelineOptions,
+  OperationOptions
+} from "@azure/core-client";
 import { GeneratedClient, TableDeleteEntityOptionalParams } from "./generated";
 import {
   NamedKeyCredential,

--- a/sdk/tables/data-tables/src/TablePolicies.ts
+++ b/sdk/tables/data-tables/src/TablePolicies.ts
@@ -1,7 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { HeaderConstants, TRANSACTION_HTTP_LINE_ENDING, TRANSACTION_HTTP_VERSION_1_1 } from "./utils/constants";
+import {
+  HeaderConstants,
+  TRANSACTION_HTTP_LINE_ENDING,
+  TRANSACTION_HTTP_VERSION_1_1
+} from "./utils/constants";
 import {
   PipelinePolicy,
   PipelineRequest,

--- a/sdk/tables/data-tables/src/TablePolicies.ts
+++ b/sdk/tables/data-tables/src/TablePolicies.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+import { HeaderConstants, TRANSACTION_HTTP_LINE_ENDING, TRANSACTION_HTTP_VERSION_1_1 } from "./utils/constants";
 import {
   PipelinePolicy,
   PipelineRequest,
@@ -9,13 +10,8 @@ import {
   createHttpHeaders,
   createPipelineRequest
 } from "@azure/core-rest-pipeline";
-import {
-  HeaderConstants,
-  TRANSACTION_HTTP_LINE_ENDING,
-  TRANSACTION_HTTP_VERSION_1_1
-} from "./utils/constants";
-import { getChangeSetBoundary } from "./utils/transactionHelpers";
 import { URL } from "./utils/url";
+import { getChangeSetBoundary } from "./utils/transactionHelpers";
 
 export const transactionRequestAssemblePolicyName = "transactionRequestAssemblePolicy";
 

--- a/sdk/tables/data-tables/src/TableServiceClient.ts
+++ b/sdk/tables/data-tables/src/TableServiceClient.ts
@@ -1,14 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { GeneratedClient } from "./generated/generatedClient";
-import { Service, Table } from "./generated";
-import {
-  ListTableItemsOptions,
-  TableItem,
-  TableQueryOptions,
-  TableServiceClientOptions
-} from "./models";
+import "@azure/core-paging";
 import {
   GetPropertiesResponse,
   GetStatisticsResponse,
@@ -16,7 +9,8 @@ import {
   SetPropertiesOptions,
   SetPropertiesResponse
 } from "./generatedModels";
-import { getClientParamsFromConnectionString } from "./utils/connectionString";
+import { InternalClientPipelineOptions, OperationOptions } from "@azure/core-client";
+import { ListTableItemsOptions, TableItem, TableQueryOptions, TableServiceClientOptions } from "./models";
 import {
   NamedKeyCredential,
   SASCredential,
@@ -25,20 +19,21 @@ import {
   isSASCredential,
   isTokenCredential
 } from "@azure/core-auth";
-import "@azure/core-paging";
-import { PagedAsyncIterableIterator } from "@azure/core-paging";
 import { STORAGE_SCOPE, TablesLoggingAllowedHeaderNames } from "./utils/constants";
-import { logger } from "./logger";
-import { InternalClientPipelineOptions, OperationOptions } from "@azure/core-client";
-import { SpanStatusCode } from "@azure/core-tracing";
-import { createSpan } from "./utils/tracing";
-import { tablesNamedKeyCredentialPolicy } from "./tablesNamedCredentialPolicy";
+import { Service, Table } from "./generated";
 import { parseXML, stringifyXML } from "@azure/core-xml";
+import { GeneratedClient } from "./generated/generatedClient";
+import { PagedAsyncIterableIterator } from "@azure/core-paging";
 import { Pipeline } from "@azure/core-rest-pipeline";
-import { isCredential } from "./utils/isCredential";
-import { tablesSASTokenPolicy } from "./tablesSASTokenPolicy";
+import { SpanStatusCode } from "@azure/core-tracing";
 import { TableItemResultPage } from "./models";
+import { createSpan } from "./utils/tracing";
+import { getClientParamsFromConnectionString } from "./utils/connectionString";
 import { handleTableAlreadyExists } from "./utils/errorHelpers";
+import { isCredential } from "./utils/isCredential";
+import { logger } from "./logger";
+import { tablesNamedKeyCredentialPolicy } from "./tablesNamedCredentialPolicy";
+import { tablesSASTokenPolicy } from "./tablesSASTokenPolicy";
 
 /**
  * A TableServiceClient represents a Client to the Azure Tables service allowing you

--- a/sdk/tables/data-tables/src/TableServiceClient.ts
+++ b/sdk/tables/data-tables/src/TableServiceClient.ts
@@ -10,7 +10,12 @@ import {
   SetPropertiesResponse
 } from "./generatedModels";
 import { InternalClientPipelineOptions, OperationOptions } from "@azure/core-client";
-import { ListTableItemsOptions, TableItem, TableQueryOptions, TableServiceClientOptions } from "./models";
+import {
+  ListTableItemsOptions,
+  TableItem,
+  TableQueryOptions,
+  TableServiceClientOptions
+} from "./models";
 import {
   NamedKeyCredential,
   SASCredential,

--- a/sdk/tables/data-tables/src/TableTransaction.ts
+++ b/sdk/tables/data-tables/src/TableTransaction.ts
@@ -2,21 +2,6 @@
 // Licensed under the MIT license.
 
 import {
-  Pipeline,
-  PipelineRequest,
-  PipelineResponse,
-  RestError,
-  createHttpHeaders,
-  createPipelineRequest
-} from "@azure/core-rest-pipeline";
-import {
-  OperationOptions,
-  ServiceClient,
-  ServiceClientOptions,
-  serializationPolicy,
-  serializationPolicyName
-} from "@azure/core-client";
-import {
   DeleteTableEntityOptions,
   TableEntity,
   TableTransactionEntityResponse,
@@ -33,26 +18,33 @@ import {
   isSASCredential,
   isTokenCredential
 } from "@azure/core-auth";
-import { getAuthorizationHeader } from "./tablesNamedCredentialPolicy";
-import { TableClientLike } from "./utils/internalModels";
-import { createSpan } from "./utils/tracing";
-import { SpanStatusCode } from "@azure/core-tracing";
-import { TableServiceErrorOdataError } from "./generated";
-import { getTransactionHeaders } from "./utils/transactionHeaders";
 import {
-  getInitialTransactionBody,
-  getTransactionHttpRequestBody
-} from "./utils/transactionHelpers";
-import { signURLWithSAS } from "./tablesSASTokenPolicy";
+  OperationOptions,
+  ServiceClient,
+  ServiceClientOptions,
+  serializationPolicy,
+  serializationPolicyName
+} from "@azure/core-client";
 import {
-  transactionHeaderFilterPolicy,
-  transactionHeaderFilterPolicyName,
-  transactionRequestAssemblePolicy,
-  transactionRequestAssemblePolicyName
-} from "./TablePolicies";
-import { isCosmosEndpoint } from "./utils/isCosmosEndpoint";
-import { cosmosPatchPolicy } from "./cosmosPathPolicy";
+  Pipeline,
+  PipelineRequest,
+  PipelineResponse,
+  RestError,
+  createHttpHeaders,
+  createPipelineRequest
+} from "@azure/core-rest-pipeline";
+import { getInitialTransactionBody, getTransactionHttpRequestBody } from "./utils/transactionHelpers";
+import { transactionHeaderFilterPolicy, transactionHeaderFilterPolicyName, transactionRequestAssemblePolicy, transactionRequestAssemblePolicyName } from "./TablePolicies";
 import { STORAGE_SCOPE } from "./utils/constants";
+import { SpanStatusCode } from "@azure/core-tracing";
+import { TableClientLike } from "./utils/internalModels";
+import { TableServiceErrorOdataError } from "./generated";
+import { cosmosPatchPolicy } from "./cosmosPathPolicy";
+import { createSpan } from "./utils/tracing";
+import { getAuthorizationHeader } from "./tablesNamedCredentialPolicy";
+import { getTransactionHeaders } from "./utils/transactionHeaders";
+import { isCosmosEndpoint } from "./utils/isCosmosEndpoint";
+import { signURLWithSAS } from "./tablesSASTokenPolicy";
 
 /**
  * Helper to build a list of transaction actions

--- a/sdk/tables/data-tables/src/TableTransaction.ts
+++ b/sdk/tables/data-tables/src/TableTransaction.ts
@@ -33,8 +33,16 @@ import {
   createHttpHeaders,
   createPipelineRequest
 } from "@azure/core-rest-pipeline";
-import { getInitialTransactionBody, getTransactionHttpRequestBody } from "./utils/transactionHelpers";
-import { transactionHeaderFilterPolicy, transactionHeaderFilterPolicyName, transactionRequestAssemblePolicy, transactionRequestAssemblePolicyName } from "./TablePolicies";
+import {
+  getInitialTransactionBody,
+  getTransactionHttpRequestBody
+} from "./utils/transactionHelpers";
+import {
+  transactionHeaderFilterPolicy,
+  transactionHeaderFilterPolicyName,
+  transactionRequestAssemblePolicy,
+  transactionRequestAssemblePolicyName
+} from "./TablePolicies";
 import { STORAGE_SCOPE } from "./utils/constants";
 import { SpanStatusCode } from "@azure/core-tracing";
 import { TableClientLike } from "./utils/internalModels";

--- a/sdk/tables/data-tables/src/models.ts
+++ b/sdk/tables/data-tables/src/models.ts
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { TableGetAccessPolicyHeaders, TableInsertEntityHeaders } from "./generated/models";
 import { CommonClientOptions, OperationOptions } from "@azure/core-client";
+import { TableGetAccessPolicyHeaders, TableInsertEntityHeaders } from "./generated/models";
 
 /**
  * Represents the Create or Delete Entity operation to be included in a Transaction request

--- a/sdk/tables/data-tables/src/sas/accountSasSignatureValues.ts
+++ b/sdk/tables/data-tables/src/sas/accountSasSignatureValues.ts
@@ -4,7 +4,10 @@
 import { AccountSasPermissions, accountSasPermissionsToString } from "./accountSasPermissions";
 import { SasIPRange, ipRangeToString } from "./sasIPRange";
 import { SasProtocol, SasQueryParameters } from "./sasQueryParameters";
-import { accountSasResourceTypesFromString, accountSasResourceTypesToString } from "./accountSasResourceTypes";
+import {
+  accountSasResourceTypesFromString,
+  accountSasResourceTypesToString
+} from "./accountSasResourceTypes";
 import { accountSasServicesFromString, accountSasServicesToString } from "./accountSasServices";
 import { NamedKeyCredential } from "@azure/core-auth";
 import { SERVICE_VERSION } from "../utils/constants";

--- a/sdk/tables/data-tables/src/sas/accountSasSignatureValues.ts
+++ b/sdk/tables/data-tables/src/sas/accountSasSignatureValues.ts
@@ -1,18 +1,15 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { NamedKeyCredential } from "@azure/core-auth";
-import { computeHMACSHA256 } from "../utils/computeHMACSHA256";
-import { SERVICE_VERSION } from "../utils/constants";
-import { truncatedISO8061Date } from "../utils/truncateISO8061Date";
 import { AccountSasPermissions, accountSasPermissionsToString } from "./accountSasPermissions";
-import {
-  accountSasResourceTypesFromString,
-  accountSasResourceTypesToString
-} from "./accountSasResourceTypes";
-import { accountSasServicesFromString, accountSasServicesToString } from "./accountSasServices";
 import { SasIPRange, ipRangeToString } from "./sasIPRange";
 import { SasProtocol, SasQueryParameters } from "./sasQueryParameters";
+import { accountSasResourceTypesFromString, accountSasResourceTypesToString } from "./accountSasResourceTypes";
+import { accountSasServicesFromString, accountSasServicesToString } from "./accountSasServices";
+import { NamedKeyCredential } from "@azure/core-auth";
+import { SERVICE_VERSION } from "../utils/constants";
+import { computeHMACSHA256 } from "../utils/computeHMACSHA256";
+import { truncatedISO8061Date } from "../utils/truncateISO8061Date";
 
 /**
  * ONLY AVAILABLE IN NODE.JS RUNTIME.

--- a/sdk/tables/data-tables/src/sas/generateAccountSas.ts
+++ b/sdk/tables/data-tables/src/sas/generateAccountSas.ts
@@ -2,7 +2,11 @@
 // Licensed under the MIT license.
 
 import { AccountSasPermissions, accountSasPermissionsFromString } from "./accountSasPermissions";
-import { AccountSasServices, accountSasServicesFromString, accountSasServicesToString } from "./accountSasServices";
+import {
+  AccountSasServices,
+  accountSasServicesFromString,
+  accountSasServicesToString
+} from "./accountSasServices";
 import { NamedKeyCredential, isNamedKeyCredential } from "@azure/core-auth";
 import { SasIPRange } from "./sasIPRange";
 import { SasProtocol } from "./sasQueryParameters";

--- a/sdk/tables/data-tables/src/sas/generateAccountSas.ts
+++ b/sdk/tables/data-tables/src/sas/generateAccountSas.ts
@@ -1,16 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { NamedKeyCredential, isNamedKeyCredential } from "@azure/core-auth";
 import { AccountSasPermissions, accountSasPermissionsFromString } from "./accountSasPermissions";
-import {
-  AccountSasServices,
-  accountSasServicesFromString,
-  accountSasServicesToString
-} from "./accountSasServices";
-import { generateAccountSasQueryParameters } from "./accountSasSignatureValues";
+import { AccountSasServices, accountSasServicesFromString, accountSasServicesToString } from "./accountSasServices";
+import { NamedKeyCredential, isNamedKeyCredential } from "@azure/core-auth";
 import { SasIPRange } from "./sasIPRange";
 import { SasProtocol } from "./sasQueryParameters";
+import { generateAccountSasQueryParameters } from "./accountSasSignatureValues";
 
 /**
  * Generates a Table Account Shared Access Signature (SAS) URI based on the client properties

--- a/sdk/tables/data-tables/src/sas/generateTableSas.ts
+++ b/sdk/tables/data-tables/src/sas/generateTableSas.ts
@@ -2,11 +2,8 @@
 // Licensed under the MIT license.
 
 import { NamedKeyCredential, isNamedKeyCredential } from "@azure/core-auth";
+import { TableSasSignatureValues, generateTableSasQueryParameters } from "./tableSasSignatureValues";
 import { tableSasPermissionsFromString } from "./tableSasPermisions";
-import {
-  TableSasSignatureValues,
-  generateTableSasQueryParameters
-} from "./tableSasSignatureValues";
 
 /**
  * Generates a Table Service Shared Access Signature (SAS) URI based on the client properties

--- a/sdk/tables/data-tables/src/sas/generateTableSas.ts
+++ b/sdk/tables/data-tables/src/sas/generateTableSas.ts
@@ -2,7 +2,10 @@
 // Licensed under the MIT license.
 
 import { NamedKeyCredential, isNamedKeyCredential } from "@azure/core-auth";
-import { TableSasSignatureValues, generateTableSasQueryParameters } from "./tableSasSignatureValues";
+import {
+  TableSasSignatureValues,
+  generateTableSasQueryParameters
+} from "./tableSasSignatureValues";
 import { tableSasPermissionsFromString } from "./tableSasPermisions";
 
 /**

--- a/sdk/tables/data-tables/src/sas/sasQueryParameters.ts
+++ b/sdk/tables/data-tables/src/sas/sasQueryParameters.ts
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { truncatedISO8061Date } from "../utils/truncateISO8061Date";
-import { UserDelegationKey } from "./models";
 import { SasIPRange, ipRangeToString } from "./sasIPRange";
+import { UserDelegationKey } from "./models";
+import { truncatedISO8061Date } from "../utils/truncateISO8061Date";
 
 /**
  * Protocols for generated SAS.

--- a/sdk/tables/data-tables/src/sas/tableSasSignatureValues.ts
+++ b/sdk/tables/data-tables/src/sas/tableSasSignatureValues.ts
@@ -7,13 +7,13 @@
  * TableSASSignatureValues is used to help generating SAS tokens for tables.
  */
 
-import { NamedKeyCredential } from "@azure/core-auth";
-import { computeHMACSHA256 } from "../utils/computeHMACSHA256";
-import { SERVICE_VERSION } from "../utils/constants";
-import { truncatedISO8061Date } from "../utils/truncateISO8061Date";
 import { SasIPRange, ipRangeToString } from "./sasIPRange";
 import { SasProtocol, SasQueryParameters } from "./sasQueryParameters";
 import { TableSasPermissions, tableSasPermissionsToString } from "./tableSasPermisions";
+import { NamedKeyCredential } from "@azure/core-auth";
+import { SERVICE_VERSION } from "../utils/constants";
+import { computeHMACSHA256 } from "../utils/computeHMACSHA256";
+import { truncatedISO8061Date } from "../utils/truncateISO8061Date";
 
 /**
  * ONLY AVAILABLE IN NODE.JS RUNTIME.

--- a/sdk/tables/data-tables/src/serialization.ts
+++ b/sdk/tables/data-tables/src/serialization.ts
@@ -1,12 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
-import { base64Decode, base64Encode } from "./utils/bufferSerializer";
+
 import { EdmTypes, SignedIdentifier, TableEntityQueryOptions } from "./models";
+import { QueryOptions as GeneratedQueryOptions, SignedIdentifier as GeneratedSignedIdentifier } from "./generated/models";
+import { base64Decode, base64Encode } from "./utils/bufferSerializer";
 import { truncatedISO8061Date } from "./utils/truncateISO8061Date";
-import {
-  QueryOptions as GeneratedQueryOptions,
-  SignedIdentifier as GeneratedSignedIdentifier
-} from "./generated/models";
 
 const propertyCaseMap: Map<string, string> = new Map<string, string>([
   ["PartitionKey", "partitionKey"],

--- a/sdk/tables/data-tables/src/serialization.ts
+++ b/sdk/tables/data-tables/src/serialization.ts
@@ -2,7 +2,10 @@
 // Licensed under the MIT license.
 
 import { EdmTypes, SignedIdentifier, TableEntityQueryOptions } from "./models";
-import { QueryOptions as GeneratedQueryOptions, SignedIdentifier as GeneratedSignedIdentifier } from "./generated/models";
+import {
+  QueryOptions as GeneratedQueryOptions,
+  SignedIdentifier as GeneratedSignedIdentifier
+} from "./generated/models";
 import { base64Decode, base64Encode } from "./utils/bufferSerializer";
 import { truncatedISO8061Date } from "./utils/truncateISO8061Date";
 

--- a/sdk/tables/data-tables/src/tablesNamedCredentialPolicy.ts
+++ b/sdk/tables/data-tables/src/tablesNamedCredentialPolicy.ts
@@ -1,14 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import {
-  PipelinePolicy,
-  PipelineRequest,
-  PipelineResponse,
-  SendRequest
-} from "@azure/core-rest-pipeline";
-import { NamedKeyCredential } from "@azure/core-auth";
+import { PipelinePolicy, PipelineRequest, PipelineResponse, SendRequest } from "@azure/core-rest-pipeline";
 import { HeaderConstants } from "./utils/constants";
+import { NamedKeyCredential } from "@azure/core-auth";
 import { URL } from "./utils/url";
 import { computeHMACSHA256 } from "./utils/computeHMACSHA256";
 

--- a/sdk/tables/data-tables/src/tablesNamedCredentialPolicy.ts
+++ b/sdk/tables/data-tables/src/tablesNamedCredentialPolicy.ts
@@ -1,7 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { PipelinePolicy, PipelineRequest, PipelineResponse, SendRequest } from "@azure/core-rest-pipeline";
+import {
+  PipelinePolicy,
+  PipelineRequest,
+  PipelineResponse,
+  SendRequest
+} from "@azure/core-rest-pipeline";
 import { HeaderConstants } from "./utils/constants";
 import { NamedKeyCredential } from "@azure/core-auth";
 import { URL } from "./utils/url";

--- a/sdk/tables/data-tables/src/tablesSASTokenPolicy.ts
+++ b/sdk/tables/data-tables/src/tablesSASTokenPolicy.ts
@@ -1,14 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import {
-  PipelinePolicy,
-  PipelineRequest,
-  PipelineResponse,
-  SendRequest
-} from "@azure/core-rest-pipeline";
-import { SASCredential } from "@azure/core-auth";
+import { PipelinePolicy, PipelineRequest, PipelineResponse, SendRequest } from "@azure/core-rest-pipeline";
 import { URL, URLSearchParams } from "./utils/url";
+import { SASCredential } from "@azure/core-auth";
 
 /**
  * The programmatic identifier of the tablesSASTokenPolicy.

--- a/sdk/tables/data-tables/src/tablesSASTokenPolicy.ts
+++ b/sdk/tables/data-tables/src/tablesSASTokenPolicy.ts
@@ -1,7 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { PipelinePolicy, PipelineRequest, PipelineResponse, SendRequest } from "@azure/core-rest-pipeline";
+import {
+  PipelinePolicy,
+  PipelineRequest,
+  PipelineResponse,
+  SendRequest
+} from "@azure/core-rest-pipeline";
 import { URL, URLSearchParams } from "./utils/url";
 import { SASCredential } from "@azure/core-auth";
 

--- a/sdk/tables/data-tables/src/utils/accountConnectionString.browser.ts
+++ b/sdk/tables/data-tables/src/utils/accountConnectionString.browser.ts
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { TableServiceClientOptions } from "..";
 import { ConnectionString } from "./internalModels";
+import { TableServiceClientOptions } from "..";
 
 /**
  * Gets client parameters from an Account Connection String

--- a/sdk/tables/data-tables/src/utils/accountConnectionString.ts
+++ b/sdk/tables/data-tables/src/utils/accountConnectionString.ts
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { TableServiceClientOptions } from "..";
 import { ClientParamsFromConnectionString, ConnectionString } from "./internalModels";
 import { AzureNamedKeyCredential } from "@azure/core-auth";
+import { TableServiceClientOptions } from "..";
 
 /**
  * Gets client parameters from an Account Connection String

--- a/sdk/tables/data-tables/src/utils/connectionString.ts
+++ b/sdk/tables/data-tables/src/utils/connectionString.ts
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { TableServiceClientOptions } from "../models";
-import { fromAccountConnectionString, getAccountConnectionString } from "./accountConnectionString";
 import { ClientParamsFromConnectionString, ConnectionString } from "./internalModels";
+import { fromAccountConnectionString, getAccountConnectionString } from "./accountConnectionString";
+import { TableServiceClientOptions } from "../models";
 import { URL } from "./url";
 
 const DevelopmentConnectionString =

--- a/sdk/tables/data-tables/src/utils/errorHelpers.ts
+++ b/sdk/tables/data-tables/src/utils/errorHelpers.ts
@@ -3,8 +3,8 @@
 
 import { OperationOptions, OperationRequest } from "@azure/core-client";
 import { PipelineResponse, RestError } from "@azure/core-rest-pipeline";
-import { SpanStatusCode } from "@azure/core-tracing";
 import { AzureLogger } from "@azure/logger";
+import { SpanStatusCode } from "@azure/core-tracing";
 import { TableServiceError } from "../generated";
 
 export type TableServiceErrorResponse = PipelineResponse & {

--- a/sdk/tables/data-tables/src/utils/internalModels.ts
+++ b/sdk/tables/data-tables/src/utils/internalModels.ts
@@ -16,11 +16,11 @@ import {
   UpdateMode,
   UpdateTableEntityOptions
 } from "../models";
+import { DeleteTableEntityResponse, UpdateEntityResponse, UpsertEntityResponse } from "..";
 import { Pipeline, PipelineRequest } from "@azure/core-rest-pipeline";
 import { NamedKeyCredential } from "@azure/core-auth";
-import { DeleteTableEntityResponse, UpdateEntityResponse, UpsertEntityResponse } from "..";
-import { PagedAsyncIterableIterator } from "@azure/core-paging";
 import { OperationOptions } from "@azure/core-client";
+import { PagedAsyncIterableIterator } from "@azure/core-paging";
 
 export interface ConnectionString {
   kind: "AccountConnString" | "SASConnString";

--- a/sdk/tables/data-tables/test/internal/odata.spec.ts
+++ b/sdk/tables/data-tables/test/internal/odata.spec.ts
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { odata } from "../../src";
 import { assert } from "chai";
+import { odata } from "../../src";
 
 describe("odata", () => {
   it("should handle empty string", () => {

--- a/sdk/tables/data-tables/test/internal/serialization.spec.ts
+++ b/sdk/tables/data-tables/test/internal/serialization.spec.ts
@@ -1,15 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { assert } from "chai";
-
+import { deserialize, deserializeSignedIdentifier, serialize, serializeSignedIdentifiers } from "../../src/serialization";
 import { Edm } from "../../src";
-import {
-  deserialize,
-  deserializeSignedIdentifier,
-  serialize,
-  serializeSignedIdentifiers
-} from "../../src/serialization";
+import { assert } from "chai";
 import { isNode8 } from "@azure/test-utils";
 
 interface Entity {

--- a/sdk/tables/data-tables/test/internal/serialization.spec.ts
+++ b/sdk/tables/data-tables/test/internal/serialization.spec.ts
@@ -1,7 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { deserialize, deserializeSignedIdentifier, serialize, serializeSignedIdentifiers } from "../../src/serialization";
+import {
+  deserialize,
+  deserializeSignedIdentifier,
+  serialize,
+  serializeSignedIdentifiers
+} from "../../src/serialization";
 import { Edm } from "../../src";
 import { assert } from "chai";
 import { isNode8 } from "@azure/test-utils";

--- a/sdk/tables/data-tables/test/internal/sharedKeyCredential.spec.ts
+++ b/sdk/tables/data-tables/test/internal/sharedKeyCredential.spec.ts
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { Context } from "mocha";
 import {
   PipelineRequest,
   PipelineResponse,
@@ -9,12 +8,12 @@ import {
   createHttpHeaders,
   createPipelineRequest
 } from "@azure/core-rest-pipeline";
-import { isNode } from "@azure/test-utils";
-import { assert } from "chai";
-
-import { tablesNamedKeyCredentialPolicy } from "../../src/tablesNamedCredentialPolicy";
 import { AzureNamedKeyCredential } from "@azure/core-auth";
+import { Context } from "mocha";
+import { assert } from "chai";
 import { expectedSharedKeyLiteHeader } from "./fakeTestSecrets";
+import { isNode } from "@azure/test-utils";
+import { tablesNamedKeyCredentialPolicy } from "../../src/tablesNamedCredentialPolicy";
 
 describe("TablesSharedKeyCredential", () => {
   let originalToUTCString: () => string;

--- a/sdk/tables/data-tables/test/internal/tableTransaction.spec.ts
+++ b/sdk/tables/data-tables/test/internal/tableTransaction.spec.ts
@@ -1,13 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+import { PipelineResponse, createHttpHeaders, createPipelineRequest } from "@azure/core-rest-pipeline";
 import { assert } from "chai";
 import { parseTransactionResponse } from "../../src/TableTransaction";
-import {
-  PipelineResponse,
-  createHttpHeaders,
-  createPipelineRequest
-} from "@azure/core-rest-pipeline";
 
 describe("TableTransaction", () => {
   describe("parseTransactionResponse", () => {

--- a/sdk/tables/data-tables/test/internal/tableTransaction.spec.ts
+++ b/sdk/tables/data-tables/test/internal/tableTransaction.spec.ts
@@ -1,7 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { PipelineResponse, createHttpHeaders, createPipelineRequest } from "@azure/core-rest-pipeline";
+import {
+  PipelineResponse,
+  createHttpHeaders,
+  createPipelineRequest
+} from "@azure/core-rest-pipeline";
 import { assert } from "chai";
 import { parseTransactionResponse } from "../../src/TableTransaction";
 

--- a/sdk/tables/data-tables/test/internal/utils.spec.ts
+++ b/sdk/tables/data-tables/test/internal/utils.spec.ts
@@ -1,12 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { extractConnectionStringParts } from "../../src/utils/connectionString";
-import { Context } from "mocha";
 import { base64Decode, base64Encode } from "../../src/utils/bufferSerializer";
-import { isNode } from "@azure/test-utils";
-import { assert } from "chai";
 import { ConnectionString } from "../../src/utils/internalModels";
+import { Context } from "mocha";
+import { assert } from "chai";
+import { extractConnectionStringParts } from "../../src/utils/connectionString";
+import { isNode } from "@azure/test-utils";
 
 describe("Utility Helpers", () => {
   describe("extractConnectionStringParts", () => {

--- a/sdk/tables/data-tables/test/public/accessPolicy.spec.ts
+++ b/sdk/tables/data-tables/test/public/accessPolicy.spec.ts
@@ -1,12 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { TableClient } from "../../src";
-import { Context } from "mocha";
 import { Recorder, isPlaybackMode, record } from "@azure-tools/test-recorder";
 import { createTableClient, recordedEnvironmentSetup } from "./utils/recordedClient";
-import { isNode } from "@azure/test-utils";
+import { Context } from "mocha";
+import { TableClient } from "../../src";
 import { assert } from "chai";
+import { isNode } from "@azure/test-utils";
 
 describe(`Access Policy operations`, () => {
   let client: TableClient;

--- a/sdk/tables/data-tables/test/public/createTable.spec.ts
+++ b/sdk/tables/data-tables/test/public/createTable.spec.ts
@@ -2,11 +2,11 @@
 // Licensed under the MIT license.
 
 import { RestError, TableClient, TableServiceClient } from "../../src";
-import { Context } from "mocha";
-import { assert } from "chai";
 import { createTableClient, createTableServiceClient } from "./utils/recordedClient";
-import { createHttpHeaders } from "@azure/core-rest-pipeline";
+import { Context } from "mocha";
 import { TableServiceErrorResponse } from "../../src/utils/errorHelpers";
+import { assert } from "chai";
+import { createHttpHeaders } from "@azure/core-rest-pipeline";
 
 describe("TableClient CreationHandling", () => {
   let client: TableClient;

--- a/sdk/tables/data-tables/test/public/specialCharacters.spec.ts
+++ b/sdk/tables/data-tables/test/public/specialCharacters.spec.ts
@@ -1,12 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { TableClient, TableEntityResult, TransactionAction, odata } from "../../src";
-import { assert } from "chai";
-import { createTableClient, recordedEnvironmentSetup } from "./utils/recordedClient";
-import { isNode } from "@azure/test-utils";
 import { Recorder, isLiveMode, record } from "@azure-tools/test-recorder";
+import { TableClient, TableEntityResult, TransactionAction, odata } from "../../src";
+import { createTableClient, recordedEnvironmentSetup } from "./utils/recordedClient";
 import { Context } from "mocha";
+import { assert } from "chai";
+import { isNode } from "@azure/test-utils";
 
 describe("SpecialCharacters", function() {
   before(function(this: Context) {

--- a/sdk/tables/data-tables/test/public/tableclient.spec.ts
+++ b/sdk/tables/data-tables/test/public/tableclient.spec.ts
@@ -1,14 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { CreateClientMode, createTableClient, recordedEnvironmentSetup } from "./utils/recordedClient";
 import {
-  Edm,
-  TableClient,
-  TableEntity,
-  TableEntityResult,
-  odata
-} from "../../src";
+  CreateClientMode,
+  createTableClient,
+  recordedEnvironmentSetup
+} from "./utils/recordedClient";
+import { Edm, TableClient, TableEntity, TableEntityResult, odata } from "../../src";
 import { Recorder, isLiveMode, isPlaybackMode, record } from "@azure-tools/test-recorder";
 import { isNode, isNode8 } from "@azure/test-utils";
 import { Context } from "mocha";

--- a/sdk/tables/data-tables/test/public/tableclient.spec.ts
+++ b/sdk/tables/data-tables/test/public/tableclient.spec.ts
@@ -1,17 +1,19 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { Edm, TableClient, TableEntity, TableEntityResult, odata } from "../../src";
-import { Context } from "mocha";
-import { assert } from "chai";
-import { Recorder, isLiveMode, isPlaybackMode, record } from "@azure-tools/test-recorder";
+import { CreateClientMode, createTableClient, recordedEnvironmentSetup } from "./utils/recordedClient";
 import {
-  CreateClientMode,
-  createTableClient,
-  recordedEnvironmentSetup
-} from "./utils/recordedClient";
+  Edm,
+  TableClient,
+  TableEntity,
+  TableEntityResult,
+  odata
+} from "../../src";
+import { Recorder, isLiveMode, isPlaybackMode, record } from "@azure-tools/test-recorder";
 import { isNode, isNode8 } from "@azure/test-utils";
+import { Context } from "mocha";
 import { FullOperationResponse } from "@azure/core-client";
+import { assert } from "chai";
 
 // SASConnectionString and SASToken are supported in both node and browser
 const authModes: CreateClientMode[] = ["TokenCredential", "SASConnectionString"];

--- a/sdk/tables/data-tables/test/public/tableserviceclient.spec.ts
+++ b/sdk/tables/data-tables/test/public/tableserviceclient.spec.ts
@@ -1,17 +1,13 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+import { CreateClientMode, createTableServiceClient, recordedEnvironmentSetup } from "./utils/recordedClient";
+import { Recorder, isLiveMode, isPlaybackMode, record } from "@azure-tools/test-recorder";
 import { TableItem, TableItemResultPage, TableServiceClient } from "../../src";
 import { Context } from "mocha";
-import { Recorder, isLiveMode, isPlaybackMode, record } from "@azure-tools/test-recorder";
-import {
-  CreateClientMode,
-  createTableServiceClient,
-  recordedEnvironmentSetup
-} from "./utils/recordedClient";
-import { isNode } from "@azure/test-utils";
-import { assert } from "chai";
 import { FullOperationResponse } from "@azure/core-client";
+import { assert } from "chai";
+import { isNode } from "@azure/test-utils";
 
 // SASConnectionString and SASToken are supported in both node and browser
 const authModes: CreateClientMode[] = ["TokenCredential", "SASConnectionString"];

--- a/sdk/tables/data-tables/test/public/tableserviceclient.spec.ts
+++ b/sdk/tables/data-tables/test/public/tableserviceclient.spec.ts
@@ -1,7 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { CreateClientMode, createTableServiceClient, recordedEnvironmentSetup } from "./utils/recordedClient";
+import {
+  CreateClientMode,
+  createTableServiceClient,
+  recordedEnvironmentSetup
+} from "./utils/recordedClient";
 import { Recorder, isLiveMode, isPlaybackMode, record } from "@azure-tools/test-recorder";
 import { TableItem, TableItemResultPage, TableServiceClient } from "../../src";
 import { Context } from "mocha";

--- a/sdk/tables/data-tables/test/public/transaction.spec.ts
+++ b/sdk/tables/data-tables/test/public/transaction.spec.ts
@@ -1,18 +1,14 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+import * as sinon from "sinon";
+import { CreateClientMode, createTableClient, recordedEnvironmentSetup } from "./utils/recordedClient";
+import { Recorder, isLiveMode, isPlaybackMode, record } from "@azure-tools/test-recorder";
 import { TableClient, TableTransaction, TransactionAction, odata } from "../../src";
 import { Context } from "mocha";
-import { assert } from "chai";
-import { Recorder, isLiveMode, isPlaybackMode, record } from "@azure-tools/test-recorder";
-import {
-  CreateClientMode,
-  createTableClient,
-  recordedEnvironmentSetup
-} from "./utils/recordedClient";
-import { isNode } from "@azure/test-utils";
 import { Uuid } from "../../src/utils/uuid";
-import * as sinon from "sinon";
+import { assert } from "chai";
+import { isNode } from "@azure/test-utils";
 
 // SASConnectionString and SASToken are supported in both node and browser
 const authModes: CreateClientMode[] = ["TokenCredential", "SASConnectionString"];

--- a/sdk/tables/data-tables/test/public/transaction.spec.ts
+++ b/sdk/tables/data-tables/test/public/transaction.spec.ts
@@ -2,7 +2,11 @@
 // Licensed under the MIT license.
 
 import * as sinon from "sinon";
-import { CreateClientMode, createTableClient, recordedEnvironmentSetup } from "./utils/recordedClient";
+import {
+  CreateClientMode,
+  createTableClient,
+  recordedEnvironmentSetup
+} from "./utils/recordedClient";
 import { Recorder, isLiveMode, isPlaybackMode, record } from "@azure-tools/test-recorder";
 import { TableClient, TableTransaction, TransactionAction, odata } from "../../src";
 import { Context } from "mocha";

--- a/sdk/tables/data-tables/test/public/utils/recordedClient.ts
+++ b/sdk/tables/data-tables/test/public/utils/recordedClient.ts
@@ -1,13 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { RecorderEnvironmentSetup, env } from "@azure-tools/test-recorder";
-
-import { ClientSecretCredential } from "@azure/identity";
-import { TableClient, TableServiceClient } from "../../../src";
-import { AzureNamedKeyCredential, AzureSASCredential } from "@azure/core-auth";
-
 import "./env";
+import { AzureNamedKeyCredential, AzureSASCredential } from "@azure/core-auth";
+import { RecorderEnvironmentSetup, env } from "@azure-tools/test-recorder";
+import { TableClient, TableServiceClient } from "../../../src";
+import { ClientSecretCredential } from "@azure/identity";
 
 const mockAccountName = "fakeaccount";
 const mockAccountKey = "fakeKey";


### PR DESCRIPTION
This PR is working in conjunction with other PRs to fix individual sections of the azure codebase with respect to the new ```sort-imports``` rule, as indicated in #9252.

In this PR, I have fixed all files under ```sdk/tables/data-tables```.