### PR TITLE
[ServiceBus][TestReliability] Increase timeout when expecting an error

### DIFF
--- a/sdk/servicebus/service-bus/test/internal/serviceBusClient.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/serviceBusClient.spec.ts
@@ -257,7 +257,7 @@ describe("ServiceBusClient live tests", () => {
       });
 
       should.equal(
-        await checkWithTimeout(() => errorWasThrown === true, 10, 3000),
+        await checkWithTimeout(() => errorWasThrown === true, 10, 5000),
         true,
         "Error thrown flag must be true"
       );


### PR DESCRIPTION
for non-existing queue.

Detailed logs show that when this test is running on China Cloud on a Mac build agent, it gets the
expected error except that it takes a little more than 3 seconds for the error to come back.

This PR increases the timeout to 5 seconds.

Fixes #17928 