### PR TITLE
[dev-tool] Handle passthrough of -- args

### DIFF
--- a/common/tools/dev-tool/src/commands/about.ts
+++ b/common/tools/dev-tool/src/commands/about.ts
@@ -9,7 +9,7 @@ import { createPrinter } from "../util/printer";
 import { leafCommand, makeCommandInfo } from "../framework/command";
 import { printCommandUsage } from "../framework/printCommandUsage";
 
-const log = createPrinter("help");
+const log = createPrinter("about");
 
 const banner = `\
        _______        __                __              __
@@ -38,7 +38,7 @@ export default leafCommand(commandInfo, async (options) => {
 
   if (options.args.length || options["--"]?.length) {
     console.log();
-    log.warn("Warning, unused options:", JSON.stringify(options));
+    log.warn("Warning, unused options:", JSON.stringify(options, null, 2));
   }
 
   await printCommandUsage(baseCommandInfo, baseCommands);

--- a/common/tools/dev-tool/src/framework/command.ts
+++ b/common/tools/dev-tool/src/framework/command.ts
@@ -59,7 +59,7 @@ export function makeCommandInfo<Opts extends CommandOptions>(
   return {
     name,
     description,
-    options: options as StrictAllowMultiple<Opts>
+    options: options as StrictAllowMultiple<Opts>,
   };
 }
 
@@ -96,12 +96,19 @@ export function subCommand<Info extends CommandInfo<CommandOptions>>(
       process.exit(1);
     }
 
-    log.debug(`$ ${commandName} ${commandArgs?.join(" ") ?? ""}`);
+    const extraArgs = options["--"];
+
+    const fullArgs =
+      extraArgs !== undefined && extraArgs.length > 0
+        ? [...commandArgs, "--", ...extraArgs]
+        : commandArgs;
+
+    log.debug(`$ ${commandName} ${fullArgs.join(" ") ?? ""}`);
 
     if (Object.prototype.hasOwnProperty.call(commands, commandName)) {
       const commandModule = await commands[commandName]();
 
-      return await commandModule.default(...commandArgs);
+      return await commandModule.default(...fullArgs);
     } else {
       log.error("No such sub-command:", commandName);
       await printCommandUsage(info, commands, console.error);

--- a/common/tools/dev-tool/test/framework.spec.ts
+++ b/common/tools/dev-tool/test/framework.spec.ts
@@ -13,8 +13,8 @@ const simpleCommandInfo = makeCommandInfo("simple", "a simple command", {
     kind: "string",
     description: "a simple argument",
     allowMultiple: false,
-    default: "foo"
-  }
+    default: "foo",
+  },
 });
 
 interface SimpleExpectedOptionsType {
@@ -33,15 +33,15 @@ describe("Command Framework", () => {
         {
           sub: async () => ({
             commandInfo: { name: "sub", description: "a leaf command" },
-            default: leafCommand({ name: "sub", description: "a leaf command" }, async () => true)
+            default: leafCommand({ name: "sub", description: "a leaf command" }, async () => true),
           }),
           fail: async () => ({
             commandInfo: { name: "fail", description: "a command that fails" },
             default: leafCommand(
               { name: "fail", description: "a command that fails" },
               async () => false
-            )
-          })
+            ),
+          }),
         }
       );
 
@@ -72,6 +72,29 @@ describe("Command Framework", () => {
         simpleCommandInfo.options
       );
       assert.equal(opts.simpleArg, "test");
+    });
+
+    it("nested", async () => {
+      const nestedOptions = {
+        name: "nested",
+        description: "",
+        options: { internal: { kind: "boolean", description: "" } },
+      } as const;
+      const command = subCommand(
+        { name: "top-level", description: "" },
+        {
+          nested: () =>
+            Promise.resolve({
+              default: leafCommand(nestedOptions, (options) => {
+                assert.deepStrictEqual(options["--"], ["test1", "test2"]);
+                return Promise.resolve(true);
+              }),
+              commandInfo: nestedOptions,
+            }),
+        }
+      );
+
+      assert.isTrue(await command("nested", "--internal", "--", "test1", "test2"));
     });
   });
 });


### PR DESCRIPTION
Merely adding `--` args wasn't enough. Dev-tool's argument parsing is recursive, and it achieves this by passing the remainder of a branching-command's `args` back through the arg parser until a leaf-command is reached. Unfortunately, that means that if `--` args are parsed at the first step of the process, they aren't passed back into further subcommands' arguments. This meant that `--` had to be used by the first command. This change updates the argument passing behavior of `subCommand` to make it so that branching commands pass `--` arguments to their children.

I had previously tested to make sure that argument parsing worked as expected, but now I've also added a test to validate that `--` options are received by child commands.

@HarshaNalluru 