### PR TITLE
[sort-imports] update ```identity-vscode``` with respect to ```sort-imports``` rule

### DIFF
--- a/sdk/identity/identity-vscode/src/index.ts
+++ b/sdk/identity/identity-vscode/src/index.ts
@@ -1,10 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { IdentityPlugin } from "@azure/identity";
-
 import { AzurePluginContext } from "../../identity/src/plugins/provider";
-
+import { IdentityPlugin } from "@azure/identity";
 import keytar from "keytar";
 
 const VSCodeServiceName = "VS Code Azure";

--- a/sdk/identity/identity-vscode/test/public/node/visualStudioCodeCredential.spec.ts
+++ b/sdk/identity/identity-vscode/test/public/node/visualStudioCodeCredential.spec.ts
@@ -4,12 +4,11 @@
 /* eslint-disable @typescript-eslint/no-non-null-asserted-optional-chain */
 /* eslint-disable @typescript-eslint/no-require-imports */
 
-import assert from "assert";
-import sinon from "sinon";
-
 import { MsalTestCleanup, msalNodeTestSetup } from "../../../../identity/test/msalTestUtils";
 import { VisualStudioCodeCredential } from "@azure/identity";
+import assert from "assert";
 import { isRecordMode } from "@azure-tools/test-recorder";
+import sinon from "sinon";
 
 const mockedResponse = [
   {


### PR DESCRIPTION
This PR is working in conjunction with other PRs to fix individual sections of the azure codebase with respect to the new ```sort-imports``` rule, as indicated in #9252.

In this PR, I have fixed all files under ```sdk/identity/identity-vscode```.