### PR TITLE
Update csv-parser version

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -1406,6 +1406,7 @@ packages:
   /@opentelemetry/node/0.22.0_@opentelemetry+api@1.0.3:
     resolution: {integrity: sha512-+HhGbDruQ7cwejVOIYyxRa28uosnG8W95NiQZ6qE8PXXPsDSyGeftAPbtYpGit0H2f5hrVcMlwmWHeAo9xkSLA==}
     engines: {node: '>=8.0.0'}
+    deprecated: Package renamed to @opentelemetry/sdk-trace-node
     peerDependencies:
       '@opentelemetry/api': ^1.0.0
     dependencies:
@@ -2847,8 +2848,8 @@ packages:
     resolution: {integrity: sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs=}
     dev: false
 
-  /csv-parse/4.16.3:
-    resolution: {integrity: sha512-cO1I/zmz4w2dcKHVvpCr7JVRu8/FymG5OEpmvsZYlccYolPBLoVGKUHgNoc4ZGkFeFlWGEDmMyBM+TTqRdW/wg==}
+  /csv-parse/5.0.3:
+    resolution: {integrity: sha512-86R0WU4aEEF/1fPZKxP3NmDAYC4Ce1t9iFgKPZogG5Lvk4m9WZQkCEsDANktG29jppejwclTtEOzubN2ieCJqw==}
     dev: false
 
   /custom-event/1.0.1:
@@ -7617,7 +7618,7 @@ packages:
     dev: false
 
   file:projects/ai-anomaly-detector.tgz:
-    resolution: {integrity: sha512-cJsU3dbrfsLFtRTnP5QinDTQxTntpwHZqrfBbHQz0zNxdZbuVPFuAv/T7sOD1zov7gU4+btYqjfzdfJjTsxZ9Q==, tarball: file:projects/ai-anomaly-detector.tgz}
+    resolution: {integrity: sha512-WHbpbaWO5MeauoXqz1GyjxINlCGfFYPa3O8pOn8TsMY9clEFX/dkGHl9W+Twc3zYSXyCi6ALbGH6JkufxbUEpg==, tarball: file:projects/ai-anomaly-detector.tgz}
     name: '@rush-temp/ai-anomaly-detector'
     version: 0.0.0
     dependencies:
@@ -7628,7 +7629,7 @@ packages:
       '@types/node': 12.20.37
       chai: 4.3.4
       cross-env: 7.0.3
-      csv-parse: 4.16.3
+      csv-parse: 5.0.3
       dotenv: 8.6.0
       eslint: 7.32.0
       inherits: 2.0.4
@@ -13079,7 +13080,7 @@ packages:
     dev: false
 
   file:projects/test-recorder-new.tgz:
-    resolution: {integrity: sha512-3vm8AuXUmIG1xAGO7frvsnbqa10IyXlFcvMyNlJATlgfqCPCUcKNB7jaq6KjijaC4K86vVRiBJ4HF1DiJ7C2eA==, tarball: file:projects/test-recorder-new.tgz}
+    resolution: {integrity: sha512-xEdkJC5rMO2mmrosjw15rNWHcxhh5uXxCdZskU9147jLdrePtr1kmPV64xnZf6GLjTndCpq9tJydQdWwbtIQ4g==, tarball: file:projects/test-recorder-new.tgz}
     name: '@rush-temp/test-recorder-new'
     version: 0.0.0
     dependencies:
@@ -13263,7 +13264,7 @@ packages:
     dev: false
 
   file:projects/testing-recorder-new.tgz:
-    resolution: {integrity: sha512-OZ560z1sPAZVa6eoSCBtMH/RRLwRtJ9PuJhFRcQv8ldBSPsFFhLgbX2S/04kqc0ShVtDJT7IQ9so01cZvyKMRg==, tarball: file:projects/testing-recorder-new.tgz}
+    resolution: {integrity: sha512-mdXZ9tCySJwZPY1AEBWEe2U+al31WEkYxH1NEziqnPjUDTHhHobXZ7SLt6IzIirAKaB7TC4/N6YFv6PPJYjR1w==, tarball: file:projects/testing-recorder-new.tgz}
     name: '@rush-temp/testing-recorder-new'
     version: 0.0.0
     dependencies:

--- a/sdk/anomalydetector/ai-anomaly-detector/package.json
+++ b/sdk/anomalydetector/ai-anomaly-detector/package.json
@@ -77,7 +77,7 @@
     "@types/node": "^12.0.0",
     "chai": "^4.2.0",
     "cross-env": "^7.0.2",
-    "csv-parse": "^4.4.0",
+    "csv-parse": "^5.0.3",
     "dotenv": "^8.2.0",
     "eslint": "^7.15.0",
     "inherits": "^2.0.3",

--- a/sdk/anomalydetector/ai-anomaly-detector/samples-dev/sample_detect_change_point.ts
+++ b/sdk/anomalydetector/ai-anomaly-detector/samples-dev/sample_detect_change_point.ts
@@ -18,7 +18,7 @@ import {
 import { AzureKeyCredential } from "@azure/core-auth";
 
 import * as fs from "fs";
-import parse from "csv-parse/lib/sync";
+import { parse } from "csv-parse/lib/sync";
 
 // Load the .env file if it exists
 import * as dotenv from "dotenv";

--- a/sdk/anomalydetector/ai-anomaly-detector/samples-dev/sample_detect_entire_series_anomaly.ts
+++ b/sdk/anomalydetector/ai-anomaly-detector/samples-dev/sample_detect_entire_series_anomaly.ts
@@ -18,7 +18,7 @@ import {
 import { AzureKeyCredential } from "@azure/core-auth";
 
 import * as fs from "fs";
-import parse from "csv-parse/lib/sync";
+import { parse } from "csv-parse/lib/sync";
 
 // Load the .env file if it exists
 import * as dotenv from "dotenv";

--- a/sdk/anomalydetector/ai-anomaly-detector/samples-dev/sample_detect_last_point_anomaly.ts
+++ b/sdk/anomalydetector/ai-anomaly-detector/samples-dev/sample_detect_last_point_anomaly.ts
@@ -18,7 +18,7 @@ import {
 import { AzureKeyCredential } from "@azure/core-auth";
 
 import * as fs from "fs";
-import parse from "csv-parse/lib/sync";
+import { parse } from "csv-parse/lib/sync";
 
 // Load the .env file if it exists
 import * as dotenv from "dotenv";


### PR DESCRIPTION
csv-parser is a dev dependency used in samples for `ai-anomaly-detector`. Updating to the latest version. The only breaking change that hit us is that parse is now a named export, so I had to change the import to a named import

Fixes #19215