### PR TITLE
Update prettier dev-dependency to v2.5.1 in Digital Twins

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -1408,6 +1408,7 @@ packages:
   /@opentelemetry/node/0.22.0_@opentelemetry+api@1.0.3:
     resolution: {integrity: sha512-+HhGbDruQ7cwejVOIYyxRa28uosnG8W95NiQZ6qE8PXXPsDSyGeftAPbtYpGit0H2f5hrVcMlwmWHeAo9xkSLA==}
     engines: {node: '>=8.0.0'}
+    deprecated: Package renamed to @opentelemetry/sdk-trace-node
     peerDependencies:
       '@opentelemetry/api': ^1.0.0
     dependencies:
@@ -10606,7 +10607,7 @@ packages:
     dev: false
 
   file:projects/digital-twins-core.tgz:
-    resolution: {integrity: sha512-EmRXFsKEZJNpofnEOpGuVkNnFxj9RfZWOoBLxP97eQfAEKKdyOEJp5PX9J7daCz9SB4sjh+QyRI7ySWSzpov2A==, tarball: file:projects/digital-twins-core.tgz}
+    resolution: {integrity: sha512-+g1UwytCUmPweJ5AQbmVt9MgiJZ/LKESrTbTQnPspd235nWy3EcPruTNZe1aGsN2gkasNWHJu4peD5EQ+hfhTA==, tarball: file:projects/digital-twins-core.tgz}
     name: '@rush-temp/digital-twins-core'
     version: 0.0.0
     dependencies:
@@ -10638,7 +10639,7 @@ packages:
       mocha: 7.2.0
       mocha-junit-reporter: 2.0.2_mocha@7.2.0
       nyc: 15.1.0
-      prettier: 1.19.1
+      prettier: 2.5.1
       rimraf: 3.0.2
       rollup: 1.32.1
       sinon: 9.2.4

--- a/sdk/digitaltwins/digital-twins-core/karma.conf.js
+++ b/sdk/digitaltwins/digital-twins-core/karma.conf.js
@@ -5,10 +5,10 @@ const {
   jsonRecordingFilterFunction,
   isPlaybackMode,
   isSoftRecordMode,
-  isRecordMode
+  isRecordMode,
 } = require("@azure-tools/test-recorder");
 
-module.exports = function(config) {
+module.exports = function (config) {
   config.set({
     // base path that will be used to resolve all patterns (eg. files, exclude)
     basePath: "./",
@@ -29,13 +29,13 @@ module.exports = function(config) {
       "karma-sourcemap-loader",
       "karma-junit-reporter",
       "karma-json-to-file-reporter",
-      "karma-json-preprocessor"
+      "karma-json-preprocessor",
     ],
 
     // list of files / patterns to load in the browser
     files: [
       "dist-test/index.browser.js",
-      { pattern: "dist-test/index.browser.js.map", type: "html", included: false, served: true }
+      { pattern: "dist-test/index.browser.js.map", type: "html", included: false, served: true },
     ].concat(isPlaybackMode() || isSoftRecordMode() ? ["recordings/browsers/**/*.json"] : []),
 
     // list of files / patterns to exclude
@@ -48,7 +48,7 @@ module.exports = function(config) {
       // IMPORTANT: COMMENT following line if you want to debug in your browsers!!
       // Preprocess source file to calculate code coverage, however this will make source file unreadable
       // "dist-test/index.browser.js": ["coverage"]
-      "recordings/browsers/**/*.json": ["json"]
+      "recordings/browsers/**/*.json": ["json"],
     },
 
     // inject following environment values into browser testing with window.__env__
@@ -59,7 +59,7 @@ module.exports = function(config) {
       "AZURE_CLIENT_ID",
       "AZURE_CLIENT_SECRET",
       "AZURE_TENANT_ID",
-      "TEST_MODE"
+      "TEST_MODE",
     ],
 
     // test results reporter to use
@@ -74,8 +74,8 @@ module.exports = function(config) {
         { type: "json", subdir: ".", file: "coverage.json" },
         { type: "lcovonly", subdir: ".", file: "lcov.info" },
         { type: "html", subdir: "html" },
-        { type: "cobertura", subdir: ".", file: "cobertura-coverage.xml" }
-      ]
+        { type: "cobertura", subdir: ".", file: "cobertura-coverage.xml" },
+      ],
     },
 
     junitReporter: {
@@ -85,13 +85,13 @@ module.exports = function(config) {
       useBrowserName: false, // add browser name to report and classes names
       nameFormatter: undefined, // function (browser, result) to customize the name attribute in xml testcase element
       classNameFormatter: undefined, // function (browser, result) to customize the classname attribute in xml testcase element
-      properties: {} // key value pair of properties to add to the <properties> section of the report
+      properties: {}, // key value pair of properties to add to the <properties> section of the report
     },
 
     jsonToFileReporter: {
       // required - to save the recordings of browser tests
       filter: jsonRecordingFilterFunction,
-      outputPath: "."
+      outputPath: ".",
     },
 
     // web server port
@@ -115,8 +115,8 @@ module.exports = function(config) {
     customLaunchers: {
       ChromeHeadlessNoSandbox: {
         base: "ChromeHeadless",
-        flags: ["--no-sandbox", "--disable-web-security"]
-      }
+        flags: ["--no-sandbox", "--disable-web-security"],
+      },
     },
 
     // Continuous Integration mode
@@ -131,15 +131,15 @@ module.exports = function(config) {
     browserDisconnectTimeout: 10000,
     browserDisconnectTolerance: 3,
     browserConsoleLogOptions: {
-      terminal: !isRecordMode()
+      terminal: !isRecordMode(),
     },
 
     client: {
       mocha: {
         // change Karma's debug.html to the mocha web reporter
         reporter: "html",
-        timeout: "600000"
-      }
-    }
+        timeout: "600000",
+      },
+    },
   });
 };

--- a/sdk/digitaltwins/digital-twins-core/package.json
+++ b/sdk/digitaltwins/digital-twins-core/package.json
@@ -101,7 +101,7 @@
     "mocha": "^7.1.1",
     "mocha-junit-reporter": "^2.0.0",
     "nyc": "^15.0.0",
-    "prettier": "^1.16.4",
+    "prettier": "^2.5.1",
     "rimraf": "^3.0.0",
     "rollup": "^1.16.3",
     "sinon": "^9.0.2",

--- a/sdk/digitaltwins/digital-twins-core/samples-dev/dt_component_lifecycle.ts
+++ b/sdk/digitaltwins/digital-twins-core/samples-dev/dt_component_lifecycle.ts
@@ -23,12 +23,8 @@ import { inspect } from "util";
 // For the purpose of this example we will create temporary digital twin using random Ids.
 // We have to make sure these model Ids are unique within the DT instance so we use generated UUIDs.
 async function main() {
-  const modelId = `dtmi:model_${v4()
-    .split("-")
-    .join("")};1`;
-  const componentId = `dtmi:component_${v4()
-    .split("-")
-    .join("")};1`;
+  const modelId = `dtmi:model_${v4().split("-").join("")};1`;
+  const componentId = `dtmi:component_${v4().split("-").join("")};1`;
   const digitalTwinId = `digitalTwin-${v4()}`;
 
   const temporaryComponent = {
@@ -40,9 +36,9 @@ async function main() {
       {
         "@type": "Property",
         name: "ComponentProp1",
-        schema: "string"
-      }
-    ]
+        schema: "string",
+      },
+    ],
   };
 
   const temporaryModel = {
@@ -54,26 +50,26 @@ async function main() {
       {
         "@type": "Property",
         name: "Prop1",
-        schema: "double"
+        schema: "double",
       },
       {
         "@type": "Component",
         name: "Component1",
-        schema: componentId
-      }
-    ]
+        schema: componentId,
+      },
+    ],
   };
 
   const temporaryTwin = {
     $dtId: digitalTwinId,
     $metadata: {
-      $model: modelId
+      $model: modelId,
     },
     Prop1: 42,
     Component1: {
       $metadata: {},
-      ComponentProp1: "value1"
-    }
+      ComponentProp1: "value1",
+    },
   };
 
   // AZURE_DIGITALTWINS_URL: The URL to your Azure Digital Twins instance
@@ -110,7 +106,7 @@ async function main() {
   const patch = {
     op: "replace",
     path: "/ComponentProp1",
-    value: "value2"
+    value: "value2",
   };
   const updateComponentResponse = await serviceClient.updateComponent(
     digitalTwinId,

--- a/sdk/digitaltwins/digital-twins-core/samples-dev/dt_digitaltwins_lifecycle.ts
+++ b/sdk/digitaltwins/digital-twins-core/samples-dev/dt_digitaltwins_lifecycle.ts
@@ -59,7 +59,7 @@ async function main() {
   const twinPatch = {
     op: "replace",
     path: "/AverageTemperature",
-    value: 42
+    value: 42,
   };
   const updatedTwin = await serviceClient.updateDigitalTwin(digitalTwinId, [twinPatch]);
   console.log(`Updated Digital Twin:`);

--- a/sdk/digitaltwins/digital-twins-core/samples-dev/dt_models_lifecycle.ts
+++ b/sdk/digitaltwins/digital-twins-core/samples-dev/dt_models_lifecycle.ts
@@ -21,12 +21,8 @@ import { v4 } from "uuid";
 // For the purpose of this example we will create temporary model and a temporary component model using random Ids.
 // We have to make sure these model Ids are unique within the DT instance so we use generated UUIDs.
 async function main() {
-  const modelId = `dtmi:model_${v4()
-    .split("-")
-    .join("")};1`;
-  const componentId = `dtmi:component_${v4()
-    .split("-")
-    .join("")};1`;
+  const modelId = `dtmi:model_${v4().split("-").join("")};1`;
+  const componentId = `dtmi:component_${v4().split("-").join("")};1`;
 
   const temporaryComponent = {
     "@id": componentId,
@@ -37,14 +33,14 @@ async function main() {
       {
         "@type": "Property",
         name: "ComponentProp1",
-        schema: "string"
+        schema: "string",
       },
       {
         "@type": "Telemetry",
         name: "ComponentTelemetry1",
-        schema: "integer"
-      }
-    ]
+        schema: "integer",
+      },
+    ],
   };
 
   const temporaryModel = {
@@ -56,19 +52,19 @@ async function main() {
       {
         "@type": "Property",
         name: "Prop1",
-        schema: "string"
+        schema: "string",
       },
       {
         "@type": "Component",
         name: "Component1",
-        schema: componentId
+        schema: componentId,
       },
       {
         "@type": "Telemetry",
         name: "Telemetry1",
-        schema: "integer"
-      }
-    ]
+        schema: "integer",
+      },
+    ],
   };
 
   // AZURE_DIGITALTWINS_URL: The URL to your Azure Digital Twins instance

--- a/sdk/digitaltwins/digital-twins-core/src/digitalTwinsClient.ts
+++ b/sdk/digitaltwins/digital-twins-core/src/digitalTwinsClient.ts
@@ -11,7 +11,7 @@ import {
   bearerTokenAuthenticationPolicy,
   createPipelineFromOptions,
   generateUuid,
-  PipelineOptions
+  PipelineOptions,
 } from "@azure/core-http";
 import { PageSettings, PagedAsyncIterableIterator } from "@azure/core-paging";
 import { AzureDigitalTwinsAPI as GeneratedClient } from "./generated/azureDigitalTwinsAPI";
@@ -50,7 +50,7 @@ import {
   EventRoutesListOptionalParams,
   QueryQueryTwinsOptionalParams,
   QueryQueryTwinsResponse,
-  QuerySpecification
+  QuerySpecification,
 } from "./generated/models";
 import { createSpan } from "./tracing";
 import { SpanStatusCode } from "@azure/core-tracing";
@@ -115,9 +115,9 @@ export class DigitalTwinsClient {
       ...{
         loggingOptions: {
           logger: logger.info,
-          allowedHeaderNames: ["x-ms-request-id"]
-        }
-      }
+          allowedHeaderNames: ["x-ms-request-id"],
+        },
+      },
     };
 
     const pipeline = createPipelineFromOptions(internalPipelineOptions, authPolicy);
@@ -125,7 +125,7 @@ export class DigitalTwinsClient {
     this.client = new GeneratedClient({
       endpoint: endpointUrl,
       apiVersion,
-      ...pipeline
+      ...pipeline,
     });
   }
 
@@ -146,7 +146,7 @@ export class DigitalTwinsClient {
     } catch (e) {
       span.setStatus({
         code: SpanStatusCode.ERROR,
-        message: e.message
+        message: e.message,
       });
       throw e;
     } finally {
@@ -175,7 +175,7 @@ export class DigitalTwinsClient {
     } catch (e) {
       span.setStatus({
         code: SpanStatusCode.ERROR,
-        message: e.message
+        message: e.message,
       });
       throw e;
     } finally {
@@ -206,7 +206,7 @@ export class DigitalTwinsClient {
     } catch (e) {
       span.setStatus({
         code: SpanStatusCode.ERROR,
-        message: e.message
+        message: e.message,
       });
       throw e;
     } finally {
@@ -232,7 +232,7 @@ export class DigitalTwinsClient {
     } catch (e) {
       span.setStatus({
         code: SpanStatusCode.ERROR,
-        message: e.message
+        message: e.message,
       });
       throw e;
     } finally {
@@ -259,7 +259,7 @@ export class DigitalTwinsClient {
     } catch (e) {
       span.setStatus({
         code: SpanStatusCode.ERROR,
-        message: e.message
+        message: e.message,
       });
       throw e;
     } finally {
@@ -295,7 +295,7 @@ export class DigitalTwinsClient {
     } catch (e) {
       span.setStatus({
         code: SpanStatusCode.ERROR,
-        message: e.message
+        message: e.message,
       });
       throw e;
     } finally {
@@ -326,7 +326,7 @@ export class DigitalTwinsClient {
     } catch (e) {
       span.setStatus({
         code: SpanStatusCode.ERROR,
-        message: e.message
+        message: e.message,
       });
       throw e;
     } finally {
@@ -361,7 +361,7 @@ export class DigitalTwinsClient {
     } catch (e) {
       span.setStatus({
         code: SpanStatusCode.ERROR,
-        message: e.message
+        message: e.message,
       });
       throw e;
     } finally {
@@ -395,7 +395,7 @@ export class DigitalTwinsClient {
     } catch (e) {
       span.setStatus({
         code: SpanStatusCode.ERROR,
-        message: e.message
+        message: e.message,
       });
       throw e;
     } finally {
@@ -427,7 +427,7 @@ export class DigitalTwinsClient {
     } catch (e) {
       span.setStatus({
         code: SpanStatusCode.ERROR,
-        message: e.message
+        message: e.message,
       });
       throw e;
     } finally {
@@ -450,7 +450,7 @@ export class DigitalTwinsClient {
   ): AsyncIterableIterator<DigitalTwinsListRelationshipsResponse> {
     if (continuationState.continuationToken == null) {
       const optionsComplete: OperationOptions = {
-        ...options
+        ...options,
       };
       const listRelationshipResponse = await this.client.digitalTwins.listRelationships(
         digitalTwinId,
@@ -508,12 +508,12 @@ export class DigitalTwinsClient {
           return this;
         },
         byPage: (settings: PageSettings = {}) =>
-          this.listRelationshipsPage(digitalTwinId, updatedOptions, settings)
+          this.listRelationshipsPage(digitalTwinId, updatedOptions, settings),
       };
     } catch (e) {
       span.setStatus({
         code: SpanStatusCode.ERROR,
-        message: e.message
+        message: e.message,
       });
       throw e;
     } finally {
@@ -536,21 +536,20 @@ export class DigitalTwinsClient {
   ): AsyncIterableIterator<DigitalTwinsListIncomingRelationshipsResponse> {
     if (continuationState.continuationToken == null) {
       const optionsComplete: OperationOptions = {
-        ...options
+        ...options,
       };
-      const listIncomingRelationshipsResponse = await this.client.digitalTwins.listIncomingRelationships(
-        digitalTwinId,
-        optionsComplete
-      );
+      const listIncomingRelationshipsResponse =
+        await this.client.digitalTwins.listIncomingRelationships(digitalTwinId, optionsComplete);
       continuationState.continuationToken = listIncomingRelationshipsResponse.nextLink;
       yield listIncomingRelationshipsResponse;
     }
     while (continuationState.continuationToken) {
-      const listIncomingRelationshipsResponse = await this.client.digitalTwins.listIncomingRelationshipsNext(
-        "",
-        continuationState.continuationToken,
-        options
-      );
+      const listIncomingRelationshipsResponse =
+        await this.client.digitalTwins.listIncomingRelationshipsNext(
+          "",
+          continuationState.continuationToken,
+          options
+        );
 
       continuationState.continuationToken = listIncomingRelationshipsResponse.nextLink;
       yield listIncomingRelationshipsResponse;
@@ -599,12 +598,12 @@ export class DigitalTwinsClient {
           return this;
         },
         byPage: (settings: PageSettings = {}) =>
-          this.listIncomingRelationshipsPage(digitalTwinId, updatedOptions, settings)
+          this.listIncomingRelationshipsPage(digitalTwinId, updatedOptions, settings),
       };
     } catch (e) {
       span.setStatus({
         code: SpanStatusCode.ERROR,
-        message: e.message
+        message: e.message,
       });
       throw e;
     } finally {
@@ -628,7 +627,8 @@ export class DigitalTwinsClient {
     messageId: string,
     options: OperationOptions = {}
   ): Promise<RestResponse> {
-    const digitalTwinsSendTelemetryOptionalParams: DigitalTwinsSendTelemetryOptionalParams = options;
+    const digitalTwinsSendTelemetryOptionalParams: DigitalTwinsSendTelemetryOptionalParams =
+      options;
     digitalTwinsSendTelemetryOptionalParams.telemetrySourceTime = new Date().toISOString();
     if (!messageId) {
       messageId = generateUuid();
@@ -647,7 +647,7 @@ export class DigitalTwinsClient {
     } catch (e) {
       span.setStatus({
         code: SpanStatusCode.ERROR,
-        message: e.message
+        message: e.message,
       });
       throw e;
     } finally {
@@ -672,7 +672,8 @@ export class DigitalTwinsClient {
     messageId: string,
     options: OperationOptions = {}
   ): Promise<RestResponse> {
-    const digitalTwinsSendComponentTelemetryOptionalParams: DigitalTwinsSendComponentTelemetryOptionalParams = options;
+    const digitalTwinsSendComponentTelemetryOptionalParams: DigitalTwinsSendComponentTelemetryOptionalParams =
+      options;
     digitalTwinsSendComponentTelemetryOptionalParams.telemetrySourceTime = new Date().toISOString();
     if (!messageId) {
       messageId = generateUuid();
@@ -692,7 +693,7 @@ export class DigitalTwinsClient {
     } catch (e) {
       span.setStatus({
         code: SpanStatusCode.ERROR,
-        message: e.message
+        message: e.message,
       });
       throw e;
     } finally {
@@ -724,7 +725,7 @@ export class DigitalTwinsClient {
     } catch (e) {
       span.setStatus({
         code: SpanStatusCode.ERROR,
-        message: e.message
+        message: e.message,
       });
       throw e;
     } finally {
@@ -797,7 +798,7 @@ export class DigitalTwinsClient {
     digitalTwinModelsListOptionalParams = {
       maxItemsPerPage: resultsPerPage,
       dependenciesFor: dependeciesFor,
-      includeModelDefinition: includeModelDefinition
+      includeModelDefinition: includeModelDefinition,
     };
     const { span, updatedOptions } = createSpan(
       "DigitalTwinsClient-listModels",
@@ -814,12 +815,12 @@ export class DigitalTwinsClient {
           return this;
         },
         byPage: (settings: PageSettings = {}) =>
-          this.getModelsPage(digitalTwinModelsListOptionalParams, settings)
+          this.getModelsPage(digitalTwinModelsListOptionalParams, settings),
       };
     } catch (e) {
       span.setStatus({
         code: SpanStatusCode.ERROR,
-        message: e.message
+        message: e.message,
       });
       throw e;
     } finally {
@@ -849,7 +850,7 @@ export class DigitalTwinsClient {
     } catch (e) {
       span.setStatus({
         code: SpanStatusCode.ERROR,
-        message: e.message
+        message: e.message,
       });
       throw e;
     } finally {
@@ -878,7 +879,7 @@ export class DigitalTwinsClient {
     } catch (e) {
       span.setStatus({
         code: SpanStatusCode.ERROR,
-        message: e.message
+        message: e.message,
       });
       throw e;
     } finally {
@@ -905,7 +906,7 @@ export class DigitalTwinsClient {
     } catch (e) {
       span.setStatus({
         code: SpanStatusCode.ERROR,
-        message: e.message
+        message: e.message,
       });
       throw e;
     } finally {
@@ -930,7 +931,7 @@ export class DigitalTwinsClient {
     } catch (e) {
       span.setStatus({
         code: SpanStatusCode.ERROR,
-        message: e.message
+        message: e.message,
       });
       throw e;
     } finally {
@@ -997,7 +998,7 @@ export class DigitalTwinsClient {
   ): PagedAsyncIterableIterator<EventRoute, EventRoutesListNextResponse> {
     let eventRoutesListOptionalParams: EventRoutesListOptionalParams = options;
     eventRoutesListOptionalParams = {
-      maxItemsPerPage: resultsPerPage
+      maxItemsPerPage: resultsPerPage,
     };
 
     const { span, updatedOptions } = createSpan(
@@ -1015,12 +1016,12 @@ export class DigitalTwinsClient {
           return this;
         },
         byPage: (settings: PageSettings = {}) =>
-          this.getEventRoutesPage(eventRoutesListOptionalParams, settings)
+          this.getEventRoutesPage(eventRoutesListOptionalParams, settings),
       };
     } catch (e) {
       span.setStatus({
         code: SpanStatusCode.ERROR,
-        message: e.message
+        message: e.message,
       });
       throw e;
     } finally {
@@ -1046,7 +1047,7 @@ export class DigitalTwinsClient {
     const eventRoutesAddOptionalParams: EventRoutesAddOptionalParams = options;
     const eventRoute: EventRoute = {
       endpointName: endpointId,
-      filter: filter
+      filter: filter,
     };
     eventRoutesAddOptionalParams.eventRoute = eventRoute;
     const { span, updatedOptions } = createSpan(
@@ -1058,7 +1059,7 @@ export class DigitalTwinsClient {
     } catch (e) {
       span.setStatus({
         code: SpanStatusCode.ERROR,
-        message: e.message
+        message: e.message,
       });
       throw e;
     } finally {
@@ -1083,7 +1084,7 @@ export class DigitalTwinsClient {
     } catch (e) {
       span.setStatus({
         code: SpanStatusCode.ERROR,
-        message: e.message
+        message: e.message,
       });
       throw e;
     } finally {
@@ -1107,7 +1108,7 @@ export class DigitalTwinsClient {
     if (continuationState.continuationToken == null) {
       const querySpecification: QuerySpecification = {
         query: query,
-        continuationToken: continuationState.continuationToken
+        continuationToken: continuationState.continuationToken,
       };
       const queryResult = await this.client.query.queryTwins(querySpecification, options);
       continuationState.continuationToken = queryResult.continuationToken;
@@ -1116,7 +1117,7 @@ export class DigitalTwinsClient {
     while (continuationState.continuationToken) {
       const querySpecification: QuerySpecification = {
         query: query,
-        continuationToken: continuationState.continuationToken
+        continuationToken: continuationState.continuationToken,
       };
       const queryResult = await this.client.query.queryTwins(querySpecification, options);
 
@@ -1159,7 +1160,7 @@ export class DigitalTwinsClient {
   ): PagedAsyncIterableIterator<any, QueryQueryTwinsResponse> {
     let queryQueryTwinsOptionalParams: QueryQueryTwinsOptionalParams = options;
     queryQueryTwinsOptionalParams = {
-      maxItemsPerPage: resultsPerPage
+      maxItemsPerPage: resultsPerPage,
     };
 
     const { span, updatedOptions } = createSpan(
@@ -1177,12 +1178,12 @@ export class DigitalTwinsClient {
           return this;
         },
         byPage: (settings: PageSettings = {}) =>
-          this.queryTwinsPage(query, queryQueryTwinsOptionalParams, settings)
+          this.queryTwinsPage(query, queryQueryTwinsOptionalParams, settings),
       };
     } catch (e) {
       span.setStatus({
         code: SpanStatusCode.ERROR,
-        message: e.message
+        message: e.message,
       });
       throw e;
     } finally {

--- a/sdk/digitaltwins/digital-twins-core/src/index.ts
+++ b/sdk/digitaltwins/digital-twins-core/src/index.ts
@@ -44,5 +44,5 @@ export {
   QueryQueryTwinsResponse,
   QueryResult,
   QuerySpecification,
-  PagedDigitalTwinsModelDataCollection
+  PagedDigitalTwinsModelDataCollection,
 } from "./generated/models";

--- a/sdk/digitaltwins/digital-twins-core/src/tracing.ts
+++ b/sdk/digitaltwins/digital-twins-core/src/tracing.ts
@@ -9,5 +9,5 @@ import { createSpanFunction } from "@azure/core-tracing";
  */
 export const createSpan = createSpanFunction({
   packagePrefix: "DigitalTwinsClient",
-  namespace: "Microsoft.DigitalTwins"
+  namespace: "Microsoft.DigitalTwins",
 });

--- a/sdk/digitaltwins/digital-twins-core/test/internal/digitalTwinsClient.spec.ts
+++ b/sdk/digitaltwins/digital-twins-core/test/internal/digitalTwinsClient.spec.ts
@@ -9,7 +9,7 @@ import {
   HttpOperationResponse,
   HttpResponse,
   WebResource,
-  HttpHeaders
+  HttpHeaders,
 } from "@azure/core-http";
 import {
   DigitalTwinsUpdateOptionalParams,
@@ -29,7 +29,7 @@ import {
   DigitalTwinsGetRelationshipByIdOptionalParams,
   DigitalTwinsGetComponentOptionalParams,
   DigitalTwinsAddOptionalParams,
-  DigitalTwinsGetByIdOptionalParams
+  DigitalTwinsGetByIdOptionalParams,
 } from "../../src/generated/models";
 import { DigitalTwinsClient } from "../../src/index";
 import { createSpan } from "../../src/tracing";
@@ -60,20 +60,20 @@ describe("DigitalTwinsClient", () => {
   let testError: Error;
   let decommissionPatch: any[];
 
-  beforeEach(async function() {
+  beforeEach(async function () {
     operationOptions = {
       requestOptions: {
         customHeaders: { ["x-ms-parameter-location"]: "client" },
-        timeout: 42
-      }
+        timeout: 42,
+      },
     };
     url = "https://aaa.xxx.azure.net";
     tokenCredential = {
       getToken: () =>
         Promise.resolve({
           token: "token",
-          expiresOnTimestamp: 12345
-        })
+          expiresOnTimestamp: 12345,
+        }),
     };
     testFilter = "*.*";
     testIfMatch = "test_ifmatch";
@@ -81,12 +81,12 @@ describe("DigitalTwinsClient", () => {
     testDefaultOperationalResponse = {
       status: 200,
       request: new WebResource(),
-      headers: new HttpHeaders()
+      headers: new HttpHeaders(),
     };
     testDefaultResponse = {
       status: 200,
       request: new WebResource(),
-      headers: new HttpHeaders()
+      headers: new HttpHeaders(),
     };
     testClient = new DigitalTwinsClient(url, tokenCredential);
     testTwinId = "test_twin_id";
@@ -101,17 +101,17 @@ describe("DigitalTwinsClient", () => {
     testEventRouteId = "test_event_route_id";
     testBody = "test_body";
     testHeaders = {
-      etag: testIfMatch
+      etag: testIfMatch,
     };
     testError = new Error("Promise Rejected");
     decommissionPatch = [{ op: "replace", path: "/decommissioned", value: true }];
   });
 
-  it(`Constructor creates an instance of the DigitalTwinsClient`, function() {
+  it(`Constructor creates an instance of the DigitalTwinsClient`, function () {
     assert.instanceOf(testClient, DigitalTwinsClient);
   });
 
-  it("getDigitalTwin calls the getById method with twinId on the generated client if there is no option defined", function() {
+  it("getDigitalTwin calls the getById method with twinId on the generated client if there is no option defined", function () {
     const stub = sinon.stub(testClient["client"].digitalTwins, "getById");
     const digitalTwinsGetByIdOptionalParams: DigitalTwinsGetByIdOptionalParams = {};
     const { span, updatedOptions } = createSpan(
@@ -125,7 +125,7 @@ describe("DigitalTwinsClient", () => {
     assert.isNotNull(span);
   });
 
-  it("getDigitalTwin calls the getById method with twinId and converted options on the generated client", function() {
+  it("getDigitalTwin calls the getById method with twinId and converted options on the generated client", function () {
     const stub = sinon.stub(testClient["client"].digitalTwins, "getById");
     const digitalTwinsGetByIdOptionalParams: DigitalTwinsGetByIdOptionalParams = operationOptions;
     const { span, updatedOptions } = createSpan(
@@ -153,7 +153,7 @@ describe("DigitalTwinsClient", () => {
     });
   });
 
-  it("upsertDigitalTwin calls the add method with twinId and twinJson on the generated client if there is no option defined", function() {
+  it("upsertDigitalTwin calls the add method with twinId and twinJson on the generated client if there is no option defined", function () {
     const stub = sinon.stub(testClient["client"].digitalTwins, "add");
     const digitalTwinsAddOptionalParams: DigitalTwinsAddOptionalParams = {};
     const { span, updatedOptions } = createSpan(
@@ -185,7 +185,7 @@ describe("DigitalTwinsClient", () => {
       });
   });
 
-  it("updateDigitalTwin calls the update method with twinId, jsonPatch and converted options on the generated client", function() {
+  it("updateDigitalTwin calls the update method with twinId, jsonPatch and converted options on the generated client", function () {
     const digitalTwinsUpdateOptionalParams: DigitalTwinsUpdateOptionalParams = operationOptions;
     const { span, updatedOptions } = createSpan(
       "DigitalTwinsClient-updateDigitalTwin",
@@ -215,7 +215,7 @@ describe("DigitalTwinsClient", () => {
     });
   });
 
-  it("deleteDigitalTwin calls the deleteMethod method with twinId and converted options on the generated client", function() {
+  it("deleteDigitalTwin calls the deleteMethod method with twinId and converted options on the generated client", function () {
     const digitalTwinsDeleteOptionalParams: DigitalTwinsDeleteOptionalParams = operationOptions;
     const { span, updatedOptions } = createSpan(
       "DigitalTwinsClient-deleteDigitalTwin",
@@ -231,7 +231,7 @@ describe("DigitalTwinsClient", () => {
 
   it("deleteDigitalTwin returns a promise of the generated code return value", async () => {
     const testReturn = {
-      _response: testDefaultOperationalResponse
+      _response: testDefaultOperationalResponse,
     };
     sinon.stub(testClient["client"].digitalTwins, "delete").resolves(testReturn);
     const retVal = await testClient.deleteDigitalTwin(testTwinId);
@@ -245,9 +245,10 @@ describe("DigitalTwinsClient", () => {
     });
   });
 
-  it("getComponent calls the getComponent method with twinId, componentPath and converted options on the generated client", function() {
+  it("getComponent calls the getComponent method with twinId, componentPath and converted options on the generated client", function () {
     const stub = sinon.stub(testClient["client"].digitalTwins, "getComponent");
-    const digitalTwinsGetComponentOptionalParams: DigitalTwinsGetComponentOptionalParams = operationOptions;
+    const digitalTwinsGetComponentOptionalParams: DigitalTwinsGetComponentOptionalParams =
+      operationOptions;
     const { span, updatedOptions } = createSpan(
       "DigitalTwinsClient-getComponent",
       digitalTwinsGetComponentOptionalParams
@@ -275,8 +276,9 @@ describe("DigitalTwinsClient", () => {
     });
   });
 
-  it("updateComponent calls the updateComponent method with twinId, componentPath, jsonPatch and converted options on the generated client", function() {
-    const digitalTwinsUpdateComponentOptionalParams: DigitalTwinsUpdateComponentOptionalParams = operationOptions;
+  it("updateComponent calls the updateComponent method with twinId, componentPath, jsonPatch and converted options on the generated client", function () {
+    const digitalTwinsUpdateComponentOptionalParams: DigitalTwinsUpdateComponentOptionalParams =
+      operationOptions;
     const { span, updatedOptions } = createSpan(
       "DigitalTwinsClient-updateComponent",
       digitalTwinsUpdateComponentOptionalParams
@@ -312,9 +314,10 @@ describe("DigitalTwinsClient", () => {
       });
   });
 
-  it("getRelationship calls the getRelationshipById method with twinId and relationshipId on the generated client if there is no option defined", function() {
+  it("getRelationship calls the getRelationshipById method with twinId and relationshipId on the generated client if there is no option defined", function () {
     const stub = sinon.stub(testClient["client"].digitalTwins, "getRelationshipById");
-    const digitalTwinsGetRelationshipByIdOptionalParams: DigitalTwinsGetRelationshipByIdOptionalParams = {};
+    const digitalTwinsGetRelationshipByIdOptionalParams: DigitalTwinsGetRelationshipByIdOptionalParams =
+      {};
     const { span, updatedOptions } = createSpan(
       "DigitalTwinsClient-getRelationship",
       digitalTwinsGetRelationshipByIdOptionalParams
@@ -328,9 +331,10 @@ describe("DigitalTwinsClient", () => {
     assert.isNotNull(span);
   });
 
-  it("getRelationship calls the getRelationshipById method with twinId, relationshipId and options on the generated client", function() {
+  it("getRelationship calls the getRelationshipById method with twinId, relationshipId and options on the generated client", function () {
     const stub = sinon.stub(testClient["client"].digitalTwins, "getRelationshipById");
-    const digitalTwinsGetRelationshipByIdOptionalParams: DigitalTwinsGetRelationshipByIdOptionalParams = operationOptions;
+    const digitalTwinsGetRelationshipByIdOptionalParams: DigitalTwinsGetRelationshipByIdOptionalParams =
+      operationOptions;
     const { span, updatedOptions } = createSpan(
       "DigitalTwinsClient-getRelationship",
       digitalTwinsGetRelationshipByIdOptionalParams
@@ -358,9 +362,10 @@ describe("DigitalTwinsClient", () => {
     });
   });
 
-  it("upsertRelationship calls the addRelationship method with twinId, relationshipId, relationshipJson and converted options on the generated client", function() {
+  it("upsertRelationship calls the addRelationship method with twinId, relationshipId, relationshipJson and converted options on the generated client", function () {
     const stub = sinon.stub(testClient["client"].digitalTwins, "addRelationship");
-    const digitalTwinsAddRelationshipOptionalParams: DigitalTwinsAddRelationshipOptionalParams = operationOptions;
+    const digitalTwinsAddRelationshipOptionalParams: DigitalTwinsAddRelationshipOptionalParams =
+      operationOptions;
     const { span, updatedOptions } = createSpan(
       "DigitalTwinsClient-upsertRelationship",
       digitalTwinsAddRelationshipOptionalParams
@@ -399,8 +404,9 @@ describe("DigitalTwinsClient", () => {
       });
   });
 
-  it("updateRelationship calls the updateRelationship method with twinId, jsonPatch and converted options on the generated client", function() {
-    const digitalTwinsUpdateRelationshipOptionalParams: DigitalTwinsUpdateRelationshipOptionalParams = operationOptions;
+  it("updateRelationship calls the updateRelationship method with twinId, jsonPatch and converted options on the generated client", function () {
+    const digitalTwinsUpdateRelationshipOptionalParams: DigitalTwinsUpdateRelationshipOptionalParams =
+      operationOptions;
     const { span, updatedOptions } = createSpan(
       "DigitalTwinsClient-updateRelationship",
       digitalTwinsUpdateRelationshipOptionalParams
@@ -440,8 +446,9 @@ describe("DigitalTwinsClient", () => {
       });
   });
 
-  it("deleteRelationship calls the deleteRelationship method with twinId, relationshipId and converted options on the generated client", function() {
-    const digitalTwinsDeleteRelationshipOptionalParams: DigitalTwinsDeleteRelationshipOptionalParams = operationOptions;
+  it("deleteRelationship calls the deleteRelationship method with twinId, relationshipId and converted options on the generated client", function () {
+    const digitalTwinsDeleteRelationshipOptionalParams: DigitalTwinsDeleteRelationshipOptionalParams =
+      operationOptions;
     const { span, updatedOptions } = createSpan(
       "DigitalTwinsClient-deleteRelationship",
       digitalTwinsDeleteRelationshipOptionalParams
@@ -458,7 +465,7 @@ describe("DigitalTwinsClient", () => {
 
   it("deleteRelationship returns a promise of the generated code return value", async () => {
     const testReturn = {
-      _response: testDefaultOperationalResponse
+      _response: testDefaultOperationalResponse,
     };
     sinon.stub(testClient["client"].digitalTwins, "deleteRelationship").resolves(testReturn);
     const retVal = await testClient.deleteRelationship(testTwinId, testRelationshipId);
@@ -474,7 +481,7 @@ describe("DigitalTwinsClient", () => {
 
   it("publishTelemetry returns a promise of the generated code return value", async () => {
     const testReturn = {
-      _response: testDefaultOperationalResponse
+      _response: testDefaultOperationalResponse,
     };
     sinon.stub(testClient["client"].digitalTwins, "sendTelemetry").resolves(testReturn);
     const retVal = await testClient.publishTelemetry(testTwinId, testPayload, testMessageId);
@@ -490,7 +497,7 @@ describe("DigitalTwinsClient", () => {
 
   it("publishComponentTelemetry returns a promise of the generated code return value", async () => {
     const testReturn = {
-      _response: testDefaultOperationalResponse
+      _response: testDefaultOperationalResponse,
     };
     sinon.stub(testClient["client"].digitalTwins, "sendComponentTelemetry").resolves(testReturn);
     const retVal = await testClient.publishComponentTelemetry(
@@ -511,9 +518,10 @@ describe("DigitalTwinsClient", () => {
       });
   });
 
-  it("getModel calls the getById method with twinId and converted options on the generated client", function() {
+  it("getModel calls the getById method with twinId and converted options on the generated client", function () {
     const includeModelDefinition: boolean = true;
-    const digitalTwinModelsGetByIdOptionalParams: DigitalTwinModelsGetByIdOptionalParams = operationOptions;
+    const digitalTwinModelsGetByIdOptionalParams: DigitalTwinModelsGetByIdOptionalParams =
+      operationOptions;
     digitalTwinModelsGetByIdOptionalParams.includeModelDefinition = includeModelDefinition;
     const { span, updatedOptions } = createSpan(
       "DigitalTwinsClient-getModel",
@@ -539,7 +547,7 @@ describe("DigitalTwinsClient", () => {
     });
   });
 
-  it("createModels calls the add method with converted options on the generated client", function() {
+  it("createModels calls the add method with converted options on the generated client", function () {
     const stub = sinon.stub(testClient["client"].digitalTwinModels, "add");
     const digitalTwinModelsAddOptionalParams: DigitalTwinModelsAddOptionalParams = operationOptions;
     digitalTwinModelsAddOptionalParams.models = testModels;
@@ -561,9 +569,10 @@ describe("DigitalTwinsClient", () => {
     });
   });
 
-  it("decomissionModel calls the update method with modelId, patchJson and options on the generated client", function() {
+  it("decomissionModel calls the update method with modelId, patchJson and options on the generated client", function () {
     const stub = sinon.stub(testClient["client"].digitalTwinModels, "update");
-    const digitalTwinModelsUpdateOptionalParams: DigitalTwinModelsUpdateOptionalParams = operationOptions;
+    const digitalTwinModelsUpdateOptionalParams: DigitalTwinModelsUpdateOptionalParams =
+      operationOptions;
     const { span, updatedOptions } = createSpan(
       "DigitalTwinsClient-decomissionModel",
       digitalTwinModelsUpdateOptionalParams
@@ -579,7 +588,7 @@ describe("DigitalTwinsClient", () => {
 
   it("decomissionModel returns a promise of the generated code return value", async () => {
     const testReturn = {
-      _response: testDefaultOperationalResponse
+      _response: testDefaultOperationalResponse,
     };
     sinon.stub(testClient["client"].digitalTwinModels, "update").resolves(testReturn);
     const retVal = await testClient.decomissionModel(testModelId);
@@ -593,9 +602,10 @@ describe("DigitalTwinsClient", () => {
     });
   });
 
-  it("deleteModel calls the deleteMethod method with modelId and options on the generated client", function() {
+  it("deleteModel calls the deleteMethod method with modelId and options on the generated client", function () {
     const stub = sinon.stub(testClient["client"].digitalTwinModels, "delete");
-    const digitalTwinModelsDeleteOptionalParams: DigitalTwinModelsDeleteOptionalParams = operationOptions;
+    const digitalTwinModelsDeleteOptionalParams: DigitalTwinModelsDeleteOptionalParams =
+      operationOptions;
     const { span, updatedOptions } = createSpan(
       "DigitalTwinsClient-deleteModel",
       digitalTwinModelsDeleteOptionalParams
@@ -609,7 +619,7 @@ describe("DigitalTwinsClient", () => {
 
   it("deleteModel returns a promise of the generated code return value", async () => {
     const testReturn = {
-      _response: testDefaultOperationalResponse
+      _response: testDefaultOperationalResponse,
     };
     sinon.stub(testClient["client"].digitalTwinModels, "delete").resolves(testReturn);
     const retVal = await testClient.deleteModel(testModelId);
@@ -623,14 +633,14 @@ describe("DigitalTwinsClient", () => {
     });
   });
 
-  it("getEventRoute calls the getById method with modelId on the generated client if there is no option defined", function() {
+  it("getEventRoute calls the getById method with modelId on the generated client if there is no option defined", function () {
     const stub = sinon.stub(testClient["client"].eventRoutes, "getById");
     testClient.getEventRoute(testEventRouteId);
     assert.isTrue(stub.calledOnce);
     assert.isTrue(stub.calledWith(testEventRouteId));
   });
 
-  it("getEventRoute calls the getById method with twinId and converted options on the generated client", function() {
+  it("getEventRoute calls the getById method with twinId and converted options on the generated client", function () {
     const stub = sinon.stub(testClient["client"].eventRoutes, "getById");
     const eventRoutesGetByIdOptionalParams: EventRoutesGetByIdOptionalParams = operationOptions;
     const { span, updatedOptions } = createSpan(
@@ -652,14 +662,14 @@ describe("DigitalTwinsClient", () => {
     });
   });
 
-  it("upsertEventRoute calls the add method with eventRouteId on the generated client if there is no option defined", function() {
+  it("upsertEventRoute calls the add method with eventRouteId on the generated client if there is no option defined", function () {
     const stub = sinon.stub(testClient["client"].eventRoutes, "add");
     testClient.upsertEventRoute(testEventRouteId, testJsonString, "");
     assert.isTrue(stub.calledOnce);
     assert.isTrue(stub.calledWith(testEventRouteId));
   });
 
-  it("upsertEventRoute calls the add method with eventRouteId and converted options on the generated client", function() {
+  it("upsertEventRoute calls the add method with eventRouteId and converted options on the generated client", function () {
     const eventRoutesAddOptionalParams: EventRoutesAddOptionalParams = operationOptions;
     const { span, updatedOptions } = createSpan(
       "DigitalTwinsClient-upsertEventRoute",
@@ -667,7 +677,7 @@ describe("DigitalTwinsClient", () => {
     );
     const eventRoute: EventRoute = {
       endpointName: testEndpointName,
-      filter: testFilter
+      filter: testFilter,
     };
     updatedOptions.eventRoute = eventRoute;
 
@@ -699,7 +709,7 @@ describe("DigitalTwinsClient", () => {
       });
   });
 
-  it("deleteEventRoute calls the deleteMethod method with eventRouteId and options on the generated client", function() {
+  it("deleteEventRoute calls the deleteMethod method with eventRouteId and options on the generated client", function () {
     const stub = sinon.stub(testClient["client"].eventRoutes, "delete");
     const eventRoutesDeleteOptionalParams: EventRoutesDeleteOptionalParams = operationOptions;
     const { span, updatedOptions } = createSpan(
@@ -719,7 +729,7 @@ describe("DigitalTwinsClient", () => {
 
   it("deleteEventRoute returns a promise of the generated code return value", async () => {
     const testReturn = {
-      _response: testDefaultOperationalResponse
+      _response: testDefaultOperationalResponse,
     };
     sinon.stub(testClient["client"].eventRoutes, "delete").resolves(testReturn);
     const retVal = await testClient.deleteEventRoute(testEventRouteId);
@@ -760,8 +770,8 @@ function operationOptionsSinonMatcher<T extends OperationOptions>(
         ..._expectedOptions.tracingOptions,
         // we verified this above. Adding it in here just to make deep equal comparison
         // simpler.
-        tracingContext: actualOptions.tracingOptions!.tracingContext
-      }
+        tracingContext: actualOptions.tracingOptions!.tracingContext,
+      },
     };
 
     assert.deepEqual(expectedOptions, actualOptions);

--- a/sdk/digitaltwins/digital-twins-core/test/public/testComponents.spec.ts
+++ b/sdk/digitaltwins/digital-twins-core/test/public/testComponents.spec.ts
@@ -22,14 +22,14 @@ const testComponent = {
     {
       "@type": "Property",
       name: "ComponentProp1",
-      schema: "string"
+      schema: "string",
     },
     {
       "@type": "Telemetry",
       name: "ComponentTelemetry1",
-      schema: "integer"
-    }
-  ]
+      schema: "integer",
+    },
+  ],
 };
 
 const testModel = {
@@ -41,43 +41,43 @@ const testModel = {
     {
       "@type": "Property",
       name: "Prop1",
-      schema: "string"
+      schema: "string",
     },
     {
       "@type": "Component",
       name: "Component1",
-      schema: COMPONENT_ID
+      schema: COMPONENT_ID,
     },
     {
       "@type": "Telemetry",
       name: "Telemetry1",
-      schema: "integer"
-    }
-  ]
+      schema: "integer",
+    },
+  ],
 };
 
 const temporary_twin = {
   $metadata: {
-    $model: MODEL_ID
+    $model: MODEL_ID,
   },
   Prop1: "value",
   Component1: {
     $metadata: {},
-    ComponentProp1: "value1"
-  }
+    ComponentProp1: "value1",
+  },
 };
 
 describe("DigitalTwins Components - read, update and delete operations", () => {
   let client: DigitalTwinsClient;
   let recorder: Recorder;
 
-  beforeEach(async function(this: Mocha.Context) {
+  beforeEach(async function (this: Mocha.Context) {
     const authentication = await authenticate(this);
     client = authentication.client;
     recorder = authentication.recorder;
   });
 
-  afterEach(async function() {
+  afterEach(async function () {
     await recorder.stop();
   });
 
@@ -118,7 +118,7 @@ describe("DigitalTwins Components - read, update and delete operations", () => {
     await client.upsertDigitalTwin(digitalTwinId, JSON.stringify(temporary_twin));
   }
 
-  it("get component not existing", async function() {
+  it("get component not existing", async function () {
     await setUpModels();
     await createDigitalTwin(DIGITAL_TWIN_ID);
 
@@ -135,7 +135,7 @@ describe("DigitalTwins Components - read, update and delete operations", () => {
     should.equal(errorWasThrown, true, "Error was not thrown");
   });
 
-  it("get component simple", async function() {
+  it("get component simple", async function () {
     await setUpModels();
     await createDigitalTwin(DIGITAL_TWIN_ID);
 
@@ -151,7 +151,7 @@ describe("DigitalTwins Components - read, update and delete operations", () => {
     }
   });
 
-  it("update component replace", async function() {
+  it("update component replace", async function () {
     await setUpModels();
     await createDigitalTwin(DIGITAL_TWIN_ID);
 
@@ -159,8 +159,8 @@ describe("DigitalTwins Components - read, update and delete operations", () => {
       {
         op: "replace",
         path: "/ComponentProp1",
-        value: "value2"
-      }
+        value: "value2",
+      },
     ];
     try {
       await client.updateComponent(DIGITAL_TWIN_ID, "Component1", patch);
@@ -174,15 +174,15 @@ describe("DigitalTwins Components - read, update and delete operations", () => {
     }
   });
 
-  it("update component remove", async function() {
+  it("update component remove", async function () {
     await setUpModels();
     await createDigitalTwin(DIGITAL_TWIN_ID);
 
     const patch = [
       {
         op: "remove",
-        path: "/ComponentProp1"
-      }
+        path: "/ComponentProp1",
+      },
     ];
     try {
       await client.updateComponent(DIGITAL_TWIN_ID, "Component1", patch);
@@ -195,7 +195,7 @@ describe("DigitalTwins Components - read, update and delete operations", () => {
     }
   });
 
-  it("update component add", async function() {
+  it("update component add", async function () {
     await setUpModels();
     await createDigitalTwin(DIGITAL_TWIN_ID);
 
@@ -203,8 +203,8 @@ describe("DigitalTwins Components - read, update and delete operations", () => {
       {
         op: "add",
         path: "/ComponentProp1",
-        value: "5"
-      }
+        value: "5",
+      },
     ];
     try {
       await client.updateComponent(DIGITAL_TWIN_ID, "Component1", patch);
@@ -218,7 +218,7 @@ describe("DigitalTwins Components - read, update and delete operations", () => {
     }
   });
 
-  it("update component multiple", async function() {
+  it("update component multiple", async function () {
     await setUpModels();
     await createDigitalTwin(DIGITAL_TWIN_ID);
 
@@ -226,12 +226,12 @@ describe("DigitalTwins Components - read, update and delete operations", () => {
       {
         op: "replace",
         path: "/ComponentProp1",
-        value: "value2"
+        value: "value2",
       },
       {
         op: "remove",
-        path: "/ComponentProp1"
-      }
+        path: "/ComponentProp1",
+      },
     ];
     try {
       await client.updateComponent(DIGITAL_TWIN_ID, "Component1", patch);
@@ -247,7 +247,7 @@ describe("DigitalTwins Components - read, update and delete operations", () => {
     }
   });
 
-  it("update component invalid patch", async function() {
+  it("update component invalid patch", async function () {
     await setUpModels();
     await createDigitalTwin(DIGITAL_TWIN_ID);
 
@@ -255,8 +255,8 @@ describe("DigitalTwins Components - read, update and delete operations", () => {
       {
         op: "move",
         path: "/AverageTemperature",
-        value: 42
-      }
+        value: 42,
+      },
     ];
     let errorWasThrown = false;
     try {
@@ -271,7 +271,7 @@ describe("DigitalTwins Components - read, update and delete operations", () => {
     should.equal(errorWasThrown, true, "Error was not thrown");
   });
 
-  it("update component conditionally if present", async function() {
+  it("update component conditionally if present", async function () {
     await setUpModels();
     await createDigitalTwin(DIGITAL_TWIN_ID);
 
@@ -279,13 +279,13 @@ describe("DigitalTwins Components - read, update and delete operations", () => {
       {
         op: "replace",
         path: "/ComponentProp1",
-        value: "value2"
-      }
+        value: "value2",
+      },
     ];
     try {
       const twin = await client.getDigitalTwin(DIGITAL_TWIN_ID);
       const options: DigitalTwinsUpdateComponentOptionalParams = {
-        ifMatch: twin.etag
+        ifMatch: twin.etag,
       };
       await client.updateComponent(DIGITAL_TWIN_ID, "Component1", patch, options);
       const component = await client.getComponent(DIGITAL_TWIN_ID, "Component1");
@@ -298,7 +298,7 @@ describe("DigitalTwins Components - read, update and delete operations", () => {
     }
   });
 
-  it("update component invalid conditions", async function() {
+  it("update component invalid conditions", async function () {
     await setUpModels();
     await createDigitalTwin(DIGITAL_TWIN_ID);
 
@@ -306,11 +306,11 @@ describe("DigitalTwins Components - read, update and delete operations", () => {
       {
         op: "replace",
         path: "/ComponentProp1",
-        value: "value2"
-      }
+        value: "value2",
+      },
     ];
     const options: DigitalTwinsUpdateComponentOptionalParams = {
-      ifMatch: "etag-value"
+      ifMatch: "etag-value",
     };
     let errorWasThrown = false;
     try {
@@ -325,7 +325,7 @@ describe("DigitalTwins Components - read, update and delete operations", () => {
     should.equal(errorWasThrown, true, "Error was not thrown");
   });
 
-  it("update component not exisiting", async function() {
+  it("update component not exisiting", async function () {
     await setUpModels();
     await createDigitalTwin(DIGITAL_TWIN_ID);
 
@@ -333,8 +333,8 @@ describe("DigitalTwins Components - read, update and delete operations", () => {
       {
         op: "replace",
         path: "/ComponentProp1",
-        value: "value2"
-      }
+        value: "value2",
+      },
     ];
     let errorWasThrown = false;
     try {
@@ -349,7 +349,7 @@ describe("DigitalTwins Components - read, update and delete operations", () => {
     should.equal(errorWasThrown, true, "Error was not thrown");
   });
 
-  it("publish component telemetry", async function() {
+  it("publish component telemetry", async function () {
     recorder.skip(undefined, "The method creates a unique Id");
 
     await setUpModels();
@@ -370,7 +370,7 @@ describe("DigitalTwins Components - read, update and delete operations", () => {
     }
   });
 
-  it("publish component telemetry with message id", async function() {
+  it("publish component telemetry with message id", async function () {
     recorder.skip(undefined, "The method creates a unique Id");
 
     await setUpModels();
@@ -391,7 +391,7 @@ describe("DigitalTwins Components - read, update and delete operations", () => {
     }
   });
 
-  it("publish component telemetry not exisiting", async function() {
+  it("publish component telemetry not exisiting", async function () {
     recorder.skip(undefined, "The method creates a unique Id");
 
     await setUpModels();

--- a/sdk/digitaltwins/digital-twins-core/test/public/testDigitalTwins.spec.ts
+++ b/sdk/digitaltwins/digital-twins-core/test/public/testDigitalTwins.spec.ts
@@ -5,7 +5,7 @@ import {
   DigitalTwinsClient,
   DigitalTwinsAddOptionalParams,
   DigitalTwinsDeleteOptionalParams,
-  DigitalTwinsUpdateOptionalParams
+  DigitalTwinsUpdateOptionalParams,
 } from "../../src";
 import { authenticate } from "../utils/testAuthentication";
 import { Recorder } from "@azure-tools/test-recorder";
@@ -25,27 +25,27 @@ const dtdl_model_building = {
     {
       "@type": "Property",
       name: "AverageTemperature",
-      schema: "double"
+      schema: "double",
     },
     {
       "@type": "Property",
       name: "TemperatureUnit",
-      schema: "string"
-    }
-  ]
+      schema: "string",
+    },
+  ],
 };
 
 describe("DigitalTwins - create, read, update, delete and telemetry operations", () => {
   let client: DigitalTwinsClient;
   let recorder: Recorder;
 
-  beforeEach(async function(this: Mocha.Context) {
+  beforeEach(async function (this: Mocha.Context) {
     const authentication = await authenticate(this);
     client = authentication.client;
     recorder = authentication.recorder;
   });
 
-  afterEach(async function() {
+  afterEach(async function () {
     await recorder.stop();
   });
 
@@ -86,7 +86,7 @@ describe("DigitalTwins - create, read, update, delete and telemetry operations",
     }
   }
 
-  it("create a simple digital twin", async function() {
+  it("create a simple digital twin", async function () {
     const digitalTwinId = recorder.getUniqueName("digitalTwin", "create-simple-digitaltwin");
 
     await setUpModels();
@@ -94,10 +94,10 @@ describe("DigitalTwins - create, read, update, delete and telemetry operations",
 
     const buildingTwin = {
       $metadata: {
-        $model: BUILDING_MODEL_ID
+        $model: BUILDING_MODEL_ID,
       },
       AverageTemperature: 68,
-      TemperatureUnit: "Celsius"
+      TemperatureUnit: "Celsius",
     };
     try {
       const createdTwin = await client.upsertDigitalTwin(
@@ -132,17 +132,17 @@ describe("DigitalTwins - create, read, update, delete and telemetry operations",
     }
   });
 
-  it("create digitaltwin without model", async function() {
+  it("create digitaltwin without model", async function () {
     const digitalTwinId = recorder.getUniqueName("digitalTwin", "create-digitaltwin-without-model");
 
     await deleteDigitalTwin(digitalTwinId);
 
     const buildingTwin = {
       $metadata: {
-        $model: "dtmi:samples:DTTestBuilding;2"
+        $model: "dtmi:samples:DTTestBuilding;2",
       },
       AverageTemperature: 68,
-      TemperatureUnit: "Celsius"
+      TemperatureUnit: "Celsius",
     };
     let errorWasThrown = false;
     try {
@@ -157,16 +157,16 @@ describe("DigitalTwins - create, read, update, delete and telemetry operations",
     should.equal(errorWasThrown, true, "Error was not thrown");
   });
 
-  it("create invalid digitaltwin", async function() {
+  it("create invalid digitaltwin", async function () {
     const digitalTwinId = recorder.getUniqueName("digitalTwin", "create-invalid-digitaltwin");
 
     await deleteDigitalTwin(digitalTwinId);
 
     const buildingTwin = {
       $metadata: {
-        $model: "dtmi:samples:DTTestBuilding;2"
+        $model: "dtmi:samples:DTTestBuilding;2",
       },
-      AverageTemperature: 68
+      AverageTemperature: 68,
     };
     let errorWasThrown = false;
     try {
@@ -181,7 +181,7 @@ describe("DigitalTwins - create, read, update, delete and telemetry operations",
     should.equal(errorWasThrown, true, "Error was not thrown");
   });
 
-  it("create digitaltwin conditionally if missing", async function() {
+  it("create digitaltwin conditionally if missing", async function () {
     const digitalTwinId = recorder.getUniqueName(
       "digitalTwin",
       "create-digitaltwin-conditionally-if-missing"
@@ -192,13 +192,13 @@ describe("DigitalTwins - create, read, update, delete and telemetry operations",
 
     const buildingTwin = {
       $metadata: {
-        $model: BUILDING_MODEL_ID
+        $model: BUILDING_MODEL_ID,
       },
       AverageTemperature: 68,
-      TemperatureUnit: "Celsius"
+      TemperatureUnit: "Celsius",
     };
     const options: DigitalTwinsAddOptionalParams = {
-      ifNoneMatch: "*"
+      ifNoneMatch: "*",
     };
     await client.upsertDigitalTwin(digitalTwinId, JSON.stringify(buildingTwin), options);
 
@@ -220,7 +220,7 @@ describe("DigitalTwins - create, read, update, delete and telemetry operations",
     should.equal(errorWasThrown, true, "Error was not thrown");
   });
 
-  it("update a simple digital twin", async function() {
+  it("update a simple digital twin", async function () {
     const digitalTwinId = recorder.getUniqueName("digitalTwin", "upsert-simple-digitaltwin");
 
     await setUpModels();
@@ -228,10 +228,10 @@ describe("DigitalTwins - create, read, update, delete and telemetry operations",
 
     const buildingTwin = {
       $metadata: {
-        $model: BUILDING_MODEL_ID
+        $model: BUILDING_MODEL_ID,
       },
       AverageTemperature: 68,
-      TemperatureUnit: "Celsius"
+      TemperatureUnit: "Celsius",
     };
     try {
       const createdTwin = await client.upsertDigitalTwin(
@@ -293,7 +293,7 @@ describe("DigitalTwins - create, read, update, delete and telemetry operations",
     }
   });
 
-  it("upsert digital twin invalid conditions", async function() {
+  it("upsert digital twin invalid conditions", async function () {
     const digitalTwinId = recorder.getUniqueName(
       "digitalTwin",
       "upsert-digitaltwin-invalid-conditions"
@@ -304,13 +304,13 @@ describe("DigitalTwins - create, read, update, delete and telemetry operations",
 
     const buildingTwin = {
       $metadata: {
-        $model: BUILDING_MODEL_ID
+        $model: BUILDING_MODEL_ID,
       },
       AverageTemperature: 68,
-      TemperatureUnit: "Celsius"
+      TemperatureUnit: "Celsius",
     };
     const options: DigitalTwinsAddOptionalParams = {
-      ifNoneMatch: "XXX"
+      ifNoneMatch: "XXX",
     };
     let errorWasThrown = false;
     try {
@@ -328,7 +328,7 @@ describe("DigitalTwins - create, read, update, delete and telemetry operations",
     should.equal(errorWasThrown, true, "Error was not thrown");
   });
 
-  it("get digitaltwin", async function() {
+  it("get digitaltwin", async function () {
     const digitalTwinId = recorder.getUniqueName("digitalTwin", "get-digitaltwin");
 
     await setUpModels();
@@ -336,10 +336,10 @@ describe("DigitalTwins - create, read, update, delete and telemetry operations",
 
     const buildingTwin = {
       $metadata: {
-        $model: BUILDING_MODEL_ID
+        $model: BUILDING_MODEL_ID,
       },
       AverageTemperature: 68,
-      TemperatureUnit: "Celsius"
+      TemperatureUnit: "Celsius",
     };
     try {
       const createdTwin = await client.upsertDigitalTwin(
@@ -355,7 +355,7 @@ describe("DigitalTwins - create, read, update, delete and telemetry operations",
     }
   });
 
-  it("get digitaltwin not existing", async function() {
+  it("get digitaltwin not existing", async function () {
     const digitalTwinId = recorder.getUniqueName("digitalTwin", "get-digitaltwin-not-existing");
 
     await setUpModels();
@@ -374,7 +374,7 @@ describe("DigitalTwins - create, read, update, delete and telemetry operations",
     should.equal(errorWasThrown, true, "Error was not thrown");
   });
 
-  it("delete digitaltwin", async function() {
+  it("delete digitaltwin", async function () {
     const digitalTwinId = recorder.getUniqueName("digitalTwin", "delete-digitaltwin");
 
     await setUpModels();
@@ -382,10 +382,10 @@ describe("DigitalTwins - create, read, update, delete and telemetry operations",
 
     const buildingTwin = {
       $metadata: {
-        $model: BUILDING_MODEL_ID
+        $model: BUILDING_MODEL_ID,
       },
       AverageTemperature: 68,
-      TemperatureUnit: "Celsius"
+      TemperatureUnit: "Celsius",
     };
     await client.upsertDigitalTwin(digitalTwinId, JSON.stringify(buildingTwin));
 
@@ -413,7 +413,7 @@ describe("DigitalTwins - create, read, update, delete and telemetry operations",
     should.equal(errorWasThrown, true, "Error was not thrown");
   });
 
-  it("delete digitaltwin not existing", async function() {
+  it("delete digitaltwin not existing", async function () {
     const digitalTwinId = recorder.getUniqueName("digitalTwin", "delete-digitaltwin-not-exisiting");
 
     await setUpModels();
@@ -432,7 +432,7 @@ describe("DigitalTwins - create, read, update, delete and telemetry operations",
     should.equal(errorWasThrown, true, "Error was not thrown");
   });
 
-  it("delete digitaltwin if present", async function() {
+  it("delete digitaltwin if present", async function () {
     const digitalTwinId = recorder.getUniqueName("digitalTwin", "delete-digitaltwin-if-present");
 
     await setUpModels();
@@ -440,15 +440,15 @@ describe("DigitalTwins - create, read, update, delete and telemetry operations",
 
     const buildingTwin = {
       $metadata: {
-        $model: BUILDING_MODEL_ID
+        $model: BUILDING_MODEL_ID,
       },
       AverageTemperature: 68,
-      TemperatureUnit: "Celsius"
+      TemperatureUnit: "Celsius",
     };
     const createdTwin = await client.upsertDigitalTwin(digitalTwinId, JSON.stringify(buildingTwin));
 
     const options: DigitalTwinsDeleteOptionalParams = {
-      ifMatch: createdTwin.etag
+      ifMatch: createdTwin.etag,
     };
     let errorWasThrown = false;
     try {
@@ -474,7 +474,7 @@ describe("DigitalTwins - create, read, update, delete and telemetry operations",
     should.equal(errorWasThrown, true, "Error was not thrown");
   });
 
-  it("delete digital twin invalid conditions", async function() {
+  it("delete digital twin invalid conditions", async function () {
     const digitalTwinId = recorder.getUniqueName(
       "digitalTwin",
       "delete-digitaltwin-invalid-conditions"
@@ -485,15 +485,15 @@ describe("DigitalTwins - create, read, update, delete and telemetry operations",
 
     const buildingTwin = {
       $metadata: {
-        $model: BUILDING_MODEL_ID
+        $model: BUILDING_MODEL_ID,
       },
       AverageTemperature: 68,
-      TemperatureUnit: "Celsius"
+      TemperatureUnit: "Celsius",
     };
     await client.upsertDigitalTwin(digitalTwinId, JSON.stringify(buildingTwin));
 
     const options: DigitalTwinsDeleteOptionalParams = {
-      ifMatch: "XXX"
+      ifMatch: "XXX",
     };
     let errorWasThrown = false;
     try {
@@ -511,7 +511,7 @@ describe("DigitalTwins - create, read, update, delete and telemetry operations",
     should.equal(errorWasThrown, true, "Error was not thrown");
   });
 
-  it("update digital twin replace", async function() {
+  it("update digital twin replace", async function () {
     const digitalTwinId = recorder.getUniqueName("digitalTwin", "update-digitaltwin-replace");
 
     await setUpModels();
@@ -519,17 +519,17 @@ describe("DigitalTwins - create, read, update, delete and telemetry operations",
 
     const buildingTwin = {
       $metadata: {
-        $model: BUILDING_MODEL_ID
+        $model: BUILDING_MODEL_ID,
       },
       AverageTemperature: 68,
-      TemperatureUnit: "Celsius"
+      TemperatureUnit: "Celsius",
     };
     const patch = [
       {
         op: "replace",
         path: "/AverageTemperature",
-        value: 42
-      }
+        value: 42,
+      },
     ];
     await client.upsertDigitalTwin(digitalTwinId, JSON.stringify(buildingTwin));
     await client.updateDigitalTwin(digitalTwinId, patch);
@@ -557,7 +557,7 @@ describe("DigitalTwins - create, read, update, delete and telemetry operations",
     should.equal(errorWasThrown, false, "Error was thrown");
   });
 
-  it("update digital twin remove", async function() {
+  it("update digital twin remove", async function () {
     const digitalTwinId = recorder.getUniqueName("digitalTwin", "update-digitaltwin-remove");
 
     await setUpModels();
@@ -565,16 +565,16 @@ describe("DigitalTwins - create, read, update, delete and telemetry operations",
 
     const buildingTwin = {
       $metadata: {
-        $model: BUILDING_MODEL_ID
+        $model: BUILDING_MODEL_ID,
       },
       AverageTemperature: 68,
-      TemperatureUnit: "Celsius"
+      TemperatureUnit: "Celsius",
     };
     const patch = [
       {
         op: "remove",
-        path: "/AverageTemperature"
-      }
+        path: "/AverageTemperature",
+      },
     ];
     await client.upsertDigitalTwin(digitalTwinId, JSON.stringify(buildingTwin));
     await client.updateDigitalTwin(digitalTwinId, patch);
@@ -602,7 +602,7 @@ describe("DigitalTwins - create, read, update, delete and telemetry operations",
     should.equal(errorWasThrown, false, "Error was thrown");
   });
 
-  it("update digital twin add", async function() {
+  it("update digital twin add", async function () {
     const digitalTwinId = recorder.getUniqueName("digitalTwin", "update-digitaltwin-add");
 
     await setUpModels();
@@ -610,16 +610,16 @@ describe("DigitalTwins - create, read, update, delete and telemetry operations",
 
     const buildingTwin = {
       $metadata: {
-        $model: BUILDING_MODEL_ID
+        $model: BUILDING_MODEL_ID,
       },
-      AverageTemperature: 68
+      AverageTemperature: 68,
     };
     const patch = [
       {
         op: "add",
         path: "/TemperatureUnit",
-        value: "Celsius"
-      }
+        value: "Celsius",
+      },
     ];
     await client.upsertDigitalTwin(digitalTwinId, JSON.stringify(buildingTwin));
     await client.updateDigitalTwin(digitalTwinId, patch);
@@ -647,7 +647,7 @@ describe("DigitalTwins - create, read, update, delete and telemetry operations",
     should.equal(errorWasThrown, false, "Error was thrown");
   });
 
-  it("update digital twin multiple", async function() {
+  it("update digital twin multiple", async function () {
     const digitalTwinId = recorder.getUniqueName("digitalTwin", "update-digitaltwin-multiple");
 
     await setUpModels();
@@ -655,21 +655,21 @@ describe("DigitalTwins - create, read, update, delete and telemetry operations",
 
     const buildingTwin = {
       $metadata: {
-        $model: BUILDING_MODEL_ID
+        $model: BUILDING_MODEL_ID,
       },
-      AverageTemperature: 68
+      AverageTemperature: 68,
     };
     const patch = [
       {
         op: "add",
         path: "/TemperatureUnit",
-        value: "Celsius"
+        value: "Celsius",
       },
       {
         op: "replace",
         path: "/AverageTemperature",
-        value: 42
-      }
+        value: 42,
+      },
     ];
     await client.upsertDigitalTwin(digitalTwinId, JSON.stringify(buildingTwin));
     await client.updateDigitalTwin(digitalTwinId, patch);
@@ -697,7 +697,7 @@ describe("DigitalTwins - create, read, update, delete and telemetry operations",
     should.equal(errorWasThrown, false, "Error was thrown");
   });
 
-  it("update digital twin invalid patch", async function() {
+  it("update digital twin invalid patch", async function () {
     const digitalTwinId = recorder.getUniqueName("digitalTwin", "update-digitaltwin-invalid-patch");
 
     await setUpModels();
@@ -705,16 +705,16 @@ describe("DigitalTwins - create, read, update, delete and telemetry operations",
 
     const buildingTwin = {
       $metadata: {
-        $model: BUILDING_MODEL_ID
+        $model: BUILDING_MODEL_ID,
       },
-      AverageTemperature: 68
+      AverageTemperature: 68,
     };
     const patch = [
       {
         op: "move",
         path: "/AverageTemperature",
-        value: 42
-      }
+        value: 42,
+      },
     ];
     await client.upsertDigitalTwin(digitalTwinId, JSON.stringify(buildingTwin));
 
@@ -731,7 +731,7 @@ describe("DigitalTwins - create, read, update, delete and telemetry operations",
     should.equal(errorWasThrown, true, "Error was not thrown");
   });
 
-  it("update digital twin confditionally if present", async function() {
+  it("update digital twin confditionally if present", async function () {
     const digitalTwinId = recorder.getUniqueName(
       "digitalTwin",
       "update-digitaltwin-conditionally-if-present"
@@ -742,20 +742,20 @@ describe("DigitalTwins - create, read, update, delete and telemetry operations",
 
     const buildingTwin = {
       $metadata: {
-        $model: BUILDING_MODEL_ID
+        $model: BUILDING_MODEL_ID,
       },
-      AverageTemperature: 68
+      AverageTemperature: 68,
     };
     const patch = [
       {
         op: "replace",
         path: "/AverageTemperature",
-        value: 42
-      }
+        value: 42,
+      },
     ];
     const createdTwin = await client.upsertDigitalTwin(digitalTwinId, JSON.stringify(buildingTwin));
     const options: DigitalTwinsUpdateOptionalParams = {
-      ifMatch: createdTwin.etag
+      ifMatch: createdTwin.etag,
     };
     await client.updateDigitalTwin(digitalTwinId, patch, options);
 
@@ -777,7 +777,7 @@ describe("DigitalTwins - create, read, update, delete and telemetry operations",
     should.equal(errorWasThrown, false, "Error was thrown");
   });
 
-  it("update digital twin invalid conditions", async function() {
+  it("update digital twin invalid conditions", async function () {
     const digitalTwinId = recorder.getUniqueName(
       "digitalTwin",
       "update-digitaltwin-invalid-conditions"
@@ -788,22 +788,22 @@ describe("DigitalTwins - create, read, update, delete and telemetry operations",
 
     const buildingTwin = {
       $metadata: {
-        $model: BUILDING_MODEL_ID
+        $model: BUILDING_MODEL_ID,
       },
       AverageTemperature: 68,
-      TemperatureUnit: "Celsius"
+      TemperatureUnit: "Celsius",
     };
     const patch = [
       {
         op: "replace",
         path: "/AverageTemperature",
-        value: 42
-      }
+        value: 42,
+      },
     ];
     await client.upsertDigitalTwin(digitalTwinId, JSON.stringify(buildingTwin));
 
     const options: DigitalTwinsDeleteOptionalParams = {
-      ifMatch: "XXX"
+      ifMatch: "XXX",
     };
     let errorWasThrown = false;
     try {
@@ -821,7 +821,7 @@ describe("DigitalTwins - create, read, update, delete and telemetry operations",
     should.equal(errorWasThrown, true, "Error was not thrown");
   });
 
-  it("update digital twin not existing", async function() {
+  it("update digital twin not existing", async function () {
     const digitalTwinId = recorder.getUniqueName("digitalTwin", "update-digitaltwin-not-existing");
 
     await setUpModels();
@@ -831,8 +831,8 @@ describe("DigitalTwins - create, read, update, delete and telemetry operations",
       {
         op: "replace",
         path: "/AverageTemperature",
-        value: 42
-      }
+        value: 42,
+      },
     ];
 
     let errorWasThrown = false;
@@ -848,7 +848,7 @@ describe("DigitalTwins - create, read, update, delete and telemetry operations",
     should.equal(errorWasThrown, true, "Error was not thrown");
   });
 
-  it("query digital twin", async function() {
+  it("query digital twin", async function () {
     const digitalTwinId = recorder.getUniqueName("digitalTwin", "query-digitaltwin");
 
     await setUpModels();
@@ -856,10 +856,10 @@ describe("DigitalTwins - create, read, update, delete and telemetry operations",
 
     const buildingTwin = {
       $metadata: {
-        $model: BUILDING_MODEL_ID
+        $model: BUILDING_MODEL_ID,
       },
       AverageTemperature: 68,
-      TemperatureUnit: "Celsius"
+      TemperatureUnit: "Celsius",
     };
     await client.upsertDigitalTwin(digitalTwinId, JSON.stringify(buildingTwin));
 
@@ -883,7 +883,7 @@ describe("DigitalTwins - create, read, update, delete and telemetry operations",
     }
   });
 
-  it("query digital twin invalid expression", async function() {
+  it("query digital twin invalid expression", async function () {
     const digitalTwinId = recorder.getUniqueName(
       "digitalTwin",
       "query-digitaltwin-invalid-expression"
@@ -913,7 +913,7 @@ describe("DigitalTwins - create, read, update, delete and telemetry operations",
     should.equal(errorWasThrown, true, "Error was not thrown");
   });
 
-  it("publish telemetry", async function() {
+  it("publish telemetry", async function () {
     recorder.skip(undefined, "The method creates a unique Id");
 
     const digitalTwinId = recorder.getUniqueName("digitalTwin", "publish-telemetry");
@@ -923,10 +923,10 @@ describe("DigitalTwins - create, read, update, delete and telemetry operations",
 
     const buildingTwin = {
       $metadata: {
-        $model: BUILDING_MODEL_ID
+        $model: BUILDING_MODEL_ID,
       },
       AverageTemperature: 68,
-      TemperatureUnit: "Celsius"
+      TemperatureUnit: "Celsius",
     };
     await client.upsertDigitalTwin(digitalTwinId, JSON.stringify(buildingTwin));
 

--- a/sdk/digitaltwins/digital-twins-core/test/public/testEventRoutes.spec.ts
+++ b/sdk/digitaltwins/digital-twins-core/test/public/testEventRoutes.spec.ts
@@ -13,17 +13,17 @@ describe("DigitalTwins EventRoutes - create, read, list and delete operations", 
   let client: DigitalTwinsClient;
   let recorder: Recorder;
 
-  beforeEach(async function(this: Mocha.Context) {
+  beforeEach(async function (this: Mocha.Context) {
     const authentication = await authenticate(this);
     client = authentication.client;
     recorder = authentication.recorder;
   });
 
-  afterEach(async function() {
+  afterEach(async function () {
     await recorder.stop();
   });
 
-  it("create event route no endpoint", async function() {
+  it("create event route no endpoint", async function () {
     const eventRouteId = recorder.getUniqueName("eventRoute", "create-event-route");
     const eventFilter =
       "$eventType = 'DigitalTwinTelemetryMessages' or $eventType = 'DigitalTwinLifecycleNotification'";
@@ -39,7 +39,7 @@ describe("DigitalTwins EventRoutes - create, read, list and delete operations", 
     should.equal(errorWasThrown, true, "Error was not thrown");
   });
 
-  it("get event route not exisiting", async function() {
+  it("get event route not exisiting", async function () {
     const eventRouteId = recorder.getUniqueName("eventRoute", "get-event-route-not-existing");
 
     let errorWasThrown = false;
@@ -52,14 +52,14 @@ describe("DigitalTwins EventRoutes - create, read, list and delete operations", 
     should.equal(errorWasThrown, true, "Error was not thrown");
   });
 
-  it("list event routes", async function() {
+  it("list event routes", async function () {
     const eventRoutes = client.listEventRoutes();
     for await (const item of eventRoutes) {
       assert.isNotNull(item);
     }
   });
 
-  it("delete event route not exisiting", async function() {
+  it("delete event route not exisiting", async function () {
     const eventRouteId = recorder.getUniqueName("eventRoute", "delete-event-routes-not-existing");
 
     let errorWasThrown = false;

--- a/sdk/digitaltwins/digital-twins-core/test/public/testModels.spec.ts
+++ b/sdk/digitaltwins/digital-twins-core/test/public/testModels.spec.ts
@@ -22,14 +22,14 @@ const testComponent = {
     {
       "@type": "Property",
       name: "ComponentProp1",
-      schema: "string"
+      schema: "string",
     },
     {
       "@type": "Telemetry",
       name: "ComponentTelemetry1",
-      schema: "integer"
-    }
-  ]
+      schema: "integer",
+    },
+  ],
 };
 
 const testModel = {
@@ -41,32 +41,32 @@ const testModel = {
     {
       "@type": "Property",
       name: "Prop1",
-      schema: "string"
+      schema: "string",
     },
     {
       "@type": "Component",
       name: "Component1",
-      schema: COMPONENT_ID
+      schema: COMPONENT_ID,
     },
     {
       "@type": "Telemetry",
       name: "Telemetry1",
-      schema: "integer"
-    }
-  ]
+      schema: "integer",
+    },
+  ],
 };
 
 describe("DigitalTwins Models - create, read, list, delete operations", () => {
   let client: DigitalTwinsClient;
   let recorder: Recorder;
 
-  beforeEach(async function(this: Mocha.Context) {
+  beforeEach(async function (this: Mocha.Context) {
     const authentication = await authenticate(this);
     client = authentication.client;
     recorder = authentication.recorder;
   });
 
-  afterEach(async function() {
+  afterEach(async function () {
     await recorder.stop();
   });
 
@@ -94,7 +94,7 @@ describe("DigitalTwins Models - create, read, list, delete operations", () => {
     await createModel();
   }
 
-  it("create models empty", async function() {
+  it("create models empty", async function () {
     await deleteModels();
 
     let errorWasThrown = false;
@@ -107,7 +107,7 @@ describe("DigitalTwins Models - create, read, list, delete operations", () => {
     should.equal(errorWasThrown, true, "Error was not thrown");
   });
 
-  it("create models", async function() {
+  it("create models", async function () {
     await deleteModels();
 
     try {
@@ -128,7 +128,7 @@ describe("DigitalTwins Models - create, read, list, delete operations", () => {
     }
   });
 
-  it("create model existing", async function() {
+  it("create model existing", async function () {
     await setUpModels();
 
     let errorWasThrown = false;
@@ -143,7 +143,7 @@ describe("DigitalTwins Models - create, read, list, delete operations", () => {
     should.equal(errorWasThrown, true, "Error was not thrown");
   });
 
-  it("create model invalid model", async function() {
+  it("create model invalid model", async function () {
     await deleteModels();
 
     const invalidComponent = {
@@ -153,14 +153,14 @@ describe("DigitalTwins Models - create, read, list, delete operations", () => {
         {
           "@type": "Property",
           name: "ComponentProp1",
-          schema: "string"
+          schema: "string",
         },
         {
           "@type": "Telemetry",
           name: "ComponentTelemetry1",
-          schema: "integer"
-        }
-      ]
+          schema: "integer",
+        },
+      ],
     };
 
     let errorWasThrown = false;
@@ -178,7 +178,7 @@ describe("DigitalTwins Models - create, read, list, delete operations", () => {
     should.equal(errorWasThrown, true, "Error was not thrown");
   });
 
-  it("create model invalid reference", async function() {
+  it("create model invalid reference", async function () {
     await deleteModels();
 
     const invalidModel = {
@@ -190,19 +190,19 @@ describe("DigitalTwins Models - create, read, list, delete operations", () => {
         {
           "@type": "Property",
           name: "Prop1",
-          schema: "string"
+          schema: "string",
         },
         {
           "@type": "Component",
           name: "Component1",
-          schema: "XXX"
+          schema: "XXX",
         },
         {
           "@type": "Telemetry",
           name: "Telemetry1",
-          schema: "integer"
-        }
-      ]
+          schema: "integer",
+        },
+      ],
     };
 
     let errorWasThrown = false;
@@ -220,7 +220,7 @@ describe("DigitalTwins Models - create, read, list, delete operations", () => {
     should.equal(errorWasThrown, true, "Error was not thrown");
   });
 
-  it("get model", async function() {
+  it("get model", async function () {
     await setUpModels();
 
     try {
@@ -235,7 +235,7 @@ describe("DigitalTwins Models - create, read, list, delete operations", () => {
     }
   });
 
-  it("get model with definition", async function() {
+  it("get model with definition", async function () {
     await setUpModels();
 
     try {
@@ -250,7 +250,7 @@ describe("DigitalTwins Models - create, read, list, delete operations", () => {
     }
   });
 
-  it("get model not existing", async function() {
+  it("get model not existing", async function () {
     await deleteModels();
 
     let errorWasThrown = false;
@@ -266,7 +266,7 @@ describe("DigitalTwins Models - create, read, list, delete operations", () => {
     should.equal(errorWasThrown, true, "Error was not thrown");
   });
 
-  it("list models", async function() {
+  it("list models", async function () {
     await setUpModels();
 
     try {
@@ -292,7 +292,7 @@ describe("DigitalTwins Models - create, read, list, delete operations", () => {
     }
   });
 
-  it("list models with definition", async function() {
+  it("list models with definition", async function () {
     await setUpModels();
 
     try {
@@ -318,7 +318,7 @@ describe("DigitalTwins Models - create, read, list, delete operations", () => {
     }
   });
 
-  it("decommission model", async function() {
+  it("decommission model", async function () {
     await deleteModels();
 
     try {
@@ -345,7 +345,7 @@ describe("DigitalTwins Models - create, read, list, delete operations", () => {
     }
   });
 
-  it("decommission model not existing", async function() {
+  it("decommission model not existing", async function () {
     await deleteModels();
     delay(500);
 
@@ -364,7 +364,7 @@ describe("DigitalTwins Models - create, read, list, delete operations", () => {
     should.equal(errorWasThrown, true, "Error was not thrown");
   });
 
-  it("decommission model already decomissioned", async function() {
+  it("decommission model already decomissioned", async function () {
     await deleteModels();
 
     try {
@@ -400,7 +400,7 @@ describe("DigitalTwins Models - create, read, list, delete operations", () => {
     }
   });
 
-  it("delete model", async function() {
+  it("delete model", async function () {
     await setUpModels();
 
     try {
@@ -434,7 +434,7 @@ describe("DigitalTwins Models - create, read, list, delete operations", () => {
     }
   });
 
-  it("delete model not existing", async function() {
+  it("delete model not existing", async function () {
     await deleteModels();
 
     let errorWasThrown = false;
@@ -452,7 +452,7 @@ describe("DigitalTwins Models - create, read, list, delete operations", () => {
     should.equal(errorWasThrown, true, "Error was not thrown");
   });
 
-  it("delete model already deleted", async function() {
+  it("delete model already deleted", async function () {
     await setUpModels();
 
     await client.deleteModel(MODEL_ID);
@@ -472,7 +472,7 @@ describe("DigitalTwins Models - create, read, list, delete operations", () => {
     should.equal(errorWasThrown, true, "Error was not thrown");
   });
 
-  it("delete model with dependencies", async function() {
+  it("delete model with dependencies", async function () {
     await setUpModels();
 
     try {

--- a/sdk/digitaltwins/digital-twins-core/test/public/testRelationships.spec.ts
+++ b/sdk/digitaltwins/digital-twins-core/test/public/testRelationships.spec.ts
@@ -30,16 +30,16 @@ const dtdl_model_building = {
         {
           "@type": "Property",
           name: "isAccessRestricted",
-          schema: "boolean"
-        }
-      ]
+          schema: "boolean",
+        },
+      ],
     },
     {
       "@type": "Property",
       name: "AverageTemperature",
-      schema: "double"
-    }
-  ]
+      schema: "double",
+    },
+  ],
 };
 
 const dtdl_model_floor = {
@@ -51,14 +51,14 @@ const dtdl_model_floor = {
     {
       "@type": "Relationship",
       name: "contains",
-      target: ROOM_MODEL_ID
+      target: ROOM_MODEL_ID,
     },
     {
       "@type": "Property",
       name: "AverageTemperature",
-      schema: "double"
-    }
-  ]
+      schema: "double",
+    },
+  ],
 };
 
 const dtdl_model_room = {
@@ -70,27 +70,27 @@ const dtdl_model_room = {
     {
       "@type": "Property",
       name: "Temperature",
-      schema: "double"
+      schema: "double",
     },
     {
       "@type": "Property",
       name: "IsOccupied",
-      schema: "boolean"
-    }
-  ]
+      schema: "boolean",
+    },
+  ],
 };
 
 describe("DigitalTwins Relationships - create, read, list, delete operations", () => {
   let client: DigitalTwinsClient;
   let recorder: Recorder;
 
-  beforeEach(async function(this: Mocha.Context) {
+  beforeEach(async function (this: Mocha.Context) {
     const authentication = await authenticate(this);
     client = authentication.client;
     recorder = authentication.recorder;
   });
 
-  afterEach(async function() {
+  afterEach(async function () {
     await recorder.stop();
   });
 
@@ -145,26 +145,26 @@ describe("DigitalTwins Relationships - create, read, list, delete operations", (
   async function createDigitalTwins(): Promise<void> {
     const buildingTwin = {
       $metadata: {
-        $model: BUILDING_MODEL_ID
+        $model: BUILDING_MODEL_ID,
       },
-      AverageTemperature: 68
+      AverageTemperature: 68,
     };
     await client.upsertDigitalTwin(BUILDING_DIGITAL_TWIN_ID, JSON.stringify(buildingTwin));
 
     const floorTwin = {
       $metadata: {
-        $model: FLOOR_MODEL_ID
+        $model: FLOOR_MODEL_ID,
       },
-      AverageTemperature: 75
+      AverageTemperature: 75,
     };
     await client.upsertDigitalTwin(FLOOR_DIGITAL_TWIN_ID, JSON.stringify(floorTwin));
 
     const roomTwin = {
       $metadata: {
-        $model: ROOM_MODEL_ID
+        $model: ROOM_MODEL_ID,
       },
       Temperature: 80,
-      IsOccupied: true
+      IsOccupied: true,
     };
     await client.upsertDigitalTwin(ROOM_DIGITAL_TWIN_ID, JSON.stringify(roomTwin));
   }
@@ -174,7 +174,7 @@ describe("DigitalTwins Relationships - create, read, list, delete operations", (
     await createDigitalTwins();
   }
 
-  it("create basic relationship", async function() {
+  it("create basic relationship", async function () {
     await setUpModels();
     await setUpDigitalTwins();
 
@@ -183,7 +183,7 @@ describe("DigitalTwins Relationships - create, read, list, delete operations", (
       $relationshipId: relationshipId,
       $sourceId: FLOOR_DIGITAL_TWIN_ID,
       $relationshipName: "contains",
-      $targetId: ROOM_DIGITAL_TWIN_ID
+      $targetId: ROOM_DIGITAL_TWIN_ID,
     };
 
     try {
@@ -222,7 +222,7 @@ describe("DigitalTwins Relationships - create, read, list, delete operations", (
     }
   });
 
-  it("create invalid relationship - invalid twin id", async function() {
+  it("create invalid relationship - invalid twin id", async function () {
     await setUpModels();
     await setUpDigitalTwins();
 
@@ -231,7 +231,7 @@ describe("DigitalTwins Relationships - create, read, list, delete operations", (
       $relationshipId: relationshipId,
       $sourceId: FLOOR_DIGITAL_TWIN_ID,
       $relationshipName: "contains",
-      $targetId: ROOM_DIGITAL_TWIN_ID
+      $targetId: ROOM_DIGITAL_TWIN_ID,
     };
 
     let errorWasThrown = false;
@@ -252,7 +252,7 @@ describe("DigitalTwins Relationships - create, read, list, delete operations", (
     should.equal(errorWasThrown, true, "Error was not thrown");
   });
 
-  it("create invalid relationship - invalid twin target id", async function() {
+  it("create invalid relationship - invalid twin target id", async function () {
     await setUpModels();
     await setUpDigitalTwins();
 
@@ -261,7 +261,7 @@ describe("DigitalTwins Relationships - create, read, list, delete operations", (
       $relationshipId: relationshipId,
       $sourceId: FLOOR_DIGITAL_TWIN_ID,
       $relationshipName: "contains",
-      $targetId: "foo"
+      $targetId: "foo",
     };
 
     let errorWasThrown = false;
@@ -282,7 +282,7 @@ describe("DigitalTwins Relationships - create, read, list, delete operations", (
     should.equal(errorWasThrown, true, "Error was not thrown");
   });
 
-  it("create relationship conditionally", async function() {
+  it("create relationship conditionally", async function () {
     await setUpModels();
     await setUpDigitalTwins();
 
@@ -291,7 +291,7 @@ describe("DigitalTwins Relationships - create, read, list, delete operations", (
       $relationshipId: relationshipId,
       $sourceId: FLOOR_DIGITAL_TWIN_ID,
       $relationshipName: "contains",
-      $targetId: ROOM_DIGITAL_TWIN_ID
+      $targetId: ROOM_DIGITAL_TWIN_ID,
     };
 
     try {
@@ -347,7 +347,7 @@ describe("DigitalTwins Relationships - create, read, list, delete operations", (
     }
   });
 
-  it("upsert relationship", async function() {
+  it("upsert relationship", async function () {
     await setUpModels();
     await setUpDigitalTwins();
 
@@ -357,7 +357,7 @@ describe("DigitalTwins Relationships - create, read, list, delete operations", (
       $sourceId: BUILDING_DIGITAL_TWIN_ID,
       $relationshipName: "has",
       $targetId: FLOOR_DIGITAL_TWIN_ID,
-      isAccessRestricted: false
+      isAccessRestricted: false,
     };
 
     try {
@@ -432,7 +432,7 @@ describe("DigitalTwins Relationships - create, read, list, delete operations", (
     }
   });
 
-  it("get relationship", async function() {
+  it("get relationship", async function () {
     await setUpModels();
     await setUpDigitalTwins();
 
@@ -442,7 +442,7 @@ describe("DigitalTwins Relationships - create, read, list, delete operations", (
       $sourceId: BUILDING_DIGITAL_TWIN_ID,
       $relationshipName: "has",
       $targetId: FLOOR_DIGITAL_TWIN_ID,
-      isAccessRestricted: false
+      isAccessRestricted: false,
     };
 
     try {
@@ -516,7 +516,7 @@ describe("DigitalTwins Relationships - create, read, list, delete operations", (
     }
   });
 
-  it("get relationship not existing", async function() {
+  it("get relationship not existing", async function () {
     await setUpModels();
     await setUpDigitalTwins();
 
@@ -543,7 +543,7 @@ describe("DigitalTwins Relationships - create, read, list, delete operations", (
     }
   });
 
-  it("delete relationship", async function() {
+  it("delete relationship", async function () {
     await setUpModels();
     await setUpDigitalTwins();
 
@@ -553,7 +553,7 @@ describe("DigitalTwins Relationships - create, read, list, delete operations", (
       $sourceId: BUILDING_DIGITAL_TWIN_ID,
       $relationshipName: "has",
       $targetId: FLOOR_DIGITAL_TWIN_ID,
-      isAccessRestricted: false
+      isAccessRestricted: false,
     };
     try {
       const createdRelationship = await client.upsertRelationship(
@@ -610,7 +610,7 @@ describe("DigitalTwins Relationships - create, read, list, delete operations", (
     }
   });
 
-  it("delete relationship not existing", async function() {
+  it("delete relationship not existing", async function () {
     await setUpModels();
     await setUpDigitalTwins();
 
@@ -637,7 +637,7 @@ describe("DigitalTwins Relationships - create, read, list, delete operations", (
     }
   });
 
-  it("update relationship replace", async function() {
+  it("update relationship replace", async function () {
     await setUpModels();
     await setUpDigitalTwins();
 
@@ -647,7 +647,7 @@ describe("DigitalTwins Relationships - create, read, list, delete operations", (
       $sourceId: BUILDING_DIGITAL_TWIN_ID,
       $relationshipName: "has",
       $targetId: FLOOR_DIGITAL_TWIN_ID,
-      isAccessRestricted: false
+      isAccessRestricted: false,
     };
 
     try {
@@ -685,8 +685,8 @@ describe("DigitalTwins Relationships - create, read, list, delete operations", (
         {
           op: "replace",
           path: "/isAccessRestricted",
-          value: true
-        }
+          value: true,
+        },
       ];
       const updatedRelationship = await client.updateRelationship(
         BUILDING_DIGITAL_TWIN_ID,
@@ -723,7 +723,7 @@ describe("DigitalTwins Relationships - create, read, list, delete operations", (
     }
   });
 
-  it("update relationship remove", async function() {
+  it("update relationship remove", async function () {
     await setUpModels();
     await setUpDigitalTwins();
 
@@ -733,7 +733,7 @@ describe("DigitalTwins Relationships - create, read, list, delete operations", (
       $sourceId: BUILDING_DIGITAL_TWIN_ID,
       $relationshipName: "has",
       $targetId: FLOOR_DIGITAL_TWIN_ID,
-      isAccessRestricted: false
+      isAccessRestricted: false,
     };
 
     try {
@@ -770,8 +770,8 @@ describe("DigitalTwins Relationships - create, read, list, delete operations", (
       const patch = [
         {
           op: "remove",
-          path: "/isAccessRestricted"
-        }
+          path: "/isAccessRestricted",
+        },
       ];
       const updatedRelationship = await client.updateRelationship(
         BUILDING_DIGITAL_TWIN_ID,
@@ -807,7 +807,7 @@ describe("DigitalTwins Relationships - create, read, list, delete operations", (
     }
   });
 
-  it("update relationship add", async function() {
+  it("update relationship add", async function () {
     await setUpModels();
     await setUpDigitalTwins();
 
@@ -817,7 +817,7 @@ describe("DigitalTwins Relationships - create, read, list, delete operations", (
       $sourceId: BUILDING_DIGITAL_TWIN_ID,
       $relationshipName: "has",
       $targetId: FLOOR_DIGITAL_TWIN_ID,
-      isAccessRestricted: false
+      isAccessRestricted: false,
     };
 
     try {
@@ -854,8 +854,8 @@ describe("DigitalTwins Relationships - create, read, list, delete operations", (
       const remove_patch = [
         {
           op: "remove",
-          path: "/isAccessRestricted"
-        }
+          path: "/isAccessRestricted",
+        },
       ];
       await client.updateRelationship(BUILDING_DIGITAL_TWIN_ID, relationshipId, remove_patch);
 
@@ -863,8 +863,8 @@ describe("DigitalTwins Relationships - create, read, list, delete operations", (
         {
           op: "add",
           path: "/isAccessRestricted",
-          value: true
-        }
+          value: true,
+        },
       ];
       const updatedRelationship = await client.updateRelationship(
         BUILDING_DIGITAL_TWIN_ID,
@@ -901,7 +901,7 @@ describe("DigitalTwins Relationships - create, read, list, delete operations", (
     }
   });
 
-  it("update relationship multiple", async function() {
+  it("update relationship multiple", async function () {
     await setUpModels();
     await setUpDigitalTwins();
 
@@ -911,7 +911,7 @@ describe("DigitalTwins Relationships - create, read, list, delete operations", (
       $sourceId: BUILDING_DIGITAL_TWIN_ID,
       $relationshipName: "has",
       $targetId: FLOOR_DIGITAL_TWIN_ID,
-      isAccessRestricted: false
+      isAccessRestricted: false,
     };
 
     try {
@@ -949,12 +949,12 @@ describe("DigitalTwins Relationships - create, read, list, delete operations", (
         {
           op: "replace",
           path: "/isAccessRestricted",
-          value: true
+          value: true,
         },
         {
           op: "remove",
-          path: "/isAccessRestricted"
-        }
+          path: "/isAccessRestricted",
+        },
       ];
       const updatedRelationship = await client.updateRelationship(
         BUILDING_DIGITAL_TWIN_ID,
@@ -990,7 +990,7 @@ describe("DigitalTwins Relationships - create, read, list, delete operations", (
     }
   });
 
-  it("update relationship invalid patch", async function() {
+  it("update relationship invalid patch", async function () {
     await setUpModels();
     await setUpDigitalTwins();
 
@@ -1000,7 +1000,7 @@ describe("DigitalTwins Relationships - create, read, list, delete operations", (
       $sourceId: BUILDING_DIGITAL_TWIN_ID,
       $relationshipName: "has",
       $targetId: FLOOR_DIGITAL_TWIN_ID,
-      isAccessRestricted: false
+      isAccessRestricted: false,
     };
 
     try {
@@ -1037,8 +1037,8 @@ describe("DigitalTwins Relationships - create, read, list, delete operations", (
       const patch1 = [
         {
           op: "move",
-          path: "/isAccessRestricted"
-        }
+          path: "/isAccessRestricted",
+        },
       ];
       let errorWasThrown = false;
       try {
@@ -1052,8 +1052,8 @@ describe("DigitalTwins Relationships - create, read, list, delete operations", (
       const patch2 = [
         {
           op: "remove",
-          path: "/isAccessDoorRestricted"
-        }
+          path: "/isAccessDoorRestricted",
+        },
       ];
       errorWasThrown = false;
       try {
@@ -1069,8 +1069,8 @@ describe("DigitalTwins Relationships - create, read, list, delete operations", (
 
       const patch3 = [
         {
-          isAccessRestricted: false
-        }
+          isAccessRestricted: false,
+        },
       ];
       errorWasThrown = false;
       try {
@@ -1101,7 +1101,7 @@ describe("DigitalTwins Relationships - create, read, list, delete operations", (
     }
   });
 
-  it("update relationship conditionally", async function() {
+  it("update relationship conditionally", async function () {
     await setUpModels();
     await setUpDigitalTwins();
 
@@ -1111,7 +1111,7 @@ describe("DigitalTwins Relationships - create, read, list, delete operations", (
       $sourceId: BUILDING_DIGITAL_TWIN_ID,
       $relationshipName: "has",
       $targetId: FLOOR_DIGITAL_TWIN_ID,
-      isAccessRestricted: false
+      isAccessRestricted: false,
     };
 
     try {
@@ -1149,8 +1149,8 @@ describe("DigitalTwins Relationships - create, read, list, delete operations", (
         {
           op: "replace",
           path: "/isAccessRestricted",
-          value: true
-        }
+          value: true,
+        },
       ];
       const options: DigitalTwinsAddRelationshipOptionalParams = {};
       options.ifNoneMatch = "*";
@@ -1190,7 +1190,7 @@ describe("DigitalTwins Relationships - create, read, list, delete operations", (
     }
   });
 
-  it("update relationship not existing", async function() {
+  it("update relationship not existing", async function () {
     await setUpModels();
     await setUpDigitalTwins();
 
@@ -1202,8 +1202,8 @@ describe("DigitalTwins Relationships - create, read, list, delete operations", (
         {
           op: "replace",
           path: "/isAccessRestricted",
-          value: true
-        }
+          value: true,
+        },
       ];
       await client.updateRelationship(BUILDING_DIGITAL_TWIN_ID, "foo", patch);
     } catch (error) {
@@ -1221,7 +1221,7 @@ describe("DigitalTwins Relationships - create, read, list, delete operations", (
     }
   });
 
-  it("list relationships", async function() {
+  it("list relationships", async function () {
     await setUpModels();
     await setUpDigitalTwins();
 
@@ -1231,7 +1231,7 @@ describe("DigitalTwins Relationships - create, read, list, delete operations", (
       $sourceId: BUILDING_DIGITAL_TWIN_ID,
       $relationshipName: "has",
       $targetId: FLOOR_DIGITAL_TWIN_ID,
-      isAccessRestricted: false
+      isAccessRestricted: false,
     };
 
     try {
@@ -1282,7 +1282,7 @@ describe("DigitalTwins Relationships - create, read, list, delete operations", (
     }
   });
 
-  it("list incoming relationships", async function() {
+  it("list incoming relationships", async function () {
     await setUpModels();
     await setUpDigitalTwins();
 
@@ -1292,7 +1292,7 @@ describe("DigitalTwins Relationships - create, read, list, delete operations", (
       $sourceId: BUILDING_DIGITAL_TWIN_ID,
       $relationshipName: "has",
       $targetId: FLOOR_DIGITAL_TWIN_ID,
-      isAccessRestricted: false
+      isAccessRestricted: false,
     };
 
     try {

--- a/sdk/digitaltwins/digital-twins-core/test/utils/recorderUtils.ts
+++ b/sdk/digitaltwins/digital-twins-core/test/utils/recorderUtils.ts
@@ -10,13 +10,9 @@ if (isNode) {
 }
 
 export function uniqueString(): string {
-  return isPlaybackMode()
-    ? ""
-    : Math.random()
-        .toString()
-        .slice(2);
+  return isPlaybackMode() ? "" : Math.random().toString().slice(2);
 }
 
 export const testPollerProperties = {
-  intervalInMs: isPlaybackMode() ? 0 : undefined
+  intervalInMs: isPlaybackMode() ? 0 : undefined,
 };

--- a/sdk/digitaltwins/digital-twins-core/test/utils/testAuthentication.ts
+++ b/sdk/digitaltwins/digital-twins-core/test/utils/testAuthentication.ts
@@ -14,15 +14,15 @@ export async function authenticate(that: Mocha.Context): Promise<any> {
       AZURE_CLIENT_ID: "azure_client_id",
       AZURE_CLIENT_SECRET: "azure_client_secret",
       AZURE_TENANT_ID: "12345678-1234-1234-1234-123456789012",
-      AZURE_DIGITALTWINS_URL: "https://AZURE_DIGITALTWINS_URL.api.wus2.digitaltwins.azure.net"
+      AZURE_DIGITALTWINS_URL: "https://AZURE_DIGITALTWINS_URL.api.wus2.digitaltwins.azure.net",
     },
     customizationsOnRecordings: [
       (recording: any): any =>
         recording.replace(/"access_token":"[^"]*"/g, `"access_token":"access_token"`),
       (recording: any): any =>
-        keySuffix === "" ? recording : recording.replace(new RegExp(keySuffix, "g"), "")
+        keySuffix === "" ? recording : recording.replace(new RegExp(keySuffix, "g"), ""),
     ],
-    queryParametersToSkip: []
+    queryParametersToSkip: [],
   };
   const recorder = record(that, recorderEnvSetup);
   const credential = new ClientSecretCredential(


### PR DESCRIPTION
Solves: https://github.com/Azure/azure-sdk-for-js/issues/9329 for packages under `sdk/digitaltwins`.
 
Updated `prettier` dev-dependency version to latest `2.5.1`.
Files were re-formatted as well. There are only format changes in this PR, no manual changes except for package.json files.
 
Main format changes with Prettier 2.x in this PR include:
- Trailing commas by default.
- Whitespace added after every `function` keyword.