### PR TITLE
Add docker on release pipeline and unified pipeline

### DIFF
--- a/eng/pipelines/templates/stages/archetype-js-release.yml
+++ b/eng/pipelines/templates/stages/archetype-js-release.yml
@@ -117,6 +117,8 @@ stages:
                 name: azsdk-pool-mms-ubuntu-2004-general
                 vmImage: MMSUbuntu20.04
 
+              variables:
+                DocValidationImageId: azuresdkimages.azurecr.io/jsrefautocr:latest
               strategy:
                 runOnce:
                   deploy:
@@ -128,6 +130,12 @@ stages:
                             - sdk/**/*.md
                             - .github/CODEOWNERS
                       - download: current
+                      # Pull and build the docker image.
+                      - template: /eng/common/pipelines/templates/steps/docker-pull-image.yml
+                        parameters:
+                          ContainerRegistryClientId: $(azuresdkimages-cr-clientid)
+                          ContainerRegistryClientSecret: $(azuresdkimages-cr-clientsecret)
+                          ImageId: "$(DocValidationImageId)"
                       - template: /eng/common/pipelines/templates/steps/update-docsms-metadata.yml
                         parameters:
                           PackageInfoLocations:
@@ -142,7 +150,8 @@ stages:
                             - metadata/
                             - ci-configs/packages-latest.json
                             - ci-configs/packages-preview.json
-
+                          DocValidationImageId: "$(DocValidationImageId)"
+                          
           - ${{if ne(artifact.skipPublishDocGithubIo, 'true')}}:
             - deployment: PublishDocsGitHubIO
               displayName: Publish Docs to GitHubIO Blob Storage
@@ -283,6 +292,8 @@ stages:
       pool:
         name: azsdk-pool-mms-ubuntu-2004-general
         vmImage: MMSUbuntu20.04
+      variables:
+        DocValidationImageId: azuresdkimages.azurecr.io/jsrefautocr:latest
       steps:
         - template: /eng/common/pipelines/templates/steps/sparse-checkout.yml
           parameters:
@@ -294,7 +305,12 @@ stages:
         - pwsh: |
             Get-ChildItem -Recurse $(Pipeline.Workspace)/${{parameters.ArtifactName}}/
           displayName: Show visible artifacts
-
+        # Pull and build the docker image.
+        - template: /eng/common/pipelines/templates/steps/docker-pull-image.yml
+          parameters:
+            ContainerRegistryClientId: $(azuresdkimages-cr-clientid)
+            ContainerRegistryClientSecret: $(azuresdkimages-cr-clientsecret)
+            ImageId: "$(DocValidationImageId)"
         - template: /eng/common/pipelines/templates/steps/update-docsms-metadata.yml
           parameters:
             PackageInfoLocations:
@@ -311,3 +327,4 @@ stages:
               - metadata/
               - ci-configs/packages-latest.json
               - ci-configs/packages-preview.json
+            DocValidationImageId: "$(DocValidationImageId)"


### PR DESCRIPTION
We have added basic validation before release doc in release pipeline and unified pipeline.

The PR is to use docker image for full validation.

Testing pipeline:
release: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1241072&view=results
unified: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1241077&view=results