### PR TITLE
[sort-imports] update ```abort-controller``` with respect to ```sort-imports``` rule

### DIFF
--- a/sdk/core/abort-controller/src/AbortController.ts
+++ b/sdk/core/abort-controller/src/AbortController.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { AbortSignal, abortSignal, AbortSignalLike } from "./AbortSignal";
+import { AbortSignal, AbortSignalLike, abortSignal } from "./AbortSignal";
 
 /**
  * This error is thrown when an asynchronous operation has been aborted.

--- a/sdk/core/abort-controller/test/aborter.spec.ts
+++ b/sdk/core/abort-controller/test/aborter.spec.ts
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+import { AbortController, AbortError, AbortSignal } from "../src";
 import { assert } from "chai";
-import { AbortController, AbortSignal, AbortError } from "../src";
 
 describe("AbortController", () => {
   function doAsyncOperation(aborter: AbortSignal, runningTimeinMs: number = 100): Promise<void> {


### PR DESCRIPTION
This PR is working in conjunction with other PRs to fix individual sections of the azure codebase with respect to the new ```sort-imports``` rule, as indicated in #9252 

In this PR, I have fixed all files under ```sdk/core/abort-controller```.