### PR TITLE
[Recorder] Changelog

### DIFF
--- a/sdk/test-utils/recorder/CHANGELOG.md
+++ b/sdk/test-utils/recorder/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.0.2 (Unreleased)
+## 1.0.2 (2021-12-20)
 
 Fixed double replacements in case the source value and the replacement happened to remain the same after encoding.
 


### PR DESCRIPTION
And as discussed here, https://github.com/Azure/azure-sdk-for-js/pull/19446#discussion_r771725207, I'm planning to delete the old recorder and call the new recorder 2.0.0 since the old recorder is already published and the existing packages/tests remain functioning the same way they do right now.

I'll make a new PR to delete once #19446  is merged.



Any change to the old recorder would go in as a hotfix from now on.

There is one unreleased item in the changelog, this PR is to release that.