### PR TITLE
[core-amqp] only compute retry delay when retrying

### DIFF
--- a/sdk/core/core-amqp/src/retry.ts
+++ b/sdk/core/core-amqp/src/retry.ts
@@ -135,6 +135,28 @@ function validateRetryConfig<T>(config: RetryConfig<T>): void {
 }
 
 /**
+ * Calculates delay between retries, in milliseconds.
+ * @internal
+ */
+function calculateDelay(
+  attemptCount: number,
+  retryDelayInMs: number,
+  maxRetryDelayInMs: number,
+  mode: RetryMode
+): number {
+  if (mode === RetryMode.Exponential) {
+    const boundedRandDelta =
+      retryDelayInMs * 0.8 +
+      Math.floor(Math.random() * (retryDelayInMs * 1.2 - retryDelayInMs * 0.8));
+
+    const incrementDelta = boundedRandDelta * (Math.pow(2, attemptCount) - 1);
+    return Math.min(incrementDelta, maxRetryDelayInMs);
+  }
+
+  return retryDelayInMs;
+}
+
+/**
  * Every operation is attempted at least once. Additional attempts are made if the previous attempt failed
  * with a retryable error. The number of additional attempts is governed by the `maxRetries` property provided
  * on the `RetryConfig` argument.
@@ -221,21 +243,12 @@ export async function retry<T>(config: RetryConfig<T>): Promise<T> {
       );
 
       if (lastError && lastError.retryable && totalNumberOfAttempts > i) {
-        let targetDelayInMs = config.retryOptions.retryDelayInMs;
-        if (config.retryOptions.mode === RetryMode.Exponential) {
-          let incrementDelta = Math.pow(2, i) - 1;
-          const boundedRandDelta =
-            config.retryOptions.retryDelayInMs * 0.8 +
-            Math.floor(
-              Math.random() *
-                (config.retryOptions.retryDelayInMs * 1.2 -
-                  config.retryOptions.retryDelayInMs * 0.8)
-            );
-          incrementDelta *= boundedRandDelta;
-
-          targetDelayInMs = Math.min(incrementDelta, config.retryOptions.maxRetryDelayInMs);
-        }
-
+        const targetDelayInMs = calculateDelay(
+          i,
+          config.retryOptions.retryDelayInMs,
+          config.retryOptions.maxRetryDelayInMs,
+          config.retryOptions.mode
+        );
         logger.verbose(
           "[%s] Sleeping for %d milliseconds for '%s'.",
           config.connectionId,

--- a/sdk/core/core-amqp/src/retry.ts
+++ b/sdk/core/core-amqp/src/retry.ts
@@ -219,21 +219,23 @@ export async function retry<T>(config: RetryConfig<T>): Promise<T> {
         i,
         err
       );
-      let targetDelayInMs = config.retryOptions.retryDelayInMs;
-      if (config.retryOptions.mode === RetryMode.Exponential) {
-        let incrementDelta = Math.pow(2, i) - 1;
-        const boundedRandDelta =
-          config.retryOptions.retryDelayInMs * 0.8 +
-          Math.floor(
-            Math.random() *
-              (config.retryOptions.retryDelayInMs * 1.2 - config.retryOptions.retryDelayInMs * 0.8)
-          );
-        incrementDelta *= boundedRandDelta;
-
-        targetDelayInMs = Math.min(incrementDelta, config.retryOptions.maxRetryDelayInMs);
-      }
 
       if (lastError && lastError.retryable && totalNumberOfAttempts > i) {
+        let targetDelayInMs = config.retryOptions.retryDelayInMs;
+        if (config.retryOptions.mode === RetryMode.Exponential) {
+          let incrementDelta = Math.pow(2, i) - 1;
+          const boundedRandDelta =
+            config.retryOptions.retryDelayInMs * 0.8 +
+            Math.floor(
+              Math.random() *
+                (config.retryOptions.retryDelayInMs * 1.2 -
+                  config.retryOptions.retryDelayInMs * 0.8)
+            );
+          incrementDelta *= boundedRandDelta;
+
+          targetDelayInMs = Math.min(incrementDelta, config.retryOptions.maxRetryDelayInMs);
+        }
+
         logger.verbose(
           "[%s] Sleeping for %d milliseconds for '%s'.",
           config.connectionId,


### PR DESCRIPTION
Add a small optimization that only computes the delay if we are retrying.