### PR TITLE
[engSys] - Fix Exclusion patterns

### DIFF
--- a/eng/guardian-tools/policheck/PolicheckExclusions.xml
+++ b/eng/guardian-tools/policheck/PolicheckExclusions.xml
@@ -1,8 +1,7 @@
 <PoliCheckExclusions>
 <!-- All strings must be UPPER CASE -->
 <!-- Each of these exclusions is a folder name - if \[name]\ exists in the file path, it will be skipped -->
-<Exclusion Type="FolderPathFull">RECORDINGS</Exclusion>
-<Exclusion Type="FolderPathFull">GENERATED</Exclusion>
+<Exclusion Type="FolderPathFull">RECORDINGS|GENERATED</Exclusion>
 <!-- Each of these exclusions is a folder name - if any folder or file starts with "\[name]", it will be 
 skipped -->
 <!--<Exclusion Type="FolderPathStart">ABC|XYZ</Exclusion>-->


### PR DESCRIPTION
In #19454 we added generated folders to the Policheck exclusion list, but it's actually not quite right. This commit fixes that issue and correctly adds generated folders to the exclusions patterns.