### PR TITLE
Update prettier dev-dependency to v2.5.1 in rest packages

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -1408,6 +1408,7 @@ packages:
   /@opentelemetry/node/0.22.0_@opentelemetry+api@1.0.3:
     resolution: {integrity: sha512-+HhGbDruQ7cwejVOIYyxRa28uosnG8W95NiQZ6qE8PXXPsDSyGeftAPbtYpGit0H2f5hrVcMlwmWHeAo9xkSLA==}
     engines: {node: '>=8.0.0'}
+    deprecated: Package renamed to @opentelemetry/sdk-trace-node
     peerDependencies:
       '@opentelemetry/api': ^1.0.0
     dependencies:
@@ -12013,7 +12014,7 @@ packages:
     dev: false
 
   file:projects/purview-account.tgz:
-    resolution: {integrity: sha512-80S7bWUiimjhZMa44NrrcpAVceEIABUpCWdxgOkRQsMifwiI1PVT2IPTNDzAALJ9LR+BBr2YaEAbBpvceW5tMQ==, tarball: file:projects/purview-account.tgz}
+    resolution: {integrity: sha512-2SgZF7TpHa9W54okUQr0+0TPdV6LnA9Op5yR0b5jrVC+XYhwO2bclHoU9dDESg2Ehr6ZkW+qfLUF6o7b+PmgAw==, tarball: file:projects/purview-account.tgz}
     name: '@rush-temp/purview-account'
     version: 0.0.0
     dependencies:
@@ -12045,7 +12046,7 @@ packages:
       mocha: 7.2.0
       mocha-junit-reporter: 2.0.2_mocha@7.2.0
       nyc: 15.1.0
-      prettier: 2.2.1
+      prettier: 2.5.1
       rimraf: 3.0.2
       rollup: 1.32.1
       source-map-support: 0.5.21
@@ -12059,7 +12060,7 @@ packages:
     dev: false
 
   file:projects/purview-administration.tgz:
-    resolution: {integrity: sha512-i4bV/YjiM80T2/DKscf7Ok8KVddw8WU+6l4/ruqhcsRD3xBuT/D0spg8/g/xd9k/kTh0JBpl1D20dRKWsfz06Q==, tarball: file:projects/purview-administration.tgz}
+    resolution: {integrity: sha512-UlUeRaxkiHu2VdQj3jStF16Gp3H7GXx7yIvRxUKq5nbDL+krcnBAyXUzAU7ozWUmLEdUieYNSKpV7Dn6rbIvAA==, tarball: file:projects/purview-administration.tgz}
     name: '@rush-temp/purview-administration'
     version: 0.0.0
     dependencies:
@@ -12090,7 +12091,7 @@ packages:
       mocha: 7.2.0
       mocha-junit-reporter: 2.0.2_mocha@7.2.0
       nyc: 15.1.0
-      prettier: 2.2.1
+      prettier: 2.5.1
       rimraf: 3.0.2
       rollup: 1.32.1
       source-map-support: 0.5.21
@@ -12104,7 +12105,7 @@ packages:
     dev: false
 
   file:projects/purview-catalog.tgz:
-    resolution: {integrity: sha512-sxVdEDLLpRxKJnnMhOJJpdr6IZYqGE7uoZcR7Tt6t7N/WtHyJVOr/PytwQiQeFCETzuqT8Xik8TW9Eo9A7MB1A==, tarball: file:projects/purview-catalog.tgz}
+    resolution: {integrity: sha512-kBvU8BT/PeSzUR/VIojuRzD1rOd9HfR4EJUf1seJy6FElzCpDlLDk3R61nAoHQn88tg7DB6akNCQp8QIOm+89g==, tarball: file:projects/purview-catalog.tgz}
     name: '@rush-temp/purview-catalog'
     version: 0.0.0
     dependencies:
@@ -12135,7 +12136,7 @@ packages:
       mocha: 7.2.0
       mocha-junit-reporter: 2.0.2_mocha@7.2.0
       nyc: 15.1.0
-      prettier: 2.2.1
+      prettier: 2.5.1
       rimraf: 3.0.2
       rollup: 1.32.1
       source-map-support: 0.5.21
@@ -12149,7 +12150,7 @@ packages:
     dev: false
 
   file:projects/purview-scanning.tgz:
-    resolution: {integrity: sha512-ocNGzp8fn3K2gS3Kyg5RCtE4YAtGXZ6qyz61mUXXBs0ktcmKKr2mxIqise4/7aQtawsGXBCTLIhA8/kh3/WHpA==, tarball: file:projects/purview-scanning.tgz}
+    resolution: {integrity: sha512-P9yipFZeWLQDurFXb2cGM4raLy6GNanN8c2qdEkf+IsMYcPyctwBzhL1Nd0DQbf2ZwFndYjhWvZSDXtaEanYfw==, tarball: file:projects/purview-scanning.tgz}
     name: '@rush-temp/purview-scanning'
     version: 0.0.0
     dependencies:
@@ -12180,7 +12181,7 @@ packages:
       mocha: 7.2.0
       mocha-junit-reporter: 2.0.2_mocha@7.2.0
       nyc: 15.1.0
-      prettier: 2.2.1
+      prettier: 2.5.1
       rimraf: 3.0.2
       rollup: 1.32.1
       source-map-support: 0.5.21
@@ -12877,7 +12878,7 @@ packages:
     dev: false
 
   file:projects/synapse-access-control.tgz:
-    resolution: {integrity: sha512-vLScf0uBb5vBJpylLlF5kAdViifx3fy1bVPzeK+VtmBOtxJFObL2vfZ5Xk6WemqEW04AbMTNxKSWafVu8h7ShA==, tarball: file:projects/synapse-access-control.tgz}
+    resolution: {integrity: sha512-XAxW1/ksG3TEBG4kyP/nJnWp+9g8fTRupupZ7mR3O51ObSP4yEMUaoli6n82dO/+X2Xxo9whH1BnA50hku2w4Q==, tarball: file:projects/synapse-access-control.tgz}
     name: '@rush-temp/synapse-access-control'
     version: 0.0.0
     dependencies:
@@ -12912,7 +12913,7 @@ packages:
       mocha: 7.2.0
       mocha-junit-reporter: 2.0.2_mocha@7.2.0
       nyc: 15.1.0
-      prettier: 1.19.1
+      prettier: 2.5.1
       rimraf: 3.0.2
       rollup: 1.32.1
       sinon: 9.2.4

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -2793,7 +2793,7 @@ packages:
 
   /core-js/2.6.12:
     resolution: {integrity: sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==}
-    deprecated: core-js@<3.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Please, upgrade your dependencies to the actual version of core-js.
+    deprecated: core-js@<3.4 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Please, upgrade your dependencies to the actual version of core-js.
     requiresBuild: true
     dev: false
 
@@ -12826,7 +12826,7 @@ packages:
     dev: false
 
   file:projects/synapse-access-control-1.tgz:
-    resolution: {integrity: sha512-ZtZWbYdfH0jPNoBbh9AN3T+CojyCJ+cmlAq6sgQANDIwb0FJUN5h++hpAee8dg3veW7YVBuuCs/GKMXRWvOC5g==, tarball: file:projects/synapse-access-control-1.tgz}
+    resolution: {integrity: sha512-oyb6JdMjvR69By0q6MReN1EcWS/Eqa7N/483q2nTvObJt+SF5UY6RST48wChvLDC1J0A3bHnRvw1JbsxulfLlg==, tarball: file:projects/synapse-access-control-1.tgz}
     name: '@rush-temp/synapse-access-control-1'
     version: 0.0.0
     dependencies:
@@ -12859,7 +12859,7 @@ packages:
       mocha: 7.2.0
       mocha-junit-reporter: 2.0.2_mocha@7.2.0
       nyc: 15.1.0
-      prettier: 1.19.1
+      prettier: 2.5.1
       rimraf: 3.0.2
       rollup: 1.32.1
       sinon: 9.2.4
@@ -12933,7 +12933,7 @@ packages:
     dev: false
 
   file:projects/synapse-artifacts.tgz:
-    resolution: {integrity: sha512-rXVjHP6gQAP4mwjPA6wVqoogEt6M6UG0tE6XCApQIrOcY1DhX0mPJCz4FGSwRw/fePtE7tS/3RvIeAkF1U2rXw==, tarball: file:projects/synapse-artifacts.tgz}
+    resolution: {integrity: sha512-yeEkzQdA2yUPfj1+gRhmkzqy9vMKqj9gEaofwGPeO8X7aJBFNDBRNhLKLN4QCkFHwGY3iL+eHTLUJxCwPc9HgA==, tarball: file:projects/synapse-artifacts.tgz}
     name: '@rush-temp/synapse-artifacts'
     version: 0.0.0
     dependencies:
@@ -12966,7 +12966,7 @@ packages:
       mocha: 7.2.0
       mocha-junit-reporter: 2.0.2_mocha@7.2.0
       nyc: 15.1.0
-      prettier: 1.19.1
+      prettier: 2.5.1
       rimraf: 3.0.2
       rollup: 1.32.1
       sinon: 9.2.4
@@ -12985,7 +12985,7 @@ packages:
     dev: false
 
   file:projects/synapse-managed-private-endpoints.tgz:
-    resolution: {integrity: sha512-4jbDOLAhVBT36a908mwm0sb8bOWPuR/vZnb4dQWklgESwHkUq0OAsDBmv/YIW/meUbzllGHuPCYQDPotdiPa0g==, tarball: file:projects/synapse-managed-private-endpoints.tgz}
+    resolution: {integrity: sha512-QH7S+f26cJUZDiVMMwtgwPpggdhBcaVmUU1KKQXAR7+bI7NTX0QrpgK3TKOUbXxlc4EC8u0ihdhPIAx4PnOzXg==, tarball: file:projects/synapse-managed-private-endpoints.tgz}
     name: '@rush-temp/synapse-managed-private-endpoints'
     version: 0.0.0
     dependencies:
@@ -13016,7 +13016,7 @@ packages:
       mocha: 7.2.0
       mocha-junit-reporter: 2.0.2_mocha@7.2.0
       nyc: 15.1.0
-      prettier: 1.19.1
+      prettier: 2.5.1
       rimraf: 3.0.2
       rollup: 1.32.1
       tslib: 2.3.1
@@ -13050,7 +13050,7 @@ packages:
     dev: false
 
   file:projects/synapse-spark.tgz:
-    resolution: {integrity: sha512-gMS4beeBfXs/gqkEhB6fl9sdivrz2W6UYO/0acqlJHFIXxgPep+KnHXJBP/Stjau61KD9tCDSvASv1YmkB31EA==, tarball: file:projects/synapse-spark.tgz}
+    resolution: {integrity: sha512-Jm0VBD49BuJPQJemURZTSBzQXtXUJqFFJ/JxQGkb+sEzGRyuUV1Xjs/m3wS3PFWZuYZyTX5y9jd/CnM6FF9Hhw==, tarball: file:projects/synapse-spark.tgz}
     name: '@rush-temp/synapse-spark'
     version: 0.0.0
     dependencies:
@@ -13081,7 +13081,7 @@ packages:
       mocha: 7.2.0
       mocha-junit-reporter: 2.0.2_mocha@7.2.0
       nyc: 15.1.0
-      prettier: 1.19.1
+      prettier: 2.5.1
       rimraf: 3.0.2
       rollup: 1.32.1
       tslib: 2.3.1

--- a/sdk/purview/purview-account-rest/package.json
+++ b/sdk/purview/purview-account-rest/package.json
@@ -119,7 +119,7 @@
     "mocha-junit-reporter": "^2.0.0",
     "mocha": "^7.1.1",
     "nyc": "^15.0.0",
-    "prettier": "2.2.1",
+    "prettier": "2.5.1",
     "rimraf": "^3.0.0",
     "rollup": "^1.16.3",
     "source-map-support": "^0.5.9",

--- a/sdk/purview/purview-account-rest/src/parameters.ts
+++ b/sdk/purview/purview-account-rest/src/parameters.ts
@@ -31,8 +31,8 @@ export interface CollectionsCreateOrUpdateCollectionBodyParam {
   body: Collection;
 }
 
-export type CollectionsCreateOrUpdateCollectionParameters = CollectionsCreateOrUpdateCollectionBodyParam &
-  RequestParameters;
+export type CollectionsCreateOrUpdateCollectionParameters =
+  CollectionsCreateOrUpdateCollectionBodyParam & RequestParameters;
 export type CollectionsDeleteCollectionParameters = RequestParameters;
 
 export interface CollectionsListCollectionsQueryParamProperties {
@@ -54,8 +54,8 @@ export interface CollectionsListChildCollectionNamesQueryParam {
   queryParameters?: CollectionsListChildCollectionNamesQueryParamProperties;
 }
 
-export type CollectionsListChildCollectionNamesParameters = CollectionsListChildCollectionNamesQueryParam &
-  RequestParameters;
+export type CollectionsListChildCollectionNamesParameters =
+  CollectionsListChildCollectionNamesQueryParam & RequestParameters;
 export type CollectionsGetCollectionPathParameters = RequestParameters;
 export type ResourceSetRulesGetResourceSetRuleParameters = RequestParameters;
 
@@ -63,8 +63,8 @@ export interface ResourceSetRulesCreateOrUpdateResourceSetRuleBodyParam {
   body: ResourceSetRuleConfig;
 }
 
-export type ResourceSetRulesCreateOrUpdateResourceSetRuleParameters = ResourceSetRulesCreateOrUpdateResourceSetRuleBodyParam &
-  RequestParameters;
+export type ResourceSetRulesCreateOrUpdateResourceSetRuleParameters =
+  ResourceSetRulesCreateOrUpdateResourceSetRuleBodyParam & RequestParameters;
 export type ResourceSetRulesDeleteResourceSetRuleParameters = RequestParameters;
 
 export interface ResourceSetRulesListResourceSetRulesQueryParamProperties {
@@ -75,5 +75,5 @@ export interface ResourceSetRulesListResourceSetRulesQueryParam {
   queryParameters?: ResourceSetRulesListResourceSetRulesQueryParamProperties;
 }
 
-export type ResourceSetRulesListResourceSetRulesParameters = ResourceSetRulesListResourceSetRulesQueryParam &
-  RequestParameters;
+export type ResourceSetRulesListResourceSetRulesParameters =
+  ResourceSetRulesListResourceSetRulesQueryParam & RequestParameters;

--- a/sdk/purview/purview-administration-rest/package.json
+++ b/sdk/purview/purview-administration-rest/package.json
@@ -121,7 +121,7 @@
     "mocha-junit-reporter": "^2.0.0",
     "mocha": "^7.1.1",
     "nyc": "^15.0.0",
-    "prettier": "2.2.1",
+    "prettier": "2.5.1",
     "rimraf": "^3.0.0",
     "rollup": "^1.16.3",
     "source-map-support": "^0.5.9",

--- a/sdk/purview/purview-administration-rest/src/account/parameters.ts
+++ b/sdk/purview/purview-administration-rest/src/account/parameters.ts
@@ -31,8 +31,8 @@ export interface CollectionsCreateOrUpdateCollectionBodyParam {
   body: Collection;
 }
 
-export type CollectionsCreateOrUpdateCollectionParameters = CollectionsCreateOrUpdateCollectionBodyParam &
-  RequestParameters;
+export type CollectionsCreateOrUpdateCollectionParameters =
+  CollectionsCreateOrUpdateCollectionBodyParam & RequestParameters;
 export type CollectionsDeleteCollectionParameters = RequestParameters;
 
 export interface CollectionsListCollectionsQueryParamProperties {
@@ -54,8 +54,8 @@ export interface CollectionsListChildCollectionNamesQueryParam {
   queryParameters?: CollectionsListChildCollectionNamesQueryParamProperties;
 }
 
-export type CollectionsListChildCollectionNamesParameters = CollectionsListChildCollectionNamesQueryParam &
-  RequestParameters;
+export type CollectionsListChildCollectionNamesParameters =
+  CollectionsListChildCollectionNamesQueryParam & RequestParameters;
 export type CollectionsGetCollectionPathParameters = RequestParameters;
 export type ResourceSetRulesGetResourceSetRuleParameters = RequestParameters;
 
@@ -63,8 +63,8 @@ export interface ResourceSetRulesCreateOrUpdateResourceSetRuleBodyParam {
   body: ResourceSetRuleConfig;
 }
 
-export type ResourceSetRulesCreateOrUpdateResourceSetRuleParameters = ResourceSetRulesCreateOrUpdateResourceSetRuleBodyParam &
-  RequestParameters;
+export type ResourceSetRulesCreateOrUpdateResourceSetRuleParameters =
+  ResourceSetRulesCreateOrUpdateResourceSetRuleBodyParam & RequestParameters;
 export type ResourceSetRulesDeleteResourceSetRuleParameters = RequestParameters;
 
 export interface ResourceSetRulesListResourceSetRulesQueryParamProperties {
@@ -75,5 +75,5 @@ export interface ResourceSetRulesListResourceSetRulesQueryParam {
   queryParameters?: ResourceSetRulesListResourceSetRulesQueryParamProperties;
 }
 
-export type ResourceSetRulesListResourceSetRulesParameters = ResourceSetRulesListResourceSetRulesQueryParam &
-  RequestParameters;
+export type ResourceSetRulesListResourceSetRulesParameters =
+  ResourceSetRulesListResourceSetRulesQueryParam & RequestParameters;

--- a/sdk/purview/purview-catalog-rest/package.json
+++ b/sdk/purview/purview-catalog-rest/package.json
@@ -121,7 +121,7 @@
     "mocha-junit-reporter": "^2.0.0",
     "mocha": "^7.1.1",
     "nyc": "^15.0.0",
-    "prettier": "2.2.1",
+    "prettier": "2.5.1",
     "rimraf": "^3.0.0",
     "rollup": "^1.16.3",
     "source-map-support": "^0.5.9",

--- a/sdk/purview/purview-catalog-rest/src/parameters.ts
+++ b/sdk/purview/purview-catalog-rest/src/parameters.ts
@@ -99,9 +99,10 @@ export interface EntityPartialUpdateEntityAttributeByGuidQueryParam {
   queryParameters: EntityPartialUpdateEntityAttributeByGuidQueryParamProperties;
 }
 
-export type EntityPartialUpdateEntityAttributeByGuidParameters = EntityPartialUpdateEntityAttributeByGuidQueryParam &
-  EntityPartialUpdateEntityAttributeByGuidBodyParam &
-  RequestParameters;
+export type EntityPartialUpdateEntityAttributeByGuidParameters =
+  EntityPartialUpdateEntityAttributeByGuidQueryParam &
+    EntityPartialUpdateEntityAttributeByGuidBodyParam &
+    RequestParameters;
 export type EntityDeleteByGuidParameters = RequestParameters;
 export type EntityGetClassificationParameters = RequestParameters;
 export type EntityDeleteClassificationParameters = RequestParameters;
@@ -153,9 +154,10 @@ export interface EntityPartialUpdateEntityByUniqueAttributesQueryParam {
   queryParameters?: EntityPartialUpdateEntityByUniqueAttributesQueryParamProperties;
 }
 
-export type EntityPartialUpdateEntityByUniqueAttributesParameters = EntityPartialUpdateEntityByUniqueAttributesQueryParam &
-  EntityPartialUpdateEntityByUniqueAttributesBodyParam &
-  RequestParameters;
+export type EntityPartialUpdateEntityByUniqueAttributesParameters =
+  EntityPartialUpdateEntityByUniqueAttributesQueryParam &
+    EntityPartialUpdateEntityByUniqueAttributesBodyParam &
+    RequestParameters;
 
 export interface EntityDeleteByUniqueAttributeQueryParamProperties {
   /** The qualified name of the entity. */
@@ -178,8 +180,8 @@ export interface EntityDeleteClassificationByUniqueAttributeQueryParam {
   queryParameters?: EntityDeleteClassificationByUniqueAttributeQueryParamProperties;
 }
 
-export type EntityDeleteClassificationByUniqueAttributeParameters = EntityDeleteClassificationByUniqueAttributeQueryParam &
-  RequestParameters;
+export type EntityDeleteClassificationByUniqueAttributeParameters =
+  EntityDeleteClassificationByUniqueAttributeQueryParam & RequestParameters;
 
 export interface EntityAddClassificationsByUniqueAttributeBodyParam {
   /** An array of classification to be added. */
@@ -195,9 +197,10 @@ export interface EntityAddClassificationsByUniqueAttributeQueryParam {
   queryParameters?: EntityAddClassificationsByUniqueAttributeQueryParamProperties;
 }
 
-export type EntityAddClassificationsByUniqueAttributeParameters = EntityAddClassificationsByUniqueAttributeQueryParam &
-  EntityAddClassificationsByUniqueAttributeBodyParam &
-  RequestParameters;
+export type EntityAddClassificationsByUniqueAttributeParameters =
+  EntityAddClassificationsByUniqueAttributeQueryParam &
+    EntityAddClassificationsByUniqueAttributeBodyParam &
+    RequestParameters;
 
 export interface EntityUpdateClassificationsByUniqueAttributeBodyParam {
   /** An array of classification to be updated. */
@@ -213,9 +216,10 @@ export interface EntityUpdateClassificationsByUniqueAttributeQueryParam {
   queryParameters?: EntityUpdateClassificationsByUniqueAttributeQueryParamProperties;
 }
 
-export type EntityUpdateClassificationsByUniqueAttributeParameters = EntityUpdateClassificationsByUniqueAttributeQueryParam &
-  EntityUpdateClassificationsByUniqueAttributeBodyParam &
-  RequestParameters;
+export type EntityUpdateClassificationsByUniqueAttributeParameters =
+  EntityUpdateClassificationsByUniqueAttributeQueryParam &
+    EntityUpdateClassificationsByUniqueAttributeBodyParam &
+    RequestParameters;
 
 export interface EntitySetClassificationsBodyParam {
   /** Atlas entity headers. */
@@ -238,8 +242,8 @@ export interface EntityGetEntitiesByUniqueAttributesQueryParam {
   queryParameters?: EntityGetEntitiesByUniqueAttributesQueryParamProperties;
 }
 
-export type EntityGetEntitiesByUniqueAttributesParameters = EntityGetEntitiesByUniqueAttributesQueryParam &
-  RequestParameters;
+export type EntityGetEntitiesByUniqueAttributesParameters =
+  EntityGetEntitiesByUniqueAttributesQueryParam & RequestParameters;
 export type EntityGetHeaderParameters = RequestParameters;
 
 export interface GlossaryListGlossariesQueryParamProperties {
@@ -303,8 +307,8 @@ export interface GlossaryPartialUpdateGlossaryCategoryBodyParam {
   body: Record<string, string>;
 }
 
-export type GlossaryPartialUpdateGlossaryCategoryParameters = GlossaryPartialUpdateGlossaryCategoryBodyParam &
-  RequestParameters;
+export type GlossaryPartialUpdateGlossaryCategoryParameters =
+  GlossaryPartialUpdateGlossaryCategoryBodyParam & RequestParameters;
 
 export interface GlossaryListRelatedCategoriesQueryParamProperties {
   /** The page size - by default there is no paging. */
@@ -394,9 +398,10 @@ export interface GlossaryPartialUpdateGlossaryTermQueryParam {
   queryParameters?: GlossaryPartialUpdateGlossaryTermQueryParamProperties;
 }
 
-export type GlossaryPartialUpdateGlossaryTermParameters = GlossaryPartialUpdateGlossaryTermQueryParam &
-  GlossaryPartialUpdateGlossaryTermBodyParam &
-  RequestParameters;
+export type GlossaryPartialUpdateGlossaryTermParameters =
+  GlossaryPartialUpdateGlossaryTermQueryParam &
+    GlossaryPartialUpdateGlossaryTermBodyParam &
+    RequestParameters;
 
 export interface GlossaryCreateGlossaryTermsBodyParam {
   /** An array of glossary term definitions to be created in bulk. */
@@ -429,8 +434,8 @@ export interface GlossaryGetEntitiesAssignedWithTermQueryParam {
   queryParameters?: GlossaryGetEntitiesAssignedWithTermQueryParamProperties;
 }
 
-export type GlossaryGetEntitiesAssignedWithTermParameters = GlossaryGetEntitiesAssignedWithTermQueryParam &
-  RequestParameters;
+export type GlossaryGetEntitiesAssignedWithTermParameters =
+  GlossaryGetEntitiesAssignedWithTermQueryParam & RequestParameters;
 
 export interface GlossaryAssignTermToEntitiesBodyParam {
   /** An array of related object IDs to which the term has to be associated. */
@@ -445,16 +450,16 @@ export interface GlossaryRemoveTermAssignmentFromEntitiesBodyParam {
   body: Array<AtlasRelatedObjectId>;
 }
 
-export type GlossaryRemoveTermAssignmentFromEntitiesParameters = GlossaryRemoveTermAssignmentFromEntitiesBodyParam &
-  RequestParameters;
+export type GlossaryRemoveTermAssignmentFromEntitiesParameters =
+  GlossaryRemoveTermAssignmentFromEntitiesBodyParam & RequestParameters;
 
 export interface GlossaryDeleteTermAssignmentFromEntitiesBodyParam {
   /** An array of related object IDs from which the term has to be dissociated. */
   body: Array<AtlasRelatedObjectId>;
 }
 
-export type GlossaryDeleteTermAssignmentFromEntitiesParameters = GlossaryDeleteTermAssignmentFromEntitiesBodyParam &
-  RequestParameters;
+export type GlossaryDeleteTermAssignmentFromEntitiesParameters =
+  GlossaryDeleteTermAssignmentFromEntitiesBodyParam & RequestParameters;
 
 export interface GlossaryListRelatedTermsQueryParamProperties {
   /** The page size - by default there is no paging. */
@@ -510,8 +515,8 @@ export interface GlossaryListGlossaryCategoriesHeadersQueryParam {
   queryParameters?: GlossaryListGlossaryCategoriesHeadersQueryParamProperties;
 }
 
-export type GlossaryListGlossaryCategoriesHeadersParameters = GlossaryListGlossaryCategoriesHeadersQueryParam &
-  RequestParameters;
+export type GlossaryListGlossaryCategoriesHeadersParameters =
+  GlossaryListGlossaryCategoriesHeadersQueryParam & RequestParameters;
 
 export interface GlossaryGetDetailedGlossaryQueryParamProperties {
   /** Whether include term hierarchy */
@@ -595,9 +600,10 @@ export interface GlossaryImportGlossaryTermsViaCsvQueryParam {
   queryParameters?: GlossaryImportGlossaryTermsViaCsvQueryParamProperties;
 }
 
-export type GlossaryImportGlossaryTermsViaCsvParameters = GlossaryImportGlossaryTermsViaCsvQueryParam &
-  GlossaryImportGlossaryTermsViaCsvBodyParam &
-  RequestParameters;
+export type GlossaryImportGlossaryTermsViaCsvParameters =
+  GlossaryImportGlossaryTermsViaCsvQueryParam &
+    GlossaryImportGlossaryTermsViaCsvBodyParam &
+    RequestParameters;
 
 export interface GlossaryImportGlossaryTermsViaCsvByGlossaryNameBodyParam {
   /**
@@ -617,9 +623,10 @@ export interface GlossaryImportGlossaryTermsViaCsvByGlossaryNameQueryParam {
   queryParameters?: GlossaryImportGlossaryTermsViaCsvByGlossaryNameQueryParamProperties;
 }
 
-export type GlossaryImportGlossaryTermsViaCsvByGlossaryNameParameters = GlossaryImportGlossaryTermsViaCsvByGlossaryNameQueryParam &
-  GlossaryImportGlossaryTermsViaCsvByGlossaryNameBodyParam &
-  RequestParameters;
+export type GlossaryImportGlossaryTermsViaCsvByGlossaryNameParameters =
+  GlossaryImportGlossaryTermsViaCsvByGlossaryNameQueryParam &
+    GlossaryImportGlossaryTermsViaCsvByGlossaryNameBodyParam &
+    RequestParameters;
 export type GlossaryGetImportCsvOperationStatusParameters = RequestParameters;
 
 export interface GlossaryExportGlossaryTermsAsCsvBodyParam {
@@ -636,9 +643,10 @@ export interface GlossaryExportGlossaryTermsAsCsvQueryParam {
   queryParameters?: GlossaryExportGlossaryTermsAsCsvQueryParamProperties;
 }
 
-export type GlossaryExportGlossaryTermsAsCsvParameters = GlossaryExportGlossaryTermsAsCsvQueryParam &
-  GlossaryExportGlossaryTermsAsCsvBodyParam &
-  RequestParameters;
+export type GlossaryExportGlossaryTermsAsCsvParameters =
+  GlossaryExportGlossaryTermsAsCsvQueryParam &
+    GlossaryExportGlossaryTermsAsCsvBodyParam &
+    RequestParameters;
 
 export interface GlossaryListTermsByGlossaryNameQueryParamProperties {
   /** The page size - by default there is no paging. */
@@ -840,5 +848,5 @@ export interface CollectionMoveEntitiesToCollectionBodyParam {
   body: MoveEntitiesRequest;
 }
 
-export type CollectionMoveEntitiesToCollectionParameters = CollectionMoveEntitiesToCollectionBodyParam &
-  RequestParameters;
+export type CollectionMoveEntitiesToCollectionParameters =
+  CollectionMoveEntitiesToCollectionBodyParam & RequestParameters;

--- a/sdk/purview/purview-scanning-rest/package.json
+++ b/sdk/purview/purview-scanning-rest/package.json
@@ -121,7 +121,7 @@
     "mocha-junit-reporter": "^2.0.0",
     "mocha": "^7.1.1",
     "nyc": "^15.0.0",
-    "prettier": "2.2.1",
+    "prettier": "2.5.1",
     "rimraf": "^3.0.0",
     "rollup": "^1.16.3",
     "source-map-support": "^0.5.9",

--- a/sdk/purview/purview-scanning-rest/src/parameters.ts
+++ b/sdk/purview/purview-scanning-rest/src/parameters.ts
@@ -28,8 +28,8 @@ export interface ClassificationRulesCreateOrUpdateBodyParam {
   body?: ClassificationRule;
 }
 
-export type ClassificationRulesCreateOrUpdateParameters = ClassificationRulesCreateOrUpdateBodyParam &
-  RequestParameters;
+export type ClassificationRulesCreateOrUpdateParameters =
+  ClassificationRulesCreateOrUpdateBodyParam & RequestParameters;
 export type ClassificationRulesDeleteParameters = RequestParameters;
 export type ClassificationRulesListAllParameters = RequestParameters;
 export type ClassificationRulesListVersionsByClassificationRuleNameParameters = RequestParameters;
@@ -42,8 +42,8 @@ export interface ClassificationRulesTagClassificationVersionQueryParam {
   queryParameters: ClassificationRulesTagClassificationVersionQueryParamProperties;
 }
 
-export type ClassificationRulesTagClassificationVersionParameters = ClassificationRulesTagClassificationVersionQueryParam &
-  RequestParameters;
+export type ClassificationRulesTagClassificationVersionParameters =
+  ClassificationRulesTagClassificationVersionQueryParam & RequestParameters;
 
 export interface DataSourcesCreateOrUpdateBodyParam {
   body?: DataSource;
@@ -203,8 +203,8 @@ export interface SystemScanRulesetsListVersionsByDataSourceQueryParam {
   queryParameters?: SystemScanRulesetsListVersionsByDataSourceQueryParamProperties;
 }
 
-export type SystemScanRulesetsListVersionsByDataSourceParameters = SystemScanRulesetsListVersionsByDataSourceQueryParam &
-  RequestParameters;
+export type SystemScanRulesetsListVersionsByDataSourceParameters =
+  SystemScanRulesetsListVersionsByDataSourceQueryParam & RequestParameters;
 export type TriggersGetTriggerParameters = RequestParameters;
 
 export interface TriggersCreateTriggerBodyParam {

--- a/sdk/synapse/synapse-access-control-rest/package.json
+++ b/sdk/synapse/synapse-access-control-rest/package.json
@@ -66,7 +66,7 @@
     "mocha-junit-reporter": "^2.0.0",
     "mocha": "^7.1.1",
     "nyc": "^15.0.0",
-    "prettier": "^1.16.4",
+    "prettier": "^2.5.1",
     "rimraf": "^3.0.0",
     "rollup": "^1.16.3",
     "uglify-js": "^3.4.9",

--- a/sdk/synapse/synapse-access-control/package.json
+++ b/sdk/synapse/synapse-access-control/package.json
@@ -66,7 +66,7 @@
     "mocha-junit-reporter": "^2.0.0",
     "mocha": "^7.1.1",
     "nyc": "^15.0.0",
-    "prettier": "^1.16.4",
+    "prettier": "^2.5.1",
     "rimraf": "^3.0.0",
     "rollup": "^1.16.3",
     "uglify-js": "^3.4.9",

--- a/sdk/synapse/synapse-artifacts/package.json
+++ b/sdk/synapse/synapse-artifacts/package.json
@@ -57,7 +57,7 @@
     "mocha-junit-reporter": "^2.0.0",
     "mocha": "^7.1.1",
     "nyc": "^15.0.0",
-    "prettier": "^1.16.4",
+    "prettier": "^2.5.1",
     "rimraf": "^3.0.0",
     "rollup": "^1.16.3",
     "uglify-js": "^3.4.9",

--- a/sdk/synapse/synapse-managed-private-endpoints/package.json
+++ b/sdk/synapse/synapse-managed-private-endpoints/package.json
@@ -71,7 +71,7 @@
     "mocha-junit-reporter": "^2.0.0",
     "mocha": "^7.1.1",
     "nyc": "^15.0.0",
-    "prettier": "^1.16.4",
+    "prettier": "^2.5.1",
     "@types/chai-as-promised": "^7.1.0",
     "chai-as-promised": "^7.1.1",
     "cross-env": "^7.0.2",

--- a/sdk/synapse/synapse-spark/package.json
+++ b/sdk/synapse/synapse-spark/package.json
@@ -55,7 +55,7 @@
     "mocha-junit-reporter": "^2.0.0",
     "mocha": "^7.1.1",
     "nyc": "^15.0.0",
-    "prettier": "^1.16.4",
+    "prettier": "^2.5.1",
     "@types/chai-as-promised": "^7.1.0",
     "chai-as-promised": "^7.1.1",
     "cross-env": "^7.0.2",


### PR DESCRIPTION
Solves: https://github.com/Azure/azure-sdk-for-js/issues/9329 for packages under `sdk/purview` and for `sdk/synapse`

Updated `prettier` dev-dependency version to latest `2.5.1`.
Files were re-formatted as well. There are only format changes in this PR, no manual changes except for package.json files.

Issue https://github.com/Azure/autorest.typescript/issues/1270 keeps track of making this change on the codegen side.

Main format changes with Prettier 2.x in this PR include:
- Trailing commas by default.
- Whitespace added after every `function` keyword.