### PR TITLE
Fix use of hidden tag in Event Hubs packages

### DIFF
--- a/sdk/eventhub/event-hubs/src/diagnostics/instrumentEventData.ts
+++ b/sdk/eventhub/event-hubs/src/diagnostics/instrumentEventData.ts
@@ -13,7 +13,7 @@ import { SpanContext } from "@azure/core-tracing";
 import { createMessageSpan } from "./tracing";
 
 /**
- * @hidden
+ * @internal
  */
 export const TRACEPARENT_PROPERTY = "Diagnostic-Id";
 

--- a/sdk/eventhub/event-hubs/src/eventData.ts
+++ b/sdk/eventhub/event-hubs/src/eventData.ts
@@ -8,7 +8,7 @@ import { isDefined, isObjectWithProperties, objectHasProperty } from "./util/typ
 
 /**
  * Describes the delivery annotations.
- * @hidden
+ * @internal
  */
 export interface EventHubDeliveryAnnotations extends DeliveryAnnotations {
   /**
@@ -35,7 +35,7 @@ export interface EventHubDeliveryAnnotations extends DeliveryAnnotations {
 
 /**
  * Map containing message attributes that will be held in the message header.
- * @hidden
+ * @internal
  */
 export interface EventHubMessageAnnotations extends MessageAnnotations {
   /**
@@ -62,7 +62,7 @@ export interface EventHubMessageAnnotations extends MessageAnnotations {
 
 /**
  * Describes the structure of an event to be sent or received from the EventHub.
- * @hidden
+ * @internal
  */
 export interface EventDataInternal {
   /**
@@ -157,7 +157,7 @@ const messagePropertiesMap = {
  * Converts the AMQP message to an EventData.
  * @param msg - The AMQP message that needs to be converted to EventData.
  * @param skipParsingBodyAsJson - Boolean to skip running JSON.parse() on message body when body type is `content`.
- * @hidden
+ * @internal
  */
 export function fromRheaMessage(
   msg: RheaMessage,

--- a/sdk/eventhub/event-hubs/src/eventHubReceiver.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubReceiver.ts
@@ -27,9 +27,6 @@ import { EventHubConsumerOptions } from "./models/private";
 import { LinkEntity } from "./linkEntity";
 import { getRetryAttemptTimeoutInMs } from "./util/retries";
 
-/**
- * @hidden
- */
 interface CreateReceiverOptions {
   onMessage: OnAmqpEvent;
   onError: OnAmqpEvent;
@@ -190,7 +187,6 @@ export class EventHubReceiver extends LinkEntity {
   /**
    * Instantiates a receiver that can be used to receive events over an AMQP receiver link in
    * either batching or streaming mode.
-   * @hidden
    * @param context -        The connection context corresponding to the EventHubClient instance
    * @param consumerGroup -  The consumer group from which the receiver should receive events from.
    * @param partitionId -    The Partition ID from which to receive.
@@ -373,7 +369,6 @@ export class EventHubReceiver extends LinkEntity {
 
   /**
    * Clears the user-provided handlers and updates the receiving messages flag.
-   * @hidden
    */
   clearHandlers(): void {
     if (this._abortSignal && this._onAbort) {
@@ -390,7 +385,6 @@ export class EventHubReceiver extends LinkEntity {
 
   /**
    * Closes the underlying AMQP receiver.
-   * @hidden
    */
   async close(): Promise<void> {
     try {
@@ -415,7 +409,6 @@ export class EventHubReceiver extends LinkEntity {
 
   /**
    * Determines whether the AMQP receiver link is open. If open then returns true else returns false.
-   * @hidden
    * @returns boolean
    */
   isOpen(): boolean {
@@ -433,7 +426,6 @@ export class EventHubReceiver extends LinkEntity {
   /**
    * Registers the user's onMessage and onError handlers.
    * Sends buffered events from the queue before adding additional credits to the AMQP link.
-   * @hidden
    */
   registerHandlers(
     onMessage: OnMessage,
@@ -552,7 +544,6 @@ export class EventHubReceiver extends LinkEntity {
 
   /**
    * Creates a new AMQP receiver under a new AMQP session.
-   * @hidden
    */
   async initialize({
     abortSignal,
@@ -626,7 +617,6 @@ export class EventHubReceiver extends LinkEntity {
 
   /**
    * Creates the options that need to be specified while creating an AMQP receiver link.
-   * @hidden
    */
   private _createReceiverOptions(options: CreateReceiverOptions): RheaReceiverOptions {
     const rcvrOptions: RheaReceiverOptions = {

--- a/sdk/eventhub/event-hubs/src/eventHubSender.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubSender.ts
@@ -71,7 +71,6 @@ export class EventHubSender extends LinkEntity {
 
   /**
    * Creates a new EventHubSender instance.
-   * @hidden
    * @param context - The connection context.
    * @param partitionId - The EventHub partition id to which the sender
    * wants to send the event data.
@@ -163,7 +162,6 @@ export class EventHubSender extends LinkEntity {
 
   /**
    * Deletes the sender from the context. Clears the token renewal timer. Closes the sender link.
-   * @hidden
    * @returns Promise<void>
    */
   async close(): Promise<void> {
@@ -188,7 +186,6 @@ export class EventHubSender extends LinkEntity {
 
   /**
    * Determines whether the AMQP sender link is open. If open then returns true else returns false.
-   * @hidden
    * @returns boolean
    */
   isOpen(): boolean {
@@ -224,7 +221,6 @@ export class EventHubSender extends LinkEntity {
    * Send a batch of EventData to the EventHub. The "message_annotations",
    * "application_properties" and "properties" of the first message will be set as that
    * of the envelope (batch message).
-   * @hidden
    * @param events -  An array of EventData objects to be sent in a Batch message.
    * @param options - Options to control the way the events are batched along with request options
    */
@@ -323,7 +319,6 @@ export class EventHubSender extends LinkEntity {
    *
    * We have implemented a synchronous send over here in the sense that we shall be waiting
    * for the message to be accepted or rejected and accordingly resolve or reject the promise.
-   * @hidden
    * @param rheaMessage - The message to be sent to EventHub.
    * @returns Promise<void>
    */
@@ -497,7 +492,6 @@ export class EventHubSender extends LinkEntity {
   /**
    * Initializes the sender session on the connection.
    * Should only be called from _createLinkIfNotOpen
-   * @hidden
    */
   private async _init(
     options: AwaitableSenderOptions & {
@@ -562,7 +556,6 @@ export class EventHubSender extends LinkEntity {
   /**
    * Creates a new sender to the given event hub, and optionally to a given partition if it is
    * not present in the context or returns the one present in the context.
-   * @hidden
    * @param partitionId - Partition ID to which it will send event data.
    */
   static create(context: ConnectionContext, partitionId?: string): EventHubSender {

--- a/sdk/eventhub/event-hubs/src/impl/awaitableQueue.ts
+++ b/sdk/eventhub/event-hubs/src/impl/awaitableQueue.ts
@@ -7,7 +7,7 @@
  * This differs from ordinary Queues in that `shift` returns a Promise for a value.
  * This allows a consumer of the queue to request an item that the queue does not yet have.
  *
- * @hidden
+ * @internal
  */
 export class AwaitableQueue<T> {
   private readonly _items: T[];

--- a/sdk/eventhub/event-hubs/src/linkEntity.ts
+++ b/sdk/eventhub/event-hubs/src/linkEntity.ts
@@ -11,7 +11,7 @@ import { logger } from "./log";
 import { v4 as uuid } from "uuid";
 
 /**
- * @hidden
+ * @internal
  */
 export interface LinkEntityOptions {
   /**
@@ -95,7 +95,6 @@ export class LinkEntity {
   protected _tokenTimeoutInMs?: number;
   /**
    * Creates a new LinkEntity instance.
-   * @hidden
    * @param context - The connection context.
    * @param options - Options that can be provided while creating the LinkEntity.
    */
@@ -110,7 +109,6 @@ export class LinkEntity {
 
   /**
    * Negotiates cbs claim for the LinkEntity.
-   * @hidden
    * @returns Promise<void>
    */
   protected async _negotiateClaim({
@@ -213,7 +211,6 @@ export class LinkEntity {
 
   /**
    * Ensures that the token is renewed within the predefined renewal margin.
-   * @hidden
    */
   protected _ensureTokenRenewal(): void {
     if (!this._tokenTimeoutInMs) {
@@ -257,7 +254,6 @@ export class LinkEntity {
   /**
    * Closes the Sender|Receiver link and it's underlying session and also removes it from the
    * internal map.
-   * @hidden
    * @param link - The Sender or Receiver link that needs to be closed and
    * removed.
    */

--- a/sdk/eventhub/event-hubs/src/loadBalancerStrategies/loadBalancingStrategy.ts
+++ b/sdk/eventhub/event-hubs/src/loadBalancerStrategies/loadBalancingStrategy.ts
@@ -58,7 +58,6 @@ interface EventProcessorCounts {
  *
  * @param partitionOwnershipMap - The existing PartitionOwnerships mapped by partition.
  * @param expirationIntervalInMs - The length of time a PartitionOwnership claim is valid.
- * @hidden
  */
 function getActivePartitionOwnerships(
   partitionOwnershipMap: Map<string, PartitionOwnership>,

--- a/sdk/eventhub/event-hubs/src/log.ts
+++ b/sdk/eventhub/event-hubs/src/log.ts
@@ -13,7 +13,7 @@ export const logger = createClientLogger("event-hubs");
 /**
  * Logs the error's stack trace to "verbose" if a stack trace is available.
  * @param error - Error containing a stack trace.
- * @hidden
+ * @internal
  */
 export function logErrorStackTrace(error: unknown): void {
   if (isObjectWithProperties(error, ["stack"]) && error.stack) {

--- a/sdk/eventhub/event-hubs/src/managementClient.ts
+++ b/sdk/eventhub/event-hubs/src/managementClient.ts
@@ -117,7 +117,6 @@ export class ManagementClient extends LinkEntity {
 
   /**
    * Instantiates the management client.
-   * @hidden
    * @param context - The connection context.
    * @param address - The address for the management endpoint. For IotHub it will be
    * `/messages/events/$management`.
@@ -155,7 +154,6 @@ export class ManagementClient extends LinkEntity {
 
   /**
    * Provides the eventhub runtime information.
-   * @hidden
    */
   async getEventHubProperties(
     options: OperationOptions & { retryOptions?: RetryOptions } = {}
@@ -211,7 +209,6 @@ export class ManagementClient extends LinkEntity {
 
   /**
    * Provides information about the specified partition.
-   * @hidden
    * @param partitionId - Partition ID for which partition information is required.
    */
   async getPartitionProperties(
@@ -285,7 +282,6 @@ export class ManagementClient extends LinkEntity {
   /**
    * Closes the AMQP management session to the Event Hub for this client,
    * returning a promise that will be resolved when disconnection is completed.
-   * @hidden
    */
   async close(): Promise<void> {
     try {

--- a/sdk/eventhub/event-hubs/src/pumpManager.ts
+++ b/sdk/eventhub/event-hubs/src/pumpManager.ts
@@ -48,7 +48,6 @@ export interface PumpManager {
  * The PumpManager handles the creation and removal of PartitionPumps.
  * It also starts a PartitionPump when it is created, and stops a
  * PartitionPump when it is removed.
- * @hidden
  * @internal
  */
 export class PumpManagerImpl implements PumpManager {
@@ -58,9 +57,6 @@ export class PumpManagerImpl implements PumpManager {
     [partitionId: string]: PartitionPump | undefined;
   } = {};
 
-  /**
-   * @hidden
-   */
   constructor(eventProcessorName: string, eventProcessorOptions: CommonEventProcessorOptions) {
     this._eventProcessorName = eventProcessorName;
     this._options = eventProcessorOptions;
@@ -68,7 +64,6 @@ export class PumpManagerImpl implements PumpManager {
 
   /**
    * Returns a list of partitionIds that are actively receiving messages.
-   * @hidden
    */
   public receivingFromPartitions(): string[] {
     return Object.keys(this._partitionIdToPumps).filter((id) => {
@@ -91,7 +86,6 @@ export class PumpManagerImpl implements PumpManager {
    * @param startPosition - The position in the partition to start reading from.
    * @param connectionContext - The ConnectionContext to forward to the PartitionPump.
    * @param partitionProcessor - The PartitionProcessor to forward to the PartitionPump.
-   * @hidden
    */
   public async createPump(
     startPosition: EventPosition,
@@ -147,7 +141,6 @@ export class PumpManagerImpl implements PumpManager {
    * Stop a PartitionPump and removes it from the internal map.
    * @param partitionId - The partitionId to remove the associated PartitionPump from.
    * @param reason - The reason for removing the pump.
-   * @hidden
    */
   public async removePump(partitionId: string, reason: CloseReason): Promise<void> {
     try {
@@ -172,7 +165,6 @@ export class PumpManagerImpl implements PumpManager {
   /**
    * Stops all PartitionPumps and removes them from the internal map.
    * @param reason - The reason for removing the pump.
-   * @hidden
    */
   public async removeAllPumps(reason: CloseReason): Promise<void> {
     const partitionIds = Object.keys(this._partitionIdToPumps);

--- a/sdk/eventhub/event-hubs/src/util/constants.ts
+++ b/sdk/eventhub/event-hubs/src/util/constants.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 
 /**
- * @hidden
+ * @internal
  */
 export const packageJsonInfo = {
   name: "@azure/event-hubs",

--- a/sdk/eventhub/eventhubs-checkpointstore-blob/src/blobCheckpointStore.ts
+++ b/sdk/eventhub/eventhubs-checkpointstore-blob/src/blobCheckpointStore.ts
@@ -342,7 +342,6 @@ type CheckpointMetadata = {
 };
 
 /**
- * @hidden
  * @internal
  */
 export function parseIntOrThrow(

--- a/sdk/eventhub/eventhubs-checkpointstore-table/src/tableCheckpointStore.ts
+++ b/sdk/eventhub/eventhubs-checkpointstore-table/src/tableCheckpointStore.ts
@@ -38,7 +38,6 @@ export interface CheckpointEntity {
 /**
  * An ownership entity of type PartitionOwnership to be stored in the table
  * @internal
- * @hidden
  */
 export interface PartitionOwnershipEntity {
   /**


### PR DESCRIPTION
This PR removes the use of `@hidden` tags from Event Hubs packages as described in #13455
- `@hidden` is not needed on members of a class when the class itself is marked as internal
- `@hidden` is not needed if `@internal` is already added

Resolves #13455