### PR TITLE
[sort-imports] update ```iot-modelsrepository``` with respect to ```sort-imports``` rule

### DIFF
--- a/sdk/iot/iot-modelsrepository/src/dtmiResolver.ts
+++ b/sdk/iot/iot-modelsrepository/src/dtmiResolver.ts
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { OperationOptions } from "@azure/core-client";
 import { DTDL } from "./psuedoDtdl";
-import { convertDtmiToPath } from "./dtmiConventions";
-import { ModelError } from "./exceptions";
 import { Fetcher } from "./fetcherAbstract";
+import { ModelError } from "./exceptions";
+import { OperationOptions } from "@azure/core-client";
+import { convertDtmiToPath } from "./dtmiConventions";
 import { logger } from "./logger";
 
 /**

--- a/sdk/iot/iot-modelsrepository/src/fetcherAbstract.ts
+++ b/sdk/iot/iot-modelsrepository/src/fetcherAbstract.ts
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { OperationOptions } from "@azure/core-client";
 import { DTDL } from "./psuedoDtdl";
+import { OperationOptions } from "@azure/core-client";
 
 /**
  * Base Interface for Fetchers, which fetch models from endpoints.

--- a/sdk/iot/iot-modelsrepository/src/fetcherFilesystem.ts
+++ b/sdk/iot/iot-modelsrepository/src/fetcherFilesystem.ts
@@ -1,12 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import fs from "fs";
 import * as path from "path";
 import { RestError, RestErrorOptions } from "@azure/core-rest-pipeline";
-import { Fetcher } from "./fetcherAbstract";
-import { logger } from "./logger";
 import { DTDL } from "./psuedoDtdl";
+import { Fetcher } from "./fetcherAbstract";
+import fs from "fs";
+import { logger } from "./logger";
 
 function readFilePromise(filePath: string): Promise<string> {
   return new Promise((resolve, reject) => {

--- a/sdk/iot/iot-modelsrepository/src/fetcherHTTP.ts
+++ b/sdk/iot/iot-modelsrepository/src/fetcherHTTP.ts
@@ -1,19 +1,19 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { OperationOptions, ServiceClient } from "@azure/core-client";
 import {
-  createHttpHeaders,
-  createPipelineRequest,
   HttpHeaders,
   HttpMethods,
   PipelineRequest,
   PipelineResponse,
-  RestError
+  RestError,
+  createHttpHeaders,
+  createPipelineRequest
 } from "@azure/core-rest-pipeline";
-import { logger } from "./logger";
-import { Fetcher } from "./fetcherAbstract";
+import { OperationOptions, ServiceClient } from "@azure/core-client";
 import { DTDL } from "./psuedoDtdl";
+import { Fetcher } from "./fetcherAbstract";
+import { logger } from "./logger";
 
 /**
  * The HTTP Fetcher implements the Fetcher interface to

--- a/sdk/iot/iot-modelsrepository/src/modelsRepositoryClient.ts
+++ b/sdk/iot/iot-modelsrepository/src/modelsRepositoryClient.ts
@@ -9,20 +9,20 @@ import {
   DEPENDENCY_MODE_ENABLED,
   DEPENDENCY_MODE_TRY_FROM_EXPANDED
 } from "./utils/constants";
-import { createClientPipeline, InternalClientPipelineOptions } from "@azure/core-client";
-import { Fetcher } from "./fetcherAbstract";
-import { URL } from "./utils/url";
+import { InternalClientPipelineOptions, createClientPipeline } from "@azure/core-client";
 import { isLocalPath, normalize } from "./utils/path";
-import { FilesystemFetcher } from "./fetcherFilesystem";
-import { dependencyResolutionType } from "./dependencyResolutionType";
-import { DtmiResolver } from "./dtmiResolver";
-import { PseudoParser } from "./psuedoParser";
-import { ModelsRepositoryClientOptions } from "./interfaces/modelsRepositoryClientOptions";
-import { logger } from "./logger";
-import { IoTModelsRepositoryServiceClient } from "./modelsRepositoryServiceClient";
-import { HttpFetcher } from "./fetcherHTTP";
-import { GetModelsOptions } from "./interfaces/getModelsOptions";
 import { DTDL } from "./psuedoDtdl";
+import { DtmiResolver } from "./dtmiResolver";
+import { Fetcher } from "./fetcherAbstract";
+import { FilesystemFetcher } from "./fetcherFilesystem";
+import { GetModelsOptions } from "./interfaces/getModelsOptions";
+import { HttpFetcher } from "./fetcherHTTP";
+import { IoTModelsRepositoryServiceClient } from "./modelsRepositoryServiceClient";
+import { ModelsRepositoryClientOptions } from "./interfaces/modelsRepositoryClientOptions";
+import { PseudoParser } from "./psuedoParser";
+import { URL } from "./utils/url";
+import { dependencyResolutionType } from "./dependencyResolutionType";
+import { logger } from "./logger";
 
 /**
  * Initializes a new instance of the IoT Models Repository Client.

--- a/sdk/iot/iot-modelsrepository/src/modelsRepositoryServiceClient.ts
+++ b/sdk/iot/iot-modelsrepository/src/modelsRepositoryServiceClient.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { ServiceClientOptions, ServiceClient } from "@azure/core-client";
+import { ServiceClient, ServiceClientOptions } from "@azure/core-client";
 import { DEFAULT_API_VERSION } from "./utils/constants";
 
 interface IoTModelsRepositoryServiceClientOptions extends ServiceClientOptions {

--- a/sdk/iot/iot-modelsrepository/src/psuedoParser.ts
+++ b/sdk/iot/iot-modelsrepository/src/psuedoParser.ts
@@ -2,9 +2,9 @@
 // Licensed under the MIT license.
 
 import { DTDL } from "./psuedoDtdl";
-import { logger } from "./logger";
 import { DtmiResolver } from "./dtmiResolver";
 import { RestError } from "@azure/core-rest-pipeline";
+import { logger } from "./logger";
 
 /**
  * The PsuedoParser is an interesting implementation. Essentially, this

--- a/sdk/iot/iot-modelsrepository/test/browser/browserTest.spec.ts
+++ b/sdk/iot/iot-modelsrepository/test/browser/browserTest.spec.ts
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { expect } from "chai";
 import { ModelsRepositoryClient } from "../../src";
+import { expect } from "chai";
 
 describe("resolver -  browser", () => {
   describe("single resolution (no pseudo-parsing)", () => {

--- a/sdk/iot/iot-modelsrepository/test/node/integration/index.spec.ts
+++ b/sdk/iot/iot-modelsrepository/test/node/integration/index.spec.ts
@@ -2,14 +2,12 @@
 // Licensed under the MIT license.
 /* eslint-disable no-undef */
 
-import { ModelsRepositoryClient, ModelsRepositoryClientOptions } from "../../../src";
-
-import { assert, expect } from "chai";
 import * as sinon from "sinon";
-
-import { dependencyResolutionType } from "../../../src/dependencyResolutionType";
-import { ServiceClient } from "@azure/core-client";
+import { ModelsRepositoryClient, ModelsRepositoryClientOptions } from "../../../src";
+import { assert, expect } from "chai";
 import { PipelineRequest } from "@azure/core-rest-pipeline";
+import { ServiceClient } from "@azure/core-client";
+import { dependencyResolutionType } from "../../../src/dependencyResolutionType";
 
 interface RemoteResolutionScenario {
   name: string;

--- a/sdk/iot/iot-modelsrepository/test/node/unit/constants.spec.ts
+++ b/sdk/iot/iot-modelsrepository/test/node/unit/constants.spec.ts
@@ -2,8 +2,9 @@
 // Licensed under the MIT license.
 
 import * as cnst from "../../../src/utils/constants";
-import { readFileSync } from "fs";
 import { expect } from "chai";
+import { readFileSync } from "fs";
+
 describe("constants", function() {
   it("uses same version as package.json", function() {
     const pkgjson = readFileSync("./package.json", "utf-8");


### PR DESCRIPTION
This PR is working in conjunction with other PRs to fix individual sections of the azure codebase with respect to the new ```sort-imports``` rule, as indicated in #9252.

In this PR, I have fixed all files under ```sdk/iot/iot-modelsrepository```.