### PR TITLE
[KeyVault] - Enable multi-version tests for KV secrets

### DIFF
--- a/sdk/keyvault/keyvault-secrets/platform-matrix.json
+++ b/sdk/keyvault/keyvault-secrets/platform-matrix.json
@@ -1,0 +1,20 @@
+{
+  "include": [
+    {
+      "Agent": {
+        "ubuntu-20.04": {
+          "OSVmImage": "MMSUbuntu20.04",
+          "Pool": "azsdk-pool-mms-ubuntu-2004-general"
+        }
+      },
+      "TestType": "node",
+      "NodeTestVersion": "16.x",
+      "ServiceVersion": ["7.0", "7.1", "7.2"]
+    }
+  ],
+  "displayNames": {
+    "7.0": "service_version_7_0",
+    "7.1": "service_version_7_1",
+    "7.2": "service_version_7_2"
+  }
+}

--- a/sdk/keyvault/keyvault-secrets/test/internal/challengeBasedAuthenticationPolicy.spec.ts
+++ b/sdk/keyvault/keyvault-secrets/test/internal/challengeBasedAuthenticationPolicy.spec.ts
@@ -17,6 +17,7 @@ import { authenticate } from "../utils/testAuthentication";
 import TestClient from "../utils/testClient";
 import { ClientSecretCredential } from "@azure/identity";
 import { WebResource } from "@azure/core-http";
+import { getServiceVersion } from "../utils/utils.common";
 
 // Following the philosophy of not testing the insides if we can test the outsides...
 // I present you with this "Get Out of Jail Free" card (in reference to Monopoly).
@@ -31,7 +32,7 @@ describe("Challenge based authentication tests", () => {
   let recorder: Recorder;
 
   beforeEach(async function(this: Context) {
-    const authentication = await authenticate(this);
+    const authentication = await authenticate(this, getServiceVersion());
     secretSuffix = authentication.secretSuffix;
     client = authentication.client;
     testClient = authentication.testClient;

--- a/sdk/keyvault/keyvault-secrets/test/public/CRUD.spec.ts
+++ b/sdk/keyvault/keyvault-secrets/test/public/CRUD.spec.ts
@@ -35,14 +35,13 @@ describe("Secret client - create, read, update and delete operations", () => {
 
   // The tests follow
 
-  it.only("can add a secret", async function(this: Context) {
-    console.log("Running with API Version:", client["client"]["apiVersion"]);
-    // const secretName = testClient.formatName(
-    //   `${secretPrefix}-${this!.test!.title}-${secretSuffix}`
-    // );
-    // const result = await client.setSecret(secretName, secretValue);
-    // assert.equal(result.name, secretName, "Unexpected secret name in result from setSecret().");
-    // assert.equal(result.value, secretValue, "Unexpected secret value in result from setSecret().");
+  it("can add a secret", async function(this: Context) {
+    const secretName = testClient.formatName(
+      `${secretPrefix}-${this!.test!.title}-${secretSuffix}`
+    );
+    const result = await client.setSecret(secretName, secretValue);
+    assert.equal(result.name, secretName, "Unexpected secret name in result from setSecret().");
+    assert.equal(result.value, secretValue, "Unexpected secret value in result from setSecret().");
   });
 
   // If this test is not skipped in the browser's playback, no other test will be played back.

--- a/sdk/keyvault/keyvault-secrets/test/public/CRUD.spec.ts
+++ b/sdk/keyvault/keyvault-secrets/test/public/CRUD.spec.ts
@@ -8,7 +8,7 @@ import { env, Recorder } from "@azure-tools/test-recorder";
 import { AbortController } from "@azure/abort-controller";
 
 import { SecretClient } from "../../src";
-import { assertThrowsAbortError } from "../utils/utils.common";
+import { assertThrowsAbortError, getServiceVersion } from "../utils/utils.common";
 import { testPollerProperties } from "../utils/recorderUtils";
 import { authenticate } from "../utils/testAuthentication";
 import TestClient from "../utils/testClient";
@@ -22,7 +22,7 @@ describe("Secret client - create, read, update and delete operations", () => {
   let recorder: Recorder;
 
   beforeEach(async function(this: Context) {
-    const authentication = await authenticate(this);
+    const authentication = await authenticate(this, getServiceVersion());
     secretSuffix = authentication.secretSuffix;
     client = authentication.client;
     testClient = authentication.testClient;
@@ -35,13 +35,14 @@ describe("Secret client - create, read, update and delete operations", () => {
 
   // The tests follow
 
-  it("can add a secret", async function(this: Context) {
-    const secretName = testClient.formatName(
-      `${secretPrefix}-${this!.test!.title}-${secretSuffix}`
-    );
-    const result = await client.setSecret(secretName, secretValue);
-    assert.equal(result.name, secretName, "Unexpected secret name in result from setSecret().");
-    assert.equal(result.value, secretValue, "Unexpected secret value in result from setSecret().");
+  it.only("can add a secret", async function(this: Context) {
+    console.log("Running with API Version:", client["client"]["apiVersion"]);
+    // const secretName = testClient.formatName(
+    //   `${secretPrefix}-${this!.test!.title}-${secretSuffix}`
+    // );
+    // const result = await client.setSecret(secretName, secretValue);
+    // assert.equal(result.name, secretName, "Unexpected secret name in result from setSecret().");
+    // assert.equal(result.value, secretValue, "Unexpected secret value in result from setSecret().");
   });
 
   // If this test is not skipped in the browser's playback, no other test will be played back.

--- a/sdk/keyvault/keyvault-secrets/test/public/list.spec.ts
+++ b/sdk/keyvault/keyvault-secrets/test/public/list.spec.ts
@@ -7,7 +7,7 @@ import chai from "chai";
 import { env, Recorder, isRecordMode } from "@azure-tools/test-recorder";
 
 import { SecretClient } from "../../src";
-import { assertThrowsAbortError } from "../utils/utils.common";
+import { assertThrowsAbortError, getServiceVersion } from "../utils/utils.common";
 import { testPollerProperties } from "../utils/recorderUtils";
 import { authenticate } from "../utils/testAuthentication";
 import TestClient from "../utils/testClient";
@@ -23,7 +23,7 @@ describe("Secret client - list secrets in various ways", () => {
   let recorder: Recorder;
 
   beforeEach(async function(this: Context) {
-    const authentication = await authenticate(this);
+    const authentication = await authenticate(this, getServiceVersion());
     secretSuffix = authentication.secretSuffix;
     client = authentication.client;
     testClient = authentication.testClient;

--- a/sdk/keyvault/keyvault-secrets/test/public/lro.delete.spec.ts
+++ b/sdk/keyvault/keyvault-secrets/test/public/lro.delete.spec.ts
@@ -7,7 +7,7 @@ import { env, Recorder } from "@azure-tools/test-recorder";
 import { PollerStoppedError } from "@azure/core-lro";
 
 import { SecretClient, DeletedSecret } from "../../src";
-import { assertThrowsAbortError } from "../utils/utils.common";
+import { assertThrowsAbortError, getServiceVersion } from "../utils/utils.common";
 import { testPollerProperties } from "../utils/recorderUtils";
 import { authenticate } from "../utils/testAuthentication";
 import TestClient from "../utils/testClient";
@@ -20,7 +20,7 @@ describe("Secrets client - Long Running Operations - delete", () => {
   let recorder: Recorder;
 
   beforeEach(async function(this: Context) {
-    const authentication = await authenticate(this);
+    const authentication = await authenticate(this, getServiceVersion());
     secretSuffix = authentication.secretSuffix;
     client = authentication.client;
     testClient = authentication.testClient;

--- a/sdk/keyvault/keyvault-secrets/test/public/lro.recover.spec.ts
+++ b/sdk/keyvault/keyvault-secrets/test/public/lro.recover.spec.ts
@@ -7,7 +7,7 @@ import { env, Recorder } from "@azure-tools/test-recorder";
 import { PollerStoppedError } from "@azure/core-lro";
 
 import { SecretClient, SecretProperties } from "../../src";
-import { assertThrowsAbortError } from "../utils/utils.common";
+import { assertThrowsAbortError, getServiceVersion } from "../utils/utils.common";
 import { testPollerProperties } from "../utils/recorderUtils";
 import { authenticate } from "../utils/testAuthentication";
 import TestClient from "../utils/testClient";
@@ -20,7 +20,7 @@ describe("Secrets client - Long Running Operations - recoverDelete", () => {
   let recorder: Recorder;
 
   beforeEach(async function(this: Context) {
-    const authentication = await authenticate(this);
+    const authentication = await authenticate(this, getServiceVersion());
     secretSuffix = authentication.secretSuffix;
     client = authentication.client;
     testClient = authentication.testClient;

--- a/sdk/keyvault/keyvault-secrets/test/public/recoverBackupRestore.spec.ts
+++ b/sdk/keyvault/keyvault-secrets/test/public/recoverBackupRestore.spec.ts
@@ -7,7 +7,7 @@ import { isNode } from "@azure/core-http";
 import { env, isPlaybackMode, Recorder, isRecordMode } from "@azure-tools/test-recorder";
 
 import { SecretClient } from "../../src";
-import { assertThrowsAbortError } from "../utils/utils.common";
+import { assertThrowsAbortError, getServiceVersion } from "../utils/utils.common";
 import { testPollerProperties } from "../utils/recorderUtils";
 import { authenticate } from "../utils/testAuthentication";
 import TestClient from "../utils/testClient";
@@ -20,7 +20,7 @@ describe("Secret client - restore secrets and recover backups", () => {
   let recorder: Recorder;
 
   beforeEach(async function(this: Context) {
-    const authentication = await authenticate(this);
+    const authentication = await authenticate(this, getServiceVersion());
     secretSuffix = authentication.secretSuffix;
     client = authentication.client;
     testClient = authentication.testClient;

--- a/sdk/keyvault/keyvault-secrets/test/utils/testAuthentication.ts
+++ b/sdk/keyvault/keyvault-secrets/test/utils/testAuthentication.ts
@@ -7,8 +7,12 @@ import { env, record, RecorderEnvironmentSetup } from "@azure-tools/test-recorde
 import { uniqueString } from "./recorderUtils";
 import TestClient from "./testClient";
 import { Context } from "mocha";
+import { getServiceVersion } from "./utils.common";
 
-export async function authenticate(that: Context): Promise<any> {
+export async function authenticate(
+  that: Context,
+  serviceVersion: ReturnType<typeof getServiceVersion>
+): Promise<any> {
   const secretSuffix = uniqueString();
   const recorderEnvSetup: RecorderEnvironmentSetup = {
     replaceableVariables: {
@@ -41,7 +45,7 @@ export async function authenticate(that: Context): Promise<any> {
     throw new Error("Missing KEYVAULT_URI environment variable.");
   }
 
-  const client = new SecretClient(keyVaultUrl, credential);
+  const client = new SecretClient(keyVaultUrl, credential, { serviceVersion });
   const testClient = new TestClient(client);
 
   return { recorder, client, testClient, secretSuffix, credential };

--- a/sdk/keyvault/keyvault-secrets/test/utils/utils.common.ts
+++ b/sdk/keyvault/keyvault-secrets/test/utils/utils.common.ts
@@ -2,6 +2,9 @@
 // Licensed under the MIT license.
 
 import { assert } from "chai";
+import { SupportedVersions, supports, TestFunctionWrapper } from "@azure/test-utils";
+import { env } from "@azure-tools/test-recorder";
+import { LATEST_API_VERSION, SecretClientOptions } from "../../src/secretsModels";
 
 export async function assertThrowsAbortError(cb: () => Promise<any>): Promise<void> {
   let passed = false;
@@ -17,4 +20,31 @@ export async function assertThrowsAbortError(cb: () => Promise<any>): Promise<vo
   if (passed) {
     throw new Error("Expected cb to throw an AbortError");
   }
+}
+/**
+ * The known API versions that we support.
+ */
+export const serviceVersions = ["7.0", "7.1", "7.2", "7.3-preview"] as const;
+
+/**
+ * Fetches the service version to test against. This version could be configured as part of CI
+ * and then passed through the environment in order to support testing prior service versions.
+ * @returns - The service version to test
+ */
+export function getServiceVersion(): NonNullable<SecretClientOptions["serviceVersion"]> {
+  return env.SERVICE_VERSION || LATEST_API_VERSION;
+}
+
+/**
+ * A convenience wrapper allowing us to limit service versions without using the `versionsToTest` wrapper.
+ *
+ * @param supportedVersions - The {@link SupportedVersions} to limit this test against.
+ * @param serviceVersion - The service version we want to test support for. If omitted we will default to the version returned from {@link getServiceVersion}.
+ * @returns A Mocha Wrapper which will skip or execute the chained tests depending the currently tested service version and the supported versions.
+ */
+export function onVersions(
+  supportedVersions: SupportedVersions,
+  serviceVersion?: SecretClientOptions["serviceVersion"]
+): TestFunctionWrapper {
+  return supports(serviceVersion || getServiceVersion(), supportedVersions, serviceVersions);
 }

--- a/sdk/keyvault/keyvault-secrets/tests.yml
+++ b/sdk/keyvault/keyvault-secrets/tests.yml
@@ -7,6 +7,11 @@ stages:
       ServiceDirectory: keyvault
       TimeoutInMinutes: 59
       SupportedClouds: 'Public,UsGov,China'
+      AdditionalMatrixConfigs:
+        - Name: Keyvault_live_test_base
+          Path: sdk/keyvault/keyvault-secrets/platform-matrix.json
+          Selection: sparse
+          GenerateVMJobs: true
       EnvVars:
         AZURE_CLIENT_ID: $(KEYVAULT_CLIENT_ID)
         AZURE_TENANT_ID: $(KEYVAULT_TENANT_ID)


### PR DESCRIPTION
## What

- Add support for multi-version testing for keyvault-secrets

## Why

Our commitment is to support the last N versions of the KeyVault service. To ensure neither we nor the service introduce breaking changes to prior versions, multi-version test support was added. We ported keys over and have already reaped the benefits of version based filtering.

This commit adds the same support for keyvault-secrets

Resolves #17892 