### PR TITLE
[sort-imports] update ```logger``` with respect to ```sort-imports``` rule

### DIFF
--- a/sdk/core/logger/src/log.ts
+++ b/sdk/core/logger/src/log.ts
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import util from "util";
 import { EOL } from "os";
+import util from "util";
 
 export function log(message: unknown, ...args: any[]): void {
   process.stderr.write(`${util.format(message, ...args)}${EOL}`);

--- a/sdk/core/logger/test/debug.spec.ts
+++ b/sdk/core/logger/test/debug.spec.ts
@@ -2,8 +2,8 @@
 // Licensed under the MIT license.
 
 import debug, { Debugger } from "../src/debug";
-import { stub } from "sinon";
 import { assert } from "chai";
+import { stub } from "sinon";
 
 describe("debug", function() {
   let logger: Debugger;


### PR DESCRIPTION
This PR is working in conjunction with other PRs to fix individual sections of the azure codebase with respect to the new ```sort-imports``` rule, as indicated in #9252.

In this PR, I have fixed all files under ```sdk/core/logger```.