### PR TITLE
[sort-imports] update ```eventhubs-checkpointstore-blob``` with respect to ```sort-imports``` rule

### DIFF
--- a/sdk/eventhub/eventhubs-checkpointstore-blob/src/blobCheckpointStore.ts
+++ b/sdk/eventhub/eventhubs-checkpointstore-blob/src/blobCheckpointStore.ts
@@ -1,14 +1,14 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+import { BlobSetMetadataResponse, ContainerClient, Metadata, RestError } from "@azure/storage-blob";
 import {
-  CheckpointStore,
-  PartitionOwnership,
   Checkpoint,
-  OperationOptions
+  CheckpointStore,
+  OperationOptions,
+  PartitionOwnership
 } from "@azure/event-hubs";
-import { ContainerClient, Metadata, RestError, BlobSetMetadataResponse } from "@azure/storage-blob";
-import { logger, logErrorStackTrace } from "./log";
+import { logErrorStackTrace, logger } from "./log";
 import { throwTypeErrorIfParameterMissing } from "./util/error";
 
 /**

--- a/sdk/eventhub/eventhubs-checkpointstore-blob/src/util/error.ts
+++ b/sdk/eventhub/eventhubs-checkpointstore-blob/src/util/error.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { logger, logErrorStackTrace } from "../log";
+import { logErrorStackTrace, logger } from "../log";
 
 /**
  * @internal

--- a/sdk/eventhub/eventhubs-checkpointstore-blob/test/blob-checkpointstore.spec.ts
+++ b/sdk/eventhub/eventhubs-checkpointstore-blob/test/blob-checkpointstore.spec.ts
@@ -1,22 +1,23 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import chai from "chai";
-const should = chai.should();
-import chaiAsPromised from "chai-as-promised";
-chai.use(chaiAsPromised);
-import chaiString from "chai-string";
-chai.use(chaiString);
-import debugModule from "debug";
-const debug = debugModule("azure:event-hubs:partitionPump");
-import { EnvVarKeys, getEnvVars } from "./utils/testUtils";
-import { BlobCheckpointStore } from "../src";
+import { Checkpoint, EventHubConsumerClient, PartitionOwnership } from "@azure/event-hubs";
 import { ContainerClient, RestError } from "@azure/storage-blob";
-import { PartitionOwnership, Checkpoint, EventHubConsumerClient } from "@azure/event-hubs";
-import { Guid } from "guid-typescript";
-import { parseIntOrThrow } from "../src/blobCheckpointStore";
-import { fail } from "assert";
+import { EnvVarKeys, getEnvVars } from "./utils/testUtils";
 import { AbortController } from "@azure/abort-controller";
+import { BlobCheckpointStore } from "../src";
+import { Guid } from "guid-typescript";
+import chai from "chai";
+import chaiAsPromised from "chai-as-promised";
+import chaiString from "chai-string";
+import debugModule from "debug";
+import { fail } from "assert";
+import { parseIntOrThrow } from "../src/blobCheckpointStore";
+
+const should = chai.should();
+chai.use(chaiAsPromised);
+chai.use(chaiString);
+const debug = debugModule("azure:event-hubs:partitionPump");
 const env = getEnvVars();
 
 describe("Blob Checkpoint Store", function(): void {

--- a/sdk/eventhub/eventhubs-checkpointstore-blob/test/snippets.spec.ts
+++ b/sdk/eventhub/eventhubs-checkpointstore-blob/test/snippets.spec.ts
@@ -1,14 +1,15 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { env } from "process";
 import * as dotenv from "dotenv";
 
 // if you modify these imports update the imports in the snippet below as well
 // (JS compatible there)
-import { EventHubConsumerClient } from "@azure/event-hubs";
-import { ContainerClient } from "@azure/storage-blob";
 import { BlobCheckpointStore } from "../src";
+import { ContainerClient } from "@azure/storage-blob";
+import { EventHubConsumerClient } from "@azure/event-hubs";
+
+import { env } from "process";
 
 describe.skip("Snippets", () => {
   // used in the eventhubs and eventhubs-checkpointstore-blob readme.


### PR DESCRIPTION
This PR is working in conjunction with other PRs to fix individual sections of the azure codebase with respect to the new ```sort-imports``` rule, as indicated in #9252.

In this PR, I have fixed all files under ```sdk/eventhub/eventhubs-checkpointstore-blob```.