### PR TITLE
[ServiceBus][Test] Fix Min-Max test build failure

### DIFF
--- a/sdk/eventhub/event-hubs/package.json
+++ b/sdk/eventhub/event-hubs/package.json
@@ -139,7 +139,7 @@
     "@types/chai-as-promised": "^7.1.0",
     "@types/chai-string": "^1.4.1",
     "@types/debug": "^4.1.4",
-    "@types/long": "^4.0.0",
+    "@types/long": "^4.0.1",
     "@types/mocha": "^7.0.2",
     "@types/node": "^12.0.0",
     "@types/sinon": "^9.0.4",

--- a/sdk/servicebus/service-bus/package.json
+++ b/sdk/servicebus/service-bus/package.json
@@ -114,7 +114,7 @@
     "@azure/core-auth": "^1.3.0",
     "@azure/logger": "^1.0.0",
     "@types/is-buffer": "^2.0.0",
-    "@types/long": "^4.0.0",
+    "@types/long": "^4.0.1",
     "buffer": "^6.0.0",
     "is-buffer": "^2.0.3",
     "jssha": "^3.1.0",


### PR DESCRIPTION
With `@types/long` min version of `4.0.0` we got compilation error

```
Namespace 'Long' has no exported member 'Long'.
```

version `4.0.1` fixes this.