### PR TITLE
[Text Analytics] Fix rate limit reached issue

### DIFF
--- a/sdk/core/core-rest-pipeline/CHANGELOG.md
+++ b/sdk/core/core-rest-pipeline/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - The `bearerTokenAuthenticationPolicy` now accepts a logger.
 - Changed behavior when sending HTTP headers to preserve the original casing of header names. Iterating over `HttpHeaders` now keeps the original name casing. There is also a new `preserveCase` option for `HttpHeaders.toJSON()`. See [PR #18517](https://github.com/Azure/azure-sdk-for-js/pull/18517)
-- The count for how many retrys in the `throttlingRetryPolicy` policy can now be configured.
+- The count for how many retries in the `throttlingRetryPolicy` policy can now be configured.
 
 ### Breaking Changes
 

--- a/sdk/core/core-rest-pipeline/CHANGELOG.md
+++ b/sdk/core/core-rest-pipeline/CHANGELOG.md
@@ -1,11 +1,12 @@
 # Release History
 
-## 1.3.3 (Unreleased)
+## 1.4.0 (Unreleased)
 
 ### Features Added
 
 - The `bearerTokenAuthenticationPolicy` now accepts a logger.
 - Changed behavior when sending HTTP headers to preserve the original casing of header names. Iterating over `HttpHeaders` now keeps the original name casing. There is also a new `preserveCase` option for `HttpHeaders.toJSON()`. See [PR #18517](https://github.com/Azure/azure-sdk-for-js/pull/18517)
+- The count for how many retrys in the `throttlingRetryPolicy` policy can now be configured.
 
 ### Breaking Changes
 

--- a/sdk/core/core-rest-pipeline/package.json
+++ b/sdk/core/core-rest-pipeline/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/core-rest-pipeline",
-  "version": "1.3.3",
+  "version": "1.4.0",
   "description": "Isomorphic client library for making HTTP requests in node.js and browser.",
   "sdk-type": "client",
   "main": "dist/index.js",

--- a/sdk/core/core-rest-pipeline/review/core-rest-pipeline.api.md
+++ b/sdk/core/core-rest-pipeline/review/core-rest-pipeline.api.md
@@ -323,7 +323,7 @@ export interface SystemErrorRetryPolicyOptions {
 }
 
 // @public
-export function throttlingRetryPolicy(): PipelinePolicy;
+export function throttlingRetryPolicy(maxRetryCount?: number): PipelinePolicy;
 
 // @public
 export const throttlingRetryPolicyName = "throttlingRetryPolicy";

--- a/sdk/core/core-rest-pipeline/review/core-rest-pipeline.api.md
+++ b/sdk/core/core-rest-pipeline/review/core-rest-pipeline.api.md
@@ -178,7 +178,7 @@ export interface Pipeline {
 export interface PipelineOptions {
     proxyOptions?: ProxySettings;
     redirectOptions?: RedirectPolicyOptions;
-    retryOptions?: ExponentialRetryPolicyOptions;
+    retryOptions?: ExponentialRetryPolicyOptions | ThrottlingRetryPolicyOptions;
     userAgentOptions?: UserAgentPolicyOptions;
 }
 
@@ -323,10 +323,15 @@ export interface SystemErrorRetryPolicyOptions {
 }
 
 // @public
-export function throttlingRetryPolicy(maxRetryCount?: number): PipelinePolicy;
+export function throttlingRetryPolicy(options?: ThrottlingRetryPolicyOptions): PipelinePolicy;
 
 // @public
 export const throttlingRetryPolicyName = "throttlingRetryPolicy";
+
+// @public
+export interface ThrottlingRetryPolicyOptions {
+    maxRetries?: number;
+}
 
 // @public
 export function tracingPolicy(options?: TracingPolicyOptions): PipelinePolicy;

--- a/sdk/core/core-rest-pipeline/review/core-rest-pipeline.api.md
+++ b/sdk/core/core-rest-pipeline/review/core-rest-pipeline.api.md
@@ -178,7 +178,7 @@ export interface Pipeline {
 export interface PipelineOptions {
     proxyOptions?: ProxySettings;
     redirectOptions?: RedirectPolicyOptions;
-    retryOptions?: ExponentialRetryPolicyOptions | ThrottlingRetryPolicyOptions;
+    retryOptions?: PipelineRetryOptions;
     userAgentOptions?: UserAgentPolicyOptions;
 }
 
@@ -240,6 +240,13 @@ export interface PipelineResponse {
     readableStreamBody?: NodeJS.ReadableStream;
     request: PipelineRequest;
     status: number;
+}
+
+// @public
+export interface PipelineRetryOptions {
+    maxRetries?: number;
+    maxRetryDelayInMs?: number;
+    retryDelayInMs?: number;
 }
 
 // @public

--- a/sdk/core/core-rest-pipeline/src/createPipelineFromOptions.ts
+++ b/sdk/core/core-rest-pipeline/src/createPipelineFromOptions.ts
@@ -2,22 +2,17 @@
 // Licensed under the MIT license.
 
 import { ProxySettings } from ".";
+import { PipelineRetryOptions } from "./interfaces";
 import { Pipeline, createEmptyPipeline } from "./pipeline";
 import { decompressResponsePolicy } from "./policies/decompressResponsePolicy";
-import {
-  exponentialRetryPolicy,
-  ExponentialRetryPolicyOptions
-} from "./policies/exponentialRetryPolicy";
+import { exponentialRetryPolicy } from "./policies/exponentialRetryPolicy";
 import { formDataPolicy } from "./policies/formDataPolicy";
 import { logPolicy, LogPolicyOptions } from "./policies/logPolicy";
 import { proxyPolicy } from "./policies/proxyPolicy";
 import { redirectPolicy, RedirectPolicyOptions } from "./policies/redirectPolicy";
 import { setClientRequestIdPolicy } from "./policies/setClientRequestIdPolicy";
 import { systemErrorRetryPolicy } from "./policies/systemErrorRetryPolicy";
-import {
-  throttlingRetryPolicy,
-  ThrottlingRetryPolicyOptions
-} from "./policies/throttlingRetryPolicy";
+import { throttlingRetryPolicy } from "./policies/throttlingRetryPolicy";
 import { tracingPolicy } from "./policies/tracingPolicy";
 import { userAgentPolicy, UserAgentPolicyOptions } from "./policies/userAgentPolicy";
 import { isNode } from "./util/helpers";
@@ -30,7 +25,7 @@ export interface PipelineOptions {
   /**
    * Options that control how to retry failed requests.
    */
-  retryOptions?: ExponentialRetryPolicyOptions | ThrottlingRetryPolicyOptions;
+  retryOptions?: PipelineRetryOptions;
 
   /**
    * Options to configure a proxy for outgoing requests.
@@ -75,7 +70,7 @@ export function createPipelineFromOptions(options: InternalPipelineOptions): Pip
   pipeline.addPolicy(tracingPolicy(options.userAgentOptions));
   pipeline.addPolicy(userAgentPolicy(options.userAgentOptions));
   pipeline.addPolicy(setClientRequestIdPolicy());
-  pipeline.addPolicy(throttlingRetryPolicy(), { phase: "Retry" });
+  pipeline.addPolicy(throttlingRetryPolicy(options.retryOptions), { phase: "Retry" });
   pipeline.addPolicy(systemErrorRetryPolicy(options.retryOptions), { phase: "Retry" });
   pipeline.addPolicy(exponentialRetryPolicy(options.retryOptions), { phase: "Retry" });
   pipeline.addPolicy(redirectPolicy(options.redirectOptions), { afterPhase: "Retry" });

--- a/sdk/core/core-rest-pipeline/src/createPipelineFromOptions.ts
+++ b/sdk/core/core-rest-pipeline/src/createPipelineFromOptions.ts
@@ -14,7 +14,10 @@ import { proxyPolicy } from "./policies/proxyPolicy";
 import { redirectPolicy, RedirectPolicyOptions } from "./policies/redirectPolicy";
 import { setClientRequestIdPolicy } from "./policies/setClientRequestIdPolicy";
 import { systemErrorRetryPolicy } from "./policies/systemErrorRetryPolicy";
-import { throttlingRetryPolicy } from "./policies/throttlingRetryPolicy";
+import {
+  throttlingRetryPolicy,
+  ThrottlingRetryPolicyOptions
+} from "./policies/throttlingRetryPolicy";
 import { tracingPolicy } from "./policies/tracingPolicy";
 import { userAgentPolicy, UserAgentPolicyOptions } from "./policies/userAgentPolicy";
 import { isNode } from "./util/helpers";
@@ -27,7 +30,7 @@ export interface PipelineOptions {
   /**
    * Options that control how to retry failed requests.
    */
-  retryOptions?: ExponentialRetryPolicyOptions;
+  retryOptions?: ExponentialRetryPolicyOptions | ThrottlingRetryPolicyOptions;
 
   /**
    * Options to configure a proxy for outgoing requests.

--- a/sdk/core/core-rest-pipeline/src/index.ts
+++ b/sdk/core/core-rest-pipeline/src/index.ts
@@ -15,7 +15,8 @@ export {
   RawHttpHeaders,
   RawHttpHeadersInput,
   TransferProgressEvent,
-  RequestBodyType
+  RequestBodyType,
+  PipelineRetryOptions
 } from "./interfaces";
 export {
   AddPolicyOptions as AddPipelineOptions,

--- a/sdk/core/core-rest-pipeline/src/index.ts
+++ b/sdk/core/core-rest-pipeline/src/index.ts
@@ -58,7 +58,11 @@ export {
   SystemErrorRetryPolicyOptions,
   systemErrorRetryPolicyName
 } from "./policies/systemErrorRetryPolicy";
-export { throttlingRetryPolicy, throttlingRetryPolicyName } from "./policies/throttlingRetryPolicy";
+export {
+  throttlingRetryPolicy,
+  throttlingRetryPolicyName,
+  ThrottlingRetryPolicyOptions
+} from "./policies/throttlingRetryPolicy";
 export { tracingPolicy, tracingPolicyName, TracingPolicyOptions } from "./policies/tracingPolicy";
 export {
   userAgentPolicy,

--- a/sdk/core/core-rest-pipeline/src/interfaces.ts
+++ b/sdk/core/core-rest-pipeline/src/interfaces.ts
@@ -294,3 +294,26 @@ export type FormDataValue = string | Blob;
  * A simple object that provides form data, as if from a browser form.
  */
 export type FormDataMap = { [key: string]: FormDataValue | FormDataValue[] };
+
+/**
+ * Options that control how to retry failed requests.
+ */
+export interface PipelineRetryOptions {
+  /**
+   * The maximum number of retry attempts. Defaults to 10.
+   */
+  maxRetries?: number;
+
+  /**
+   * The amount of delay in milliseconds between retry attempts. Defaults to 1000
+   * (1 second). The delay increases exponentially with each retry up to a maximum
+   * specified by maxRetryDelayInMs.
+   */
+  retryDelayInMs?: number;
+
+  /**
+   * The maximum delay in milliseconds allowed before retrying an operation. Defaults
+   * to 64000 (64 seconds).
+   */
+  maxRetryDelayInMs?: number;
+}

--- a/sdk/core/core-rest-pipeline/src/policies/throttlingRetryPolicy.ts
+++ b/sdk/core/core-rest-pipeline/src/policies/throttlingRetryPolicy.ts
@@ -23,13 +23,14 @@ export const DEFAULT_CLIENT_MAX_RETRY_COUNT = 3;
  * https://docs.microsoft.com/en-us/azure/azure-subscription-service-limits and
  * https://docs.microsoft.com/en-us/azure/virtual-machines/troubleshooting/troubleshooting-throttling-errors
  */
-export function throttlingRetryPolicy(): PipelinePolicy {
+export function throttlingRetryPolicy(maxRetryCount?: number): PipelinePolicy {
   return {
     name: throttlingRetryPolicyName,
     async sendRequest(request: PipelineRequest, next: SendRequest): Promise<PipelineResponse> {
       let response = await next(request);
+      const chosenMaxRetryCount = maxRetryCount ?? DEFAULT_CLIENT_MAX_RETRY_COUNT;
 
-      for (let count = 0; count < DEFAULT_CLIENT_MAX_RETRY_COUNT; count++) {
+      for (let count = 0; count < chosenMaxRetryCount; count++) {
         if (response.status !== 429 && response.status !== 503) {
           return response;
         }

--- a/sdk/core/core-rest-pipeline/src/policies/throttlingRetryPolicy.ts
+++ b/sdk/core/core-rest-pipeline/src/policies/throttlingRetryPolicy.ts
@@ -16,21 +16,33 @@ export const throttlingRetryPolicyName = "throttlingRetryPolicy";
 export const DEFAULT_CLIENT_MAX_RETRY_COUNT = 3;
 
 /**
+ * Options that control how to retry failed requests.
+ */
+export interface ThrottlingRetryPolicyOptions {
+  /**
+   * The maximum number of retry attempts. Defaults to 3.
+   */
+   maxRetries?: number;
+}
+
+/**
  * A policy that retries when the server sends a 429 response with a Retry-After header.
  *
  * To learn more, please refer to
  * https://docs.microsoft.com/en-us/azure/azure-resource-manager/resource-manager-request-limits,
  * https://docs.microsoft.com/en-us/azure/azure-subscription-service-limits and
  * https://docs.microsoft.com/en-us/azure/virtual-machines/troubleshooting/troubleshooting-throttling-errors
+ *
+ * @param options - Options that configure retry logic.
  */
-export function throttlingRetryPolicy(maxRetryCount?: number): PipelinePolicy {
+export function throttlingRetryPolicy(options: ThrottlingRetryPolicyOptions = {}): PipelinePolicy {
   return {
     name: throttlingRetryPolicyName,
     async sendRequest(request: PipelineRequest, next: SendRequest): Promise<PipelineResponse> {
       let response = await next(request);
-      const chosenMaxRetryCount = maxRetryCount ?? DEFAULT_CLIENT_MAX_RETRY_COUNT;
+      const maxRetryCount = options.maxRetries ?? DEFAULT_CLIENT_MAX_RETRY_COUNT;
 
-      for (let count = 0; count < chosenMaxRetryCount; count++) {
+      for (let count = 0; count < maxRetryCount; count++) {
         if (response.status !== 429 && response.status !== 503) {
           return response;
         }

--- a/sdk/core/core-rest-pipeline/src/policies/throttlingRetryPolicy.ts
+++ b/sdk/core/core-rest-pipeline/src/policies/throttlingRetryPolicy.ts
@@ -13,16 +13,16 @@ export const throttlingRetryPolicyName = "throttlingRetryPolicy";
 /**
  * Maximum number of retries for the throttling retry policy
  */
-export const DEFAULT_CLIENT_MAX_RETRY_COUNT = 3;
+export const DEFAULT_CLIENT_MAX_RETRY_COUNT = 10;
 
 /**
  * Options that control how to retry failed requests.
  */
 export interface ThrottlingRetryPolicyOptions {
   /**
-   * The maximum number of retry attempts. Defaults to 3.
+   * The maximum number of retry attempts. Defaults to 10.
    */
-   maxRetries?: number;
+  maxRetries?: number;
 }
 
 /**

--- a/sdk/textanalytics/ai-text-analytics/src/util.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/util.ts
@@ -190,6 +190,9 @@ export function compileError(errorResponse: unknown): any {
     };
     statusCode: number;
   };
+  if (!castErrorResponse.response) {
+    throw errorResponse;
+  }
   const topLevelError = castErrorResponse.response.parsedBody?.error;
   if (!topLevelError) return errorResponse;
   let errorMessage = topLevelError.message || "";

--- a/sdk/textanalytics/ai-text-analytics/test/public/textAnalyticsClient.spec.ts
+++ b/sdk/textanalytics/ai-text-analytics/test/public/textAnalyticsClient.spec.ts
@@ -926,6 +926,12 @@ matrix([["APIKey", "AAD"]] as const, async (authMethod: AuthMethod) => {
         this.timeout(isPlaybackMode() ? fastTimeout : CLITimeout);
       });
 
+      /**
+       * The service's rate limit is sometimes reached for the beginAnalyzeActions tests
+       * because of the many requests the tests send. It appears that the number of
+       * max retries should be big enough to get around this issue. 10 seems to work
+       * fine for now.
+       */
       describe("#analyze", function() {
         it("single custom entity recognition action", async function() {
           const docs = [

--- a/sdk/textanalytics/ai-text-analytics/test/public/utils/recordedClient.ts
+++ b/sdk/textanalytics/ai-text-analytics/test/public/utils/recordedClient.ts
@@ -81,13 +81,13 @@ export function createClient(
 
   /**
    * The service's rate limit is sometimes reached for the beginAnalyzeActoins tests
-   * because of the many calls the tests send. It appears that retrying only 3 times
-   * (the default) is not enough so I am increasing the number here to 10.
+   * because of the many requests the tests send. It appears that retrying only 3 times
+   * (the default) is not enough so this logic increases that to 10.
    */
   client["client"].pipeline.removePolicy({
     name: "throttlingRetryPolicy"
   });
-  client["client"].pipeline.addPolicy(throttlingRetryPolicy(10));
+  client["client"].pipeline.addPolicy(throttlingRetryPolicy({ maxRetries: 10 }));
   return client;
 }
 

--- a/sdk/textanalytics/ai-text-analytics/test/public/utils/recordedClient.ts
+++ b/sdk/textanalytics/ai-text-analytics/test/public/utils/recordedClient.ts
@@ -10,7 +10,6 @@ import { TokenCredential, ClientSecretCredential } from "@azure/identity";
 
 import { AzureKeyCredential, TextAnalyticsClient, TextAnalyticsClientOptions } from "../../../src/";
 import "./env";
-import { throttlingRetryPolicy } from "@azure/core-rest-pipeline";
 
 const replaceableVariables: { [k: string]: string } = {
   AZURE_CLIENT_ID: "azure_client_id",

--- a/sdk/textanalytics/ai-text-analytics/test/public/utils/recordedClient.ts
+++ b/sdk/textanalytics/ai-text-analytics/test/public/utils/recordedClient.ts
@@ -76,7 +76,7 @@ export function createClient(
     env.ENDPOINT || "https://dummy.cognitiveservices.azure.com/",
     credential,
     /**
-     * The service's rate limit is sometimes reached for the beginAnalyzeActoins tests
+     * The service's rate limit is sometimes reached for the beginAnalyzeActions tests
      * because of the many requests the tests send. It appears that retrying only 3 times
      * (the default) is not enough so this logic increases that to 10.
      */

--- a/sdk/textanalytics/ai-text-analytics/test/public/utils/recordedClient.ts
+++ b/sdk/textanalytics/ai-text-analytics/test/public/utils/recordedClient.ts
@@ -75,12 +75,7 @@ export function createClient(
   return new TextAnalyticsClient(
     env.ENDPOINT || "https://dummy.cognitiveservices.azure.com/",
     credential,
-    /**
-     * The service's rate limit is sometimes reached for the beginAnalyzeActions tests
-     * because of the many requests the tests send. It appears that retrying only 3 times
-     * (the default) is not enough so this logic increases that to 10.
-     */
-    { ...options, retryOptions: { maxRetries: 10 } }
+    options
   );
 }
 

--- a/sdk/textanalytics/ai-text-analytics/test/public/utils/recordedClient.ts
+++ b/sdk/textanalytics/ai-text-analytics/test/public/utils/recordedClient.ts
@@ -73,22 +73,16 @@ export function createClient(
       throw Error(`Unsupported authentication method: ${authMethod}`);
     }
   }
-  const client = new TextAnalyticsClient(
+  return new TextAnalyticsClient(
     env.ENDPOINT || "https://dummy.cognitiveservices.azure.com/",
     credential,
-    options
+    /**
+     * The service's rate limit is sometimes reached for the beginAnalyzeActoins tests
+     * because of the many requests the tests send. It appears that retrying only 3 times
+     * (the default) is not enough so this logic increases that to 10.
+     */
+    { ...options, retryOptions: { maxRetries: 10 } }
   );
-
-  /**
-   * The service's rate limit is sometimes reached for the beginAnalyzeActoins tests
-   * because of the many requests the tests send. It appears that retrying only 3 times
-   * (the default) is not enough so this logic increases that to 10.
-   */
-  client["client"].pipeline.removePolicy({
-    name: "throttlingRetryPolicy"
-  });
-  client["client"].pipeline.addPolicy(throttlingRetryPolicy({ maxRetries: 10 }));
-  return client;
 }
 
 /**


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-sdk-for-js/issues/18941

Sometimes, we get rate limit reached error responses from the service that exceed the default number of retrys in the throttling retry policy.

For context, this particular API supports running multiple Text Analytics actions from one request, so the service does not like getting many successive requests for it. I also confirmed with their engineering team that the test suite is a bit too big.

To fix this, the test suite could be trimmed down but I am afraid that will affect the current coverage. Instead, I updated the retry policy for the test client to retry more.