### PR TITLE
Replace assert imports with chai in AppConfiguration

### DIFF
--- a/sdk/appconfiguration/app-configuration/rollup.base.config.js
+++ b/sdk/appconfiguration/app-configuration/rollup.base.config.js
@@ -119,7 +119,6 @@ export function browserConfig(test = false) {
       cjs({
         namedExports: {
           chai: ["assert", "expect", "use"],
-          assert: ["ok", "equal", "strictEqual", "deepEqual", "fail", "throws", "notEqual"],
           events: ["EventEmitter"],
           ...openTelemetryCommonJs()
         }

--- a/sdk/appconfiguration/app-configuration/test/internal/helpers.spec.ts
+++ b/sdk/appconfiguration/app-configuration/test/internal/helpers.spec.ts
@@ -13,7 +13,7 @@ import {
   formatFieldsForSelect,
   serializeAsConfigurationSettingParam
 } from "../../src/internal/helpers";
-import * as assert from "assert";
+import { assert } from "chai";
 import {
   ConfigurationSetting,
   featureFlagContentType,
@@ -155,7 +155,7 @@ describe("helper methods", () => {
         featureFlag.value = value as any;
         assert.deepEqual(
           serializeAsConfigurationSettingParam(featureFlag),
-          featureFlag,
+          featureFlag as any,
           "setting was modified"
         );
       });
@@ -170,7 +170,7 @@ describe("helper methods", () => {
         setting.value = value as any;
         assert.deepEqual(
           serializeAsConfigurationSettingParam(setting),
-          setting,
+          setting as any,
           "setting was modified"
         );
       });
@@ -184,21 +184,21 @@ describe("helper methods", () => {
         abortSignal: {
           aborted: true,
           // eslint-disable-next-line @typescript-eslint/no-empty-function
-          addEventListener: () => {},
+          addEventListener: () => { },
           // eslint-disable-next-line @typescript-eslint/no-empty-function
-          removeEventListener: () => {}
+          removeEventListener: () => { }
         },
         method: "GET",
         withCredentials: false,
         headers: new HttpHeaders(),
         timeout: 0,
         requestId: "",
-        clone: function() {
+        clone: function () {
           return this;
         },
         // eslint-disable-next-line @typescript-eslint/no-empty-function
-        validateRequestProperties: () => {},
-        prepare: function() {
+        validateRequestProperties: () => { },
+        prepare: function () {
           return this;
         }
       },

--- a/sdk/appconfiguration/app-configuration/test/internal/helpers.spec.ts
+++ b/sdk/appconfiguration/app-configuration/test/internal/helpers.spec.ts
@@ -16,6 +16,7 @@ import {
 import { assert } from "chai";
 import {
   ConfigurationSetting,
+  ConfigurationSettingParam,
   featureFlagContentType,
   HttpResponseField,
   HttpResponseFields,
@@ -155,7 +156,7 @@ describe("helper methods", () => {
         featureFlag.value = value as any;
         assert.deepEqual(
           serializeAsConfigurationSettingParam(featureFlag),
-          featureFlag as any,
+          (featureFlag as unknown) as ConfigurationSettingParam<string>,
           "setting was modified"
         );
       });

--- a/sdk/appconfiguration/app-configuration/test/internal/helpers.spec.ts
+++ b/sdk/appconfiguration/app-configuration/test/internal/helpers.spec.ts
@@ -184,21 +184,21 @@ describe("helper methods", () => {
         abortSignal: {
           aborted: true,
           // eslint-disable-next-line @typescript-eslint/no-empty-function
-          addEventListener: () => { },
+          addEventListener: () => {},
           // eslint-disable-next-line @typescript-eslint/no-empty-function
-          removeEventListener: () => { }
+          removeEventListener: () => {}
         },
         method: "GET",
         withCredentials: false,
         headers: new HttpHeaders(),
         timeout: 0,
         requestId: "",
-        clone: function () {
+        clone: function() {
           return this;
         },
         // eslint-disable-next-line @typescript-eslint/no-empty-function
-        validateRequestProperties: () => { },
-        prepare: function () {
+        validateRequestProperties: () => {},
+        prepare: function() {
           return this;
         }
       },

--- a/sdk/appconfiguration/app-configuration/test/internal/http.spec.ts
+++ b/sdk/appconfiguration/app-configuration/test/internal/http.spec.ts
@@ -23,7 +23,7 @@ import * as chai from "chai";
 import { Recorder } from "@azure-tools/test-recorder";
 import { Context } from "mocha";
 
-describe("http request related tests", function () {
+describe("http request related tests", function() {
   describe("unit tests", () => {
     describe("parseSyncToken", () => {
       it("can parse various sync tokens", () => {
@@ -111,12 +111,12 @@ describe("http request related tests", function () {
     let client: AppConfigurationClient;
     let recorder: Recorder;
 
-    beforeEach(function (this: Context) {
+    beforeEach(function(this: Context) {
       recorder = startRecorder(this);
       client = createAppConfigurationClientForTests() || this.skip();
     });
 
-    afterEach(async function () {
+    afterEach(async function() {
       await recorder.stop();
     });
 
@@ -147,7 +147,7 @@ describe("http request related tests", function () {
     let syncTokens: SyncTokens;
     let scope: nock.Scope;
 
-    beforeEach(function (this: Context) {
+    beforeEach(function(this: Context) {
       if (nock == null || nock.recorder == null) {
         this.skip();
         return;
@@ -169,7 +169,7 @@ describe("http request related tests", function () {
       scope = nock(/.*/);
     });
 
-    afterEach(function (this: Context) {
+    afterEach(function(this: Context) {
       if (nock == null || nock.recorder == null) {
         return;
       }
@@ -182,7 +182,7 @@ describe("http request related tests", function () {
       nock.cleanAll();
     });
 
-    it("policy is setup properly to send sync tokens", async function () {
+    it("policy is setup properly to send sync tokens", async function() {
       syncTokens.addSyncTokenFromHeaderValue(`hello=world;sn=1`);
 
       const policyScope = nock(/.*/, {

--- a/sdk/appconfiguration/app-configuration/test/internal/http.spec.ts
+++ b/sdk/appconfiguration/app-configuration/test/internal/http.spec.ts
@@ -5,7 +5,7 @@
 // Licensed under the MIT License.
 
 import { parseSyncToken, SyncTokens } from "../../src/internal/synctokenpolicy";
-import * as assert from "assert";
+import { assert } from "chai";
 import { AppConfigurationClient } from "../../src";
 import nock from "nock";
 import {
@@ -23,7 +23,7 @@ import * as chai from "chai";
 import { Recorder } from "@azure-tools/test-recorder";
 import { Context } from "mocha";
 
-describe("http request related tests", function() {
+describe("http request related tests", function () {
   describe("unit tests", () => {
     describe("parseSyncToken", () => {
       it("can parse various sync tokens", () => {
@@ -111,12 +111,12 @@ describe("http request related tests", function() {
     let client: AppConfigurationClient;
     let recorder: Recorder;
 
-    beforeEach(function(this: Context) {
+    beforeEach(function (this: Context) {
       recorder = startRecorder(this);
       client = createAppConfigurationClientForTests() || this.skip();
     });
 
-    afterEach(async function() {
+    afterEach(async function () {
       await recorder.stop();
     });
 
@@ -147,7 +147,7 @@ describe("http request related tests", function() {
     let syncTokens: SyncTokens;
     let scope: nock.Scope;
 
-    beforeEach(function(this: Context) {
+    beforeEach(function (this: Context) {
       if (nock == null || nock.recorder == null) {
         this.skip();
         return;
@@ -169,7 +169,7 @@ describe("http request related tests", function() {
       scope = nock(/.*/);
     });
 
-    afterEach(function(this: Context) {
+    afterEach(function (this: Context) {
       if (nock == null || nock.recorder == null) {
         return;
       }
@@ -182,7 +182,7 @@ describe("http request related tests", function() {
       nock.cleanAll();
     });
 
-    it("policy is setup properly to send sync tokens", async function() {
+    it("policy is setup properly to send sync tokens", async function () {
       syncTokens.addSyncTokenFromHeaderValue(`hello=world;sn=1`);
 
       const policyScope = nock(/.*/, {

--- a/sdk/appconfiguration/app-configuration/test/internal/package.spec.ts
+++ b/sdk/appconfiguration/app-configuration/test/internal/package.spec.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import * as assert from "assert";
+import { assert } from "chai";
 import { isNode } from "@azure/core-http";
 
 import { packageVersion } from "../../src/appConfigurationClient";
@@ -12,7 +12,7 @@ import fs from "fs";
 describe("packagejson related tests", () => {
   // if this test is failing you need to update the contant `packageVersion` referenced above
   // in the generated code.
-  it("user agent string matches the package version", function(this: Context) {
+  it("user agent string matches the package version", function (this: Context) {
     if (!isNode) {
       this.skip();
     }

--- a/sdk/appconfiguration/app-configuration/test/internal/package.spec.ts
+++ b/sdk/appconfiguration/app-configuration/test/internal/package.spec.ts
@@ -12,7 +12,7 @@ import fs from "fs";
 describe("packagejson related tests", () => {
   // if this test is failing you need to update the contant `packageVersion` referenced above
   // in the generated code.
-  it("user agent string matches the package version", function (this: Context) {
+  it("user agent string matches the package version", function(this: Context) {
     if (!isNode) {
       this.skip();
     }

--- a/sdk/appconfiguration/app-configuration/test/internal/tracingHelpers.spec.ts
+++ b/sdk/appconfiguration/app-configuration/test/internal/tracingHelpers.spec.ts
@@ -175,7 +175,9 @@ describe("tracingHelpers", () => {
 
     assert.deepEqual(traceData, {
       operationName: "listConfigurationSettings",
-      options: { ...operationOptions, keyFilter: "ignored" } as OperationOptions
+      options: { ...operationOptions, keyFilter: "ignored" } as OperationOptions & {
+        keyFilter?: string;
+      }
     });
 
     const it2 = appConfigurationClient.listRevisions({ keyFilter: "ignored", ...operationOptions });
@@ -183,7 +185,9 @@ describe("tracingHelpers", () => {
 
     assert.deepEqual(traceData, {
       operationName: "listRevisions",
-      options: { ...operationOptions, keyFilter: "ignored" } as OperationOptions
+      options: { ...operationOptions, keyFilter: "ignored" } as OperationOptions & {
+        keyFilter?: string;
+      }
     });
   });
 });

--- a/sdk/appconfiguration/app-configuration/test/internal/tracingHelpers.spec.ts
+++ b/sdk/appconfiguration/app-configuration/test/internal/tracingHelpers.spec.ts
@@ -93,7 +93,7 @@ describe("tracingHelpers", () => {
       assert.fail("Exception should have been thrown from `trace` since the inner action threw");
     } catch (err) {
       if (!(err instanceof Error)) {
-        throw new Error("Error is not recognized")
+        throw new Error("Error is not recognized");
       }
       assert.equal(err.message, "Purposefully thrown error");
     }

--- a/sdk/appconfiguration/app-configuration/test/internal/tracingHelpers.spec.ts
+++ b/sdk/appconfiguration/app-configuration/test/internal/tracingHelpers.spec.ts
@@ -4,7 +4,7 @@
 import { createSpan, trace } from "../../src/internal/tracingHelpers";
 import { Span, SpanStatus, SpanStatusCode } from "@azure/core-tracing";
 
-import * as assert from "assert";
+import { assert } from "chai";
 import sinon from "sinon";
 import { AppConfigurationClient } from "../../src/appConfigurationClient";
 import { AbortSignalLike, OperationOptions } from "@azure/core-http";
@@ -91,8 +91,8 @@ describe("tracingHelpers", () => {
       );
 
       assert.fail("Exception should have been thrown from `trace` since the inner action threw");
-    } catch (err) {
-      assert.equal(err.message, "Purposefully thrown error");
+    } catch (err: any) {
+      assert.equal(err.message as string, "Purposefully thrown error");
     }
 
     assert.ok(setStatusStub, "setStatus should have been called");
@@ -172,7 +172,7 @@ describe("tracingHelpers", () => {
 
     assert.deepEqual(traceData, {
       operationName: "listConfigurationSettings",
-      options: { ...operationOptions, keyFilter: "ignored" }
+      options: { ...operationOptions, keyFilter: "ignored" } as OperationOptions
     });
 
     const it2 = appConfigurationClient.listRevisions({ keyFilter: "ignored", ...operationOptions });
@@ -180,7 +180,7 @@ describe("tracingHelpers", () => {
 
     assert.deepEqual(traceData, {
       operationName: "listRevisions",
-      options: { ...operationOptions, keyFilter: "ignored" }
+      options: { ...operationOptions, keyFilter: "ignored" } as OperationOptions
     });
   });
 });

--- a/sdk/appconfiguration/app-configuration/test/internal/tracingHelpers.spec.ts
+++ b/sdk/appconfiguration/app-configuration/test/internal/tracingHelpers.spec.ts
@@ -91,8 +91,11 @@ describe("tracingHelpers", () => {
       );
 
       assert.fail("Exception should have been thrown from `trace` since the inner action threw");
-    } catch (err: any) {
-      assert.equal(err.message as string, "Purposefully thrown error");
+    } catch (err) {
+      if (!(err instanceof Error)) {
+        throw new Error("Error is not recognized")
+      }
+      assert.equal(err.message, "Purposefully thrown error");
     }
 
     assert.ok(setStatusStub, "setStatus should have been called");

--- a/sdk/appconfiguration/app-configuration/test/public/auth.spec.ts
+++ b/sdk/appconfiguration/app-configuration/test/public/auth.spec.ts
@@ -15,15 +15,15 @@ describe("Authentication", () => {
   let credsAndEndpoint: CredsAndEndpoint;
   let recorder: Recorder;
 
-  beforeEach(function (this: Context) {
+  beforeEach(function(this: Context) {
     recorder = startRecorder(this);
     credsAndEndpoint = getTokenAuthenticationCredential() || this.skip();
   });
 
-  afterEach(async function () {
+  afterEach(async function() {
     await recorder.stop();
   });
-  it("token authentication works", async function () {
+  it("token authentication works", async function() {
     const client = new AppConfigurationClient(
       credsAndEndpoint.endpoint,
       credsAndEndpoint.credential

--- a/sdk/appconfiguration/app-configuration/test/public/auth.spec.ts
+++ b/sdk/appconfiguration/app-configuration/test/public/auth.spec.ts
@@ -7,7 +7,7 @@ import {
   getTokenAuthenticationCredential,
   CredsAndEndpoint
 } from "./utils/testHelpers";
-import * as assert from "assert";
+import { assert } from "chai";
 import { Recorder } from "@azure-tools/test-recorder";
 import { Context } from "mocha";
 
@@ -15,15 +15,15 @@ describe("Authentication", () => {
   let credsAndEndpoint: CredsAndEndpoint;
   let recorder: Recorder;
 
-  beforeEach(function(this: Context) {
+  beforeEach(function (this: Context) {
     recorder = startRecorder(this);
     credsAndEndpoint = getTokenAuthenticationCredential() || this.skip();
   });
 
-  afterEach(async function() {
+  afterEach(async function () {
     await recorder.stop();
   });
-  it("token authentication works", async function() {
+  it("token authentication works", async function () {
     const client = new AppConfigurationClient(
       credsAndEndpoint.endpoint,
       credsAndEndpoint.credential

--- a/sdk/appconfiguration/app-configuration/test/public/etags.spec.ts
+++ b/sdk/appconfiguration/app-configuration/test/public/etags.spec.ts
@@ -17,7 +17,7 @@ describe("etags", () => {
   let recorder: Recorder;
   let key: string;
 
-  beforeEach(async function (this: Context) {
+  beforeEach(async function(this: Context) {
     recorder = startRecorder(this);
     key = recorder.getUniqueName("etags");
     client = createAppConfigurationClientForTests() || this.skip();
@@ -27,7 +27,7 @@ describe("etags", () => {
     });
   });
 
-  afterEach(async function () {
+  afterEach(async function() {
     await deleteKeyCompletely([key], client);
     await recorder.stop();
   });

--- a/sdk/appconfiguration/app-configuration/test/public/etags.spec.ts
+++ b/sdk/appconfiguration/app-configuration/test/public/etags.spec.ts
@@ -8,7 +8,7 @@ import {
   deleteKeyCompletely,
   assertThrowsRestError
 } from "./utils/testHelpers";
-import * as assert from "assert";
+import { assert } from "chai";
 import { Recorder } from "@azure-tools/test-recorder";
 import { Context } from "mocha";
 
@@ -17,7 +17,7 @@ describe("etags", () => {
   let recorder: Recorder;
   let key: string;
 
-  beforeEach(async function(this: Context) {
+  beforeEach(async function (this: Context) {
     recorder = startRecorder(this);
     key = recorder.getUniqueName("etags");
     client = createAppConfigurationClientForTests() || this.skip();
@@ -27,7 +27,7 @@ describe("etags", () => {
     });
   });
 
-  afterEach(async function() {
+  afterEach(async function () {
     await deleteKeyCompletely([key], client);
     await recorder.stop();
   });

--- a/sdk/appconfiguration/app-configuration/test/public/index.readonlytests.spec.ts
+++ b/sdk/appconfiguration/app-configuration/test/public/index.readonlytests.spec.ts
@@ -9,7 +9,7 @@ import {
   startRecorder
 } from "./utils/testHelpers";
 import { AppConfigurationClient } from "../../src";
-import * as assert from "assert";
+import { assert } from "chai";
 import { Recorder } from "@azure-tools/test-recorder";
 import { Context } from "mocha";
 
@@ -22,7 +22,7 @@ describe("AppConfigurationClient (set|clear)ReadOnly", () => {
     label: "some label"
   };
 
-  beforeEach(async function(this: Context) {
+  beforeEach(async function (this: Context) {
     recorder = startRecorder(this);
     testConfigSetting.key = recorder.getUniqueName("readOnlyTests");
     client = createAppConfigurationClientForTests() || this.skip();
@@ -30,12 +30,12 @@ describe("AppConfigurationClient (set|clear)ReadOnly", () => {
     await client.setConfigurationSetting(testConfigSetting);
   });
 
-  afterEach(async function() {
+  afterEach(async function () {
     await deleteKeyCompletely([testConfigSetting.key], client);
     await recorder.stop();
   });
 
-  it("basic", async function() {
+  it("basic", async function () {
     let storedSetting = await client.getConfigurationSetting({
       key: testConfigSetting.key,
       label: testConfigSetting.label
@@ -67,7 +67,7 @@ describe("AppConfigurationClient (set|clear)ReadOnly", () => {
     );
   });
 
-  it("accepts operation options", async function() {
+  it("accepts operation options", async function () {
     await client.getConfigurationSetting({
       key: testConfigSetting.key,
       label: testConfigSetting.label

--- a/sdk/appconfiguration/app-configuration/test/public/index.readonlytests.spec.ts
+++ b/sdk/appconfiguration/app-configuration/test/public/index.readonlytests.spec.ts
@@ -22,7 +22,7 @@ describe("AppConfigurationClient (set|clear)ReadOnly", () => {
     label: "some label"
   };
 
-  beforeEach(async function (this: Context) {
+  beforeEach(async function(this: Context) {
     recorder = startRecorder(this);
     testConfigSetting.key = recorder.getUniqueName("readOnlyTests");
     client = createAppConfigurationClientForTests() || this.skip();
@@ -30,12 +30,12 @@ describe("AppConfigurationClient (set|clear)ReadOnly", () => {
     await client.setConfigurationSetting(testConfigSetting);
   });
 
-  afterEach(async function () {
+  afterEach(async function() {
     await deleteKeyCompletely([testConfigSetting.key], client);
     await recorder.stop();
   });
 
-  it("basic", async function () {
+  it("basic", async function() {
     let storedSetting = await client.getConfigurationSetting({
       key: testConfigSetting.key,
       label: testConfigSetting.label
@@ -67,7 +67,7 @@ describe("AppConfigurationClient (set|clear)ReadOnly", () => {
     );
   });
 
-  it("accepts operation options", async function () {
+  it("accepts operation options", async function() {
     await client.getConfigurationSetting({
       key: testConfigSetting.key,
       label: testConfigSetting.label

--- a/sdk/appconfiguration/app-configuration/test/public/index.spec.ts
+++ b/sdk/appconfiguration/app-configuration/test/public/index.spec.ts
@@ -19,12 +19,12 @@ describe("AppConfigurationClient", () => {
   let client: AppConfigurationClient;
   let recorder: Recorder;
 
-  beforeEach(function (this: Context) {
+  beforeEach(function(this: Context) {
     recorder = startRecorder(this);
     client = createAppConfigurationClientForTests() || this.skip();
   });
 
-  afterEach(async function (this: Context) {
+  afterEach(async function(this: Context) {
     await recorder.stop();
   });
 
@@ -723,7 +723,7 @@ describe("AppConfigurationClient", () => {
       assert.ok(foundMyExactSettingToo);
     });
 
-    it("list with multiple pages", async function () {
+    it("list with multiple pages", async function() {
       // This occasionally hits 429 error (throttling) since we are making 100s of requests in the test to create, get and delete keys.
       // To avoid hitting the service with too many requests, skipping the test in live.
       // More details at https://github.com/Azure/azure-sdk-for-js/issues/16743

--- a/sdk/appconfiguration/app-configuration/test/public/index.spec.ts
+++ b/sdk/appconfiguration/app-configuration/test/public/index.spec.ts
@@ -19,12 +19,12 @@ describe("AppConfigurationClient", () => {
   let client: AppConfigurationClient;
   let recorder: Recorder;
 
-  beforeEach(function(this: Context) {
+  beforeEach(function (this: Context) {
     recorder = startRecorder(this);
     client = createAppConfigurationClientForTests() || this.skip();
   });
 
-  afterEach(async function(this: Context) {
+  afterEach(async function (this: Context) {
     await recorder.stop();
   });
 
@@ -723,7 +723,7 @@ describe("AppConfigurationClient", () => {
       assert.ok(foundMyExactSettingToo);
     });
 
-    it("list with multiple pages", async function() {
+    it("list with multiple pages", async function () {
       // This occasionally hits 429 error (throttling) since we are making 100s of requests in the test to create, get and delete keys.
       // To avoid hitting the service with too many requests, skipping the test in live.
       // More details at https://github.com/Azure/azure-sdk-for-js/issues/16743

--- a/sdk/appconfiguration/app-configuration/test/public/throwOrNotThrow.spec.ts
+++ b/sdk/appconfiguration/app-configuration/test/public/throwOrNotThrow.spec.ts
@@ -8,7 +8,7 @@ import {
   assertThrowsRestError,
   startRecorder
 } from "./utils/testHelpers";
-import * as assert from "assert";
+import { assert } from "chai";
 import { Recorder } from "@azure-tools/test-recorder";
 import { Context } from "mocha";
 
@@ -21,12 +21,12 @@ describe("Various error cases", () => {
   let recorder: Recorder;
   const nonMatchingETag = "never-match-etag";
 
-  beforeEach(function(this: Context) {
+  beforeEach(function (this: Context) {
     recorder = startRecorder(this);
     client = createAppConfigurationClientForTests() || this.skip();
   });
 
-  afterEach(async function() {
+  afterEach(async function () {
     await recorder.stop();
   });
 
@@ -43,7 +43,7 @@ describe("Various error cases", () => {
       nonExistentKey = "non-existent key " + addedSetting.key;
     });
 
-    afterEach(async function(this: Context) {
+    afterEach(async function (this: Context) {
       if (!this.currentTest?.isPending()) {
         await deleteKeyCompletely([addedSetting.key], client);
       }
@@ -104,7 +104,7 @@ describe("Various error cases", () => {
       nonExistentKey = "bogus key " + addedSetting.key;
     });
 
-    afterEach(async function(this: Context) {
+    afterEach(async function (this: Context) {
       if (!this.currentTest?.isPending()) {
         await deleteKeyCompletely([addedSetting.key], client);
       }

--- a/sdk/appconfiguration/app-configuration/test/public/throwOrNotThrow.spec.ts
+++ b/sdk/appconfiguration/app-configuration/test/public/throwOrNotThrow.spec.ts
@@ -21,12 +21,12 @@ describe("Various error cases", () => {
   let recorder: Recorder;
   const nonMatchingETag = "never-match-etag";
 
-  beforeEach(function (this: Context) {
+  beforeEach(function(this: Context) {
     recorder = startRecorder(this);
     client = createAppConfigurationClientForTests() || this.skip();
   });
 
-  afterEach(async function () {
+  afterEach(async function() {
     await recorder.stop();
   });
 
@@ -43,7 +43,7 @@ describe("Various error cases", () => {
       nonExistentKey = "non-existent key " + addedSetting.key;
     });
 
-    afterEach(async function (this: Context) {
+    afterEach(async function(this: Context) {
       if (!this.currentTest?.isPending()) {
         await deleteKeyCompletely([addedSetting.key], client);
       }
@@ -104,7 +104,7 @@ describe("Various error cases", () => {
       nonExistentKey = "bogus key " + addedSetting.key;
     });
 
-    afterEach(async function (this: Context) {
+    afterEach(async function(this: Context) {
       if (!this.currentTest?.isPending()) {
         await deleteKeyCompletely([addedSetting.key], client);
       }

--- a/sdk/appconfiguration/app-configuration/test/public/utils/testHelpers.ts
+++ b/sdk/appconfiguration/app-configuration/test/public/utils/testHelpers.ts
@@ -18,6 +18,7 @@ import {
 import { assert } from "chai";
 
 import { DefaultAzureCredential, TokenCredential } from "@azure/identity";
+import { RestError } from "@azure/core-http";
 
 let connectionStringNotPresentWarning = false;
 let tokenCredentialsNotPresentWarning = false;
@@ -144,7 +145,7 @@ export function assertEqualSettings(
   actual = actual.map((setting) => {
     return {
       key: setting.key,
-      label: setting.label,
+      label: setting.label || undefined,
       value: setting.value,
       isReadOnly: setting.isReadOnly
     };
@@ -161,7 +162,10 @@ export async function assertThrowsRestError(
   try {
     await testFunction();
     assert.fail(`${message}: No error thrown`);
-  } catch (err: any) {
+  } catch (err) {
+    if (!(err instanceof RestError)) {
+      throw new Error("Error is not recognized")
+    }
     if (err.name === "RestError") {
       assert.equal(expectedStatusCode, err.statusCode, message);
       return err;
@@ -180,7 +184,10 @@ export async function assertThrowsAbortError(
   try {
     await testFunction();
     assert.fail(`${message}: No error thrown`);
-  } catch (e: any) {
+  } catch (e) {
+    if (!(e instanceof Error)) {
+      throw new Error("Error is not recognized")
+    }
     if (isPlaybackMode() && (e.name === "FetchError" || e.name === "AbortError")) {
       return e;
     } else {

--- a/sdk/appconfiguration/app-configuration/test/public/utils/testHelpers.ts
+++ b/sdk/appconfiguration/app-configuration/test/public/utils/testHelpers.ts
@@ -164,7 +164,7 @@ export async function assertThrowsRestError(
     assert.fail(`${message}: No error thrown`);
   } catch (err) {
     if (!(err instanceof RestError)) {
-      throw new Error("Error is not recognized")
+      throw new Error("Error is not recognized");
     }
     if (err.name === "RestError") {
       assert.equal(expectedStatusCode, err.statusCode, message);
@@ -186,7 +186,7 @@ export async function assertThrowsAbortError(
     assert.fail(`${message}: No error thrown`);
   } catch (e) {
     if (!(e instanceof Error)) {
-      throw new Error("Error is not recognized")
+      throw new Error("Error is not recognized");
     }
     if (isPlaybackMode() && (e.name === "FetchError" || e.name === "AbortError")) {
       return e;

--- a/sdk/appconfiguration/app-configuration/test/public/utils/testHelpers.ts
+++ b/sdk/appconfiguration/app-configuration/test/public/utils/testHelpers.ts
@@ -15,7 +15,7 @@ import {
   record,
   Recorder
 } from "@azure-tools/test-recorder";
-import * as assert from "assert";
+import { assert } from "chai";
 
 import { DefaultAzureCredential, TokenCredential } from "@azure/identity";
 

--- a/sdk/appconfiguration/app-configuration/test/public/utils/testHelpers.ts
+++ b/sdk/appconfiguration/app-configuration/test/public/utils/testHelpers.ts
@@ -161,7 +161,7 @@ export async function assertThrowsRestError(
   try {
     await testFunction();
     assert.fail(`${message}: No error thrown`);
-  } catch (err) {
+  } catch (err: any) {
     if (err.name === "RestError") {
       assert.equal(expectedStatusCode, err.statusCode, message);
       return err;
@@ -180,7 +180,7 @@ export async function assertThrowsAbortError(
   try {
     await testFunction();
     assert.fail(`${message}: No error thrown`);
-  } catch (e) {
+  } catch (e: any) {
     if (isPlaybackMode() && (e.name === "FetchError" || e.name === "AbortError")) {
       return e;
     } else {


### PR DESCRIPTION
This is a follow up for https://github.com/Azure/azure-sdk-for-js/pull/18930 and solves issue https://github.com/Azure/azure-sdk-for-js/issues/17110

There were test files in which `assert` was being imported even that is no longer a dependency. This PR replaces those imports with `{ assert } from "chai"`.

For this package, `assert` was also deleted from the rollup.base.config.js file.

Some tests were also modified due to undefined types, by catching unrecognized errors, or casting a var to a specific type.