### PR TITLE
[sort-imports] update ```digital-twins-core``` with respect to ```sort-imports``` rule

### DIFF
--- a/sdk/digitaltwins/digital-twins-core/src/digitalTwinsClient.ts
+++ b/sdk/digitaltwins/digital-twins-core/src/digitalTwinsClient.ts
@@ -4,56 +4,56 @@
 /// <reference lib="esnext.asynciterable" />
 
 import {
-  TokenCredential,
-  RestResponse,
-  OperationOptions,
-  InternalPipelineOptions,
-  bearerTokenAuthenticationPolicy,
-  createPipelineFromOptions,
-  generateUuid,
-  PipelineOptions
-} from "@azure/core-http";
-import { PageSettings, PagedAsyncIterableIterator } from "@azure/core-paging";
-import { AzureDigitalTwinsAPI as GeneratedClient } from "./generated/azureDigitalTwinsAPI";
-import {
-  DigitalTwinsGetByIdResponse,
+  DigitalTwinModelsAddOptionalParams,
+  DigitalTwinModelsAddResponse,
+  DigitalTwinModelsGetByIdOptionalParams,
+  DigitalTwinModelsGetByIdResponse,
+  DigitalTwinModelsListOptionalParams,
+  DigitalTwinModelsListResponse,
   DigitalTwinsAddOptionalParams,
-  DigitalTwinsAddResponse,
-  DigitalTwinsUpdateOptionalParams,
-  DigitalTwinsUpdateResponse,
-  DigitalTwinsDeleteOptionalParams,
-  DigitalTwinsGetComponentResponse,
-  DigitalTwinsUpdateComponentResponse,
-  DigitalTwinsUpdateComponentOptionalParams,
-  DigitalTwinsAddRelationshipResponse,
   DigitalTwinsAddRelationshipOptionalParams,
+  DigitalTwinsAddRelationshipResponse,
+  DigitalTwinsAddResponse,
+  DigitalTwinsDeleteOptionalParams,
+  DigitalTwinsDeleteRelationshipOptionalParams,
+  DigitalTwinsGetByIdResponse,
+  DigitalTwinsGetComponentResponse,
+  DigitalTwinsGetRelationshipByIdResponse,
+  DigitalTwinsListIncomingRelationshipsResponse,
+  DigitalTwinsListRelationshipsResponse,
+  DigitalTwinsModelData,
+  DigitalTwinsSendComponentTelemetryOptionalParams,
+  DigitalTwinsSendTelemetryOptionalParams,
+  DigitalTwinsUpdateComponentOptionalParams,
+  DigitalTwinsUpdateComponentResponse,
+  DigitalTwinsUpdateOptionalParams,
   DigitalTwinsUpdateRelationshipOptionalParams,
   DigitalTwinsUpdateRelationshipResponse,
-  DigitalTwinsDeleteRelationshipOptionalParams,
-  DigitalTwinsSendTelemetryOptionalParams,
-  DigitalTwinsSendComponentTelemetryOptionalParams,
-  DigitalTwinsListRelationshipsResponse,
-  IncomingRelationship,
-  DigitalTwinsListIncomingRelationshipsResponse,
-  DigitalTwinsGetRelationshipByIdResponse,
-  DigitalTwinsModelData,
-  DigitalTwinModelsGetByIdResponse,
-  DigitalTwinModelsGetByIdOptionalParams,
-  DigitalTwinModelsAddResponse,
-  DigitalTwinModelsAddOptionalParams,
-  DigitalTwinModelsListResponse,
-  DigitalTwinModelsListOptionalParams,
-  EventRoutesGetByIdResponse,
+  DigitalTwinsUpdateResponse,
   EventRoute,
   EventRoutesAddOptionalParams,
+  EventRoutesGetByIdResponse,
   EventRoutesListNextResponse,
   EventRoutesListOptionalParams,
+  IncomingRelationship,
   QueryQueryTwinsOptionalParams,
   QueryQueryTwinsResponse,
   QuerySpecification
 } from "./generated/models";
-import { createSpan } from "./tracing";
+import {
+  InternalPipelineOptions,
+  OperationOptions,
+  PipelineOptions,
+  RestResponse,
+  TokenCredential,
+  bearerTokenAuthenticationPolicy,
+  createPipelineFromOptions,
+  generateUuid
+} from "@azure/core-http";
+import { PageSettings, PagedAsyncIterableIterator } from "@azure/core-paging";
+import { AzureDigitalTwinsAPI as GeneratedClient } from "./generated/azureDigitalTwinsAPI";
 import { SpanStatusCode } from "@azure/core-tracing";
+import { createSpan } from "./tracing";
 import { logger } from "./logger";
 
 export const SDK_VERSION: string = "1.1.0";

--- a/sdk/digitaltwins/digital-twins-core/test/internal/digitalTwinsClient.spec.ts
+++ b/sdk/digitaltwins/digital-twins-core/test/internal/digitalTwinsClient.spec.ts
@@ -1,36 +1,36 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { assert, expect } from "chai";
 import * as sinon from "sinon";
 import {
-  TokenCredential,
-  OperationOptions,
-  HttpOperationResponse,
-  HttpResponse,
-  WebResource,
-  HttpHeaders
-} from "@azure/core-http";
-import {
-  DigitalTwinsUpdateOptionalParams,
-  DigitalTwinsDeleteOptionalParams,
-  DigitalTwinsUpdateComponentOptionalParams,
-  DigitalTwinsAddRelationshipOptionalParams,
-  DigitalTwinsUpdateRelationshipOptionalParams,
-  DigitalTwinsDeleteRelationshipOptionalParams,
-  DigitalTwinModelsGetByIdOptionalParams,
   DigitalTwinModelsAddOptionalParams,
+  DigitalTwinModelsDeleteOptionalParams,
+  DigitalTwinModelsGetByIdOptionalParams,
+  DigitalTwinModelsUpdateOptionalParams,
+  DigitalTwinsAddOptionalParams,
+  DigitalTwinsAddRelationshipOptionalParams,
+  DigitalTwinsDeleteOptionalParams,
+  DigitalTwinsDeleteRelationshipOptionalParams,
+  DigitalTwinsGetByIdOptionalParams,
+  DigitalTwinsGetComponentOptionalParams,
+  DigitalTwinsGetRelationshipByIdOptionalParams,
+  DigitalTwinsUpdateComponentOptionalParams,
+  DigitalTwinsUpdateOptionalParams,
+  DigitalTwinsUpdateRelationshipOptionalParams,
   EventRoute,
   EventRoutesAddOptionalParams,
   EventRoutesDeleteOptionalParams,
-  EventRoutesGetByIdOptionalParams,
-  DigitalTwinModelsDeleteOptionalParams,
-  DigitalTwinModelsUpdateOptionalParams,
-  DigitalTwinsGetRelationshipByIdOptionalParams,
-  DigitalTwinsGetComponentOptionalParams,
-  DigitalTwinsAddOptionalParams,
-  DigitalTwinsGetByIdOptionalParams
+  EventRoutesGetByIdOptionalParams
 } from "../../src/generated/models";
+import {
+  HttpHeaders,
+  HttpOperationResponse,
+  HttpResponse,
+  OperationOptions,
+  TokenCredential,
+  WebResource
+} from "@azure/core-http";
+import { assert, expect } from "chai";
 import { DigitalTwinsClient } from "../../src/index";
 import { createSpan } from "../../src/tracing";
 import { getSpanContext } from "@azure/core-tracing";

--- a/sdk/digitaltwins/digital-twins-core/test/public/testComponents.spec.ts
+++ b/sdk/digitaltwins/digital-twins-core/test/public/testComponents.spec.ts
@@ -2,8 +2,8 @@
 // Licensed under the MIT license.
 
 import { DigitalTwinsClient, DigitalTwinsUpdateComponentOptionalParams } from "../../src";
-import { authenticate } from "../utils/testAuthentication";
 import { Recorder } from "@azure-tools/test-recorder";
+import { authenticate } from "../utils/testAuthentication";
 import chai from "chai";
 
 const assert = chai.assert;

--- a/sdk/digitaltwins/digital-twins-core/test/public/testDigitalTwins.spec.ts
+++ b/sdk/digitaltwins/digital-twins-core/test/public/testDigitalTwins.spec.ts
@@ -1,16 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import {
-  DigitalTwinsClient,
-  DigitalTwinsAddOptionalParams,
-  DigitalTwinsDeleteOptionalParams,
-  DigitalTwinsUpdateOptionalParams
-} from "../../src";
-import { authenticate } from "../utils/testAuthentication";
+import { DigitalTwinsAddOptionalParams, DigitalTwinsClient, DigitalTwinsDeleteOptionalParams, DigitalTwinsUpdateOptionalParams } from "../../src";
 import { Recorder } from "@azure-tools/test-recorder";
-import { delay } from "@azure/core-http";
+import { authenticate } from "../utils/testAuthentication";
 import chai from "chai";
+import { delay } from "@azure/core-http";
 
 const assert = chai.assert;
 const should = chai.should();

--- a/sdk/digitaltwins/digital-twins-core/test/public/testDigitalTwins.spec.ts
+++ b/sdk/digitaltwins/digital-twins-core/test/public/testDigitalTwins.spec.ts
@@ -1,7 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { DigitalTwinsAddOptionalParams, DigitalTwinsClient, DigitalTwinsDeleteOptionalParams, DigitalTwinsUpdateOptionalParams } from "../../src";
+import {
+  DigitalTwinsAddOptionalParams,
+  DigitalTwinsClient,
+  DigitalTwinsDeleteOptionalParams,
+  DigitalTwinsUpdateOptionalParams
+} from "../../src";
 import { Recorder } from "@azure-tools/test-recorder";
 import { authenticate } from "../utils/testAuthentication";
 import chai from "chai";

--- a/sdk/digitaltwins/digital-twins-core/test/public/testEventRoutes.spec.ts
+++ b/sdk/digitaltwins/digital-twins-core/test/public/testEventRoutes.spec.ts
@@ -2,8 +2,8 @@
 // Licensed under the MIT license.
 
 import { DigitalTwinsClient } from "../../src";
-import { authenticate } from "../utils/testAuthentication";
 import { Recorder } from "@azure-tools/test-recorder";
+import { authenticate } from "../utils/testAuthentication";
 import chai from "chai";
 
 const assert = chai.assert;

--- a/sdk/digitaltwins/digital-twins-core/test/public/testModels.spec.ts
+++ b/sdk/digitaltwins/digital-twins-core/test/public/testModels.spec.ts
@@ -2,8 +2,8 @@
 // Licensed under the MIT license.
 
 import { DigitalTwinsClient } from "../../src";
-import { authenticate } from "../utils/testAuthentication";
 import { Recorder } from "@azure-tools/test-recorder";
+import { authenticate } from "../utils/testAuthentication";
 import chai from "chai";
 import { delay } from "@azure/core-http";
 

--- a/sdk/digitaltwins/digital-twins-core/test/public/testRelationships.spec.ts
+++ b/sdk/digitaltwins/digital-twins-core/test/public/testRelationships.spec.ts
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { DigitalTwinsClient, DigitalTwinsAddRelationshipOptionalParams } from "../../src";
-import { authenticate } from "../utils/testAuthentication";
+import { DigitalTwinsAddRelationshipOptionalParams, DigitalTwinsClient } from "../../src";
 import { Recorder } from "@azure-tools/test-recorder";
+import { authenticate } from "../utils/testAuthentication";
 import chai from "chai";
 
 const assert = chai.assert;

--- a/sdk/digitaltwins/digital-twins-core/test/utils/recorderUtils.ts
+++ b/sdk/digitaltwins/digital-twins-core/test/utils/recorderUtils.ts
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { isPlaybackMode } from "@azure-tools/test-recorder";
-import { isNode } from "@azure/core-http";
 import * as dotenv from "dotenv";
+import { isNode } from "@azure/core-http";
+import { isPlaybackMode } from "@azure-tools/test-recorder";
 
 if (isNode) {
   dotenv.config();

--- a/sdk/digitaltwins/digital-twins-core/test/utils/testAuthentication.ts
+++ b/sdk/digitaltwins/digital-twins-core/test/utils/testAuthentication.ts
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+import { RecorderEnvironmentSetup, env, record } from "@azure-tools/test-recorder";
 import { ClientSecretCredential } from "@azure/identity";
 import { DigitalTwinsClient } from "../../src";
-import { env, record, RecorderEnvironmentSetup } from "@azure-tools/test-recorder";
-import { uniqueString } from "./recorderUtils";
 import TestClient from "./testClient";
+import { uniqueString } from "./recorderUtils";
 
 export async function authenticate(that: Mocha.Context): Promise<any> {
   const keySuffix = uniqueString();


### PR DESCRIPTION
This PR is working in conjunction with other PRs to fix individual sections of the azure codebase with respect to the new ```sort-imports``` rule, as indicated in #9252.

In this PR, I have fixed all files under ```sdk/digitaltwins/digital-twins-core```.