### PR TITLE
[engSys] - Add generated folders to policheck exclusions

### DIFF
--- a/eng/guardian-tools/policheck/PolicheckExclusions.xml
+++ b/eng/guardian-tools/policheck/PolicheckExclusions.xml
@@ -2,6 +2,7 @@
 <!-- All strings must be UPPER CASE -->
 <!-- Each of these exclusions is a folder name - if \[name]\ exists in the file path, it will be skipped -->
 <Exclusion Type="FolderPathFull">RECORDINGS</Exclusion>
+<Exclusion Type="FolderPathFull">GENERATED</Exclusion>
 <!-- Each of these exclusions is a folder name - if any folder or file starts with "\[name]", it will be 
 skipped -->
 <!--<Exclusion Type="FolderPathStart">ABC|XYZ</Exclusion>-->


### PR DESCRIPTION
## What

- Add `*generated*` folders to Policheck exclusions

## Why

Because generated code is generated directly from the swagger we should not flag
it as Policheck terms as that would be noisy, the upstream service swagger as
presumably already validated their terms, and really the service team owns the
terms here.

While we should continue to validate our codebase for global readiness, limiting
our checks to hand-authored and/or API review files only makes sense. Similar to
our recordings (which are also excluded). I spoke to @chidozieononiwu offline 
about this as well.
