### PR TITLE
[sort-imports] update ```event-hubs``` with respect to ```sort-imports``` rule

### DIFF
--- a/sdk/eventhub/event-hubs/src/batchingPartitionChannel.ts
+++ b/sdk/eventhub/event-hubs/src/batchingPartitionChannel.ts
@@ -9,9 +9,9 @@ import {
   EventHubProducerClient,
   OperationOptions
 } from "./index";
-import { AwaitableQueue } from "./impl/awaitableQueue";
 import { isDefined, isObjectWithProperties } from "./util/typeGuards";
 import { AbortSignalLike } from "@azure/abort-controller";
+import { AwaitableQueue } from "./impl/awaitableQueue";
 import { getPromiseParts } from "./util/getPromiseParts";
 import { logger } from "./log";
 

--- a/sdk/eventhub/event-hubs/src/connectionContext.ts
+++ b/sdk/eventhub/event-hubs/src/connectionContext.ts
@@ -4,13 +4,7 @@
 /* eslint-disable @typescript-eslint/no-namespace */
 /* eslint-disable no-inner-declarations */
 
-import {
-  Connection,
-  ConnectionEvents,
-  Dictionary,
-  EventContext,
-  OnAmqpEvent
-} from "rhea-promise";
+import { Connection, ConnectionEvents, Dictionary, EventContext, OnAmqpEvent } from "rhea-promise";
 import {
   ConnectionConfig,
   ConnectionContextBase,
@@ -19,7 +13,10 @@ import {
   SasTokenProvider,
   createSasTokenProvider
 } from "@azure/core-amqp";
-import { EventHubConnectionStringProperties, parseEventHubConnectionString } from "./util/connectionStringUtils";
+import {
+  EventHubConnectionStringProperties,
+  parseEventHubConnectionString
+} from "./util/connectionStringUtils";
 import { ManagementClient, ManagementClientOptions } from "./managementClient";
 import {
   NamedKeyCredential,

--- a/sdk/eventhub/event-hubs/src/connectionContext.ts
+++ b/sdk/eventhub/event-hubs/src/connectionContext.ts
@@ -4,35 +4,38 @@
 /* eslint-disable @typescript-eslint/no-namespace */
 /* eslint-disable no-inner-declarations */
 
-import { logger, logErrorStackTrace } from "./log";
-import { getRuntimeInfo } from "./util/runtimeInfo";
-import { packageJsonInfo } from "./util/constants";
 import {
-  EventHubConnectionStringProperties,
-  parseEventHubConnectionString
-} from "./util/connectionStringUtils";
-import { EventHubReceiver } from "./eventHubReceiver";
-import { EventHubSender } from "./eventHubSender";
+  Connection,
+  ConnectionEvents,
+  Dictionary,
+  EventContext,
+  OnAmqpEvent
+} from "rhea-promise";
 import {
+  ConnectionConfig,
   ConnectionContextBase,
   Constants,
   CreateConnectionContextBaseParameters,
-  ConnectionConfig,
   SasTokenProvider,
   createSasTokenProvider
 } from "@azure/core-amqp";
+import { EventHubConnectionStringProperties, parseEventHubConnectionString } from "./util/connectionStringUtils";
+import { ManagementClient, ManagementClientOptions } from "./managementClient";
 import {
-  TokenCredential,
   NamedKeyCredential,
   SASCredential,
+  TokenCredential,
   isNamedKeyCredential,
   isSASCredential
 } from "@azure/core-auth";
-import { ManagementClient, ManagementClientOptions } from "./managementClient";
+import { logErrorStackTrace, logger } from "./log";
 import { EventHubClientOptions } from "./models/public";
-import { Connection, ConnectionEvents, Dictionary, EventContext, OnAmqpEvent } from "rhea-promise";
 import { EventHubConnectionConfig } from "./eventhubConnectionConfig";
+import { EventHubReceiver } from "./eventHubReceiver";
+import { EventHubSender } from "./eventHubSender";
+import { getRuntimeInfo } from "./util/runtimeInfo";
 import { isCredential } from "./util/typeGuards";
+import { packageJsonInfo } from "./util/constants";
 
 /**
  * @internal

--- a/sdk/eventhub/event-hubs/src/dataTransformer.ts
+++ b/sdk/eventhub/event-hubs/src/dataTransformer.ts
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { message } from "rhea-promise";
-import isBuffer from "is-buffer";
-import { Buffer } from "buffer";
 import { logErrorStackTrace, logger } from "./log";
+import { Buffer } from "buffer";
+import isBuffer from "is-buffer";
+import { message } from "rhea-promise";
 
 /**
  * The allowed AMQP message body types.

--- a/sdk/eventhub/event-hubs/src/diagnostics/instrumentEventData.ts
+++ b/sdk/eventhub/event-hubs/src/diagnostics/instrumentEventData.ts
@@ -1,15 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import {
-  extractSpanContextFromTraceParentHeader,
-  getTraceParentHeader,
-  isSpanContextValid
-} from "@azure/core-tracing";
-import { SpanContext } from "@azure/core-tracing";
-import { AmqpAnnotatedMessage } from "@azure/core-amqp";
 import { EventData, isAmqpAnnotatedMessage } from "../eventData";
+import { extractSpanContextFromTraceParentHeader, getTraceParentHeader, isSpanContextValid } from "@azure/core-tracing";
+import { AmqpAnnotatedMessage } from "@azure/core-amqp";
 import { OperationOptions } from "../util/operationOptions";
+import { SpanContext } from "@azure/core-tracing";
 import { createMessageSpan } from "./tracing";
 
 /**

--- a/sdk/eventhub/event-hubs/src/diagnostics/instrumentEventData.ts
+++ b/sdk/eventhub/event-hubs/src/diagnostics/instrumentEventData.ts
@@ -2,7 +2,11 @@
 // Licensed under the MIT license.
 
 import { EventData, isAmqpAnnotatedMessage } from "../eventData";
-import { extractSpanContextFromTraceParentHeader, getTraceParentHeader, isSpanContextValid } from "@azure/core-tracing";
+import {
+  extractSpanContextFromTraceParentHeader,
+  getTraceParentHeader,
+  isSpanContextValid
+} from "@azure/core-tracing";
 import { AmqpAnnotatedMessage } from "@azure/core-amqp";
 import { OperationOptions } from "../util/operationOptions";
 import { SpanContext } from "@azure/core-tracing";

--- a/sdk/eventhub/event-hubs/src/diagnostics/tracing.ts
+++ b/sdk/eventhub/event-hubs/src/diagnostics/tracing.ts
@@ -2,18 +2,18 @@
 // Licensed under the MIT license.
 
 import {
-  createSpanFunction,
-  SpanContext,
-  SpanOptions,
-  setSpan,
-  setSpanContext,
   Span,
+  SpanContext,
   SpanKind,
-  context
+  SpanOptions,
+  context,
+  createSpanFunction,
+  setSpan,
+  setSpanContext
 } from "@azure/core-tracing";
-import { TryAddOptions } from "../eventDataBatch";
 import { EventHubConnectionConfig } from "../eventhubConnectionConfig";
 import { OperationOptions } from "../util/operationOptions";
+import { TryAddOptions } from "../eventDataBatch";
 
 const _createSpan = createSpanFunction({
   namespace: "Microsoft.EventHub",
@@ -86,8 +86,8 @@ export function convertTryAddOptionsForCompatibility(tryAddOptions: TryAddOption
     }
 
     function takeSomeOptionsFromSomewhere(someOptionsPassedIntoTheirFunction) {
-      
-      batch.tryAddMessage(message, { 
+
+      batch.tryAddMessage(message, {
         // "runtime" blend of options from some other part of their app
         ...someOptionsPassedIntoTheirFunction,      // parentSpan comes along for the ride...
 
@@ -102,9 +102,9 @@ export function convertTryAddOptionsForCompatibility(tryAddOptions: TryAddOption
 
     And now they've accidentally been opted into the legacy code path even though they think
     they're using the modern code path.
-    
+
     This does kick the can down the road a bit - at some point we will be putting them in this
-    situation where things looked okay but their spans are becoming unparented but we can 
+    situation where things looked okay but their spans are becoming unparented but we can
     try to announce this (and other changes related to tracing) in our next big rev.
   */
 

--- a/sdk/eventhub/event-hubs/src/eventData.ts
+++ b/sdk/eventhub/event-hubs/src/eventData.ts
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { DeliveryAnnotations, Message as RheaMessage, MessageAnnotations } from "rhea-promise";
 import { AmqpAnnotatedMessage, Constants } from "@azure/core-amqp";
-import { isDefined, isObjectWithProperties, objectHasProperty } from "./util/typeGuards";
 import { BodyTypes, defaultDataTransformer } from "./dataTransformer";
+import { DeliveryAnnotations, MessageAnnotations, Message as RheaMessage } from "rhea-promise";
+import { isDefined, isObjectWithProperties, objectHasProperty } from "./util/typeGuards";
 
 /**
  * Describes the delivery annotations.

--- a/sdk/eventhub/event-hubs/src/eventDataBatch.ts
+++ b/sdk/eventhub/event-hubs/src/eventDataBatch.ts
@@ -2,15 +2,15 @@
 // Licensed under the MIT license.
 
 import { EventData, toRheaMessage } from "./eventData";
-import { ConnectionContext } from "./connectionContext";
-import { MessageAnnotations, message, Message as RheaMessage } from "rhea-promise";
-import { throwTypeErrorIfParameterMissing } from "./util/error";
-import { AmqpAnnotatedMessage } from "@azure/core-amqp";
+import { MessageAnnotations, Message as RheaMessage, message } from "rhea-promise";
 import { Span, SpanContext } from "@azure/core-tracing";
-import { instrumentEventData } from "./diagnostics/instrumentEventData";
-import { convertTryAddOptionsForCompatibility } from "./diagnostics/tracing";
 import { isDefined, isObjectWithProperties } from "./util/typeGuards";
+import { AmqpAnnotatedMessage } from "@azure/core-amqp";
+import { ConnectionContext } from "./connectionContext";
 import { OperationTracingOptions } from "@azure/core-tracing";
+import { convertTryAddOptionsForCompatibility } from "./diagnostics/tracing";
+import { instrumentEventData } from "./diagnostics/instrumentEventData";
+import { throwTypeErrorIfParameterMissing } from "./util/error";
 
 /**
  * The amount of bytes to reserve as overhead for a small message.

--- a/sdk/eventhub/event-hubs/src/eventHubBufferedProducerClient.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubBufferedProducerClient.ts
@@ -1,13 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { AbortController } from "@azure/abort-controller";
-import { AmqpAnnotatedMessage } from "@azure/core-amqp";
-import { NamedKeyCredential, SASCredential, TokenCredential } from "@azure/core-auth";
-import { BatchingPartitionChannel } from "./batchingPartitionChannel";
-import { PartitionAssigner } from "./impl/partitionAssigner";
 import { EventData, EventHubProducerClient, OperationOptions } from "./index";
-import { EventHubProperties, PartitionProperties } from "./managementClient";
 import {
   EventHubClientOptions,
   GetEventHubPropertiesOptions,
@@ -15,7 +9,13 @@ import {
   GetPartitionPropertiesOptions,
   SendBatchOptions
 } from "./models/public";
+import { EventHubProperties, PartitionProperties } from "./managementClient";
+import { NamedKeyCredential, SASCredential, TokenCredential } from "@azure/core-auth";
 import { isCredential, isDefined } from "./util/typeGuards";
+import { AbortController } from "@azure/abort-controller";
+import { AmqpAnnotatedMessage } from "@azure/core-amqp";
+import { BatchingPartitionChannel } from "./batchingPartitionChannel";
+import { PartitionAssigner } from "./impl/partitionAssigner";
 
 /**
  * Contains the events that were successfully sent to the Event Hub,

--- a/sdk/eventhub/event-hubs/src/eventHubConsumerClient.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubConsumerClient.ts
@@ -12,7 +12,11 @@ import {
 } from "./models/public";
 import { EventHubProperties, PartitionProperties } from "./managementClient";
 import { NamedKeyCredential, SASCredential, TokenCredential } from "@azure/core-auth";
-import { SubscribeOptions, Subscription, SubscriptionEventHandlers } from "./eventHubConsumerClientModels";
+import {
+  SubscribeOptions,
+  Subscription,
+  SubscriptionEventHandlers
+} from "./eventHubConsumerClientModels";
 import { BalancedLoadBalancingStrategy } from "./loadBalancerStrategies/balancedStrategy";
 import { Constants } from "@azure/core-amqp";
 import { GreedyLoadBalancingStrategy } from "./loadBalancerStrategies/greedyStrategy";

--- a/sdk/eventhub/event-hubs/src/eventHubConsumerClient.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubConsumerClient.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+import { CheckpointStore, EventProcessor, FullEventProcessorOptions } from "./eventProcessor";
 import { ConnectionContext, createConnectionContext } from "./connectionContext";
 import {
   EventHubConsumerClientOptions,
@@ -9,26 +10,20 @@ import {
   GetPartitionPropertiesOptions,
   LoadBalancingOptions
 } from "./models/public";
-import { InMemoryCheckpointStore } from "./inMemoryCheckpointStore";
-import { CheckpointStore, EventProcessor, FullEventProcessorOptions } from "./eventProcessor";
-import { Constants } from "@azure/core-amqp";
-import { logger } from "./log";
-
-import {
-  SubscribeOptions,
-  Subscription,
-  SubscriptionEventHandlers
-} from "./eventHubConsumerClientModels";
-import { TokenCredential, NamedKeyCredential, SASCredential } from "@azure/core-auth";
 import { EventHubProperties, PartitionProperties } from "./managementClient";
+import { NamedKeyCredential, SASCredential, TokenCredential } from "@azure/core-auth";
+import { SubscribeOptions, Subscription, SubscriptionEventHandlers } from "./eventHubConsumerClientModels";
+import { BalancedLoadBalancingStrategy } from "./loadBalancerStrategies/balancedStrategy";
+import { Constants } from "@azure/core-amqp";
+import { GreedyLoadBalancingStrategy } from "./loadBalancerStrategies/greedyStrategy";
+import { InMemoryCheckpointStore } from "./inMemoryCheckpointStore";
+import { LoadBalancingStrategy } from "./loadBalancerStrategies/loadBalancingStrategy";
 import { PartitionGate } from "./impl/partitionGate";
+import { UnbalancedLoadBalancingStrategy } from "./loadBalancerStrategies/unbalancedStrategy";
+import { isCredential } from "./util/typeGuards";
+import { logger } from "./log";
 import { v4 as uuid } from "uuid";
 import { validateEventPositions } from "./eventPosition";
-import { LoadBalancingStrategy } from "./loadBalancerStrategies/loadBalancingStrategy";
-import { UnbalancedLoadBalancingStrategy } from "./loadBalancerStrategies/unbalancedStrategy";
-import { GreedyLoadBalancingStrategy } from "./loadBalancerStrategies/greedyStrategy";
-import { BalancedLoadBalancingStrategy } from "./loadBalancerStrategies/balancedStrategy";
-import { isCredential } from "./util/typeGuards";
 
 const defaultConsumerClientOptions: Required<Pick<
   FullEventProcessorOptions,

--- a/sdk/eventhub/event-hubs/src/eventHubConsumerClientModels.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubConsumerClientModels.ts
@@ -2,11 +2,11 @@
 // Licensed under the MIT license.
 
 import { CloseReason } from "./models/public";
-import { ReceivedEventData } from "./eventData";
-import { LastEnqueuedEventProperties } from "./eventHubReceiver";
 import { EventPosition } from "./eventPosition";
-import { OperationTracingOptions } from "@azure/core-tracing";
+import { LastEnqueuedEventProperties } from "./eventHubReceiver";
 import { MessagingError } from "@azure/core-amqp";
+import { OperationTracingOptions } from "@azure/core-tracing";
+import { ReceivedEventData } from "./eventData";
 
 /**
  * @internal
@@ -184,7 +184,7 @@ export interface SubscribeOptions {
    * Indicates whether or not the consumer should request information on the last enqueued event on its
    * associated partition, and track that information as events are received.
 
-   * When information about the partition's last enqueued event is being tracked, each event received 
+   * When information about the partition's last enqueued event is being tracked, each event received
    * from the Event Hubs service will carry metadata about the partition that it otherwise would not. This results in a small amount of
    * additional network bandwidth consumption that is generally a favorable trade-off when considered
    * against periodically making requests for partition properties using the Event Hub client.

--- a/sdk/eventhub/event-hubs/src/eventHubProducerClient.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubProducerClient.ts
@@ -12,13 +12,7 @@ import {
 } from "./models/public";
 import { EventDataBatch, EventDataBatchImpl, isEventDataBatch } from "./eventDataBatch";
 import { EventHubProperties, PartitionProperties } from "./managementClient";
-import {
-  Link,
-  Span,
-  SpanContext,
-  SpanKind,
-  SpanStatusCode
-} from "@azure/core-tracing";
+import { Link, Span, SpanContext, SpanKind, SpanStatusCode } from "@azure/core-tracing";
 import { NamedKeyCredential, SASCredential, TokenCredential } from "@azure/core-auth";
 import { isCredential, isDefined } from "./util/typeGuards";
 import { logErrorStackTrace, logger } from "./log";

--- a/sdk/eventhub/event-hubs/src/eventHubProducerClient.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubProducerClient.ts
@@ -1,16 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { AmqpAnnotatedMessage } from "@azure/core-amqp";
-import { NamedKeyCredential, SASCredential, TokenCredential } from "@azure/core-auth";
-import { SpanStatusCode, Link, Span, SpanContext, SpanKind } from "@azure/core-tracing";
 import { ConnectionContext, createConnectionContext } from "./connectionContext";
-import { instrumentEventData } from "./diagnostics/instrumentEventData";
-import { EventData } from "./eventData";
-import { EventDataBatch, EventDataBatchImpl, isEventDataBatch } from "./eventDataBatch";
-import { EventHubSender } from "./eventHubSender";
-import { logErrorStackTrace, logger } from "./log";
-import { EventHubProperties, PartitionProperties } from "./managementClient";
 import {
   CreateBatchOptions,
   EventHubClientOptions,
@@ -19,10 +10,25 @@ import {
   GetPartitionPropertiesOptions,
   SendBatchOptions
 } from "./models/public";
-import { throwErrorIfConnectionClosed, throwTypeErrorIfParameterMissing } from "./util/error";
+import { EventDataBatch, EventDataBatchImpl, isEventDataBatch } from "./eventDataBatch";
+import { EventHubProperties, PartitionProperties } from "./managementClient";
+import {
+  Link,
+  Span,
+  SpanContext,
+  SpanKind,
+  SpanStatusCode
+} from "@azure/core-tracing";
+import { NamedKeyCredential, SASCredential, TokenCredential } from "@azure/core-auth";
 import { isCredential, isDefined } from "./util/typeGuards";
+import { logErrorStackTrace, logger } from "./log";
+import { throwErrorIfConnectionClosed, throwTypeErrorIfParameterMissing } from "./util/error";
+import { AmqpAnnotatedMessage } from "@azure/core-amqp";
+import { EventData } from "./eventData";
+import { EventHubSender } from "./eventHubSender";
 import { OperationOptions } from "./util/operationOptions";
 import { createEventHubSpan } from "./diagnostics/tracing";
+import { instrumentEventData } from "./diagnostics/instrumentEventData";
 
 /**
  * The `EventHubProducerClient` class is used to send events to an Event Hub.

--- a/sdk/eventhub/event-hubs/src/eventHubReceiver.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubReceiver.ts
@@ -1,7 +1,17 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { logErrorStackTrace, logger } from "./log";
+import { AbortError, AbortSignalLike } from "@azure/abort-controller";
+import {
+  Constants,
+  MessagingError,
+  RetryConfig,
+  RetryOperationType,
+  StandardAbortMessage,
+  delay,
+  retry,
+  translate
+} from "@azure/core-amqp";
 import {
   EventContext,
   OnAmqpEvent,
@@ -9,22 +19,12 @@ import {
   ReceiverOptions as RheaReceiverOptions,
   types
 } from "rhea-promise";
-import {
-  Constants,
-  MessagingError,
-  delay,
-  translate,
-  RetryConfig,
-  RetryOperationType,
-  retry,
-  StandardAbortMessage
-} from "@azure/core-amqp";
 import { EventDataInternal, ReceivedEventData, fromRheaMessage } from "./eventData";
-import { EventHubConsumerOptions } from "./models/private";
-import { ConnectionContext } from "./connectionContext";
-import { LinkEntity } from "./linkEntity";
 import { EventPosition, getEventPositionFilter } from "./eventPosition";
-import { AbortError, AbortSignalLike } from "@azure/abort-controller";
+import { logErrorStackTrace, logger } from "./log";
+import { ConnectionContext } from "./connectionContext";
+import { EventHubConsumerOptions } from "./models/private";
+import { LinkEntity } from "./linkEntity";
 import { getRetryAttemptTimeoutInMs } from "./util/retries";
 
 /**

--- a/sdk/eventhub/event-hubs/src/eventHubSender.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubSender.ts
@@ -1,35 +1,35 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { v4 as uuid } from "uuid";
-import { logErrorStackTrace, logger } from "./log";
 import {
   AmqpError,
   AwaitableSender,
   AwaitableSenderOptions,
   EventContext,
   OnAmqpEvent,
-  message,
-  Message as RheaMessage
+  Message as RheaMessage,
+  message
 } from "rhea-promise";
 import {
-  delay,
   ErrorNameConditionMapper,
   RetryConfig,
   RetryOperationType,
   RetryOptions,
   defaultCancellableLock,
+  delay,
   retry,
   translate
 } from "@azure/core-amqp";
 import { EventData, toRheaMessage } from "./eventData";
+import { EventDataBatch, isEventDataBatch } from "./eventDataBatch";
+import { logErrorStackTrace, logger } from "./log";
+import { AbortSignalLike } from "@azure/abort-controller";
 import { ConnectionContext } from "./connectionContext";
-import { LinkEntity } from "./linkEntity";
 import { EventHubProducerOptions } from "./models/private";
+import { LinkEntity } from "./linkEntity";
 import { SendOptions } from "./models/public";
 import { getRetryAttemptTimeoutInMs } from "./util/retries";
-import { AbortSignalLike } from "@azure/abort-controller";
-import { EventDataBatch, isEventDataBatch } from "./eventDataBatch";
+import { v4 as uuid } from "uuid";
 
 /**
  * Describes the EventHubSender that will send event data to EventHub.

--- a/sdk/eventhub/event-hubs/src/eventProcessor.ts
+++ b/sdk/eventhub/event-hubs/src/eventProcessor.ts
@@ -1,19 +1,19 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { v4 as uuid } from "uuid";
-import { PumpManager, PumpManagerImpl } from "./pumpManager";
-import { AbortController, AbortSignalLike, AbortError } from "@azure/abort-controller";
-import { logErrorStackTrace, logger } from "./log";
+import { AbortController, AbortError, AbortSignalLike } from "@azure/abort-controller";
 import { Checkpoint, PartitionProcessor } from "./partitionProcessor";
-import { SubscriptionEventHandlers } from "./eventHubConsumerClientModels";
 import { EventPosition, isEventPosition, latestEventPosition } from "./eventPosition";
-import { delayWithoutThrow } from "./util/delayWithoutThrow";
-import { CommonEventProcessorOptions } from "./models/private";
+import { PumpManager, PumpManagerImpl } from "./pumpManager";
+import { logErrorStackTrace, logger } from "./log";
 import { CloseReason } from "./models/public";
+import { CommonEventProcessorOptions } from "./models/private";
 import { ConnectionContext } from "./connectionContext";
 import { LoadBalancingStrategy } from "./loadBalancerStrategies/loadBalancingStrategy";
 import { OperationOptions } from "./util/operationOptions";
+import { SubscriptionEventHandlers } from "./eventHubConsumerClientModels";
+import { delayWithoutThrow } from "./util/delayWithoutThrow";
+import { v4 as uuid } from "uuid";
 
 /**
  * An interface representing the details on which instance of a `EventProcessor` owns processing

--- a/sdk/eventhub/event-hubs/src/linkEntity.ts
+++ b/sdk/eventhub/event-hubs/src/linkEntity.ts
@@ -1,14 +1,14 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { v4 as uuid } from "uuid";
+import { AwaitableSender, Receiver } from "rhea-promise";
 import { Constants, TokenType, defaultCancellableLock, isSasTokenProvider } from "@azure/core-amqp";
+import { AbortSignalLike } from "@azure/abort-controller";
 import { AccessToken } from "@azure/core-auth";
 import { ConnectionContext } from "./connectionContext";
-import { AwaitableSender, Receiver } from "rhea-promise";
-import { logger } from "./log";
 import { getRetryAttemptTimeoutInMs } from "./util/retries";
-import { AbortSignalLike } from "@azure/abort-controller";
+import { logger } from "./log";
+import { v4 as uuid } from "uuid";
 
 /**
  * @hidden

--- a/sdk/eventhub/event-hubs/src/loadBalancerStrategies/balancedStrategy.ts
+++ b/sdk/eventhub/event-hubs/src/loadBalancerStrategies/balancedStrategy.ts
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { PartitionOwnership } from "../eventProcessor";
 import { LoadBalancingStrategy, listAvailablePartitions } from "./loadBalancingStrategy";
+import { PartitionOwnership } from "../eventProcessor";
 
 /**
  * The BalancedLoadBalancerStrategy is meant to be used when the user

--- a/sdk/eventhub/event-hubs/src/loadBalancerStrategies/greedyStrategy.ts
+++ b/sdk/eventhub/event-hubs/src/loadBalancerStrategies/greedyStrategy.ts
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { PartitionOwnership } from "../eventProcessor";
 import { LoadBalancingStrategy, listAvailablePartitions } from "./loadBalancingStrategy";
+import { PartitionOwnership } from "../eventProcessor";
 
 /**
  * @internal

--- a/sdk/eventhub/event-hubs/src/loadBalancerStrategies/unbalancedStrategy.ts
+++ b/sdk/eventhub/event-hubs/src/loadBalancerStrategies/unbalancedStrategy.ts
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { PartitionOwnership } from "../eventProcessor";
 import { LoadBalancingStrategy } from "./loadBalancingStrategy";
+import { PartitionOwnership } from "../eventProcessor";
 
 /**
  * The UnbalancedLoadBalancingStrategy does no actual load balancing.

--- a/sdk/eventhub/event-hubs/src/managementClient.ts
+++ b/sdk/eventhub/event-hubs/src/managementClient.ts
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { v4 as uuid } from "uuid";
 import {
   Constants,
   RequestResponseLink,
@@ -14,7 +13,6 @@ import {
   retry,
   translate
 } from "@azure/core-amqp";
-import { AccessToken } from "@azure/core-auth";
 import {
   EventContext,
   Message,
@@ -24,15 +22,17 @@ import {
   SenderOptions,
   generate_uuid
 } from "rhea-promise";
+import { logErrorStackTrace, logger } from "./log";
+import { throwErrorIfConnectionClosed, throwTypeErrorIfParameterMissing } from "./util/error";
+import { AbortSignalLike } from "@azure/abort-controller";
+import { AccessToken } from "@azure/core-auth";
 import { ConnectionContext } from "./connectionContext";
 import { LinkEntity } from "./linkEntity";
-import { logErrorStackTrace, logger } from "./log";
-import { getRetryAttemptTimeoutInMs } from "./util/retries";
-import { AbortSignalLike } from "@azure/abort-controller";
-import { throwErrorIfConnectionClosed, throwTypeErrorIfParameterMissing } from "./util/error";
-import { SpanStatusCode } from "@azure/core-tracing";
 import { OperationOptions } from "./util/operationOptions";
+import { SpanStatusCode } from "@azure/core-tracing";
 import { createEventHubSpan } from "./diagnostics/tracing";
+import { getRetryAttemptTimeoutInMs } from "./util/retries";
+import { v4 as uuid } from "uuid";
 
 /**
  * Describes the runtime information of an Event Hub.

--- a/sdk/eventhub/event-hubs/src/models/private.ts
+++ b/sdk/eventhub/event-hubs/src/models/private.ts
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+import { LoadBalancingStrategy } from "../loadBalancerStrategies/loadBalancingStrategy";
 import { RetryOptions } from "@azure/core-amqp";
 import { SubscribeOptions } from "../eventHubConsumerClientModels";
-import { LoadBalancingStrategy } from "../loadBalancerStrategies/loadBalancingStrategy";
 
 /**
  * The set of options to configure the behavior of an `EventHubProducer`.
@@ -111,7 +111,7 @@ export interface EventHubConsumerOptions {
    * Indicates whether or not the consumer should request information on the last enqueued event on its
    * associated partition, and track that information as events are received.
 
-   * When information about the partition's last enqueued event is being tracked, each event received 
+   * When information about the partition's last enqueued event is being tracked, each event received
    * from the Event Hubs service will carry metadata about the partition that it otherwise would not. This results in a small amount of
    * additional network bandwidth consumption that is generally a favorable trade-off when considered
    * against periodically making requests for partition properties using the Event Hub client.

--- a/sdk/eventhub/event-hubs/src/models/public.ts
+++ b/sdk/eventhub/event-hubs/src/models/public.ts
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { OperationOptions } from "../util/operationOptions";
 import { RetryOptions, WebSocketOptions } from "@azure/core-amqp";
+import { OperationOptions } from "../util/operationOptions";
 
 /**
  * The set of options to configure the behavior of `getEventHubProperties`.

--- a/sdk/eventhub/event-hubs/src/partitionProcessor.ts
+++ b/sdk/eventhub/event-hubs/src/partitionProcessor.ts
@@ -1,15 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+import { BasicPartitionProperties, PartitionContext, SubscriptionEventHandlers } from "./eventHubConsumerClientModels";
 import { CheckpointStore } from "./eventProcessor";
 import { CloseReason } from "./models/public";
-import { ReceivedEventData } from "./eventData";
 import { LastEnqueuedEventProperties } from "./eventHubReceiver";
-import {
-  BasicPartitionProperties,
-  PartitionContext,
-  SubscriptionEventHandlers
-} from "./eventHubConsumerClientModels";
+import { ReceivedEventData } from "./eventData";
 import { logger } from "./log";
 
 /**

--- a/sdk/eventhub/event-hubs/src/partitionProcessor.ts
+++ b/sdk/eventhub/event-hubs/src/partitionProcessor.ts
@@ -1,7 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { BasicPartitionProperties, PartitionContext, SubscriptionEventHandlers } from "./eventHubConsumerClientModels";
+import {
+  BasicPartitionProperties,
+  PartitionContext,
+  SubscriptionEventHandlers
+} from "./eventHubConsumerClientModels";
 import { CheckpointStore } from "./eventProcessor";
 import { CloseReason } from "./models/public";
 import { LastEnqueuedEventProperties } from "./eventHubReceiver";

--- a/sdk/eventhub/event-hubs/src/partitionPump.ts
+++ b/sdk/eventhub/event-hubs/src/partitionPump.ts
@@ -1,21 +1,21 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+import { Link, Span, SpanKind, SpanStatusCode } from "@azure/core-tracing";
 import { logErrorStackTrace, logger } from "./log";
-import { CommonEventProcessorOptions } from "./models/private";
-import { CloseReason } from "./models/public";
-import { EventPosition } from "./eventPosition";
-import { PartitionProcessor } from "./partitionProcessor";
-import { EventHubReceiver } from "./eventHubReceiver";
 import { AbortController } from "@azure/abort-controller";
+import { CloseReason } from "./models/public";
+import { CommonEventProcessorOptions } from "./models/private";
+import { ConnectionContext } from "./connectionContext";
+import { EventHubConnectionConfig } from "./eventhubConnectionConfig";
+import { EventHubReceiver } from "./eventHubReceiver";
+import { EventPosition } from "./eventPosition";
 import { MessagingError } from "@azure/core-amqp";
 import { OperationOptions } from "./util/operationOptions";
-import { SpanStatusCode, Link, Span, SpanKind } from "@azure/core-tracing";
-import { extractSpanContextFromEventData } from "./diagnostics/instrumentEventData";
+import { PartitionProcessor } from "./partitionProcessor";
 import { ReceivedEventData } from "./eventData";
-import { ConnectionContext } from "./connectionContext";
 import { createEventHubSpan } from "./diagnostics/tracing";
-import { EventHubConnectionConfig } from "./eventhubConnectionConfig";
+import { extractSpanContextFromEventData } from "./diagnostics/instrumentEventData";
 
 /**
  * @internal

--- a/sdk/eventhub/event-hubs/src/pumpManager.ts
+++ b/sdk/eventhub/event-hubs/src/pumpManager.ts
@@ -1,14 +1,14 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { EventPosition } from "./eventPosition";
-import { CommonEventProcessorOptions } from "./models/private";
-import { CloseReason } from "./models/public";
-import { PartitionProcessor } from "./partitionProcessor";
-import { PartitionPump } from "./partitionPump";
 import { logErrorStackTrace, logger } from "./log";
 import { AbortSignalLike } from "@azure/abort-controller";
+import { CloseReason } from "./models/public";
+import { CommonEventProcessorOptions } from "./models/private";
 import { ConnectionContext } from "./connectionContext";
+import { EventPosition } from "./eventPosition";
+import { PartitionProcessor } from "./partitionProcessor";
+import { PartitionPump } from "./partitionPump";
 
 /**
  * The PumpManager handles the creation and removal of PartitionPumps.

--- a/sdk/eventhub/event-hubs/src/receiveHandler.ts
+++ b/sdk/eventhub/event-hubs/src/receiveHandler.ts
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { EventHubReceiver } from "./eventHubReceiver";
 import { logErrorStackTrace, logger } from "./log";
+import { EventHubReceiver } from "./eventHubReceiver";
 
 /**
  * Describes the receive handler object that is returned from the receive() method with handlers.

--- a/sdk/eventhub/event-hubs/src/util/delayWithoutThrow.ts
+++ b/sdk/eventhub/event-hubs/src/util/delayWithoutThrow.ts
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { delay } from "@azure/core-amqp";
 import { AbortSignalLike } from "@azure/abort-controller";
+import { delay } from "@azure/core-amqp";
 
 /**
  * @param delayInMs - The number of milliseconds to be delayed.

--- a/sdk/eventhub/event-hubs/src/util/typeGuards.ts
+++ b/sdk/eventhub/event-hubs/src/util/typeGuards.ts
@@ -2,12 +2,12 @@
 // Licensed under the MIT license.
 
 import {
-  isNamedKeyCredential,
-  isSASCredential,
-  isTokenCredential,
   NamedKeyCredential,
   SASCredential,
-  TokenCredential
+  TokenCredential,
+  isNamedKeyCredential,
+  isSASCredential,
+  isTokenCredential
 } from "@azure/core-auth";
 
 /**

--- a/sdk/eventhub/event-hubs/test/connectionStringUtils.spec.ts
+++ b/sdk/eventhub/event-hubs/test/connectionStringUtils.spec.ts
@@ -1,10 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import {
-  parseEventHubConnectionString,
-  EventHubConnectionStringProperties
-} from "../src/util/connectionStringUtils";
+import { EventHubConnectionStringProperties, parseEventHubConnectionString } from "../src/util/connectionStringUtils";
 import chai from "chai";
 
 const assert = chai.assert;

--- a/sdk/eventhub/event-hubs/test/connectionStringUtils.spec.ts
+++ b/sdk/eventhub/event-hubs/test/connectionStringUtils.spec.ts
@@ -1,7 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { EventHubConnectionStringProperties, parseEventHubConnectionString } from "../src/util/connectionStringUtils";
+import {
+  EventHubConnectionStringProperties,
+  parseEventHubConnectionString
+} from "../src/util/connectionStringUtils";
 import chai from "chai";
 
 const assert = chai.assert;

--- a/sdk/eventhub/event-hubs/test/impl/parseEndpoint.spec.ts
+++ b/sdk/eventhub/event-hubs/test/impl/parseEndpoint.spec.ts
@@ -1,8 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { parseEndpoint } from "../../src/util/parseEndpoint";
 import chai from "chai";
+import { parseEndpoint } from "../../src/util/parseEndpoint";
+
 const should = chai.should();
 
 describe("parseEndpoint", () => {

--- a/sdk/eventhub/event-hubs/test/internal/amqp.spec.ts
+++ b/sdk/eventhub/event-hubs/test/internal/amqp.spec.ts
@@ -1,10 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import chai from "chai";
-import { Constants } from "@azure/core-amqp";
 import { fromRheaMessage, isAmqpAnnotatedMessage } from "../../src/eventData";
+import { Constants } from "@azure/core-amqp";
+import chai from "chai";
 import { testWithServiceTypes } from "../public/utils/testWithServiceTypes";
+
 const assert = chai.assert;
 
 testWithServiceTypes(() => {

--- a/sdk/eventhub/event-hubs/test/internal/auth.spec.ts
+++ b/sdk/eventhub/event-hubs/test/internal/auth.spec.ts
@@ -1,18 +1,13 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import {
-  EventHubConnectionStringProperties,
-  EventHubConsumerClient,
-  EventHubProducerClient,
-  parseEventHubConnectionString
-} from "../../src";
-import { EnvVarKeys, getEnvVars } from "../public/utils/testUtils";
-import chai from "chai";
 import { AzureNamedKeyCredential, AzureSASCredential } from "@azure/core-auth";
+import { EnvVarKeys, getEnvVars } from "../public/utils/testUtils";
+import { EventHubConnectionStringProperties, EventHubConsumerClient, EventHubProducerClient, parseEventHubConnectionString } from "../../src";
+import chai from "chai";
+import { createMockServer } from "../public/utils/mockService";
 import { createSasTokenProvider } from "@azure/core-amqp";
 import { testWithServiceTypes } from "../public/utils/testWithServiceTypes";
-import { createMockServer } from "../public/utils/mockService";
 
 const should = chai.should();
 

--- a/sdk/eventhub/event-hubs/test/internal/auth.spec.ts
+++ b/sdk/eventhub/event-hubs/test/internal/auth.spec.ts
@@ -3,7 +3,12 @@
 
 import { AzureNamedKeyCredential, AzureSASCredential } from "@azure/core-auth";
 import { EnvVarKeys, getEnvVars } from "../public/utils/testUtils";
-import { EventHubConnectionStringProperties, EventHubConsumerClient, EventHubProducerClient, parseEventHubConnectionString } from "../../src";
+import {
+  EventHubConnectionStringProperties,
+  EventHubConsumerClient,
+  EventHubProducerClient,
+  parseEventHubConnectionString
+} from "../../src";
 import chai from "chai";
 import { createMockServer } from "../public/utils/mockService";
 import { createSasTokenProvider } from "@azure/core-amqp";

--- a/sdk/eventhub/event-hubs/test/internal/cancellation.spec.ts
+++ b/sdk/eventhub/event-hubs/test/internal/cancellation.spec.ts
@@ -1,18 +1,18 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+import { EnvVarKeys, getEnvVars } from "../public/utils/testUtils";
 import { AbortController } from "@azure/abort-controller";
-import chai from "chai";
-const should = chai.should();
-import chaiAsPromised from "chai-as-promised";
-import { createConnectionContext } from "../../src/connectionContext";
 import { EventHubReceiver } from "../../src/eventHubReceiver";
 import { EventHubSender } from "../../src/eventHubSender";
+import chai from "chai";
+import chaiAsPromised from "chai-as-promised";
+import { createConnectionContext } from "../../src/connectionContext";
 import { createMockServer } from "../public/utils/mockService";
-chai.use(chaiAsPromised);
-
-import { EnvVarKeys, getEnvVars } from "../public/utils/testUtils";
 import { testWithServiceTypes } from "../public/utils/testWithServiceTypes";
+
+const should = chai.should();
+chai.use(chaiAsPromised);
 
 testWithServiceTypes((serviceVersion) => {
   const env = getEnvVars();

--- a/sdk/eventhub/event-hubs/test/internal/client.spec.ts
+++ b/sdk/eventhub/event-hubs/test/internal/client.spec.ts
@@ -2,7 +2,12 @@
 // Licensed under the MIT license.
 
 import { EnvVarKeys, getEnvVars, isNode } from "../public/utils/testUtils";
-import { EventHubConsumerClient, EventHubProducerClient, Subscription, TokenCredential } from "../../src";
+import {
+  EventHubConsumerClient,
+  EventHubProducerClient,
+  Subscription,
+  TokenCredential
+} from "../../src";
 import { ConnectionContext } from "../../src/connectionContext";
 import { MessagingError } from "@azure/core-amqp";
 import chai from "chai";

--- a/sdk/eventhub/event-hubs/test/internal/client.spec.ts
+++ b/sdk/eventhub/event-hubs/test/internal/client.spec.ts
@@ -1,27 +1,23 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import chai from "chai";
-const should = chai.should();
-import chaiAsPromised from "chai-as-promised";
-chai.use(chaiAsPromised);
-import chaiString from "chai-string";
-chai.use(chaiString);
-import debugModule from "debug";
-const debug = debugModule("azure:event-hubs:client-spec");
-import {
-  TokenCredential,
-  EventHubProducerClient,
-  EventHubConsumerClient,
-  Subscription
-} from "../../src";
-import { packageJsonInfo } from "../../src/util/constants";
 import { EnvVarKeys, getEnvVars, isNode } from "../public/utils/testUtils";
-import { MessagingError } from "@azure/core-amqp";
+import { EventHubConsumerClient, EventHubProducerClient, Subscription, TokenCredential } from "../../src";
 import { ConnectionContext } from "../../src/connectionContext";
-import { getRuntimeInfo } from "../../src/util/runtimeInfo";
-import { testWithServiceTypes } from "../public/utils/testWithServiceTypes";
+import { MessagingError } from "@azure/core-amqp";
+import chai from "chai";
+import chaiAsPromised from "chai-as-promised";
+import chaiString from "chai-string";
 import { createMockServer } from "../public/utils/mockService";
+import debugModule from "debug";
+import { getRuntimeInfo } from "../../src/util/runtimeInfo";
+import { packageJsonInfo } from "../../src/util/constants";
+import { testWithServiceTypes } from "../public/utils/testWithServiceTypes";
+
+const should = chai.should();
+chai.use(chaiAsPromised);
+chai.use(chaiString);
+const debug = debugModule("azure:event-hubs:client-spec");
 
 const testFailureMessage = "Test failure";
 function validateConnectionError<E extends Error & { code?: string }>(err: E): void {

--- a/sdk/eventhub/event-hubs/test/internal/dataTransformer.spec.ts
+++ b/sdk/eventhub/event-hubs/test/internal/dataTransformer.spec.ts
@@ -1,13 +1,14 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { Buffer } from "buffer";
-import * as chai from "chai";
-const should = chai.should();
 import * as assert from "assert";
-import isBuffer from "is-buffer";
+import * as chai from "chai";
 import { dataSectionTypeCode, defaultDataTransformer } from "../../src/dataTransformer";
+import { Buffer } from "buffer";
+import isBuffer from "is-buffer";
 import { testWithServiceTypes } from "../public/utils/testWithServiceTypes";
+
+const should = chai.should();
 
 testWithServiceTypes(() => {
   describe("DataTransformer", function() {

--- a/sdk/eventhub/event-hubs/test/internal/diagnostics/messageSpan.spec.ts
+++ b/sdk/eventhub/event-hubs/test/internal/diagnostics/messageSpan.spec.ts
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+import { resetTracer, setTracer } from "@azure/test-utils";
 import chai from "chai";
 import { createMessageSpan } from "../../../src/diagnostics/tracing";
-import { setTracer, resetTracer } from "@azure/test-utils";
 import { testWithServiceTypes } from "../../public/utils/testWithServiceTypes";
 
 const should = chai.should();

--- a/sdk/eventhub/event-hubs/test/internal/eventHubConsumerClientUnitTests.spec.ts
+++ b/sdk/eventhub/event-hubs/test/internal/eventHubConsumerClientUnitTests.spec.ts
@@ -1,17 +1,18 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
+
 import { CheckpointStore, SubscriptionEventHandlers } from "../../src";
+import { EnvVarKeys, getEnvVars } from "../public/utils/testUtils";
 import { EventHubConsumerClient, isCheckpointStore } from "../../src/eventHubConsumerClient";
-import { InMemoryCheckpointStore } from "../../src/inMemoryCheckpointStore";
 import { EventProcessor, FullEventProcessorOptions } from "../../src/eventProcessor";
 import { SinonStubbedInstance, createStubInstance } from "sinon";
-import { ConnectionContext } from "../../src/connectionContext";
 import { BalancedLoadBalancingStrategy } from "../../src/loadBalancerStrategies/balancedStrategy";
+import { ConnectionContext } from "../../src/connectionContext";
 import { GreedyLoadBalancingStrategy } from "../../src/loadBalancerStrategies/greedyStrategy";
+import { InMemoryCheckpointStore } from "../../src/inMemoryCheckpointStore";
 import chai from "chai";
-import { EnvVarKeys, getEnvVars } from "../public/utils/testUtils";
-import { testWithServiceTypes } from "../public/utils/testWithServiceTypes";
 import { createMockServer } from "../public/utils/mockService";
+import { testWithServiceTypes } from "../public/utils/testWithServiceTypes";
 
 const should = chai.should();
 

--- a/sdk/eventhub/event-hubs/test/internal/eventPosition.spec.ts
+++ b/sdk/eventhub/event-hubs/test/internal/eventPosition.spec.ts
@@ -1,12 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import chai from "chai";
-chai.should();
-
 import { earliestEventPosition, latestEventPosition } from "../../src";
 import { getEventPositionFilter, validateEventPositions } from "../../src/eventPosition";
+import chai from "chai";
 import { testWithServiceTypes } from "../public/utils/testWithServiceTypes";
+
+chai.should();
 
 testWithServiceTypes(() => {
   describe("EventPosition", function(): void {

--- a/sdk/eventhub/event-hubs/test/internal/eventProcessor.spec.ts
+++ b/sdk/eventhub/event-hubs/test/internal/eventProcessor.spec.ts
@@ -17,7 +17,10 @@ import {
 import { Dictionary, generate_uuid } from "rhea-promise";
 import { EnvVarKeys, getEnvVars, loopUntil } from "../public/utils/testUtils";
 import { EventProcessor, FullEventProcessorOptions } from "../../src/eventProcessor";
-import { SubscriptionHandlerForTests, sendOneMessagePerPartition } from "../public/utils/subscriptionHandlerForTests";
+import {
+  SubscriptionHandlerForTests,
+  sendOneMessagePerPartition
+} from "../public/utils/subscriptionHandlerForTests";
 import { AbortController } from "@azure/abort-controller";
 import { BalancedLoadBalancingStrategy } from "../../src/loadBalancerStrategies/balancedStrategy";
 import { Checkpoint } from "../../src/partitionProcessor";

--- a/sdk/eventhub/event-hubs/test/internal/eventProcessor.spec.ts
+++ b/sdk/eventhub/event-hubs/test/internal/eventProcessor.spec.ts
@@ -1,45 +1,43 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import chai from "chai";
-const should = chai.should();
-import chaiAsPromised from "chai-as-promised";
-chai.use(chaiAsPromised);
-import debugModule from "debug";
-const debug = debugModule("azure:event-hubs:partitionPump");
+import { AbortError, AbortSignal } from "@azure/abort-controller";
 import {
   CheckpointStore,
   CloseReason,
   EventData,
+  EventHubConsumerClient,
+  EventHubProducerClient,
   PartitionOwnership,
   ReceivedEventData,
   SubscriptionEventHandlers,
   earliestEventPosition,
-  latestEventPosition,
-  EventHubConsumerClient,
-  EventHubProducerClient
+  latestEventPosition
 } from "../../src";
-import { EnvVarKeys, getEnvVars, loopUntil } from "../public/utils/testUtils";
 import { Dictionary, generate_uuid } from "rhea-promise";
+import { EnvVarKeys, getEnvVars, loopUntil } from "../public/utils/testUtils";
 import { EventProcessor, FullEventProcessorOptions } from "../../src/eventProcessor";
-import { Checkpoint } from "../../src/partitionProcessor";
-import { delay } from "@azure/core-amqp";
-import { PartitionContext } from "../../src/eventHubConsumerClientModels";
-import { InMemoryCheckpointStore } from "../../src/inMemoryCheckpointStore";
-import { loggerForTest } from "../public/utils/logHelpers";
-import {
-  SubscriptionHandlerForTests,
-  sendOneMessagePerPartition
-} from "../public/utils/subscriptionHandlerForTests";
-import { AbortError, AbortSignal } from "@azure/abort-controller";
-import { FakeSubscriptionEventHandlers } from "../public/utils/fakeSubscriptionEventHandlers";
-import { isLatestPosition } from "../../src/eventPosition";
+import { SubscriptionHandlerForTests, sendOneMessagePerPartition } from "../public/utils/subscriptionHandlerForTests";
 import { AbortController } from "@azure/abort-controller";
-import { UnbalancedLoadBalancingStrategy } from "../../src/loadBalancerStrategies/unbalancedStrategy";
 import { BalancedLoadBalancingStrategy } from "../../src/loadBalancerStrategies/balancedStrategy";
+import { Checkpoint } from "../../src/partitionProcessor";
+import { FakeSubscriptionEventHandlers } from "../public/utils/fakeSubscriptionEventHandlers";
 import { GreedyLoadBalancingStrategy } from "../../src/loadBalancerStrategies/greedyStrategy";
-import { testWithServiceTypes } from "../public/utils/testWithServiceTypes";
+import { InMemoryCheckpointStore } from "../../src/inMemoryCheckpointStore";
+import { PartitionContext } from "../../src/eventHubConsumerClientModels";
+import { UnbalancedLoadBalancingStrategy } from "../../src/loadBalancerStrategies/unbalancedStrategy";
+import chai from "chai";
+import chaiAsPromised from "chai-as-promised";
 import { createMockServer } from "../public/utils/mockService";
+import debugModule from "debug";
+import { delay } from "@azure/core-amqp";
+import { isLatestPosition } from "../../src/eventPosition";
+import { loggerForTest } from "../public/utils/logHelpers";
+import { testWithServiceTypes } from "../public/utils/testWithServiceTypes";
+
+const should = chai.should();
+chai.use(chaiAsPromised);
+const debug = debugModule("azure:event-hubs:partitionPump");
 
 testWithServiceTypes((serviceVersion) => {
   const env = getEnvVars();

--- a/sdk/eventhub/event-hubs/test/internal/eventdata.spec.ts
+++ b/sdk/eventhub/event-hubs/test/internal/eventdata.spec.ts
@@ -1,18 +1,14 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+import { EventData, ReceivedEventData, fromRheaMessage, toRheaMessage } from "../../src/eventData";
 import chai, { assert, should } from "chai";
-chai.should();
-
-import { EventData, fromRheaMessage, ReceivedEventData, toRheaMessage } from "../../src/eventData";
-import { Message } from "rhea-promise";
-import {
-  dataSectionTypeCode,
-  sequenceSectionTypeCode,
-  valueSectionTypeCode
-} from "../../src/dataTransformer";
+import { dataSectionTypeCode, sequenceSectionTypeCode, valueSectionTypeCode } from "../../src/dataTransformer";
 import { AmqpAnnotatedMessage } from "@azure/core-amqp";
+import { Message } from "rhea-promise";
 import { testWithServiceTypes } from "../public/utils/testWithServiceTypes";
+
+chai.should();
 
 const testAnnotations = {
   "x-opt-enqueued-time": Date.now(),

--- a/sdk/eventhub/event-hubs/test/internal/eventdata.spec.ts
+++ b/sdk/eventhub/event-hubs/test/internal/eventdata.spec.ts
@@ -3,7 +3,11 @@
 
 import { EventData, ReceivedEventData, fromRheaMessage, toRheaMessage } from "../../src/eventData";
 import chai, { assert, should } from "chai";
-import { dataSectionTypeCode, sequenceSectionTypeCode, valueSectionTypeCode } from "../../src/dataTransformer";
+import {
+  dataSectionTypeCode,
+  sequenceSectionTypeCode,
+  valueSectionTypeCode
+} from "../../src/dataTransformer";
 import { AmqpAnnotatedMessage } from "@azure/core-amqp";
 import { Message } from "rhea-promise";
 import { testWithServiceTypes } from "../public/utils/testWithServiceTypes";

--- a/sdk/eventhub/event-hubs/test/internal/impl/awaitableQueue.spec.ts
+++ b/sdk/eventhub/event-hubs/test/internal/impl/awaitableQueue.spec.ts
@@ -1,9 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+import { AwaitableQueue } from "../../../src/impl/awaitableQueue";
 import chai from "chai";
 import { testWithServiceTypes } from "../../public/utils/testWithServiceTypes";
-import { AwaitableQueue } from "../../../src/impl/awaitableQueue";
+
 const should = chai.should();
 
 testWithServiceTypes(() => {

--- a/sdk/eventhub/event-hubs/test/internal/loadBalancingStrategy.spec.ts
+++ b/sdk/eventhub/event-hubs/test/internal/loadBalancingStrategy.spec.ts
@@ -1,12 +1,13 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import chai from "chai";
-import { PartitionOwnership } from "../../src";
 import { BalancedLoadBalancingStrategy } from "../../src/loadBalancerStrategies/balancedStrategy";
 import { GreedyLoadBalancingStrategy } from "../../src/loadBalancerStrategies/greedyStrategy";
+import { PartitionOwnership } from "../../src";
 import { UnbalancedLoadBalancingStrategy } from "../../src/loadBalancerStrategies/unbalancedStrategy";
+import chai from "chai";
 import { testWithServiceTypes } from "../public/utils/testWithServiceTypes";
+
 const should = chai.should();
 
 testWithServiceTypes(() => {

--- a/sdk/eventhub/event-hubs/test/internal/misc.spec.ts
+++ b/sdk/eventhub/event-hubs/test/internal/misc.spec.ts
@@ -10,7 +10,10 @@ import {
   ReceivedEventData,
   Subscription
 } from "../../src";
-import { TRACEPARENT_PROPERTY, extractSpanContextFromEventData } from "../../src/diagnostics/instrumentEventData";
+import {
+  TRACEPARENT_PROPERTY,
+  extractSpanContextFromEventData
+} from "../../src/diagnostics/instrumentEventData";
 import { SubscriptionHandlerForTests } from "../public/utils/subscriptionHandlerForTests";
 import { TraceFlags } from "@azure/core-tracing";
 import assert from "assert";

--- a/sdk/eventhub/event-hubs/test/internal/misc.spec.ts
+++ b/sdk/eventhub/event-hubs/test/internal/misc.spec.ts
@@ -1,14 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { v4 as uuid } from "uuid";
-import chai from "chai";
-import assert from "assert";
-const should = chai.should();
-import chaiAsPromised from "chai-as-promised";
-chai.use(chaiAsPromised);
-import debugModule from "debug";
-const debug = debugModule("azure:event-hubs:misc-spec");
+import { EnvVarKeys, getEnvVars } from "../public/utils/testUtils";
 import {
   EventData,
   EventHubConsumerClient,
@@ -17,15 +10,20 @@ import {
   ReceivedEventData,
   Subscription
 } from "../../src";
-import { EnvVarKeys, getEnvVars } from "../public/utils/testUtils";
-import {
-  TRACEPARENT_PROPERTY,
-  extractSpanContextFromEventData
-} from "../../src/diagnostics/instrumentEventData";
-import { TraceFlags } from "@azure/core-tracing";
+import { TRACEPARENT_PROPERTY, extractSpanContextFromEventData } from "../../src/diagnostics/instrumentEventData";
 import { SubscriptionHandlerForTests } from "../public/utils/subscriptionHandlerForTests";
-import { testWithServiceTypes } from "../public/utils/testWithServiceTypes";
+import { TraceFlags } from "@azure/core-tracing";
+import assert from "assert";
+import chai from "chai";
+import chaiAsPromised from "chai-as-promised";
 import { createMockServer } from "../public/utils/mockService";
+import debugModule from "debug";
+import { testWithServiceTypes } from "../public/utils/testWithServiceTypes";
+import { v4 as uuid } from "uuid";
+
+const should = chai.should();
+chai.use(chaiAsPromised);
+const debug = debugModule("azure:event-hubs:misc-spec");
 
 testWithServiceTypes((serviceVersion) => {
   const env = getEnvVars();

--- a/sdk/eventhub/event-hubs/test/internal/node/disconnect.spec.ts
+++ b/sdk/eventhub/event-hubs/test/internal/node/disconnect.spec.ts
@@ -1,19 +1,20 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import chai from "chai";
-const should = chai.should();
-import chaiAsPromised from "chai-as-promised";
-chai.use(chaiAsPromised);
 import { EnvVarKeys, getEnvVars } from "../../public/utils/testUtils";
-import { EventHubSender } from "../../../src/eventHubSender";
-import { createConnectionContext } from "../../../src/connectionContext";
-import { stub } from "sinon";
-import { MessagingError } from "@azure/core-amqp";
-import { EventHubReceiver } from "../../../src/eventHubReceiver";
 import { EventHubConsumerClient, latestEventPosition } from "../../../src";
+import { EventHubReceiver } from "../../../src/eventHubReceiver";
+import { EventHubSender } from "../../../src/eventHubSender";
+import { MessagingError } from "@azure/core-amqp";
+import chai from "chai";
+import chaiAsPromised from "chai-as-promised";
+import { createConnectionContext } from "../../../src/connectionContext";
 import { createMockServer } from "../../public/utils/mockService";
+import { stub } from "sinon";
 import { testWithServiceTypes } from "../../public/utils/testWithServiceTypes";
+
+const should = chai.should();
+chai.use(chaiAsPromised);
 
 testWithServiceTypes((serviceVersion) => {
   const env = getEnvVars();

--- a/sdk/eventhub/event-hubs/test/internal/node/packageInfo.spec.ts
+++ b/sdk/eventhub/event-hubs/test/internal/node/packageInfo.spec.ts
@@ -2,11 +2,12 @@
 // Licensed under the MIT license.
 
 import chai from "chai";
-const should = chai.should();
 import fs from "fs";
-import path from "path";
 import { packageJsonInfo } from "../../../src/util/constants";
+import path from "path";
 import { testWithServiceTypes } from "../../public/utils/testWithServiceTypes";
+
+const should = chai.should();
 
 // Since we currently hardcode package name and version in `constants.ts` file,
 // following test is in place to ensure the values in package.json and in this file are consistent

--- a/sdk/eventhub/event-hubs/test/internal/partitionPump.spec.ts
+++ b/sdk/eventhub/event-hubs/test/internal/partitionPump.spec.ts
@@ -1,18 +1,18 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { createProcessingSpan, trace } from "../../src/partitionPump";
 import {
-  SpanStatusCode,
+  Context,
   SpanKind,
   SpanOptions,
-  Context,
-  setSpanContext,
-  context
+  SpanStatusCode,
+  context,
+  setSpanContext
 } from "@azure/core-tracing";
 import { TestSpan, TestTracer } from "@azure/test-utils";
-import chai from "chai";
+import { createProcessingSpan, trace } from "../../src/partitionPump";
 import { ReceivedEventData } from "../../src/eventData";
+import chai from "chai";
 import { instrumentEventData } from "../../src/diagnostics/instrumentEventData";
 import { setTracerForTest } from "../public/utils/testUtils";
 import { testWithServiceTypes } from "../public/utils/testWithServiceTypes";

--- a/sdk/eventhub/event-hubs/test/internal/receiveBatch.spec.ts
+++ b/sdk/eventhub/event-hubs/test/internal/receiveBatch.spec.ts
@@ -1,23 +1,23 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import chai from "chai";
-const should = chai.should();
-import chaiAsPromised from "chai-as-promised";
-chai.use(chaiAsPromised);
-
+import { EnvVarKeys, getEnvVars } from "../public/utils/testUtils";
 import {
   EventData,
-  MessagingError,
   EventHubConsumerClient,
   EventHubProducerClient,
-  EventPosition
+  EventPosition,
+  MessagingError
 } from "../../src";
-import { EnvVarKeys, getEnvVars } from "../public/utils/testUtils";
 import { EventHubReceiver } from "../../src/eventHubReceiver";
-import { translate } from "@azure/core-amqp";
-import { testWithServiceTypes } from "../public/utils/testWithServiceTypes";
+import chai from "chai";
+import chaiAsPromised from "chai-as-promised";
 import { createMockServer } from "../public/utils/mockService";
+import { testWithServiceTypes } from "../public/utils/testWithServiceTypes";
+import { translate } from "@azure/core-amqp";
+
+const should = chai.should();
+chai.use(chaiAsPromised);
 
 testWithServiceTypes((serviceVersion) => {
   const env = getEnvVars();

--- a/sdk/eventhub/event-hubs/test/internal/sender.spec.ts
+++ b/sdk/eventhub/event-hubs/test/internal/sender.spec.ts
@@ -1,7 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { EnvVarKeys, getEnvVars, getStartingPositionsForTests, setTracerForTest } from "../public/utils/testUtils";
+import {
+  EnvVarKeys,
+  getEnvVars,
+  getStartingPositionsForTests,
+  setTracerForTest
+} from "../public/utils/testUtils";
 import {
   EventData,
   EventHubConsumerClient,

--- a/sdk/eventhub/event-hubs/test/internal/sender.spec.ts
+++ b/sdk/eventhub/event-hubs/test/internal/sender.spec.ts
@@ -1,12 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import chai from "chai";
-const should = chai.should();
-import chaiAsPromised from "chai-as-promised";
-chai.use(chaiAsPromised);
-import debugModule from "debug";
-const debug = debugModule("azure:event-hubs:sender-spec");
+import { EnvVarKeys, getEnvVars, getStartingPositionsForTests, setTracerForTest } from "../public/utils/testUtils";
 import {
   EventData,
   EventHubConsumerClient,
@@ -17,18 +12,19 @@ import {
   SendBatchOptions,
   TryAddOptions
 } from "../../src";
-import {
-  EnvVarKeys,
-  getEnvVars,
-  getStartingPositionsForTests,
-  setTracerForTest
-} from "../public/utils/testUtils";
 import { SpanGraph, TestSpan } from "@azure/test-utils";
-import { TRACEPARENT_PROPERTY } from "../../src/diagnostics/instrumentEventData";
+import { context, setSpan } from "@azure/core-tracing";
 import { SubscriptionHandlerForTests } from "../public/utils/subscriptionHandlerForTests";
-import { setSpan, context } from "@azure/core-tracing";
-import { testWithServiceTypes } from "../public/utils/testWithServiceTypes";
+import { TRACEPARENT_PROPERTY } from "../../src/diagnostics/instrumentEventData";
+import chai from "chai";
+import chaiAsPromised from "chai-as-promised";
 import { createMockServer } from "../public/utils/mockService";
+import debugModule from "debug";
+import { testWithServiceTypes } from "../public/utils/testWithServiceTypes";
+
+const should = chai.should();
+chai.use(chaiAsPromised);
+const debug = debugModule("azure:event-hubs:sender-spec");
 
 testWithServiceTypes((serviceVersion) => {
   const env = getEnvVars();

--- a/sdk/eventhub/event-hubs/test/public/amqpAnnotatedMessage.spec.ts
+++ b/sdk/eventhub/event-hubs/test/public/amqpAnnotatedMessage.spec.ts
@@ -1,12 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import chai from "chai";
-import chaiAsPromised from "chai-as-promised";
-import chaiExclude from "chai-exclude";
-import { Buffer } from "buffer";
-import { AmqpAnnotatedMessage } from "@azure/core-amqp";
-import { v4 } from "uuid";
 import { EnvVarKeys, getEnvVars, getStartingPositionsForTests } from "./utils/testUtils";
 import {
   EventHubConsumerClient,
@@ -15,9 +9,15 @@ import {
   ReceivedEventData,
   Subscription
 } from "../../src";
+import { AmqpAnnotatedMessage } from "@azure/core-amqp";
 import { BodyTypes } from "../../src/dataTransformer";
-import { testWithServiceTypes } from "./utils/testWithServiceTypes";
+import { Buffer } from "buffer";
+import chai from "chai";
+import chaiAsPromised from "chai-as-promised";
+import chaiExclude from "chai-exclude";
 import { createMockServer } from "./utils/mockService";
+import { testWithServiceTypes } from "./utils/testWithServiceTypes";
+import { v4 } from "uuid";
 
 const should = chai.should();
 chai.use(chaiAsPromised);

--- a/sdk/eventhub/event-hubs/test/public/auth.spec.ts
+++ b/sdk/eventhub/event-hubs/test/public/auth.spec.ts
@@ -3,7 +3,11 @@
 
 import { AzureNamedKeyCredential, AzureSASCredential } from "@azure/core-auth";
 import { EnvVarKeys, getEnvVars } from "./utils/testUtils";
-import { EventHubConsumerClient, EventHubProducerClient, parseEventHubConnectionString } from "../../src/index";
+import {
+  EventHubConsumerClient,
+  EventHubProducerClient,
+  parseEventHubConnectionString
+} from "../../src/index";
 import { SinonFakeTimers, useFakeTimers } from "sinon";
 import chai from "chai";
 import { createMockServer } from "./utils/mockService";

--- a/sdk/eventhub/event-hubs/test/public/auth.spec.ts
+++ b/sdk/eventhub/event-hubs/test/public/auth.spec.ts
@@ -1,18 +1,14 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import {
-  EventHubConsumerClient,
-  EventHubProducerClient,
-  parseEventHubConnectionString
-} from "../../src/index";
-import { EnvVarKeys, getEnvVars } from "./utils/testUtils";
-import chai from "chai";
 import { AzureNamedKeyCredential, AzureSASCredential } from "@azure/core-auth";
-import { createSasTokenProvider } from "@azure/core-amqp";
+import { EnvVarKeys, getEnvVars } from "./utils/testUtils";
+import { EventHubConsumerClient, EventHubProducerClient, parseEventHubConnectionString } from "../../src/index";
 import { SinonFakeTimers, useFakeTimers } from "sinon";
-import { testWithServiceTypes } from "./utils/testWithServiceTypes";
+import chai from "chai";
 import { createMockServer } from "./utils/mockService";
+import { createSasTokenProvider } from "@azure/core-amqp";
+import { testWithServiceTypes } from "./utils/testWithServiceTypes";
 
 const should = chai.should();
 

--- a/sdk/eventhub/event-hubs/test/public/cancellation.spec.ts
+++ b/sdk/eventhub/event-hubs/test/public/cancellation.spec.ts
@@ -1,16 +1,16 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+import { EnvVarKeys, getEnvVars } from "./utils/testUtils";
+import { EventHubConsumerClient, EventHubProducerClient } from "../../src";
 import { AbortController } from "@azure/abort-controller";
 import chai from "chai";
-const should = chai.should();
 import chaiAsPromised from "chai-as-promised";
-import { EventHubConsumerClient, EventHubProducerClient } from "../../src";
 import { createMockServer } from "./utils/mockService";
-chai.use(chaiAsPromised);
-
-import { EnvVarKeys, getEnvVars } from "./utils/testUtils";
 import { testWithServiceTypes } from "./utils/testWithServiceTypes";
+
+const should = chai.should();
+chai.use(chaiAsPromised);
 
 testWithServiceTypes((serviceVersion) => {
   const env = getEnvVars();

--- a/sdk/eventhub/event-hubs/test/public/eventData.spec.ts
+++ b/sdk/eventhub/event-hubs/test/public/eventData.spec.ts
@@ -1,10 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import chai from "chai";
-import chaiAsPromised from "chai-as-promised";
-import chaiExclude from "chai-exclude";
-import { v4 } from "uuid";
 import { EnvVarKeys, getEnvVars, getStartingPositionsForTests } from "./utils/testUtils";
 import {
   EventData,
@@ -14,8 +10,12 @@ import {
   ReceivedEventData,
   Subscription
 } from "../../src";
-import { testWithServiceTypes } from "./utils/testWithServiceTypes";
+import chai from "chai";
+import chaiAsPromised from "chai-as-promised";
+import chaiExclude from "chai-exclude";
 import { createMockServer } from "./utils/mockService";
+import { testWithServiceTypes } from "./utils/testWithServiceTypes";
+import { v4 } from "uuid";
 
 const should = chai.should();
 chai.use(chaiAsPromised);

--- a/sdk/eventhub/event-hubs/test/public/eventHubBufferedProducerClient.spec.ts
+++ b/sdk/eventhub/event-hubs/test/public/eventHubBufferedProducerClient.spec.ts
@@ -1,17 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import chai from "chai";
 import { EnvVarKeys, getEnvVars } from "./utils/testUtils";
-import { testWithServiceTypes } from "./utils/testWithServiceTypes";
-import { createMockServer } from "./utils/mockService";
-import {
-  EventHubBufferedProducerClient,
-  EventData,
-  OnSendEventsErrorContext,
-  OnSendEventsSuccessContext
-} from "../../src/index";
+import { EventData, EventHubBufferedProducerClient, OnSendEventsErrorContext, OnSendEventsSuccessContext } from "../../src/index";
 import { AmqpAnnotatedMessage } from "@azure/core-amqp";
+import chai from "chai";
+import { createMockServer } from "./utils/mockService";
+import { testWithServiceTypes } from "./utils/testWithServiceTypes";
 
 const assert = chai.assert;
 

--- a/sdk/eventhub/event-hubs/test/public/eventHubBufferedProducerClient.spec.ts
+++ b/sdk/eventhub/event-hubs/test/public/eventHubBufferedProducerClient.spec.ts
@@ -2,7 +2,12 @@
 // Licensed under the MIT license.
 
 import { EnvVarKeys, getEnvVars } from "./utils/testUtils";
-import { EventData, EventHubBufferedProducerClient, OnSendEventsErrorContext, OnSendEventsSuccessContext } from "../../src/index";
+import {
+  EventData,
+  EventHubBufferedProducerClient,
+  OnSendEventsErrorContext,
+  OnSendEventsSuccessContext
+} from "../../src/index";
 import { AmqpAnnotatedMessage } from "@azure/core-amqp";
 import chai from "chai";
 import { createMockServer } from "./utils/mockService";

--- a/sdk/eventhub/event-hubs/test/public/eventHubConsumerClient.spec.ts
+++ b/sdk/eventhub/event-hubs/test/public/eventHubConsumerClient.spec.ts
@@ -2,28 +2,28 @@
 // Licensed under the MIT license.
 
 import {
-  EventHubProducerClient,
-  Subscription,
-  SubscriptionEventHandlers,
-  latestEventPosition,
-  logger,
   CloseReason,
-  EventHubConsumerClient,
   EventData,
+  EventHubConsumerClient,
+  EventHubProducerClient,
   MessagingError,
   ReceivedEventData,
-  earliestEventPosition
+  Subscription,
+  SubscriptionEventHandlers,
+  earliestEventPosition,
+  latestEventPosition,
+  logger
 } from "../../src";
-import debugModule from "debug";
-const debug = debugModule("azure:event-hubs:receiver-spec");
-import { EnvVarKeys, loopUntil, getStartingPositionsForTests, getEnvVars } from "./utils/testUtils";
-import chai from "chai";
-import { ReceivedMessagesTester } from "./utils/receivedMessagesTester";
+import { EnvVarKeys, getEnvVars, getStartingPositionsForTests, loopUntil } from "./utils/testUtils";
 import { LogTester } from "./utils/logHelpers";
+import { ReceivedMessagesTester } from "./utils/receivedMessagesTester";
 import { TestInMemoryCheckpointStore } from "./utils/testInMemoryCheckpointStore";
-import { testWithServiceTypes } from "./utils/testWithServiceTypes";
+import chai from "chai";
 import { createMockServer } from "./utils/mockService";
+import debugModule from "debug";
+import { testWithServiceTypes } from "./utils/testWithServiceTypes";
 
+const debug = debugModule("azure:event-hubs:receiver-spec");
 const should = chai.should();
 
 testWithServiceTypes((serviceVersion) => {

--- a/sdk/eventhub/event-hubs/test/public/hubruntime.spec.ts
+++ b/sdk/eventhub/event-hubs/test/public/hubruntime.spec.ts
@@ -2,7 +2,12 @@
 // Licensed under the MIT license.
 
 import { EnvVarKeys, getEnvVars, setTracerForTest } from "./utils/testUtils";
-import { EventHubBufferedProducerClient, EventHubConsumerClient, EventHubProducerClient, MessagingError } from "../../src";
+import {
+  EventHubBufferedProducerClient,
+  EventHubConsumerClient,
+  EventHubProducerClient,
+  MessagingError
+} from "../../src";
 import { context, setSpan } from "@azure/core-tracing";
 import { SpanGraph } from "@azure/test-utils";
 import chai from "chai";

--- a/sdk/eventhub/event-hubs/test/public/hubruntime.spec.ts
+++ b/sdk/eventhub/event-hubs/test/public/hubruntime.spec.ts
@@ -1,24 +1,19 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import chai from "chai";
-const should = chai.should();
-import chaiAsPromised from "chai-as-promised";
-chai.use(chaiAsPromised);
-import debugModule from "debug";
-const debug = debugModule("azure:event-hubs:hubruntime-spec");
 import { EnvVarKeys, getEnvVars, setTracerForTest } from "./utils/testUtils";
-import { setSpan, context } from "@azure/core-tracing";
-
+import { EventHubBufferedProducerClient, EventHubConsumerClient, EventHubProducerClient, MessagingError } from "../../src";
+import { context, setSpan } from "@azure/core-tracing";
 import { SpanGraph } from "@azure/test-utils";
-import {
-  EventHubBufferedProducerClient,
-  EventHubProducerClient,
-  EventHubConsumerClient,
-  MessagingError
-} from "../../src";
-import { testWithServiceTypes } from "./utils/testWithServiceTypes";
+import chai from "chai";
+import chaiAsPromised from "chai-as-promised";
 import { createMockServer } from "./utils/mockService";
+import debugModule from "debug";
+import { testWithServiceTypes } from "./utils/testWithServiceTypes";
+
+const should = chai.should();
+chai.use(chaiAsPromised);
+const debug = debugModule("azure:event-hubs:hubruntime-spec");
 
 type ClientCommonMethods = Pick<
   EventHubProducerClient,

--- a/sdk/eventhub/event-hubs/test/public/node/client.spec.ts
+++ b/sdk/eventhub/event-hubs/test/public/node/client.spec.ts
@@ -1,18 +1,19 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import chai from "chai";
-const should = chai.should();
-import chaiAsPromised from "chai-as-promised";
-chai.use(chaiAsPromised);
-import chaiString from "chai-string";
-chai.use(chaiString);
 import { EnvVarKeys, getEnvVars } from "../utils/testUtils";
 import { EnvironmentCredential, TokenCredential } from "@azure/identity";
-import { EventHubProducerClient, EventHubConsumerClient } from "../../../src";
-import { TestTracer, setTracer, resetTracer } from "@azure/test-utils";
-import { testWithServiceTypes } from "../utils/testWithServiceTypes";
+import { EventHubConsumerClient, EventHubProducerClient } from "../../../src";
+import { TestTracer, resetTracer, setTracer } from "@azure/test-utils";
+import chai from "chai";
+import chaiAsPromised from "chai-as-promised";
+import chaiString from "chai-string";
 import { createMockServer } from "../utils/mockService";
+import { testWithServiceTypes } from "../utils/testWithServiceTypes";
+
+const should = chai.should();
+chai.use(chaiAsPromised);
+chai.use(chaiString);
 
 testWithServiceTypes((serviceVersion) => {
   const env = getEnvVars();

--- a/sdk/eventhub/event-hubs/test/public/node/disconnects.spec.ts
+++ b/sdk/eventhub/event-hubs/test/public/node/disconnects.spec.ts
@@ -1,14 +1,15 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import chai from "chai";
-const should = chai.should();
-import chaiAsPromised from "chai-as-promised";
-chai.use(chaiAsPromised);
 import { EnvVarKeys, getEnvVars } from "../utils/testUtils";
 import { EventHubConsumerClient, EventHubProducerClient, Subscription } from "../../../src";
-import { testWithServiceTypes } from "../utils/testWithServiceTypes";
+import chai from "chai";
+import chaiAsPromised from "chai-as-promised";
 import { createMockServer } from "../utils/mockService";
+import { testWithServiceTypes } from "../utils/testWithServiceTypes";
+
+const should = chai.should();
+chai.use(chaiAsPromised);
 
 testWithServiceTypes((serviceVersion, onVersions) => {
   const env = getEnvVars();

--- a/sdk/eventhub/event-hubs/test/public/receiver.spec.ts
+++ b/sdk/eventhub/event-hubs/test/public/receiver.spec.ts
@@ -1,24 +1,25 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import chai from "chai";
-const should = chai.should();
-import chaiAsPromised from "chai-as-promised";
-chai.use(chaiAsPromised);
-import debugModule from "debug";
-const debug = debugModule("azure:event-hubs:receiver-spec");
+import { EnvVarKeys, getEnvVars } from "./utils/testUtils";
 import {
   EventData,
-  ReceivedEventData,
-  latestEventPosition,
-  earliestEventPosition,
   EventHubConsumerClient,
   EventHubProducerClient,
-  Subscription
+  ReceivedEventData,
+  Subscription,
+  earliestEventPosition,
+  latestEventPosition
 } from "../../src";
+import chai from "chai";
+import chaiAsPromised from "chai-as-promised";
 import { createMockServer } from "./utils/mockService";
-import { EnvVarKeys, getEnvVars } from "./utils/testUtils";
+import debugModule from "debug";
 import { testWithServiceTypes } from "./utils/testWithServiceTypes";
+
+const should = chai.should();
+chai.use(chaiAsPromised);
+const debug = debugModule("azure:event-hubs:receiver-spec");
 
 testWithServiceTypes((serviceVersion) => {
   const env = getEnvVars();

--- a/sdk/eventhub/event-hubs/test/public/utils/mockService.ts
+++ b/sdk/eventhub/event-hubs/test/public/utils/mockService.ts
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { readFileSync } from "fs";
-import { resolve as resolvePath } from "path";
 import { MockEventHub, MockServerOptions } from "@azure/mock-hub";
 import { getEnvVars } from "./testUtils";
+import { readFileSync } from "fs";
+import { resolve as resolvePath } from "path";
 
 export function createMockServer(options: MockServerOptions = {}): MockEventHub {
   const { EVENTHUB_NAME } = getEnvVars();

--- a/sdk/eventhub/event-hubs/test/public/utils/subscriptionHandlerForTests.ts
+++ b/sdk/eventhub/event-hubs/test/public/utils/subscriptionHandlerForTests.ts
@@ -1,19 +1,20 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { delay } from "@azure/core-amqp";
-import chai from "chai";
 import {
   CloseReason,
   EventHubConsumerClient,
   EventHubProducerClient,
   EventPosition,
-  ReceivedEventData,
   PartitionContext,
+  ReceivedEventData,
   SubscriptionEventHandlers
 } from "../../../src";
+import chai from "chai";
+import { delay } from "@azure/core-amqp";
 import { loggerForTest } from "./logHelpers";
 import { loopUntil } from "./testUtils";
+
 const should = chai.should();
 
 export interface HandlerAndPositions {

--- a/sdk/eventhub/event-hubs/test/public/utils/testInMemoryCheckpointStore.ts
+++ b/sdk/eventhub/event-hubs/test/public/utils/testInMemoryCheckpointStore.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { CheckpointStore, PartitionOwnership, Checkpoint } from "../../../src";
+import { Checkpoint, CheckpointStore, PartitionOwnership } from "../../../src";
 import { generate_uuid } from "rhea-promise";
 
 /**

--- a/sdk/eventhub/event-hubs/test/public/utils/testUtils.ts
+++ b/sdk/eventhub/event-hubs/test/public/utils/testUtils.ts
@@ -2,10 +2,10 @@
 // Licensed under the MIT license.
 
 import * as dotenv from "dotenv";
-import { loggerForTest } from "./logHelpers";
-import { delay } from "@azure/core-amqp";
 import { EventHubConsumerClient, EventHubProducerClient, EventPosition } from "../../../src";
-import { TestTracer, setTracer, resetTracer } from "@azure/test-utils";
+import { TestTracer, resetTracer, setTracer } from "@azure/test-utils";
+import { delay } from "@azure/core-amqp";
+import { loggerForTest } from "./logHelpers";
 
 dotenv.config();
 

--- a/sdk/eventhub/event-hubs/test/public/utils/testWithServiceTypes.ts
+++ b/sdk/eventhub/event-hubs/test/public/utils/testWithServiceTypes.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { isNode, TestFunctionWrapper, versionsToTest } from "@azure/test-utils";
+import { TestFunctionWrapper, isNode, versionsToTest } from "@azure/test-utils";
 import { getEnvVarValue } from "./testUtils";
 
 export type SupportedTargets = "mock" | "live";


### PR DESCRIPTION
This PR is working in conjunction with other PRs to fix individual sections of the azure codebase with respect to the new ```sort-imports``` rule, as indicated in #9252.

In this PR, I have fixed all files under ```sdk/eventhub/event-hubs```.