### PR TITLE
[storage,tables] Update `signedExpiry` to computed value

### DIFF
--- a/sdk/storage/test-resources.json
+++ b/sdk/storage/test-resources.json
@@ -64,7 +64,7 @@
       "signedPermission": "rwdlacup",
       "signedResourceTypes": "sco",
       "keyToSign": "key2",
-      "signedExpiry": "2022-01-01T23:59:00Z"
+      "signedExpiry": "[dateTimeAdd(parameters('baseTime'), 'PT2H')]"
     },
     "authorizationApiVersion": "2018-01-01-preview",
     "blobDataContributorRoleId": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/ba92f5b4-2d11-453d-a403-e96b0029c9fe')]",

--- a/sdk/storage/test-resources.json
+++ b/sdk/storage/test-resources.json
@@ -43,6 +43,10 @@
       "metadata": {
         "description": "Storage endpoint suffix. The default value uses Azure Public Cloud (core.windows.net)"
       }
+    },
+    "baseTime": {
+      "type": "string",
+      "defaultValue": "[utcNow('u')]"
     }
   },
   "variables": {

--- a/sdk/tables/test-resources.json
+++ b/sdk/tables/test-resources.json
@@ -27,6 +27,10 @@
       "metadata": {
         "description": "Storage endpoint suffix. The default value uses Azure Public Cloud (core.windows.net)"
       }
+    },
+    "baseTime": {
+      "type": "string",
+      "defaultValue": "[utcNow('u')]"
     }
   },
   "variables": {

--- a/sdk/tables/test-resources.json
+++ b/sdk/tables/test-resources.json
@@ -42,7 +42,7 @@
       "signedPermission": "rwdlacup",
       "signedResourceTypes": "sco",
       "keyToSign": "key2",
-      "signedExpiry": "2022-01-01T23:59:00Z"
+      "signedExpiry": "[dateTimeAdd(parameters('baseTime'), 'PT2H')]"
     }
   },
   "resources": [


### PR DESCRIPTION
instead of hard-coded one which has expired and failed test resource deployments