### PR TITLE
[sort-imports] update ```identity-cache-persistence``` with respect to ```sort-imports``` rule

### DIFF
--- a/sdk/identity/identity-cache-persistence/src/index.ts
+++ b/sdk/identity/identity-cache-persistence/src/index.ts
@@ -1,9 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { IdentityPlugin } from "@azure/identity";
-
 import { AzurePluginContext } from "../../identity/src/plugins/provider";
+import { IdentityPlugin } from "@azure/identity";
 import { createPersistenceCachePlugin } from "./provider";
 
 /**

--- a/sdk/identity/identity-cache-persistence/src/platforms.ts
+++ b/sdk/identity/identity-cache-persistence/src/platforms.ts
@@ -4,16 +4,14 @@
 /* eslint-disable tsdoc/syntax */
 
 import * as path from "path";
-
 import {
-  KeychainPersistence,
-  FilePersistence,
   DataProtectionScope,
+  FilePersistence,
   FilePersistenceWithDataProtection,
+  KeychainPersistence,
   LibSecretPersistence,
   IPersistence as Persistence
 } from "@azure/msal-node-extensions";
-
 import { TokenCachePersistenceOptions } from "@azure/identity";
 
 /**

--- a/sdk/identity/identity-cache-persistence/src/provider.ts
+++ b/sdk/identity/identity-cache-persistence/src/provider.ts
@@ -1,10 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { ICachePlugin as CachePlugin } from "@azure/msal-node";
-import { PersistenceCachePlugin, IPersistence as Persistence } from "@azure/msal-node-extensions";
-
 import { MsalPersistenceOptions, msalPersistencePlatforms } from "./platforms";
+import { IPersistence as Persistence, PersistenceCachePlugin } from "@azure/msal-node-extensions";
+import { ICachePlugin as CachePlugin } from "@azure/msal-node";
 
 /**
  * This is used to gain access to the underlying Persistence instance, which we use for testing

--- a/sdk/identity/identity-cache-persistence/test/internal/node/clientCertificateCredential.spec.ts
+++ b/sdk/identity/identity-cache-persistence/test/internal/node/clientCertificateCredential.spec.ts
@@ -4,7 +4,10 @@
 /* eslint-disable @typescript-eslint/no-non-null-asserted-optional-chain */
 
 import * as path from "path";
-import { ClientCertificateCredential, TokenCachePersistenceOptions } from "../../../../identity/src";
+import {
+  ClientCertificateCredential,
+  TokenCachePersistenceOptions
+} from "../../../../identity/src";
 import { MsalTestCleanup, msalNodeTestSetup } from "../../../../identity/test/msalTestUtils";
 import { env, isPlaybackMode } from "@azure-tools/test-recorder";
 import { ConfidentialClientApplication } from "@azure/msal-node";

--- a/sdk/identity/identity-cache-persistence/test/internal/node/clientCertificateCredential.spec.ts
+++ b/sdk/identity/identity-cache-persistence/test/internal/node/clientCertificateCredential.spec.ts
@@ -3,20 +3,14 @@
 
 /* eslint-disable @typescript-eslint/no-non-null-asserted-optional-chain */
 
-import Sinon from "sinon";
-import assert from "assert";
 import * as path from "path";
-
+import { ClientCertificateCredential, TokenCachePersistenceOptions } from "../../../../identity/src";
+import { MsalTestCleanup, msalNodeTestSetup } from "../../../../identity/test/msalTestUtils";
 import { env, isPlaybackMode } from "@azure-tools/test-recorder";
 import { ConfidentialClientApplication } from "@azure/msal-node";
-
-import {
-  ClientCertificateCredential,
-  TokenCachePersistenceOptions
-} from "../../../../identity/src";
-import { MsalTestCleanup, msalNodeTestSetup } from "../../../../identity/test/msalTestUtils";
 import { MsalNode } from "../../../../identity/src/msal/nodeFlows/msalNodeCommon";
-
+import Sinon from "sinon";
+import assert from "assert";
 import { createPersistence } from "./setup.spec";
 
 const ASSET_PATH = "assets";

--- a/sdk/identity/identity-cache-persistence/test/internal/node/clientSecretCredential.spec.ts
+++ b/sdk/identity/identity-cache-persistence/test/internal/node/clientSecretCredential.spec.ts
@@ -3,17 +3,14 @@
 
 /* eslint-disable @typescript-eslint/no-non-null-asserted-optional-chain */
 
-import Sinon from "sinon";
-import assert from "assert";
-
-import { env } from "@azure-tools/test-recorder";
-import { ConfidentialClientApplication } from "@azure/msal-node";
-
 import { ClientSecretCredential, TokenCachePersistenceOptions } from "../../../../identity/src";
 import { MsalTestCleanup, msalNodeTestSetup } from "../../../../identity/test/msalTestUtils";
+import { ConfidentialClientApplication } from "@azure/msal-node";
 import { MsalNode } from "../../../../identity/src/msal/nodeFlows/msalNodeCommon";
-
+import Sinon from "sinon";
+import assert from "assert";
 import { createPersistence } from "./setup.spec";
+import { env } from "@azure-tools/test-recorder";
 
 const scope = "https://graph.microsoft.com/.default";
 

--- a/sdk/identity/identity-cache-persistence/test/internal/node/deviceCodeCredential.spec.ts
+++ b/sdk/identity/identity-cache-persistence/test/internal/node/deviceCodeCredential.spec.ts
@@ -3,17 +3,14 @@
 
 /* eslint-disable @typescript-eslint/no-non-null-asserted-optional-chain */
 
-import Sinon from "sinon";
-import assert from "assert";
-
-import { PublicClientApplication } from "@azure/msal-node";
-import { isLiveMode } from "@azure-tools/test-recorder";
-
 import { DeviceCodeCredential, TokenCachePersistenceOptions } from "../../../../identity/src";
 import { MsalTestCleanup, msalNodeTestSetup } from "../../../../identity/test/msalTestUtils";
 import { MsalNode } from "../../../../identity/src/msal/nodeFlows/msalNodeCommon";
-
+import { PublicClientApplication } from "@azure/msal-node";
+import Sinon from "sinon";
+import assert from "assert";
 import { createPersistence } from "./setup.spec";
+import { isLiveMode } from "@azure-tools/test-recorder";
 
 describe("DeviceCodeCredential (internal)", function(this: Mocha.Suite) {
   let cleanup: MsalTestCleanup;

--- a/sdk/identity/identity-cache-persistence/test/internal/node/usernamePasswordCredential.spec.ts
+++ b/sdk/identity/identity-cache-persistence/test/internal/node/usernamePasswordCredential.spec.ts
@@ -3,17 +3,14 @@
 
 /* eslint-disable @typescript-eslint/no-non-null-asserted-optional-chain */
 
+import { MsalTestCleanup, msalNodeTestSetup } from "../../../../identity/test/msalTestUtils";
+import { TokenCachePersistenceOptions, UsernamePasswordCredential } from "../../../../identity/src";
+import { MsalNode } from "../../../../identity/src/msal/nodeFlows/msalNodeCommon";
+import { PublicClientApplication } from "@azure/msal-node";
 import Sinon from "sinon";
 import assert from "assert";
-
-import { env } from "@azure-tools/test-recorder";
-import { PublicClientApplication } from "@azure/msal-node";
-
-import { UsernamePasswordCredential, TokenCachePersistenceOptions } from "../../../../identity/src";
-import { MsalTestCleanup, msalNodeTestSetup } from "../../../../identity/test/msalTestUtils";
-import { MsalNode } from "../../../../identity/src/msal/nodeFlows/msalNodeCommon";
-
 import { createPersistence } from "./setup.spec";
+import { env } from "@azure-tools/test-recorder";
 
 describe("UsernamePasswordCredential (internal)", function(this: Mocha.Suite) {
   let cleanup: MsalTestCleanup;


### PR DESCRIPTION
This PR is working in conjunction with other PRs to fix individual sections of the azure codebase with respect to the new ```sort-imports``` rule, as indicated in #9252.

In this PR, I have fixed all files under ```sdk/identity/identity-cache-persistence```.