### PR TITLE
Update prettier dev-dependency to v2.5.1 in Attestation

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -752,7 +752,7 @@ packages:
     resolution: {integrity: sha512-Q71Buur3RMcg6lCnisLL8Im562DBw+ybzgm+YQj/FbAaI8ZNu/zl/5z1fE4k3Q9LSIzYrz6HLRzlhdSBXpydlQ==}
     engines: {node: '>=8.0.0'}
     dependencies:
-      '@azure/core-http': 1.2.3
+      '@azure/core-http': 1.2.6
       '@azure/core-tracing': 1.0.0-preview.9
       '@azure/logger': 1.0.3
       '@azure/msal-node': 1.0.0-beta.6_debug@4.3.3
@@ -2883,7 +2883,7 @@ packages:
     resolution: {integrity: sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==}
     deprecated: Debug versions >=3.2.0 <3.2.7 || >=4 <4.3.1 have a low-severity ReDos regression when used in a Node.js environment. It is recommended you upgrade to 3.2.7 or 4.3.1. (https://github.com/visionmedia/debug/issues/797)
     dependencies:
-      ms: 2.1.1
+      ms: 2.1.3
     dev: false
 
   /debug/3.2.7:
@@ -7285,7 +7285,7 @@ packages:
   /wide-align/1.1.5:
     resolution: {integrity: sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==}
     dependencies:
-      string-width: 1.0.2
+      string-width: 4.2.3
     dev: false
 
   /word-wrap/1.2.3:
@@ -9175,7 +9175,7 @@ packages:
     dev: false
 
   file:projects/attestation.tgz:
-    resolution: {integrity: sha512-nwxtRgmucmaelDhzzaN3dmFp6RowTCopWRD/BHOLQE2+3DOLei6Y66mgP33ImNUI/NX0IIYHYNR0CfwoYXCA4Q==, tarball: file:projects/attestation.tgz}
+    resolution: {integrity: sha512-IELRthBObg6cXDGOw++npOHOzJx1zF7N0dmAY7M6tD9nLAy2fN0Eymsbv2kW+oiFqQBjskSDfXQcX+A0N7ujeQ==, tarball: file:projects/attestation.tgz}
     name: '@rush-temp/attestation'
     version: 0.0.0
     dependencies:
@@ -9212,7 +9212,7 @@ packages:
       mocha: 7.2.0
       mocha-junit-reporter: 2.0.2_mocha@7.2.0
       nyc: 15.1.0
-      prettier: 1.19.1
+      prettier: 2.5.1
       rimraf: 3.0.2
       rollup: 1.32.1
       safe-buffer: 5.2.1

--- a/sdk/attestation/attestation/karma.conf.js
+++ b/sdk/attestation/attestation/karma.conf.js
@@ -8,10 +8,10 @@ const {
   jsonRecordingFilterFunction,
   isPlaybackMode,
   isSoftRecordMode,
-  isRecordMode
+  isRecordMode,
 } = require("@azure-tools/test-recorder");
 
-module.exports = function(config) {
+module.exports = function (config) {
   config.set({
     // base path that will be used to resolve all patterns (eg. files, exclude)
     basePath: "./",
@@ -33,13 +33,13 @@ module.exports = function(config) {
       "karma-junit-reporter",
       "karma-json-to-file-reporter",
       "karma-source-map-support",
-      "karma-json-preprocessor"
+      "karma-json-preprocessor",
     ],
 
     // list of files / patterns to load in the browser
     files: [
       "dist-test/index.browser.js",
-      { pattern: "dist-test/index.browser.js.map", type: "html", included: false, served: true }
+      { pattern: "dist-test/index.browser.js.map", type: "html", included: false, served: true },
     ].concat(isPlaybackMode() || isSoftRecordMode() ? ["recordings/browsers/**/*.json"] : []),
 
     // list of files / patterns to exclude
@@ -49,7 +49,7 @@ module.exports = function(config) {
     // available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
     preprocessors: {
       "**/*.js": ["env"],
-      "recordings/browsers/**/*.json": ["json"]
+      "recordings/browsers/**/*.json": ["json"],
       // IMPORTANT: COMMENT following line if you want to debug in your browsers!!
       // Preprocess source file to calculate code coverage, however this will make source file unreadable
       // "dist-test/index.js": ["coverage"]
@@ -68,7 +68,7 @@ module.exports = function(config) {
       "ATTESTATION_ISOLATED_SIGNING_KEY",
       "AZURE_CLIENT_ID",
       "AZURE_CLIENT_SECRET",
-      "AZURE_TENANT_ID"
+      "AZURE_TENANT_ID",
     ],
 
     // test results reporter to use
@@ -83,8 +83,8 @@ module.exports = function(config) {
         { type: "json", subdir: ".", file: "coverage.json" },
         { type: "lcovonly", subdir: ".", file: "lcov.info" },
         { type: "html", subdir: "html" },
-        { type: "cobertura", subdir: ".", file: "cobertura-coverage.xml" }
-      ]
+        { type: "cobertura", subdir: ".", file: "cobertura-coverage.xml" },
+      ],
     },
 
     junitReporter: {
@@ -94,12 +94,12 @@ module.exports = function(config) {
       useBrowserName: false, // add browser name to report and classes names
       nameFormatter: undefined, // function (browser, result) to customize the name attribute in xml testcase element
       classNameFormatter: undefined, // function (browser, result) to customize the classname attribute in xml testcase element
-      properties: {} // key value pair of properties to add to the <properties> section of the report
+      properties: {}, // key value pair of properties to add to the <properties> section of the report
     },
 
     jsonToFileReporter: {
       filter: jsonRecordingFilterFunction,
-      outputPath: "."
+      outputPath: ".",
     },
 
     // web server port
@@ -121,12 +121,12 @@ module.exports = function(config) {
     customLaunchers: {
       ChromeHeadlessNoSandbox: {
         base: "ChromeHeadless",
-        flags: ["--no-sandbox", "--disable-web-security"]
+        flags: ["--no-sandbox", "--disable-web-security"],
       },
       ChromeInteractiveNoSandbox: {
         base: "Chrome",
-        flags: ["--no-sandbox", "--disable-web-security"]
-      }
+        flags: ["--no-sandbox", "--disable-web-security"],
+      },
     },
 
     // Continuous Integration mode
@@ -141,15 +141,15 @@ module.exports = function(config) {
     browserDisconnectTimeout: 10000,
     browserDisconnectTolerance: 3,
     browserConsoleLogOptions: {
-      terminal: !isRecordMode()
+      terminal: !isRecordMode(),
     },
 
     client: {
       mocha: {
         // change Karma's debug.html to the mocha web reporter
         reporter: "html",
-        timeout: 0
-      }
-    }
+        timeout: 0,
+      },
+    },
   });
 };

--- a/sdk/attestation/attestation/package.json
+++ b/sdk/attestation/attestation/package.json
@@ -135,7 +135,7 @@
     "mocha": "^7.1.1",
     "mocha-junit-reporter": "^2.0.0",
     "nyc": "^15.0.0",
-    "prettier": "^1.16.4",
+    "prettier": "^2.5.1",
     "rimraf": "^3.0.0",
     "rollup": "^1.16.3",
     "safe-buffer": "^5.2.1",

--- a/sdk/attestation/attestation/samples-dev/attestEnclaves.ts
+++ b/sdk/attestation/attestation/samples-dev/attestEnclaves.ts
@@ -222,7 +222,7 @@ async function attestOpenEnclaveWithRuntimeData() {
   // it does, it will emit a token for the quote.
   {
     const attestResponse = await client.attestOpenEnclave(openEnclaveReport, {
-      runTimeData: runtimeData
+      runTimeData: runtimeData,
     });
 
     console.log("Received attestation token: ", attestResponse.token.serialize());
@@ -270,7 +270,7 @@ async function attestOpenEnclaveWithRuntimeJson() {
   // it does, it will emit a token for the quote.
   {
     const attestResponse = await client.attestOpenEnclave(openEnclaveReport, {
-      runTimeJson: runtimeJson
+      runTimeJson: runtimeJson,
     });
 
     console.log("Received attestation token: ", attestResponse.token.serialize());
@@ -331,7 +331,7 @@ issuancerules
   c:[type=="x-ms-attestation-type"] => issue(type="tee", value=c.value);
 };`;
     const attestResponse = await client.attestOpenEnclave(openEnclaveReport, {
-      draftPolicyForAttestation: testPolicy
+      draftPolicyForAttestation: testPolicy,
     });
 
     console.log("Received attestation token: ", attestResponse.token.serialize());

--- a/sdk/attestation/attestation/samples-dev/setAttestationPolicy.ts
+++ b/sdk/attestation/attestation/samples-dev/setAttestationPolicy.ts
@@ -33,7 +33,7 @@
 import {
   AttestationAdministrationClient,
   createAttestationPolicyToken,
-  KnownAttestationType
+  KnownAttestationType,
 } from "@azure/attestation";
 import { DefaultAzureCredential } from "@azure/identity";
 
@@ -137,7 +137,7 @@ async function setOpenEnclaveAttestationPolicyAadSecured() {
 
   const setPolicyResult = await client.setPolicy(KnownAttestationType.OpenEnclave, newPolicy, {
     privateKey: privateKey,
-    certificate: certificate
+    certificate: certificate,
   });
 
   // Verify that the attestation service received the new policy.
@@ -207,7 +207,7 @@ async function setSgxEnclaveAttestationPolicyIsolatedSecured() {
 
   const setPolicyResult = await client.setPolicy(KnownAttestationType.SgxEnclave, newPolicy, {
     privateKey: privateKey,
-    certificate: certificate
+    certificate: certificate,
   });
 
   // Verify that the attestation service received the new policy.
@@ -230,7 +230,7 @@ async function setSgxEnclaveAttestationPolicyIsolatedSecured() {
   // Now reset the policy to the default policy.
   const resetPolicyResult = await client.resetPolicy(KnownAttestationType.SgxEnclave, {
     privateKey: privateKey,
-    certificate: certificate
+    certificate: certificate,
   });
 
   console.log("Reset attestation policy. Policy status: ", resetPolicyResult.body.policyResolution);

--- a/sdk/attestation/attestation/samples-dev/utils/cryptoUtils.ts
+++ b/sdk/attestation/attestation/samples-dev/utils/cryptoUtils.ts
@@ -11,7 +11,7 @@ export function createECDSKey(): [string, string] {
   const keyPair = jsrsasign.KEYUTIL.generateKeypair("EC", "secp256r1");
   return [
     jsrsasign.KEYUTIL.getPEM(keyPair.prvKeyObj, "PKCS8PRV"),
-    jsrsasign.KEYUTIL.getPEM(keyPair.pubKeyObj, "PKCS8PUB")
+    jsrsasign.KEYUTIL.getPEM(keyPair.pubKeyObj, "PKCS8PUB"),
   ];
 }
 
@@ -19,7 +19,7 @@ export function createRSAKey(): [string, string] {
   const keyPair = jsrsasign.KEYUTIL.generateKeypair("RSA", 1024);
   return [
     jsrsasign.KEYUTIL.getPEM(keyPair.prvKeyObj, "PKCS8PRV"),
-    jsrsasign.KEYUTIL.getPEM(keyPair.pubKeyObj, "PKCS8PUB")
+    jsrsasign.KEYUTIL.getPEM(keyPair.pubKeyObj, "PKCS8PUB"),
   ];
 }
 
@@ -70,10 +70,10 @@ export function createX509Certificate(
     ext: [
       { extname: "basicConstraints", critical: false, cA: false, pathLen: 0 },
       { extname: "subjectAltName", critical: false, array: [{ uri: "https://" + subject_name }] },
-      { extname: "keyUsage", critical: true, names: ["digitalSignature"] }
+      { extname: "keyUsage", critical: true, names: ["digitalSignature"] },
     ],
     sigalg: { name: "SHA256withRSA" },
-    cakey: privKey
+    cakey: privKey,
   });
 
   const x509 = new jsrsasign.X509();

--- a/sdk/attestation/attestation/src/attestationAdministrationClient.ts
+++ b/sdk/attestation/attestation/src/attestationAdministrationClient.ts
@@ -12,7 +12,7 @@ import {
   AttestationCertificateManagementBody,
   GeneratedClientOptionalParams,
   JsonWebKey,
-  PolicyCertificatesResult
+  PolicyCertificatesResult,
 } from "./generated/models";
 
 import { bytesToString } from "./utils/utf8";
@@ -23,7 +23,7 @@ import {
   AttestationType,
   PolicyResult,
   AttestationSigner,
-  PolicyCertificatesModificationResult
+  PolicyCertificatesModificationResult,
 } from "./models";
 import { StoredAttestationPolicy } from "./models/storedAttestationPolicy";
 
@@ -138,9 +138,9 @@ export class AttestationAdministrationClient {
         credentialScopes: ["https://attest.azure.net/.default"],
         loggingOptions: {
           logger: logger.info,
-          allowedHeaderNames: ["x-ms-request-id", "x-ms-maa-service-version"]
-        }
-      }
+          allowedHeaderNames: ["x-ms-request-id", "x-ms-maa-service-version"],
+        },
+      },
     };
 
     this._client = new GeneratedClient(endpoint, internalPipelineOptions);
@@ -254,7 +254,7 @@ export class AttestationAdministrationClient {
       const storedAttestationPolicy = new StoredAttestationPolicy(newPolicyDocument).serialize();
       const setPolicyToken = AttestationTokenImpl.create({
         body: storedAttestationPolicy,
-        ...options
+        ...options,
       });
 
       const setPolicyResult = await this._client.policy.set(
@@ -334,7 +334,7 @@ export class AttestationAdministrationClient {
 
       const resetPolicyToken = AttestationTokenImpl.create({
         privateKey: options.privateKey,
-        certificate: options.certificate
+        certificate: options.certificate,
       });
 
       const resetPolicyResult = await this._client.policy.reset(
@@ -405,7 +405,7 @@ export class AttestationAdministrationClient {
         {
           PolicyCertificatesResult: Mappers.PolicyCertificatesResult,
           JsonWebKeySet: Mappers.JsonWebKeySet,
-          JsonWebKey: Mappers.JsonWebKey
+          JsonWebKey: Mappers.JsonWebKey,
         },
         "PolicyCertificatesResult"
       ) as PolicyCertificatesResult;
@@ -469,11 +469,11 @@ export class AttestationAdministrationClient {
 
       const jwk: JsonWebKey = {
         x5C: [hexToBase64(cert.hex)],
-        kty: kty
+        kty: kty,
       };
 
       const addBody: AttestationCertificateManagementBody = {
-        policyCertificate: jwk
+        policyCertificate: jwk,
       };
 
       const addCertToken = AttestationTokenImpl.create({
@@ -481,12 +481,12 @@ export class AttestationAdministrationClient {
           addBody,
           {
             AttestationCertificateManagementBody: Mappers.AttestationCertificateManagementBody,
-            JsonWebKey: Mappers.JsonWebKey
+            JsonWebKey: Mappers.JsonWebKey,
           },
           Mappers.AttestationCertificateManagementBody
         ),
         privateKey: privateKey,
-        certificate: certificate
+        certificate: certificate,
       });
 
       const addCertificateResult = await this._client.policyCertificates.add(
@@ -510,7 +510,7 @@ export class AttestationAdministrationClient {
         {
           PolicyCertificatesModificationResult: Mappers.PolicyCertificatesModificationResult,
           JsonWebKeySet: Mappers.JsonWebKeySet,
-          JsonWebKey: Mappers.JsonWebKey
+          JsonWebKey: Mappers.JsonWebKey,
         },
         "PolicyCertificatesModificationResult"
       ) as PolicyCertificatesModificationResult;
@@ -587,11 +587,11 @@ export class AttestationAdministrationClient {
 
       const jwk: JsonWebKey = {
         x5C: [hexToBase64(cert.hex)],
-        kty: kty
+        kty: kty,
       };
 
       const addBody: AttestationCertificateManagementBody = {
-        policyCertificate: jwk
+        policyCertificate: jwk,
       };
 
       const removeCertToken = AttestationTokenImpl.create({
@@ -599,12 +599,12 @@ export class AttestationAdministrationClient {
           addBody,
           {
             AttestationCertificateManagementBody: Mappers.AttestationCertificateManagementBody,
-            JsonWebKey: Mappers.JsonWebKey
+            JsonWebKey: Mappers.JsonWebKey,
           },
           Mappers.AttestationCertificateManagementBody
         ),
         privateKey: privateKey,
-        certificate: certificate
+        certificate: certificate,
       });
 
       const removeCertificateResult = await this._client.policyCertificates.remove(
@@ -628,7 +628,7 @@ export class AttestationAdministrationClient {
         {
           PolicyCertificatesModificationResult: Mappers.PolicyCertificatesModificationResult,
           JsonWebKeySet: Mappers.JsonWebKeySet,
-          JsonWebKey: Mappers.JsonWebKey
+          JsonWebKey: Mappers.JsonWebKey,
         },
         "PolicyCertificatesModificationResult"
       ) as PolicyCertificatesModificationResult;

--- a/sdk/attestation/attestation/src/attestationClient.ts
+++ b/sdk/attestation/attestation/src/attestationClient.ts
@@ -9,7 +9,7 @@ import {
   GeneratedAttestationResult,
   InitTimeData,
   KnownDataType,
-  RuntimeData
+  RuntimeData,
 } from "./generated/models";
 
 import { logger } from "./logger";
@@ -208,9 +208,9 @@ export class AttestationClient {
         credential: credential,
         loggingOptions: {
           logger: logger.info,
-          allowedHeaderNames: ["x-ms-request-id", "x-ms-maa-service-version"]
-        }
-      }
+          allowedHeaderNames: ["x-ms-request-id", "x-ms-maa-service-version"],
+        },
+      },
     };
 
     this._client = new GeneratedClient(endpoint, internalPipelineOptions);
@@ -249,7 +249,8 @@ export class AttestationClient {
       const initTimeData: InitTimeData | undefined = initData
         ? {
             data: initData,
-            dataType: options.initTimeJson !== undefined ? KnownDataType.Json : KnownDataType.Binary
+            dataType:
+              options.initTimeJson !== undefined ? KnownDataType.Json : KnownDataType.Binary,
           }
         : undefined;
 
@@ -258,7 +259,7 @@ export class AttestationClient {
       const runTimeData: RuntimeData | undefined = runData
         ? {
             data: runData,
-            dataType: options.runTimeJson !== undefined ? KnownDataType.Json : KnownDataType.Binary
+            dataType: options.runTimeJson !== undefined ? KnownDataType.Json : KnownDataType.Binary,
           }
         : undefined;
 
@@ -267,7 +268,7 @@ export class AttestationClient {
           report: await Uint8ArrayFromInput(report),
           initTimeData: initTimeData,
           runtimeData: runTimeData,
-          draftPolicyForAttestation: options.draftPolicyForAttestation ?? undefined
+          draftPolicyForAttestation: options.draftPolicyForAttestation ?? undefined,
         },
         updatedOptions
       );
@@ -285,7 +286,7 @@ export class AttestationClient {
         token.getBody(),
         {
           GeneratedAttestationResult: Mappers.GeneratedAttestationResult,
-          JsonWebKey: Mappers.JsonWebKey
+          JsonWebKey: Mappers.JsonWebKey,
         },
         "GeneratedAttestationResult"
       ) as GeneratedAttestationResult;
@@ -330,7 +331,8 @@ export class AttestationClient {
       const initTimeData: InitTimeData | undefined = initData
         ? {
             data: initData,
-            dataType: options.initTimeJson !== undefined ? KnownDataType.Json : KnownDataType.Binary
+            dataType:
+              options.initTimeJson !== undefined ? KnownDataType.Json : KnownDataType.Binary,
           }
         : undefined;
 
@@ -338,7 +340,7 @@ export class AttestationClient {
       const runTimeData: RuntimeData | undefined = runData
         ? {
             data: runData,
-            dataType: options.runTimeJson !== undefined ? KnownDataType.Json : KnownDataType.Binary
+            dataType: options.runTimeJson !== undefined ? KnownDataType.Json : KnownDataType.Binary,
           }
         : undefined;
 
@@ -347,7 +349,7 @@ export class AttestationClient {
           quote: await Uint8ArrayFromInput(quote),
           initTimeData: initTimeData,
           runtimeData: runTimeData,
-          draftPolicyForAttestation: options.draftPolicyForAttestation ?? undefined
+          draftPolicyForAttestation: options.draftPolicyForAttestation ?? undefined,
         },
         updatedOptions
       );
@@ -365,7 +367,7 @@ export class AttestationClient {
         token.getBody(),
         {
           GeneratedAttestationResult: Mappers.GeneratedAttestationResult,
-          JsonWebKey: Mappers.JsonWebKey
+          JsonWebKey: Mappers.JsonWebKey,
         },
         "GeneratedAttestationResult"
       ) as GeneratedAttestationResult;

--- a/sdk/attestation/attestation/src/index.ts
+++ b/sdk/attestation/attestation/src/index.ts
@@ -7,7 +7,7 @@ export {
   AttestOpenEnclaveOptions,
   AttestSgxEnclaveOptions,
   AttestTpmOptions,
-  AttestationClientOperationOptions
+  AttestationClientOperationOptions,
 } from "./attestationClient";
 
 export {
@@ -15,5 +15,5 @@ export {
   AttestationAdministrationClientOptions,
   AttestationAdministrationClientOperationOptions,
   AttestationAdministrationClientPolicyOperationOptions,
-  AttestationAdministrationClientPolicyCertificateOperationOptions
+  AttestationAdministrationClientPolicyCertificateOperationOptions,
 } from "./attestationAdministrationClient";

--- a/sdk/attestation/attestation/src/models/attestationPolicyToken.ts
+++ b/sdk/attestation/attestation/src/models/attestationPolicyToken.ts
@@ -38,7 +38,7 @@ export function createAttestationPolicyToken(
   const token = AttestationTokenImpl.create({
     body: new StoredAttestationPolicy(policy).serialize(),
     privateKey: privateKey,
-    certificate: certificate
+    certificate: certificate,
   });
   return token;
 }

--- a/sdk/attestation/attestation/src/models/attestationResult.ts
+++ b/sdk/attestation/attestation/src/models/attestationResult.ts
@@ -390,6 +390,6 @@ export function _attestationResultFromGenerated(
     mrSigner: generated.mrSigner,
     svn: generated.svn,
     enclaveHeldData: generated.enclaveHeldData,
-    sgxCollateral: generated.sgxCollateral
+    sgxCollateral: generated.sgxCollateral,
   });
 }

--- a/sdk/attestation/attestation/src/models/attestationSigner.ts
+++ b/sdk/attestation/attestation/src/models/attestationSigner.ts
@@ -33,6 +33,6 @@ export interface AttestationSigner {
 export function _attestationSignerFromGenerated(key?: JsonWebKey): AttestationSigner {
   return {
     keyId: key?.kid,
-    certificates: key?.x5C?.map((cert) => pemFromBase64(cert, "CERTIFICATE")) ?? []
+    certificates: key?.x5C?.map((cert) => pemFromBase64(cert, "CERTIFICATE")) ?? [],
   };
 }

--- a/sdk/attestation/attestation/src/models/attestationToken.ts
+++ b/sdk/attestation/attestation/src/models/attestationToken.ts
@@ -294,7 +294,7 @@ export class AttestationTokenImpl implements AttestationToken {
     options: AttestationTokenValidationOptions = {
       validateExpirationTime: true,
       validateToken: true,
-      validateNotBeforeTime: true
+      validateNotBeforeTime: true,
     }
   ): string[] {
     let problems = new Array<string>();

--- a/sdk/attestation/attestation/src/models/index.ts
+++ b/sdk/attestation/attestation/src/models/index.ts
@@ -13,6 +13,6 @@ export {
   AttestationType,
   CertificateModification,
   PolicyModification,
-  PolicyCertificatesModificationResult
+  PolicyCertificatesModificationResult,
 } from "../generated/models/index";
 export { AttestationPolicyToken, createAttestationPolicyToken } from "./attestationPolicyToken";

--- a/sdk/attestation/attestation/src/models/policyResult.ts
+++ b/sdk/attestation/attestation/src/models/policyResult.ts
@@ -55,6 +55,6 @@ export function _policyResultFromGenerated(rawJson: unknown): PolicyResult {
     policy: policyResult.policy,
     policySigner: policyResult.policySigner
       ? _attestationSignerFromGenerated(policyResult.policySigner)
-      : undefined
+      : undefined,
   };
 }

--- a/sdk/attestation/attestation/src/tracing.ts
+++ b/sdk/attestation/attestation/src/tracing.ts
@@ -13,5 +13,5 @@ import { createSpanFunction } from "@azure/core-tracing";
  */
 export const createSpan = createSpanFunction({
   namespace: "Azure.Security.Attestation",
-  packagePrefix: "Azure.Security.Attestation"
+  packagePrefix: "Azure.Security.Attestation",
 });

--- a/sdk/attestation/attestation/src/utils/base64.browser.ts
+++ b/sdk/attestation/attestation/src/utils/base64.browser.ts
@@ -34,10 +34,7 @@ export function base64UrlEncodeByteArray(value: Uint8Array): string {
   }
   const base64 = btoa(str);
   // Convert the base64 buffer to base64url.
-  return base64
-    .replace(/\+/g, "-")
-    .replace(/\//, "_")
-    .split("=")[0];
+  return base64.replace(/\+/g, "-").replace(/\//, "_").split("=")[0];
 }
 
 /**

--- a/sdk/attestation/attestation/src/utils/base64.ts
+++ b/sdk/attestation/attestation/src/utils/base64.ts
@@ -30,10 +30,7 @@ export function base64UrlEncodeByteArray(value: Uint8Array): string {
   const bufferValue = value instanceof Buffer ? value : Buffer.from(value.buffer as ArrayBuffer);
   const base64 = bufferValue.toString("base64");
   // Convert the base64 buffer to base64url.
-  return base64
-    .replace(/\+/g, "-")
-    .replace(/\//, "_")
-    .split("=")[0];
+  return base64.replace(/\+/g, "-").replace(/\//, "_").split("=")[0];
 }
 
 /**

--- a/sdk/attestation/attestation/test/browser/attestationTests.browser.spec.ts
+++ b/sdk/attestation/attestation/test/browser/attestationTests.browser.spec.ts
@@ -12,20 +12,20 @@ import {
   createRecordedAdminClient,
   createRecordedClient,
   createRecorder,
-  EndpointType
+  EndpointType,
 } from "../utils/recordedClient";
 import * as base64url from "../utils/base64url";
 
 import { KnownAttestationType } from "../../src";
 
-describe("AttestationClient in Browser", function() {
+describe("AttestationClient in Browser", function () {
   let recorder: Recorder;
 
-  beforeEach(function(this: Context) {
+  beforeEach(function (this: Context) {
     recorder = createRecorder(this);
   });
 
-  afterEach(async function() {
+  afterEach(async function () {
     await recorder.stop();
   });
 
@@ -201,7 +201,7 @@ describe("AttestationClient in Browser", function() {
       await expect(
         client.attestOpenEnclave(new Blob([base64url.decodeString(_openEnclaveReport)]), {
           runTimeData: binaryRuntimeData,
-          runTimeJson: binaryRuntimeData
+          runTimeJson: binaryRuntimeData,
         })
       ).to.eventually.be.rejectedWith("Cannot provide both runTimeData and runTimeJson");
     }
@@ -210,7 +210,7 @@ describe("AttestationClient in Browser", function() {
       const attestationResult = await client.attestOpenEnclave(
         new Blob([base64url.decodeString(_openEnclaveReport)]),
         {
-          runTimeData: binaryRuntimeData
+          runTimeData: binaryRuntimeData,
         }
       );
 
@@ -228,7 +228,7 @@ describe("AttestationClient in Browser", function() {
       const attestationResult = await client.attestOpenEnclave(
         new Blob([base64url.decodeString(_openEnclaveReport)]),
         {
-          runTimeJson: binaryRuntimeData
+          runTimeJson: binaryRuntimeData,
         }
       );
 
@@ -259,7 +259,7 @@ describe("AttestationClient in Browser", function() {
           new Blob([base64url.decodeString(_openEnclaveReport).subarray(0x10)]),
           {
             runTimeData: binaryRuntimeData,
-            runTimeJson: binaryRuntimeData
+            runTimeJson: binaryRuntimeData,
           }
         )
       ).to.eventually.be.rejectedWith("Cannot provide both runTimeData and runTimeJson");
@@ -272,7 +272,7 @@ describe("AttestationClient in Browser", function() {
       const attestationResult = await client.attestSgxEnclave(
         new Blob([base64url.decodeString(_openEnclaveReport).subarray(0x10)]),
         {
-          runTimeData: binaryRuntimeData
+          runTimeData: binaryRuntimeData,
         }
       );
 
@@ -292,7 +292,7 @@ describe("AttestationClient in Browser", function() {
       const attestationResult = await client.attestSgxEnclave(
         new Blob([base64url.decodeString(_openEnclaveReport).subarray(0x10)]),
         {
-          runTimeJson: binaryRuntimeData
+          runTimeJson: binaryRuntimeData,
         }
       );
 

--- a/sdk/attestation/attestation/test/public/attestationTests.spec.ts
+++ b/sdk/attestation/attestation/test/public/attestationTests.spec.ts
@@ -12,20 +12,20 @@ import {
   createRecordedAdminClient,
   createRecordedClient,
   createRecorder,
-  EndpointType
+  EndpointType,
 } from "../utils/recordedClient";
 import * as base64url from "../utils/base64url";
 
 import { KnownAttestationType } from "../../src";
 
-describe("[AAD] Attestation Client", function() {
+describe("[AAD] Attestation Client", function () {
   let recorder: Recorder;
 
-  beforeEach(function(this: Context) {
+  beforeEach(function (this: Context) {
     recorder = createRecorder(this);
   });
 
-  afterEach(async function() {
+  afterEach(async function () {
     await recorder.stop();
   });
 
@@ -201,7 +201,7 @@ describe("[AAD] Attestation Client", function() {
       await expect(
         client.attestOpenEnclave(base64url.decodeString(_openEnclaveReport).subarray(0x10), {
           runTimeData: binaryRuntimeData,
-          runTimeJson: binaryRuntimeData
+          runTimeJson: binaryRuntimeData,
         })
       ).to.eventually.be.rejectedWith("Cannot provide both runTimeData and runTimeJson");
     }
@@ -210,7 +210,7 @@ describe("[AAD] Attestation Client", function() {
       const attestationResult = await client.attestOpenEnclave(
         base64url.decodeString(_openEnclaveReport),
         {
-          runTimeData: binaryRuntimeData
+          runTimeData: binaryRuntimeData,
         }
       );
 
@@ -226,7 +226,7 @@ describe("[AAD] Attestation Client", function() {
       const attestationResult = await client.attestOpenEnclave(
         base64url.decodeString(_openEnclaveReport),
         {
-          runTimeJson: binaryRuntimeData
+          runTimeJson: binaryRuntimeData,
         }
       );
 
@@ -255,7 +255,7 @@ describe("[AAD] Attestation Client", function() {
       await expect(
         client.attestSgxEnclave(base64url.decodeString(_openEnclaveReport).subarray(0x10), {
           runTimeData: binaryRuntimeData,
-          runTimeJson: binaryRuntimeData
+          runTimeJson: binaryRuntimeData,
         })
       ).to.eventually.be.rejectedWith("Cannot provide both runTimeData and runTimeJson");
     }
@@ -267,7 +267,7 @@ describe("[AAD] Attestation Client", function() {
       const attestationResult = await client.attestSgxEnclave(
         base64url.decodeString(_openEnclaveReport).subarray(0x10),
         {
-          runTimeData: binaryRuntimeData
+          runTimeData: binaryRuntimeData,
         }
       );
 
@@ -285,7 +285,7 @@ describe("[AAD] Attestation Client", function() {
       const attestationResult = await client.attestSgxEnclave(
         base64url.decodeString(_openEnclaveReport).subarray(0x10),
         {
-          runTimeJson: binaryRuntimeData
+          runTimeJson: binaryRuntimeData,
         }
       );
 

--- a/sdk/attestation/attestation/test/public/attestationTokenTests.spec.ts
+++ b/sdk/attestation/attestation/test/public/attestationTokenTests.spec.ts
@@ -20,14 +20,14 @@ import { createECDSKey, createRSAKey, createX509Certificate } from "../utils/cry
 import { verifyAttestationSigningKey } from "../../src/utils/helpers";
 import { AttestationTokenImpl } from "../../src/models/attestationToken";
 
-describe("AttestationTokenTests", function() {
+describe("AttestationTokenTests", function () {
   let recorder: Recorder;
 
-  beforeEach(function(this: Context) {
+  beforeEach(function (this: Context) {
     recorder = createRecorder(this);
   });
 
-  afterEach(async function() {
+  afterEach(async function () {
     await recorder.stop();
   });
 
@@ -145,14 +145,14 @@ describe("AttestationTokenTests", function() {
       exp: currentTime + 30,
       iat: currentTime,
       nbf: currentTime,
-      iss: "this is an issuer"
+      iss: "this is an issuer",
     };
 
     const sourceJson = JSON.stringify(sourceObject);
     const token = AttestationTokenImpl.create({
       body: sourceJson,
       privateKey: privKey,
-      certificate: cert
+      certificate: cert,
     });
 
     // Let's look at some of the properties on the token and confirm they match
@@ -180,7 +180,7 @@ describe("AttestationTokenTests", function() {
         validateAttestationToken: (tokenToCheck) => {
           console.log("In callback, token algorithm: " + tokenToCheck.algorithm);
           return undefined;
-        }
+        },
       })
     );
 
@@ -191,7 +191,7 @@ describe("AttestationTokenTests", function() {
           validateAttestationToken: (tokenToCheck) => {
             console.log("In callback, token algorithm: " + tokenToCheck.algorithm);
             return ["There was a validation failure"];
-          }
+          },
         })
         .find((s) => s.search("validation")) !== undefined
     );
@@ -207,7 +207,7 @@ describe("AttestationTokenTests", function() {
         nbf: currentTime,
         iss: "this is an issuer",
         foo: "foo",
-        bar: 10
+        bar: 10,
       });
 
       const token = AttestationTokenImpl.create({ body: sourceObject });
@@ -217,7 +217,7 @@ describe("AttestationTokenTests", function() {
         token.getTokenProblems(undefined, {
           validateToken: true,
           validateIssuer: true,
-          expectedIssuer: "this is an issuer"
+          expectedIssuer: "this is an issuer",
         })
       );
 
@@ -226,7 +226,7 @@ describe("AttestationTokenTests", function() {
           .getTokenProblems(undefined, {
             validateToken: true,
             validateIssuer: true,
-            expectedIssuer: "this is a different issuer"
+            expectedIssuer: "this is a different issuer",
           })
           .find((s) => s.search("different issuer")) !== undefined
       );
@@ -242,7 +242,7 @@ describe("AttestationTokenTests", function() {
         iat: currentTime,
         nbf: currentTime,
         foo: "foo",
-        bar: 10
+        bar: 10,
       });
 
       const token = AttestationTokenImpl.create({ body: sourceObject });
@@ -252,7 +252,7 @@ describe("AttestationTokenTests", function() {
         token.getTokenProblems(undefined, {
           validateToken: true,
           validateExpirationTime: true,
-          validateNotBeforeTime: true
+          validateNotBeforeTime: true,
         })
       );
     }
@@ -264,7 +264,7 @@ describe("AttestationTokenTests", function() {
         iat: currentTime,
         nbf: currentTime,
         foo: "foo",
-        bar: 10
+        bar: 10,
       });
 
       const token = AttestationTokenImpl.create({ body: sourceObject });
@@ -274,7 +274,7 @@ describe("AttestationTokenTests", function() {
           .getTokenProblems(undefined, {
             validateToken: true,
             validateExpirationTime: true,
-            validateNotBeforeTime: true
+            validateNotBeforeTime: true,
           })
           .find((s) => s.search("expired")) !== undefined
       );
@@ -287,7 +287,7 @@ describe("AttestationTokenTests", function() {
           validateToken: true,
           validateExpirationTime: true,
           validateNotBeforeTime: true,
-          timeValidationSlack: 10
+          timeValidationSlack: 10,
         })
       );
     }
@@ -298,7 +298,7 @@ describe("AttestationTokenTests", function() {
         iat: currentTime + 5,
         nbf: currentTime + 5,
         foo: "foo",
-        bar: 10
+        bar: 10,
       });
 
       const token = AttestationTokenImpl.create({ body: sourceObject });
@@ -307,7 +307,7 @@ describe("AttestationTokenTests", function() {
           .getTokenProblems(undefined, {
             validateToken: true,
             validateExpirationTime: true,
-            validateNotBeforeTime: true
+            validateNotBeforeTime: true,
           })
           .find((s) => s.search("not yet")) !== undefined
       );
@@ -320,7 +320,7 @@ describe("AttestationTokenTests", function() {
           validateToken: true,
           validateExpirationTime: true,
           validateNotBeforeTime: true,
-          timeValidationSlack: 10
+          timeValidationSlack: 10,
         })
       );
     }

--- a/sdk/attestation/attestation/test/public/policyGetSetTests.spec.ts
+++ b/sdk/attestation/attestation/test/public/policyGetSetTests.spec.ts
@@ -17,21 +17,21 @@ import {
   createRecordedAdminClient,
   createRecorder,
   EndpointType,
-  getIsolatedSigningKey
+  getIsolatedSigningKey,
 } from "../utils/recordedClient";
 import { KnownAttestationType, AttestationType, createAttestationPolicyToken } from "../../src";
 import { generateSha256Hash, createRSAKey, createX509Certificate } from "../utils/cryptoUtils";
 import { KnownPolicyModification } from "../../src/generated";
 import { verifyAttestationSigningKey } from "../../src/utils/helpers";
 
-describe("PolicyGetSetTests ", function() {
+describe("PolicyGetSetTests ", function () {
   let recorder: Recorder;
 
-  beforeEach(function(this: Context) {
+  beforeEach(function (this: Context) {
     recorder = createRecorder(this);
   });
 
-  afterEach(async function() {
+  afterEach(async function () {
     await recorder.stop();
   });
 
@@ -66,21 +66,21 @@ describe("PolicyGetSetTests ", function() {
 
     await expect(
       adminClient.setPolicy(KnownAttestationType.SgxEnclave, minimalPolicy, {
-        certificate: rsaCertificate
+        certificate: rsaCertificate,
       })
     ).to.be.rejectedWith("privateKey is specified");
 
     await expect(
       adminClient.setPolicy(KnownAttestationType.SgxEnclave, minimalPolicy, {
         privateKey: rsaKey2,
-        certificate: rsaCertificate
+        certificate: rsaCertificate,
       })
     ).to.be.rejectedWith("Key does not match Certificate");
 
     await expect(
       adminClient.setPolicy(KnownAttestationType.SgxEnclave, minimalPolicy, {
         privateKey: "BogusKey",
-        certificate: rsaCertificate
+        certificate: rsaCertificate,
       })
     ).to.be.rejectedWith("not supported argument");
 
@@ -107,14 +107,14 @@ describe("PolicyGetSetTests ", function() {
     await expect(
       adminClient.resetPolicy(KnownAttestationType.SgxEnclave, {
         privateKey: "BogusKey",
-        certificate: rsaCertificate
+        certificate: rsaCertificate,
       })
     ).to.be.rejectedWith("not supported argument");
 
     await expect(
       adminClient.resetPolicy(KnownAttestationType.SgxEnclave, {
         privateKey: rsaKey2,
-        certificate: rsaCertificate
+        certificate: rsaCertificate,
       })
     ).to.be.rejectedWith("Key does not match Certificate");
 
@@ -130,7 +130,7 @@ describe("PolicyGetSetTests ", function() {
     const rsaCertificate = createX509Certificate(rsaKey, rsapubKey, "CertificateName");
     await testSetPolicy(KnownAttestationType.SgxEnclave, "AAD", {
       privateKey: rsaKey,
-      certificate: rsaCertificate
+      certificate: rsaCertificate,
     });
   });
 
@@ -186,7 +186,7 @@ describe("PolicyGetSetTests ", function() {
 
     const policyResult = await adminClient.setPolicy(attestationType, minimalPolicy, {
       privateKey: signer?.privateKey,
-      certificate: signer?.certificate
+      certificate: signer?.certificate,
     });
 
     assert.equal(KnownPolicyModification.Updated, policyResult.body.policyResolution);
@@ -239,7 +239,7 @@ describe("PolicyGetSetTests ", function() {
 
     const policyResult = await adminClient.setPolicy(attestationType, minimalPolicy, {
       privateKey: signer?.privateKey,
-      certificate: signer?.certificate
+      certificate: signer?.certificate,
     });
 
     assert.equal(KnownPolicyModification.Updated, policyResult.body.policyResolution);

--- a/sdk/attestation/attestation/test/public/policyManagementGetSetTests.spec.ts
+++ b/sdk/attestation/attestation/test/public/policyManagementGetSetTests.spec.ts
@@ -11,7 +11,7 @@ import { Recorder } from "@azure-tools/test-recorder";
 import {
   createRecordedAdminClient,
   createRecorder,
-  getIsolatedSigningKey
+  getIsolatedSigningKey,
 } from "../utils/recordedClient";
 import { createRSAKey, createX509Certificate, generateSha1Hash } from "../utils/cryptoUtils";
 import { KnownCertificateModification } from "../../src/generated";
@@ -21,14 +21,14 @@ import { KnownCertificateModification } from "../../src/generated";
 import * as jsrsasign from "jsrsasign";
 import { byteArrayToHex } from "../../src/utils/base64";
 
-describe("PolicyManagementTests ", function() {
+describe("PolicyManagementTests ", function () {
   let recorder: Recorder;
 
-  beforeEach(function(this: Context) {
+  beforeEach(function (this: Context) {
     recorder = createRecorder(this);
   });
 
-  afterEach(async function() {
+  afterEach(async function () {
     await recorder.stop();
   });
 

--- a/sdk/attestation/attestation/test/public/tokenCertTests.spec.ts
+++ b/sdk/attestation/attestation/test/public/tokenCertTests.spec.ts
@@ -14,14 +14,14 @@ import { Recorder } from "@azure-tools/test-recorder";
 
 import { createRecordedClient, createRecorder, getAttestationUri } from "../utils/recordedClient";
 import { AttestationClient } from "../../src";
-describe("TokenCertTests", function() {
+describe("TokenCertTests", function () {
   let recorder: Recorder;
 
-  beforeEach(function(this: Context) {
+  beforeEach(function (this: Context) {
     recorder = createRecorder(this);
   });
 
-  afterEach(async function() {
+  afterEach(async function () {
     await recorder.stop();
   });
 

--- a/sdk/attestation/attestation/test/utils/cryptoUtils.ts
+++ b/sdk/attestation/attestation/test/utils/cryptoUtils.ts
@@ -11,7 +11,7 @@ export function createECDSKey(): [string, string] {
   const keyPair = jsrsasign.KEYUTIL.generateKeypair("EC", "secp256r1");
   return [
     jsrsasign.KEYUTIL.getPEM(keyPair.prvKeyObj, "PKCS8PRV"),
-    jsrsasign.KEYUTIL.getPEM(keyPair.pubKeyObj, "PKCS8PUB")
+    jsrsasign.KEYUTIL.getPEM(keyPair.pubKeyObj, "PKCS8PUB"),
   ];
 }
 
@@ -19,7 +19,7 @@ export function createRSAKey(): [string, string] {
   const keyPair = jsrsasign.KEYUTIL.generateKeypair("RSA", 1024);
   return [
     jsrsasign.KEYUTIL.getPEM(keyPair.prvKeyObj, "PKCS8PRV"),
-    jsrsasign.KEYUTIL.getPEM(keyPair.pubKeyObj, "PKCS8PUB")
+    jsrsasign.KEYUTIL.getPEM(keyPair.pubKeyObj, "PKCS8PUB"),
   ];
 }
 
@@ -70,10 +70,10 @@ export function createX509Certificate(
     ext: [
       { extname: "basicConstraints", critical: false, cA: false, pathLen: 0 },
       { extname: "subjectAltName", critical: false, array: [{ uri: "https://" + subject_name }] },
-      { extname: "keyUsage", critical: true, names: ["digitalSignature"] }
+      { extname: "keyUsage", critical: true, names: ["digitalSignature"] },
     ],
     sigalg: { name: "SHA256withRSA" },
-    cakey: privKey
+    cakey: privKey,
   });
 
   const x509 = new jsrsasign.X509();

--- a/sdk/attestation/attestation/test/utils/recordedClient.ts
+++ b/sdk/attestation/attestation/test/utils/recordedClient.ts
@@ -9,13 +9,13 @@ import {
   Recorder,
   record,
   RecorderEnvironmentSetup,
-  isPlaybackMode
+  isPlaybackMode,
 } from "@azure-tools/test-recorder";
 
 import {
   AttestationClient,
   AttestationClientOptions,
-  AttestationAdministrationClient
+  AttestationAdministrationClient,
 } from "../../src/";
 import "./env";
 import { pemFromBase64 } from "../utils/helpers";
@@ -31,7 +31,7 @@ const replaceableVariables: { [k: string]: string } = {
   policySigningCertificate1: "policy_signing_certificate1",
   policySigningCertificate2: "policy_signing_certificate2",
   ATTESTATION_ISOLATED_SIGNING_CERTIFICATE: "isolated_signing_certificate",
-  ATTESTATION_ISOLATED_SIGNING_KEY: "isolated_signing_key"
+  ATTESTATION_ISOLATED_SIGNING_KEY: "isolated_signing_key",
 };
 
 const environmentSetup: RecorderEnvironmentSetup = {
@@ -48,9 +48,9 @@ const environmentSetup: RecorderEnvironmentSetup = {
         .replace("aad_attestation_url:443", "aad_attestation_url")
         .replace("isolated_attestation_url:443", "isolated_attestation_url");
       return replaced;
-    }
+    },
   ],
-  queryParametersToSkip: []
+  queryParametersToSkip: [],
 };
 
 export function createRecorder(context: Context): Recorder {
@@ -109,8 +109,8 @@ export function createRecordedClient(
         validateNotBeforeTime: !isPlaybackMode(),
         validateIssuer: !isPlaybackMode(),
         timeValidationSlack: 10, // 10 seconds slack in validation time.
-        expectedIssuer: getAttestationUri(endpointType)
-      }
+        expectedIssuer: getAttestationUri(endpointType),
+      },
     };
   }
   if (authenticatedClient !== undefined && authenticatedClient) {
@@ -144,8 +144,8 @@ export function createRecordedAdminClient(
         validateNotBeforeTime: !isPlaybackMode(),
         timeValidationSlack: 10, // 10 seconds slack in validation time.
         validateIssuer: !isPlaybackMode(),
-        expectedIssuer: getAttestationUri(endpointType)
-      }
+        expectedIssuer: getAttestationUri(endpointType),
+      },
     };
   }
   return new AttestationAdministrationClient(getAttestationUri(endpointType), credential, options);


### PR DESCRIPTION
Solves: https://github.com/Azure/azure-sdk-for-js/issues/9329 for packages in `sdk/attestation`.

Updated `prettier` dev-dependency version from `^1.19.1` to latest (`2.5.1`).
Files were re-formatted as well. Only format changes in this PR.

Main format changes with Prettier 2.x in this PR include:
- Trailing commas by default.
- Whitespace added after every `function` keyword.