### PR TITLE
Update prettier dev-dependency to v2.5.1 in Remote Rendering, Schema Registry and Web-PubSub

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -1408,6 +1408,7 @@ packages:
   /@opentelemetry/node/0.22.0_@opentelemetry+api@1.0.3:
     resolution: {integrity: sha512-+HhGbDruQ7cwejVOIYyxRa28uosnG8W95NiQZ6qE8PXXPsDSyGeftAPbtYpGit0H2f5hrVcMlwmWHeAo9xkSLA==}
     engines: {node: '>=8.0.0'}
+    deprecated: Package renamed to @opentelemetry/sdk-trace-node
     peerDependencies:
       '@opentelemetry/api': ^1.0.0
     dependencies:
@@ -2792,7 +2793,7 @@ packages:
 
   /core-js/2.6.12:
     resolution: {integrity: sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==}
-    deprecated: core-js@<3.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Please, upgrade your dependencies to the actual version of core-js.
+    deprecated: core-js@<3.4 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Please, upgrade your dependencies to the actual version of core-js.
     requiresBuild: true
     dev: false
 
@@ -8066,7 +8067,7 @@ packages:
     dev: false
 
   file:projects/arm-batch.tgz:
-    resolution: {integrity: sha512-QDWMjs1TGNDU/wHWTMlAvGsBnDgX25veyFnRoHZCFlbWTTMY/yrt9teLhcXL8Jcrbn1fyEApNNtrcw0iFarr+A==, tarball: file:projects/arm-batch.tgz}
+    resolution: {integrity: sha512-3Icocw0QnB8/JYmiR/jIr/2A2XhYvFbte2ah1d8s7Mx4Bb23RCnZjTREPQinlGgdpuNSUL0va2ixFwyXTRCiBA==, tarball: file:projects/arm-batch.tgz}
     name: '@rush-temp/arm-batch'
     version: 0.0.0
     dependencies:
@@ -11448,7 +11449,7 @@ packages:
     dev: false
 
   file:projects/mixed-reality-remote-rendering.tgz:
-    resolution: {integrity: sha512-mRLZqZFQnTfvZjaZU7ZXBh82Kx8Nxl9REZudzyIU5MlkXPoYs0iNIndPX6BL7StQ6CGvz2kzwGfSRtxi5UoIsw==, tarball: file:projects/mixed-reality-remote-rendering.tgz}
+    resolution: {integrity: sha512-wDQhN9kT7dRXkO+aO2AVV7C94TBvPTPE9vIjHX/ncU0bkFgM//UwgSm9Lmr0wUL86eXyFCImdz6Kx5412V+thQ==, tarball: file:projects/mixed-reality-remote-rendering.tgz}
     name: '@rush-temp/mixed-reality-remote-rendering'
     version: 0.0.0
     dependencies:
@@ -11480,7 +11481,7 @@ packages:
       mocha: 7.2.0
       mocha-junit-reporter: 2.0.2_mocha@7.2.0
       nyc: 15.1.0
-      prettier: 1.19.1
+      prettier: 2.5.1
       rimraf: 3.0.2
       rollup: 1.32.1
       tslib: 2.3.1
@@ -12243,7 +12244,7 @@ packages:
     dev: false
 
   file:projects/schema-registry-avro.tgz:
-    resolution: {integrity: sha512-lCpDUBPIPTqToa1r1xA4pURdkEQ8Q7nMocwZOnLk1+g+sNbo1n3dx/t8eeMfpcY7+RQ1pB5U6ypHotrKI0kXzw==, tarball: file:projects/schema-registry-avro.tgz}
+    resolution: {integrity: sha512-X/hZLrVREZDlgnJQnf3F/s3J0Jo0enaPAP3Ydr6v2yVL6eqEXQx5ssoA6h7PJLq8rgYvn4Tt2NBeptvzswvOoQ==, tarball: file:projects/schema-registry-avro.tgz}
     name: '@rush-temp/schema-registry-avro'
     version: 0.0.0
     dependencies:
@@ -12279,7 +12280,7 @@ packages:
       mocha: 7.2.0
       mocha-junit-reporter: 2.0.2_mocha@7.2.0
       nyc: 15.1.0
-      prettier: 1.19.1
+      prettier: 2.5.1
       rimraf: 3.0.2
       rollup: 1.32.1
       rollup-plugin-shim: 1.0.0
@@ -12294,7 +12295,7 @@ packages:
     dev: false
 
   file:projects/schema-registry.tgz:
-    resolution: {integrity: sha512-O28oxHO75o3PHV/SRMXjXOiSmP/qT0RacLYZXcEXlFYW6uF5bqMiDvFgNHA5A68a24goJl6EJzCZvbLUcyBCDw==, tarball: file:projects/schema-registry.tgz}
+    resolution: {integrity: sha512-s7CW2urfzFLDuxStn5xO1RvtGWA15/HoLDWb+0fX0CYRkQGrdCvSXGDcTpPTncgjEkmvtGA2QL7ZcPMRgzccBA==, tarball: file:projects/schema-registry.tgz}
     name: '@rush-temp/schema-registry'
     version: 0.0.0
     dependencies:
@@ -12325,7 +12326,7 @@ packages:
       mocha: 7.2.0
       mocha-junit-reporter: 2.0.2_mocha@7.2.0
       nyc: 15.1.0
-      prettier: 1.19.1
+      prettier: 2.5.1
       rimraf: 3.0.2
       rollup: 1.32.1
       source-map-support: 0.5.21
@@ -13439,7 +13440,7 @@ packages:
     dev: false
 
   file:projects/web-pubsub-express.tgz:
-    resolution: {integrity: sha512-YYMkfUGEIJH2SYXzdPQAINA3DmLIrhaMzV+fIRdsXyQHspMst00YZNX0Sy8rVfoYohsCLHkHJ9Qo9ic9nKdmpw==, tarball: file:projects/web-pubsub-express.tgz}
+    resolution: {integrity: sha512-XHFDp/PaBzZs7IH85xM5yQNG39ZKE/V6O7FpErS/cBg7QEai5S4yoI5N5C7ma0bXkceE7/6pk+8wUYY1/gMCxg==, tarball: file:projects/web-pubsub-express.tgz}
     name: '@rush-temp/web-pubsub-express'
     version: 0.0.0
     dependencies:
@@ -13473,7 +13474,7 @@ packages:
       mocha: 7.2.0
       mocha-junit-reporter: 2.0.2_mocha@7.2.0
       nyc: 15.1.0
-      prettier: 1.19.1
+      prettier: 2.5.1
       puppeteer: 10.4.0
       rimraf: 3.0.2
       rollup: 1.32.1
@@ -13489,7 +13490,7 @@ packages:
     dev: false
 
   file:projects/web-pubsub.tgz:
-    resolution: {integrity: sha512-NbfQ8d9+AnqeSBFGlaHcm6U25WRVYNT/N241Gh5wZwwtYsvAD9TXykudLijPd/p9JheRC7DuM94Dv6nadeye2w==, tarball: file:projects/web-pubsub.tgz}
+    resolution: {integrity: sha512-NngkpUc6uTF3aIG2nn6OOp+IWQzS0FL4ctOy1SOtG31BaI6HvF9Zd5N9OPgKKe8ivAulscGCE7PC/zVfvj1NWg==, tarball: file:projects/web-pubsub.tgz}
     name: '@rush-temp/web-pubsub'
     version: 0.0.0
     dependencies:
@@ -13523,7 +13524,7 @@ packages:
       mocha: 7.2.0
       mocha-junit-reporter: 2.0.2_mocha@7.2.0
       nyc: 15.1.0
-      prettier: 1.19.1
+      prettier: 2.5.1
       puppeteer: 10.4.0
       rimraf: 3.0.2
       rollup: 1.32.1

--- a/sdk/remoterendering/mixed-reality-remote-rendering/karma.conf.js
+++ b/sdk/remoterendering/mixed-reality-remote-rendering/karma.conf.js
@@ -8,10 +8,10 @@ const {
   jsonRecordingFilterFunction,
   isPlaybackMode,
   isSoftRecordMode,
-  isRecordMode
+  isRecordMode,
 } = require("@azure-tools/test-recorder");
 
-module.exports = function(config) {
+module.exports = function (config) {
   config.set({
     // base path that will be used to resolve all patterns (eg. files, exclude)
     basePath: "./",
@@ -31,13 +31,13 @@ module.exports = function(config) {
       "karma-coverage",
       "karma-junit-reporter",
       "karma-json-to-file-reporter",
-      "karma-json-preprocessor"
+      "karma-json-preprocessor",
     ],
 
     // list of files / patterns to load in the browser
     files: [
       "dist-test/index.browser.js",
-      { pattern: "dist-test/index.browser.js.map", type: "html", included: false, served: true }
+      { pattern: "dist-test/index.browser.js.map", type: "html", included: false, served: true },
     ].concat(isPlaybackMode() || isSoftRecordMode() ? ["recordings/browsers/**/*.json"] : []),
 
     // list of files / patterns to exclude
@@ -50,7 +50,7 @@ module.exports = function(config) {
       "recordings/browsers/**/*.json": ["json"],
       // IMPORTANT: COMMENT following line if you want to debug in your browsers!!
       // Preprocess source file to calculate code coverage, however this will make source file unreadable
-      "test-browser/index.js": ["coverage"]
+      "test-browser/index.js": ["coverage"],
     },
 
     envPreprocessor: [
@@ -64,7 +64,7 @@ module.exports = function(config) {
       "REMOTERENDERING_ARR_SERVICE_ENDPOINT",
       "AZURE_CLIENT_ID",
       "AZURE_CLIENT_SECRET",
-      "AZURE_TENANT_ID"
+      "AZURE_TENANT_ID",
     ],
 
     // test results reporter to use
@@ -75,7 +75,7 @@ module.exports = function(config) {
     coverageReporter: {
       // specify a common output directory
       dir: "coverage-browser/",
-      reporters: [{ type: "json", subdir: ".", file: "coverage.json" }]
+      reporters: [{ type: "json", subdir: ".", file: "coverage.json" }],
     },
 
     junitReporter: {
@@ -85,12 +85,12 @@ module.exports = function(config) {
       useBrowserName: false, // add browser name to report and classes names
       nameFormatter: undefined, // function (browser, result) to customize the name attribute in xml testcase element
       classNameFormatter: undefined, // function (browser, result) to customize the classname attribute in xml testcase element
-      properties: {} // key value pair of properties to add to the <properties> section of the report
+      properties: {}, // key value pair of properties to add to the <properties> section of the report
     },
 
     jsonToFileReporter: {
       filter: jsonRecordingFilterFunction,
-      outputPath: "."
+      outputPath: ".",
     },
 
     // web server port
@@ -112,8 +112,8 @@ module.exports = function(config) {
     customLaunchers: {
       ChromeHeadlessNoSandbox: {
         base: "ChromeHeadless",
-        flags: ["--no-sandbox", "--disable-web-security"]
-      }
+        flags: ["--no-sandbox", "--disable-web-security"],
+      },
     },
 
     // Continuous Integration mode
@@ -128,15 +128,15 @@ module.exports = function(config) {
     browserDisconnectTimeout: 10000,
     browserDisconnectTolerance: 3,
     browserConsoleLogOptions: {
-      terminal: !isRecordMode()
+      terminal: !isRecordMode(),
     },
 
     client: {
       mocha: {
         // change Karma's debug.html to the mocha web reporter
         reporter: "html",
-        timeout: "600000"
-      }
-    }
+        timeout: "600000",
+      },
+    },
   });
 };

--- a/sdk/remoterendering/mixed-reality-remote-rendering/package.json
+++ b/sdk/remoterendering/mixed-reality-remote-rendering/package.json
@@ -115,7 +115,7 @@
     "mocha": "^7.1.1",
     "mocha-junit-reporter": "^2.0.0",
     "nyc": "^15.0.0",
-    "prettier": "^1.16.4",
+    "prettier": "^2.5.1",
     "rimraf": "^3.0.0",
     "rollup": "^1.16.3",
     "typescript": "~4.2.0",

--- a/sdk/remoterendering/mixed-reality-remote-rendering/samples-dev/listSessions.ts
+++ b/sdk/remoterendering/mixed-reality-remote-rendering/samples-dev/listSessions.ts
@@ -37,7 +37,7 @@ export async function main() {
   const sessionId: string = uuid();
   await client.beginSession(sessionId, {
     maxLeaseTimeInMinutes: 5,
-    size: "Standard"
+    size: "Standard",
   });
   await delay(10000);
 

--- a/sdk/remoterendering/mixed-reality-remote-rendering/samples-dev/moreComplexConversion.ts
+++ b/sdk/remoterendering/mixed-reality-remote-rendering/samples-dev/moreComplexConversion.ts
@@ -15,13 +15,13 @@ import {
   AssetConversionOutputSettings,
   AssetConversionSettings,
   AssetConversionPollerLike,
-  AssetConversion
+  AssetConversion,
 } from "@azure/mixed-reality-remote-rendering";
 import {
   DeviceCodeCredential,
   DeviceCodeInfo,
   ClientSecretCredential,
-  DefaultAzureCredential
+  DefaultAzureCredential,
 } from "@azure/identity";
 import { AzureKeyCredential } from "@azure/core-auth";
 
@@ -58,11 +58,11 @@ export function getClientWithAccountKey() {
 
 export function getClientWithAAD() {
   const credential = new ClientSecretCredential(tenantId, clientId, clientSecret, {
-    authorityHost: "https://login.microsoftonline.com/" + tenantId
+    authorityHost: "https://login.microsoftonline.com/" + tenantId,
   });
 
   return new RemoteRenderingClient(serviceEndpoint, accountId, accountDomain, credential, {
-    authenticationEndpointUrl: "https://sts.mixedreality.azure.com"
+    authenticationEndpointUrl: "https://sts.mixedreality.azure.com",
   });
 }
 
@@ -76,11 +76,11 @@ export function getClientWithDeviceCode() {
     tenantId: tenantId,
     clientId: clientId,
     userPromptCallback: userPromptCallback,
-    authorityHost: "https://login.microsoftonline.com/" + tenantId
+    authorityHost: "https://login.microsoftonline.com/" + tenantId,
   });
 
   return new RemoteRenderingClient(serviceEndpoint, accountId, accountDomain, credential, {
-    authenticationEndpointUrl: "https://sts.mixedreality.azure.com/mixedreality.signin"
+    authenticationEndpointUrl: "https://sts.mixedreality.azure.com/mixedreality.signin",
   });
 }
 
@@ -88,7 +88,7 @@ export function getClientWithDefaultAzureCredential() {
   const credential = new DefaultAzureCredential();
 
   return new RemoteRenderingClient(serviceEndpoint, accountId, accountDomain, credential, {
-    authenticationEndpointUrl: "https://sts.mixedreality.azure.com"
+    authenticationEndpointUrl: "https://sts.mixedreality.azure.com",
   });
 }
 
@@ -107,11 +107,11 @@ export async function main() {
   const inputSettings: AssetConversionInputSettings = {
     storageContainerUrl: inputStorageUrl,
     blobPrefix: "Bicycle",
-    relativeInputAssetPath: "bicycle.gltf"
+    relativeInputAssetPath: "bicycle.gltf",
   };
   const outputSettings: AssetConversionOutputSettings = {
     storageContainerUrl: outputStorageUrl,
-    blobPrefix: "ConvertedBicycle"
+    blobPrefix: "ConvertedBicycle",
   };
   const conversionSettings: AssetConversionSettings = { inputSettings, outputSettings };
 

--- a/sdk/remoterendering/mixed-reality-remote-rendering/samples-dev/session.ts
+++ b/sdk/remoterendering/mixed-reality-remote-rendering/samples-dev/session.ts
@@ -13,7 +13,7 @@ import {
   RemoteRenderingClient,
   RenderingSessionSettings,
   RenderingSessionPollerLike,
-  RenderingSession
+  RenderingSession,
 } from "@azure/mixed-reality-remote-rendering";
 import { AzureKeyCredential } from "@azure/core-auth";
 
@@ -41,7 +41,7 @@ export async function main() {
 
   const sessionSettings: RenderingSessionSettings = {
     maxLeaseTimeInMinutes: 4,
-    size: "Standard"
+    size: "Standard",
   };
 
   // A randomly generated UUID is a good choice for a conversionId.

--- a/sdk/remoterendering/mixed-reality-remote-rendering/samples-dev/simpleConversion.ts
+++ b/sdk/remoterendering/mixed-reality-remote-rendering/samples-dev/simpleConversion.ts
@@ -15,7 +15,7 @@ import {
   AssetConversionOutputSettings,
   AssetConversionSettings,
   AssetConversionPollerLike,
-  AssetConversion
+  AssetConversion,
 } from "@azure/mixed-reality-remote-rendering";
 import { AzureKeyCredential } from "@azure/core-auth";
 
@@ -49,10 +49,10 @@ export async function main() {
 
   const inputSettings: AssetConversionInputSettings = {
     storageContainerUrl,
-    relativeInputAssetPath: "box.fbx"
+    relativeInputAssetPath: "box.fbx",
   };
   const outputSettings: AssetConversionOutputSettings = {
-    storageContainerUrl
+    storageContainerUrl,
   };
   const conversionSettings: AssetConversionSettings = { inputSettings, outputSettings };
 

--- a/sdk/remoterendering/mixed-reality-remote-rendering/src/authentication/mixedRealityAccountKeyCredential.ts
+++ b/sdk/remoterendering/mixed-reality-remote-rendering/src/authentication/mixedRealityAccountKeyCredential.ts
@@ -38,7 +38,7 @@ export class MixedRealityAccountKeyCredential implements TokenCredential {
   getToken(_scopes: string | string[], _options?: GetTokenOptions): Promise<AccessToken | null> {
     const result: AccessToken = {
       expiresOnTimestamp: maxTimestampMs,
-      token: `${this.accountId}:${this.accountKey.key}`
+      token: `${this.accountId}:${this.accountKey.key}`,
     };
 
     return Promise.resolve(result);

--- a/sdk/remoterendering/mixed-reality-remote-rendering/src/authentication/mixedRealityTokenCredential.ts
+++ b/sdk/remoterendering/mixed-reality-remote-rendering/src/authentication/mixedRealityTokenCredential.ts
@@ -5,7 +5,7 @@ import { TokenCredential, GetTokenOptions, AccessToken } from "@azure/core-auth"
 
 import {
   MixedRealityStsClient,
-  MixedRealityStsClientOptions
+  MixedRealityStsClientOptions,
 } from "@azure/mixed-reality-authentication";
 
 /**

--- a/sdk/remoterendering/mixed-reality-remote-rendering/src/internal/assetConversion.ts
+++ b/sdk/remoterendering/mixed-reality-remote-rendering/src/internal/assetConversion.ts
@@ -5,11 +5,11 @@ import {
   Conversion,
   AssetConversionSettings,
   AssetConversionOutput,
-  KnownAssetConversionStatus
+  KnownAssetConversionStatus,
 } from "../generated/models/index";
 import {
   RemoteRenderingServiceError,
-  createRemoteRenderingServiceError
+  createRemoteRenderingServiceError,
 } from "../remoteRenderingServiceError";
 
 /** Properties available for an AssetConversion in any state. */
@@ -74,35 +74,35 @@ export function assetConversionFromConversion(conversion: Conversion): AssetConv
   const baseProperties: AssetConversionBase = {
     conversionId: conversion.conversionId,
     settings: conversion.settings,
-    createdOn: conversion.createdOn
+    createdOn: conversion.createdOn,
   };
   switch (conversion.status) {
     case KnownAssetConversionStatus.NotStarted:
       return {
         status: "NotStarted",
-        ...baseProperties
+        ...baseProperties,
       };
     case KnownAssetConversionStatus.Running:
       return {
         status: "Running",
-        ...baseProperties
+        ...baseProperties,
       };
     case KnownAssetConversionStatus.Succeeded:
       return {
         status: "Succeeded",
         ...baseProperties,
-        output: conversion.output!
+        output: conversion.output!,
       };
     case KnownAssetConversionStatus.Cancelled:
       return {
         status: "Cancelled",
-        ...baseProperties
+        ...baseProperties,
       };
     case KnownAssetConversionStatus.Failed:
       return {
         status: "Failed",
         ...baseProperties,
-        error: createRemoteRenderingServiceError(conversion.error!)
+        error: createRemoteRenderingServiceError(conversion.error!),
       };
     default:
       throw new Error("Unrecognized AssetConversionStatus returned by the service");

--- a/sdk/remoterendering/mixed-reality-remote-rendering/src/internal/commonQueries.ts
+++ b/sdk/remoterendering/mixed-reality-remote-rendering/src/internal/commonQueries.ts
@@ -22,7 +22,7 @@ export async function getConversionInternal(
 ): Promise<AssetConversion> {
   const { span, updatedOptions } = createSpan(tracingSpanName, {
     conversionId: conversionId,
-    ...options
+    ...options,
   });
 
   try {
@@ -31,7 +31,7 @@ export async function getConversionInternal(
   } catch (e) {
     span.setStatus({
       code: SpanStatusCode.ERROR,
-      message: e.message
+      message: e.message,
     });
     throw e;
   } finally {
@@ -53,7 +53,7 @@ export async function getSessionInternal(
 ): Promise<RenderingSession> {
   const { span, updatedOptions } = createSpan(tracingSpanName, {
     sessionId,
-    ...options
+    ...options,
   });
 
   try {
@@ -62,7 +62,7 @@ export async function getSessionInternal(
   } catch (e) {
     span.setStatus({
       code: SpanStatusCode.ERROR,
-      message: e.message
+      message: e.message,
     });
     throw e;
   } finally {
@@ -84,7 +84,7 @@ export async function endSessionInternal(
 ): Promise<void> {
   const { span, updatedOptions } = createSpan(tracingSpanName, {
     conversionId: sessionId,
-    ...options
+    ...options,
   });
 
   try {
@@ -92,7 +92,7 @@ export async function endSessionInternal(
   } catch (e) {
     span.setStatus({
       code: SpanStatusCode.ERROR,
-      message: e.message
+      message: e.message,
     });
     throw e;
   } finally {

--- a/sdk/remoterendering/mixed-reality-remote-rendering/src/internal/renderingSession.ts
+++ b/sdk/remoterendering/mixed-reality-remote-rendering/src/internal/renderingSession.ts
@@ -4,11 +4,11 @@
 import {
   RenderingServerSize,
   SessionProperties,
-  KnownRenderingSessionStatus
+  KnownRenderingSessionStatus,
 } from "../generated/index";
 import {
   RemoteRenderingServiceError,
-  createRemoteRenderingServiceError
+  createRemoteRenderingServiceError,
 } from "../remoteRenderingServiceError";
 
 /** Properties available for a rendering session in any state */
@@ -153,7 +153,7 @@ function renderingSessionPropertiesFromSessionProperties(
     elapsedTimeInMinutes: session.elapsedTimeInMinutes!,
     host: session.host!,
     teraflops: session.teraflops!,
-    createdOn: session.createdOn!
+    createdOn: session.createdOn!,
   };
 }
 
@@ -169,7 +169,7 @@ function partialRenderingSessionPropertiesFromSessionProperties(
     elapsedTimeInMinutes: session.elapsedTimeInMinutes,
     host: session.host,
     teraflops: session.teraflops,
-    createdOn: session.createdOn
+    createdOn: session.createdOn,
   };
 }
 
@@ -183,39 +183,39 @@ export function renderingSessionFromSessionProperties(
   const baseProperties: RenderingSessionBase = {
     sessionId: session.sessionId,
     size: session.size,
-    maxLeaseTimeInMinutes: session.maxLeaseTimeInMinutes!
+    maxLeaseTimeInMinutes: session.maxLeaseTimeInMinutes!,
   };
   switch (session.status) {
     case KnownRenderingSessionStatus.Ready:
       return {
         status: "Ready",
         ...baseProperties,
-        properties: renderingSessionPropertiesFromSessionProperties(session)
+        properties: renderingSessionPropertiesFromSessionProperties(session),
       };
     case KnownRenderingSessionStatus.Starting:
       return {
         status: "Starting",
         ...baseProperties,
-        partialProperties: partialRenderingSessionPropertiesFromSessionProperties(session)
+        partialProperties: partialRenderingSessionPropertiesFromSessionProperties(session),
       };
     case KnownRenderingSessionStatus.Error:
       return {
         status: "Error",
         ...baseProperties,
         error: createRemoteRenderingServiceError(session.error!),
-        partialProperties: partialRenderingSessionPropertiesFromSessionProperties(session)
+        partialProperties: partialRenderingSessionPropertiesFromSessionProperties(session),
       };
     case KnownRenderingSessionStatus.Expired:
       return {
         status: "Expired",
         ...baseProperties,
-        properties: renderingSessionPropertiesFromSessionProperties(session)
+        properties: renderingSessionPropertiesFromSessionProperties(session),
       };
     case KnownRenderingSessionStatus.Stopped:
       return {
         status: "Stopped",
         ...baseProperties,
-        partialProperties: partialRenderingSessionPropertiesFromSessionProperties(session)
+        partialProperties: partialRenderingSessionPropertiesFromSessionProperties(session),
       };
     default:
       throw new Error("Unrecognized RenderingSessionStatus returned by the service");

--- a/sdk/remoterendering/mixed-reality-remote-rendering/src/lro/assetConversionPoller.ts
+++ b/sdk/remoterendering/mixed-reality-remote-rendering/src/lro/assetConversionPoller.ts
@@ -70,7 +70,8 @@ export class AssetConversionOperationStateImpl implements AssetConversionOperati
  * @internal
  */
 class AssetConversionOperation
-  implements PollOperation<AssetConversionOperationState, AssetConversion> {
+  implements PollOperation<AssetConversionOperationState, AssetConversion>
+{
   private accountId: string;
   private operations: RemoteRendering;
   state: AssetConversionOperationState;

--- a/sdk/remoterendering/mixed-reality-remote-rendering/src/lro/renderingSessionPoller.ts
+++ b/sdk/remoterendering/mixed-reality-remote-rendering/src/lro/renderingSessionPoller.ts
@@ -65,7 +65,8 @@ export class RenderingSessionOperationStateImpl implements RenderingSessionOpera
  * @internal
  */
 class RenderingSessionOperation
-  implements PollOperation<RenderingSessionOperationState, RenderingSession> {
+  implements PollOperation<RenderingSessionOperationState, RenderingSession>
+{
   private accountId: string;
   private operations: RemoteRendering;
   state: RenderingSessionOperationState;

--- a/sdk/remoterendering/mixed-reality-remote-rendering/src/remoteRenderingClient.ts
+++ b/sdk/remoterendering/mixed-reality-remote-rendering/src/remoteRenderingClient.ts
@@ -9,7 +9,7 @@ import {
   AccessToken,
   AzureKeyCredential,
   isTokenCredential,
-  TokenCredential
+  TokenCredential,
 } from "@azure/core-auth";
 
 import { RemoteRenderingRestClient } from "./generated";
@@ -19,7 +19,7 @@ import {
   RemoteRenderingCreateConversionResponse,
   RenderingSessionSettings,
   RemoteRenderingCreateSessionResponse,
-  UpdateSessionSettings
+  UpdateSessionSettings,
 } from "./generated/models/index";
 
 import { RemoteRenderingClientOptions } from "./options";
@@ -40,18 +40,18 @@ import { RemoteRenderingImpl } from "./generated/operations";
 import {
   AssetConversionPoller,
   AssetConversionOperationState,
-  AssetConversionPollerOptions
+  AssetConversionPollerOptions,
 } from "./lro/assetConversionPoller";
 import {
   RenderingSessionPoller,
   RenderingSessionOperationState,
-  RenderingSessionPollerOptions
+  RenderingSessionPollerOptions,
 } from "./lro/renderingSessionPoller";
 
 import {
   endSessionInternal,
   getConversionInternal,
-  getSessionInternal
+  getSessionInternal,
 } from "./internal/commonQueries";
 
 import {
@@ -62,7 +62,7 @@ import {
   SucceededAssetConversion,
   FailedAssetConversion,
   CancelledAssetConversion,
-  assetConversionFromConversion
+  assetConversionFromConversion,
 } from "./internal/assetConversion";
 import {
   RenderingSession,
@@ -74,7 +74,7 @@ import {
   StartingRenderingSession,
   ExpiredRenderingSession,
   StoppedRenderingSession,
-  renderingSessionFromSessionProperties
+  renderingSessionFromSessionProperties,
 } from "./internal/renderingSession";
 
 export {
@@ -101,7 +101,7 @@ export {
   UpdateSessionSettings,
   RemoteRenderingClientOptions,
   AssetConversionPollerOptions,
-  RenderingSessionPollerOptions
+  RenderingSessionPollerOptions,
 };
 
 import {
@@ -112,7 +112,7 @@ import {
   KnownAssetConversionStatus,
   KnownRenderingSessionStatus,
   RenderingServerSize,
-  KnownRenderingServerSize
+  KnownRenderingServerSize,
 } from "./generated/models/index";
 
 import { RemoteRenderingServiceError } from "./remoteRenderingServiceError";
@@ -126,7 +126,7 @@ export {
   KnownAssetConversionStatus,
   KnownRenderingSessionStatus,
   RenderingServerSize,
-  KnownRenderingServerSize
+  KnownRenderingServerSize,
 };
 
 /** The poller returned by the beginConversion operation. */
@@ -297,15 +297,15 @@ export class RemoteRenderingClient {
         logger: logger.info,
         // This array contains header names we want to log that are not already
         // included as safe. Unknown/unsafe headers are logged as "<REDACTED>".
-        additionalAllowedHeaderNames: ["X-MRC-CV", "MS-CV"]
-      }
+        additionalAllowedHeaderNames: ["X-MRC-CV", "MS-CV"],
+      },
     };
 
     const clientOptions: RemoteRenderingRestClientOptionalParams = {
       ...internalPipelineOptions,
       endpoint: endpoint,
       credential: tokenCredential,
-      credentialScopes: `${endpoint}/.default`
+      credentialScopes: `${endpoint}/.default`,
     };
 
     this.client = new RemoteRenderingRestClient(endpoint, clientOptions);
@@ -365,16 +365,17 @@ export class RemoteRenderingClient {
 
     const { span, updatedOptions } = createSpan("RemoteRenderingClient-BeginConversion", {
       conversionId: conversionId,
-      ...options
+      ...options,
     });
 
     try {
-      const conversion: RemoteRenderingCreateConversionResponse = await this.operations.createConversion(
-        this.accountId,
-        conversionId,
-        { settings: settings },
-        updatedOptions
-      );
+      const conversion: RemoteRenderingCreateConversionResponse =
+        await this.operations.createConversion(
+          this.accountId,
+          conversionId,
+          { settings: settings },
+          updatedOptions
+        );
 
       const poller = new AssetConversionPoller(
         this.accountId,
@@ -391,7 +392,7 @@ export class RemoteRenderingClient {
       // https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/api.md#status
       span.setStatus({
         code: SpanStatusCode.ERROR,
-        message: e.message
+        message: e.message,
       });
 
       throw e;
@@ -453,7 +454,7 @@ export class RemoteRenderingClient {
     options?: ListConversionsOptions
   ): PagedAsyncIterableIterator<AssetConversion> {
     const { span, updatedOptions } = createSpan("RemoteRenderingClient-ListConversion", {
-      ...options
+      ...options,
     });
     try {
       const iter = this.getAllConversionsPagingAll(updatedOptions);
@@ -466,12 +467,12 @@ export class RemoteRenderingClient {
         },
         byPage: () => {
           return this.getAllConversionsPagingPage(updatedOptions);
-        }
+        },
       };
     } catch (e) {
       span.setStatus({
         code: SpanStatusCode.ERROR,
-        message: e.message
+        message: e.message,
       });
       throw e;
     } finally {
@@ -531,16 +532,12 @@ export class RemoteRenderingClient {
 
     const { span, updatedOptions } = createSpan("RemoteRenderingClient-BeginSession", {
       conversionId: sessionId,
-      ...operationOptions
+      ...operationOptions,
     });
 
     try {
-      const sessionProperties: RemoteRenderingCreateSessionResponse = await this.operations.createSession(
-        this.accountId,
-        sessionId,
-        settings,
-        updatedOptions
-      );
+      const sessionProperties: RemoteRenderingCreateSessionResponse =
+        await this.operations.createSession(this.accountId, sessionId, settings, updatedOptions);
 
       const poller = new RenderingSessionPoller(
         this.accountId,
@@ -556,7 +553,7 @@ export class RemoteRenderingClient {
     } catch (e) {
       span.setStatus({
         code: SpanStatusCode.ERROR,
-        message: e.message
+        message: e.message,
       });
       throw e;
     } finally {
@@ -599,7 +596,7 @@ export class RemoteRenderingClient {
   ): Promise<RenderingSession> {
     const { span, updatedOptions } = createSpan("RemoteRenderingClient-UpdateSession", {
       conversionId: sessionId,
-      ...options
+      ...options,
     });
 
     try {
@@ -613,7 +610,7 @@ export class RemoteRenderingClient {
     } catch (e) {
       span.setStatus({
         code: SpanStatusCode.ERROR,
-        message: e.message
+        message: e.message,
       });
       throw e;
     } finally {
@@ -667,7 +664,7 @@ export class RemoteRenderingClient {
    */
   public listSessions(options?: ListSessionsOptions): PagedAsyncIterableIterator<RenderingSession> {
     const { span, updatedOptions } = createSpan("RemoteRenderingClient-ListConversion", {
-      ...options
+      ...options,
     });
     try {
       const iter = this.getAllSessionsPagingAll(updatedOptions);
@@ -680,12 +677,12 @@ export class RemoteRenderingClient {
         },
         byPage: () => {
           return this.getAllSessionsPagingPage(updatedOptions);
-        }
+        },
       };
     } catch (e) {
       span.setStatus({
         code: SpanStatusCode.ERROR,
-        message: e.message
+        message: e.message,
       });
       throw e;
     } finally {

--- a/sdk/remoterendering/mixed-reality-remote-rendering/src/tracing.ts
+++ b/sdk/remoterendering/mixed-reality-remote-rendering/src/tracing.ts
@@ -9,5 +9,5 @@ import { createSpanFunction } from "@azure/core-tracing";
  */
 export const createSpan = createSpanFunction({
   packagePrefix: "Azure.mixed-reality-remote-rendering",
-  namespace: "Microsoft.MixedReality"
+  namespace: "Microsoft.MixedReality",
 });

--- a/sdk/remoterendering/mixed-reality-remote-rendering/test/public/remoteRenderingClient.spec.ts
+++ b/sdk/remoterendering/mixed-reality-remote-rendering/test/public/remoteRenderingClient.spec.ts
@@ -16,13 +16,13 @@ import {
   KnownAssetConversionStatus,
   RenderingSessionPollerLike,
   RenderingSessionSettings,
-  RenderingSession
+  RenderingSession,
 } from "../../src";
 import {
   AccessToken,
   AzureKeyCredential,
   TokenCredential,
-  GetTokenOptions
+  GetTokenOptions,
 } from "@azure/core-auth";
 import { createClient, createRecorder, getEnv } from "../utils/recordedClient";
 
@@ -61,7 +61,7 @@ describe("RemoteRenderingClient construction", () => {
     const tokenCredential: TokenCredential = {
       getToken: (_scopes: string | string[], _options?: GetTokenOptions) => {
         return Promise.resolve(null);
-      }
+      },
     };
     const client = new RemoteRenderingClient(
       serviceEndpoint,
@@ -110,12 +110,12 @@ describe("RemoteRendering functional tests", () => {
   let client: RemoteRenderingClient;
   let recorder: Recorder;
 
-  beforeEach(function(this: Context) {
+  beforeEach(function (this: Context) {
     recorder = createRecorder(this);
     client = createClient();
   });
 
-  afterEach(async function() {
+  afterEach(async function () {
     // Stop the recording.
     await recorder.stop();
   });
@@ -131,12 +131,12 @@ describe("RemoteRendering functional tests", () => {
       storageContainerUrl,
       storageContainerReadListSas: getEnv("REMOTERENDERING_ARR_SAS_TOKEN"),
       relativeInputAssetPath: "testBox.fbx",
-      blobPrefix: "Input"
+      blobPrefix: "Input",
     };
     const outputSettings: AssetConversionOutputSettings = {
       storageContainerUrl,
       storageContainerWriteSas: getEnv("REMOTERENDERING_ARR_SAS_TOKEN"),
-      blobPrefix: "Output"
+      blobPrefix: "Output",
     };
     const conversionSettings: AssetConversionSettings = { inputSettings, outputSettings };
 
@@ -189,11 +189,11 @@ describe("RemoteRendering functional tests", () => {
     const inputSettings: AssetConversionInputSettings = {
       storageContainerUrl,
       relativeInputAssetPath: "testBox.fbx",
-      blobPrefix: "Input"
+      blobPrefix: "Input",
     };
     const outputSettings: AssetConversionOutputSettings = {
       storageContainerUrl,
-      blobPrefix: "Output"
+      blobPrefix: "Output",
     };
     const conversionSettings: AssetConversionSettings = { inputSettings, outputSettings };
 
@@ -224,12 +224,12 @@ describe("RemoteRendering functional tests", () => {
       storageContainerUrl,
       storageContainerReadListSas: getEnv("REMOTERENDERING_ARR_SAS_TOKEN"),
       relativeInputAssetPath: "boxWhichDoesNotExist.fbx",
-      blobPrefix: "Input"
+      blobPrefix: "Input",
     };
     const outputSettings: AssetConversionOutputSettings = {
       storageContainerUrl,
       storageContainerWriteSas: getEnv("REMOTERENDERING_ARR_SAS_TOKEN"),
-      blobPrefix: "Output"
+      blobPrefix: "Output",
     };
     const conversionSettings: AssetConversionSettings = { inputSettings, outputSettings };
 
@@ -259,7 +259,7 @@ describe("RemoteRendering functional tests", () => {
   it("can start a session", async () => {
     const sessionSettings: RenderingSessionSettings = {
       maxLeaseTimeInMinutes: 4,
-      size: "Standard"
+      size: "Standard",
     };
     const sessionId: string = recorder.getUniqueName("sessionId");
 
@@ -284,7 +284,7 @@ describe("RemoteRendering functional tests", () => {
     assert.equal(newPoller.getOperationState().latestResponse.sessionId, sessionId);
 
     const updatedSession: RenderingSession = await client.updateSession(sessionId, {
-      maxLeaseTimeInMinutes: 5
+      maxLeaseTimeInMinutes: 5,
     });
     assert.equal(updatedSession.maxLeaseTimeInMinutes, 5);
 
@@ -313,7 +313,7 @@ describe("RemoteRendering functional tests", () => {
   it("throws the correct exception on invalid session properties", async () => {
     const sessionSettings: RenderingSessionSettings = {
       maxLeaseTimeInMinutes: -4,
-      size: "Standard"
+      size: "Standard",
     };
     const sessionId: string = recorder.getUniqueName("sessionId");
 

--- a/sdk/remoterendering/mixed-reality-remote-rendering/test/utils/recordedClient.ts
+++ b/sdk/remoterendering/mixed-reality-remote-rendering/test/utils/recordedClient.ts
@@ -9,7 +9,7 @@ import {
   record,
   Recorder,
   RecorderEnvironmentSetup,
-  isPlaybackMode
+  isPlaybackMode,
 } from "@azure-tools/test-recorder";
 
 import { RemoteRenderingClient } from "../../src";
@@ -25,7 +25,7 @@ const replaceableVariables: Record<string, string> = {
   REMOTERENDERING_ARR_BLOB_CONTAINER_NAME: "test",
   REMOTERENDERING_ARR_SAS_TOKEN: "arr_sas_token",
   REMOTERENDERING_ARR_SERVICE_ENDPOINT: "https://remoterendering.eastus2.mixedreality.azure.com",
-  REMOTERENDERING_ARR_STORAGE_ACCOUNT_NAME: "sdktest"
+  REMOTERENDERING_ARR_STORAGE_ACCOUNT_NAME: "sdktest",
 };
 
 export const environmentSetup: RecorderEnvironmentSetup = {
@@ -34,8 +34,8 @@ export const environmentSetup: RecorderEnvironmentSetup = {
   customizationsOnRecordings: [
     // Replace the recorded AccessToken value with a fake one.
     (recording: string): string =>
-      recording.replace(/"AccessToken":"[^"]*"/g, `"AccessToken":"<access_token>"`)
-  ]
+      recording.replace(/"AccessToken":"[^"]*"/g, `"AccessToken":"<access_token>"`),
+  ],
 };
 
 export function getEnv(name: string): string {

--- a/sdk/schemaregistry/schema-registry-avro/karma.conf.js
+++ b/sdk/schemaregistry/schema-registry-avro/karma.conf.js
@@ -8,10 +8,10 @@ const {
   jsonRecordingFilterFunction,
   isPlaybackMode,
   isSoftRecordMode,
-  isRecordMode
+  isRecordMode,
 } = require("@azure-tools/test-recorder");
 
-module.exports = function(config) {
+module.exports = function (config) {
   config.set({
     // base path that will be used to resolve all patterns (eg. files, exclude)
     basePath: "./",
@@ -33,13 +33,13 @@ module.exports = function(config) {
       "karma-junit-reporter",
       "karma-json-to-file-reporter",
       "karma-source-map-support",
-      "karma-json-preprocessor"
+      "karma-json-preprocessor",
     ],
 
     // list of files / patterns to load in the browser
     files: [
       "dist-test/index.browser.js",
-      { pattern: "dist-test/index.browser.js.map", type: "html", included: false, served: true }
+      { pattern: "dist-test/index.browser.js.map", type: "html", included: false, served: true },
     ].concat(isPlaybackMode() || isSoftRecordMode() ? ["recordings/browsers/**/*.json"] : []),
 
     // list of files / patterns to exclude
@@ -49,7 +49,7 @@ module.exports = function(config) {
     // available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
     preprocessors: {
       "**/*.js": ["sourcemap", "env"],
-      "recordings/browsers/**/*.json": ["json"]
+      "recordings/browsers/**/*.json": ["json"],
       // IMPORTANT: COMMENT following line if you want to debug in your browsers!!
       // Preprocess source file to calculate code coverage, however this will make source file unreadable
       // "dist-test/index.js": ["coverage"]
@@ -60,7 +60,7 @@ module.exports = function(config) {
       "SCHEMA_REGISTRY_ENDPOINT",
       "AZURE_CLIENT_ID",
       "AZURE_CLIENT_SECRET",
-      "AZURE_TENANT_ID"
+      "AZURE_TENANT_ID",
     ],
 
     // test results reporter to use
@@ -75,8 +75,8 @@ module.exports = function(config) {
         { type: "json", subdir: ".", file: "coverage.json" },
         { type: "lcovonly", subdir: ".", file: "lcov.info" },
         { type: "html", subdir: "html" },
-        { type: "cobertura", subdir: ".", file: "cobertura-coverage.xml" }
-      ]
+        { type: "cobertura", subdir: ".", file: "cobertura-coverage.xml" },
+      ],
     },
 
     junitReporter: {
@@ -86,12 +86,12 @@ module.exports = function(config) {
       useBrowserName: false, // add browser name to report and classes names
       nameFormatter: undefined, // function (browser, result) to customize the name attribute in xml testcase element
       classNameFormatter: undefined, // function (browser, result) to customize the classname attribute in xml testcase element
-      properties: {} // key value pair of properties to add to the <properties> section of the report
+      properties: {}, // key value pair of properties to add to the <properties> section of the report
     },
 
     jsonToFileReporter: {
       filter: jsonRecordingFilterFunction,
-      outputPath: "."
+      outputPath: ".",
     },
 
     // web server port
@@ -113,8 +113,8 @@ module.exports = function(config) {
     customLaunchers: {
       ChromeHeadlessNoSandbox: {
         base: "ChromeHeadless",
-        flags: ["--no-sandbox", "--disable-web-security"]
-      }
+        flags: ["--no-sandbox", "--disable-web-security"],
+      },
     },
 
     // Continuous Integration mode
@@ -129,15 +129,15 @@ module.exports = function(config) {
     browserDisconnectTimeout: 10000,
     browserDisconnectTolerance: 3,
     browserConsoleLogOptions: {
-      terminal: !isRecordMode()
+      terminal: !isRecordMode(),
     },
 
     client: {
       mocha: {
         // change Karma's debug.html to the mocha web reporter
         reporter: "html",
-        timeout: "600000"
-      }
-    }
+        timeout: "600000",
+      },
+    },
   });
 };

--- a/sdk/schemaregistry/schema-registry-avro/package.json
+++ b/sdk/schemaregistry/schema-registry-avro/package.json
@@ -111,7 +111,7 @@
     "mocha": "^7.1.1",
     "mocha-junit-reporter": "^2.0.0",
     "nyc": "^15.0.0",
-    "prettier": "^1.16.4",
+    "prettier": "^2.5.1",
     "rimraf": "^3.0.0",
     "rollup": "^1.16.3",
     "rollup-plugin-shim": "^1.0.0",

--- a/sdk/schemaregistry/schema-registry-avro/rollup.patched.config.js
+++ b/sdk/schemaregistry/schema-registry-avro/rollup.patched.config.js
@@ -21,19 +21,19 @@ export function makeBrowserTestConfigPatchProcess() {
         // the util polyfill does not explicitly depend on the process polyfill so
         // we replace that util's line
         // see https://github.com/browserify/node-util/issues/43
-        "if (process.env.NODE_DEBUG)": "if (false)"
-      }
+        "if (process.env.NODE_DEBUG)": "if (false)",
+      },
     }),
     inject({
       // avsc uses NodeJS's buffers so we inject an import to the browser polyfill one
       exclude: "./**/package.json",
       modules: {
-        Buffer: ["buffer", "Buffer"]
-      }
+        Buffer: ["buffer", "Buffer"],
+      },
     }),
     // avsc uses NodeJS's internal streams so we shim them there.
     shim({
-      stream: `export default {}`
+      stream: `export default {}`,
     })
   );
 

--- a/sdk/schemaregistry/schema-registry-avro/samples-dev/schemaRegistryAvroSample.ts
+++ b/sdk/schemaregistry/schema-registry-avro/samples-dev/schemaRegistryAvroSample.ts
@@ -25,13 +25,13 @@ const schemaObject = {
   fields: [
     {
       name: "firstName",
-      type: "string"
+      type: "string",
     },
     {
       name: "lastName",
-      type: "string"
-    }
-  ]
+      type: "string",
+    },
+  ],
 };
 
 // Matching TypeScript interface for schema
@@ -47,7 +47,7 @@ const schemaDescription: SchemaDescription = {
   name: `${schemaObject.namespace}.${schemaObject.name}`,
   groupName,
   format: "Avro",
-  definition: schema
+  definition: schema,
 };
 
 export async function main() {

--- a/sdk/schemaregistry/schema-registry-avro/src/index.ts
+++ b/sdk/schemaregistry/schema-registry-avro/src/index.ts
@@ -3,5 +3,5 @@
 
 export {
   SchemaRegistryAvroSerializer,
-  SchemaRegistryAvroSerializerOptions
+  SchemaRegistryAvroSerializerOptions,
 } from "./schemaRegistryAvroSerializer";

--- a/sdk/schemaregistry/schema-registry-avro/src/schemaRegistryAvroSerializer.ts
+++ b/sdk/schemaregistry/schema-registry-avro/src/schemaRegistryAvroSerializer.ts
@@ -198,7 +198,7 @@ export class SchemaRegistryAvroSerializer {
       groupName: this.schemaGroup,
       name: avroType.name,
       format: "Avro",
-      definition: schema
+      definition: schema,
     };
 
     let id: string;

--- a/sdk/schemaregistry/schema-registry-avro/test/schemaRegistryAvroSerializer.spec.ts
+++ b/sdk/schemaregistry/schema-registry-avro/test/schemaRegistryAvroSerializer.spec.ts
@@ -9,7 +9,7 @@ import { createTestSerializer, registerTestSchema } from "./utils/mockedSerializ
 
 chaiUse(chaiPromises);
 
-describe("SchemaRegistryAvroSerializer", function() {
+describe("SchemaRegistryAvroSerializer", function () {
   it("rejects buffers that are too small", async () => {
     const serializer = await createTestSerializer();
     await assert.isRejected(serializer.deserialize(Buffer.alloc(3)), /small/);
@@ -35,7 +35,7 @@ describe("SchemaRegistryAvroSerializer", function() {
       name: "_",
       definition: "_",
       format: "NotAvro",
-      groupName: testGroup
+      groupName: testGroup,
     });
 
     const buffer = Buffer.alloc(36);
@@ -52,7 +52,7 @@ describe("SchemaRegistryAvroSerializer", function() {
       type: "record",
       name: "NeverRegistered",
       namespace: "my.example",
-      fields: [{ name: "count", type: "int" }]
+      fields: [{ name: "count", type: "int" }],
     });
     await assert.isRejected(serializer.serialize({ count: 42 }, schema), /not found/);
   });
@@ -117,7 +117,7 @@ describe("SchemaRegistryAvroSerializer", function() {
       type: "record",
       name: "Rating",
       namespace: "my.example",
-      fields: [{ name: "score", type: "int" }]
+      fields: [{ name: "score", type: "int" }],
     });
 
     // Example value that matches the Avro schema above

--- a/sdk/schemaregistry/schema-registry-avro/test/utils/dummies.ts
+++ b/sdk/schemaregistry/schema-registry-avro/test/utils/dummies.ts
@@ -10,20 +10,20 @@ export const testSchemaObject: avro.schema.RecordType = {
   fields: [
     {
       name: "name",
-      type: "string"
+      type: "string",
     },
     {
       name: "favoriteNumber",
-      type: "int"
-    }
-  ]
+      type: "int",
+    },
+  ],
 };
 
 export const testGroup = "azsdk_js_test_group";
 
 export const testSchemaIds = [
   "{773E17BE-793E-40B0-98F1-0A6EA3C11895}",
-  "{DC7EF290-CDB1-4245-8EE8-3DD52965866E}"
+  "{DC7EF290-CDB1-4245-8EE8-3DD52965866E}",
 ].map((x) => x.replace(/[{\-}]/g, ""));
 
 export const testSchema = JSON.stringify(testSchemaObject);

--- a/sdk/schemaregistry/schema-registry-avro/test/utils/mockedRegistryClient.ts
+++ b/sdk/schemaregistry/schema-registry-avro/test/utils/mockedRegistryClient.ts
@@ -9,7 +9,7 @@ import {
   SchemaDescription,
   SchemaProperties,
   SchemaRegistry,
-  SchemaRegistryClient
+  SchemaRegistryClient,
 } from "@azure/schema-registry";
 import { ClientSecretCredential } from "@azure/identity";
 import { env, isLiveMode } from "@azure-tools/test-recorder";
@@ -41,8 +41,8 @@ export function createTestRegistry(neverLive = false): SchemaRegistry {
         definition: schema.definition,
         properties: {
           id: newId(),
-          format: schema.format
-        }
+          format: schema.format,
+        },
       };
       mapByContent.set(result.definition, result);
       mapById.set(result.properties.id, result);

--- a/sdk/schemaregistry/schema-registry-avro/test/utils/mockedSerializer.ts
+++ b/sdk/schemaregistry/schema-registry-avro/test/utils/mockedSerializer.ts
@@ -21,7 +21,7 @@ export async function registerTestSchema(registry: SchemaRegistry): Promise<stri
     name: `${testSchemaObject.namespace}.${testSchemaObject.name}`,
     groupName: testGroup,
     definition: testSchema,
-    format: "avro"
+    format: "avro",
   });
   return schema.id;
 }

--- a/sdk/schemaregistry/schema-registry/karma.conf.js
+++ b/sdk/schemaregistry/schema-registry/karma.conf.js
@@ -8,10 +8,10 @@ const {
   jsonRecordingFilterFunction,
   isPlaybackMode,
   isSoftRecordMode,
-  isRecordMode
+  isRecordMode,
 } = require("@azure-tools/test-recorder");
 
-module.exports = function(config) {
+module.exports = function (config) {
   config.set({
     // base path that will be used to resolve all patterns (eg. files, exclude)
     basePath: "./",
@@ -32,13 +32,13 @@ module.exports = function(config) {
       "karma-sourcemap-loader",
       "karma-junit-reporter",
       "karma-json-to-file-reporter",
-      "karma-json-preprocessor"
+      "karma-json-preprocessor",
     ],
 
     // list of files / patterns to load in the browser
     files: [
       "dist-test/index.browser.js",
-      { pattern: "dist-test/index.browser.js.map", type: "html", included: false, served: true }
+      { pattern: "dist-test/index.browser.js.map", type: "html", included: false, served: true },
     ].concat(isPlaybackMode() || isSoftRecordMode() ? ["recordings/browsers/**/*.json"] : []),
 
     // list of files / patterns to exclude
@@ -48,7 +48,7 @@ module.exports = function(config) {
     // available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
     preprocessors: {
       "**/*.js": ["sourcemap", "env"],
-      "recordings/browsers/**/*.json": ["json"]
+      "recordings/browsers/**/*.json": ["json"],
       // IMPORTANT: COMMENT following line if you want to debug in your browsers!!
       // Preprocess source file to calculate code coverage, however this will make source file unreadable
       // "dist-test/index.js": ["coverage"]
@@ -60,7 +60,7 @@ module.exports = function(config) {
       "SCHEMA_REGISTRY_GROUP",
       "AZURE_CLIENT_ID",
       "AZURE_CLIENT_SECRET",
-      "AZURE_TENANT_ID"
+      "AZURE_TENANT_ID",
     ],
 
     // test results reporter to use
@@ -75,8 +75,8 @@ module.exports = function(config) {
         { type: "json", subdir: ".", file: "coverage.json" },
         { type: "lcovonly", subdir: ".", file: "lcov.info" },
         { type: "html", subdir: "html" },
-        { type: "cobertura", subdir: ".", file: "cobertura-coverage.xml" }
-      ]
+        { type: "cobertura", subdir: ".", file: "cobertura-coverage.xml" },
+      ],
     },
 
     junitReporter: {
@@ -86,12 +86,12 @@ module.exports = function(config) {
       useBrowserName: false, // add browser name to report and classes names
       nameFormatter: undefined, // function (browser, result) to customize the name attribute in xml testcase element
       classNameFormatter: undefined, // function (browser, result) to customize the classname attribute in xml testcase element
-      properties: {} // key value pair of properties to add to the <properties> section of the report
+      properties: {}, // key value pair of properties to add to the <properties> section of the report
     },
 
     jsonToFileReporter: {
       filter: jsonRecordingFilterFunction,
-      outputPath: "."
+      outputPath: ".",
     },
 
     // web server port
@@ -113,8 +113,8 @@ module.exports = function(config) {
     customLaunchers: {
       ChromeHeadlessNoSandbox: {
         base: "ChromeHeadless",
-        flags: ["--no-sandbox", "--disable-web-security"]
-      }
+        flags: ["--no-sandbox", "--disable-web-security"],
+      },
     },
 
     // Continuous Integration mode
@@ -129,15 +129,15 @@ module.exports = function(config) {
     browserDisconnectTimeout: 10000,
     browserDisconnectTolerance: 3,
     browserConsoleLogOptions: {
-      terminal: !isRecordMode()
+      terminal: !isRecordMode(),
     },
 
     client: {
       mocha: {
         // change Karma's debug.html to the mocha web reporter
         reporter: "html",
-        timeout: "600000"
-      }
-    }
+        timeout: "600000",
+      },
+    },
   });
 };

--- a/sdk/schemaregistry/schema-registry/package.json
+++ b/sdk/schemaregistry/schema-registry/package.json
@@ -118,7 +118,7 @@
     "mocha": "^7.1.1",
     "mocha-junit-reporter": "^2.0.0",
     "nyc": "^15.0.0",
-    "prettier": "^1.16.4",
+    "prettier": "^2.5.1",
     "rimraf": "^3.0.0",
     "rollup": "^1.16.3",
     "source-map-support": "^0.5.9",

--- a/sdk/schemaregistry/schema-registry/samples-dev/schemaRegistrySample.ts
+++ b/sdk/schemaregistry/schema-registry/samples-dev/schemaRegistrySample.ts
@@ -25,13 +25,13 @@ const schemaObject = {
   fields: [
     {
       name: "firstName",
-      type: "string"
+      type: "string",
     },
     {
       name: "lastName",
-      type: "string"
-    }
-  ]
+      type: "string",
+    },
+  ],
 };
 
 // Description of the schema for registration
@@ -39,7 +39,7 @@ const schemaDescription: SchemaDescription = {
   name: `${schemaObject.namespace}-${schemaObject.name}`,
   groupName: group,
   format: "Avro",
-  definition: JSON.stringify(schemaObject)
+  definition: JSON.stringify(schemaObject),
 };
 
 export async function main() {

--- a/sdk/schemaregistry/schema-registry/src/conversions.ts
+++ b/sdk/schemaregistry/schema-registry/src/conversions.ts
@@ -6,7 +6,7 @@ import { SchemaProperties, Schema } from "./models";
 import {
   SchemaGetByIdResponse,
   SchemaRegisterResponse,
-  SchemaQueryIdByContentResponse as SchemaQueryIdByDefinitionResponse
+  SchemaQueryIdByContentResponse as SchemaQueryIdByDefinitionResponse,
 } from "./generated/models";
 import { getSchemaDefinition } from "./getSchemaDefinition";
 
@@ -31,8 +31,8 @@ export async function convertSchemaResponse(response: GeneratedSchemaResponse): 
     definition: schemaDefinition,
     properties: {
       id: response.schemaId!,
-      format: mapContentTypeToFormat(response.contentType!)
-    }
+      format: mapContentTypeToFormat(response.contentType!),
+    },
   };
 }
 
@@ -49,7 +49,7 @@ export function convertSchemaIdResponse(
       // `!`s here because server is required to return these on success, but that
       // is not modeled by the generated client.
       id: response.schemaId!,
-      format: schemaFormat
+      format: schemaFormat,
     };
   };
 }

--- a/sdk/schemaregistry/schema-registry/src/schemaRegistryClient.ts
+++ b/sdk/schemaregistry/schema-registry/src/schemaRegistryClient.ts
@@ -5,7 +5,7 @@ import { GeneratedSchemaRegistryClient } from "./generated/generatedSchemaRegist
 import { TokenCredential } from "@azure/core-auth";
 import {
   bearerTokenAuthenticationPolicy,
-  InternalPipelineOptions
+  InternalPipelineOptions,
 } from "@azure/core-rest-pipeline";
 import { convertSchemaIdResponse, convertSchemaResponse } from "./conversions";
 
@@ -17,7 +17,7 @@ import {
   SchemaRegistry,
   RegisterSchemaOptions,
   SchemaProperties,
-  Schema
+  Schema,
 } from "./models";
 import { DEFAULT_SCOPE } from "./constants";
 import { logger } from "./logger";
@@ -51,15 +51,15 @@ export class SchemaRegistryClient implements SchemaRegistry {
       ...options,
       ...{
         loggingOptions: {
-          logger: logger.info
-        }
-      }
+          logger: logger.info,
+        },
+      },
     };
 
     this.client = new GeneratedSchemaRegistryClient(this.fullyQualifiedNamespace, {
       endpoint: this.fullyQualifiedNamespace,
       apiVersion: options.apiVersion,
-      ...internalPipelineOptions
+      ...internalPipelineOptions,
     });
 
     const authPolicy = bearerTokenAuthenticationPolicy({ credential, scopes: DEFAULT_SCOPE });

--- a/sdk/schemaregistry/schema-registry/test/public/schemaRegistry.spec.ts
+++ b/sdk/schemaregistry/schema-registry/test/public/schemaRegistry.spec.ts
@@ -14,7 +14,7 @@ import { SchemaRegistryClient, SchemaDescription, SchemaProperties, Schema } fro
 const options = {
   onResponse: (rawResponse: { status: number }) => {
     assert.equal(rawResponse.status, 204);
-  }
+  },
 };
 
 function assertIsValidSchemaProperties(
@@ -59,12 +59,12 @@ async function isRejected<T>(
   }
 }
 
-describe("SchemaRegistryClient", function() {
+describe("SchemaRegistryClient", function () {
   let recorder: Recorder;
   let client: SchemaRegistryClient;
   let schema: SchemaDescription;
 
-  beforeEach(function(this: Context) {
+  beforeEach(function (this: Context) {
     ({ client, recorder } = createRecordedClient(this));
     schema = {
       name: "azsdk_js_test",
@@ -77,18 +77,18 @@ describe("SchemaRegistryClient", function() {
         fields: [
           {
             name: "name",
-            type: "string"
+            type: "string",
           },
           {
             name: "favoriteNumber",
-            type: "int"
-          }
-        ]
-      })
+            type: "int",
+          },
+        ],
+      }),
     };
   });
 
-  afterEach(async function() {
+  afterEach(async function () {
     await recorder.stop();
   });
 
@@ -165,7 +165,7 @@ describe("SchemaRegistryClient", function() {
     const found = await client.getSchema(registered.id, {
       onResponse: (rawResponse: { status: number }) => {
         assert.equal(rawResponse.status, 200);
-      }
+      },
     });
     assertIsValidSchema(found);
     assert.equal(found.definition, schema.definition);
@@ -181,7 +181,7 @@ describe("SchemaRegistryClient", function() {
         '  "type": "record",\n' +
         '  "name": "Test",\n' +
         '  "fields": [{ "name": "X", "type": { "type": "string" } }]\n' +
-        "}\n"
+        "}\n",
     };
     // definition that is going to the service has whitespaces
     const registered = await client.registerSchema(schema2, options);
@@ -197,7 +197,7 @@ describe("SchemaRegistryClient", function() {
       definition: foundSchema.definition,
       groupName: schema2.groupName,
       name: schema2.name,
-      format: foundSchema.properties.format
+      format: foundSchema.properties.format,
     });
     assertIsValidSchemaProperties(foundId);
   });
@@ -205,7 +205,7 @@ describe("SchemaRegistryClient", function() {
   it("Allows schema names with dots in them", async () => {
     const schemaProperties = await client.registerSchema({
       ...schema,
-      name: "com.azure.schemaregistry.samples.User"
+      name: "com.azure.schemaregistry.samples.User",
     });
     assertIsValidSchemaProperties(schemaProperties);
   });

--- a/sdk/schemaregistry/schema-registry/test/public/utils/recordedClient.ts
+++ b/sdk/schemaregistry/schema-registry/test/public/utils/recordedClient.ts
@@ -18,7 +18,7 @@ const replaceableVariables: { [k: string]: string } = {
   AZURE_CLIENT_SECRET: "azure_client_secret",
   AZURE_TENANT_ID: "azuretenantid",
   SCHEMA_REGISTRY_ENDPOINT: "https://endpoint",
-  SCHEMA_REGISTRY_GROUP: "group-1"
+  SCHEMA_REGISTRY_GROUP: "group-1",
 };
 
 const environmentSetup: RecorderEnvironmentSetup = {
@@ -33,9 +33,9 @@ const environmentSetup: RecorderEnvironmentSetup = {
     (recording: string): string => {
       const replaced = recording.replace("endpoint:443", "endpoint");
       return replaced;
-    }
+    },
   ],
-  queryParametersToSkip: []
+  queryParametersToSkip: [],
 };
 
 export function createRecordedClient(context: Context): RecordedClient {

--- a/sdk/web-pubsub/web-pubsub-express/karma.conf.js
+++ b/sdk/web-pubsub/web-pubsub-express/karma.conf.js
@@ -5,9 +5,9 @@ const {
   jsonRecordingFilterFunction,
   isPlaybackMode,
   isSoftRecordMode,
-  isRecordMode
+  isRecordMode,
 } = require("@azure-tools/test-recorder");
-module.exports = function(config) {
+module.exports = function (config) {
   config.set({
     // base path that will be used to resolve all patterns (eg. files, exclude)
     basePath: "./",
@@ -28,7 +28,7 @@ module.exports = function(config) {
       "karma-remap-istanbul",
       "karma-junit-reporter",
       "karma-json-to-file-reporter",
-      "karma-json-preprocessor"
+      "karma-json-preprocessor",
     ],
 
     // list of files / patterns to load in the browser
@@ -46,7 +46,7 @@ module.exports = function(config) {
       "recordings/browsers/**/*.json": ["json"],
       // IMPORTANT: COMMENT following line if you want to debug in your browsers!!
       // Preprocess source file to calculate code coverage, however this will make source file unreadable
-      "test-browser/index.js": ["coverage"]
+      "test-browser/index.js": ["coverage"],
     },
 
     // inject following environment values into browser testing with window.__env__
@@ -61,7 +61,7 @@ module.exports = function(config) {
 
     coverageReporter: {
       dir: "coverage-browser/",
-      reporters: [{ type: "json", subdir: ".", file: "coverage.json" }]
+      reporters: [{ type: "json", subdir: ".", file: "coverage.json" }],
     },
 
     remapIstanbulReporter: {
@@ -70,8 +70,8 @@ module.exports = function(config) {
         lcovonly: "coverage-browser/lcov.info",
         html: "coverage-browser/html/report",
         "text-summary": null,
-        cobertura: "./coverage-browser/cobertura-coverage.xml"
-      }
+        cobertura: "./coverage-browser/cobertura-coverage.xml",
+      },
     },
 
     junitReporter: {
@@ -81,12 +81,12 @@ module.exports = function(config) {
       useBrowserName: false, // add browser name to report and classes names
       nameFormatter: undefined, // function (browser, result) to customize the name attribute in xml testcase element
       classNameFormatter: undefined, // function (browser, result) to customize the classname attribute in xml testcase element
-      properties: {} // key value pair of properties to add to the <properties> section of the report
+      properties: {}, // key value pair of properties to add to the <properties> section of the report
     },
 
     jsonToFileReporter: {
       filter: jsonRecordingFilterFunction,
-      outputPath: "."
+      outputPath: ".",
     },
 
     // web server port
@@ -120,15 +120,15 @@ module.exports = function(config) {
     browserDisconnectTolerance: 3,
 
     browserConsoleLogOptions: {
-      terminal: !isRecordMode()
+      terminal: !isRecordMode(),
     },
 
     client: {
       mocha: {
         // change Karma's debug.html to the mocha web reporter
         reporter: "html",
-        timeout: "600000"
-      }
-    }
+        timeout: "600000",
+      },
+    },
   });
 };

--- a/sdk/web-pubsub/web-pubsub-express/package.json
+++ b/sdk/web-pubsub/web-pubsub-express/package.json
@@ -92,7 +92,7 @@
     "mocha": "^7.1.1",
     "mocha-junit-reporter": "^2.0.0",
     "nyc": "^15.0.0",
-    "prettier": "^1.16.4",
+    "prettier": "^2.5.1",
     "puppeteer": "^10.2.0",
     "rimraf": "^3.0.0",
     "rollup": "^1.16.3",

--- a/sdk/web-pubsub/web-pubsub-express/samples-dev/server.ts
+++ b/sdk/web-pubsub/web-pubsub-express/samples-dev/server.ts
@@ -27,7 +27,7 @@ const handler = new WebPubSubEventHandler("chat", {
     res.setState("calledTime", calledTime);
     res.success("Hello", "text");
   },
-  allowedEndpoints: ["https://xxx.webpubsub.azure.com"]
+  allowedEndpoints: ["https://xxx.webpubsub.azure.com"],
 });
 
 const app = express();

--- a/sdk/web-pubsub/web-pubsub-express/src/cloudEventsDispatcher.ts
+++ b/sdk/web-pubsub/web-pubsub-express/src/cloudEventsDispatcher.ts
@@ -16,14 +16,14 @@ import {
   ConnectionContext,
   ConnectResponseHandler,
   UserEventResponseHandler,
-  WebPubSubEventHandlerOptions
+  WebPubSubEventHandlerOptions,
 } from "./cloudEventsProtocols";
 
 enum EventType {
   Connect,
   Connected,
   Disconnected,
-  UserEvent
+  UserEvent,
 }
 
 function getConnectResponseHandler(
@@ -52,7 +52,7 @@ function getConnectResponseHandler(
     fail(code: 400 | 401 | 500, detail?: string): void {
       response.statusCode = code;
       response.end(detail ?? "");
-    }
+    },
   };
 
   return handler;
@@ -91,7 +91,7 @@ function getUserEventResponseHandler(
     fail(code: 400 | 401 | 500, detail?: string): void {
       response.statusCode = code;
       response.end(detail ?? "");
-    }
+    },
   };
   return handler;
 }
@@ -104,7 +104,7 @@ function getContext(ce: CloudEvent, origin: string): ConnectionContext {
     connectionId: ce["connectionid"] as string,
     eventName: ce["eventname"] as string,
     origin: origin,
-    states: utils.fromBase64JsonString(ce["connectionstate"] as string)
+    states: utils.fromBase64JsonString(ce["connectionstate"] as string),
   };
 
   // TODO: validation
@@ -269,7 +269,7 @@ export class CloudEventsDispatcher {
           userRequest = {
             context: getContext(receivedEvent, origin),
             data: Buffer.from(receivedEvent.data_base64, "base64"),
-            dataType: "binary"
+            dataType: "binary",
           };
         } else if (receivedEvent.data !== undefined) {
           userRequest = {
@@ -277,7 +277,7 @@ export class CloudEventsDispatcher {
             data: receivedEvent.data as string,
             dataType: receivedEvent.datacontenttype?.startsWith("application/json;")
               ? "json"
-              : "text"
+              : "text",
           };
         } else {
           throw new Error("Unexpected data.");

--- a/sdk/web-pubsub/web-pubsub-express/src/utils.ts
+++ b/sdk/web-pubsub/web-pubsub-express/src/utils.ts
@@ -43,7 +43,7 @@ export function getHttpHeader(req: IncomingMessage, key: string): string | undef
 export async function convertHttpToEvent(request: IncomingMessage): Promise<Message> {
   const normalized: Message = {
     headers: {},
-    body: ""
+    body: "",
   };
   if (request.headers) {
     for (const key in request.headers) {
@@ -61,17 +61,17 @@ export async function convertHttpToEvent(request: IncomingMessage): Promise<Mess
 }
 
 export function readRequestBody(req: IncomingMessage): Promise<string> {
-  return new Promise(function(resolve, reject) {
+  return new Promise(function (resolve, reject) {
     const chunks: any = [];
-    req.on("data", function(chunk) {
+    req.on("data", function (chunk) {
       chunks.push(chunk);
     });
-    req.on("end", function() {
+    req.on("end", function () {
       const buffer = Buffer.concat(chunks);
       resolve(buffer.toString());
     });
     // reject on request error
-    req.on("error", function(err) {
+    req.on("error", function (err) {
       // This is not a "Second reject", just a different sort of failure
       reject(err);
     });

--- a/sdk/web-pubsub/web-pubsub-express/test/connect.spec.ts
+++ b/sdk/web-pubsub/web-pubsub-express/test/connect.spec.ts
@@ -37,16 +37,16 @@ function mockBody(req: IncomingMessage, body: string): void {
   req.emit("end");
 }
 
-describe("Can handle connect event", function() {
+describe("Can handle connect event", function () {
   let req: IncomingMessage;
   let res: ServerResponse;
 
-  beforeEach(function() {
+  beforeEach(function () {
     req = new IncomingMessage(new Socket());
     res = new ServerResponse(req);
   });
 
-  it("Should not handle the request if request is not cloud events", async function() {
+  it("Should not handle the request if request is not cloud events", async function () {
     const endSpy = sinon.spy(res.end);
 
     const dispatcher = new CloudEventsDispatcher("hub1");
@@ -55,7 +55,7 @@ describe("Can handle connect event", function() {
     assert.isTrue(endSpy.notCalled);
   });
 
-  it("Should not handle the request if hub does not match", async function() {
+  it("Should not handle the request if hub does not match", async function () {
     const endSpy = sinon.spy(res, "end");
     buildRequest(req, "hub", "conn1");
 
@@ -65,7 +65,7 @@ describe("Can handle connect event", function() {
     assert.isTrue(endSpy.notCalled);
   });
 
-  it("Should response with 200 when option is not specified", async function() {
+  it("Should response with 200 when option is not specified", async function () {
     const endSpy = sinon.spy(res, "end");
     buildRequest(req, "hub", "conn1");
 
@@ -76,7 +76,7 @@ describe("Can handle connect event", function() {
     assert.equal(200, res.statusCode, "should be 200");
   });
 
-  it("Should response with 200 when handler is not specified", async function() {
+  it("Should response with 200 when handler is not specified", async function () {
     const endSpy = sinon.spy(res, "end");
     buildRequest(req, "hub", "conn1");
 
@@ -87,14 +87,14 @@ describe("Can handle connect event", function() {
     assert.equal(200, res.statusCode, "should be 200");
   });
 
-  it("Should response with error when handler returns error", async function() {
+  it("Should response with error when handler returns error", async function () {
     const endSpy = sinon.spy(res, "end");
     buildRequest(req, "hub", "conn1");
 
     const dispatcher = new CloudEventsDispatcher("hub", {
       handleConnect: async (_, response) => {
         response.fail(400);
-      }
+      },
     });
     const process = dispatcher.handleRequest(req, res);
     mockBody(req, JSON.stringify({}));
@@ -104,14 +104,14 @@ describe("Can handle connect event", function() {
     assert.equal(400, res.statusCode, "should be error");
   });
 
-  it("Should response with success when handler returns success", async function() {
+  it("Should response with success when handler returns success", async function () {
     const endSpy = sinon.spy(res, "end");
     buildRequest(req, "hub", "conn1");
 
     const dispatcher = new CloudEventsDispatcher("hub", {
       handleConnect: async (_, response) => {
         response.success();
-      }
+      },
     });
     const process = dispatcher.handleRequest(req, res);
     mockBody(req, JSON.stringify({}));
@@ -121,14 +121,14 @@ describe("Can handle connect event", function() {
     assert.equal(200, res.statusCode, "should be success");
   });
 
-  it("Should response with success when handler returns success value", async function() {
+  it("Should response with success when handler returns success value", async function () {
     const endSpy = sinon.spy(res, "end");
     buildRequest(req, "hub", "conn1");
 
     const dispatcher = new CloudEventsDispatcher("hub", {
       handleConnect: async (_, response) => {
         response.success({ userId: "vic" });
-      }
+      },
     });
     const process = dispatcher.handleRequest(req, res);
     mockBody(req, JSON.stringify({}));
@@ -138,7 +138,7 @@ describe("Can handle connect event", function() {
     assert.equal(200, res.statusCode, "should be success");
   });
 
-  it("Should be able to set connection state", async function() {
+  it("Should be able to set connection state", async function () {
     const endSpy = sinon.spy(res, "end");
     buildRequest(req, "hub", "conn1");
 
@@ -149,7 +149,7 @@ describe("Can handle connect event", function() {
         response.setState("key1", ["val3"]);
         response.setState("key3", "");
         response.success({ userId: "vic" });
-      }
+      },
     });
     const process = dispatcher.handleRequest(req, res);
     mockBody(req, JSON.stringify({}));
@@ -160,19 +160,19 @@ describe("Can handle connect event", function() {
       toBase64JsonString({
         key1: ["val3"],
         key2: "val2",
-        key3: ""
+        key3: "",
       }),
       res.getHeader("ce-connectionState"),
       "should contain multiple state headers"
     );
   });
 
-  it("Should be able to get the connection states if it exists in the header", async function() {
+  it("Should be able to get the connection states if it exists in the header", async function () {
     const endSpy = sinon.spy(res, "end");
     const states = toBase64JsonString({
       key1: ["val3"],
       key2: "val2",
-      key3: ""
+      key3: "",
     });
     buildRequest(req, "hub1", "conn1", undefined, states);
     const dispatcher = new CloudEventsDispatcher("hub1", {
@@ -181,7 +181,7 @@ describe("Can handle connect event", function() {
         assert.equal("val2", request.context.states["key2"]);
         assert.equal("", request.context.states["key3"]);
         response.success();
-      }
+      },
     });
     const process = dispatcher.handleRequest(req, res);
     mockBody(req, JSON.stringify({}));
@@ -191,14 +191,14 @@ describe("Can handle connect event", function() {
     assert.equal(200, res.statusCode, "should be success");
   });
 
-  it("Invalid state header gets ignored", async function() {
+  it("Invalid state header gets ignored", async function () {
     const endSpy = sinon.spy(res, "end");
     buildRequest(req, "hub1", "conn1", undefined, "");
     const dispatcher = new CloudEventsDispatcher("hub1", {
       handleConnect: (request, response) => {
         assert.deepEqual({}, request.context.states);
         response.success();
-      }
+      },
     });
     const process = dispatcher.handleRequest(req, res);
     mockBody(req, JSON.stringify({}));

--- a/sdk/web-pubsub/web-pubsub-express/test/connected.spec.ts
+++ b/sdk/web-pubsub/web-pubsub-express/test/connected.spec.ts
@@ -34,16 +34,16 @@ function mockBody(req: IncomingMessage, body: string): void {
   req.emit("end");
 }
 
-describe("Can handle connected event", function() {
+describe("Can handle connected event", function () {
   let req: IncomingMessage;
   let res: ServerResponse;
 
-  beforeEach(function() {
+  beforeEach(function () {
     req = new IncomingMessage(new Socket());
     res = new ServerResponse(req);
   });
 
-  it("Should not handle the request if request is not cloud events", async function() {
+  it("Should not handle the request if request is not cloud events", async function () {
     const endSpy = sinon.spy(res.end);
 
     const dispatcher = new CloudEventsDispatcher("hub1");
@@ -52,7 +52,7 @@ describe("Can handle connected event", function() {
     assert.isTrue(endSpy.notCalled);
   });
 
-  it("Should not handle the request if hub does not match", async function() {
+  it("Should not handle the request if hub does not match", async function () {
     const endSpy = sinon.spy(res.end);
     buildRequest(req, "hub", "conn1");
 
@@ -62,7 +62,7 @@ describe("Can handle connected event", function() {
     assert.isTrue(endSpy.notCalled);
   });
 
-  it("Should response with 200 when option is not specified", async function() {
+  it("Should response with 200 when option is not specified", async function () {
     const endSpy = sinon.spy(res, "end");
     buildRequest(req, "hub", "conn1");
 
@@ -73,7 +73,7 @@ describe("Can handle connected event", function() {
     assert.equal(200, res.statusCode, "should be 200");
   });
 
-  it("Should response with 200 when handler is not specified", async function() {
+  it("Should response with 200 when handler is not specified", async function () {
     const endSpy = sinon.spy(res, "end");
     buildRequest(req, "hub", "conn1");
 
@@ -84,14 +84,14 @@ describe("Can handle connected event", function() {
     assert.equal(200, res.statusCode, "should be 200");
   });
 
-  it("Should response 200 even the event handler throws", async function() {
+  it("Should response 200 even the event handler throws", async function () {
     const endSpy = sinon.spy(res, "end");
     buildRequest(req, "hub", "conn1");
 
     const dispatcher = new CloudEventsDispatcher("hub", {
       onConnected: async (_) => {
         throw new Error();
-      }
+      },
     });
     const process = dispatcher.handleRequest(req, res);
     mockBody(req, JSON.stringify({}));

--- a/sdk/web-pubsub/web-pubsub-express/test/ctor.spec.ts
+++ b/sdk/web-pubsub/web-pubsub-express/test/ctor.spec.ts
@@ -4,20 +4,20 @@
 import { WebPubSubEventHandler } from "../src/webPubSubEventHandler";
 import { assert } from "chai";
 
-describe("Can creat event handler", function() {
-  it("Can provide default path", function() {
+describe("Can creat event handler", function () {
+  it("Can provide default path", function () {
     const dispatcher = new WebPubSubEventHandler("hub");
     assert.equal("/api/webpubsub/hubs/hub/", dispatcher.path);
   });
 
-  it("Supports custom path", function() {
+  it("Supports custom path", function () {
     const dispatcher = new WebPubSubEventHandler("hub", {
-      path: "/custom"
+      path: "/custom",
     });
     assert.equal("/custom/", dispatcher.path);
   });
 
-  it("Throw with invalid endpoints", function() {
+  it("Throw with invalid endpoints", function () {
     try {
       new WebPubSubEventHandler("hub", { allowedEndpoints: ["b.com"] });
       assert.fail("Should have thrown ERROR_INVALID_URL");

--- a/sdk/web-pubsub/web-pubsub-express/test/disconnected.spec.ts
+++ b/sdk/web-pubsub/web-pubsub-express/test/disconnected.spec.ts
@@ -34,16 +34,16 @@ function mockBody(req: IncomingMessage, body: string): void {
   req.emit("end");
 }
 
-describe("Can handle disconnected event", function() {
+describe("Can handle disconnected event", function () {
   let req: IncomingMessage;
   let res: ServerResponse;
 
-  beforeEach(function() {
+  beforeEach(function () {
     req = new IncomingMessage(new Socket());
     res = new ServerResponse(req);
   });
 
-  it("Should not handle the request if request is not cloud events", async function() {
+  it("Should not handle the request if request is not cloud events", async function () {
     const endSpy = sinon.spy(res.end);
 
     const dispatcher = new CloudEventsDispatcher("hub1");
@@ -52,7 +52,7 @@ describe("Can handle disconnected event", function() {
     assert.isTrue(endSpy.notCalled);
   });
 
-  it("Should not handle the request if hub does not match", async function() {
+  it("Should not handle the request if hub does not match", async function () {
     const endSpy = sinon.spy(res.end);
     buildRequest(req, "hub", "conn1");
 
@@ -62,7 +62,7 @@ describe("Can handle disconnected event", function() {
     assert.isTrue(endSpy.notCalled);
   });
 
-  it("Should response with 200 when option is not specified", async function() {
+  it("Should response with 200 when option is not specified", async function () {
     const endSpy = sinon.spy(res, "end");
     buildRequest(req, "hub", "conn1");
 
@@ -73,7 +73,7 @@ describe("Can handle disconnected event", function() {
     assert.equal(200, res.statusCode, "should be 200");
   });
 
-  it("Should response with 200 when handler is not specified", async function() {
+  it("Should response with 200 when handler is not specified", async function () {
     const endSpy = sinon.spy(res, "end");
     buildRequest(req, "hub", "conn1");
 
@@ -84,14 +84,14 @@ describe("Can handle disconnected event", function() {
     assert.equal(200, res.statusCode, "should be 200");
   });
 
-  it("Should response 200 even the event handler throws", async function() {
+  it("Should response 200 even the event handler throws", async function () {
     const endSpy = sinon.spy(res, "end");
     buildRequest(req, "hub", "conn1");
 
     const dispatcher = new CloudEventsDispatcher("hub", {
       onConnected: async (_) => {
         throw new Error();
-      }
+      },
     });
     const process = dispatcher.handleRequest(req, res);
     mockBody(req, JSON.stringify({}));

--- a/sdk/web-pubsub/web-pubsub-express/test/user.spec.ts
+++ b/sdk/web-pubsub/web-pubsub-express/test/user.spec.ts
@@ -34,16 +34,16 @@ function mockBody(req: IncomingMessage, body: string): void {
   req.emit("end");
 }
 
-describe("Can handle user event", function() {
+describe("Can handle user event", function () {
   let req: IncomingMessage;
   let res: ServerResponse;
 
-  beforeEach(function() {
+  beforeEach(function () {
     req = new IncomingMessage(new Socket());
     res = new ServerResponse(req);
   });
 
-  it("Should not handle the request if request is not cloud events", async function() {
+  it("Should not handle the request if request is not cloud events", async function () {
     const endSpy = sinon.spy(res.end);
 
     const dispatcher = new CloudEventsDispatcher("hub1");
@@ -52,7 +52,7 @@ describe("Can handle user event", function() {
     assert.isTrue(endSpy.notCalled);
   });
 
-  it("Should not handle the request if hub does not match", async function() {
+  it("Should not handle the request if hub does not match", async function () {
     const endSpy = sinon.spy(res.end);
     buildRequest(req, "hub", "conn1");
 
@@ -62,7 +62,7 @@ describe("Can handle user event", function() {
     assert.isTrue(endSpy.notCalled);
   });
 
-  it("Should response with 200 when option is not specified", async function() {
+  it("Should response with 200 when option is not specified", async function () {
     const endSpy = sinon.spy(res, "end");
     buildRequest(req, "hub", "conn1");
 
@@ -73,7 +73,7 @@ describe("Can handle user event", function() {
     assert.equal(200, res.statusCode, "should be 200");
   });
 
-  it("Should response with 200 when handler is not specified", async function() {
+  it("Should response with 200 when handler is not specified", async function () {
     const endSpy = sinon.spy(res, "end");
     buildRequest(req, "hub", "conn1");
 
@@ -84,14 +84,14 @@ describe("Can handle user event", function() {
     assert.equal(200, res.statusCode, "should be 200");
   });
 
-  it("Should response with error when handler returns error", async function() {
+  it("Should response with error when handler returns error", async function () {
     const endSpy = sinon.spy(res, "end");
     buildRequest(req, "hub", "conn1");
 
     const dispatcher = new CloudEventsDispatcher("hub", {
       handleUserEvent: async (_, response) => {
         response.fail(500);
-      }
+      },
     });
     const process = dispatcher.handleRequest(req, res);
     mockBody(req, JSON.stringify({}));
@@ -101,14 +101,14 @@ describe("Can handle user event", function() {
     assert.equal(500, res.statusCode, "should be error");
   });
 
-  it("Should response with success when handler returns success", async function() {
+  it("Should response with success when handler returns success", async function () {
     const endSpy = sinon.spy(res, "end");
     buildRequest(req, "hub", "conn1");
 
     const dispatcher = new CloudEventsDispatcher("hub", {
       handleUserEvent: async (_, response) => {
         response.success();
-      }
+      },
     });
     const process = dispatcher.handleRequest(req, res);
     mockBody(req, JSON.stringify({}));
@@ -118,14 +118,14 @@ describe("Can handle user event", function() {
     assert.equal(200, res.statusCode, "should be success");
   });
 
-  it("Should response with success when returns success binary", async function() {
+  it("Should response with success when returns success binary", async function () {
     const endSpy = sinon.spy(res, "end");
     buildRequest(req, "hub", "conn1");
 
     const dispatcher = new CloudEventsDispatcher("hub", {
       handleUserEvent: async (_, response) => {
         response.success("a");
-      }
+      },
     });
     const process = dispatcher.handleRequest(req, res);
     mockBody(req, JSON.stringify({}));
@@ -136,14 +136,14 @@ describe("Can handle user event", function() {
     assert.equal("application/octet-stream", res.getHeader("content-type"), "should be binary");
   });
 
-  it("Should response with success when returns success text", async function() {
+  it("Should response with success when returns success text", async function () {
     const endSpy = sinon.spy(res, "end");
     buildRequest(req, "hub", "conn1");
 
     const dispatcher = new CloudEventsDispatcher("hub", {
       handleUserEvent: async (_, response) => {
         response.success("a", "text");
-      }
+      },
     });
     const process = dispatcher.handleRequest(req, res);
     mockBody(req, JSON.stringify({}));
@@ -154,14 +154,14 @@ describe("Can handle user event", function() {
     assert.equal("text/plain; charset=utf-8", res.getHeader("content-type"), "should be text");
   });
 
-  it("Should response with success when returns success json", async function() {
+  it("Should response with success when returns success json", async function () {
     const endSpy = sinon.spy(res, "end");
     buildRequest(req, "hub", "conn1");
 
     const dispatcher = new CloudEventsDispatcher("hub", {
       handleUserEvent: async (_, response) => {
         response.success("a", "json");
-      }
+      },
     });
     const process = dispatcher.handleRequest(req, res);
     mockBody(req, JSON.stringify({}));
@@ -176,7 +176,7 @@ describe("Can handle user event", function() {
     );
   });
 
-  it("Should be able to set connection state", async function() {
+  it("Should be able to set connection state", async function () {
     const endSpy = sinon.spy(res, "end");
     buildRequest(req, "hub", "conn1");
 
@@ -187,7 +187,7 @@ describe("Can handle user event", function() {
         response.setState("key1", "val3");
         response.setState("key3", "");
         response.success();
-      }
+      },
     });
     const process = dispatcher.handleRequest(req, res);
     mockBody(req, JSON.stringify({}));
@@ -201,7 +201,7 @@ describe("Can handle user event", function() {
         JSON.stringify({
           key1: "val3",
           key2: "val2",
-          key3: ""
+          key3: "",
         })
       ).toString("base64"),
       res.getHeader("ce-connectionState"),

--- a/sdk/web-pubsub/web-pubsub-express/test/validate.spec.ts
+++ b/sdk/web-pubsub/web-pubsub-express/test/validate.spec.ts
@@ -6,8 +6,8 @@ import { assert } from "chai";
 import { IncomingMessage, ServerResponse } from "http";
 import { Socket } from "net";
 
-describe("Abuse protection works", function() {
-  it("Only requests with valid header will be processed", function() {
+describe("Abuse protection works", function () {
+  it("Only requests with valid header will be processed", function () {
     const req = new IncomingMessage(new Socket());
     const res = new ServerResponse(req);
     const dispatcher = new CloudEventsDispatcher("hub");
@@ -16,7 +16,7 @@ describe("Abuse protection works", function() {
     assert.isFalse(result);
   });
 
-  it("When allow all endpoints the requested host should return", function() {
+  it("When allow all endpoints the requested host should return", function () {
     const req = new IncomingMessage(new Socket());
     req.headers["ce-awpsversion"] = "1.0";
     req.headers["webhook-request-origin"] = "a.com";
@@ -28,13 +28,13 @@ describe("Abuse protection works", function() {
     assert.equal("a.com", res.getHeader("webhook-allowed-origin"));
   });
 
-  it("Support valid url in allowed endpoints and only return the one in the request", function() {
+  it("Support valid url in allowed endpoints and only return the one in the request", function () {
     const req = new IncomingMessage(new Socket());
     req.headers["ce-awpsversion"] = "1.0";
     req.headers["webhook-request-origin"] = "a.com";
     const res = new ServerResponse(req);
     const dispatcher = new CloudEventsDispatcher("hub", {
-      allowedEndpoints: ["https://a.com/c", "http://b.com"]
+      allowedEndpoints: ["https://a.com/c", "http://b.com"],
     });
 
     const result = dispatcher.handlePreflight(req, res);
@@ -42,13 +42,13 @@ describe("Abuse protection works", function() {
     assert.equal("a.com", res.getHeader("webhook-allowed-origin"));
   });
 
-  it("Not allowed endpoints should return 400", function() {
+  it("Not allowed endpoints should return 400", function () {
     const req = new IncomingMessage(new Socket());
     req.headers["ce-awpsversion"] = "1.0";
     req.headers["webhook-request-origin"] = "a.com";
     const res = new ServerResponse(req);
     const dispatcher = new CloudEventsDispatcher("hub", {
-      allowedEndpoints: ["https://c.com/c", "http://b.com"]
+      allowedEndpoints: ["https://c.com/c", "http://b.com"],
     });
 
     const result = dispatcher.handlePreflight(req, res);

--- a/sdk/web-pubsub/web-pubsub/karma.conf.js
+++ b/sdk/web-pubsub/web-pubsub/karma.conf.js
@@ -5,9 +5,9 @@ const {
   jsonRecordingFilterFunction,
   isPlaybackMode,
   isSoftRecordMode,
-  isRecordMode
+  isRecordMode,
 } = require("@azure-tools/test-recorder");
-module.exports = function(config) {
+module.exports = function (config) {
   config.set({
     // base path that will be used to resolve all patterns (eg. files, exclude)
     basePath: "./",
@@ -27,7 +27,7 @@ module.exports = function(config) {
       "karma-coverage",
       "karma-junit-reporter",
       "karma-json-to-file-reporter",
-      "karma-json-preprocessor"
+      "karma-json-preprocessor",
     ],
 
     // list of files / patterns to load in the browser
@@ -45,7 +45,7 @@ module.exports = function(config) {
       "recordings/browsers/**/*.json": ["json"],
       // IMPORTANT: COMMENT following line if you want to debug in your browsers!!
       // Preprocess source file to calculate code coverage, however this will make source file unreadable
-      "test-browser/index.js": ["coverage"]
+      "test-browser/index.js": ["coverage"],
     },
 
     // inject following environment values into browser testing with window.__env__
@@ -60,7 +60,7 @@ module.exports = function(config) {
 
     coverageReporter: {
       dir: "coverage-browser/",
-      reporters: [{ type: "json", subdir: ".", file: "coverage.json" }]
+      reporters: [{ type: "json", subdir: ".", file: "coverage.json" }],
     },
 
     remapIstanbulReporter: {
@@ -69,8 +69,8 @@ module.exports = function(config) {
         lcovonly: "coverage-browser/lcov.info",
         html: "coverage-browser/html/report",
         "text-summary": null,
-        cobertura: "./coverage-browser/cobertura-coverage.xml"
-      }
+        cobertura: "./coverage-browser/cobertura-coverage.xml",
+      },
     },
 
     junitReporter: {
@@ -80,12 +80,12 @@ module.exports = function(config) {
       useBrowserName: false, // add browser name to report and classes names
       nameFormatter: undefined, // function (browser, result) to customize the name attribute in xml testcase element
       classNameFormatter: undefined, // function (browser, result) to customize the classname attribute in xml testcase element
-      properties: {} // key value pair of properties to add to the <properties> section of the report
+      properties: {}, // key value pair of properties to add to the <properties> section of the report
     },
 
     jsonToFileReporter: {
       filter: jsonRecordingFilterFunction,
-      outputPath: "."
+      outputPath: ".",
     },
 
     // web server port
@@ -119,15 +119,15 @@ module.exports = function(config) {
     browserDisconnectTolerance: 3,
 
     browserConsoleLogOptions: {
-      terminal: !isRecordMode()
+      terminal: !isRecordMode(),
     },
 
     client: {
       mocha: {
         // change Karma's debug.html to the mocha web reporter
         reporter: "html",
-        timeout: "600000"
-      }
-    }
+        timeout: "600000",
+      },
+    },
   });
 };

--- a/sdk/web-pubsub/web-pubsub/package.json
+++ b/sdk/web-pubsub/web-pubsub/package.json
@@ -111,7 +111,7 @@
     "mocha": "^7.1.1",
     "mocha-junit-reporter": "^2.0.0",
     "nyc": "^15.0.0",
-    "prettier": "^1.16.4",
+    "prettier": "^2.5.1",
     "puppeteer": "^10.2.0",
     "rimraf": "^3.0.0",
     "rollup": "^1.16.3",

--- a/sdk/web-pubsub/web-pubsub/src/groupClient.ts
+++ b/sdk/web-pubsub/web-pubsub/src/groupClient.ts
@@ -212,14 +212,14 @@ export class WebPubSubGroupImpl implements WebPubSubGroup {
     try {
       await this.client.webPubSub.addConnectionToGroup(this.hubName, this.groupName, connectionId, {
         ...updatedOptions,
-        onResponse
+        onResponse,
       });
 
       if (response!.status === 404) {
         throw new RestError(`Connection id '${connectionId}' doesn't exist`, {
           statusCode: response?.status,
           request: response?.request,
-          response: response
+          response: response,
         });
       }
     } finally {

--- a/sdk/web-pubsub/web-pubsub/src/hubClient.ts
+++ b/sdk/web-pubsub/web-pubsub/src/hubClient.ts
@@ -287,15 +287,15 @@ export class WebPubSubServiceClient {
       ...{
         apiVersion: this.apiVersion,
         loggingOptions: {
-          logger: logger.info
-        }
+          logger: logger.info,
+        },
       },
       ...(isTokenCredential(this.credential)
         ? {
             credential: this.credential,
-            credentialScopes: ["https://webpubsub.azure.com/.default"]
+            credentialScopes: ["https://webpubsub.azure.com/.default"],
           }
-        : {})
+        : {}),
     };
 
     this.client = new GeneratedClient(this.endpoint, internalPipelineOptions);
@@ -511,7 +511,7 @@ export class WebPubSubServiceClient {
     try {
       await this.client.webPubSub.connectionExists(this.hubName, connectionId, {
         ...updatedOptions,
-        onResponse
+        onResponse,
       });
 
       if (response!.status === 200) {
@@ -523,7 +523,7 @@ export class WebPubSubServiceClient {
         throw new RestError(response!.bodyAsText!, {
           statusCode: response?.status,
           request: response?.request,
-          response: response
+          response: response,
         });
       }
     } finally {
@@ -637,7 +637,7 @@ export class WebPubSubServiceClient {
     try {
       await this.client.webPubSub.groupExists(this.hubName, groupName, {
         ...updatedOptions,
-        onResponse
+        onResponse,
       });
 
       if (response!.status === 200) {
@@ -648,7 +648,7 @@ export class WebPubSubServiceClient {
         throw new RestError(response!.bodyAsText!, {
           statusCode: response?.status,
           request: response?.request,
-          response: response
+          response: response,
         });
       }
     } finally {
@@ -676,7 +676,7 @@ export class WebPubSubServiceClient {
     try {
       await this.client.webPubSub.userExists(this.hubName, username, {
         ...updatedOptions,
-        onResponse
+        onResponse,
       });
 
       if (response!.status === 200) {
@@ -688,7 +688,7 @@ export class WebPubSubServiceClient {
         throw new RestError(response!.bodyAsText!, {
           statusCode: response?.status,
           request: response?.request,
-          response: response
+          response: response,
         });
       }
     } finally {
@@ -781,7 +781,7 @@ export class WebPubSubServiceClient {
     try {
       await this.client.webPubSub.checkPermission(this.hubName, permission, connectionId, {
         ...updatedOptions,
-        onResponse
+        onResponse,
       });
 
       if (response!.status === 200) {
@@ -793,7 +793,7 @@ export class WebPubSubServiceClient {
         throw new RestError(response!.bodyAsText!, {
           statusCode: response?.status,
           request: response?.request,
-          response: response
+          response: response,
         });
       }
     } finally {
@@ -836,7 +836,7 @@ export class WebPubSubServiceClient {
             options?.expirationTimeInMinutes === undefined
               ? "1h"
               : `${options.expirationTimeInMinutes}m`,
-          algorithm: "HS256"
+          algorithm: "HS256",
         };
         if (options?.userId) {
           signOptions.subject = options?.userId;
@@ -847,7 +847,7 @@ export class WebPubSubServiceClient {
       return {
         token,
         baseUrl,
-        url: `${baseUrl}?access_token=${token}`
+        url: `${baseUrl}?access_token=${token}`,
       };
     } finally {
       span.end();

--- a/sdk/web-pubsub/web-pubsub/src/index.ts
+++ b/sdk/web-pubsub/web-pubsub/src/index.ts
@@ -23,7 +23,7 @@ export {
   HubSendTextToConnectionOptions,
   HubSendTextToUserOptions,
   JSONTypes,
-  Permission
+  Permission,
 } from "./hubClient";
 export {
   WebPubSubGroup,
@@ -35,5 +35,5 @@ export {
   GroupRemoveConnectionOptions,
   GroupRemoveUserOptions,
   GroupSendTextToAllOptions,
-  GroupSendToAllOptions
+  GroupSendToAllOptions,
 } from "./groupClient";

--- a/sdk/web-pubsub/web-pubsub/src/reverseProxyPolicy.ts
+++ b/sdk/web-pubsub/web-pubsub/src/reverseProxyPolicy.ts
@@ -5,7 +5,7 @@ import {
   PipelineResponse,
   PipelineRequest,
   SendRequest,
-  PipelinePolicy
+  PipelinePolicy,
 } from "@azure/core-rest-pipeline";
 
 export const webPubSubReverseProxyPolicyName = "webPubSubReverseProxyPolicy";
@@ -24,6 +24,6 @@ export function webPubSubReverseProxyPolicy(endpoint: string): PipelinePolicy {
       parsedUrl.host = rpEndpointUrl.host;
       request.url = parsedUrl.toString();
       return next(request);
-    }
+    },
   };
 }

--- a/sdk/web-pubsub/web-pubsub/src/tracing.ts
+++ b/sdk/web-pubsub/web-pubsub/src/tracing.ts
@@ -6,5 +6,5 @@ import { createSpanFunction } from "@azure/core-tracing";
 /** @internal */
 export const createSpan = createSpanFunction({
   namespace: "Microsoft.WebPubSub",
-  packagePrefix: "Azure.Messaging.WebPubSub"
+  packagePrefix: "Azure.Messaging.WebPubSub",
 });

--- a/sdk/web-pubsub/web-pubsub/src/webPubSubCredentialPolicy.ts
+++ b/sdk/web-pubsub/web-pubsub/src/webPubSubCredentialPolicy.ts
@@ -6,7 +6,7 @@ import {
   PipelineResponse,
   PipelineRequest,
   SendRequest,
-  PipelinePolicy
+  PipelinePolicy,
 } from "@azure/core-rest-pipeline";
 
 import jwt from "jsonwebtoken";
@@ -28,10 +28,10 @@ export function webPubSubKeyCredentialPolicy(credential: KeyCredential): Pipelin
       const bearerToken = jwt.sign({}, credential.key, {
         audience: request.url,
         expiresIn: "1h",
-        algorithm: "HS256"
+        algorithm: "HS256",
       });
       request.headers.set("Authorization", `Bearer ${bearerToken}`);
       return next(request);
-    }
+    },
   };
 }

--- a/sdk/web-pubsub/web-pubsub/test/conn.spec.ts
+++ b/sdk/web-pubsub/web-pubsub/test/conn.spec.ts
@@ -4,7 +4,7 @@
 import { parseConnectionString } from "../src/parseConnectionString";
 import { assert } from "chai";
 
-describe("Can parse connection string", function() {
+describe("Can parse connection string", function () {
   it("can parse valid connection string", async () => {
     let conn = "Endpoint=http://localhost;AccessKey=ABC;Port=8080;Version=1.0;";
     let parsed = parseConnectionString(conn);

--- a/sdk/web-pubsub/web-pubsub/test/groups.spec.ts
+++ b/sdk/web-pubsub/web-pubsub/test/groups.spec.ts
@@ -9,14 +9,14 @@ import { FullOperationResponse } from "@azure/core-client";
 import { RestError } from "@azure/core-rest-pipeline";
 /* eslint-disable @typescript-eslint/no-invalid-this */
 
-describe("Group client working with a group", function() {
+describe("Group client working with a group", function () {
   let recorder: Recorder;
   let client: WebPubSubGroup;
   let lastResponse: FullOperationResponse | undefined;
   function onResponse(response: FullOperationResponse) {
     lastResponse = response;
   }
-  beforeEach(function() {
+  beforeEach(function () {
     recorder = record(this, environmentSetup);
     const hubClient = new WebPubSubServiceClient(env.WPS_CONNECTION_STRING, "simplechat");
     client = hubClient.group("group");
@@ -64,7 +64,7 @@ describe("Group client working with a group", function() {
     await client.removeUser("brian");
   });
 
-  afterEach(async function() {
+  afterEach(async function () {
     if (recorder) {
       recorder.stop();
     }

--- a/sdk/web-pubsub/web-pubsub/test/hubs.spec.ts
+++ b/sdk/web-pubsub/web-pubsub/test/hubs.spec.ts
@@ -9,13 +9,13 @@ import { FullOperationResponse } from "@azure/core-client";
 import { DefaultAzureCredential } from "@azure/identity";
 /* eslint-disable @typescript-eslint/no-invalid-this */
 
-describe("HubClient", function() {
+describe("HubClient", function () {
   let recorder: Recorder;
-  beforeEach(function() {
+  beforeEach(function () {
     recorder = record(this, environmentSetup);
   });
 
-  afterEach(async function() {
+  afterEach(async function () {
     if (recorder) {
       await recorder.stop();
     }
@@ -25,7 +25,7 @@ describe("HubClient", function() {
     it("takes a connection string, hub name, and options", () => {
       assert.doesNotThrow(() => {
         new WebPubSubServiceClient(env.WPS_CONNECTION_STRING, "test-hub", {
-          retryOptions: { maxRetries: 2 }
+          retryOptions: { maxRetries: 2 },
         });
       });
     });
@@ -37,7 +37,7 @@ describe("HubClient", function() {
           new AzureKeyCredential(env.WPS_API_KEY),
           "test-hub",
           {
-            retryOptions: { maxRetries: 2 }
+            retryOptions: { maxRetries: 2 },
           }
         );
       });
@@ -46,19 +46,19 @@ describe("HubClient", function() {
     it("takes an endpoint, DefaultAzureCredential, a hub name, and options", () => {
       assert.doesNotThrow(() => {
         new WebPubSubServiceClient(env.ENDPOINT, new DefaultAzureCredential(), "test-hub", {
-          retryOptions: { maxRetries: 2 }
+          retryOptions: { maxRetries: 2 },
         });
       });
     });
   });
 
-  describe("Working with a hub", function() {
+  describe("Working with a hub", function () {
     let client: WebPubSubServiceClient;
     let lastResponse: FullOperationResponse | undefined;
     function onResponse(response: FullOperationResponse) {
       lastResponse = response;
     }
-    beforeEach(function() {
+    beforeEach(function () {
       client = new WebPubSubServiceClient(env.WPS_CONNECTION_STRING, "simplechat");
     });
 
@@ -94,7 +94,7 @@ describe("HubClient", function() {
 
     it("can broadcast using APIM", async () => {
       const apimClient = new WebPubSubServiceClient(env.WPS_CONNECTION_STRING, "simplechat", {
-        reverseProxyEndpoint: env.REVERSE_PROXY_ENDPOINT
+        reverseProxyEndpoint: env.REVERSE_PROXY_ENDPOINT,
       });
 
       await apimClient.sendToAll("hello", { contentType: "text/plain", onResponse });
@@ -111,7 +111,7 @@ describe("HubClient", function() {
     it("can send messages to a user", async () => {
       await client.sendToUser("brian", "hello", {
         contentType: "text/plain",
-        onResponse
+        onResponse,
       });
       assert.equal(lastResponse?.status, 202);
 
@@ -144,7 +144,7 @@ describe("HubClient", function() {
       assert.equal(lastResponse?.status, 200);
     });
 
-    it("can check if a connection exists", async function() {
+    it("can check if a connection exists", async function () {
       // likely bug in recorder for this test - recording not generating properly
       if (!isLiveMode()) this.skip();
       const res = await client.connectionExists("xxx");
@@ -162,7 +162,7 @@ describe("HubClient", function() {
       assert.equal(error.statusCode, 404);
     });
 
-    it("can revoke permissions from connections", async function() {
+    it("can revoke permissions from connections", async function () {
       // likely bug in recorder for this test - recording not generating properly
       if (!isLiveMode()) this.skip();
       let error;
@@ -178,7 +178,7 @@ describe("HubClient", function() {
     // service API doesn't work yet.
     it.skip("can generate client tokens", async () => {
       await client.getClientAccessToken({
-        userId: "brian"
+        userId: "brian",
       });
     });
   });

--- a/sdk/web-pubsub/web-pubsub/test/integration.spec.ts
+++ b/sdk/web-pubsub/web-pubsub/test/integration.spec.ts
@@ -23,7 +23,7 @@ function defer<T>(): {
   return {
     promise,
     resolve: actualResolve!,
-    reject: actualReject!
+    reject: actualReject!,
   };
 }
 
@@ -69,8 +69,8 @@ function getEndSignal(): Uint8Array {
   return payload;
 }
 
-describe("ServiceClient to manage the connected WebSocket connections", function() {
-  it("Simple clients can receive expected messages with different content types", async function(this: Context) {
+describe("ServiceClient to manage the connected WebSocket connections", function () {
+  it("Simple clients can receive expected messages with different content types", async function (this: Context) {
     if (!isLiveMode()) this.skip();
     const hub = "SimpleClientCanReceiveMessage";
 
@@ -109,7 +109,7 @@ describe("ServiceClient to manage the connected WebSocket connections", function
     assert.equal(messages[1].dataAsString, "Hi there!");
   });
 
-  it("Subprotocol clients can receive expected messages with different content types", async function(this: Context) {
+  it("Subprotocol clients can receive expected messages with different content types", async function (this: Context) {
     if (!isLiveMode()) this.skip();
     const hub = "PubSubClientCanReceiveMessage";
     const messages: PubSubWebSocketFrame[] = [];

--- a/sdk/web-pubsub/web-pubsub/test/testEnv.ts
+++ b/sdk/web-pubsub/web-pubsub/test/testEnv.ts
@@ -10,10 +10,10 @@ const environmentSetup: RecorderEnvironmentSetup = {
     REVERSE_PROXY_ENDPOINT: "https://rp-endpoint",
     AZURE_CLIENT_ID: "azure_client_id",
     AZURE_CLIENT_SECRET: "azure_client_secret",
-    AZURE_TENANT_ID: "azuretenantid"
+    AZURE_TENANT_ID: "azuretenantid",
   },
   customizationsOnRecordings: [],
-  queryParametersToSkip: []
+  queryParametersToSkip: [],
 };
 
 export default environmentSetup;


### PR DESCRIPTION
Solves: https://github.com/Azure/azure-sdk-for-js/issues/9329 for packages under:
- `sdk/remoterendering`.
- `sdk/schemaregistry`
- `sdk/web-pubsub`
 
Updated `prettier` dev-dependency version to latest `2.5.1`.
Files were re-formatted as well. There are only format changes in this PR, no manual changes except for package.json files.
 
Main format changes with Prettier 2.x in this PR include:
- Trailing commas by default.
- Whitespace added after every `function` keyword.
