### PR TITLE
[ai-form-recognizer] Update tests.yml

### DIFF
--- a/sdk/formrecognizer/ai-form-recognizer/test/public/training.spec.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/test/public/training.spec.ts
@@ -251,7 +251,9 @@ matrix([[true, false]] as const, async (useAad) => {
       assert.equal(Object.entries(composedModel.docTypes ?? {}).length, 2);
     });
 
-    it("copy model", async function () {
+    // TODO: re-enable when preview service degradation is mitigated.
+    // See: https://github.com/Azure/azure-sdk-for-js/issues/19604
+    it.skip("copy model", async function () {
       // Since this test is isolated, we'll create a fresh set of resources for it
 
       const trainingClient = new DocumentModelAdministrationClient(

--- a/sdk/formrecognizer/ai-form-recognizer/tests.yml
+++ b/sdk/formrecognizer/ai-form-recognizer/tests.yml
@@ -6,7 +6,7 @@ parameters:
 - name: Location
   displayName: Location
   type: string
-  default: centraluseuap
+  default: canadacentral
 
 trigger: none
 


### PR DESCRIPTION
Form Recognizer tests are ready to move back onto a prod region, and Canada Central is our preferred prod region for testing.