### PR TITLE
[core-rest-pipeline] Fix build error after upgrading @types/node 

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -1836,8 +1836,8 @@ packages:
     resolution: {integrity: sha512-yxDeaQIAJlMav7fH5AQqPH1u8YIuhYJXYBzxaQ4PifsU0GDO38MSdmEDeRlIxrKbC6NbEaaEHDanWb+y30U8SQ==}
     dev: false
 
-  /@types/node/12.20.37:
-    resolution: {integrity: sha512-i1KGxqcvJaLQali+WuypQnXwcplhtNtjs66eNsZpp2P2FL/trJJxx/VWsM0YCL2iMoIJrbXje48lvIQAQ4p2ZA==}
+  /@types/node/12.20.40:
+    resolution: {integrity: sha512-RX6hFa0hxkFuktu5629zJEkWK5e0HreW4vpNSLn4nWkOui7CTGCjtKiKpvtZ4QwCZ2Am5uhrb5ULHKNyunYYqg==}
     dev: false
 
   /@types/node/17.0.1:
@@ -6992,7 +6992,7 @@ packages:
       '@tsconfig/node12': 1.0.9
       '@tsconfig/node14': 1.0.1
       '@tsconfig/node16': 1.0.2
-      '@types/node': 12.20.37
+      '@types/node': 12.20.40
       acorn: 8.6.0
       acorn-walk: 8.2.0
       arg: 4.1.3
@@ -7022,7 +7022,7 @@ packages:
       '@tsconfig/node12': 1.0.9
       '@tsconfig/node14': 1.0.1
       '@tsconfig/node16': 1.0.2
-      '@types/node': 12.20.37
+      '@types/node': 12.20.40
       acorn: 8.6.0
       acorn-walk: 8.2.0
       arg: 4.1.3
@@ -7603,7 +7603,7 @@ packages:
       '@microsoft/api-extractor': 7.19.2
       '@types/chai': 4.3.0
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.37
+      '@types/node': 12.20.40
       chai: 4.3.4
       cross-env: 7.0.3
       downlevel-dts: 0.4.0
@@ -7647,7 +7647,7 @@ packages:
       '@microsoft/api-extractor': 7.19.2
       '@types/chai': 4.3.0
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.37
+      '@types/node': 12.20.40
       chai: 4.3.4
       cross-env: 7.0.3
       dotenv: 8.6.0
@@ -7692,7 +7692,7 @@ packages:
       '@microsoft/api-extractor': 7.19.2
       '@types/chai': 4.3.0
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.37
+      '@types/node': 12.20.40
       chai: 4.3.4
       cross-env: 7.0.3
       csv-parse: 5.0.3
@@ -7735,7 +7735,7 @@ packages:
       '@microsoft/api-extractor': 7.19.2
       '@types/chai': 4.3.0
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.37
+      '@types/node': 12.20.40
       chai: 4.3.4
       cross-env: 7.0.3
       dotenv: 8.6.0
@@ -7779,7 +7779,7 @@ packages:
       '@microsoft/api-extractor': 7.19.2
       '@types/chai': 4.3.0
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.37
+      '@types/node': 12.20.40
       '@types/sinon': 9.0.11
       chai: 4.3.4
       chai-as-promised: 7.1.1_chai@4.3.4
@@ -7825,7 +7825,7 @@ packages:
       '@microsoft/api-extractor': 7.19.2
       '@types/chai': 4.3.0
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.37
+      '@types/node': 12.20.40
       '@types/sinon': 9.0.11
       chai: 4.3.4
       chai-as-promised: 7.1.1_chai@4.3.4
@@ -7875,7 +7875,7 @@ packages:
       '@types/chai': 4.3.0
       '@types/chai-as-promised': 7.1.4
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.37
+      '@types/node': 12.20.40
       '@types/sinon': 9.0.11
       chai: 4.3.4
       chai-as-promised: 7.1.1_chai@4.3.4
@@ -7932,7 +7932,7 @@ packages:
       '@rollup/plugin-replace': 2.4.2_rollup@1.32.1
       '@types/chai': 4.3.0
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.37
+      '@types/node': 12.20.40
       '@types/sinon': 9.0.11
       chai: 4.3.4
       cross-env: 7.0.3
@@ -9408,7 +9408,7 @@ packages:
       '@types/chai': 4.3.0
       '@types/chai-as-promised': 7.1.4
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.37
+      '@types/node': 12.20.40
       buffer: 6.0.3
       chai: 4.3.4
       chai-as-promised: 7.1.1_chai@4.3.4
@@ -9470,7 +9470,7 @@ packages:
       '@rollup/plugin-replace': 2.4.2_rollup@1.32.1
       '@types/chai': 4.3.0
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.37
+      '@types/node': 12.20.40
       '@types/sinon': 9.0.11
       '@types/uuid': 8.3.3
       chai: 4.3.4
@@ -9530,7 +9530,7 @@ packages:
       '@types/chai-as-promised': 7.1.4
       '@types/jwt-decode': 2.2.1
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.37
+      '@types/node': 12.20.40
       '@types/sinon': 9.0.11
       chai: 4.3.4
       chai-as-promised: 7.1.1_chai@4.3.4
@@ -9584,7 +9584,7 @@ packages:
       '@rollup/plugin-replace': 2.4.2_rollup@1.32.1
       '@types/chai': 4.3.0
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.37
+      '@types/node': 12.20.40
       '@types/sinon': 9.0.11
       chai: 4.3.4
       cross-env: 7.0.3
@@ -9640,7 +9640,7 @@ packages:
       '@rollup/plugin-replace': 2.4.2_rollup@1.32.1
       '@types/chai': 4.3.0
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.37
+      '@types/node': 12.20.40
       '@types/sinon': 9.0.11
       chai: 4.3.4
       cross-env: 7.0.3
@@ -9695,7 +9695,7 @@ packages:
       '@rollup/plugin-replace': 2.4.2_rollup@1.32.1
       '@types/chai': 4.3.0
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.37
+      '@types/node': 12.20.40
       '@types/sinon': 9.0.11
       chai: 4.3.4
       cross-env: 7.0.3
@@ -9750,7 +9750,7 @@ packages:
       '@rollup/plugin-replace': 2.4.2_rollup@1.32.1
       '@types/chai': 4.3.0
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.37
+      '@types/node': 12.20.40
       '@types/sinon': 9.0.11
       chai: 4.3.4
       cross-env: 7.0.3
@@ -9805,7 +9805,7 @@ packages:
       '@rollup/plugin-replace': 2.4.2_rollup@1.32.1
       '@types/chai': 4.3.0
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.37
+      '@types/node': 12.20.40
       '@types/sinon': 9.0.11
       chai: 4.3.4
       cross-env: 7.0.3
@@ -9854,7 +9854,7 @@ packages:
       '@microsoft/api-extractor': 7.19.2
       '@types/chai': 4.3.0
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.37
+      '@types/node': 12.20.40
       chai: 4.3.4
       cross-env: 7.0.3
       dotenv: 8.6.0
@@ -9899,7 +9899,7 @@ packages:
       '@types/chai': 4.3.0
       '@types/chai-as-promised': 7.1.4
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.37
+      '@types/node': 12.20.40
       chai: 4.3.4
       chai-as-promised: 7.1.1_chai@4.3.4
       cross-env: 7.0.3
@@ -9950,7 +9950,7 @@ packages:
       '@types/chai': 4.3.0
       '@types/debug': 4.1.7
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.37
+      '@types/node': 12.20.40
       '@types/sinon': 9.0.11
       '@types/ws': 7.4.7
       buffer: 6.0.3
@@ -9998,7 +9998,7 @@ packages:
     name: '@rush-temp/core-asynciterator-polyfill'
     version: 0.0.0
     dependencies:
-      '@types/node': 12.20.37
+      '@types/node': 12.20.40
       eslint: 7.32.0
       prettier: 2.5.1
       typescript: 4.2.4
@@ -10014,7 +10014,7 @@ packages:
       '@microsoft/api-extractor': 7.19.2
       '@types/chai': 4.3.0
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.37
+      '@types/node': 12.20.40
       chai: 4.3.4
       cross-env: 7.0.3
       downlevel-dts: 0.4.0
@@ -10041,7 +10041,7 @@ packages:
       '@microsoft/api-extractor': 7.19.2
       '@types/chai': 4.3.0
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.37
+      '@types/node': 12.20.40
       '@types/sinon': 9.0.11
       chai: 4.3.4
       cross-env: 7.0.3
@@ -10087,7 +10087,7 @@ packages:
       '@microsoft/api-extractor': 7.19.2
       '@types/chai': 4.3.0
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.37
+      '@types/node': 12.20.40
       chai: 4.3.4
       cross-env: 7.0.3
       eslint: 7.32.0
@@ -10128,7 +10128,7 @@ packages:
       '@microsoft/api-extractor': 7.19.2
       '@types/chai': 4.3.0
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.37
+      '@types/node': 12.20.40
       chai: 4.3.4
       cross-env: 7.0.3
       eslint: 7.32.0
@@ -10168,7 +10168,7 @@ packages:
       '@microsoft/api-extractor': 7.19.2
       '@types/chai': 4.3.0
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.37
+      '@types/node': 12.20.40
       '@types/sinon': 9.0.11
       chai: 4.3.4
       cross-env: 7.0.3
@@ -10212,7 +10212,7 @@ packages:
       '@rollup/plugin-replace': 2.4.2_rollup@1.32.1
       '@types/chai': 4.3.0
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.37
+      '@types/node': 12.20.40
       '@types/sinon': 9.0.11
       chai: 4.3.4
       cross-env: 7.0.3
@@ -10258,7 +10258,7 @@ packages:
       '@types/express': 4.17.13
       '@types/glob': 7.2.0
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.37
+      '@types/node': 12.20.40
       '@types/node-fetch': 2.5.12
       '@types/sinon': 9.0.11
       '@types/tough-cookie': 4.0.1
@@ -10322,7 +10322,7 @@ packages:
       '@microsoft/api-extractor': 7.19.2
       '@types/chai': 4.3.0
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.37
+      '@types/node': 12.20.40
       chai: 4.3.4
       cross-env: 7.0.3
       eslint: 7.32.0
@@ -10365,7 +10365,7 @@ packages:
       '@microsoft/api-extractor': 7.19.2
       '@types/chai': 4.3.0
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.37
+      '@types/node': 12.20.40
       chai: 4.3.4
       downlevel-dts: 0.4.0
       eslint: 7.32.0
@@ -10404,7 +10404,7 @@ packages:
       '@opentelemetry/api': 1.0.3
       '@types/chai': 4.3.0
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.37
+      '@types/node': 12.20.40
       '@types/sinon': 9.0.11
       '@types/uuid': 8.3.3
       chai: 4.3.4
@@ -10454,7 +10454,7 @@ packages:
       '@opentelemetry/tracing': 0.22.0_@opentelemetry+api@1.0.3
       '@types/chai': 4.3.0
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.37
+      '@types/node': 12.20.40
       '@types/sinon': 9.0.11
       chai: 4.3.4
       cross-env: 7.0.3
@@ -10495,7 +10495,7 @@ packages:
       '@microsoft/api-extractor': 7.19.2
       '@types/chai': 4.3.0
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.37
+      '@types/node': 12.20.40
       '@types/sinon': 9.0.11
       chai: 4.3.4
       cross-env: 7.0.3
@@ -10537,7 +10537,7 @@ packages:
       '@microsoft/api-extractor': 7.19.2
       '@types/chai': 4.3.0
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.37
+      '@types/node': 12.20.40
       '@types/sinon': 9.0.11
       '@types/xml2js': 0.4.9
       chai: 4.3.4
@@ -10583,7 +10583,7 @@ packages:
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
       '@types/debug': 4.1.7
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.37
+      '@types/node': 12.20.40
       '@types/priorityqueuejs': 1.0.1
       '@types/semaphore': 1.1.1
       '@types/sinon': 9.0.11
@@ -10637,7 +10637,7 @@ packages:
       '@rollup/plugin-replace': 2.4.2_rollup@1.32.1
       '@types/chai': 4.3.0
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.37
+      '@types/node': 12.20.40
       '@types/sinon': 9.0.11
       '@types/uuid': 8.3.3
       chai: 4.3.4
@@ -10697,7 +10697,7 @@ packages:
       '@types/fs-extra': 8.1.2
       '@types/minimist': 1.2.2
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.37
+      '@types/node': 12.20.40
       '@types/prettier': 2.4.2
       builtin-modules: 3.2.0
       chai: 4.3.4
@@ -10733,7 +10733,7 @@ packages:
       '@microsoft/api-extractor': 7.19.2
       '@types/chai': 4.3.0
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.37
+      '@types/node': 12.20.40
       '@types/sinon': 9.0.11
       '@types/uuid': 8.3.3
       chai: 4.3.4
@@ -10783,7 +10783,7 @@ packages:
       '@types/glob': 7.2.0
       '@types/json-schema': 7.0.9
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.37
+      '@types/node': 12.20.40
       '@typescript-eslint/eslint-plugin': 4.19.0_359354e87b989469ccdce12bde18eddc
       '@typescript-eslint/experimental-utils': 4.19.0_eslint@7.32.0+typescript@4.2.4
       '@typescript-eslint/parser': 4.19.0_eslint@7.32.0+typescript@4.2.4
@@ -10828,7 +10828,7 @@ packages:
       '@types/debug': 4.1.7
       '@types/long': 4.0.1
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.37
+      '@types/node': 12.20.40
       '@types/sinon': 9.0.11
       '@types/uuid': 8.3.3
       '@types/ws': 7.4.7
@@ -10900,7 +10900,7 @@ packages:
       '@types/chai': 4.3.0
       '@types/chai-as-promised': 7.1.4
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.37
+      '@types/node': 12.20.40
       '@types/sinon': 9.0.11
       '@types/uuid': 8.3.3
       chai: 4.3.4
@@ -10959,7 +10959,7 @@ packages:
       '@types/chai-string': 1.4.2
       '@types/debug': 4.1.7
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.37
+      '@types/node': 12.20.40
       chai: 4.3.4
       chai-as-promised: 7.1.1_chai@4.3.4
       chai-string: 1.5.0_chai@4.3.4
@@ -11013,7 +11013,7 @@ packages:
       '@types/chai-string': 1.4.2
       '@types/debug': 4.1.7
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.37
+      '@types/node': 12.20.40
       chai: 4.3.4
       chai-as-promised: 7.1.1_chai@4.3.4
       chai-string: 1.5.0_chai@4.3.4
@@ -11063,7 +11063,7 @@ packages:
       '@microsoft/api-extractor': 7.19.2
       '@types/jws': 3.2.4
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.37
+      '@types/node': 12.20.40
       '@types/qs': 6.9.7
       '@types/sinon': 9.0.11
       cross-env: 7.0.3
@@ -11096,7 +11096,7 @@ packages:
       '@microsoft/api-extractor': 7.19.2
       '@types/jws': 3.2.4
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.37
+      '@types/node': 12.20.40
       '@types/qs': 6.9.7
       '@types/sinon': 9.0.11
       '@types/uuid': 8.3.3
@@ -11135,7 +11135,7 @@ packages:
       '@types/chai': 4.3.0
       '@types/jws': 3.2.4
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.37
+      '@types/node': 12.20.40
       '@types/sinon': 9.0.11
       '@types/stoppable': 1.1.1
       '@types/uuid': 8.3.3
@@ -11182,7 +11182,7 @@ packages:
     dependencies:
       '@azure/core-tracing': 1.0.0-preview.13
       '@microsoft/api-extractor': 7.19.2
-      '@types/node': 12.20.37
+      '@types/node': 12.20.40
       '@types/uuid': 8.3.3
       cross-env: 7.0.3
       dotenv: 8.6.0
@@ -11214,7 +11214,7 @@ packages:
       '@rollup/plugin-replace': 2.4.2_rollup@1.32.1
       '@types/chai': 4.3.0
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.37
+      '@types/node': 12.20.40
       '@types/sinon': 9.0.11
       chai: 4.3.4
       cross-env: 7.0.3
@@ -11267,7 +11267,7 @@ packages:
       '@types/chai': 4.3.0
       '@types/chai-as-promised': 7.1.4
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.37
+      '@types/node': 12.20.40
       '@types/sinon': 9.0.11
       '@types/uuid': 8.3.3
       chai: 4.3.4
@@ -11306,7 +11306,7 @@ packages:
       '@rollup/plugin-replace': 2.4.2_rollup@1.32.1
       '@types/chai': 4.3.0
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.37
+      '@types/node': 12.20.40
       '@types/sinon': 9.0.11
       chai: 4.3.4
       cross-env: 7.0.3
@@ -11374,7 +11374,7 @@ packages:
       '@types/chai': 4.3.0
       '@types/chai-as-promised': 7.1.4
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.37
+      '@types/node': 12.20.40
       '@types/sinon': 9.0.11
       chai: 4.3.4
       chai-as-promised: 7.1.1_chai@4.3.4
@@ -11430,7 +11430,7 @@ packages:
       '@rollup/plugin-replace': 2.4.2_rollup@1.32.1
       '@types/chai': 4.3.0
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.37
+      '@types/node': 12.20.40
       '@types/sinon': 9.0.11
       chai: 4.3.4
       cross-env: 7.0.3
@@ -11481,7 +11481,7 @@ packages:
       '@microsoft/api-extractor': 7.19.2
       '@types/chai': 4.3.0
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.37
+      '@types/node': 12.20.40
       '@types/sinon': 9.0.11
       chai: 4.3.4
       cross-env: 7.0.3
@@ -11529,7 +11529,7 @@ packages:
       '@types/chai': 4.3.0
       '@types/chai-as-promised': 7.1.4
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.37
+      '@types/node': 12.20.40
       chai: 4.3.4
       chai-as-promised: 7.1.1_chai@4.3.4
       cross-env: 7.0.3
@@ -11575,7 +11575,7 @@ packages:
       '@types/chai': 4.3.0
       '@types/chai-as-promised': 7.1.4
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.37
+      '@types/node': 12.20.40
       '@types/uuid': 8.3.3
       chai: 4.3.4
       chai-as-promised: 7.1.1_chai@4.3.4
@@ -11617,7 +11617,7 @@ packages:
     name: '@rush-temp/mock-hub'
     version: 0.0.0
     dependencies:
-      '@types/node': 12.20.37
+      '@types/node': 12.20.40
       dotenv: 8.6.0
       eslint: 7.32.0
       prettier: 2.5.1
@@ -11644,7 +11644,7 @@ packages:
       '@opentelemetry/semantic-conventions': 0.24.0
       '@opentelemetry/tracing': 0.22.0_@opentelemetry+api@1.0.3
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.37
+      '@types/node': 12.20.40
       dotenv: 8.6.0
       eslint: 7.32.0
       eslint-plugin-node: 11.1.0_eslint@7.32.0
@@ -11679,7 +11679,7 @@ packages:
       '@types/chai': 4.3.0
       '@types/chai-as-promised': 7.1.4
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.37
+      '@types/node': 12.20.40
       chai: 4.3.4
       chai-as-promised: 7.1.1_chai@4.3.4
       cross-env: 7.0.3
@@ -11723,7 +11723,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/ai-form-recognizer': 3.1.0-beta.3
-      '@types/node': 12.20.37
+      '@types/node': 12.20.40
       dotenv: 8.6.0
       eslint: 7.32.0
       prettier: 2.5.1
@@ -11743,7 +11743,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/ai-metrics-advisor': 1.0.0-beta.3
-      '@types/node': 12.20.37
+      '@types/node': 12.20.40
       dotenv: 8.6.0
       eslint: 7.32.0
       prettier: 2.5.1
@@ -11763,7 +11763,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/ai-text-analytics': 5.1.0
-      '@types/node': 12.20.37
+      '@types/node': 12.20.40
       dotenv: 8.6.0
       eslint: 7.32.0
       prettier: 2.5.1
@@ -11782,7 +11782,7 @@ packages:
     name: '@rush-temp/perf-app-configuration'
     version: 0.0.0
     dependencies:
-      '@types/node': 12.20.37
+      '@types/node': 12.20.40
       '@types/uuid': 8.3.3
       dotenv: 8.6.0
       eslint: 7.32.0
@@ -11804,7 +11804,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/container-registry': 1.0.0-beta.4
-      '@types/node': 12.20.37
+      '@types/node': 12.20.40
       dotenv: 8.6.0
       eslint: 7.32.0
       prettier: 2.5.1
@@ -11821,7 +11821,7 @@ packages:
     name: '@rush-temp/perf-core-rest-pipeline'
     version: 0.0.0
     dependencies:
-      '@types/node': 12.20.37
+      '@types/node': 12.20.40
       '@types/uuid': 8.3.3
       dotenv: 8.6.0
       eslint: 7.32.0
@@ -11842,7 +11842,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/data-tables': 12.1.2
-      '@types/node': 12.20.37
+      '@types/node': 12.20.40
       '@types/uuid': 8.3.3
       dotenv: 8.6.0
       eslint: 7.32.0
@@ -11864,7 +11864,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/event-hubs': 5.6.0
-      '@types/node': 12.20.37
+      '@types/node': 12.20.40
       '@types/uuid': 8.3.3
       dotenv: 8.6.0
       eslint: 7.32.0
@@ -11886,7 +11886,7 @@ packages:
     name: '@rush-temp/perf-eventgrid'
     version: 0.0.0
     dependencies:
-      '@types/node': 12.20.37
+      '@types/node': 12.20.40
       dotenv: 8.6.0
       eslint: 7.32.0
       prettier: 1.19.1
@@ -11905,7 +11905,7 @@ packages:
     name: '@rush-temp/perf-identity'
     version: 0.0.0
     dependencies:
-      '@types/node': 12.20.37
+      '@types/node': 12.20.40
       '@types/uuid': 8.3.3
       dotenv: 8.6.0
       eslint: 7.32.0
@@ -11926,7 +11926,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/keyvault-certificates': 4.3.0
-      '@types/node': 12.20.37
+      '@types/node': 12.20.40
       '@types/uuid': 8.3.3
       dotenv: 8.6.0
       eslint: 7.32.0
@@ -11948,7 +11948,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/keyvault-keys': 4.3.0
-      '@types/node': 12.20.37
+      '@types/node': 12.20.40
       '@types/uuid': 8.3.3
       dotenv: 8.6.0
       eslint: 7.32.0
@@ -11969,7 +11969,7 @@ packages:
     name: '@rush-temp/perf-keyvault-secrets'
     version: 0.0.0
     dependencies:
-      '@types/node': 12.20.37
+      '@types/node': 12.20.40
       '@types/uuid': 8.3.3
       dotenv: 8.6.0
       eslint: 7.32.0
@@ -11990,7 +11990,7 @@ packages:
     name: '@rush-temp/perf-monitor-query'
     version: 0.0.0
     dependencies:
-      '@types/node': 12.20.37
+      '@types/node': 12.20.40
       dotenv: 8.6.0
       eslint: 7.32.0
       prettier: 1.19.1
@@ -12009,7 +12009,7 @@ packages:
     name: '@rush-temp/perf-search-documents'
     version: 0.0.0
     dependencies:
-      '@types/node': 12.20.37
+      '@types/node': 12.20.40
       dotenv: 8.6.0
       eslint: 7.32.0
       prettier: 1.19.1
@@ -12029,7 +12029,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/service-bus': 7.4.0
-      '@types/node': 12.20.37
+      '@types/node': 12.20.40
       '@types/uuid': 8.3.3
       dotenv: 8.6.0
       eslint: 7.32.0
@@ -12050,7 +12050,7 @@ packages:
     name: '@rush-temp/perf-storage-blob'
     version: 0.0.0
     dependencies:
-      '@types/node': 12.20.37
+      '@types/node': 12.20.40
       '@types/node-fetch': 2.5.12
       '@types/uuid': 8.3.3
       dotenv: 8.6.0
@@ -12073,7 +12073,7 @@ packages:
     name: '@rush-temp/perf-storage-file-datalake'
     version: 0.0.0
     dependencies:
-      '@types/node': 12.20.37
+      '@types/node': 12.20.40
       '@types/uuid': 8.3.3
       dotenv: 8.6.0
       eslint: 7.32.0
@@ -12094,7 +12094,7 @@ packages:
     name: '@rush-temp/perf-storage-file-share'
     version: 0.0.0
     dependencies:
-      '@types/node': 12.20.37
+      '@types/node': 12.20.40
       '@types/uuid': 8.3.3
       dotenv: 8.6.0
       eslint: 7.32.0
@@ -12115,7 +12115,7 @@ packages:
     name: '@rush-temp/perf-template'
     version: 0.0.0
     dependencies:
-      '@types/node': 12.20.37
+      '@types/node': 12.20.40
       '@types/uuid': 8.3.3
       dotenv: 8.6.0
       eslint: 7.32.0
@@ -12141,7 +12141,7 @@ packages:
       '@microsoft/api-extractor': 7.19.2
       '@types/chai': 4.3.0
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.37
+      '@types/node': 12.20.40
       chai: 4.3.4
       cross-env: 7.0.3
       dotenv: 8.6.0
@@ -12186,7 +12186,7 @@ packages:
       '@microsoft/api-extractor': 7.19.2
       '@types/chai': 4.3.0
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.37
+      '@types/node': 12.20.40
       chai: 4.3.4
       cross-env: 7.0.3
       dotenv: 8.6.0
@@ -12231,7 +12231,7 @@ packages:
       '@microsoft/api-extractor': 7.19.2
       '@types/chai': 4.3.0
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.37
+      '@types/node': 12.20.40
       chai: 4.3.4
       cross-env: 7.0.3
       dotenv: 8.6.0
@@ -12276,7 +12276,7 @@ packages:
       '@microsoft/api-extractor': 7.19.2
       '@types/chai': 4.3.0
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.37
+      '@types/node': 12.20.40
       chai: 4.3.4
       cross-env: 7.0.3
       dotenv: 8.6.0
@@ -12322,7 +12322,7 @@ packages:
       '@microsoft/api-extractor': 7.19.2
       '@types/chai': 4.3.0
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.37
+      '@types/node': 12.20.40
       '@types/sinon': 9.0.11
       chai: 4.3.4
       cross-env: 7.0.3
@@ -12372,7 +12372,7 @@ packages:
       '@types/chai': 4.3.0
       '@types/chai-as-promised': 7.1.4
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.37
+      '@types/node': 12.20.40
       avsc: 5.7.3
       buffer: 6.0.3
       chai: 4.3.4
@@ -12421,7 +12421,7 @@ packages:
       '@types/chai': 4.3.0
       '@types/chai-as-promised': 7.1.4
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.37
+      '@types/node': 12.20.40
       chai: 4.3.4
       chai-as-promised: 7.1.1_chai@4.3.4
       cross-env: 7.0.3
@@ -12465,7 +12465,7 @@ packages:
       '@microsoft/api-extractor': 7.19.2
       '@types/chai': 4.3.0
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.37
+      '@types/node': 12.20.40
       '@types/sinon': 9.0.11
       chai: 4.3.4
       cross-env: 7.0.3
@@ -12520,7 +12520,7 @@ packages:
       '@types/is-buffer': 2.0.0
       '@types/long': 4.0.1
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.37
+      '@types/node': 12.20.40
       '@types/sinon': 9.0.11
       '@types/ws': 7.4.7
       buffer: 6.0.3
@@ -12588,7 +12588,7 @@ packages:
       '@rollup/plugin-replace': 2.4.2_rollup@1.32.1
       '@types/chai': 4.3.0
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.37
+      '@types/node': 12.20.40
       '@types/sinon': 9.0.11
       chai: 4.3.4
       cross-env: 7.0.3
@@ -12652,7 +12652,7 @@ packages:
       '@rollup/plugin-replace': 2.4.2_rollup@1.32.1
       '@types/chai': 4.3.0
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.37
+      '@types/node': 12.20.40
       '@types/node-fetch': 2.5.12
       chai: 4.3.4
       cross-env: 7.0.3
@@ -12715,7 +12715,7 @@ packages:
       '@rollup/plugin-replace': 2.4.2_rollup@1.32.1
       '@types/chai': 4.3.0
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.37
+      '@types/node': 12.20.40
       chai: 4.3.4
       cross-env: 7.0.3
       dotenv: 8.6.0
@@ -12777,7 +12777,7 @@ packages:
       '@rollup/plugin-replace': 2.4.2_rollup@1.32.1
       '@types/chai': 4.3.0
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.37
+      '@types/node': 12.20.40
       chai: 4.3.4
       cross-env: 7.0.3
       dotenv: 8.6.0
@@ -12837,7 +12837,7 @@ packages:
       '@rollup/plugin-replace': 2.4.2_rollup@1.32.1
       '@types/chai': 4.3.0
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.37
+      '@types/node': 12.20.40
       chai: 4.3.4
       dotenv: 8.6.0
       downlevel-dts: 0.4.0
@@ -12896,7 +12896,7 @@ packages:
       '@rollup/plugin-replace': 2.4.2_rollup@1.32.1
       '@types/chai': 4.3.0
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.37
+      '@types/node': 12.20.40
       chai: 4.3.4
       cross-env: 7.0.3
       dotenv: 8.6.0
@@ -12953,7 +12953,7 @@ packages:
       '@types/chai': 4.3.0
       '@types/chai-as-promised': 7.1.4
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.37
+      '@types/node': 12.20.40
       '@types/sinon': 9.0.11
       chai: 4.3.4
       chai-as-promised: 7.1.1_chai@4.3.4
@@ -13006,7 +13006,7 @@ packages:
       '@types/chai': 4.3.0
       '@types/chai-as-promised': 7.1.4
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.37
+      '@types/node': 12.20.40
       '@types/sinon': 9.0.11
       '@types/uuid': 8.3.3
       chai: 4.3.4
@@ -13060,7 +13060,7 @@ packages:
       '@types/chai': 4.3.0
       '@types/chai-as-promised': 7.1.4
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.37
+      '@types/node': 12.20.40
       '@types/sinon': 9.0.11
       chai: 4.3.4
       chai-as-promised: 7.1.1_chai@4.3.4
@@ -13222,7 +13222,7 @@ packages:
       '@types/chai': 4.3.0
       '@types/chai-as-promised': 7.1.4
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.37
+      '@types/node': 12.20.40
       chai: 4.3.4
       chai-as-promised: 7.1.1_chai@4.3.4
       cross-env: 7.0.3
@@ -13265,7 +13265,7 @@ packages:
     name: '@rush-temp/test-credential'
     version: 0.0.0
     dependencies:
-      '@types/node': 12.20.37
+      '@types/node': 12.20.40
       eslint: 7.32.0
       prettier: 1.19.1
       rimraf: 3.0.2
@@ -13292,7 +13292,7 @@ packages:
       '@types/mock-fs': 4.13.1
       '@types/mock-require': 2.0.0
       '@types/nise': 1.4.0
-      '@types/node': 12.20.37
+      '@types/node': 12.20.40
       '@types/uuid': 8.3.3
       chai: 4.3.4
       concurrently: 6.5.1
@@ -13355,7 +13355,7 @@ packages:
       '@types/mock-fs': 4.13.1
       '@types/mock-require': 2.0.0
       '@types/nise': 1.4.0
-      '@types/node': 12.20.37
+      '@types/node': 12.20.40
       chai: 4.3.4
       dotenv: 8.6.0
       eslint: 7.32.0
@@ -13405,7 +13405,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@types/minimist': 1.2.2
-      '@types/node': 12.20.37
+      '@types/node': 12.20.40
       '@types/node-fetch': 2.5.12
       eslint: 7.32.0
       karma: 6.3.9
@@ -13436,7 +13436,7 @@ packages:
       '@opentelemetry/api': 1.0.3
       '@types/chai': 4.3.0
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.37
+      '@types/node': 12.20.40
       '@types/sinon': 9.0.11
       chai: 4.3.4
       chai-as-promised: 7.1.1_chai@4.3.4
@@ -13473,7 +13473,7 @@ packages:
       '@types/mock-fs': 4.13.1
       '@types/mock-require': 2.0.0
       '@types/nise': 1.4.0
-      '@types/node': 12.20.37
+      '@types/node': 12.20.40
       '@types/uuid': 8.3.3
       chai: 4.3.4
       dotenv: 8.6.0
@@ -13520,7 +13520,7 @@ packages:
       '@types/chai': 4.3.0
       '@types/chai-as-promised': 7.1.4
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.37
+      '@types/node': 12.20.40
       azure-iothub: 1.14.6
       chai: 4.3.4
       chai-as-promised: 7.1.1_chai@4.3.4
@@ -13567,7 +13567,7 @@ packages:
       '@types/express-serve-static-core': 4.17.26
       '@types/jsonwebtoken': 8.5.6
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.37
+      '@types/node': 12.20.40
       '@types/sinon': 9.0.11
       chai: 4.3.4
       cloudevents: 4.0.3
@@ -13616,7 +13616,7 @@ packages:
       '@types/chai': 4.3.0
       '@types/jsonwebtoken': 8.5.6
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.37
+      '@types/node': 12.20.40
       '@types/sinon': 9.0.11
       '@types/ws': 8.2.2
       chai: 4.3.4

--- a/sdk/core/core-rest-pipeline/test/node/nodeHttpClient.spec.ts
+++ b/sdk/core/core-rest-pipeline/test/node/nodeHttpClient.spec.ts
@@ -364,6 +364,7 @@ describe("NodeHttpClient", function () {
       setTimeout(() => {
         streamResponse.destroy(e);
       }, 0);
+      return clientRequest;
     };
     streamResponse.headers = {};
     streamResponse.statusCode = 200;


### PR DESCRIPTION
to v12.20.40.

This PR reacts to changes in `@types/node` where the return type of `destroy()`
has been updated to `this`.  See
DefinitelyTyped/DefinitelyTyped#57473 for details.