### PR TITLE
update the unit-tests for TimeIntervalObject

### DIFF
--- a/sdk/monitor/monitor-query/CHANGELOG.md
+++ b/sdk/monitor/monitor-query/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Fixed the `timeInterval` field of `MetricsQueryResult`object to correctly return all the fields of `QueryTimeInterval` object. The internal conversion had a bug where it was only returning the `startTime`.
+
 ### Other Changes
 
 ## 1.0.0 (2021-10-07)

--- a/sdk/monitor/monitor-query/CHANGELOG.md
+++ b/sdk/monitor/monitor-query/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Bugs Fixed
 
-- Fixed the `timeInterval` field of `MetricsQueryResult`object to correctly return all the fields of `QueryTimeInterval` object. The internal conversion had a bug where it was only returning the `startTime`.
+- Fixed the `timeInterval` field of `MetricsQueryResult` object to correctly return all the fields of `QueryTimeInterval`.
 
 ### Other Changes
 

--- a/sdk/monitor/monitor-query/src/timespanConversion.ts
+++ b/sdk/monitor/monitor-query/src/timespanConversion.ts
@@ -24,12 +24,12 @@ export function convertTimespanToInterval(timespan: QueryTimeInterval): string {
 export function convertIntervalToTimeIntervalObject(timespan: string): QueryTimeInterval {
   if (timespan.includes("/")) {
     const intervalUnits: string[] = timespan.split("/");
-    if (Date.parse(intervalUnits[0]) && Date.parse(intervalUnits[2])) {
-      return { startTime: new Date(intervalUnits[0]), endTime: new Date(intervalUnits[2]) };
-    } else if (Date.parse(intervalUnits[0]) && !Date.parse(intervalUnits[2])) {
-      return { startTime: new Date(intervalUnits[0]), duration: intervalUnits[2] };
-    } else if (!Date.parse(intervalUnits[0]) && Date.parse(intervalUnits[2])) {
-      return { duration: intervalUnits[0], endTime: new Date(intervalUnits[2]) };
+    if (Date.parse(intervalUnits[0]) && Date.parse(intervalUnits[1])) {
+      return { startTime: new Date(intervalUnits[0]), endTime: new Date(intervalUnits[1]) };
+    } else if (Date.parse(intervalUnits[0]) && !Date.parse(intervalUnits[1])) {
+      return { startTime: new Date(intervalUnits[0]), duration: intervalUnits[1] };
+    } else if (!Date.parse(intervalUnits[0]) && Date.parse(intervalUnits[1])) {
+      return { duration: intervalUnits[0], endTime: new Date(intervalUnits[1]) };
     } else {
       return { duration: timespan };
     }

--- a/sdk/monitor/monitor-query/test/internal/unit/modelConverters.unittest.spec.ts
+++ b/sdk/monitor/monitor-query/test/internal/unit/modelConverters.unittest.spec.ts
@@ -28,9 +28,11 @@ import {
   Durations,
   ListMetricDefinitionsOptions,
   MetricsQueryOptions,
-  MetricsQueryResult
+  MetricsQueryResult,
+  QueryTimeInterval
 } from "../../../src";
 import { AbortSignalLike } from "@azure/abort-controller";
+import { convertIntervalToTimeIntervalObject } from "../../../src/timespanConversion";
 
 describe("Model unit tests", () => {
   describe("LogsClient", () => {
@@ -327,14 +329,28 @@ describe("Model unit tests", () => {
       );
     });
 
-    // it("convertResponseForMetricNamespaces", () => {
-    //   const actualResponse = convertResponseForMetricNamespaces({
-    //     value: [{ id: "anything" } as any]
-    //   });
-
-    //   assert.deepEqual(actualResponse, <GetMetricNamespacesResult>{
-    //     namespaces: [{ id: "anything" } as any]
-    //   });
-    // });
+    it("convertIntervalToTimeIntervalObject", () => {
+      const res1: QueryTimeInterval = convertIntervalToTimeIntervalObject(
+        "2007-11-13T00:00/2007-11-16T00:00"
+      );
+      assert.deepEqual(res1, {
+        startTime: new Date("2007-11-13T00:00"),
+        endTime: new Date("2007-11-16T00:00")
+      });
+      const res2 = convertIntervalToTimeIntervalObject("2007-03-01T13:00:00Z/P1Y2M10DT2H30M");
+      assert.deepEqual(res2, {
+        startTime: new Date("2007-03-01T13:00:00Z"),
+        duration: "P1Y2M10DT2H30M"
+      });
+      const res3 = convertIntervalToTimeIntervalObject("P1Y2M10DT2H30M/2008-05-11T15:30:00Z");
+      assert.deepEqual(res3, {
+        duration: "P1Y2M10DT2H30M",
+        endTime: new Date("2008-05-11T15:30:00Z")
+      });
+      const res4 = convertIntervalToTimeIntervalObject("P1Y2M10DT2H30M");
+      assert.deepEqual(res4, {
+        duration: "P1Y2M10DT2H30M"
+      });
+    });
   });
 });

--- a/sdk/monitor/monitor-query/test/internal/unit/modelConverters.unittest.spec.ts
+++ b/sdk/monitor/monitor-query/test/internal/unit/modelConverters.unittest.spec.ts
@@ -355,8 +355,8 @@ describe("Model unit tests", () => {
 
     it("convertTimespanToInterval", () => {
       const res1 = convertTimespanToInterval({
-        startTime: new Date("2007-11-13T00:00"),
-        endTime: new Date("2007-11-16T00:00")
+        startTime: new Date("2007-11-13T08:00:00"),
+        endTime: new Date("2007-11-16T08:00:00")
       });
       assert.deepEqual(res1, "2007-11-13T08:00:00.000Z/2007-11-16T08:00:00.000Z");
 

--- a/sdk/monitor/monitor-query/test/internal/unit/modelConverters.unittest.spec.ts
+++ b/sdk/monitor/monitor-query/test/internal/unit/modelConverters.unittest.spec.ts
@@ -358,7 +358,7 @@ describe("Model unit tests", () => {
         startTime: new Date("2007-11-13T08:00:00"),
         endTime: new Date("2007-11-16T08:00:00")
       });
-      assert.deepEqual(res1, "2007-11-13T08:00:00.000Z/2007-11-16T08:00:00.000Z");
+      assert.equal(res1, "2007-11-13T08:00:00.000Z/2007-11-16T08:00:00.000Z");
 
       const res2 = convertTimespanToInterval({
         startTime: new Date("2007-03-01T13:00:00Z"),

--- a/sdk/monitor/monitor-query/test/internal/unit/modelConverters.unittest.spec.ts
+++ b/sdk/monitor/monitor-query/test/internal/unit/modelConverters.unittest.spec.ts
@@ -28,8 +28,7 @@ import {
   Durations,
   ListMetricDefinitionsOptions,
   MetricsQueryOptions,
-  MetricsQueryResult,
-  QueryTimeInterval
+  MetricsQueryResult
 } from "../../../src";
 import { AbortSignalLike } from "@azure/abort-controller";
 import { convertIntervalToTimeIntervalObject } from "../../../src/timespanConversion";
@@ -330,9 +329,7 @@ describe("Model unit tests", () => {
     });
 
     it("convertIntervalToTimeIntervalObject", () => {
-      const res1: QueryTimeInterval = convertIntervalToTimeIntervalObject(
-        "2007-11-13T00:00/2007-11-16T00:00"
-      );
+      const res1 = convertIntervalToTimeIntervalObject("2007-11-13T00:00/2007-11-16T00:00");
       assert.deepEqual(res1, {
         startTime: new Date("2007-11-13T00:00"),
         endTime: new Date("2007-11-16T00:00")

--- a/sdk/monitor/monitor-query/test/internal/unit/modelConverters.unittest.spec.ts
+++ b/sdk/monitor/monitor-query/test/internal/unit/modelConverters.unittest.spec.ts
@@ -31,7 +31,10 @@ import {
   MetricsQueryResult
 } from "../../../src";
 import { AbortSignalLike } from "@azure/abort-controller";
-import { convertIntervalToTimeIntervalObject } from "../../../src/timespanConversion";
+import {
+  convertIntervalToTimeIntervalObject,
+  convertTimespanToInterval
+} from "../../../src/timespanConversion";
 
 describe("Model unit tests", () => {
   describe("LogsClient", () => {
@@ -348,6 +351,31 @@ describe("Model unit tests", () => {
       assert.deepEqual(res4, {
         duration: "P1Y2M10DT2H30M"
       });
+    });
+
+    it("convertTimespanToInterval", () => {
+      const res1 = convertTimespanToInterval({
+        startTime: new Date("2007-11-13T00:00"),
+        endTime: new Date("2007-11-16T00:00")
+      });
+      assert.deepEqual(res1, "2007-11-13T08:00:00.000Z/2007-11-16T08:00:00.000Z");
+
+      const res2 = convertTimespanToInterval({
+        startTime: new Date("2007-03-01T13:00:00Z"),
+        duration: "P1Y2M10DT2H30M"
+      });
+      assert.deepEqual(res2, "2007-03-01T13:00:00.000Z/P1Y2M10DT2H30M");
+
+      const res3 = convertTimespanToInterval({
+        duration: "P1Y2M10DT2H30M",
+        endTime: new Date("2008-05-11T15:30:00Z")
+      });
+      assert.deepEqual(res3, "P1Y2M10DT2H30M/2008-05-11T15:30:00.000Z");
+
+      const res4 = convertTimespanToInterval({
+        duration: "P1Y2M10DT2H30M"
+      });
+      assert.deepEqual(res4, "P1Y2M10DT2H30M");
     });
   });
 });


### PR DESCRIPTION
- Fixes #17502 
- Added unit tests for `convertTimespanToInterval` and `convertIntervalToTimeIntervalObject`
- Bug fix - Fixed the `timeInterval` field of `MetricsQueryResult`object to correctly return all the fields of `QueryTimeInterval` object