### PR TITLE
[ServiceBus][Test] fix unstable tests that verify message state

### DIFF
--- a/sdk/servicebus/service-bus/test/public/sendAndSchedule.spec.ts
+++ b/sdk/servicebus/service-bus/test/public/sendAndSchedule.spec.ts
@@ -61,23 +61,19 @@ describe("Sender Tests", () => {
       : TestMessage.getSample();
     await sender.sendMessages(testMessage);
     const msgs = await receiver.receiveMessages(1);
+    const receivedMessage = msgs[0];
     // remove message first in case any assertion fails to ensure we don't have lingering message
-    await receiver.completeMessage(msgs[0]);
-
+    await receiver.completeMessage(receivedMessage);
     should.equal(Array.isArray(msgs), true, "`ReceivedMessages` is not an array");
     should.equal(msgs.length, 1, "Unexpected number of messages");
-    should.equal(msgs[0].deliveryCount, 0, "DeliveryCount is different than expected");
-    should.equal(msgs[0].messageId, testMessage.messageId);
-    // the message could be in "scheduled" state because we set `scheduledEnqueueTimeUtc` property
-    should.equal(
-      msgs[0].state === "active" || msgs[0].state === "scheduled",
-      true,
-      `actual message state: ${msgs[0].state}`
-    );
+    should.equal(receivedMessage.deliveryCount, 0, "DeliveryCount is different than expected");
+    should.equal(receivedMessage.messageId, testMessage.messageId);
+    // the message could be in "active" or "scheduled" state because we set `scheduledEnqueueTimeUtc` property
+    (receivedMessage.state === "active" || receivedMessage.state === "scheduled").should.be.true;
 
     TestMessage.checkMessageContents(
       testMessage,
-      msgs[0],
+      receivedMessage,
       entityName.usesSessions,
       entityName.isPartitioned
     );
@@ -108,7 +104,7 @@ describe("Sender Tests", () => {
     const msgs = await receiver.receiveMessages(1);
     // remove message first in case any assertion fails to ensure we don't have lingering message
     await receiver.completeMessage(msgs[0]);
-    should.equal(msgs[0].state === "active", true, `actual message state: ${msgs[0].state}`);
+    msgs[0].state.should.equal("active");
   });
 
   async function testSimpleSendArray(): Promise<void> {

--- a/sdk/servicebus/service-bus/test/public/sendAndSchedule.spec.ts
+++ b/sdk/servicebus/service-bus/test/public/sendAndSchedule.spec.ts
@@ -69,6 +69,7 @@ describe("Sender Tests", () => {
     should.equal(receivedMessage.deliveryCount, 0, "DeliveryCount is different than expected");
     should.equal(receivedMessage.messageId, testMessage.messageId);
     // the message could be in "active" or "scheduled" state because we set `scheduledEnqueueTimeUtc` property
+    // eslint-disable-next-line no-unused-expressions
     (receivedMessage.state === "active" || receivedMessage.state === "scheduled").should.be.true;
 
     TestMessage.checkMessageContents(

--- a/sdk/servicebus/service-bus/test/public/sendAndSchedule.spec.ts
+++ b/sdk/servicebus/service-bus/test/public/sendAndSchedule.spec.ts
@@ -68,9 +68,6 @@ describe("Sender Tests", () => {
     should.equal(msgs.length, 1, "Unexpected number of messages");
     should.equal(receivedMessage.deliveryCount, 0, "DeliveryCount is different than expected");
     should.equal(receivedMessage.messageId, testMessage.messageId);
-    // the message could be in "active" or "scheduled" state because we set `scheduledEnqueueTimeUtc` property
-    // eslint-disable-next-line no-unused-expressions
-    (receivedMessage.state === "active" || receivedMessage.state === "scheduled").should.be.true;
 
     TestMessage.checkMessageContents(
       testMessage,

--- a/sdk/servicebus/service-bus/tests.yml
+++ b/sdk/servicebus/service-bus/tests.yml
@@ -5,6 +5,8 @@ stages:
     parameters:
       PackageName: "@azure/service-bus"
       ServiceDirectory: servicebus
+      MatrixFilters:
+        - Pool=.*Pipelines
       TimeoutInMinutes: 180
       Clouds: 'Public,Canary'
       EnvVars:

--- a/sdk/servicebus/service-bus/tests.yml
+++ b/sdk/servicebus/service-bus/tests.yml
@@ -5,8 +5,6 @@ stages:
     parameters:
       PackageName: "@azure/service-bus"
       ServiceDirectory: servicebus
-      MatrixFilters:
-        - Pool=.*Pipelines
       TimeoutInMinutes: 180
       Clouds: 'Public,Canary'
       EnvVars:


### PR DESCRIPTION
The test messages we create have `scheduledEnqueueTimeUtc` set. Most of the time
messages received from the service have "active" state, but occasionally have
"scheduled" state due to the set property, thus failing the assertion.

This PR updates the verification to check for either "active" or "schedule". In
addition, a test is added for "active" state where the `scheduledEnqueueTimeUtc`
property is removed before sending the message.

Also shown in the failing pipeline that after this test failed, the message wasn't
removed because `receiver.completeMessage()` was not called. The lingering
message caused the next test to fail. While fixing I also moved the
cleanup step before assertions so the messages are always removed.