### PR TITLE
Update prettier dev-dependency to v2.5.1 in IoT

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -1408,6 +1408,7 @@ packages:
   /@opentelemetry/node/0.22.0_@opentelemetry+api@1.0.3:
     resolution: {integrity: sha512-+HhGbDruQ7cwejVOIYyxRa28uosnG8W95NiQZ6qE8PXXPsDSyGeftAPbtYpGit0H2f5hrVcMlwmWHeAo9xkSLA==}
     engines: {node: '>=8.0.0'}
+    deprecated: Package renamed to @opentelemetry/sdk-trace-node
     peerDependencies:
       '@opentelemetry/api': ^1.0.0
     dependencies:
@@ -11083,7 +11084,7 @@ packages:
     dev: false
 
   file:projects/iot-modelsrepository.tgz:
-    resolution: {integrity: sha512-Hs+C3CUfDM8OoorHAPy/TXhaf7Nopw54ESJyjRfrJAKP3gRC8rvgM4SY1LUWRIA0oSeIbLsqdRYuOknFRwsX3Q==, tarball: file:projects/iot-modelsrepository.tgz}
+    resolution: {integrity: sha512-FHhmlwhSRL5pN/Ad8/v2HvyQ2ZxCBy9l0A8k6+lnAueHzfem8D/UTvdjFomm0IBx6nXT8GpgSG5Uz4kajivB/A==, tarball: file:projects/iot-modelsrepository.tgz}
     name: '@rush-temp/iot-modelsrepository'
     version: 0.0.0
     dependencies:
@@ -11118,7 +11119,7 @@ packages:
       mocha: 7.2.0
       mocha-junit-reporter: 2.0.2_mocha@7.2.0
       nyc: 15.1.0
-      prettier: 1.19.1
+      prettier: 2.5.1
       rimraf: 3.0.2
       rollup: 1.32.1
       rollup-plugin-sourcemaps: 0.4.2_rollup@1.32.1

--- a/sdk/iot/iot-modelsrepository/karma.conf.js
+++ b/sdk/iot/iot-modelsrepository/karma.conf.js
@@ -8,10 +8,10 @@ const {
   jsonRecordingFilterFunction,
   isPlaybackMode,
   isSoftRecordMode,
-  isRecordMode
+  isRecordMode,
 } = require("@azure-tools/test-recorder");
 
-module.exports = function(config) {
+module.exports = function (config) {
   config.set({
     // base path that will be used to resolve all patterns (eg. files, exclude)
     basePath: "./",
@@ -31,13 +31,13 @@ module.exports = function(config) {
       "karma-coverage",
       "karma-junit-reporter",
       "karma-json-to-file-reporter",
-      "karma-json-preprocessor"
+      "karma-json-preprocessor",
     ],
 
     // list of files / patterns to load in the browser
     files: [
       "dist-test/index.browser.js",
-      { pattern: "dist-test/index.browser.js.map", type: "html", included: false, served: true }
+      { pattern: "dist-test/index.browser.js.map", type: "html", included: false, served: true },
     ].concat(isPlaybackMode() || isSoftRecordMode() ? ["recordings/browsers/**/*.json"] : []),
 
     // list of files / patterns to exclude
@@ -50,7 +50,7 @@ module.exports = function(config) {
       "recordings/browsers/**/*.json": ["json"],
       // IMPORTANT: COMMENT following line if you want to debug in your browsers!!
       // Preprocess source file to calculate code coverage, however this will make source file unreadable
-      "test-browser/index.js": ["coverage"]
+      "test-browser/index.js": ["coverage"],
     },
 
     envPreprocessor: [],
@@ -63,7 +63,7 @@ module.exports = function(config) {
     coverageReporter: {
       // specify a common output directory
       dir: "coverage-browser/",
-      reporters: [{ type: "json", subdir: ".", file: "coverage.json" }]
+      reporters: [{ type: "json", subdir: ".", file: "coverage.json" }],
     },
 
     junitReporter: {
@@ -73,12 +73,12 @@ module.exports = function(config) {
       useBrowserName: false, // add browser name to report and classes names
       nameFormatter: undefined, // function (browser, result) to customize the name attribute in xml testcase element
       classNameFormatter: undefined, // function (browser, result) to customize the classname attribute in xml testcase element
-      properties: {} // key value pair of properties to add to the <properties> section of the report
+      properties: {}, // key value pair of properties to add to the <properties> section of the report
     },
 
     jsonToFileReporter: {
       filter: jsonRecordingFilterFunction,
-      outputPath: "."
+      outputPath: ".",
     },
 
     // web server port
@@ -100,8 +100,8 @@ module.exports = function(config) {
     customLaunchers: {
       ChromeHeadlessNoSandbox: {
         base: "ChromeHeadless",
-        flags: ["--no-sandbox", "--disable-web-security"]
-      }
+        flags: ["--no-sandbox", "--disable-web-security"],
+      },
     },
 
     // Continuous Integration mode
@@ -116,15 +116,15 @@ module.exports = function(config) {
     browserDisconnectTimeout: 10000,
     browserDisconnectTolerance: 3,
     browserConsoleLogOptions: {
-      terminal: !isRecordMode()
+      terminal: !isRecordMode(),
     },
 
     client: {
       mocha: {
         // change Karma's debug.html to the mocha web reporter
         reporter: "html",
-        timeout: "600000"
-      }
-    }
+        timeout: "600000",
+      },
+    },
   });
 };

--- a/sdk/iot/iot-modelsrepository/package.json
+++ b/sdk/iot/iot-modelsrepository/package.json
@@ -104,7 +104,7 @@
     "mocha": "^7.1.1",
     "mocha-junit-reporter": "^2.0.0",
     "nyc": "^15.0.0",
-    "prettier": "^1.16.4",
+    "prettier": "^2.5.1",
     "rimraf": "^3.0.0",
     "rollup": "^1.16.3",
     "rollup-plugin-sourcemaps": "^0.4.2",

--- a/sdk/iot/iot-modelsrepository/src/dtmiConventions.ts
+++ b/sdk/iot/iot-modelsrepository/src/dtmiConventions.ts
@@ -10,7 +10,8 @@
  */
 export function isValidDtmi(dtmi: string): boolean {
   if (typeof dtmi !== "string") return false;
-  const re = /^dtmi:[A-Za-z](?:[A-Za-z0-9_]*[A-Za-z0-9])?(?::[A-Za-z](?:[A-Za-z0-9_]*[A-Za-z0-9])?)*;[1-9][0-9]{0,8}$/;
+  const re =
+    /^dtmi:[A-Za-z](?:[A-Za-z0-9_]*[A-Za-z0-9])?(?::[A-Za-z](?:[A-Za-z0-9_]*[A-Za-z0-9])?)*;[1-9][0-9]{0,8}$/;
   return re.test(dtmi); // true if dtmi matches regular expression, false otherwise
 }
 
@@ -46,10 +47,7 @@ export function convertDtmiToPath(dtmi: string, expanded: boolean): string {
   // that happens in the dtmiToQualifiedPath function
 
   if (isValidDtmi(dtmi)) {
-    let thePath = `${dtmi
-      .toLowerCase()
-      .replace(/:/gm, "/")
-      .replace(/;/gm, "-")}.json`;
+    let thePath = `${dtmi.toLowerCase().replace(/:/gm, "/").replace(/;/gm, "-")}.json`;
     if (expanded) {
       thePath = thePath.replace(".json", ".expanded.json");
     }

--- a/sdk/iot/iot-modelsrepository/src/fetcherFilesystem.ts
+++ b/sdk/iot/iot-modelsrepository/src/fetcherFilesystem.ts
@@ -49,7 +49,7 @@ export class FilesystemFetcher implements Fetcher {
     } catch (e) {
       const options: RestErrorOptions = {
         code: "ResourceNotFound",
-        statusCode: e?.status
+        statusCode: e?.status,
       };
       throw new RestError("Failed to fetch from Filesystem", options);
     }

--- a/sdk/iot/iot-modelsrepository/src/fetcherHTTP.ts
+++ b/sdk/iot/iot-modelsrepository/src/fetcherHTTP.ts
@@ -9,7 +9,7 @@ import {
   HttpMethods,
   PipelineRequest,
   PipelineResponse,
-  RestError
+  RestError,
 } from "@azure/core-rest-pipeline";
 import { logger } from "./logger";
 import { Fetcher } from "./fetcherAbstract";
@@ -45,7 +45,7 @@ export class HttpFetcher implements Fetcher {
       timeout: options.requestOptions?.timeout,
       abortSignal: options.abortSignal,
       tracingOptions: options.tracingOptions,
-      allowInsecureConnection: true
+      allowInsecureConnection: true,
     };
     const request: PipelineRequest = createPipelineRequest(requestOptions);
     const res: PipelineResponse = await this._client.sendRequest(request);
@@ -59,7 +59,7 @@ export class HttpFetcher implements Fetcher {
         code: "ResourceNotFound",
         statusCode: res.status,
         response: res,
-        request: request
+        request: request,
       });
     }
   }

--- a/sdk/iot/iot-modelsrepository/src/modelsRepositoryClient.ts
+++ b/sdk/iot/iot-modelsrepository/src/modelsRepositoryClient.ts
@@ -7,7 +7,7 @@ import {
   DEFAULT_USER_AGENT,
   DEPENDENCY_MODE_DISABLED,
   DEPENDENCY_MODE_ENABLED,
-  DEPENDENCY_MODE_TRY_FROM_EXPANDED
+  DEPENDENCY_MODE_TRY_FROM_EXPANDED,
 } from "./utils/constants";
 import { createClientPipeline, InternalClientPipelineOptions } from "@azure/core-client";
 import { Fetcher } from "./fetcherAbstract";
@@ -110,9 +110,9 @@ export class ModelsRepositoryClient {
       ...pipelineOptions,
       ...{
         loggingOptions: {
-          logger: logger.info
-        }
-      }
+          logger: logger.info,
+        },
+      },
     };
 
     const pipeline = createClientPipeline(internalPipelineOptions);

--- a/sdk/iot/iot-modelsrepository/src/modelsRepositoryServiceClient.ts
+++ b/sdk/iot/iot-modelsrepository/src/modelsRepositoryServiceClient.ts
@@ -27,12 +27,12 @@ export class IoTModelsRepositoryServiceClient extends ServiceClient {
   constructor(url: string, options: IoTModelsRepositoryServiceClientOptions = {}) {
     const defaults: IoTModelsRepositoryServiceClientOptions = {
       baseUri: `${url}`,
-      requestContentType: "application/json; charset=utf-8"
+      requestContentType: "application/json; charset=utf-8",
     };
 
     const optionsWithDefaults = {
       ...defaults,
-      ...options
+      ...options,
     };
 
     super(optionsWithDefaults);

--- a/sdk/iot/iot-modelsrepository/test/browser/browserTest.spec.ts
+++ b/sdk/iot/iot-modelsrepository/test/browser/browserTest.spec.ts
@@ -6,12 +6,12 @@ import { ModelsRepositoryClient } from "../../src";
 
 describe("resolver -  browser", () => {
   describe("single resolution (no pseudo-parsing)", () => {
-    it("integration works in browser", async function() {
+    it("integration works in browser", async function () {
       const dtmi: string = "dtmi:azure:DeviceManagement:DeviceInformation;1";
       const endpoint = "https://devicemodels.azure.com";
       const client = new ModelsRepositoryClient({ repositoryLocation: endpoint });
       const actualOutput: { [x: string]: any } = await client.getModels(dtmi, {
-        dependencyResolution: "tryFromExpanded"
+        dependencyResolution: "tryFromExpanded",
       });
       expect(actualOutput["dtmi:azure:DeviceManagement:DeviceInformation;1"]).to.not.equal(
         undefined

--- a/sdk/iot/iot-modelsrepository/test/node/integration/index.spec.ts
+++ b/sdk/iot/iot-modelsrepository/test/node/integration/index.spec.ts
@@ -31,7 +31,7 @@ const remoteResolutionScenarios: RemoteResolutionScenario[] = [
     name: "dependencyResolution: disabled, single DTMI, no options",
     clientOptions: {
       dependencyResolution: "disabled",
-      repositoryLocation: "https://www.devicemodels.contoso.com"
+      repositoryLocation: "https://www.devicemodels.contoso.com",
     },
     getModelsOptions: undefined,
     dtmis: [
@@ -41,20 +41,20 @@ const remoteResolutionScenarios: RemoteResolutionScenario[] = [
           "https://www.devicemodels.contoso.com/dtmi/contoso/fakedevicemanagement/deviceinformation-1.json",
         mockedResponse: {
           "@id": "dtmi:contoso:FakeDeviceManagement:DeviceInformation;1",
-          fakeDtdl: "fakeBodyAsText"
+          fakeDtdl: "fakeBodyAsText",
         },
         expectedOutputJson: {
           "@id": "dtmi:contoso:FakeDeviceManagement:DeviceInformation;1",
-          fakeDtdl: "fakeBodyAsText"
-        }
-      }
-    ]
+          fakeDtdl: "fakeBodyAsText",
+        },
+      },
+    ],
   },
   {
     name: "dependencyResolution: disabled, single DTMI, no dependencies",
     clientOptions: {
       dependencyResolution: "disabled",
-      repositoryLocation: "https://www.devicemodels.contoso.com"
+      repositoryLocation: "https://www.devicemodels.contoso.com",
     },
     getModelsOptions: {},
     dtmis: [
@@ -64,20 +64,20 @@ const remoteResolutionScenarios: RemoteResolutionScenario[] = [
           "https://www.devicemodels.contoso.com/dtmi/contoso/fakedevicemanagement/deviceinformation-1.json",
         mockedResponse: {
           "@id": "dtmi:contoso:FakeDeviceManagement:DeviceInformation;1",
-          fakeDtdl: "fakeBodyAsText"
+          fakeDtdl: "fakeBodyAsText",
         },
         expectedOutputJson: {
           "@id": "dtmi:contoso:FakeDeviceManagement:DeviceInformation;1",
-          fakeDtdl: "fakeBodyAsText"
-        }
-      }
-    ]
+          fakeDtdl: "fakeBodyAsText",
+        },
+      },
+    ],
   },
   {
     name: "dependencyResolution: enabled, single DTMI, no dependencies",
     clientOptions: {
       dependencyResolution: "enabled",
-      repositoryLocation: "https://www.devicemodels.contoso.com"
+      repositoryLocation: "https://www.devicemodels.contoso.com",
     },
     getModelsOptions: {},
     dtmis: [
@@ -87,20 +87,20 @@ const remoteResolutionScenarios: RemoteResolutionScenario[] = [
           "https://www.devicemodels.contoso.com/dtmi/contoso/fakedevicemanagement/deviceinformation-1.json",
         mockedResponse: {
           "@id": "dtmi:contoso:FakeDeviceManagement:DeviceInformation;1",
-          fakeDtdl: "fakeBodyAsText"
+          fakeDtdl: "fakeBodyAsText",
         },
         expectedOutputJson: {
           "@id": "dtmi:contoso:FakeDeviceManagement:DeviceInformation;1",
-          fakeDtdl: "fakeBodyAsText"
-        }
-      }
-    ]
+          fakeDtdl: "fakeBodyAsText",
+        },
+      },
+    ],
   },
   {
     name: "dependencyResolution: tryFromExpanded, single DTMI, no dependencies",
     clientOptions: {
       dependencyResolution: "tryFromExpanded",
-      repositoryLocation: "https://www.devicemodels.contoso.com"
+      repositoryLocation: "https://www.devicemodels.contoso.com",
     },
     getModelsOptions: {},
     dtmis: [
@@ -111,21 +111,21 @@ const remoteResolutionScenarios: RemoteResolutionScenario[] = [
         mockedResponse: [
           {
             "@id": "dtmi:contoso:FakeDeviceManagement:DeviceInformation;1",
-            fakeDtdl: "fakeBodyAsText"
-          }
+            fakeDtdl: "fakeBodyAsText",
+          },
         ],
         expectedOutputJson: {
           "@id": "dtmi:contoso:FakeDeviceManagement:DeviceInformation;1",
-          fakeDtdl: "fakeBodyAsText"
-        }
-      }
-    ]
+          fakeDtdl: "fakeBodyAsText",
+        },
+      },
+    ],
   },
   {
     name: "dependencyResolution: disabled, multiple DTMI, no dependencies",
     clientOptions: {
       dependencyResolution: "tryFromExpanded",
-      repositoryLocation: "https://www.devicemodels.contoso.com"
+      repositoryLocation: "https://www.devicemodels.contoso.com",
     },
     getModelsOptions: {},
     dtmis: [
@@ -136,32 +136,32 @@ const remoteResolutionScenarios: RemoteResolutionScenario[] = [
         mockedResponse: [
           {
             "@id": "dtmi:contoso:FakeDeviceManagement:DeviceInformation;1",
-            fakeDtdl: "fakeBodyAsText"
-          }
+            fakeDtdl: "fakeBodyAsText",
+          },
         ],
         expectedOutputJson: {
           "@id": "dtmi:contoso:FakeDeviceManagement:DeviceInformation;1",
-          fakeDtdl: "fakeBodyAsText"
-        }
+          fakeDtdl: "fakeBodyAsText",
+        },
       },
       {
         dtmi: "dtmi:com:FooFooFoo;4",
         expectedUri: "https://www.devicemodels.contoso.com/dtmi/com/foofoofoo-4.expanded.json",
         mockedResponse: [{ "@id": "dtmi:com:FooFooFoo;4", fakeDtdl: "fakeBodyAsText" }],
-        expectedOutputJson: { "@id": "dtmi:com:FooFooFoo;4", fakeDtdl: "fakeBodyAsText" }
-      }
-    ]
-  }
+        expectedOutputJson: { "@id": "dtmi:com:FooFooFoo;4", fakeDtdl: "fakeBodyAsText" },
+      },
+    ],
+  },
 ];
 
-describe("resolver - node", function() {
-  afterEach(function() {
+describe("resolver - node", function () {
+  afterEach(function () {
     sinon.restore();
   });
 
-  describe("remote URL resolution", function() {
+  describe("remote URL resolution", function () {
     remoteResolutionScenarios.forEach((scenario: RemoteResolutionScenario) => {
-      it(scenario.name, async function() {
+      it(scenario.name, async function () {
         console.log(scenario.name);
         const myStub = sinon.stub(ServiceClient.prototype, "sendRequest");
         for (let i = 0; i < scenario.dtmis.length; i++) {
@@ -173,7 +173,7 @@ describe("resolver - node", function() {
               request: request,
               bodyAsText: JSON.stringify(scenario.dtmis[i].mockedResponse),
               status: 200,
-              headers: undefined
+              headers: undefined,
             };
             return Promise.resolve(pipelineResponse);
           });

--- a/sdk/iot/iot-modelsrepository/test/node/unit/constants.spec.ts
+++ b/sdk/iot/iot-modelsrepository/test/node/unit/constants.spec.ts
@@ -4,8 +4,8 @@
 import * as cnst from "../../../src/utils/constants";
 import { readFileSync } from "fs";
 import { expect } from "chai";
-describe("constants", function() {
-  it("uses same version as package.json", function() {
+describe("constants", function () {
+  it("uses same version as package.json", function () {
     const pkgjson = readFileSync("./package.json", "utf-8");
     const pkgjsonVersion = JSON.parse(pkgjson).version;
     expect(cnst.SDK_VERSION).to.equal(pkgjsonVersion);

--- a/sdk/iot/iot-modelsrepository/test/node/unit/dtmiConventions.spec.ts
+++ b/sdk/iot/iot-modelsrepository/test/node/unit/dtmiConventions.spec.ts
@@ -17,32 +17,32 @@ const testCases: TestCase[] = [
     dtmi: "dtmi:azure:DeviceManagement:DeviceInformation;1",
     valid: true,
     expectedPath: "dtmi/azure/devicemanagement/deviceinformation-1.json",
-    expectedURL: "https://contoso.com/dtmi/azure/devicemanagement/deviceinformation-1.json"
+    expectedURL: "https://contoso.com/dtmi/azure/devicemanagement/deviceinformation-1.json",
   },
   {
     dtmi: "dtmiazure:DeviceManagement:DeviceInformation;1",
-    valid: false
+    valid: false,
   },
   {
     dtmi: "dtmi:foobar:DeviceInformation;1",
     valid: true,
     expectedPath: "dtmi/foobar/deviceinformation-1.json",
-    expectedURL: "https://contoso.com/dtmi/foobar/deviceinformation-1.json"
-  }
+    expectedURL: "https://contoso.com/dtmi/foobar/deviceinformation-1.json",
+  },
 ];
 
 const fakeBasePath = "https://contoso.com";
 
-describe("dtmiConventions", function() {
+describe("dtmiConventions", function () {
   testCases.forEach((testCase) => {
-    describe("isValidDtmi", function() {
+    describe("isValidDtmi", function () {
       if (testCase.valid) {
-        it(`valid dtmi - ${testCase.dtmi}`, function() {
+        it(`valid dtmi - ${testCase.dtmi}`, function () {
           const result = lib.isValidDtmi(testCase.dtmi);
           assert(result, `${testCase.dtmi} was incorrectly labelled invalid.`);
         });
       } else {
-        it(`invalid dtmi - ${testCase.dtmi}`, function() {
+        it(`invalid dtmi - ${testCase.dtmi}`, function () {
           const result = lib.isValidDtmi(testCase.dtmi);
           expect(result, `${testCase.dtmi} was incorrectly labelled as valid.`).to.equal(false);
         });
@@ -51,19 +51,19 @@ describe("dtmiConventions", function() {
   });
 
   testCases.forEach((testCase) => {
-    describe("convertDtmiToPath", function() {
+    describe("convertDtmiToPath", function () {
       if (testCase.valid) {
-        it(`converts dtmi to path - ${testCase.dtmi}`, function() {
+        it(`converts dtmi to path - ${testCase.dtmi}`, function () {
           const result = lib.convertDtmiToPath(testCase.dtmi, false);
           expect(result).to.deep.equal(testCase.expectedPath);
         });
-        it(`converts dtmi to expanded path - ${testCase.dtmi}`, function() {
+        it(`converts dtmi to expanded path - ${testCase.dtmi}`, function () {
           const result = lib.convertDtmiToPath(testCase.dtmi, true);
           const expected = testCase.expectedPath?.replace(".json", ".expanded.json");
           expect(result).to.deep.equal(expected);
         });
       } else {
-        it(`throw error on invalid dtmi - ${testCase.dtmi}`, function() {
+        it(`throw error on invalid dtmi - ${testCase.dtmi}`, function () {
           expect(() => {
             lib.convertDtmiToPath(testCase.dtmi, false);
           }).to.throw("DTMI provided is invalid. Ensure it follows DTMI conventions.");
@@ -73,20 +73,20 @@ describe("dtmiConventions", function() {
   });
 
   testCases.forEach((testCase) => {
-    describe("getModelUri", function() {
+    describe("getModelUri", function () {
       if (testCase.valid) {
-        it(`generates model uri - ${testCase.dtmi}`, function() {
+        it(`generates model uri - ${testCase.dtmi}`, function () {
           const result = lib.getModelUri(testCase.dtmi, fakeBasePath, false);
           expect(result).to.equal(testCase.expectedURL);
         });
 
-        it(`generates expanded model uri - ${testCase.dtmi}`, function() {
+        it(`generates expanded model uri - ${testCase.dtmi}`, function () {
           const result = lib.getModelUri(testCase.dtmi, fakeBasePath, true);
           const expected = testCase.expectedURL?.replace(".json", ".expanded.json");
           expect(result).to.equal(expected);
         });
       } else {
-        it("should fail if the dtmi is not formatted correctly", function() {
+        it("should fail if the dtmi is not formatted correctly", function () {
           expect(() => {
             lib.getModelUri(testCase.dtmi, fakeBasePath, false);
           }).to.throw("DTMI provided is invalid. Ensure it follows DTMI conventions.");


### PR DESCRIPTION
Solves: https://github.com/Azure/azure-sdk-for-js/issues/9329 for packages under `sdk/iot`.
 
Updated `prettier` dev-dependency version to latest `2.5.1`.
Files were re-formatted as well. There are only format changes in this PR, no manual changes except for package.json files.
 
Main format changes with Prettier 2.x in this PR include:
- Trailing commas by default.
- Whitespace added after every `function` keyword.