### PR TITLE
Removing type validation for errors

### DIFF
--- a/sdk/appconfiguration/app-configuration/test/internal/tracingHelpers.spec.ts
+++ b/sdk/appconfiguration/app-configuration/test/internal/tracingHelpers.spec.ts
@@ -92,6 +92,9 @@ describe("tracingHelpers", () => {
 
       assert.fail("Exception should have been thrown from `trace` since the inner action threw");
     } catch (err) {
+      if (!(err instanceof Error)) {
+        throw new Error("Error is not recognized");
+      }
       assert.equal(err.message, "Purposefully thrown error");
     }
 

--- a/sdk/appconfiguration/app-configuration/test/internal/tracingHelpers.spec.ts
+++ b/sdk/appconfiguration/app-configuration/test/internal/tracingHelpers.spec.ts
@@ -92,9 +92,6 @@ describe("tracingHelpers", () => {
 
       assert.fail("Exception should have been thrown from `trace` since the inner action threw");
     } catch (err) {
-      if (!(err instanceof Error)) {
-        throw new Error("Error is not recognized");
-      }
       assert.equal(err.message, "Purposefully thrown error");
     }
 

--- a/sdk/appconfiguration/app-configuration/test/public/utils/testHelpers.ts
+++ b/sdk/appconfiguration/app-configuration/test/public/utils/testHelpers.ts
@@ -18,7 +18,6 @@ import {
 import { assert } from "chai";
 
 import { DefaultAzureCredential, TokenCredential } from "@azure/identity";
-import { RestError } from "@azure/core-http";
 
 let connectionStringNotPresentWarning = false;
 let tokenCredentialsNotPresentWarning = false;
@@ -163,9 +162,6 @@ export async function assertThrowsRestError(
     await testFunction();
     assert.fail(`${message}: No error thrown`);
   } catch (err) {
-    if (!(err instanceof RestError)) {
-      throw new Error("Error is not recognized");
-    }
     if (err.name === "RestError") {
       assert.equal(expectedStatusCode, err.statusCode, message);
       return err;
@@ -185,9 +181,6 @@ export async function assertThrowsAbortError(
     await testFunction();
     assert.fail(`${message}: No error thrown`);
   } catch (e) {
-    if (!(e instanceof Error)) {
-      throw new Error("Error is not recognized");
-    }
     if (isPlaybackMode() && (e.name === "FetchError" || e.name === "AbortError")) {
       return e;
     } else {

--- a/sdk/appconfiguration/app-configuration/test/public/utils/testHelpers.ts
+++ b/sdk/appconfiguration/app-configuration/test/public/utils/testHelpers.ts
@@ -18,6 +18,7 @@ import {
 import { assert } from "chai";
 
 import { DefaultAzureCredential, TokenCredential } from "@azure/identity";
+import { RestError } from "@azure/core-http";
 
 let connectionStringNotPresentWarning = false;
 let tokenCredentialsNotPresentWarning = false;
@@ -162,6 +163,9 @@ export async function assertThrowsRestError(
     await testFunction();
     assert.fail(`${message}: No error thrown`);
   } catch (err) {
+    if (!(err instanceof RestError)) {
+      throw new Error("Error is not recognized");
+    }
     if (err.name === "RestError") {
       assert.equal(expectedStatusCode, err.statusCode, message);
       return err;
@@ -181,6 +185,9 @@ export async function assertThrowsAbortError(
     await testFunction();
     assert.fail(`${message}: No error thrown`);
   } catch (e) {
+    if (!(e instanceof Error)) {
+      throw new Error("Error is not recognized");
+    }
     if (isPlaybackMode() && (e.name === "FetchError" || e.name === "AbortError")) {
       return e;
     } else {

--- a/sdk/appconfiguration/app-configuration/test/public/utils/testHelpers.ts
+++ b/sdk/appconfiguration/app-configuration/test/public/utils/testHelpers.ts
@@ -163,11 +163,12 @@ export async function assertThrowsRestError(
     await testFunction();
     assert.fail(`${message}: No error thrown`);
   } catch (err) {
-    if (!(err instanceof RestError)) {
+    if (!(err instanceof Error)) {
       throw new Error("Error is not recognized");
     }
     if (err.name === "RestError") {
-      assert.equal(expectedStatusCode, err.statusCode, message);
+      const restError = err as RestError;
+      assert.equal(expectedStatusCode, restError.statusCode, message);
       return err;
     }
 


### PR DESCRIPTION
Fixes: https://github.com/Azure/azure-sdk-for-js/issues/19355

Removing the type validation for the errors since they are not needed with the current typescript version and they were introduced in PR:  https://github.com/Azure/azure-sdk-for-js/pull/19245