### PR TITLE
Fix test case failures in data lake package

### DIFF
--- a/sdk/storage/storage-file-datalake/test/browser/highlevel.browser.spec.ts
+++ b/sdk/storage/storage-file-datalake/test/browser/highlevel.browser.spec.ts
@@ -152,29 +152,28 @@ describe("Highlevel browser only", () => {
       uint8Array[i] = i;
     }
 
-    const blob = new Blob([arrayBuf], { type: "text/plain;charset=utf-8" });
+    const blob = new Blob([arrayBuf]);
     await fileClient.upload(blob);
-    const downloadedBlob = await (await fileClient.read()).contentAsBlob;
-    assert.deepStrictEqual(downloadedBlob, blob);
+    const downloadedBlob = await (await fileClient.read()).contentAsBlob!;
+    assert.ok(arrayBufferEqual(await downloadedBlob.arrayBuffer(), await blob.arrayBuffer()));
 
     await fileClient.upload(arrayBuf);
-    const downloadedBlob1 = await (await fileClient.read()).contentAsBlob;
-    assert.deepStrictEqual(downloadedBlob1, blob);
+    const downloadedBlob1 = await (await fileClient.read()).contentAsBlob!;
+    assert.ok(arrayBufferEqual(await downloadedBlob1.arrayBuffer(), await blob.arrayBuffer()));
 
     const uint8ArrayPartial = new Uint8Array(arrayBuf, 1, 3);
     await fileClient.upload(uint8ArrayPartial);
     const downloadedBlob2 = await (await fileClient.read()).contentAsBlob!;
-    assert.deepStrictEqual(
-      downloadedBlob2,
-      new Blob([uint8ArrayPartial], { type: "text/plain;charset=utf-8" })
-    );
+    assert.ok(arrayBufferEqual(await downloadedBlob2.arrayBuffer(), uint8ArrayPartial));
 
     const uint16Array = new Uint16Array(arrayBuf, 4, 2);
     await fileClient.upload(uint16Array);
     const downloadedBlob3 = await (await fileClient.read()).contentAsBlob!;
-    assert.deepStrictEqual(
-      downloadedBlob3,
-      new Blob([uint16Array], { type: "text/plain;charset=utf-8" })
+    assert.ok(
+      arrayBufferEqual(
+        await downloadedBlob3.arrayBuffer(),
+        new Uint8Array(uint16Array.buffer, uint16Array.byteOffset, uint16Array.byteLength)
+      )
     );
   });
 });

--- a/sdk/storage/storage-file-datalake/test/filesystemclient.spec.ts
+++ b/sdk/storage/storage-file-datalake/test/filesystemclient.spec.ts
@@ -37,11 +37,11 @@ describe("DataLakeFileSystemClient", () => {
     serviceClient = getDataLakeServiceClient();
     fileSystemName = recorder.getUniqueName("filesystem");
     fileSystemClient = serviceClient.getFileSystemClient(fileSystemName);
-    await fileSystemClient.create();
+    await fileSystemClient.createIfNotExists();
   });
 
   afterEach(async function() {
-    await fileSystemClient.delete();
+    await fileSystemClient.deleteIfExists();
     await recorder.stop();
   });
 
@@ -146,7 +146,7 @@ describe("DataLakeFileSystemClient", () => {
     const createRes2 = await cClient.createIfNotExists({ metadata, access });
     assert.ok(!createRes2.succeeded);
 
-    await cClient.delete();
+    await cClient.deleteIfExists();
   });
 
   it("deleteIfExists", async () => {
@@ -463,12 +463,12 @@ describe("DataLakeFileSystemClient with soft delete", () => {
     }
 
     fileSystemClient = serviceClient.getFileSystemClient(recorder.getUniqueName(`filesystem`));
-    await fileSystemClient.create();
+    await fileSystemClient.createIfNotExists();
   });
 
   afterEach(async function() {
     if (fileSystemClient !== undefined) {
-      await fileSystemClient.delete();
+      await fileSystemClient.deleteIfExists();
     }
     await recorder.stop();
   });

--- a/sdk/storage/storage-file-datalake/test/leaseclient.spec.ts
+++ b/sdk/storage/storage-file-datalake/test/leaseclient.spec.ts
@@ -22,11 +22,11 @@ describe("LeaseClient from FileSystem", () => {
     const serviceClient = getDataLakeServiceClient();
     fileSystemName = recorder.getUniqueName("filesystem");
     fileSystemClient = serviceClient.getFileSystemClient(fileSystemName);
-    await fileSystemClient.create();
+    await fileSystemClient.createIfNotExists();
   });
 
   afterEach(async function() {
-    await fileSystemClient.delete();
+    await fileSystemClient.deleteIfExists();
     await recorder.stop();
   });
 
@@ -154,14 +154,14 @@ describe("LeaseClient from File", () => {
     const serviceClient = getDataLakeServiceClient();
     fileSystemName = recorder.getUniqueName("filesystem");
     fileSystemClient = serviceClient.getFileSystemClient(fileSystemName);
-    await fileSystemClient.create();
+    await fileSystemClient.createIfNotExists();
     fileName = recorder.getUniqueName("file");
     fileClient = fileSystemClient.getFileClient(fileName);
     await fileClient.create();
   });
 
   afterEach(async function() {
-    await fileSystemClient.delete();
+    await fileSystemClient.deleteIfExists();
     await recorder.stop();
   });
 
@@ -277,14 +277,14 @@ describe("LeaseClient from Directory", () => {
     const serviceClient = getDataLakeServiceClient();
     fileSystemName = recorder.getUniqueName("filesystem");
     fileSystemClient = serviceClient.getFileSystemClient(fileSystemName);
-    await fileSystemClient.create();
+    await fileSystemClient.createIfNotExists();
     directoryName = recorder.getUniqueName("dir");
     directoryClient = fileSystemClient.getDirectoryClient(directoryName);
     await directoryClient.create();
   });
 
   afterEach(async function() {
-    await fileSystemClient.delete();
+    await fileSystemClient.deleteIfExists();
     await recorder.stop();
   });
 

--- a/sdk/storage/storage-file-datalake/test/node/filesystemclient.spec.ts
+++ b/sdk/storage/storage-file-datalake/test/node/filesystemclient.spec.ts
@@ -26,11 +26,11 @@ describe("DataLakeFileSystemClient Node.js only", () => {
     const serviceClient = getDataLakeServiceClient();
     fileSystemName = recorder.getUniqueName("filesystem");
     fileSystemClient = serviceClient.getFileSystemClient(fileSystemName);
-    await fileSystemClient.create();
+    await fileSystemClient.createIfNotExists();
   });
 
   afterEach(async function() {
-    await fileSystemClient.delete();
+    await fileSystemClient.deleteIfExists();
     await recorder.stop();
   });
 

--- a/sdk/storage/storage-file-datalake/test/node/highlevel.node.spec.ts
+++ b/sdk/storage/storage-file-datalake/test/node/highlevel.node.spec.ts
@@ -50,14 +50,14 @@ describe("Highlevel Node.js only", () => {
     });
     fileSystemName = recorder.getUniqueName("filesystem");
     fileSystemClient = serviceClient.getFileSystemClient(fileSystemName);
-    await fileSystemClient.create();
+    await fileSystemClient.createIfNotExists();
     fileName = recorder.getUniqueName("file");
     fileClient = fileSystemClient.getFileClient(fileName);
   });
 
   afterEach(async function(this: Context) {
     if (!this.currentTest?.isPending()) {
-      await fileSystemClient.delete();
+      await fileSystemClient.deleteIfExists();
       await recorder.stop();
     }
   });
@@ -250,7 +250,7 @@ describe("Highlevel Node.js only", () => {
   it("upload to a leased file should succeed when LeaseAccessConditions is specified", async () => {
     await fileClient.upload(Buffer.from("aaa"));
 
-    const duration = 30;
+    const duration = 60;
     const leaseClient = fileClient.getDataLakeLeaseClient();
     await leaseClient.acquireLease(duration);
 

--- a/sdk/storage/storage-file-datalake/test/node/pathclient.spec.ts
+++ b/sdk/storage/storage-file-datalake/test/node/pathclient.spec.ts
@@ -43,7 +43,7 @@ describe("DataLakePathClient Node.js only", () => {
     serviceClient = getDataLakeServiceClient();
     fileSystemName = recorder.getUniqueName("filesystem");
     fileSystemClient = serviceClient.getFileSystemClient(fileSystemName);
-    await fileSystemClient.create();
+    await fileSystemClient.createIfNotExists();
     fileName = recorder.getUniqueName("file");
     fileClient = fileSystemClient.getFileClient(fileName);
     await fileClient.create();
@@ -52,7 +52,7 @@ describe("DataLakePathClient Node.js only", () => {
   });
 
   afterEach(async function() {
-    await fileSystemClient.delete();
+    await fileSystemClient.deleteIfExists();
     await recorder.stop();
   });
 
@@ -342,7 +342,7 @@ describe("DataLakePathClient Node.js only", () => {
     await fileClient.move(destFileSystemName, destFileName);
 
     await destFileClient.getProperties();
-    await destFileSystemClient.delete();
+    await destFileSystemClient.deleteIfExists();
   });
 
   it("move should not encode / in the source", async () => {
@@ -463,7 +463,7 @@ describe("DataLakePathClient setAccessControlRecursive Node.js only", () => {
     serviceClient = getDataLakeServiceClient();
     fileSystemName = recorder.getUniqueName("filesystem");
     fileSystemClient = serviceClient.getFileSystemClient(fileSystemName);
-    await fileSystemClient.create();
+    await fileSystemClient.createIfNotExists();
     fileName = recorder.getUniqueName("file");
     fileClient = fileSystemClient.getFileClient(fileName);
     await fileClient.create();
@@ -472,7 +472,7 @@ describe("DataLakePathClient setAccessControlRecursive Node.js only", () => {
   });
 
   afterEach(async function() {
-    await fileSystemClient.delete();
+    await fileSystemClient.deleteIfExists();
     await recorder.stop();
   });
 

--- a/sdk/storage/storage-file-datalake/test/node/sas.spec.ts
+++ b/sdk/storage/storage-file-datalake/test/node/sas.spec.ts
@@ -224,7 +224,7 @@ describe("Shared Access Signature (SAS) generation Node.js only", () => {
         .next()
     ).value;
     assert.deepStrictEqual(result.pathItems.length, 0);
-    await fileSystemClient.delete();
+    await fileSystemClient.deleteIfExists();
   });
 
   it("generateDataLakeSASQueryParameters should work for file with previous API version", async () => {
@@ -281,7 +281,7 @@ describe("Shared Access Signature (SAS) generation Node.js only", () => {
     assert.equal(properties.contentLanguage, "content-language-override");
     assert.equal(properties.contentType, "content-type-override");
 
-    await fileSystemClient.delete();
+    await fileSystemClient.deleteIfExists();
   });
 
   it("generateDataLakeSASQueryParameters should work for file", async () => {
@@ -338,7 +338,7 @@ describe("Shared Access Signature (SAS) generation Node.js only", () => {
     assert.equal(properties.contentLanguage, "content-language-override");
     assert.equal(properties.contentType, "content-type-override");
 
-    await fileSystemClient.delete();
+    await fileSystemClient.deleteIfExists();
   });
 
   it("generateDataLakeSASQueryParameters should work for file with special namings", async () => {
@@ -398,7 +398,7 @@ describe("Shared Access Signature (SAS) generation Node.js only", () => {
     assert.equal(properties.contentLanguage, "content-language-override");
     assert.equal(properties.contentType, "content-type-override");
 
-    await fileSystemClient.delete();
+    await fileSystemClient.deleteIfExists();
   });
 
   it("generateDataLakeSASQueryParameters should work for fileSystem with access policy", async () => {
@@ -456,7 +456,7 @@ describe("Shared Access Signature (SAS) generation Node.js only", () => {
     );
 
     await fileClientWithSAS.getProperties();
-    await fileSystemClient.delete();
+    await fileSystemClient.deleteIfExists();
   });
 
   it("generateDataLakeSASQueryParameters should work for file with access policy", async () => {
@@ -515,7 +515,7 @@ describe("Shared Access Signature (SAS) generation Node.js only", () => {
     );
 
     await fileClientWithSAS.getProperties();
-    await fileSystemClient.delete();
+    await fileSystemClient.deleteIfExists();
   });
 
   it("GenerateUserDelegationSAS should work for filesystem with all configurations", async function(this: Context) {
@@ -576,7 +576,7 @@ describe("Shared Access Signature (SAS) generation Node.js only", () => {
         .next()
     ).value;
     assert.deepStrictEqual(result.pathItems.length, 0);
-    await fileSystemClient.delete();
+    await fileSystemClient.deleteIfExists();
   });
 
   it("GenerateUserDelegationSAS should work for filesystem with minimum parameters", async function(this: Context) {
@@ -633,7 +633,7 @@ describe("Shared Access Signature (SAS) generation Node.js only", () => {
         .next()
     ).value;
     assert.deepStrictEqual(result.pathItems.length, 0);
-    await fileSystemClient.delete();
+    await fileSystemClient.deleteIfExists();
   });
 
   it("GenerateUserDelegationSAS should work for file", async function(this: Context) {
@@ -707,7 +707,7 @@ describe("Shared Access Signature (SAS) generation Node.js only", () => {
     assert.equal(properties.contentLanguage, "content-language-override");
     assert.equal(properties.contentType, "content-type-override");
 
-    await fileSystemClient.delete();
+    await fileSystemClient.deleteIfExists();
   });
 
   it("GenerateUserDelegationSAS should work for file for 2019-12-12", async function(this: Context) {
@@ -877,7 +877,7 @@ describe("Shared Access Signature (SAS) generation Node.js only", () => {
   it("DataLakeFileSystemClient.generateSasUrl() should work", async () => {
     const fileSystemName = recorder.getUniqueName("filesystem");
     const fileSystemClient = serviceClient.getFileSystemClient(fileSystemName);
-    await fileSystemClient.create();
+    await fileSystemClient.createIfNotExists();
 
     const now = recorder.newDate("now");
     now.setMinutes(now.getMinutes() - 10); // Skip clock skew with server
@@ -912,7 +912,7 @@ describe("Shared Access Signature (SAS) generation Node.js only", () => {
     }
     assert.ok(exceptionCaught);
 
-    await fileSystemClient.delete();
+    await fileSystemClient.deleteIfExists();
   });
 });
 
@@ -952,7 +952,7 @@ describe("SAS generation Node.js only for directory SAS", () => {
 
     const fileSystemName = recorder.getUniqueName("filesystem");
     fileSystemClient = serviceClient.getFileSystemClient(fileSystemName);
-    await fileSystemClient.create();
+    await fileSystemClient.createIfNotExists();
 
     const directoryName = recorder.getUniqueName("directory");
     directoryClient = fileSystemClient.getDirectoryClient(directoryName);
@@ -971,7 +971,7 @@ describe("SAS generation Node.js only for directory SAS", () => {
   });
 
   afterEach(async function() {
-    await fileSystemClient.delete();
+    await fileSystemClient.deleteIfExists();
     await recorder.stop();
   });
 
@@ -1278,7 +1278,7 @@ describe("SAS generation Node.js only for delegation SAS", () => {
 
     fileSystemName = recorder.getUniqueName("filesystem");
     fileSystemClient = oauthServiceClient.getFileSystemClient(fileSystemName);
-    await fileSystemClient.create();
+    await fileSystemClient.createIfNotExists();
 
     const directoryName = recorder.getUniqueName("directory");
     directoryClient = fileSystemClient.getDirectoryClient(directoryName);
@@ -1291,7 +1291,7 @@ describe("SAS generation Node.js only for delegation SAS", () => {
 
   afterEach(async function() {
     if (fileSystemClient) {
-      await fileSystemClient.delete();
+      await fileSystemClient.deleteIfExists();
     }
     await recorder.stop();
   });

--- a/sdk/storage/storage-file-datalake/test/pathclient.spec.ts
+++ b/sdk/storage/storage-file-datalake/test/pathclient.spec.ts
@@ -30,7 +30,7 @@ describe("DataLakePathClient", () => {
     const serviceClient = getDataLakeServiceClient();
     fileSystemName = recorder.getUniqueName("filesystem");
     fileSystemClient = serviceClient.getFileSystemClient(fileSystemName);
-    await fileSystemClient.create();
+    await fileSystemClient.createIfNotExists();
     fileName = recorder.getUniqueName("file");
     fileClient = fileSystemClient.getFileClient(fileName);
     await fileClient.create();
@@ -39,7 +39,7 @@ describe("DataLakePathClient", () => {
   });
 
   afterEach(async function() {
-    await fileSystemClient.delete();
+    await fileSystemClient.deleteIfExists();
     await recorder.stop();
   });
 

--- a/sdk/storage/storage-file-datalake/test/retrypolicy.spec.ts
+++ b/sdk/storage/storage-file-datalake/test/retrypolicy.spec.ts
@@ -26,11 +26,11 @@ describe("RetryPolicy", () => {
     serviceClient = getDataLakeServiceClient();
     fileSystemName = recorder.getUniqueName("container");
     dataLakeFileSystemClient = serviceClient.getFileSystemClient(fileSystemName);
-    await dataLakeFileSystemClient.create();
+    await dataLakeFileSystemClient.createIfNotExists();
   });
 
   afterEach(async function() {
-    await dataLakeFileSystemClient.delete();
+    await dataLakeFileSystemClient.deleteIfExists();
     await recorder.stop();
   });
 

--- a/sdk/storage/storage-file-datalake/test/serviceclient.spec.ts
+++ b/sdk/storage/storage-file-datalake/test/serviceclient.spec.ts
@@ -230,8 +230,8 @@ describe("DataLakeServiceClient", () => {
     assert.deepEqual(result2.fileSystemItems[0].properties.leaseStatus, "unlocked");
     assert.deepEqual(result2.fileSystemItems[0].metadata!.key, "val");
 
-    await fileSystemClient1.delete();
-    await fileSystemClient2.delete();
+    await fileSystemClient1.deleteIfExists();
+    await fileSystemClient2.deleteIfExists();
   });
 
   it("Verify PagedAsyncIterableIterator for ListFileSystems", async () => {
@@ -262,7 +262,7 @@ describe("DataLakeServiceClient", () => {
     }
 
     for (const client of fileSystemClients) {
-      await client.delete();
+      await client.deleteIfExists();
     }
   });
 
@@ -302,8 +302,8 @@ describe("DataLakeServiceClient", () => {
     assert.deepEqual(fileSystemItem.value.properties.leaseStatus, "unlocked");
     assert.deepEqual(fileSystemItem.value.metadata!.key, "val");
 
-    await fileSystemClient1.delete();
-    await fileSystemClient2.delete();
+    await fileSystemClient1.deleteIfExists();
+    await fileSystemClient2.deleteIfExists();
   });
 
   it("Verify PagedAsyncIterableIterator(byPage()) for ListFileSystems", async () => {
@@ -341,7 +341,7 @@ describe("DataLakeServiceClient", () => {
     }
 
     for (const client of fileSystemClients) {
-      await client.delete();
+      await client.deleteIfExists();
     }
   });
 
@@ -401,7 +401,7 @@ describe("DataLakeServiceClient", () => {
     }
 
     for (const client of fileSystemClients) {
-      await client.delete();
+      await client.deleteIfExists();
     }
   });
 
@@ -521,7 +521,7 @@ describe("DataLakeServiceClient", () => {
     assert.deepStrictEqual(newFileSystemClient, renameRes.fileSystemClient);
     await newFileSystemClient.getProperties();
 
-    await newFileSystemClient.delete();
+    await newFileSystemClient.deleteIfExists();
   });
 
   it("undelete and list deleted file system should work", async function(this: Context) {

--- a/sdk/storage/storage-file-datalake/test/specialnaming.spec.ts
+++ b/sdk/storage/storage-file-datalake/test/specialnaming.spec.ts
@@ -25,11 +25,11 @@ describe("Special Naming Tests", () => {
     const serviceClient = getDataLakeServiceClient();
     fileSystemName = recorder.getUniqueName("1container-with-dash");
     fileSystemClient = serviceClient.getFileSystemClient(fileSystemName);
-    await fileSystemClient.create();
+    await fileSystemClient.createIfNotExists();
   });
 
   afterEach(async function() {
-    await fileSystemClient.delete();
+    await fileSystemClient.deleteIfExists();
     await recorder.stop();
   });
 


### PR DESCRIPTION
1. File system client creating/deleting may fail due to retrying, change to use createIfNotExists and deleteIfExists to avoid the failure.

2.  A lease case may fail when lease is expired, set a longer duration to try to mitigate the failure.

3. Data lake file uploading should only care about content, change a case to only validate content instead of checking Blob instance properties.