### PR TITLE
Update Identity dependency to v2 from v2 beta

### DIFF
--- a/sdk/communication/communication-short-codes/package.json
+++ b/sdk/communication/communication-short-codes/package.json
@@ -74,7 +74,7 @@
     "@azure-tools/test-recorder": "^1.0.0",
     "@azure/dev-tool": "^1.0.0",
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
-    "@azure/identity": "2.0.0-beta.6",
+    "@azure/identity": "^2.0.1",
     "@azure/test-utils": "^1.0.0",
     "@microsoft/api-extractor": "^7.18.11",
     "@rollup/plugin-commonjs": "11.0.2",

--- a/sdk/containerregistry/arm-containerregistry/package.json
+++ b/sdk/containerregistry/arm-containerregistry/package.json
@@ -4,7 +4,9 @@
   "author": "Microsoft Corporation",
   "description": "A generated SDK for ContainerRegistryManagementClient.",
   "version": "10.0.0-beta.1",
-  "engines": { "node": ">=12.0.0" },
+  "engines": {
+    "node": ">=12.0.0"
+  },
   "dependencies": {
     "@azure/core-lro": "^2.2.0",
     "@azure/abort-controller": "^1.0.0",
@@ -14,7 +16,13 @@
     "@azure/core-rest-pipeline": "^1.1.0",
     "tslib": "^2.2.0"
   },
-  "keywords": ["node", "azure", "typescript", "browser", "isomorphic"],
+  "keywords": [
+    "node",
+    "azure",
+    "typescript",
+    "browser",
+    "isomorphic"
+  ],
   "license": "MIT",
   "main": "./dist/index.js",
   "module": "./dist-esm/src/index.js",
@@ -30,7 +38,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "typescript": "~4.2.0",
     "uglify-js": "^3.4.9",
-    "@azure/identity": "2.0.0-beta.6",
+    "@azure/identity": "^2.0.1",
     "@azure-tools/test-recorder": "^1.0.0",
     "mocha": "^7.1.1",
     "cross-env": "^7.0.2"
@@ -40,7 +48,9 @@
     "type": "git",
     "url": "https://github.com/Azure/azure-sdk-for-js.git"
   },
-  "bugs": { "url": "https://github.com/Azure/azure-sdk-for-js/issues" },
+  "bugs": {
+    "url": "https://github.com/Azure/azure-sdk-for-js/issues"
+  },
   "files": [
     "dist/**/*.js",
     "dist/**/*.js.map",

--- a/sdk/mysql/arm-mysql/package.json
+++ b/sdk/mysql/arm-mysql/package.json
@@ -4,7 +4,9 @@
   "author": "Microsoft Corporation",
   "description": "A generated SDK for MySQLManagementClient.",
   "version": "5.0.0-beta.1",
-  "engines": { "node": ">=12.0.0" },
+  "engines": {
+    "node": ">=12.0.0"
+  },
   "dependencies": {
     "@azure/core-lro": "^2.2.0",
     "@azure/abort-controller": "^1.0.0",
@@ -14,7 +16,13 @@
     "@azure/core-rest-pipeline": "^1.1.0",
     "tslib": "^2.2.0"
   },
-  "keywords": ["node", "azure", "typescript", "browser", "isomorphic"],
+  "keywords": [
+    "node",
+    "azure",
+    "typescript",
+    "browser",
+    "isomorphic"
+  ],
   "license": "MIT",
   "main": "./dist/index.js",
   "module": "./dist-esm/src/index.js",
@@ -30,7 +38,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "typescript": "~4.2.0",
     "uglify-js": "^3.4.9",
-    "@azure/identity": "2.0.0-beta.6",
+    "@azure/identity": "^2.0.1",
     "@azure-tools/test-recorder": "^1.0.0",
     "mocha": "^7.1.1",
     "cross-env": "^7.0.2"
@@ -40,7 +48,9 @@
     "type": "git",
     "url": "https://github.com/Azure/azure-sdk-for-js.git"
   },
-  "bugs": { "url": "https://github.com/Azure/azure-sdk-for-js/issues" },
+  "bugs": {
+    "url": "https://github.com/Azure/azure-sdk-for-js/issues"
+  },
   "files": [
     "dist/**/*.js",
     "dist/**/*.js.map",

--- a/sdk/synapse/synapse-access-control-rest/samples/v1/javascript/package.json
+++ b/sdk/synapse/synapse-access-control-rest/samples/v1/javascript/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "@azure-rest/synapse-access-control": "next",
     "dotenv": "latest",
-    "@azure/identity": "2.0.0-beta.6",
+    "@azure/identity": "^2.0.1",
     "uuid": "^8.3.0"
   }
 }

--- a/sdk/synapse/synapse-access-control-rest/samples/v1/typescript/package.json
+++ b/sdk/synapse/synapse-access-control-rest/samples/v1/typescript/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "@azure-rest/synapse-access-control": "next",
     "dotenv": "latest",
-    "@azure/identity": "2.0.0-beta.6",
+    "@azure/identity": "^2.0.1",
     "uuid": "^8.3.0"
   },
   "devDependencies": {


### PR DESCRIPTION
A handful of packages were still using v2 beta of the identity package. This PR updates such cases to use `^2.01` instead