### PR TITLE
[test-utils] Export chai plugin

### DIFF
--- a/sdk/test-utils/test-utils/src/index.ts
+++ b/sdk/test-utils/test-utils/src/index.ts
@@ -9,12 +9,13 @@ export {
   TestFunctionWrapper
 } from "./multiVersion";
 
+export { chaiAzureTrace } from "./tracing/chaiAzureTrace";
 export { matrix } from "./matrix";
 export { isNode, isNode8 } from "./utils";
+export { TestSpan } from "./tracing/testSpan";
 
 export * from "./tracing/mockInstrumenter";
 export * from "./tracing/mockTracingSpan";
-export { TestSpan } from "./tracing/testSpan";
 export * from "./tracing/testTracer";
 export * from "./tracing/testTracerProvider";
 export * from "./tracing/spanGraphModel";

--- a/sdk/test-utils/test-utils/src/tracing/chaiAzureTrace.ts
+++ b/sdk/test-utils/test-utils/src/tracing/chaiAzureTrace.ts
@@ -13,8 +13,8 @@ import { SpanGraph, SpanGraphNode } from "./spanGraphModel";
  *
  * ```ts
  * import chai from "chai";
- * import { chaiAzureTracing } from "@azure/test-utils";
- * chai.use(chaiAzureTracing);
+ * import { chaiAzureTrace } from "@azure/test-utils";
+ * chai.use(chaiAzureTrace);
  *
  * it("supportsTracing", async () => {
  *   await assert.supportsTracing((updatedOptions) => myClient.doSomething(updatedOptions), ["myClient.doSomething"]);


### PR DESCRIPTION
In #18910 we created a chai plugin for supporting tracing validation. Because the base branch was stale, we weren't able to export this without _also_ suppressing chai warnings that are already being suppressed on main.

This commit just exports the plugin after fetching the latest changes from main.