### PR TITLE
Update version for types/prettier

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -1846,8 +1846,8 @@ packages:
     resolution: {integrity: sha512-i1KGxqcvJaLQali+WuypQnXwcplhtNtjs66eNsZpp2P2FL/trJJxx/VWsM0YCL2iMoIJrbXje48lvIQAQ4p2ZA==}
     dev: false
 
-  /@types/prettier/2.0.2:
-    resolution: {integrity: sha512-IkVfat549ggtkZUthUzEX49562eGikhSYeVGX97SkMFn+sTZrgRewXjQ4tPKFPCykZHkX1Zfd9OoELGqKU2jJA==}
+  /@types/prettier/2.4.2:
+    resolution: {integrity: sha512-ekoj4qOQYp7CvjX8ZDBgN86w3MqQhLE1hczEJbEIjgFEumDy+na/4AJAbLXfgEWFNB2pKadM5rPFtuSGMWK7xA==}
     dev: false
 
   /@types/priorityqueuejs/1.0.1:
@@ -2481,7 +2481,7 @@ packages:
     hasBin: true
     dependencies:
       caniuse-lite: 1.0.30001286
-      electron-to-chromium: 1.4.18
+      electron-to-chromium: 1.4.19
       escalade: 3.1.1
       node-releases: 2.0.1
       picocolors: 1.0.0
@@ -2848,8 +2848,8 @@ packages:
     requiresBuild: true
     dev: false
 
-  /core-js/3.19.3:
-    resolution: {integrity: sha512-LeLBMgEGSsG7giquSzvgBrTS7V5UL6ks3eQlUSbN8dJStlLFiRzUm5iqsRyzUB8carhfKjkJ2vzKqE6z1Vga9g==}
+  /core-js/3.20.0:
+    resolution: {integrity: sha512-KjbKU7UEfg4YPpskMtMXPhUKn7m/1OdTHTVjy09ScR2LVaoUXe8Jh0UdvN2EKUR6iKTJph52SJP95mAB0MnVLQ==}
     requiresBuild: true
     dev: false
 
@@ -3160,8 +3160,8 @@ packages:
     resolution: {integrity: sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=}
     dev: false
 
-  /electron-to-chromium/1.4.18:
-    resolution: {integrity: sha512-i7nKjGGBE1+YUIbfLObA1EZPmN7J1ITEllbhusDk+KIk6V6gUxN9PFe36v+Sd+8Cg0k3cgUv9lQhQZalr8rggw==}
+  /electron-to-chromium/1.4.19:
+    resolution: {integrity: sha512-TeAjwsC/vhvxEtX/xN1JQUMkl+UrwKXlB4rwLyuLYVuBuRtqJJrU4Jy5pCVihMQg4m1ceZ3MEJ0yYuxHj8vC+w==}
     dev: false
 
   /emoji-regex/7.0.3:
@@ -3670,7 +3670,7 @@ packages:
     dependencies:
       '@babel/core': 7.16.5
       '@babel/runtime': 7.16.5
-      core-js: 3.19.3
+      core-js: 3.20.0
       debug: 4.3.3
       glob-to-regexp: 0.4.1
       is-subset: 0.1.1
@@ -10527,7 +10527,7 @@ packages:
     dev: false
 
   file:projects/dev-tool.tgz:
-    resolution: {integrity: sha512-ExPHrCE3m71/FrakA576UduFoYRSKlzn1I33/TfiUBCuqQzMWUqUVdwsG/WGo83rbNfSpdJSeK+KCxcVOwrMcg==, tarball: file:projects/dev-tool.tgz}
+    resolution: {integrity: sha512-zrispsrfUltzNFv10SXVEhGRL5UrjFgzLXbQ36RscV7kJ4PtDsWQgzLqVeL2gEi5X+Kof8HHdd9a628lswsQPA==, tarball: file:projects/dev-tool.tgz}
     name: '@rush-temp/dev-tool'
     version: 0.0.0
     dependencies:
@@ -10542,7 +10542,7 @@ packages:
       '@types/minimist': 1.2.2
       '@types/mocha': 7.0.2
       '@types/node': 12.20.37
-      '@types/prettier': 2.0.2
+      '@types/prettier': 2.4.2
       builtin-modules: 3.2.0
       chai: 4.3.4
       chai-as-promised: 7.1.1_chai@4.3.4

--- a/common/tools/dev-tool/package.json
+++ b/common/tools/dev-tool/package.json
@@ -63,7 +63,7 @@
     "@types/minimist": "~1.2.0",
     "@types/mocha": "^7.0.2",
     "@types/node": "^12.0.0",
-    "@types/prettier": "~2.0.1",
+    "@types/prettier": "^2.0.1",
     "builtin-modules": "^3.1.0",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",


### PR DESCRIPTION
Resolves #19166 by updating the version of `@types/prettier` being used in `dev-tool`

Running `rush update` after changing from ~ to ^ didnt make any changes to the lock file. So went with `rush update --full` instead

@witemple-msft, Do you remember why you chose to go with ~ instead of ^ here in the first place?