### PR TITLE
[Tables] Honor custom HTTP client in transactions

### DIFF
--- a/sdk/tables/data-tables/src/TableClient.ts
+++ b/sdk/tables/data-tables/src/TableClient.ts
@@ -87,6 +87,7 @@ export class TableClient {
   private table: Table;
   private credential?: NamedKeyCredential | SASCredential | TokenCredential;
   private transactionClient?: InternalTableTransaction;
+  private clientOptions: TableClientOptions;
   private readonly allowInsecureConnection: boolean;
 
   /**
@@ -224,14 +225,13 @@ export class TableClient {
     const credential = isCredential(credentialOrOptions) ? credentialOrOptions : undefined;
     this.credential = credential;
 
-    const clientOptions =
-      (!isCredential(credentialOrOptions) ? credentialOrOptions : options) || {};
+    this.clientOptions = (!isCredential(credentialOrOptions) ? credentialOrOptions : options) || {};
 
-    this.allowInsecureConnection = clientOptions.allowInsecureConnection ?? false;
-    clientOptions.endpoint = clientOptions.endpoint || this.url;
+    this.allowInsecureConnection = this.clientOptions.allowInsecureConnection ?? false;
+    this.clientOptions.endpoint = this.clientOptions.endpoint || this.url;
 
     const internalPipelineOptions: InternalClientPipelineOptions = {
-      ...clientOptions,
+      ...this.clientOptions,
       loggingOptions: {
         logger: logger.info,
         additionalAllowedHeaderNames: [...TablesLoggingAllowedHeaderNames]
@@ -890,6 +890,7 @@ export class TableClient {
         partitionKey,
         transactionId,
         changesetId,
+        this.clientOptions,
         new TableClient(this.url, this.tableName),
         this.credential,
         this.allowInsecureConnection

--- a/sdk/tables/data-tables/test/public/transaction.spec.ts
+++ b/sdk/tables/data-tables/test/public/transaction.spec.ts
@@ -13,7 +13,6 @@ import { Context } from "mocha";
 import { Uuid } from "../../src/utils/uuid";
 import { assert } from "chai";
 import { isNode } from "@azure/test-utils";
-import { createHttpHeaders, HttpClient } from "@azure/core-rest-pipeline";
 
 // SASConnectionString and SASToken are supported in both node and browser
 const authModes: CreateClientMode[] = ["TokenCredential", "SASConnectionString"];
@@ -81,23 +80,6 @@ authModes.forEach((authMode) => {
       assert.lengthOf(result.subResponses, 2);
       assert.equal(result.getResponseForEntity("1")?.status, 204);
       assert.equal(result.getResponseForEntity("2")?.status, 204);
-    });
-
-    it("should honor the custom httpClient passed to the TableClient", async () => {
-      let isProxy = false;
-      const proxyHttpClient: HttpClient = {
-        sendRequest: async (request) => {
-          isProxy = true;
-          return { status: 200, headers: createHttpHeaders(), request };
-        }
-      };
-      client = new TableClient("https://example.org", tableName, { httpClient: proxyHttpClient });
-      const transaction = new TableTransaction();
-      transaction.createEntity({ partitionKey: "helper", rowKey: "1", value: "t1" });
-      transaction.createEntity({ partitionKey: "helper", rowKey: "2", value: "t2" });
-
-      await client.submitTransaction(transaction.actions);
-      assert.isTrue(isProxy);
     });
 
     it("should send a set of create batch operations", async () => {


### PR DESCRIPTION
**Problem**
Within the transaction, we are creating a new service client to send the custom transactional batch request. However, we are dismissing any client options passed to the table client.

**Fix**
Pass the client options to `InternalTableTransaction` constructor and then in `submitTransaction` build the serviceClient with these options

Reported in #19243