### PR TITLE
[Event Hubs] Add support for MessageWithMetadata

### DIFF
--- a/sdk/eventhub/event-hubs/CHANGELOG.md
+++ b/sdk/eventhub/event-hubs/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Features Added
 
+- Added support for sending messages of type `MessageWithMetadata` that can be created by Schema Registry encoders.
+
 ### Breaking Changes
 
 ### Bugs Fixed

--- a/sdk/eventhub/event-hubs/review/event-hubs.api.md
+++ b/sdk/eventhub/event-hubs/review/event-hubs.api.md
@@ -92,7 +92,7 @@ export interface EventDataBatch {
     // @internal
     readonly partitionKey?: string;
     readonly sizeInBytes: number;
-    tryAdd(eventData: EventData | AmqpAnnotatedMessage, options?: TryAddOptions): boolean;
+    tryAdd(eventData: EventData | AmqpAnnotatedMessage | MessageWithMetadata, options?: TryAddOptions): boolean;
 }
 
 // @public
@@ -101,8 +101,8 @@ export class EventHubBufferedProducerClient {
     constructor(connectionString: string, eventHubName: string, options: EventHubBufferedProducerClientOptions);
     constructor(fullyQualifiedNamespace: string, eventHubName: string, credential: TokenCredential | NamedKeyCredential | SASCredential, options: EventHubBufferedProducerClientOptions);
     close(options?: BufferedCloseOptions): Promise<void>;
-    enqueueEvent(event: EventData | AmqpAnnotatedMessage, options?: EnqueueEventOptions): Promise<number>;
-    enqueueEvents(events: EventData[] | AmqpAnnotatedMessage[], options?: EnqueueEventOptions): Promise<number>;
+    enqueueEvent(event: EventData | AmqpAnnotatedMessage | MessageWithMetadata, options?: EnqueueEventOptions): Promise<number>;
+    enqueueEvents(events: EventData[] | AmqpAnnotatedMessage[] | MessageWithMetadata[], options?: EnqueueEventOptions): Promise<number>;
     get eventHubName(): string;
     flush(options?: BufferedFlushOptions): Promise<void>;
     get fullyQualifiedNamespace(): string;
@@ -173,7 +173,7 @@ export class EventHubProducerClient {
     getEventHubProperties(options?: GetEventHubPropertiesOptions): Promise<EventHubProperties>;
     getPartitionIds(options?: GetPartitionIdsOptions): Promise<Array<string>>;
     getPartitionProperties(partitionId: string, options?: GetPartitionPropertiesOptions): Promise<PartitionProperties>;
-    sendBatch(batch: EventData[] | AmqpAnnotatedMessage[], options?: SendBatchOptions): Promise<void>;
+    sendBatch(batch: EventData[] | AmqpAnnotatedMessage[] | MessageWithMetadata[], options?: SendBatchOptions): Promise<void>;
     sendBatch(batch: EventDataBatch, options?: OperationOptions): Promise<void>;
 }
 
@@ -225,18 +225,24 @@ export interface LoadBalancingOptions {
 // @public
 export const logger: AzureLogger;
 
+// @public
+export interface MessageWithMetadata {
+    contentType: string;
+    data: Uint8Array;
+}
+
 export { MessagingError }
 
 // @public
 export interface OnSendEventsErrorContext {
     error: Error;
-    events: Array<EventData | AmqpAnnotatedMessage>;
+    events: Array<EventData | AmqpAnnotatedMessage | MessageWithMetadata>;
     partitionId: string;
 }
 
 // @public
 export interface OnSendEventsSuccessContext {
-    events: Array<EventData | AmqpAnnotatedMessage>;
+    events: Array<EventData | AmqpAnnotatedMessage | MessageWithMetadata>;
     partitionId: string;
 }
 

--- a/sdk/eventhub/event-hubs/src/eventHubBufferedProducerClient.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubBufferedProducerClient.ts
@@ -16,6 +16,7 @@ import { AbortController } from "@azure/abort-controller";
 import { AmqpAnnotatedMessage } from "@azure/core-amqp";
 import { BatchingPartitionChannel } from "./batchingPartitionChannel";
 import { PartitionAssigner } from "./impl/partitionAssigner";
+import { MessageWithMetadata } from "./messageWithMetadata";
 
 /**
  * Contains the events that were successfully sent to the Event Hub,
@@ -27,9 +28,9 @@ export interface OnSendEventsSuccessContext {
    */
   partitionId: string;
   /**
-   * The array of {@link EventData} and/or `AmqpAnnotatedMessage` that were successfully sent to the Event Hub.
+   * The array of {@link EventData}, `AmqpAnnotatedMessage`, and/or {@link MessageWithMetadata} that were successfully sent to the Event Hub.
    */
-  events: Array<EventData | AmqpAnnotatedMessage>;
+  events: Array<EventData | AmqpAnnotatedMessage | MessageWithMetadata>;
 }
 
 /**
@@ -42,9 +43,9 @@ export interface OnSendEventsErrorContext {
    */
   partitionId: string;
   /**
-   * The array of {@link EventData} and/or `AmqpAnnotatedMessage` that were not successfully sent to the Event Hub.
+   * The array of {@link EventData}, `AmqpAnnotatedMessage`, and/or {@link MessageWithMetadata}  that were not successfully sent to the Event Hub.
    */
-  events: Array<EventData | AmqpAnnotatedMessage>;
+  events: Array<EventData | AmqpAnnotatedMessage | MessageWithMetadata>;
   /**
    * The error that occurred when sending the associated events to the Event Hub.
    */
@@ -305,7 +306,7 @@ export class EventHubBufferedProducerClient {
    * but it may not have been published yet.
    * Publishing will take place at a nondeterministic point in the future as the buffer is processed.
    *
-   * @param events - An {@link EventData} or `AmqpAnnotatedMessage`.
+   * @param events - An {@link EventData}, `AmqpAnnotatedMessage`, or {@link MessageWithMetadata}.
    * @param options - A set of options that can be specified to influence the way in which
    * the event is sent to the associated Event Hub.
    * - `abortSignal`  : A signal used to cancel the enqueueEvent operation.
@@ -314,7 +315,7 @@ export class EventHubBufferedProducerClient {
    * @returns The total number of events that are currently buffered and waiting to be published, across all partitions.
    */
   async enqueueEvent(
-    event: EventData | AmqpAnnotatedMessage,
+    event: EventData | AmqpAnnotatedMessage | MessageWithMetadata,
     options: EnqueueEventOptions = {}
   ): Promise<number> {
     if (this._isClosed) {
@@ -350,7 +351,7 @@ export class EventHubBufferedProducerClient {
    * but it may not have been published yet.
    * Publishing will take place at a nondeterministic point in the future as the buffer is processed.
    *
-   * @param events - An array of {@link EventData} or `AmqpAnnotatedMessage`.
+   * @param events - An array of {@link EventData}, `AmqpAnnotatedMessage`, or {@link MessageWithMetadata}.
    * @param options - A set of options that can be specified to influence the way in which
    * events are sent to the associated Event Hub.
    * - `abortSignal`  : A signal used to cancel the enqueueEvents operation.
@@ -359,7 +360,7 @@ export class EventHubBufferedProducerClient {
    * @returns The total number of events that are currently buffered and waiting to be published, across all partitions.
    */
   async enqueueEvents(
-    events: EventData[] | AmqpAnnotatedMessage[],
+    events: EventData[] | AmqpAnnotatedMessage[] | MessageWithMetadata[],
     options: EnqueueEventOptions = {}
   ): Promise<number> {
     for (const event of events) {

--- a/sdk/eventhub/event-hubs/src/index.ts
+++ b/sdk/eventhub/event-hubs/src/index.ts
@@ -51,3 +51,4 @@ export {
   parseEventHubConnectionString,
   EventHubConnectionStringProperties
 } from "./util/connectionStringUtils";
+export { MessageWithMetadata } from "./messageWithMetadata";

--- a/sdk/eventhub/event-hubs/src/messageWithMetadata.ts
+++ b/sdk/eventhub/event-hubs/src/messageWithMetadata.ts
@@ -1,0 +1,43 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { AmqpAnnotatedMessage } from "@azure/core-amqp";
+import { EventData } from "./eventData";
+import { isObjectWithProperties, objectHasProperty } from "./util/typeGuards";
+
+/**
+ * A message that contains binary data and a content type.
+ */
+export interface MessageWithMetadata {
+  /**
+   * The message's binary data
+   */
+  data: Uint8Array;
+  /**
+   * The message's content type
+   */
+  contentType: string;
+}
+
+/**
+ * @internal
+ */
+export function isMessageWithMetadata(possible: unknown): possible is MessageWithMetadata {
+  return (
+    isObjectWithProperties(possible, ["data", "contentType"]) &&
+    !objectHasProperty(possible, "getRawAmqpMessage")
+  );
+}
+
+export function convertMessageWithMetadataToEventData(message: MessageWithMetadata): EventData {
+  return {
+    body: message.data,
+    contentType: message.contentType
+  };
+}
+
+export function toEventData(
+  message: EventData | AmqpAnnotatedMessage | MessageWithMetadata
+): EventData {
+  return isMessageWithMetadata(message) ? convertMessageWithMetadataToEventData(message) : message;
+}


### PR DESCRIPTION
Adds support for sending messages of type `MessageWithMetadata` that can be created by Schema Registry encoders. See https://github.com/Azure/azure-sdk-for-js/pull/18365/ for samples.