### PR TITLE
[Tables] Fix live tests

### DIFF
--- a/sdk/tables/data-tables/README.md
+++ b/sdk/tables/data-tables/README.md
@@ -123,6 +123,24 @@ const { TableServiceClient, AzureNamedKeyCredential } = require("@azure/data-tab
 
 The `TableServiceClient` requires a URL to the table service and an access credential. It also optionally accepts some settings in the `options` parameter.
 
+#### `TableServiceClient` with AzureNamedKeyCredential
+
+You can instantiate a `TableServiceClient` with a `AzureNamedKeyCredential` by passing account-name and account-key as arguments. (The account-name and account-key can be obtained from the azure portal.)
+[ONLY AVAILABLE IN NODE.JS RUNTIME]
+
+```javascript
+const { TableServiceClient, AzureNamedKeyCredential } = require("@azure/data-tables");
+
+const account = "<account>";
+const accountKey = "<accountkey>";
+
+const credential = new AzureNamedKeyCredential(account, accountKey);
+const serviceClient = new TableServiceClient(
+  `https://${account}.table.core.windows.net`,
+  credential
+);
+```
+
 #### `TableServiceClient` with TokenCredential (AAD)
 
 Azure Tables provides integration with Azure Active Directory (Azure AD) for identity-based authentication of requests
@@ -220,7 +238,7 @@ const serviceClient = new TableServiceClient(
 
 async function main() {
   const tableName = `newtable`;
-  // If the table 'newTable' already exists, createTable doesn' throw
+  // If the table 'newTable' already exists, createTable doesn't throw
   await serviceClient.createTable(tableName);
 }
 
@@ -323,6 +341,36 @@ const clientWithSAS = new TableClient(
   `https://${account}.table.core.windows.net`,
   tableName,
   new AzureSASCredential(sas)
+);
+```
+
+#### `TableClient` with TokenCredential (AAD)
+
+Azure Tables provides integration with Azure Active Directory (Azure AD) for identity-based authentication of requests
+to the Table service when targeting a Storage endpoint. With Azure AD, you can use role-based access control (RBAC) to
+grant access to your Azure Table resources to users, groups, or applications.
+
+To access a table resource with a `TokenCredential`, the authenticated identity should have either the "Storage Table Data Contributor" or "Storage Table Data Reader" role.
+
+With the `@azure/identity` package, you can seamlessly authorize requests in both development and production environments.
+To learn more about Azure AD integration in Azure Storage, see the [Azure.Identity README](https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/identity/identity/README.md)
+
+```javascript
+const { TableClient } = require("@azure/data-tables");
+const { DefaultAzureCredential } = require("@azure/identity");
+
+// DefaultAzureCredential expects the following three environment variables:
+// - AZURE_TENANT_ID: The tenant ID in Azure Active Directory
+// - AZURE_CLIENT_ID: The application (client) ID registered in the AAD tenant
+// - AZURE_CLIENT_SECRET: The client secret for the registered application
+const credential = new DefaultAzureCredential();
+const account = "<account name>";
+const tableName = "<tableName>";
+
+const clientWithAAD = new TableClient(
+  `https://${account}.table.core.windows.net`,
+  tableName,
+  credential
 );
 ```
 

--- a/sdk/tables/data-tables/samples-dev/authenticationMethods.ts
+++ b/sdk/tables/data-tables/samples-dev/authenticationMethods.ts
@@ -36,7 +36,7 @@ const sasConnectionString = process.env["SAS_CONNECTION_STRING"] || "";
 const sasToken = process.env["SAS_TOKEN"] || "";
 
 /**
- * Create a TableServiceCLient using a SAS connection String
+ * Create a TableServiceClient using a SAS connection String
  */
 async function tableServiceClientWithSasConnectionString() {
   const client = TableServiceClient.fromConnectionString(sasConnectionString);
@@ -44,7 +44,7 @@ async function tableServiceClientWithSasConnectionString() {
 }
 
 /**
- * Create a TableServiceCLient using a SAS connection String
+ * Create a TableServiceClient using a SAS connection String
  */
 async function tableServiceClientWithAAD() {
   // DefaultAzureCredential expects the following three environment variables:
@@ -57,7 +57,7 @@ async function tableServiceClientWithAAD() {
 }
 
 /**
- * Create a TableServiceCLient using a SAS token
+ * Create a TableServiceClient using a SAS token
  */
 async function tableServiceClientWithSasToken() {
   const client = new TableServiceClient(tablesUrl, new AzureSASCredential(sasToken));
@@ -65,7 +65,7 @@ async function tableServiceClientWithSasToken() {
 }
 
 /**
- * Create a TableServiceCLient using an Account connection String.
+ * Create a TableServiceClient using an Account connection String.
  * Note that this authentication method is only supported in Node,
  * and it is not available for browsers
  */
@@ -75,7 +75,7 @@ async function tableServiceClientWithAccountConnectionString() {
 }
 
 /**
- * Create a TableServiceCLient using account name and account key
+ * Create a TableServiceClient using account name and account key
  * Note that this authentication method is only supported in Node,
  * and it is not available for browsers
  */

--- a/sdk/tables/data-tables/samples-dev/generateTableSAS.ts
+++ b/sdk/tables/data-tables/samples-dev/generateTableSAS.ts
@@ -49,9 +49,10 @@ async function generateTableSasSample() {
   };
 
   // Generate an account SAS with the NamedKeyCredential and the permissions set previously
+  // by default, expiration is set an hour after the SAS is created. Expiration can be
+  // set explicitly by passing expiresOn with the desired expiration Date
   const accountSas = generateAccountSas(cred, {
-    permissions,
-    expiresOn: new Date("2021-12-12")
+    permissions
   });
 
   const tableService = new TableServiceClient(tablesUrl, new AzureSASCredential(accountSas));
@@ -90,7 +91,11 @@ async function generateTableSasSample() {
   const table = new TableClient(tablesUrl, tableName, new AzureSASCredential(tableSas));
 
   // Create an entity in the table
-  await table.createEntity({ partitionKey: "test", rowKey: "1", foo: "bar" });
+  await table.createEntity({
+    partitionKey: "test",
+    rowKey: "1",
+    foo: "bar"
+  });
 
   // List all the entities in the table
   const entities = table.listEntities();

--- a/sdk/tables/data-tables/test/internal/node/generateSas.spec.ts
+++ b/sdk/tables/data-tables/test/internal/node/generateSas.spec.ts
@@ -14,7 +14,7 @@ describe("SAS generation", function() {
 
     afterEach(() => {
       if (clock) {
-        clock.reset();
+        clock.restore();
       }
     });
 
@@ -92,7 +92,7 @@ describe("SAS generation", function() {
 
     afterEach(() => {
       if (clock) {
-        clock.reset();
+        clock.restore();
       }
     });
 


### PR DESCRIPTION
Live tests got broken. After spending some time investigating the errors, I was able to find the root cause. It is because generateSas tests are mocking the system's timer and we were incorrectly restoring the timers after each test. This causes the following test to use the mocked timers hence producing invalid signatures.

The fix is to call `clock.restore()` instead of `clock.reset()` in `afterEach` when mocking the timers

Also adding a few documentation fixes in this PR

Fixes #19313, #19021 and #19019