### PR TITLE
[sort-imports] update ```keyvault-certificates``` with respect to ```sort-imports``` rule

### DIFF
--- a/sdk/keyvault/keyvault-certificates/src/certificatesModels.ts
+++ b/sdk/keyvault/keyvault-certificates/src/certificatesModels.ts
@@ -2,7 +2,12 @@
 // Licensed under the MIT license.
 
 import * as coreHttp from "@azure/core-http";
-import { JsonWebKeyCurveName as CertificateKeyCurveName, JsonWebKeyType as CertificateKeyType, DeletionRecoveryLevel, KeyUsageType } from "./generated/models";
+import {
+  JsonWebKeyCurveName as CertificateKeyCurveName,
+  JsonWebKeyType as CertificateKeyType,
+  DeletionRecoveryLevel,
+  KeyUsageType
+} from "./generated/models";
 
 /**
  * The latest supported KeyVault service API version

--- a/sdk/keyvault/keyvault-certificates/src/certificatesModels.ts
+++ b/sdk/keyvault/keyvault-certificates/src/certificatesModels.ts
@@ -2,12 +2,7 @@
 // Licensed under the MIT license.
 
 import * as coreHttp from "@azure/core-http";
-import {
-  DeletionRecoveryLevel,
-  KeyUsageType,
-  JsonWebKeyType as CertificateKeyType,
-  JsonWebKeyCurveName as CertificateKeyCurveName
-} from "./generated/models";
+import { JsonWebKeyCurveName as CertificateKeyCurveName, JsonWebKeyType as CertificateKeyType, DeletionRecoveryLevel, KeyUsageType } from "./generated/models";
 
 /**
  * The latest supported KeyVault service API version

--- a/sdk/keyvault/keyvault-certificates/src/index.ts
+++ b/sdk/keyvault/keyvault-certificates/src/index.ts
@@ -9,117 +9,102 @@
 
 /// <reference lib="esnext.asynciterable" />
 
+import "@azure/core-paging";
 import {
-  TokenCredential,
-  isTokenCredential,
-  signingPolicy,
-  PipelineOptions,
-  createPipelineFromOptions,
-  InternalPipelineOptions
-} from "@azure/core-http";
-
-import { logger } from "./log";
-import { PollerLike, PollOperationState } from "@azure/core-lro";
-
+  ActionType,
+  BackupCertificateResult,
+  JsonWebKeyCurveName as CertificateKeyCurveName,
+  JsonWebKeyType as CertificateKeyType,
+  SubjectAlternativeNames as CoreSubjectAlternativeNames,
+  DeletionRecoveryLevel,
+  IssuerAttributes,
+  IssuerCredentials,
+  IssuerParameters,
+  KeyUsageType,
+  KeyVaultClientGetCertificateIssuersOptionalParams,
+  KeyVaultClientGetCertificateVersionsOptionalParams,
+  KeyVaultClientGetCertificatesOptionalParams,
+  KeyVaultClientGetDeletedCertificatesOptionalParams,
+  KeyVaultClientSetCertificateIssuerOptionalParams,
+  KnownDeletionRecoveryLevel as KnownDeletionRecoveryLevels,
+  X509CertificateProperties
+} from "./generated/models";
 import {
-  KeyVaultCertificate,
-  KeyVaultCertificateWithPolicy,
   AdministratorContact,
+  ArrayOneOrMore,
   BackupCertificateOptions,
   BeginCreateCertificateOptions,
   BeginDeleteCertificateOptions,
   BeginRecoverDeletedCertificateOptions,
-  CertificateIssuer,
+  CancelCertificateOperationOptions,
+  CertificateClientOptions,
   CertificateContact,
+  CertificateContactAll,
   CertificateContentType,
+  CertificateIssuer,
+  CertificateOperation,
+  CertificateOperationError,
   CertificatePolicy,
+  CertificatePolicyAction,
+  CertificatePolicyProperties,
+  CertificatePollerOptions,
   CertificateProperties,
+  CertificateTags,
   CreateCertificateOptions,
+  CreateIssuerOptions,
+  DefaultCertificatePolicy,
   DeleteCertificateOperationOptions,
   DeleteContactsOptions,
   DeleteIssuerOptions,
   DeletedCertificate,
-  GetContactsOptions,
-  GetIssuerOptions,
+  ErrorModel,
   GetCertificateOperationOptions,
-  GetPlainCertificateOperationOptions,
   GetCertificateOptions,
   GetCertificatePolicyOptions,
   GetCertificateVersionOptions,
+  GetContactsOptions,
   GetDeletedCertificateOptions,
-  CertificateTags,
+  GetIssuerOptions,
+  GetPlainCertificateOperationOptions,
   ImportCertificateOptions,
-  ListPropertiesOfCertificatesOptions,
-  ErrorModel,
-  ListPropertiesOfCertificateVersionsOptions,
-  ListPropertiesOfIssuersOptions,
-  ListDeletedCertificatesOptions,
-  MergeCertificateOptions,
-  PurgeDeletedCertificateOptions,
-  RestoreCertificateBackupOptions,
-  SetContactsOptions,
-  CreateIssuerOptions,
-  CertificateOperation,
-  CertificateOperationError,
-  SubjectAlternativeNames,
-  UpdateIssuerOptions,
-  UpdateCertificatePropertiesOptions,
-  UpdateCertificatePolicyOptions,
-  WellKnownIssuerNames,
-  CertificatePollerOptions,
-  IssuerProperties,
-  CertificateContactAll,
-  CertificatePolicyAction,
-  LifetimeAction,
-  RequireAtLeastOne,
-  ArrayOneOrMore,
-  SubjectAlternativeNamesAll,
-  CertificatePolicyProperties,
-  PolicySubjectProperties,
-  DefaultCertificatePolicy,
-  CertificateClientOptions,
-  LATEST_API_VERSION,
-  CancelCertificateOperationOptions,
   ImportCertificatePolicy,
+  IssuerProperties,
+  KeyVaultCertificate,
+  KeyVaultCertificateWithPolicy,
   KnownCertificateKeyCurveNames,
   KnownCertificateKeyTypes,
-  KnownKeyUsageTypes
+  KnownKeyUsageTypes,
+  LATEST_API_VERSION,
+  LifetimeAction,
+  ListDeletedCertificatesOptions,
+  ListPropertiesOfCertificateVersionsOptions,
+  ListPropertiesOfCertificatesOptions,
+  ListPropertiesOfIssuersOptions,
+  MergeCertificateOptions,
+  PolicySubjectProperties,
+  PurgeDeletedCertificateOptions,
+  RequireAtLeastOne,
+  RestoreCertificateBackupOptions,
+  SetContactsOptions,
+  SubjectAlternativeNames,
+  SubjectAlternativeNamesAll,
+  UpdateCertificatePolicyOptions,
+  UpdateCertificatePropertiesOptions,
+  UpdateIssuerOptions,
+  WellKnownIssuerNames
 } from "./certificatesModels";
-
 import {
-  KeyVaultClientGetCertificatesOptionalParams,
-  KeyVaultClientGetCertificateIssuersOptionalParams,
-  KeyVaultClientGetCertificateVersionsOptionalParams,
-  KeyVaultClientSetCertificateIssuerOptionalParams,
-  BackupCertificateResult,
-  KeyVaultClientGetDeletedCertificatesOptionalParams,
-  IssuerParameters,
-  IssuerCredentials,
-  IssuerAttributes,
-  X509CertificateProperties,
-  SubjectAlternativeNames as CoreSubjectAlternativeNames,
-  ActionType,
-  DeletionRecoveryLevel,
-  JsonWebKeyType as CertificateKeyType,
-  JsonWebKeyCurveName as CertificateKeyCurveName,
-  KnownDeletionRecoveryLevel as KnownDeletionRecoveryLevels,
-  KeyUsageType
-} from "./generated/models";
-import { KeyVaultClient } from "./generated/keyVaultClient";
-import { SDK_VERSION } from "./constants";
-import "@azure/core-paging";
-import { PageSettings, PagedAsyncIterableIterator } from "@azure/core-paging";
-import { challengeBasedAuthenticationPolicy, createTraceFunction } from "../../keyvault-common/src";
-import { CreateCertificatePoller } from "./lro/create/poller";
-import { CertificateOperationPoller } from "./lro/operation/poller";
-import { DeleteCertificatePoller } from "./lro/delete/poller";
-import { RecoverDeletedCertificatePoller } from "./lro/recover/poller";
-import { CertificateOperationState } from "./lro/operation/operation";
-import { DeleteCertificateState } from "./lro/delete/operation";
-import { CreateCertificateState } from "./lro/create/operation";
-import { RecoverDeletedCertificateState } from "./lro/recover/operation";
-import { parseCertificateBytes } from "./utils";
+  InternalPipelineOptions,
+  PipelineOptions,
+  TokenCredential,
+  createPipelineFromOptions,
+  isTokenCredential,
+  signingPolicy
+} from "@azure/core-http";
 import { KeyVaultCertificateIdentifier, parseKeyVaultCertificateIdentifier } from "./identifier";
+import { PageSettings, PagedAsyncIterableIterator } from "@azure/core-paging";
+import { PollOperationState, PollerLike } from "@azure/core-lro";
+import { challengeBasedAuthenticationPolicy, createTraceFunction } from "../../keyvault-common/src";
 import {
   coreContactsToCertificateContacts,
   getCertificateFromCertificateBundle,
@@ -133,7 +118,19 @@ import {
   toPublicIssuer,
   toPublicPolicy
 } from "./transformations";
+import { CertificateOperationPoller } from "./lro/operation/poller";
+import { CertificateOperationState } from "./lro/operation/operation";
+import { CreateCertificatePoller } from "./lro/create/poller";
+import { CreateCertificateState } from "./lro/create/operation";
+import { DeleteCertificatePoller } from "./lro/delete/poller";
+import { DeleteCertificateState } from "./lro/delete/operation";
 import { KeyVaultCertificatePollOperationState } from "./lro/keyVaultCertificatePoller";
+import { KeyVaultClient } from "./generated/keyVaultClient";
+import { RecoverDeletedCertificatePoller } from "./lro/recover/poller";
+import { RecoverDeletedCertificateState } from "./lro/recover/operation";
+import { SDK_VERSION } from "./constants";
+import { logger } from "./log";
+import { parseCertificateBytes } from "./utils";
 
 export {
   CertificateClientOptions,

--- a/sdk/keyvault/keyvault-certificates/src/lro/create/operation.ts
+++ b/sdk/keyvault/keyvault-certificates/src/lro/create/operation.ts
@@ -1,28 +1,20 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { AbortSignalLike, AbortSignal } from "@azure/abort-controller";
-import { OperationOptions } from "@azure/core-http";
+import { AbortSignal, AbortSignalLike } from "@azure/abort-controller";
 import {
-  KeyVaultCertificateWithPolicy,
-  CreateCertificateOptions,
+  CancelCertificateOperationOptions,
   CertificatePolicy,
+  CreateCertificateOptions,
   GetCertificateOptions,
   GetPlainCertificateOperationOptions,
-  CancelCertificateOperationOptions
+  KeyVaultCertificateWithPolicy
 } from "../../certificatesModels";
+import { KeyVaultCertificatePollOperation, KeyVaultCertificatePollOperationState } from "../keyVaultCertificatePoller";
+import { getCertificateOperationFromCoreOperation, getCertificateWithPolicyFromCertificateBundle, toCoreAttributes, toCorePolicy } from "../../transformations";
 import { CertificateOperation } from "../../generated/models";
-import {
-  KeyVaultCertificatePollOperation,
-  KeyVaultCertificatePollOperationState
-} from "../keyVaultCertificatePoller";
 import { KeyVaultClient } from "../../generated/keyVaultClient";
-import {
-  getCertificateOperationFromCoreOperation,
-  getCertificateWithPolicyFromCertificateBundle,
-  toCoreAttributes,
-  toCorePolicy
-} from "../../transformations";
+import { OperationOptions } from "@azure/core-http";
 import { createTraceFunction } from "../../../../keyvault-common/src";
 
 /**

--- a/sdk/keyvault/keyvault-certificates/src/lro/create/operation.ts
+++ b/sdk/keyvault/keyvault-certificates/src/lro/create/operation.ts
@@ -10,8 +10,16 @@ import {
   GetPlainCertificateOperationOptions,
   KeyVaultCertificateWithPolicy
 } from "../../certificatesModels";
-import { KeyVaultCertificatePollOperation, KeyVaultCertificatePollOperationState } from "../keyVaultCertificatePoller";
-import { getCertificateOperationFromCoreOperation, getCertificateWithPolicyFromCertificateBundle, toCoreAttributes, toCorePolicy } from "../../transformations";
+import {
+  KeyVaultCertificatePollOperation,
+  KeyVaultCertificatePollOperationState
+} from "../keyVaultCertificatePoller";
+import {
+  getCertificateOperationFromCoreOperation,
+  getCertificateWithPolicyFromCertificateBundle,
+  toCoreAttributes,
+  toCorePolicy
+} from "../../transformations";
 import { CertificateOperation } from "../../generated/models";
 import { KeyVaultClient } from "../../generated/keyVaultClient";
 import { OperationOptions } from "@azure/core-http";

--- a/sdk/keyvault/keyvault-certificates/src/lro/create/poller.ts
+++ b/sdk/keyvault/keyvault-certificates/src/lro/create/poller.ts
@@ -1,16 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+import { CertificatePolicy, CreateCertificateOptions, KeyVaultCertificateWithPolicy } from "../../certificatesModels";
 import { CreateCertificatePollOperation, CreateCertificateState } from "./operation";
-import {
-  KeyVaultCertificateWithPolicy,
-  CreateCertificateOptions,
-  CertificatePolicy
-} from "../../certificatesModels";
-import {
-  KeyVaultCertificatePoller,
-  KeyVaultCertificatePollerOptions
-} from "../keyVaultCertificatePoller";
+import { KeyVaultCertificatePoller, KeyVaultCertificatePollerOptions } from "../keyVaultCertificatePoller";
 
 export interface CreateCertificatePollerOptions extends KeyVaultCertificatePollerOptions {
   certificatePolicy?: CertificatePolicy;

--- a/sdk/keyvault/keyvault-certificates/src/lro/create/poller.ts
+++ b/sdk/keyvault/keyvault-certificates/src/lro/create/poller.ts
@@ -1,9 +1,16 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { CertificatePolicy, CreateCertificateOptions, KeyVaultCertificateWithPolicy } from "../../certificatesModels";
+import {
+  CertificatePolicy,
+  CreateCertificateOptions,
+  KeyVaultCertificateWithPolicy
+} from "../../certificatesModels";
 import { CreateCertificatePollOperation, CreateCertificateState } from "./operation";
-import { KeyVaultCertificatePoller, KeyVaultCertificatePollerOptions } from "../keyVaultCertificatePoller";
+import {
+  KeyVaultCertificatePoller,
+  KeyVaultCertificatePollerOptions
+} from "../keyVaultCertificatePoller";
 
 export interface CreateCertificatePollerOptions extends KeyVaultCertificatePollerOptions {
   certificatePolicy?: CertificatePolicy;

--- a/sdk/keyvault/keyvault-certificates/src/lro/delete/operation.ts
+++ b/sdk/keyvault/keyvault-certificates/src/lro/delete/operation.ts
@@ -1,8 +1,15 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { DeleteCertificateOptions, DeletedCertificate, GetDeletedCertificateOptions } from "../../certificatesModels";
-import { KeyVaultCertificatePollOperation, KeyVaultCertificatePollOperationState } from "../keyVaultCertificatePoller";
+import {
+  DeleteCertificateOptions,
+  DeletedCertificate,
+  GetDeletedCertificateOptions
+} from "../../certificatesModels";
+import {
+  KeyVaultCertificatePollOperation,
+  KeyVaultCertificatePollOperationState
+} from "../keyVaultCertificatePoller";
 import { AbortSignalLike } from "@azure/abort-controller";
 import { KeyVaultClient } from "../../generated/keyVaultClient";
 import { OperationOptions } from "@azure/core-http";

--- a/sdk/keyvault/keyvault-certificates/src/lro/delete/operation.ts
+++ b/sdk/keyvault/keyvault-certificates/src/lro/delete/operation.ts
@@ -1,20 +1,13 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+import { DeleteCertificateOptions, DeletedCertificate, GetDeletedCertificateOptions } from "../../certificatesModels";
+import { KeyVaultCertificatePollOperation, KeyVaultCertificatePollOperationState } from "../keyVaultCertificatePoller";
 import { AbortSignalLike } from "@azure/abort-controller";
-import { OperationOptions } from "@azure/core-http";
-import {
-  DeleteCertificateOptions,
-  DeletedCertificate,
-  GetDeletedCertificateOptions
-} from "../../certificatesModels";
-import {
-  KeyVaultCertificatePollOperation,
-  KeyVaultCertificatePollOperationState
-} from "../keyVaultCertificatePoller";
 import { KeyVaultClient } from "../../generated/keyVaultClient";
-import { getDeletedCertificateFromDeletedCertificateBundle } from "../../transformations";
+import { OperationOptions } from "@azure/core-http";
 import { createTraceFunction } from "../../../../keyvault-common/src";
+import { getDeletedCertificateFromDeletedCertificateBundle } from "../../transformations";
 
 /**
  * @internal

--- a/sdk/keyvault/keyvault-certificates/src/lro/delete/poller.ts
+++ b/sdk/keyvault/keyvault-certificates/src/lro/delete/poller.ts
@@ -2,7 +2,10 @@
 // Licensed under the MIT license.
 
 import { DeleteCertificatePollOperation, DeleteCertificatePollOperationState } from "./operation";
-import { KeyVaultCertificatePoller, KeyVaultCertificatePollerOptions } from "../keyVaultCertificatePoller";
+import {
+  KeyVaultCertificatePoller,
+  KeyVaultCertificatePollerOptions
+} from "../keyVaultCertificatePoller";
 import { DeletedCertificate } from "../../certificatesModels";
 
 export interface DeleteCertificatePollerOptions extends KeyVaultCertificatePollerOptions {}

--- a/sdk/keyvault/keyvault-certificates/src/lro/delete/poller.ts
+++ b/sdk/keyvault/keyvault-certificates/src/lro/delete/poller.ts
@@ -2,11 +2,8 @@
 // Licensed under the MIT license.
 
 import { DeleteCertificatePollOperation, DeleteCertificatePollOperationState } from "./operation";
+import { KeyVaultCertificatePoller, KeyVaultCertificatePollerOptions } from "../keyVaultCertificatePoller";
 import { DeletedCertificate } from "../../certificatesModels";
-import {
-  KeyVaultCertificatePoller,
-  KeyVaultCertificatePollerOptions
-} from "../keyVaultCertificatePoller";
 
 export interface DeleteCertificatePollerOptions extends KeyVaultCertificatePollerOptions {}
 

--- a/sdk/keyvault/keyvault-certificates/src/lro/keyVaultCertificatePoller.ts
+++ b/sdk/keyvault/keyvault-certificates/src/lro/keyVaultCertificatePoller.ts
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { delay, OperationOptions } from "@azure/core-http";
-import { Poller, PollOperation, PollOperationState } from "@azure/core-lro";
+import { OperationOptions, delay } from "@azure/core-http";
+import { PollOperation, PollOperationState, Poller } from "@azure/core-lro";
 import { KeyVaultClient } from "../generated/keyVaultClient";
 
 /**

--- a/sdk/keyvault/keyvault-certificates/src/lro/operation/operation.ts
+++ b/sdk/keyvault/keyvault-certificates/src/lro/operation/operation.ts
@@ -1,8 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { AbortSignalLike, AbortSignal } from "@azure/abort-controller";
-import { OperationOptions } from "@azure/core-http";
+import { AbortSignal, AbortSignalLike } from "@azure/abort-controller";
 import {
   CancelCertificateOperationOptions,
   CertificateOperation,
@@ -10,16 +9,10 @@ import {
   GetPlainCertificateOperationOptions,
   KeyVaultCertificateWithPolicy
 } from "../../certificatesModels";
-import {
-  cleanState,
-  KeyVaultCertificatePollOperation,
-  KeyVaultCertificatePollOperationState
-} from "../keyVaultCertificatePoller";
+import { KeyVaultCertificatePollOperation, KeyVaultCertificatePollOperationState, cleanState } from "../keyVaultCertificatePoller";
+import { getCertificateOperationFromCoreOperation, getCertificateWithPolicyFromCertificateBundle } from "../../transformations";
 import { KeyVaultClient } from "../../generated/keyVaultClient";
-import {
-  getCertificateOperationFromCoreOperation,
-  getCertificateWithPolicyFromCertificateBundle
-} from "../../transformations";
+import { OperationOptions } from "@azure/core-http";
 import { createTraceFunction } from "../../../../keyvault-common/src";
 
 /**

--- a/sdk/keyvault/keyvault-certificates/src/lro/operation/operation.ts
+++ b/sdk/keyvault/keyvault-certificates/src/lro/operation/operation.ts
@@ -9,8 +9,15 @@ import {
   GetPlainCertificateOperationOptions,
   KeyVaultCertificateWithPolicy
 } from "../../certificatesModels";
-import { KeyVaultCertificatePollOperation, KeyVaultCertificatePollOperationState, cleanState } from "../keyVaultCertificatePoller";
-import { getCertificateOperationFromCoreOperation, getCertificateWithPolicyFromCertificateBundle } from "../../transformations";
+import {
+  KeyVaultCertificatePollOperation,
+  KeyVaultCertificatePollOperationState,
+  cleanState
+} from "../keyVaultCertificatePoller";
+import {
+  getCertificateOperationFromCoreOperation,
+  getCertificateWithPolicyFromCertificateBundle
+} from "../../transformations";
 import { KeyVaultClient } from "../../generated/keyVaultClient";
 import { OperationOptions } from "@azure/core-http";
 import { createTraceFunction } from "../../../../keyvault-common/src";

--- a/sdk/keyvault/keyvault-certificates/src/lro/operation/poller.ts
+++ b/sdk/keyvault/keyvault-certificates/src/lro/operation/poller.ts
@@ -2,12 +2,8 @@
 // Licensed under the MIT license.
 
 import { CertificateOperationPollOperation, CertificateOperationState } from "./operation";
+import { KeyVaultCertificatePoller, KeyVaultCertificatePollerOptions, cleanState } from "../keyVaultCertificatePoller";
 import { KeyVaultCertificateWithPolicy } from "../../certificatesModels";
-import {
-  KeyVaultCertificatePoller,
-  KeyVaultCertificatePollerOptions,
-  cleanState
-} from "../keyVaultCertificatePoller";
 
 export interface CertificateOperationPollerOptions extends KeyVaultCertificatePollerOptions {}
 

--- a/sdk/keyvault/keyvault-certificates/src/lro/operation/poller.ts
+++ b/sdk/keyvault/keyvault-certificates/src/lro/operation/poller.ts
@@ -2,7 +2,11 @@
 // Licensed under the MIT license.
 
 import { CertificateOperationPollOperation, CertificateOperationState } from "./operation";
-import { KeyVaultCertificatePoller, KeyVaultCertificatePollerOptions, cleanState } from "../keyVaultCertificatePoller";
+import {
+  KeyVaultCertificatePoller,
+  KeyVaultCertificatePollerOptions,
+  cleanState
+} from "../keyVaultCertificatePoller";
 import { KeyVaultCertificateWithPolicy } from "../../certificatesModels";
 
 export interface CertificateOperationPollerOptions extends KeyVaultCertificatePollerOptions {}

--- a/sdk/keyvault/keyvault-certificates/src/lro/recover/operation.ts
+++ b/sdk/keyvault/keyvault-certificates/src/lro/recover/operation.ts
@@ -1,20 +1,13 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+import { GetCertificateOptions, KeyVaultCertificateWithPolicy, RecoverDeletedCertificateOptions } from "../../certificatesModels";
+import { KeyVaultCertificatePollOperation, KeyVaultCertificatePollOperationState } from "../keyVaultCertificatePoller";
 import { AbortSignalLike } from "@azure/abort-controller";
+import { KeyVaultClient } from "../../generated/keyVaultClient";
 import { OperationOptions } from "@azure/core-http";
 import { createTraceFunction } from "../../../../keyvault-common/src";
-import {
-  GetCertificateOptions,
-  KeyVaultCertificateWithPolicy,
-  RecoverDeletedCertificateOptions
-} from "../../certificatesModels";
-import { KeyVaultClient } from "../../generated/keyVaultClient";
 import { getCertificateWithPolicyFromCertificateBundle } from "../../transformations";
-import {
-  KeyVaultCertificatePollOperation,
-  KeyVaultCertificatePollOperationState
-} from "../keyVaultCertificatePoller";
 
 /**
  * @internal

--- a/sdk/keyvault/keyvault-certificates/src/lro/recover/operation.ts
+++ b/sdk/keyvault/keyvault-certificates/src/lro/recover/operation.ts
@@ -1,8 +1,15 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { GetCertificateOptions, KeyVaultCertificateWithPolicy, RecoverDeletedCertificateOptions } from "../../certificatesModels";
-import { KeyVaultCertificatePollOperation, KeyVaultCertificatePollOperationState } from "../keyVaultCertificatePoller";
+import {
+  GetCertificateOptions,
+  KeyVaultCertificateWithPolicy,
+  RecoverDeletedCertificateOptions
+} from "../../certificatesModels";
+import {
+  KeyVaultCertificatePollOperation,
+  KeyVaultCertificatePollOperationState
+} from "../keyVaultCertificatePoller";
 import { AbortSignalLike } from "@azure/abort-controller";
 import { KeyVaultClient } from "../../generated/keyVaultClient";
 import { OperationOptions } from "@azure/core-http";

--- a/sdk/keyvault/keyvault-certificates/src/lro/recover/poller.ts
+++ b/sdk/keyvault/keyvault-certificates/src/lro/recover/poller.ts
@@ -1,8 +1,14 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { KeyVaultCertificatePoller, KeyVaultCertificatePollerOptions } from "../keyVaultCertificatePoller";
-import { RecoverDeletedCertificatePollOperation, RecoverDeletedCertificateState } from "./operation";
+import {
+  KeyVaultCertificatePoller,
+  KeyVaultCertificatePollerOptions
+} from "../keyVaultCertificatePoller";
+import {
+  RecoverDeletedCertificatePollOperation,
+  RecoverDeletedCertificateState
+} from "./operation";
 import { KeyVaultCertificateWithPolicy } from "../../certificatesModels";
 
 export interface RecoverDeletedCertificatePollerOptions extends KeyVaultCertificatePollerOptions {}

--- a/sdk/keyvault/keyvault-certificates/src/lro/recover/poller.ts
+++ b/sdk/keyvault/keyvault-certificates/src/lro/recover/poller.ts
@@ -1,15 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import {
-  RecoverDeletedCertificatePollOperation,
-  RecoverDeletedCertificateState
-} from "./operation";
+import { KeyVaultCertificatePoller, KeyVaultCertificatePollerOptions } from "../keyVaultCertificatePoller";
+import { RecoverDeletedCertificatePollOperation, RecoverDeletedCertificateState } from "./operation";
 import { KeyVaultCertificateWithPolicy } from "../../certificatesModels";
-import {
-  KeyVaultCertificatePoller,
-  KeyVaultCertificatePollerOptions
-} from "../keyVaultCertificatePoller";
 
 export interface RecoverDeletedCertificatePollerOptions extends KeyVaultCertificatePollerOptions {}
 

--- a/sdk/keyvault/keyvault-certificates/src/transformations.ts
+++ b/sdk/keyvault/keyvault-certificates/src/transformations.ts
@@ -3,32 +3,32 @@
 
 import {
   ArrayOneOrMore,
+  CertificateContact,
   CertificateContentType,
-  CertificateOperation,
   CertificateIssuer,
+  CertificateOperation,
+  CertificateOperationError,
   CertificatePolicy,
   CertificateProperties,
   DeletedCertificate,
   KeyVaultCertificate,
   KeyVaultCertificateWithPolicy,
-  SubjectAlternativeNames,
-  CertificateContact,
-  CertificateOperationError
+  SubjectAlternativeNames
 } from "./certificatesModels";
 import {
   CertificateAttributes,
   CertificateBundle,
+  JsonWebKeyType as CertificateKeyType,
+  CertificateOperation as CoreCertificateOperation,
   CertificatePolicy as CoreCertificatePolicy,
+  Contacts as CoreContacts,
+  SubjectAlternativeNames as CoreSubjectAlternativeNames,
   DeletedCertificateBundle,
   DeletedCertificateItem,
+  ErrorModel,
   IssuerAttributes,
   IssuerBundle,
-  SubjectAlternativeNames as CoreSubjectAlternativeNames,
-  X509CertificateProperties,
-  CertificateOperation as CoreCertificateOperation,
-  Contacts as CoreContacts,
-  JsonWebKeyType as CertificateKeyType,
-  ErrorModel
+  X509CertificateProperties
 } from "./generated/models";
 import { parseKeyVaultCertificateIdentifier } from "./identifier";
 

--- a/sdk/keyvault/keyvault-certificates/src/utils.ts
+++ b/sdk/keyvault/keyvault-certificates/src/utils.ts
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { isNode } from "@azure/core-http";
 import { CertificateContentType } from "./certificatesModels";
+import { isNode } from "@azure/core-http";
 
 /**
  * Decodes a Uint8Array into a Base64 string.

--- a/sdk/keyvault/keyvault-certificates/test/internal/challengeBasedAuthenticationPolicy.spec.ts
+++ b/sdk/keyvault/keyvault-certificates/test/internal/challengeBasedAuthenticationPolicy.spec.ts
@@ -1,23 +1,17 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { assert } from "chai";
-import { Context } from "mocha";
-import { createSandbox } from "sinon";
-import { env, Recorder } from "@azure-tools/test-recorder";
-
-import {
-  AuthenticationChallengeCache,
-  AuthenticationChallenge,
-  parseWWWAuthenticate,
-  challengeBasedAuthenticationPolicy
-} from "../../../keyvault-common/src";
+import { AuthenticationChallenge, AuthenticationChallengeCache, challengeBasedAuthenticationPolicy, parseWWWAuthenticate } from "../../../keyvault-common/src";
+import { Recorder, env } from "@azure-tools/test-recorder";
 import { CertificateClient } from "../../src";
-import { testPollerProperties } from "../utils/recorderUtils";
-import { authenticate } from "../utils/testAuthentication";
+import { ClientSecretCredential } from "@azure/identity";
+import { Context } from "mocha";
 import TestClient from "../utils/testClient";
 import { WebResource } from "@azure/core-http";
-import { ClientSecretCredential } from "@azure/identity";
+import { assert } from "chai";
+import { authenticate } from "../utils/testAuthentication";
+import { createSandbox } from "sinon";
+import { testPollerProperties } from "../utils/recorderUtils";
 
 // Following the philosophy of not testing the insides if we can test the outsides...
 // I present you with this "Get Out of Jail Free" card (in reference to Monopoly).

--- a/sdk/keyvault/keyvault-certificates/test/internal/challengeBasedAuthenticationPolicy.spec.ts
+++ b/sdk/keyvault/keyvault-certificates/test/internal/challengeBasedAuthenticationPolicy.spec.ts
@@ -1,7 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { AuthenticationChallenge, AuthenticationChallengeCache, challengeBasedAuthenticationPolicy, parseWWWAuthenticate } from "../../../keyvault-common/src";
+import {
+  AuthenticationChallenge,
+  AuthenticationChallengeCache,
+  challengeBasedAuthenticationPolicy,
+  parseWWWAuthenticate
+} from "../../../keyvault-common/src";
 import { Recorder, env } from "@azure-tools/test-recorder";
 import { CertificateClient } from "../../src";
 import { ClientSecretCredential } from "@azure/identity";

--- a/sdk/keyvault/keyvault-certificates/test/internal/lroUnexpectedErrors.spec.ts
+++ b/sdk/keyvault/keyvault-certificates/test/internal/lroUnexpectedErrors.spec.ts
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { assert } from "chai";
-import { RestError } from "@azure/core-http";
 import { DeleteCertificatePoller } from "../../src/lro/delete/poller";
 import { RecoverDeletedCertificatePoller } from "../../src/lro/recover/poller";
+import { RestError } from "@azure/core-http";
+import { assert } from "chai";
 
 describe("The LROs properly throw on unexpected errors", () => {
   const vaultUrl = `https://keyVaultName.vault.azure.net`;

--- a/sdk/keyvault/keyvault-certificates/test/internal/serviceVersionParameter.spec.ts
+++ b/sdk/keyvault/keyvault-certificates/test/internal/serviceVersionParameter.spec.ts
@@ -2,11 +2,11 @@
 // Licensed under the MIT license.
 
 import * as assert from "assert";
-import { createSandbox, SinonSandbox, SinonSpy } from "sinon";
+import { HttpClient, HttpHeaders, HttpOperationResponse, WebResourceLike } from "@azure/core-http";
+import { SinonSandbox, SinonSpy, createSandbox } from "sinon";
 import { CertificateClient } from "../../src";
-import { LATEST_API_VERSION } from "../../src/certificatesModels";
-import { HttpClient, WebResourceLike, HttpOperationResponse, HttpHeaders } from "@azure/core-http";
 import { ClientSecretCredential } from "@azure/identity";
+import { LATEST_API_VERSION } from "../../src/certificatesModels";
 import { env } from "@azure-tools/test-recorder";
 
 describe("The Certificates client should set the serviceVersion", () => {

--- a/sdk/keyvault/keyvault-certificates/test/internal/transformations.spec.ts
+++ b/sdk/keyvault/keyvault-certificates/test/internal/transformations.spec.ts
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { assert } from "chai";
 import { CertificateOperation as CoreCertificateOperation } from "../../src/generated/models";
+import { assert } from "chai";
 import { getCertificateOperationFromCoreOperation } from "../../src/transformations";
 
 describe("transformations", function() {

--- a/sdk/keyvault/keyvault-certificates/test/internal/userAgent.spec.ts
+++ b/sdk/keyvault/keyvault-certificates/test/internal/userAgent.spec.ts
@@ -4,10 +4,10 @@
 import * as assert from "assert";
 import { Context } from "mocha";
 import { SDK_VERSION } from "../../src/constants";
-import { packageVersion } from "../../src/generated/keyVaultClientContext";
-import { isNode } from "@azure/core-http";
-import path from "path";
 import fs from "fs";
+import { isNode } from "@azure/core-http";
+import { packageVersion } from "../../src/generated/keyVaultClientContext";
+import path from "path";
 
 describe("Certificates client's user agent (only in Node, because of fs)", () => {
   it("SDK_VERSION and packageVersion should match", async function() {

--- a/sdk/keyvault/keyvault-certificates/test/public/CRUD.spec.ts
+++ b/sdk/keyvault/keyvault-certificates/test/public/CRUD.spec.ts
@@ -1,24 +1,22 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import os from "os";
-import { Context } from "mocha";
-import fs from "fs";
-import childProcess from "child_process";
-import { assert } from "chai";
-import { supportsTracing } from "../../../keyvault-common/test/utils/supportsTracing";
-
-import { env, Recorder } from "@azure-tools/test-recorder";
+import { Recorder, env } from "@azure-tools/test-recorder";
 import { AbortController } from "@azure/abort-controller";
-import { SecretClient } from "@azure/keyvault-secrets";
-import { ClientSecretCredential } from "@azure/identity";
-import { isNode } from "@azure/core-http";
-
 import { CertificateClient } from "../../src";
-import { assertThrowsAbortError } from "../utils/utils.common";
-import { testPollerProperties } from "../utils/recorderUtils";
-import { authenticate } from "../utils/testAuthentication";
+import { ClientSecretCredential } from "@azure/identity";
+import { Context } from "mocha";
+import { SecretClient } from "@azure/keyvault-secrets";
 import TestClient from "../utils/testClient";
+import { assert } from "chai";
+import { assertThrowsAbortError } from "../utils/utils.common";
+import { authenticate } from "../utils/testAuthentication";
+import childProcess from "child_process";
+import fs from "fs";
+import { isNode } from "@azure/core-http";
+import os from "os";
+import { supportsTracing } from "../../../keyvault-common/test/utils/supportsTracing";
+import { testPollerProperties } from "../utils/recorderUtils";
 
 describe("Certificates client - create, read, update and delete", () => {
   const prefix = `CRUD${env.CERTIFICATE_NAME || "CertificateName"}`;

--- a/sdk/keyvault/keyvault-certificates/test/public/identifier.spec.ts
+++ b/sdk/keyvault/keyvault-certificates/test/public/identifier.spec.ts
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { parseKeyVaultCertificateIdentifier } from "../../src/identifier";
 import * as assert from "assert";
+import { parseKeyVaultCertificateIdentifier } from "../../src/identifier";
 
 describe("Key Vault Certificates Identifier", () => {
   it("It should work with a URI of a certificate before it gets a version", async function() {

--- a/sdk/keyvault/keyvault-certificates/test/public/list.spec.ts
+++ b/sdk/keyvault/keyvault-certificates/test/public/list.spec.ts
@@ -1,17 +1,16 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import chai from "chai";
-import { Context } from "mocha";
 import * as assert from "assert";
-import { env, isPlaybackMode, Recorder, isRecordMode } from "@azure-tools/test-recorder";
-import { isNode } from "@azure/core-http";
-
+import { Recorder, env, isPlaybackMode, isRecordMode } from "@azure-tools/test-recorder";
 import { CertificateClient } from "../../src";
-import { assertThrowsAbortError } from "../utils/utils.common";
-import { testPollerProperties } from "../utils/recorderUtils";
-import { authenticate } from "../utils/testAuthentication";
+import { Context } from "mocha";
 import TestClient from "../utils/testClient";
+import { assertThrowsAbortError } from "../utils/utils.common";
+import { authenticate } from "../utils/testAuthentication";
+import chai from "chai";
+import { isNode } from "@azure/core-http";
+import { testPollerProperties } from "../utils/recorderUtils";
 
 const { expect } = chai;
 

--- a/sdk/keyvault/keyvault-certificates/test/public/lro.create.spec.ts
+++ b/sdk/keyvault/keyvault-certificates/test/public/lro.create.spec.ts
@@ -2,14 +2,13 @@
 // Licensed under the MIT license.
 
 import * as assert from "assert";
+import { CertificateClient, DefaultCertificatePolicy, KeyVaultCertificate } from "../../src";
+import { Recorder, env } from "@azure-tools/test-recorder";
 import { Context } from "mocha";
 import { PollerStoppedError } from "@azure/core-lro";
-import { env, Recorder } from "@azure-tools/test-recorder";
-
-import { CertificateClient, KeyVaultCertificate, DefaultCertificatePolicy } from "../../src";
-import { testPollerProperties } from "../utils/recorderUtils";
-import { authenticate } from "../utils/testAuthentication";
 import TestClient from "../utils/testClient";
+import { authenticate } from "../utils/testAuthentication";
+import { testPollerProperties } from "../utils/recorderUtils";
 
 describe("Certificates client - LRO - create", () => {
   const certificatePrefix = `lroCreate${env.CERTIFICATE_NAME || "CertificateName"}`;

--- a/sdk/keyvault/keyvault-certificates/test/public/lro.delete.spec.ts
+++ b/sdk/keyvault/keyvault-certificates/test/public/lro.delete.spec.ts
@@ -2,14 +2,13 @@
 // Licensed under the MIT license.
 
 import * as assert from "assert";
+import { CertificateClient, DefaultCertificatePolicy, DeletedCertificate } from "../../src";
+import { Recorder, env } from "@azure-tools/test-recorder";
 import { Context } from "mocha";
 import { PollerStoppedError } from "@azure/core-lro";
-import { env, Recorder } from "@azure-tools/test-recorder";
-
-import { CertificateClient, DeletedCertificate, DefaultCertificatePolicy } from "../../src";
-import { testPollerProperties } from "../utils/recorderUtils";
-import { authenticate } from "../utils/testAuthentication";
 import TestClient from "../utils/testClient";
+import { authenticate } from "../utils/testAuthentication";
+import { testPollerProperties } from "../utils/recorderUtils";
 
 describe("Certificates client - lro - delete", () => {
   const certificatePrefix = `lroDelete${env.CERTIFICATE_NAME || "CertificateName"}`;

--- a/sdk/keyvault/keyvault-certificates/test/public/lro.operation.spec.ts
+++ b/sdk/keyvault/keyvault-certificates/test/public/lro.operation.spec.ts
@@ -2,7 +2,12 @@
 // Licensed under the MIT license.
 
 import * as assert from "assert";
-import { CertificateClient, CertificateOperation, DefaultCertificatePolicy, KeyVaultCertificateWithPolicy } from "../../src";
+import {
+  CertificateClient,
+  CertificateOperation,
+  DefaultCertificatePolicy,
+  KeyVaultCertificateWithPolicy
+} from "../../src";
 import { Recorder, env } from "@azure-tools/test-recorder";
 import { Context } from "mocha";
 import TestClient from "../utils/testClient";

--- a/sdk/keyvault/keyvault-certificates/test/public/lro.operation.spec.ts
+++ b/sdk/keyvault/keyvault-certificates/test/public/lro.operation.spec.ts
@@ -2,18 +2,12 @@
 // Licensed under the MIT license.
 
 import * as assert from "assert";
+import { CertificateClient, CertificateOperation, DefaultCertificatePolicy, KeyVaultCertificateWithPolicy } from "../../src";
+import { Recorder, env } from "@azure-tools/test-recorder";
 import { Context } from "mocha";
-import { env, Recorder } from "@azure-tools/test-recorder";
-
-import {
-  CertificateClient,
-  CertificateOperation,
-  DefaultCertificatePolicy,
-  KeyVaultCertificateWithPolicy
-} from "../../src";
-import { testPollerProperties } from "../utils/recorderUtils";
-import { authenticate } from "../utils/testAuthentication";
 import TestClient from "../utils/testClient";
+import { authenticate } from "../utils/testAuthentication";
+import { testPollerProperties } from "../utils/recorderUtils";
 
 describe("Certificates client - LRO - certificate operation", () => {
   const certificatePrefix = `lroOperation${env.CERTIFICATE_NAME || "CertificateName"}`;

--- a/sdk/keyvault/keyvault-certificates/test/public/lro.recover.spec.ts
+++ b/sdk/keyvault/keyvault-certificates/test/public/lro.recover.spec.ts
@@ -2,15 +2,14 @@
 // Licensed under the MIT license.
 
 import * as assert from "assert";
+import { CertificateClient, DefaultCertificatePolicy, DeletedCertificate } from "../../src";
+import { Recorder, env } from "@azure-tools/test-recorder";
 import { Context } from "mocha";
-import { env, Recorder } from "@azure-tools/test-recorder";
 import { PollerStoppedError } from "@azure/core-lro";
-
-import { CertificateClient, DeletedCertificate, DefaultCertificatePolicy } from "../../src";
-import { assertThrowsAbortError } from "../utils/utils.common";
-import { testPollerProperties } from "../utils/recorderUtils";
-import { authenticate } from "../utils/testAuthentication";
 import TestClient from "../utils/testClient";
+import { assertThrowsAbortError } from "../utils/utils.common";
+import { authenticate } from "../utils/testAuthentication";
+import { testPollerProperties } from "../utils/recorderUtils";
 
 describe("Certificates client - LRO - recoverDelete", () => {
   const certificatePrefix = `lroRecover${env.CERTIFICATE_NAME || "CertificateName"}`;

--- a/sdk/keyvault/keyvault-certificates/test/public/mergeAndImport.spec.ts
+++ b/sdk/keyvault/keyvault-certificates/test/public/mergeAndImport.spec.ts
@@ -1,19 +1,18 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import fs from "fs";
-import { Context } from "mocha";
-import childProcess from "child_process";
-import { isNode } from "@azure/core-http";
-import { env, Recorder } from "@azure-tools/test-recorder";
-import { SecretClient } from "@azure/keyvault-secrets";
-import { ClientSecretCredential } from "@azure/identity";
-
-import { CertificateClient } from "../../src";
+import { Recorder, env } from "@azure-tools/test-recorder";
 import { base64ToUint8Array, stringToUint8Array } from "../../src/utils";
-import { testPollerProperties } from "../utils/recorderUtils";
-import { authenticate } from "../utils/testAuthentication";
+import { CertificateClient } from "../../src";
+import { ClientSecretCredential } from "@azure/identity";
+import { Context } from "mocha";
+import { SecretClient } from "@azure/keyvault-secrets";
 import TestClient from "../utils/testClient";
+import { authenticate } from "../utils/testAuthentication";
+import childProcess from "child_process";
+import fs from "fs";
+import { isNode } from "@azure/core-http";
+import { testPollerProperties } from "../utils/recorderUtils";
 
 describe("Certificates client - merge and import certificates", () => {
   const prefix = `merge${env.CERTIFICATE_NAME || "CertificateName"}`;

--- a/sdk/keyvault/keyvault-certificates/test/public/recoverBackupRestore.spec.ts
+++ b/sdk/keyvault/keyvault-certificates/test/public/recoverBackupRestore.spec.ts
@@ -2,15 +2,14 @@
 // Licensed under the MIT license.
 
 import * as assert from "assert";
-import { Context } from "mocha";
-import { env, isPlaybackMode, Recorder, isRecordMode } from "@azure-tools/test-recorder";
-import { isNode } from "@azure/core-http";
-
+import { Recorder, env, isPlaybackMode, isRecordMode } from "@azure-tools/test-recorder";
 import { CertificateClient } from "../../src";
-import { testPollerProperties } from "../utils/recorderUtils";
+import { Context } from "mocha";
+import TestClient from "../utils/testClient";
 import { assertThrowsAbortError } from "../utils/utils.common";
 import { authenticate } from "../utils/testAuthentication";
-import TestClient from "../utils/testClient";
+import { isNode } from "@azure/core-http";
+import { testPollerProperties } from "../utils/recorderUtils";
 
 describe("Certificates client - restore certificates and recover backups", () => {
   const prefix = `backupRestore${env.CERTIFICATE_NAME || "CertificateName"}`;

--- a/sdk/keyvault/keyvault-certificates/test/utils/lro/restore/operation.ts
+++ b/sdk/keyvault/keyvault-certificates/test/utils/lro/restore/operation.ts
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+import { CertificatePollerOptions, KeyVaultCertificate } from "../../../../src/certificatesModels";
+import { PollOperation, PollOperationState } from "@azure/core-lro";
 import { AbortSignalLike } from "@azure/abort-controller";
-import { PollOperationState, PollOperation } from "@azure/core-lro";
 import { OperationOptions } from "@azure/core-http";
-import { KeyVaultCertificate, CertificatePollerOptions } from "../../../../src/certificatesModels";
 
 /**
  * Options sent to the beginRestoreCertificateBackup method.

--- a/sdk/keyvault/keyvault-certificates/test/utils/lro/restore/poller.ts
+++ b/sdk/keyvault/keyvault-certificates/test/utils/lro/restore/poller.ts
@@ -2,7 +2,11 @@
 // Licensed under the MIT license.
 
 import { OperationOptions, delay } from "@azure/core-http";
-import { RestoreCertificateBackupPollOperationState, TestCertificateClientInterface, makeRestoreCertificateBackupPollOperation } from "./operation";
+import {
+  RestoreCertificateBackupPollOperationState,
+  TestCertificateClientInterface,
+  makeRestoreCertificateBackupPollOperation
+} from "./operation";
 import { KeyVaultCertificate } from "../../../../src/certificatesModels";
 import { Poller } from "@azure/core-lro";
 

--- a/sdk/keyvault/keyvault-certificates/test/utils/lro/restore/poller.ts
+++ b/sdk/keyvault/keyvault-certificates/test/utils/lro/restore/poller.ts
@@ -1,14 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { delay, OperationOptions } from "@azure/core-http";
-import { Poller } from "@azure/core-lro";
-import {
-  RestoreCertificateBackupPollOperationState,
-  makeRestoreCertificateBackupPollOperation,
-  TestCertificateClientInterface
-} from "./operation";
+import { OperationOptions, delay } from "@azure/core-http";
+import { RestoreCertificateBackupPollOperationState, TestCertificateClientInterface, makeRestoreCertificateBackupPollOperation } from "./operation";
 import { KeyVaultCertificate } from "../../../../src/certificatesModels";
+import { Poller } from "@azure/core-lro";
 
 export interface RestoreCertificateBackupPollerOptions {
   client: TestCertificateClientInterface;

--- a/sdk/keyvault/keyvault-certificates/test/utils/recorderUtils.ts
+++ b/sdk/keyvault/keyvault-certificates/test/utils/recorderUtils.ts
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { isNode } from "@azure/core-http";
 import * as dotenv from "dotenv";
+import { isNode } from "@azure/core-http";
 import { isPlaybackMode } from "@azure-tools/test-recorder";
 
 if (isNode) {

--- a/sdk/keyvault/keyvault-certificates/test/utils/testAuthentication.ts
+++ b/sdk/keyvault/keyvault-certificates/test/utils/testAuthentication.ts
@@ -1,12 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { ClientSecretCredential } from "@azure/identity";
+import { RecorderEnvironmentSetup, env, record } from "@azure-tools/test-recorder";
 import { CertificateClient } from "../../src";
-import { uniqueString } from "./recorderUtils";
-import { env, record, RecorderEnvironmentSetup } from "@azure-tools/test-recorder";
-import TestClient from "./testClient";
+import { ClientSecretCredential } from "@azure/identity";
 import { Context } from "mocha";
+import TestClient from "./testClient";
+import { uniqueString } from "./recorderUtils";
 
 export async function authenticate(that: Context): Promise<any> {
   const suffix = uniqueString();

--- a/sdk/keyvault/keyvault-certificates/test/utils/testClient.ts
+++ b/sdk/keyvault/keyvault-certificates/test/utils/testClient.ts
@@ -2,9 +2,9 @@
 // Licensed under the MIT license.
 
 import { CertificateClient, KeyVaultCertificate } from "../../src";
-import { PollerLike, PollOperationState } from "@azure/core-lro";
-import { RestoreCertificateBackupPoller } from "./lro/restore/poller";
+import { PollOperationState, PollerLike } from "@azure/core-lro";
 import { BeginRestoreCertificateBackupOptions } from "./lro/restore/operation";
+import { RestoreCertificateBackupPoller } from "./lro/restore/poller";
 import { testPollerProperties } from "./recorderUtils";
 
 export default class TestClient {

--- a/sdk/keyvault/keyvault-certificates/test/utils/utils.common.ts
+++ b/sdk/keyvault/keyvault-certificates/test/utils/utils.common.ts
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { env } from "@azure-tools/test-recorder";
 import * as assert from "assert";
+import { env } from "@azure-tools/test-recorder";
 
 export function getKeyvaultName(): string {
   const keyVaultEnvVarName = "KEYVAULT_NAME";


### PR DESCRIPTION
This PR is working in conjunction with other PRs to fix individual sections of the azure codebase with respect to the new ```sort-imports``` rule, as indicated in #9252.

In this PR, I have fixed all files under ```sdk/keyvault/keyvault-certificates```.