### PR TITLE
Remove event-processor-host from ci.yml and the sdk-type

### DIFF
--- a/sdk/eventhub/ci.yml
+++ b/sdk/eventhub/ci.yml
@@ -30,8 +30,6 @@ extends:
         safeName: azureeventhubs
       - name: azure-eventhubs-checkpointstore-blob
         safeName: azureeventhubscheckpointstoreblob
-      - name: azure-event-processor-host
-        safename: azureeventprocessorhost
       - name: azure-eventhubs-checkpointstore-table
         safeName: azureeventhubscheckpointstoretable
       - name: azure-arm-eventhub

--- a/sdk/eventhub/event-processor-host/package.json
+++ b/sdk/eventhub/event-processor-host/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@azure/event-processor-host",
-  "sdk-type": "client",
   "version": "2.1.1",
   "description": "Azure Event Processor Host (Event Hubs) SDK for JS.",
   "author": "Microsoft Corporation",


### PR DESCRIPTION
This is a follow up from https://github.com/Azure/azure-sdk-for-js/pull/19250
A clean up was needed in ci.yml file and the removal of sdk-type so that CI does not try to find event-processor-host