### PR TITLE
[sort-imports] update ```keyvault-keys``` with respect to ```sort-imports``` rule

### DIFF
--- a/sdk/keyvault/keyvault-keys/src/cryptography/aesCryptographyProvider.ts
+++ b/sdk/keyvault/keyvault-keys/src/cryptography/aesCryptographyProvider.ts
@@ -1,31 +1,27 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { OperationOptions } from "@azure/core-http";
 import * as crypto from "crypto";
 import {
-  EncryptOptions,
-  EncryptResult,
+  AesCbcEncryptParameters,
   DecryptOptions,
   DecryptResult,
+  EncryptOptions,
+  EncryptResult,
+  JsonWebKey,
   KeyWrapAlgorithm,
-  WrapKeyOptions,
-  WrapResult,
-  UnwrapKeyOptions,
-  UnwrapResult,
   SignOptions,
   SignResult,
+  UnwrapKeyOptions,
+  UnwrapResult,
   VerifyOptions,
   VerifyResult,
-  AesCbcEncryptParameters,
-  JsonWebKey
+  WrapKeyOptions,
+  WrapResult
 } from "..";
+import { CryptographyProvider, CryptographyProviderOperation, LocalCryptographyUnsupportedError } from "./models";
 import { AesCbcDecryptParameters } from "../cryptographyClientModels";
-import {
-  CryptographyProvider,
-  CryptographyProviderOperation,
-  LocalCryptographyUnsupportedError
-} from "./models";
+import { OperationOptions } from "@azure/core-http";
 
 /**
  * An AES cryptography provider supporting AES algorithms.

--- a/sdk/keyvault/keyvault-keys/src/cryptography/aesCryptographyProvider.ts
+++ b/sdk/keyvault/keyvault-keys/src/cryptography/aesCryptographyProvider.ts
@@ -19,7 +19,11 @@ import {
   WrapKeyOptions,
   WrapResult
 } from "..";
-import { CryptographyProvider, CryptographyProviderOperation, LocalCryptographyUnsupportedError } from "./models";
+import {
+  CryptographyProvider,
+  CryptographyProviderOperation,
+  LocalCryptographyUnsupportedError
+} from "./models";
 import { AesCbcDecryptParameters } from "../cryptographyClientModels";
 import { OperationOptions } from "@azure/core-http";
 

--- a/sdk/keyvault/keyvault-keys/src/cryptography/crypto.ts
+++ b/sdk/keyvault/keyvault-keys/src/cryptography/crypto.ts
@@ -1,7 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { Verify, createHash as cryptoCreateHash, createVerify as cryptoCreateVerify, randomBytes as cryptoRandomBytes } from "crypto";
+import {
+  Verify,
+  createHash as cryptoCreateHash,
+  createVerify as cryptoCreateVerify,
+  randomBytes as cryptoRandomBytes
+} from "crypto";
 
 /**
  * @internal

--- a/sdk/keyvault/keyvault-keys/src/cryptography/crypto.ts
+++ b/sdk/keyvault/keyvault-keys/src/cryptography/crypto.ts
@@ -1,12 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import {
-  createHash as cryptoCreateHash,
-  createVerify as cryptoCreateVerify,
-  Verify,
-  randomBytes as cryptoRandomBytes
-} from "crypto";
+import { Verify, createHash as cryptoCreateHash, createVerify as cryptoCreateVerify, randomBytes as cryptoRandomBytes } from "crypto";
 
 /**
  * @internal

--- a/sdk/keyvault/keyvault-keys/src/cryptography/models.ts
+++ b/sdk/keyvault/keyvault-keys/src/cryptography/models.ts
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { OperationOptions } from "@azure/core-http";
 import {
   DecryptOptions,
   DecryptParameters,
@@ -10,9 +9,9 @@ import {
   EncryptParameters,
   EncryptResult,
   KeyWrapAlgorithm,
-  SignatureAlgorithm,
   SignOptions,
   SignResult,
+  SignatureAlgorithm,
   UnwrapKeyOptions,
   UnwrapResult,
   VerifyOptions,
@@ -20,6 +19,7 @@ import {
   WrapKeyOptions,
   WrapResult
 } from "..";
+import { OperationOptions } from "@azure/core-http";
 
 export class LocalCryptographyUnsupportedError extends Error {}
 

--- a/sdk/keyvault/keyvault-keys/src/cryptography/remoteCryptographyProvider.ts
+++ b/sdk/keyvault/keyvault-keys/src/cryptography/remoteCryptographyProvider.ts
@@ -1,7 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { CryptographyClientOptions, GetKeyOptions, KeyVaultKey, LATEST_API_VERSION } from "../keysModels";
+import {
+  CryptographyClientOptions,
+  GetKeyOptions,
+  KeyVaultKey,
+  LATEST_API_VERSION
+} from "../keysModels";
 import { CryptographyProvider, CryptographyProviderOperation } from "./models";
 import {
   DecryptOptions,
@@ -19,8 +24,17 @@ import {
   WrapKeyOptions,
   WrapResult
 } from "../cryptographyClientModels";
-import { TokenCredential, createPipelineFromOptions, isTokenCredential, signingPolicy } from "@azure/core-http";
-import { TracedFunction, challengeBasedAuthenticationPolicy, createTraceFunction } from "../../../keyvault-common/src";
+import {
+  TokenCredential,
+  createPipelineFromOptions,
+  isTokenCredential,
+  signingPolicy
+} from "@azure/core-http";
+import {
+  TracedFunction,
+  challengeBasedAuthenticationPolicy,
+  createTraceFunction
+} from "../../../keyvault-common/src";
 import { KeyVaultClient } from "../generated";
 import { SDK_VERSION } from "../constants";
 import { UnwrapResult } from "../cryptographyClientModels";

--- a/sdk/keyvault/keyvault-keys/src/cryptography/remoteCryptographyProvider.ts
+++ b/sdk/keyvault/keyvault-keys/src/cryptography/remoteCryptographyProvider.ts
@@ -1,47 +1,33 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+import { CryptographyClientOptions, GetKeyOptions, KeyVaultKey, LATEST_API_VERSION } from "../keysModels";
+import { CryptographyProvider, CryptographyProviderOperation } from "./models";
 import {
-  createPipelineFromOptions,
-  isTokenCredential,
-  TokenCredential,
-  signingPolicy
-} from "@azure/core-http";
-import {
-  EncryptParameters,
+  DecryptOptions,
+  DecryptParameters,
+  DecryptResult,
   EncryptOptions,
+  EncryptParameters,
   EncryptResult,
   KeyWrapAlgorithm,
-  WrapKeyOptions,
-  WrapResult,
+  SignOptions,
+  SignResult,
+  UnwrapKeyOptions,
   VerifyOptions,
   VerifyResult,
-  DecryptParameters,
-  DecryptOptions,
-  DecryptResult,
-  UnwrapKeyOptions,
-  SignOptions,
-  SignResult
+  WrapKeyOptions,
+  WrapResult
 } from "../cryptographyClientModels";
+import { TokenCredential, createPipelineFromOptions, isTokenCredential, signingPolicy } from "@azure/core-http";
+import { TracedFunction, challengeBasedAuthenticationPolicy, createTraceFunction } from "../../../keyvault-common/src";
+import { KeyVaultClient } from "../generated";
 import { SDK_VERSION } from "../constants";
 import { UnwrapResult } from "../cryptographyClientModels";
-import { KeyVaultClient } from "../generated";
-import { parseKeyVaultKeyIdentifier } from "../identifier";
-import {
-  CryptographyClientOptions,
-  GetKeyOptions,
-  KeyVaultKey,
-  LATEST_API_VERSION
-} from "../keysModels";
-import { getKeyFromKeyBundle } from "../transformations";
 import { createHash } from "./crypto";
-import { CryptographyProvider, CryptographyProviderOperation } from "./models";
+import { getKeyFromKeyBundle } from "../transformations";
 import { logger } from "../log";
-import {
-  createTraceFunction,
-  TracedFunction,
-  challengeBasedAuthenticationPolicy
-} from "../../../keyvault-common/src";
+import { parseKeyVaultKeyIdentifier } from "../identifier";
 
 const withTrace: TracedFunction = createTraceFunction(
   "Azure.KeyVault.Keys.RemoteCryptographyProvider"

--- a/sdk/keyvault/keyvault-keys/src/cryptography/rsaCryptographyProvider.ts
+++ b/sdk/keyvault/keyvault-keys/src/cryptography/rsaCryptographyProvider.ts
@@ -1,7 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { CryptographyProvider, CryptographyProviderOperation, LocalCryptographyUnsupportedError } from "./models";
+import {
+  CryptographyProvider,
+  CryptographyProviderOperation,
+  LocalCryptographyUnsupportedError
+} from "./models";
 import {
   DecryptOptions,
   DecryptParameters,

--- a/sdk/keyvault/keyvault-keys/src/cryptography/rsaCryptographyProvider.ts
+++ b/sdk/keyvault/keyvault-keys/src/cryptography/rsaCryptographyProvider.ts
@@ -1,34 +1,30 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { RSA_PKCS1_OAEP_PADDING, RSA_PKCS1_PADDING } from "constants";
-import { publicEncrypt } from "crypto";
-import { createVerify } from "./crypto";
+import { CryptographyProvider, CryptographyProviderOperation, LocalCryptographyUnsupportedError } from "./models";
 import {
-  JsonWebKey,
   DecryptOptions,
+  DecryptParameters,
+  DecryptResult,
   EncryptOptions,
   EncryptParameters,
   EncryptResult,
+  JsonWebKey,
   KeyWrapAlgorithm,
+  SignOptions,
+  SignResult,
+  SignatureAlgorithm,
   UnwrapKeyOptions,
+  UnwrapResult,
   VerifyOptions,
   VerifyResult,
   WrapKeyOptions,
-  DecryptParameters,
-  DecryptResult,
-  SignatureAlgorithm,
-  SignOptions,
-  SignResult,
-  UnwrapResult,
   WrapResult
 } from "..";
+import { RSA_PKCS1_OAEP_PADDING, RSA_PKCS1_PADDING } from "constants";
 import { convertJWKtoPEM } from "./conversions";
-import {
-  CryptographyProvider,
-  CryptographyProviderOperation,
-  LocalCryptographyUnsupportedError
-} from "./models";
+import { createVerify } from "./crypto";
+import { publicEncrypt } from "crypto";
 
 /**
  * An RSA cryptography provider supporting RSA algorithms.

--- a/sdk/keyvault/keyvault-keys/src/cryptographyClient.ts
+++ b/sdk/keyvault/keyvault-keys/src/cryptographyClient.ts
@@ -1,43 +1,43 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { OperationOptions, TokenCredential } from "@azure/core-http";
 import {
-  JsonWebKey,
-  KeyVaultKey,
-  CryptographyClientOptions,
-  GetKeyOptions,
-  KeyOperation,
-  KnownKeyOperations
-} from "./keysModels";
-import {
+  AesCbcEncryptParameters,
+  AesCbcEncryptionAlgorithm,
+  CryptographyClientKey,
+  DecryptOptions,
+  DecryptParameters,
+  DecryptResult,
+  EncryptOptions,
+  EncryptParameters,
+  EncryptResult,
   EncryptionAlgorithm,
   KeyWrapAlgorithm,
-  WrapResult,
-  UnwrapResult,
-  DecryptResult,
-  SignatureAlgorithm,
-  SignResult,
-  VerifyResult,
-  EncryptResult,
-  EncryptOptions,
-  DecryptOptions,
-  WrapKeyOptions,
-  UnwrapKeyOptions,
-  EncryptParameters,
   SignOptions,
+  SignResult,
+  SignatureAlgorithm,
+  UnwrapKeyOptions,
+  UnwrapResult,
   VerifyOptions,
-  DecryptParameters,
-  CryptographyClientKey,
-  AesCbcEncryptParameters,
-  AesCbcEncryptionAlgorithm
+  VerifyResult,
+  WrapKeyOptions,
+  WrapResult
 } from "./cryptographyClientModels";
-import { RemoteCryptographyProvider } from "./cryptography/remoteCryptographyProvider";
-import { randomBytes } from "./cryptography/crypto";
+import {
+  CryptographyClientOptions,
+  GetKeyOptions,
+  JsonWebKey,
+  KeyOperation,
+  KeyVaultKey,
+  KnownKeyOperations
+} from "./keysModels";
 import { CryptographyProvider, CryptographyProviderOperation } from "./cryptography/models";
-import { RsaCryptographyProvider } from "./cryptography/rsaCryptographyProvider";
+import { OperationOptions, TokenCredential } from "@azure/core-http";
 import { AesCryptographyProvider } from "./cryptography/aesCryptographyProvider";
+import { RemoteCryptographyProvider } from "./cryptography/remoteCryptographyProvider";
+import { RsaCryptographyProvider } from "./cryptography/rsaCryptographyProvider";
 import { createTraceFunction } from "../../keyvault-common/src";
+import { randomBytes } from "./cryptography/crypto";
 
 const withTrace = createTraceFunction("Azure.KeyVault.Keys.CryptographyClient");
 

--- a/sdk/keyvault/keyvault-keys/src/cryptographyClientModels.ts
+++ b/sdk/keyvault/keyvault-keys/src/cryptographyClientModels.ts
@@ -2,15 +2,14 @@
 // Licensed under the MIT license.
 
 import { CryptographyOptions, KeyVaultKey } from "./keysModels";
-
 import {
+  JsonWebKeyEncryptionAlgorithm as EncryptionAlgorithm,
   JsonWebKey,
   JsonWebKeyCurveName as KeyCurveName,
-  KnownJsonWebKeyCurveName as KnownKeyCurveNames,
-  JsonWebKeyEncryptionAlgorithm as EncryptionAlgorithm,
   KnownJsonWebKeyEncryptionAlgorithm as KnownEncryptionAlgorithms,
-  JsonWebKeySignatureAlgorithm as SignatureAlgorithm,
-  KnownJsonWebKeySignatureAlgorithm as KnownSignatureAlgorithms
+  KnownJsonWebKeyCurveName as KnownKeyCurveNames,
+  KnownJsonWebKeySignatureAlgorithm as KnownSignatureAlgorithms,
+  JsonWebKeySignatureAlgorithm as SignatureAlgorithm
 } from "./generated/models";
 
 export {

--- a/sdk/keyvault/keyvault-keys/src/index.ts
+++ b/sdk/keyvault/keyvault-keys/src/index.ts
@@ -82,7 +82,12 @@ import {
   UpdateKeyPropertiesOptions,
   UpdateKeyRotationPolicyOptions
 } from "./keysModels";
-import { DeletionRecoveryLevel, KeyVaultClientGetKeysOptionalParams, KnownDeletionRecoveryLevel, KnownJsonWebKeyType } from "./generated/models";
+import {
+  DeletionRecoveryLevel,
+  KeyVaultClientGetKeysOptionalParams,
+  KnownDeletionRecoveryLevel,
+  KnownJsonWebKeyType
+} from "./generated/models";
 import { KeyVaultKeyIdentifier, parseKeyVaultKeyIdentifier } from "./identifier";
 import { PageSettings, PagedAsyncIterableIterator } from "@azure/core-paging";
 import {
@@ -93,7 +98,12 @@ import {
   signingPolicy
 } from "@azure/core-http";
 import { PollOperationState, PollerLike } from "@azure/core-lro";
-import { getDeletedKeyFromDeletedKeyItem, getKeyFromKeyBundle, getKeyPropertiesFromKeyItem, keyRotationTransformations } from "./transformations";
+import {
+  getDeletedKeyFromDeletedKeyItem,
+  getKeyFromKeyBundle,
+  getKeyPropertiesFromKeyItem,
+  keyRotationTransformations
+} from "./transformations";
 import { CryptographyClient } from "./cryptographyClient";
 import { DeleteKeyPoller } from "./lro/delete/poller";
 import { KeyVaultClient } from "./generated/keyVaultClient";

--- a/sdk/keyvault/keyvault-keys/src/keysModels.ts
+++ b/sdk/keyvault/keyvault-keys/src/keysModels.ts
@@ -2,7 +2,12 @@
 // Licensed under the MIT license.
 
 import * as coreHttp from "@azure/core-http";
-import { DeletionRecoveryLevel, JsonWebKeyOperation as KeyOperation, JsonWebKeyType as KeyType, KnownJsonWebKeyType as KnownKeyTypes } from "./generated/models";
+import {
+  DeletionRecoveryLevel,
+  JsonWebKeyOperation as KeyOperation,
+  JsonWebKeyType as KeyType,
+  KnownJsonWebKeyType as KnownKeyTypes
+} from "./generated/models";
 import { KeyCurveName } from "./cryptographyClientModels";
 
 export { KeyType, KnownKeyTypes, KeyOperation };

--- a/sdk/keyvault/keyvault-keys/src/keysModels.ts
+++ b/sdk/keyvault/keyvault-keys/src/keysModels.ts
@@ -2,12 +2,7 @@
 // Licensed under the MIT license.
 
 import * as coreHttp from "@azure/core-http";
-import {
-  DeletionRecoveryLevel,
-  JsonWebKeyType as KeyType,
-  KnownJsonWebKeyType as KnownKeyTypes,
-  JsonWebKeyOperation as KeyOperation
-} from "./generated/models";
+import { DeletionRecoveryLevel, JsonWebKeyOperation as KeyOperation, JsonWebKeyType as KeyType, KnownJsonWebKeyType as KnownKeyTypes } from "./generated/models";
 import { KeyCurveName } from "./cryptographyClientModels";
 
 export { KeyType, KnownKeyTypes, KeyOperation };

--- a/sdk/keyvault/keyvault-keys/src/lro/delete/operation.ts
+++ b/sdk/keyvault/keyvault-keys/src/lro/delete/operation.ts
@@ -1,13 +1,13 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { AbortSignalLike } from "@azure/abort-controller";
-import { OperationOptions } from "@azure/core-http";
-import { KeyVaultClient } from "../../generated/keyVaultClient";
-import { DeletedKey, DeleteKeyOptions, GetDeletedKeyOptions } from "../../keysModels";
-import { getKeyFromKeyBundle } from "../../transformations";
+import { DeleteKeyOptions, DeletedKey, GetDeletedKeyOptions } from "../../keysModels";
 import { KeyVaultKeyPollOperation, KeyVaultKeyPollOperationState } from "../keyVaultKeyPoller";
+import { AbortSignalLike } from "@azure/abort-controller";
+import { KeyVaultClient } from "../../generated/keyVaultClient";
+import { OperationOptions } from "@azure/core-http";
 import { createTraceFunction } from "../../../../keyvault-common/src";
+import { getKeyFromKeyBundle } from "../../transformations";
 
 /**
  * @internal

--- a/sdk/keyvault/keyvault-keys/src/lro/delete/poller.ts
+++ b/sdk/keyvault/keyvault-keys/src/lro/delete/poller.ts
@@ -2,8 +2,8 @@
 // Licensed under the MIT license.
 
 import { DeleteKeyPollOperation, DeleteKeyPollOperationState } from "./operation";
-import { DeletedKey } from "../../keysModels";
 import { KeyVaultKeyPoller, KeyVaultKeyPollerOptions } from "../keyVaultKeyPoller";
+import { DeletedKey } from "../../keysModels";
 
 /**
  * Class that creates a poller that waits until a key finishes being deleted.

--- a/sdk/keyvault/keyvault-keys/src/lro/keyVaultKeyPoller.ts
+++ b/sdk/keyvault/keyvault-keys/src/lro/keyVaultKeyPoller.ts
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { delay, OperationOptions } from "@azure/core-http";
-import { Poller, PollOperation, PollOperationState } from "@azure/core-lro";
+import { OperationOptions, delay } from "@azure/core-http";
+import { PollOperation, PollOperationState, Poller } from "@azure/core-lro";
 import { KeyVaultClient } from "../generated/keyVaultClient";
 
 /**

--- a/sdk/keyvault/keyvault-keys/src/lro/recover/operation.ts
+++ b/sdk/keyvault/keyvault-keys/src/lro/recover/operation.ts
@@ -1,14 +1,13 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { AbortSignalLike } from "@azure/abort-controller";
-import { OperationOptions } from "@azure/core-http";
-import { KeyVaultClient } from "../../generated/keyVaultClient";
-import { KeyVaultKey, GetKeyOptions, RecoverDeletedKeyOptions } from "../../keysModels";
-import { getKeyFromKeyBundle } from "../../transformations";
+import { GetKeyOptions, KeyVaultKey, RecoverDeletedKeyOptions } from "../../keysModels";
 import { KeyVaultKeyPollOperation, KeyVaultKeyPollOperationState } from "../keyVaultKeyPoller";
-
+import { AbortSignalLike } from "@azure/abort-controller";
+import { KeyVaultClient } from "../../generated/keyVaultClient";
+import { OperationOptions } from "@azure/core-http";
 import { createTraceFunction } from "../../../../keyvault-common/src";
+import { getKeyFromKeyBundle } from "../../transformations";
 
 /**
  * @internal

--- a/sdk/keyvault/keyvault-keys/src/lro/recover/poller.ts
+++ b/sdk/keyvault/keyvault-keys/src/lro/recover/poller.ts
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+import { KeyVaultKeyPoller, KeyVaultKeyPollerOptions } from "../keyVaultKeyPoller";
 import { RecoverDeletedKeyPollOperation, RecoverDeletedKeyPollOperationState } from "./operation";
 import { KeyVaultKey } from "../../keysModels";
-import { KeyVaultKeyPoller, KeyVaultKeyPollerOptions } from "../keyVaultKeyPoller";
 
 /**
  * Class that deletes a poller that waits until a key finishes being deleted

--- a/sdk/keyvault/keyvault-keys/src/transformations.ts
+++ b/sdk/keyvault/keyvault-keys/src/transformations.ts
@@ -2,22 +2,22 @@
 // Licensed under the MIT license.
 
 import {
+  DeletedKey,
+  KeyProperties,
+  KeyRotationPolicy,
+  KeyRotationPolicyProperties,
+  KeyVaultKey
+} from "./keysModels";
+import {
   DeletedKeyBundle,
   DeletedKeyItem,
+  KeyRotationPolicy as GeneratedPolicy,
   KeyAttributes,
   KeyBundle,
   KeyItem,
-  KeyRotationPolicy as GeneratedPolicy,
   LifetimeActions
 } from "./generated/models";
 import { parseKeyVaultKeyIdentifier } from "./identifier";
-import {
-  DeletedKey,
-  KeyVaultKey,
-  KeyProperties,
-  KeyRotationPolicy,
-  KeyRotationPolicyProperties
-} from "./keysModels";
 
 /**
  * @internal

--- a/sdk/keyvault/keyvault-keys/test/internal/aesCryptography.spec.ts
+++ b/sdk/keyvault/keyvault-keys/test/internal/aesCryptography.spec.ts
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { assert } from "chai";
-import { Context } from "mocha";
 import {
   AesCbcEncryptionAlgorithm,
   CryptographyClient,
@@ -10,15 +8,17 @@ import {
   KeyClient,
   KeyVaultKey
 } from "../../src";
+import { Recorder, env } from "@azure-tools/test-recorder";
 import { getKey, stringToUint8Array, uint8ArrayToString } from "../utils/crypto";
-import { isNode } from "@azure/core-http";
 import { AesCryptographyProvider } from "../../src/cryptography/aesCryptographyProvider";
-import TestClient from "../utils/testClient";
-import { authenticate } from "../utils/testAuthentication";
-import { env, Recorder } from "@azure-tools/test-recorder";
-import { RemoteCryptographyProvider } from "../../src/cryptography/remoteCryptographyProvider";
 import { ClientSecretCredential } from "@azure/identity";
+import { Context } from "mocha";
+import { RemoteCryptographyProvider } from "../../src/cryptography/remoteCryptographyProvider";
+import TestClient from "../utils/testClient";
+import { assert } from "chai";
+import { authenticate } from "../utils/testAuthentication";
 import { getServiceVersion } from "../utils/utils.common";
+import { isNode } from "@azure/core-http";
 
 describe("AesCryptographyProvider browser tests", function() {
   it("uses the browser replacement when running in the browser", async function(this: Context) {

--- a/sdk/keyvault/keyvault-keys/test/internal/challengeBasedAuthenticationPolicy.spec.ts
+++ b/sdk/keyvault/keyvault-keys/test/internal/challengeBasedAuthenticationPolicy.spec.ts
@@ -1,7 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { AuthenticationChallenge, AuthenticationChallengeCache, challengeBasedAuthenticationPolicy, parseWWWAuthenticate } from "../../../keyvault-common/src";
+import {
+  AuthenticationChallenge,
+  AuthenticationChallengeCache,
+  challengeBasedAuthenticationPolicy,
+  parseWWWAuthenticate
+} from "../../../keyvault-common/src";
 import { HttpHeaders, WebResource, isNode } from "@azure/core-http";
 import { Recorder, env } from "@azure-tools/test-recorder";
 import { ClientSecretCredential } from "@azure/identity";

--- a/sdk/keyvault/keyvault-keys/test/internal/challengeBasedAuthenticationPolicy.spec.ts
+++ b/sdk/keyvault/keyvault-keys/test/internal/challengeBasedAuthenticationPolicy.spec.ts
@@ -1,23 +1,17 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { assert } from "chai";
-import { Context } from "mocha";
-import { createSandbox } from "sinon";
-import { env, Recorder } from "@azure-tools/test-recorder";
-
-import {
-  AuthenticationChallengeCache,
-  AuthenticationChallenge,
-  parseWWWAuthenticate,
-  challengeBasedAuthenticationPolicy
-} from "../../../keyvault-common/src";
-import { KeyClient } from "../../src";
-import { authenticate } from "../utils/testAuthentication";
-import TestClient from "../utils/testClient";
-import { getServiceVersion } from "../utils/utils.common";
-import { HttpHeaders, isNode, WebResource } from "@azure/core-http";
+import { AuthenticationChallenge, AuthenticationChallengeCache, challengeBasedAuthenticationPolicy, parseWWWAuthenticate } from "../../../keyvault-common/src";
+import { HttpHeaders, WebResource, isNode } from "@azure/core-http";
+import { Recorder, env } from "@azure-tools/test-recorder";
 import { ClientSecretCredential } from "@azure/identity";
+import { Context } from "mocha";
+import { KeyClient } from "../../src";
+import TestClient from "../utils/testClient";
+import { assert } from "chai";
+import { authenticate } from "../utils/testAuthentication";
+import { createSandbox } from "sinon";
+import { getServiceVersion } from "../utils/utils.common";
 import sinon from "sinon";
 
 // Following the philosophy of not testing the insides if we can test the outsides...

--- a/sdk/keyvault/keyvault-keys/test/internal/crypto.spec.ts
+++ b/sdk/keyvault/keyvault-keys/test/internal/crypto.spec.ts
@@ -1,14 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { isNode, TokenCredential, OperationOptions } from "@azure/core-http";
-import { Context } from "mocha";
-import chai, { assert } from "chai";
-import chaiAsPromised from "chai-as-promised";
-chai.use(chaiAsPromised);
-import chaiExclude from "chai-exclude";
-chai.use(chaiExclude);
-import sinon from "sinon";
 import {
   CryptographyClient,
   DecryptParameters,
@@ -16,11 +8,20 @@ import {
   KeyClient,
   KeyVaultKey
 } from "../../src";
-import { RsaCryptographyProvider } from "../../src/cryptography/rsaCryptographyProvider";
-import { JsonWebKey } from "../../src";
-import { stringToUint8Array } from "../utils/crypto";
+import { OperationOptions, TokenCredential, isNode } from "@azure/core-http";
+import chai, { assert } from "chai";
+import { Context } from "mocha";
 import { CryptographyProvider } from "../../src/cryptography/models";
+import { JsonWebKey } from "../../src";
 import { RemoteCryptographyProvider } from "../../src/cryptography/remoteCryptographyProvider";
+import { RsaCryptographyProvider } from "../../src/cryptography/rsaCryptographyProvider";
+import chaiAsPromised from "chai-as-promised";
+import chaiExclude from "chai-exclude";
+import sinon from "sinon";
+import { stringToUint8Array } from "../utils/crypto";
+
+chai.use(chaiAsPromised);
+chai.use(chaiExclude);
 
 describe("internal crypto tests", () => {
   const tokenCredential: TokenCredential = {

--- a/sdk/keyvault/keyvault-keys/test/internal/lroUnexpectedErrors.spec.ts
+++ b/sdk/keyvault/keyvault-keys/test/internal/lroUnexpectedErrors.spec.ts
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { assert } from "chai";
-import { RestError } from "@azure/core-http";
 import { DeleteKeyPoller } from "../../src/lro/delete/poller";
 import { RecoverDeletedKeyPoller } from "../../src/lro/recover/poller";
+import { RestError } from "@azure/core-http";
+import { assert } from "chai";
 
 describe("The LROs properly throw on unexpected errors", () => {
   const vaultUrl = `https://keyVaultName.vault.azure.net`;

--- a/sdk/keyvault/keyvault-keys/test/internal/serviceVersionParameter.spec.ts
+++ b/sdk/keyvault/keyvault-keys/test/internal/serviceVersionParameter.spec.ts
@@ -2,14 +2,14 @@
 // Licensed under the MIT license.
 
 import * as assert from "assert";
-import { createSandbox, SinonSandbox, SinonSpy } from "sinon";
+import { HttpClient, HttpHeaders, HttpOperationResponse, WebResourceLike } from "@azure/core-http";
+import { SinonSandbox, SinonSpy, createSandbox } from "sinon";
+import { ClientSecretCredential } from "@azure/identity";
 import { KeyClient } from "../../src";
 import { LATEST_API_VERSION } from "../../src/keysModels";
-import { HttpClient, HttpOperationResponse, WebResourceLike, HttpHeaders } from "@azure/core-http";
-import { ClientSecretCredential } from "@azure/identity";
 import { env } from "@azure-tools/test-recorder";
-import { versionsToTest } from "@azure/test-utils";
 import { serviceVersions } from "../utils/utils.common";
+import { versionsToTest } from "@azure/test-utils";
 
 describe("The Keys client should set the serviceVersion", () => {
   const keyVaultUrl = `https://keyVaultName.vault.azure.net`;

--- a/sdk/keyvault/keyvault-keys/test/internal/transformations.spec.ts
+++ b/sdk/keyvault/keyvault-keys/test/internal/transformations.spec.ts
@@ -1,26 +1,16 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { assert } from "chai";
-import {
-  DeletedKeyBundle,
-  DeletedKeyItem,
-  KeyBundle,
-  KeyRotationPolicy as GeneratedKeyRotationPolicy
-} from "../../src/generated";
 import {
   DeletedKey,
   KeyProperties,
-  KeyVaultKey,
   KeyRotationPolicy,
-  KeyRotationPolicyProperties
+  KeyRotationPolicyProperties,
+  KeyVaultKey
 } from "../../src/keysModels";
-import {
-  getDeletedKeyFromDeletedKeyItem,
-  getKeyFromKeyBundle,
-  getKeyPropertiesFromKeyItem,
-  keyRotationTransformations
-} from "../../src/transformations";
+import { DeletedKeyBundle, DeletedKeyItem, KeyRotationPolicy as GeneratedKeyRotationPolicy, KeyBundle } from "../../src/generated";
+import { getDeletedKeyFromDeletedKeyItem, getKeyFromKeyBundle, getKeyPropertiesFromKeyItem, keyRotationTransformations } from "../../src/transformations";
+import { assert } from "chai";
 import { stringToUint8Array } from "../utils/crypto";
 
 describe("Transformations", () => {

--- a/sdk/keyvault/keyvault-keys/test/internal/transformations.spec.ts
+++ b/sdk/keyvault/keyvault-keys/test/internal/transformations.spec.ts
@@ -8,8 +8,18 @@ import {
   KeyRotationPolicyProperties,
   KeyVaultKey
 } from "../../src/keysModels";
-import { DeletedKeyBundle, DeletedKeyItem, KeyRotationPolicy as GeneratedKeyRotationPolicy, KeyBundle } from "../../src/generated";
-import { getDeletedKeyFromDeletedKeyItem, getKeyFromKeyBundle, getKeyPropertiesFromKeyItem, keyRotationTransformations } from "../../src/transformations";
+import {
+  DeletedKeyBundle,
+  DeletedKeyItem,
+  KeyRotationPolicy as GeneratedKeyRotationPolicy,
+  KeyBundle
+} from "../../src/generated";
+import {
+  getDeletedKeyFromDeletedKeyItem,
+  getKeyFromKeyBundle,
+  getKeyPropertiesFromKeyItem,
+  keyRotationTransformations
+} from "../../src/transformations";
 import { assert } from "chai";
 import { stringToUint8Array } from "../utils/crypto";
 

--- a/sdk/keyvault/keyvault-keys/test/internal/userAgent.spec.ts
+++ b/sdk/keyvault/keyvault-keys/test/internal/userAgent.spec.ts
@@ -4,10 +4,10 @@
 import * as assert from "assert";
 import { Context } from "mocha";
 import { SDK_VERSION } from "../../src/constants";
-import { packageVersion } from "../../src/generated/keyVaultClientContext";
-import { isNode } from "@azure/core-http";
-import path from "path";
 import fs from "fs";
+import { isNode } from "@azure/core-http";
+import { packageVersion } from "../../src/generated/keyVaultClientContext";
+import path from "path";
 
 describe("Keys client's user agent (only in Node, because of fs)", () => {
   it("SDK_VERSION and packageVersion should match", async function() {

--- a/sdk/keyvault/keyvault-keys/test/public/crypto.hsm.spec.ts
+++ b/sdk/keyvault/keyvault-keys/test/public/crypto.hsm.spec.ts
@@ -1,16 +1,15 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { assert } from "chai";
+import { CryptographyClient, KeyClient, KeyVaultKey } from "../../src";
+import { getServiceVersion, onVersions } from "../utils/utils.common";
+import { stringToUint8Array, uint8ArrayToString } from "../utils/crypto";
+import { ClientSecretCredential } from "@azure/identity";
 import { Context } from "mocha";
 import { Recorder } from "@azure-tools/test-recorder";
-import { ClientSecretCredential } from "@azure/identity";
-
-import { CryptographyClient, KeyVaultKey, KeyClient } from "../../src";
-import { authenticate } from "../utils/testAuthentication";
-import { stringToUint8Array, uint8ArrayToString } from "../utils/crypto";
 import TestClient from "../utils/testClient";
-import { getServiceVersion, onVersions } from "../utils/utils.common";
+import { assert } from "chai";
+import { authenticate } from "../utils/testAuthentication";
 import { isNode } from "@azure/core-http";
 
 onVersions({ minVer: "7.2" }).describe(

--- a/sdk/keyvault/keyvault-keys/test/public/crypto.spec.ts
+++ b/sdk/keyvault/keyvault-keys/test/public/crypto.spec.ts
@@ -1,20 +1,19 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { assert } from "chai";
-import { supportsTracing } from "../../../keyvault-common/test/utils/supportsTracing";
-import { Context } from "mocha";
-import { createHash } from "crypto";
+import { CryptographyClient, KeyClient, KeyVaultKey } from "../../src";
 import { Recorder, env, isLiveMode } from "@azure-tools/test-recorder";
-import { ClientSecretCredential } from "@azure/identity";
-
-import { CryptographyClient, KeyVaultKey, KeyClient } from "../../src";
-import { authenticate } from "../utils/testAuthentication";
-import TestClient from "../utils/testClient";
 import { stringToUint8Array, uint8ArrayToString } from "../utils/crypto";
+import { ClientSecretCredential } from "@azure/identity";
+import { Context } from "mocha";
 import { RsaCryptographyProvider } from "../../src/cryptography/rsaCryptographyProvider";
+import TestClient from "../utils/testClient";
+import { assert } from "chai";
+import { authenticate } from "../utils/testAuthentication";
+import { createHash } from "crypto";
 import { getServiceVersion } from "../utils/utils.common";
 import { isNode } from "@azure/core-http";
+import { supportsTracing } from "../../../keyvault-common/test/utils/supportsTracing";
 
 describe("CryptographyClient (all decrypts happen remotely)", () => {
   const keyPrefix = `crypto${env.KEY_NAME || "KeyName"}`;

--- a/sdk/keyvault/keyvault-keys/test/public/identifier.spec.ts
+++ b/sdk/keyvault/keyvault-keys/test/public/identifier.spec.ts
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { parseKeyVaultKeyIdentifier } from "../../src/identifier";
 import * as assert from "assert";
+import { parseKeyVaultKeyIdentifier } from "../../src/identifier";
 
 describe("Key Vault Keys Identifier", () => {
   it("It should work with a URI of a key before it gets a version", async function() {

--- a/sdk/keyvault/keyvault-keys/test/public/import.spec.ts
+++ b/sdk/keyvault/keyvault-keys/test/public/import.spec.ts
@@ -2,14 +2,13 @@
 // Licensed under the MIT license.
 
 import * as assert from "assert";
+import { Recorder, env } from "@azure-tools/test-recorder";
 import { Context } from "mocha";
-import { env, Recorder } from "@azure-tools/test-recorder";
-
 import { KeyClient } from "../../src";
-import { authenticate } from "../utils/testAuthentication";
 import TestClient from "../utils/testClient";
-import { getServiceVersion } from "../utils/utils.common";
+import { authenticate } from "../utils/testAuthentication";
 import { createRsaKey } from "../utils/crypto";
+import { getServiceVersion } from "../utils/utils.common";
 
 describe("Keys client - import keys", () => {
   const prefix = `import${env.CERTIFICATE_NAME || "KeyName"}`;

--- a/sdk/keyvault/keyvault-keys/test/public/keyClient.hsm.spec.ts
+++ b/sdk/keyvault/keyvault-keys/test/public/keyClient.hsm.spec.ts
@@ -1,17 +1,17 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { assert } from "chai";
-import { Context } from "mocha";
-import { env, Recorder } from "@azure-tools/test-recorder";
-import { KeyClient } from "../../src";
-import { authenticate } from "../utils/testAuthentication";
-import TestClient from "../utils/testClient";
 import { CreateOctKeyOptions, KnownKeyExportEncryptionAlgorithm } from "../../src/keysModels";
-import { getServiceVersion, onVersions } from "../utils/utils.common";
-import { supportsTracing } from "../../../keyvault-common/test/utils/supportsTracing";
-import { createRsaKey, stringToUint8Array, uint8ArrayToString } from "../utils/crypto";
 import { DefaultHttpClient, WebResource } from "@azure/core-http";
+import { Recorder, env } from "@azure-tools/test-recorder";
+import { createRsaKey, stringToUint8Array, uint8ArrayToString } from "../utils/crypto";
+import { getServiceVersion, onVersions } from "../utils/utils.common";
+import { Context } from "mocha";
+import { KeyClient } from "../../src";
+import TestClient from "../utils/testClient";
+import { assert } from "chai";
+import { authenticate } from "../utils/testAuthentication";
+import { supportsTracing } from "../../../keyvault-common/test/utils/supportsTracing";
 
 onVersions({ minVer: "7.2" }).describe(
   "Keys client - create, read, update and delete operations for managed HSM",

--- a/sdk/keyvault/keyvault-keys/test/public/keyClient.spec.ts
+++ b/sdk/keyvault/keyvault-keys/test/public/keyClient.spec.ts
@@ -1,9 +1,19 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { CreateEcKeyOptions, GetKeyOptions, KeyClient, UpdateKeyPropertiesOptions } from "../../src";
+import {
+  CreateEcKeyOptions,
+  GetKeyOptions,
+  KeyClient,
+  UpdateKeyPropertiesOptions
+} from "../../src";
 import { Recorder, env, isPlaybackMode, isRecordMode } from "@azure-tools/test-recorder";
-import { assertThrowsAbortError, getServiceVersion, isPublicCloud, onVersions } from "../utils/utils.common";
+import {
+  assertThrowsAbortError,
+  getServiceVersion,
+  isPublicCloud,
+  onVersions
+} from "../utils/utils.common";
 import chai, { assert } from "chai";
 import { AbortController } from "@azure/abort-controller";
 import { Context } from "mocha";

--- a/sdk/keyvault/keyvault-keys/test/public/keyClient.spec.ts
+++ b/sdk/keyvault/keyvault-keys/test/public/keyClient.spec.ts
@@ -1,32 +1,22 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+import { CreateEcKeyOptions, GetKeyOptions, KeyClient, UpdateKeyPropertiesOptions } from "../../src";
+import { Recorder, env, isPlaybackMode, isRecordMode } from "@azure-tools/test-recorder";
+import { assertThrowsAbortError, getServiceVersion, isPublicCloud, onVersions } from "../utils/utils.common";
 import chai, { assert } from "chai";
-import chaiExclude from "chai-exclude";
-import chaiAsPromised from "chai-as-promised";
-chai.use(chaiExclude);
-chai.use(chaiAsPromised);
+import { AbortController } from "@azure/abort-controller";
 import { Context } from "mocha";
 import { RestError } from "@azure/core-http";
-import { AbortController } from "@azure/abort-controller";
-import { env, isPlaybackMode, isRecordMode, Recorder } from "@azure-tools/test-recorder";
-
-import {
-  KeyClient,
-  CreateEcKeyOptions,
-  UpdateKeyPropertiesOptions,
-  GetKeyOptions
-} from "../../src";
-import {
-  assertThrowsAbortError,
-  getServiceVersion,
-  isPublicCloud,
-  onVersions
-} from "../utils/utils.common";
-import { testPollerProperties } from "../utils/recorderUtils";
-import { authenticate } from "../utils/testAuthentication";
 import TestClient from "../utils/testClient";
+import { authenticate } from "../utils/testAuthentication";
+import chaiAsPromised from "chai-as-promised";
+import chaiExclude from "chai-exclude";
 import { supportsTracing } from "../../../keyvault-common/test/utils/supportsTracing";
+import { testPollerProperties } from "../utils/recorderUtils";
+
+chai.use(chaiExclude);
+chai.use(chaiAsPromised);
 
 describe("Keys client - create, read, update and delete operations", () => {
   const keyPrefix = `CRUD${env.KEY_NAME || "KeyName"}`;

--- a/sdk/keyvault/keyvault-keys/test/public/list.spec.ts
+++ b/sdk/keyvault/keyvault-keys/test/public/list.spec.ts
@@ -2,14 +2,13 @@
 // Licensed under the MIT license.
 
 import * as assert from "assert";
-import { Context } from "mocha";
-import { env, Recorder, isRecordMode } from "@azure-tools/test-recorder";
-
-import { KeyClient } from "../../src";
+import { Recorder, env, isRecordMode } from "@azure-tools/test-recorder";
 import { assertThrowsAbortError, getServiceVersion } from "../utils/utils.common";
-import { testPollerProperties } from "../utils/recorderUtils";
-import { authenticate } from "../utils/testAuthentication";
+import { Context } from "mocha";
+import { KeyClient } from "../../src";
 import TestClient from "../utils/testClient";
+import { authenticate } from "../utils/testAuthentication";
+import { testPollerProperties } from "../utils/recorderUtils";
 
 describe("Keys client - list keys in various ways", () => {
   const keyPrefix = `list${env.KEY_NAME || "KeyName"}`;

--- a/sdk/keyvault/keyvault-keys/test/public/localCryptography.spec.ts
+++ b/sdk/keyvault/keyvault-keys/test/public/localCryptography.spec.ts
@@ -1,19 +1,20 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { Context } from "mocha";
-import { KeyClient, CryptographyClient, SignatureAlgorithm, KeyVaultKey } from "../../src";
 import * as chai from "chai";
-import chaiAsPromised from "chai-as-promised";
-chai.use(chaiAsPromised);
-import { isNode } from "@azure/core-http";
-import { createHash } from "crypto";
-import { authenticate } from "../utils/testAuthentication";
-import TestClient from "../utils/testClient";
+import { CryptographyClient, KeyClient, KeyVaultKey, SignatureAlgorithm } from "../../src";
 import { Recorder, env } from "@azure-tools/test-recorder";
 import { ClientSecretCredential } from "@azure/identity";
+import { Context } from "mocha";
 import { RsaCryptographyProvider } from "../../src/cryptography/rsaCryptographyProvider";
+import TestClient from "../utils/testClient";
+import { authenticate } from "../utils/testAuthentication";
+import chaiAsPromised from "chai-as-promised";
+import { createHash } from "crypto";
 import { getServiceVersion } from "../utils/utils.common";
+import { isNode } from "@azure/core-http";
+
+chai.use(chaiAsPromised);
 const { assert } = chai;
 
 describe("Local cryptography public tests", () => {

--- a/sdk/keyvault/keyvault-keys/test/public/lro.delete.spec.ts
+++ b/sdk/keyvault/keyvault-keys/test/public/lro.delete.spec.ts
@@ -2,15 +2,14 @@
 // Licensed under the MIT license.
 
 import * as assert from "assert";
+import { DeletedKey, KeyClient } from "../../src";
+import { Recorder, env } from "@azure-tools/test-recorder";
 import { Context } from "mocha";
-import { env, Recorder } from "@azure-tools/test-recorder";
 import { PollerStoppedError } from "@azure/core-lro";
-
-import { KeyClient, DeletedKey } from "../../src";
-import { testPollerProperties } from "../utils/recorderUtils";
-import { authenticate } from "../utils/testAuthentication";
 import TestClient from "../utils/testClient";
+import { authenticate } from "../utils/testAuthentication";
 import { getServiceVersion } from "../utils/utils.common";
+import { testPollerProperties } from "../utils/recorderUtils";
 
 describe("Keys client - Long Running Operations - delete", () => {
   const keyPrefix = `lroDelete${env.CERTIFICATE_NAME || "KeyName"}`;

--- a/sdk/keyvault/keyvault-keys/test/public/lro.recoverDelete.spec.ts
+++ b/sdk/keyvault/keyvault-keys/test/public/lro.recoverDelete.spec.ts
@@ -2,15 +2,14 @@
 // Licensed under the MIT license.
 
 import * as assert from "assert";
-import { Context } from "mocha";
-import { env, Recorder } from "@azure-tools/test-recorder";
-import { PollerStoppedError } from "@azure/core-lro";
-
-import { KeyClient, DeletedKey } from "../../src";
+import { DeletedKey, KeyClient } from "../../src";
+import { Recorder, env } from "@azure-tools/test-recorder";
 import { assertThrowsAbortError, getServiceVersion } from "../utils/utils.common";
-import { testPollerProperties } from "../utils/recorderUtils";
-import { authenticate } from "../utils/testAuthentication";
+import { Context } from "mocha";
+import { PollerStoppedError } from "@azure/core-lro";
 import TestClient from "../utils/testClient";
+import { authenticate } from "../utils/testAuthentication";
+import { testPollerProperties } from "../utils/recorderUtils";
 
 describe("Keys client - Long Running Operations - recoverDelete", () => {
   const keyPrefix = `lroRecoverDelete${env.CERTIFICATE_NAME || "KeyName"}`;

--- a/sdk/keyvault/keyvault-keys/test/public/recoverBackupRestore.spec.ts
+++ b/sdk/keyvault/keyvault-keys/test/public/recoverBackupRestore.spec.ts
@@ -2,14 +2,14 @@
 // Licensed under the MIT license.
 
 import * as assert from "assert";
-import { Context } from "mocha";
-import { isNode } from "@azure/core-http";
-import { KeyClient } from "../../src";
+import { Recorder, env, isPlaybackMode, isRecordMode } from "@azure-tools/test-recorder";
 import { assertThrowsAbortError, getServiceVersion } from "../utils/utils.common";
-import { testPollerProperties } from "../utils/recorderUtils";
-import { env, Recorder, isRecordMode, isPlaybackMode } from "@azure-tools/test-recorder";
-import { authenticate } from "../utils/testAuthentication";
+import { Context } from "mocha";
+import { KeyClient } from "../../src";
 import TestClient from "../utils/testClient";
+import { authenticate } from "../utils/testAuthentication";
+import { isNode } from "@azure/core-http";
+import { testPollerProperties } from "../utils/recorderUtils";
 
 describe("Keys client - restore keys and recover backups", () => {
   const keyPrefix = `backupRestore${env.KEY_NAME || "KeyName"}`;

--- a/sdk/keyvault/keyvault-keys/test/utils/crypto.ts
+++ b/sdk/keyvault/keyvault-keys/test/utils/crypto.ts
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { isNode } from "@azure/core-http";
 import { JsonWebKey } from "../../src/keysModels";
+import { isNode } from "@azure/core-http";
 
 export function stringToUint8Array(str: string): Uint8Array {
   if (isNode) {

--- a/sdk/keyvault/keyvault-keys/test/utils/lro/restore/operation.ts
+++ b/sdk/keyvault/keyvault-keys/test/utils/lro/restore/operation.ts
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+import { KeyPollerOptions, KeyVaultKey } from "../../../../src/keysModels";
+import { PollOperation, PollOperationState } from "@azure/core-lro";
 import { AbortSignalLike } from "@azure/abort-controller";
-import { PollOperationState, PollOperation } from "@azure/core-lro";
 import { RequestOptionsBase } from "@azure/core-http";
-import { KeyVaultKey, KeyPollerOptions } from "../../../../src/keysModels";
 
 /**
  * Options sent to the beginRestoreKeyBackup method.

--- a/sdk/keyvault/keyvault-keys/test/utils/lro/restore/poller.ts
+++ b/sdk/keyvault/keyvault-keys/test/utils/lro/restore/poller.ts
@@ -1,14 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { delay, RequestOptionsBase } from "@azure/core-http";
-import { Poller } from "@azure/core-lro";
-import {
-  RestoreKeyBackupPollOperationState,
-  makeRestoreKeyBackupPollOperation,
-  TestKeyClientInterface
-} from "./operation";
+import { RequestOptionsBase, delay } from "@azure/core-http";
+import { RestoreKeyBackupPollOperationState, TestKeyClientInterface, makeRestoreKeyBackupPollOperation } from "./operation";
 import { KeyVaultKey } from "../../../../src/keysModels";
+import { Poller } from "@azure/core-lro";
 
 export interface RestoreKeyBackupPollerOptions {
   client: TestKeyClientInterface;

--- a/sdk/keyvault/keyvault-keys/test/utils/lro/restore/poller.ts
+++ b/sdk/keyvault/keyvault-keys/test/utils/lro/restore/poller.ts
@@ -2,7 +2,11 @@
 // Licensed under the MIT license.
 
 import { RequestOptionsBase, delay } from "@azure/core-http";
-import { RestoreKeyBackupPollOperationState, TestKeyClientInterface, makeRestoreKeyBackupPollOperation } from "./operation";
+import {
+  RestoreKeyBackupPollOperationState,
+  TestKeyClientInterface,
+  makeRestoreKeyBackupPollOperation
+} from "./operation";
 import { KeyVaultKey } from "../../../../src/keysModels";
 import { Poller } from "@azure/core-lro";
 

--- a/sdk/keyvault/keyvault-keys/test/utils/recorderUtils.ts
+++ b/sdk/keyvault/keyvault-keys/test/utils/recorderUtils.ts
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { isPlaybackMode } from "@azure-tools/test-recorder";
-import { isNode } from "@azure/core-http";
 import * as dotenv from "dotenv";
+import { isNode } from "@azure/core-http";
+import { isPlaybackMode } from "@azure-tools/test-recorder";
 
 if (isNode) {
   dotenv.config();

--- a/sdk/keyvault/keyvault-keys/test/utils/testAuthentication.ts
+++ b/sdk/keyvault/keyvault-keys/test/utils/testAuthentication.ts
@@ -1,13 +1,13 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { ClientSecretCredential } from "@azure/identity";
-import { KeyClient } from "../../src";
-import { env, record, RecorderEnvironmentSetup } from "@azure-tools/test-recorder";
-import { uniqueString } from "./recorderUtils";
-import TestClient from "./testClient";
-import { Context } from "mocha";
+import { RecorderEnvironmentSetup, env, record } from "@azure-tools/test-recorder";
 import { fromBase64url, toBase64url } from "./base64url";
+import { ClientSecretCredential } from "@azure/identity";
+import { Context } from "mocha";
+import { KeyClient } from "../../src";
+import TestClient from "./testClient";
+import { uniqueString } from "./recorderUtils";
 
 const replaceableVariables = {
   AZURE_CLIENT_ID: "azure_client_id",

--- a/sdk/keyvault/keyvault-keys/test/utils/testClient.ts
+++ b/sdk/keyvault/keyvault-keys/test/utils/testClient.ts
@@ -1,12 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { testPollerProperties } from "./recorderUtils";
 import { KeyClient, KeyVaultKey } from "../../src";
-import { PollerLike, PollOperationState } from "@azure/core-lro";
-import { operationOptionsToRequestOptionsBase } from "@azure/core-http";
-import { RestoreKeyBackupPoller } from "./lro/restore/poller";
+import { PollOperationState, PollerLike } from "@azure/core-lro";
 import { BeginRestoreKeyBackupOptions } from "./lro/restore/operation";
+import { RestoreKeyBackupPoller } from "./lro/restore/poller";
+import { operationOptionsToRequestOptionsBase } from "@azure/core-http";
+import { testPollerProperties } from "./recorderUtils";
 
 export default class TestClient {
   public readonly client: KeyClient;

--- a/sdk/keyvault/keyvault-keys/test/utils/utils.common.ts
+++ b/sdk/keyvault/keyvault-keys/test/utils/utils.common.ts
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { SupportedVersions, supports, TestFunctionWrapper } from "@azure/test-utils";
-import { env } from "@azure-tools/test-recorder";
 import * as assert from "assert";
+import { SupportedVersions, TestFunctionWrapper, supports } from "@azure/test-utils";
 import { LATEST_API_VERSION } from "../../src/keysModels";
+import { env } from "@azure-tools/test-recorder";
 
 export function getKeyvaultName(): string {
   const keyVaultEnvVarName = "KEYVAULT_NAME";


### PR DESCRIPTION
This PR is working in conjunction with other PRs to fix individual sections of the azure codebase with respect to the new ```sort-imports``` rule, as indicated in #9252.

In this PR, I have fixed all files under ```sdk/keyvault/keyvault-keys```.