### PR TITLE
[eventgrid] fix distributed tracing enricher

### DIFF
--- a/sdk/eventgrid/eventgrid/src/eventGridClient.ts
+++ b/sdk/eventgrid/eventgrid/src/eventGridClient.ts
@@ -21,7 +21,7 @@ import { createSpan } from "./tracing";
 import { SpanStatusCode } from "@azure/core-tracing";
 import { v4 as uuidv4 } from "uuid";
 import { TokenCredential } from "@azure/core-auth";
-import { bearerTokenAuthenticationPolicy } from "@azure/core-rest-pipeline";
+import { bearerTokenAuthenticationPolicy, tracingPolicyName } from "@azure/core-rest-pipeline";
 
 /**
  * Options for the Event Grid Client.
@@ -116,7 +116,9 @@ export class EventGridPublisherClient<T extends InputSchema> {
       : eventGridCredentialPolicy(credential);
 
     this.client.pipeline.addPolicy(authPolicy);
-    this.client.pipeline.addPolicy(cloudEventDistributedTracingEnricherPolicy());
+    this.client.pipeline.addPolicy(cloudEventDistributedTracingEnricherPolicy(), {
+      afterPolicies: [tracingPolicyName]
+    });
     this.apiVersion = this.client.apiVersion;
   }
 


### PR DESCRIPTION
The cloud event distributed tracing enricher depends on `tracingPolicy` being
applied before it so it can copy the `traceparent` header that is added by
`tracingPolicy` to its event payload. However, it doesn't specify this
dependency and relies on the implicit policy ordering when request pipeline is
created. This happened to work because `tracingPolicy` was not in a phase, and
was added before `cloudEventDistributedTracingEnricherPolicy` which is not in a
phase either. But after refactoring done in PR #19078, `tracingPolicy` is moved
to be after the Retry phase, which comes after policies that are not in a phase.
Now the `traceparent` has not been set when
`cloudEventDistributedTracingEnricherPolicy` is applied. This is not the
expected behavior and caused test failure.

This change fixes the issue by explicitly requiring the
`cloudEventDistributedTracingEnricherPolicy` to be applied after the
`tracingPolicy`.