### PR TITLE
Fixing error in samples build from Communication-SMS

### DIFF
--- a/sdk/communication/communication-sms/samples-dev/sendSms.ts
+++ b/sdk/communication/communication-sms/samples-dev/sendSms.ts
@@ -23,10 +23,10 @@ export async function main() {
   const client = new SmsClient(connectionString);
 
   // construct send request
-  var phoneNumbers: string[];
-  if (process.env.TO_PHONE_NUMBERS != undefined) {
+  let phoneNumbers: string[];
+  if (process.env.TO_PHONE_NUMBERS !== undefined) {
     phoneNumbers = process.env.TO_PHONE_NUMBERS.split(",");
-  } else if (process.env.AZURE_PHONE_NUMBER != undefined) {
+  } else if (process.env.AZURE_PHONE_NUMBER !== undefined) {
     phoneNumbers = [process.env.AZURE_PHONE_NUMBER];
   } else {
     phoneNumbers = ["<to-phone-number-1>", "<to-phone-number-2>"];

--- a/sdk/communication/communication-sms/samples-dev/sendSms.ts
+++ b/sdk/communication/communication-sms/samples-dev/sendSms.ts
@@ -23,12 +23,18 @@ export async function main() {
   const client = new SmsClient(connectionString);
 
   // construct send request
+  var phoneNumbers: string[];
+  if (process.env.TO_PHONE_NUMBERS != undefined) {
+    phoneNumbers = process.env.TO_PHONE_NUMBERS.split(",");
+  } else if (process.env.AZURE_PHONE_NUMBER != undefined) {
+    phoneNumbers = [process.env.AZURE_PHONE_NUMBER];
+  } else {
+    phoneNumbers = ["<to-phone-number-1>", "<to-phone-number-2>"];
+  }
+
   const sendRequest: SmsSendRequest = {
     from: process.env.FROM_PHONE_NUMBER || process.env.AZURE_PHONE_NUMBER || "<from-phone-number>",
-    to: process.env.TO_PHONE_NUMBERS?.split(",") || [process.env.AZURE_PHONE_NUMBER!] || [
-        "<to-phone-number-1>",
-        "<to-phone-number-2>"
-      ],
+    to: phoneNumbers,
     message: "Hello World via SMS!"
   };
 

--- a/sdk/communication/communication-sms/samples-dev/sendSmsWithOptions.ts
+++ b/sdk/communication/communication-sms/samples-dev/sendSmsWithOptions.ts
@@ -24,10 +24,10 @@ export async function main() {
   const client = new SmsClient(connectionString);
 
   // construct send request
-  var phoneNumbers: string[];
-  if (process.env.TO_PHONE_NUMBERS != undefined) {
+  let phoneNumbers: string[];
+  if (process.env.TO_PHONE_NUMBERS !== undefined) {
     phoneNumbers = process.env.TO_PHONE_NUMBERS.split(",");
-  } else if (process.env.AZURE_PHONE_NUMBER != undefined) {
+  } else if (process.env.AZURE_PHONE_NUMBER !== undefined) {
     phoneNumbers = [process.env.AZURE_PHONE_NUMBER];
   } else {
     phoneNumbers = ["<to-phone-number-1>", "<to-phone-number-2>"];

--- a/sdk/communication/communication-sms/samples-dev/sendSmsWithOptions.ts
+++ b/sdk/communication/communication-sms/samples-dev/sendSmsWithOptions.ts
@@ -24,12 +24,18 @@ export async function main() {
   const client = new SmsClient(connectionString);
 
   // construct send request
+  var phoneNumbers: string[];
+  if (process.env.TO_PHONE_NUMBERS != undefined) {
+    phoneNumbers = process.env.TO_PHONE_NUMBERS.split(",");
+  } else if (process.env.AZURE_PHONE_NUMBER != undefined) {
+    phoneNumbers = [process.env.AZURE_PHONE_NUMBER];
+  } else {
+    phoneNumbers = ["<to-phone-number-1>", "<to-phone-number-2>"];
+  }
+
   const sendRequest: SmsSendRequest = {
     from: process.env.FROM_PHONE_NUMBER || process.env.AZURE_PHONE_NUMBER || "<from-phone-number>",
-    to: process.env.TO_PHONE_NUMBERS?.split(",") || [process.env.AZURE_PHONE_NUMBER!] || [
-        "<to-phone-number-1>",
-        "<to-phone-number-2>"
-      ],
+    to: phoneNumbers,
     message: "Hello World via SMS!"
   };
 

--- a/sdk/communication/communication-sms/samples-dev/usingAadAuth.ts
+++ b/sdk/communication/communication-sms/samples-dev/usingAadAuth.ts
@@ -47,10 +47,10 @@ export async function main() {
   const client = new SmsClient(endpoint, credential);
 
   // construct send request
-  var phoneNumbers: string[];
-  if (process.env.TO_PHONE_NUMBERS != undefined) {
+  let phoneNumbers: string[];
+  if (process.env.TO_PHONE_NUMBERS !== undefined) {
     phoneNumbers = process.env.TO_PHONE_NUMBERS.split(",");
-  } else if (process.env.AZURE_PHONE_NUMBER != undefined) {
+  } else if (process.env.AZURE_PHONE_NUMBER !== undefined) {
     phoneNumbers = [process.env.AZURE_PHONE_NUMBER];
   } else {
     phoneNumbers = ["<to-phone-number-1>", "<to-phone-number-2>"];

--- a/sdk/communication/communication-sms/samples-dev/usingAadAuth.ts
+++ b/sdk/communication/communication-sms/samples-dev/usingAadAuth.ts
@@ -47,12 +47,18 @@ export async function main() {
   const client = new SmsClient(endpoint, credential);
 
   // construct send request
+  var phoneNumbers: string[];
+  if (process.env.TO_PHONE_NUMBERS != undefined) {
+    phoneNumbers = process.env.TO_PHONE_NUMBERS.split(",");
+  } else if (process.env.AZURE_PHONE_NUMBER != undefined) {
+    phoneNumbers = [process.env.AZURE_PHONE_NUMBER];
+  } else {
+    phoneNumbers = ["<to-phone-number-1>", "<to-phone-number-2>"];
+  }
+
   const sendRequest: SmsSendRequest = {
     from: process.env.FROM_PHONE_NUMBER || process.env.AZURE_PHONE_NUMBER || "<from-phone-number>",
-    to: process.env.TO_PHONE_NUMBERS?.split(",") || [process.env.AZURE_PHONE_NUMBER!] || [
-        "<to-phone-number-1>",
-        "<to-phone-number-2>"
-      ],
+    to: phoneNumbers,
     message: "Hello World via SMS!"
   };
 

--- a/sdk/communication/communication-sms/samples/v1/typescript/src/sendSms.ts
+++ b/sdk/communication/communication-sms/samples/v1/typescript/src/sendSms.ts
@@ -23,11 +23,11 @@ export async function main() {
   const client = new SmsClient(connectionString);
 
   // construct send request
-  var phoneNumbers: string[];
-  if (process.env.TO_PHONE_NUMBERS != undefined) {
+  let phoneNumbers: string[];
+  if (process.env.TO_PHONE_NUMBERS !== undefined) {
     phoneNumbers = process.env.TO_PHONE_NUMBERS.split(",")
   }
-  else if (process.env.AZURE_PHONE_NUMBER != undefined) {
+  else if (process.env.AZURE_PHONE_NUMBER !== undefined) {
     phoneNumbers = [process.env.AZURE_PHONE_NUMBER]
   }
   else {

--- a/sdk/communication/communication-sms/samples/v1/typescript/src/sendSms.ts
+++ b/sdk/communication/communication-sms/samples/v1/typescript/src/sendSms.ts
@@ -23,12 +23,20 @@ export async function main() {
   const client = new SmsClient(connectionString);
 
   // construct send request
+  var phoneNumbers: string[];
+  if (process.env.TO_PHONE_NUMBERS != undefined) {
+    phoneNumbers = process.env.TO_PHONE_NUMBERS.split(",")
+  }
+  else if (process.env.AZURE_PHONE_NUMBER != undefined) {
+    phoneNumbers = [process.env.AZURE_PHONE_NUMBER]
+  }
+  else {
+    phoneNumbers = ["<to-phone-number-1>", "<to-phone-number-2>"]
+  }
+
   const sendRequest: SmsSendRequest = {
     from: process.env.FROM_PHONE_NUMBER || process.env.AZURE_PHONE_NUMBER || "<from-phone-number>",
-    to: process.env.TO_PHONE_NUMBERS?.split(",") || [process.env.AZURE_PHONE_NUMBER!] || [
-        "<to-phone-number-1>",
-        "<to-phone-number-2>"
-      ],
+    to: phoneNumbers,
     message: "Hello World via SMS!"
   };
 

--- a/sdk/communication/communication-sms/samples/v1/typescript/src/sendSmsWithOptions.ts
+++ b/sdk/communication/communication-sms/samples/v1/typescript/src/sendSmsWithOptions.ts
@@ -24,11 +24,11 @@ export async function main() {
   const client = new SmsClient(connectionString);
 
   // construct send request
-  var phoneNumbers: string[];
-  if (process.env.TO_PHONE_NUMBERS != undefined) {
+  let phoneNumbers: string[];
+  if (process.env.TO_PHONE_NUMBERS !== undefined) {
     phoneNumbers = process.env.TO_PHONE_NUMBERS.split(",")
   }
-  else if (process.env.AZURE_PHONE_NUMBER != undefined) {
+  else if (process.env.AZURE_PHONE_NUMBER !== undefined) {
     phoneNumbers = [process.env.AZURE_PHONE_NUMBER]
   }
   else {

--- a/sdk/communication/communication-sms/samples/v1/typescript/src/sendSmsWithOptions.ts
+++ b/sdk/communication/communication-sms/samples/v1/typescript/src/sendSmsWithOptions.ts
@@ -24,12 +24,20 @@ export async function main() {
   const client = new SmsClient(connectionString);
 
   // construct send request
+  var phoneNumbers: string[];
+  if (process.env.TO_PHONE_NUMBERS != undefined) {
+    phoneNumbers = process.env.TO_PHONE_NUMBERS.split(",")
+  }
+  else if (process.env.AZURE_PHONE_NUMBER != undefined) {
+    phoneNumbers = [process.env.AZURE_PHONE_NUMBER]
+  }
+  else {
+    phoneNumbers = ["<to-phone-number-1>", "<to-phone-number-2>"]
+  }
+
   const sendRequest: SmsSendRequest = {
     from: process.env.FROM_PHONE_NUMBER || process.env.AZURE_PHONE_NUMBER || "<from-phone-number>",
-    to: process.env.TO_PHONE_NUMBERS?.split(",") || [process.env.AZURE_PHONE_NUMBER!] || [
-        "<to-phone-number-1>",
-        "<to-phone-number-2>"
-      ],
+    to: phoneNumbers,
     message: "Hello World via SMS!"
   };
 

--- a/sdk/communication/communication-sms/samples/v1/typescript/src/usingAadAuth.ts
+++ b/sdk/communication/communication-sms/samples/v1/typescript/src/usingAadAuth.ts
@@ -47,11 +47,11 @@ export async function main() {
   const client = new SmsClient(endpoint, credential);
 
   // construct send request
-  var phoneNumbers: string[];
-  if (process.env.TO_PHONE_NUMBERS != undefined) {
+  let phoneNumbers: string[];
+  if (process.env.TO_PHONE_NUMBERS !== undefined) {
     phoneNumbers = process.env.TO_PHONE_NUMBERS.split(",")
   }
-  else if (process.env.AZURE_PHONE_NUMBER != undefined) {
+  else if (process.env.AZURE_PHONE_NUMBER !== undefined) {
     phoneNumbers = [process.env.AZURE_PHONE_NUMBER]
   }
   else {

--- a/sdk/communication/communication-sms/samples/v1/typescript/src/usingAadAuth.ts
+++ b/sdk/communication/communication-sms/samples/v1/typescript/src/usingAadAuth.ts
@@ -38,21 +38,29 @@ export async function main() {
   const credential: TokenCredential = isNode
     ? new DefaultAzureCredential()
     : new ClientSecretCredential(
-        process.env.AZURE_TENANT_ID,
-        process.env.AZURE_CLIENT_ID,
-        process.env.AZURE_CLIENT_SECRET
-      );
+      process.env.AZURE_TENANT_ID,
+      process.env.AZURE_CLIENT_ID,
+      process.env.AZURE_CLIENT_SECRET
+    );
 
   // create new client with endpoint and credentials
   const client = new SmsClient(endpoint, credential);
 
   // construct send request
+  var phoneNumbers: string[];
+  if (process.env.TO_PHONE_NUMBERS != undefined) {
+    phoneNumbers = process.env.TO_PHONE_NUMBERS.split(",")
+  }
+  else if (process.env.AZURE_PHONE_NUMBER != undefined) {
+    phoneNumbers = [process.env.AZURE_PHONE_NUMBER]
+  }
+  else {
+    phoneNumbers = ["<to-phone-number-1>", "<to-phone-number-2>"]
+  }
+
   const sendRequest: SmsSendRequest = {
     from: process.env.FROM_PHONE_NUMBER || process.env.AZURE_PHONE_NUMBER || "<from-phone-number>",
-    to: process.env.TO_PHONE_NUMBERS?.split(",") || [process.env.AZURE_PHONE_NUMBER!] || [
-        "<to-phone-number-1>",
-        "<to-phone-number-2>"
-      ],
+    to: phoneNumbers,
     message: "Hello World via SMS!"
   };
 


### PR DESCRIPTION
On PR https://github.com/Azure/azure-sdk-for-js/pull/19489 there is the following error when building the samples for communication-sms:
```
samples-dev/sendSms.ts:28:9 - error TS-AZURE: unsupported ES2020 "OptionalChain" syntax

28     to: process.env.TO_PHONE_NUMBERS?.split(",") || [process.env.AZURE_PHONE_NUMBER!] || [
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

    Suggestion: try `process.env.TO_PHONE_NUMBERS.split && process.env.TO_PHONE_NUMBERS.split(",")` if it does not affect runtime behavior, or use an explicit `if` block to handle the nullish case

[publish] Cannot read properties of undefined (reading 'kind')
[dev-tool] Errors occured. See the output above.
The script failed with exit code 1
```

This error is also present on main.

In this PR I changed the optional chain to `if` blocks as suggested. This fixes the error.