### PR TITLE
[sort-imports] update ```keyvault-common``` with respect to ```sort-imports``` rule

### DIFF
--- a/sdk/keyvault/keyvault-common/src/challengeBasedAuthenticationPolicy.ts
+++ b/sdk/keyvault/keyvault-common/src/challengeBasedAuthenticationPolicy.ts
@@ -3,7 +3,12 @@
 /* eslint-disable @azure/azure-sdk/ts-use-interface-parameters */
 
 import { AccessTokenCache, ExpiringAccessTokenCache } from "@azure/core-http";
-import { BaseRequestPolicy, RequestPolicy, RequestPolicyFactory, RequestPolicyOptions } from "@azure/core-http";
+import {
+  BaseRequestPolicy,
+  RequestPolicy,
+  RequestPolicyFactory,
+  RequestPolicyOptions
+} from "@azure/core-http";
 import { ParsedWWWAuthenticate, parseWWWAuthenticate } from "./parseWWWAuthenticate";
 import { Constants } from "@azure/core-http";
 import { HttpOperationResponse } from "@azure/core-http";

--- a/sdk/keyvault/keyvault-common/src/challengeBasedAuthenticationPolicy.ts
+++ b/sdk/keyvault/keyvault-common/src/challengeBasedAuthenticationPolicy.ts
@@ -2,18 +2,13 @@
 // Licensed under the MIT license.
 /* eslint-disable @azure/azure-sdk/ts-use-interface-parameters */
 
-import { TokenCredential } from "@azure/core-http";
-import {
-  BaseRequestPolicy,
-  RequestPolicy,
-  RequestPolicyOptions,
-  RequestPolicyFactory
-} from "@azure/core-http";
+import { AccessTokenCache, ExpiringAccessTokenCache } from "@azure/core-http";
+import { BaseRequestPolicy, RequestPolicy, RequestPolicyFactory, RequestPolicyOptions } from "@azure/core-http";
+import { ParsedWWWAuthenticate, parseWWWAuthenticate } from "./parseWWWAuthenticate";
 import { Constants } from "@azure/core-http";
 import { HttpOperationResponse } from "@azure/core-http";
+import { TokenCredential } from "@azure/core-http";
 import { WebResource } from "@azure/core-http";
-import { AccessTokenCache, ExpiringAccessTokenCache } from "@azure/core-http";
-import { parseWWWAuthenticate, ParsedWWWAuthenticate } from "./parseWWWAuthenticate";
 
 /**
  * Representation of the Authentication Challenge

--- a/sdk/keyvault/keyvault-common/src/tracingHelpers.ts
+++ b/sdk/keyvault/keyvault-common/src/tracingHelpers.ts
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+import { Span, SpanStatusCode, createSpanFunction } from "@azure/core-tracing";
 import { OperationOptions } from "@azure/core-http";
-import { createSpanFunction, Span, SpanStatusCode } from "@azure/core-tracing";
 
 /**
  * An interface representing a function that is traced.


### PR DESCRIPTION
This PR is working in conjunction with other PRs to fix individual sections of the azure codebase with respect to the new ```sort-imports``` rule, as indicated in #9252.

In this PR, I have fixed all files under ```sdk/keyvault/keyvault-common```.