### PR TITLE
[EPH] Clean up logs that use >>>>

### DIFF
--- a/sdk/eventhub/event-processor-host/test/iothub.spec.ts
+++ b/sdk/eventhub/event-processor-host/test/iothub.spec.ts
@@ -46,14 +46,14 @@ describe("EPH with iothub connection string", function(): void {
           }
         );
         const onMessage: OnReceivedMessage = (context: PartitionContext, data: EventData) => {
-          debug(">>> [%s] Rx message from '%s': '%O'", hostName, context.partitionId, data);
+          debug("Test logs: [%s] Rx message from '%s': '%O'", hostName, context.partitionId, data);
         };
         const onError: OnReceivedError = (err) => {
           debug("An error occurred while receiving the message: %O", err);
           throw err;
         };
         const runtimeInfo = await host.getHubRuntimeInformation();
-        debug(">>>> runtimeInfo: %O", runtimeInfo);
+        debug("Test logs: runtimeInfo: %O", runtimeInfo);
         // tslint:disable-next-line: no-unused-expression
         runtimeInfo.createdAt.should.exist;
         (typeof runtimeInfo.partitionCount).should.equal("number");

--- a/sdk/eventhub/event-processor-host/test/negative.spec.ts
+++ b/sdk/eventhub/event-processor-host/test/negative.spec.ts
@@ -51,7 +51,7 @@ describe("negative", function(): void {
         }
       );
       const onMessage: OnReceivedMessage = (context: PartitionContext, data: EventData) => {
-        debug(">>> [%s] Rx message from '%s': '%O'", hostName, context.partitionId, data);
+        debug("Test logs: [%s] Rx message from '%s': '%O'", hostName, context.partitionId, data);
       };
       const onError: OnReceivedError = (err) => {
         debug("An error occurred while receiving the message: %O", err);
@@ -59,7 +59,7 @@ describe("negative", function(): void {
       };
       await host.start(onMessage, onError);
       try {
-        debug(">>> [%s] Trying to start second time.", hostName);
+        debug("Test logs: [%s] Trying to start second time.", hostName);
         await host.start(onMessage, onError);
         throw new Error("The second call to start() should have failed.");
       } catch (err) {
@@ -90,7 +90,7 @@ describe("negative", function(): void {
       }
     );
     const onMessage: OnReceivedMessage = (context: PartitionContext, data: EventData) => {
-      debug(">>> [%s] Rx message from '%s': '%O'", hostName, context.partitionId, data);
+      debug("Test logs: [%s] Rx message from '%s': '%O'", hostName, context.partitionId, data);
     };
     const onError: OnReceivedError = (err) => {
       debug("An error occurred while receiving the message: %O", err);
@@ -102,7 +102,7 @@ describe("negative", function(): void {
         return Promise.reject(new Error("This statement should not have executed."));
       })
       .catch((err) => {
-        debug(">>>>>>> %s", err.action);
+        debug("Err action: %s", err.action);
         err.action.should.equal("Getting PartitionIds");
         done();
       });
@@ -120,7 +120,7 @@ describe("negative", function(): void {
       }
     );
     const onMessage: OnReceivedMessage = (context: PartitionContext, data: EventData) => {
-      debug(">>> [%s] Rx message from '%s': '%O'", hostName, context.partitionId, data);
+      debug("Test logs: [%s] Rx message from '%s': '%O'", hostName, context.partitionId, data);
     };
     const onError: OnReceivedError = (err) => {
       debug("An error occurred while receiving the message: %O", err);
@@ -132,7 +132,7 @@ describe("negative", function(): void {
         return Promise.reject(new Error("This statement should not have executed."));
       })
       .catch((err) => {
-        debug(">>>>>>> %s", err.action);
+        debug("Err action: %s", err.action);
         err.action.should.equal("Getting PartitionIds");
         done();
       });


### PR DESCRIPTION
Resolves #19360

This PR cleans up the logs in the test files in the `@azure/event-processor-host` package to address the concerns brought up in #19360 around `>>>>>` being the same as git conflict markers.

I am using the prefix `Test logs` instead to differentiate these logs from the logs coming from the actual client code unless we are logging errors

Please note that the `@azure/event-processor-host` package is actually deprecated at this moment