### PR TITLE
[tracing] - Address some of the feedback for tracing changes

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -11661,7 +11661,7 @@ packages:
     dev: false
 
   file:projects/instrumentation-opentelemetry.tgz:
-    resolution: {integrity: sha512-T6QnQ6wVHA0RRZpRcXtL38MmoMiOFnMpDj76Awdq+9t4ZTMGY0SnXmzCNA+f78ra67S9tWgcSOOXwNI+01OAlw==, tarball: file:projects/instrumentation-opentelemetry.tgz}
+    resolution: {integrity: sha512-iZBVU8W1QYUak36cZoLpUnK+LO8mbvKp335Ri10FarLvxEa1hFtksQ/dt/mzQrbtV/BchL3zIidePQSFvxp8xQ==, tarball: file:projects/instrumentation-opentelemetry.tgz}
     name: '@rush-temp/instrumentation-opentelemetry'
     version: 0.0.0
     dependencies:
@@ -11694,7 +11694,7 @@ packages:
       mocha: 7.2.0
       mocha-junit-reporter: 1.23.3_mocha@7.2.0
       nyc: 14.1.1
-      prettier: 1.19.1
+      prettier: 2.5.1
       rimraf: 3.0.2
       rollup: 1.32.1
       sinon: 12.0.1

--- a/sdk/core/core-tracing/review/core-tracing.api.md
+++ b/sdk/core/core-tracing/review/core-tracing.api.md
@@ -15,7 +15,7 @@ export interface Instrumenter {
         span: TracingSpan;
         tracingContext: TracingContext;
     };
-    withContext<CallbackArgs extends unknown[], Callback extends (...args: CallbackArgs) => ReturnType<Callback>>(context: TracingContext, callback: Callback, callbackThis?: ThisParameterType<Callback>, ...callbackArgs: CallbackArgs): ReturnType<Callback>;
+    withContext<CallbackArgs extends unknown[], Callback extends (...args: CallbackArgs) => ReturnType<Callback>>(context: TracingContext, callback: Callback, ...callbackArgs: CallbackArgs): ReturnType<Callback>;
 }
 
 // @public
@@ -46,13 +46,12 @@ export interface TracingClient {
         tracingOptions?: OperationTracingOptions;
     }>(name: string, operationOptions?: Options, spanOptions?: TracingSpanOptions): {
         span: TracingSpan;
-        tracingContext: TracingContext;
         updatedOptions: Options;
     };
-    withContext<CallbackArgs extends unknown[], Callback extends (...args: CallbackArgs) => ReturnType<Callback>>(context: TracingContext, callback: Callback, callbackThis?: ThisParameterType<Callback>, ...callbackArgs: CallbackArgs): ReturnType<Callback>;
+    withContext<CallbackArgs extends unknown[], Callback extends (...args: CallbackArgs) => ReturnType<Callback>>(context: TracingContext, callback: Callback, ...callbackArgs: CallbackArgs): ReturnType<Callback>;
     withSpan<Options extends {
         tracingOptions?: OperationTracingOptions;
-    }, Callback extends (updatedOptions: Options, span: Omit<TracingSpan, "end">) => ReturnType<Callback>>(name: string, operationOptions: Options, callback: Callback, spanOptions?: TracingSpanOptions, callbackThis?: ThisParameterType<Callback>): Promise<ReturnType<Callback>>;
+    }, Callback extends (updatedOptions: Options, span: Omit<TracingSpan, "end">) => ReturnType<Callback>>(name: string, operationOptions: Options, callback: Callback, spanOptions?: TracingSpanOptions): Promise<ReturnType<Callback>>;
 }
 
 // @public

--- a/sdk/core/core-tracing/src/index.ts
+++ b/sdk/core/core-tracing/src/index.ts
@@ -1,6 +1,19 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-export * from "./interfaces";
+export {
+  Instrumenter,
+  InstrumenterSpanOptions,
+  OperationTracingOptions,
+  SpanStatus,
+  TracingClient,
+  TracingClientOptions,
+  TracingContext,
+  TracingSpan,
+  TracingSpanContext,
+  TracingSpanKind,
+  TracingSpanLink,
+  TracingSpanOptions,
+} from "./interfaces";
 export { useInstrumenter } from "./instrumenter";
 export { createTracingClient } from "./tracingClient";

--- a/sdk/core/core-tracing/src/instrumenter.ts
+++ b/sdk/core/core-tracing/src/instrumenter.ts
@@ -58,10 +58,9 @@ export function createDefaultInstrumenter(): Instrumenter {
     >(
       _context: TracingContext,
       callback: Callback,
-      callbackThis?: ThisParameterType<Callback>,
       ...callbackArgs: CallbackArgs
     ): ReturnType<Callback> {
-      return callback.apply(callbackThis, callbackArgs);
+      return callback(...callbackArgs);
     },
   };
 }

--- a/sdk/core/core-tracing/src/interfaces.ts
+++ b/sdk/core/core-tracing/src/interfaces.ts
@@ -52,7 +52,7 @@ export interface TracingClient {
     name: string,
     operationOptions?: Options,
     spanOptions?: TracingSpanOptions
-  ): { span: TracingSpan; tracingContext: TracingContext; updatedOptions: Options };
+  ): { span: TracingSpan; updatedOptions: Options };
   /**
    * Wraps a callback with an active context and calls the callback.
    * Depending on the implementation, this may set the globally available active context.

--- a/sdk/core/core-tracing/src/interfaces.ts
+++ b/sdk/core/core-tracing/src/interfaces.ts
@@ -20,7 +20,6 @@ export interface TracingClient {
    * @param name - The name of the span. By convention this should be `${className}.${methodName}`.
    * @param operationOptions - The original options passed to the method. The callback will receive these options with the newly created {@link TracingContext}.
    * @param callback - The callback to be invoked with the updated options and newly created {@link TracingSpan}.
-   * @param callbackThis - An optional `this` parameter to bind the callback to.
    */
   withSpan<
     Options extends { tracingOptions?: OperationTracingOptions },
@@ -32,8 +31,7 @@ export interface TracingClient {
     name: string,
     operationOptions: Options,
     callback: Callback,
-    spanOptions?: TracingSpanOptions,
-    callbackThis?: ThisParameterType<Callback>
+    spanOptions?: TracingSpanOptions
   ): Promise<ReturnType<Callback>>;
   /**
    * Start a given span but does not set it as the active span.
@@ -61,7 +59,6 @@ export interface TracingClient {
    *
    * @param context - The {@link TracingContext} to use as the active context in the scope of the callback.
    * @param callback - The callback to be invoked with the given context set as the globally active context.
-   * @param callbackThis - An optional `this` parameter to bind the callback to.
    * @param callbackArgs - The callback arguments.
    */
   withContext<
@@ -70,7 +67,6 @@ export interface TracingClient {
   >(
     context: TracingContext,
     callback: Callback,
-    callbackThis?: ThisParameterType<Callback>,
     ...callbackArgs: CallbackArgs
   ): ReturnType<Callback>;
 
@@ -163,7 +159,6 @@ export interface Instrumenter {
    *
    * @param context - The {@link TracingContext} to use as the active context in the scope of the callback.
    * @param callback - The callback to be invoked with the given context set as the globally active context.
-   * @param callbackThis - An optional `this` parameter to bind the callback to.
    * @param callbackArgs - The callback arguments.
    */
   withContext<
@@ -172,7 +167,6 @@ export interface Instrumenter {
   >(
     context: TracingContext,
     callback: Callback,
-    callbackThis?: ThisParameterType<Callback>,
     ...callbackArgs: CallbackArgs
   ): ReturnType<Callback>;
 

--- a/sdk/core/core-tracing/src/tracingClient.ts
+++ b/sdk/core/core-tracing/src/tracingClient.ts
@@ -28,7 +28,6 @@ export function createTracingClient(options: TracingClientOptions): TracingClien
     spanOptions?: TracingSpanOptions
   ): {
     span: TracingSpan;
-    tracingContext: TracingContext;
     updatedOptions: Options;
   } {
     const startSpanResult = getInstrumenter().startSpan(name, {
@@ -51,7 +50,6 @@ export function createTracingClient(options: TracingClientOptions): TracingClien
     } as Options;
     return {
       span,
-      tracingContext: tracingContext,
       updatedOptions,
     };
   }
@@ -69,10 +67,10 @@ export function createTracingClient(options: TracingClientOptions): TracingClien
     spanOptions?: TracingSpanOptions,
     callbackThis?: ThisParameterType<Callback>
   ): Promise<ReturnType<Callback>> {
-    const { span, tracingContext, updatedOptions } = startSpan(name, operationOptions, spanOptions);
+    const { span, updatedOptions } = startSpan(name, operationOptions, spanOptions);
     try {
       const result = await withContext(
-        tracingContext,
+        updatedOptions.tracingOptions!.tracingContext!,
         () => Promise.resolve(callback(updatedOptions, span)),
         callbackThis
       );

--- a/sdk/core/core-tracing/src/tracingClient.ts
+++ b/sdk/core/core-tracing/src/tracingClient.ts
@@ -64,15 +64,12 @@ export function createTracingClient(options: TracingClientOptions): TracingClien
     name: string,
     operationOptions: Options,
     callback: Callback,
-    spanOptions?: TracingSpanOptions,
-    callbackThis?: ThisParameterType<Callback>
+    spanOptions?: TracingSpanOptions
   ): Promise<ReturnType<Callback>> {
     const { span, updatedOptions } = startSpan(name, operationOptions, spanOptions);
     try {
-      const result = await withContext(
-        updatedOptions.tracingOptions!.tracingContext!,
-        () => Promise.resolve(callback(updatedOptions, span)),
-        callbackThis
+      const result = await withContext(updatedOptions.tracingOptions!.tracingContext!, () =>
+        Promise.resolve(callback(updatedOptions, span))
       );
       span.setStatus({ status: "success" });
       return result;
@@ -90,10 +87,9 @@ export function createTracingClient(options: TracingClientOptions): TracingClien
   >(
     context: TracingContext,
     callback: Callback,
-    callbackThis?: ThisParameterType<Callback>,
     ...callbackArgs: CallbackArgs
   ): ReturnType<Callback> {
-    return getInstrumenter().withContext(context, callback, callbackThis, ...callbackArgs);
+    return getInstrumenter().withContext(context, callback, ...callbackArgs);
   }
 
   /**

--- a/sdk/core/core-tracing/src/tracingContext.ts
+++ b/sdk/core/core-tracing/src/tracingContext.ts
@@ -8,7 +8,7 @@ export const knownContextKeys = {
   Span: Symbol.for("@azure/core-tracing span"),
   Namespace: Symbol.for("@azure/core-tracing namespace"),
   Client: Symbol.for("@azure/core-tracing client"),
-  ParentContext: Symbol.for("@azure/core-tracing parent context")
+  ParentContext: Symbol.for("@azure/core-tracing parent context"),
 };
 
 /**

--- a/sdk/core/core-tracing/test/instrumenter.spec.ts
+++ b/sdk/core/core-tracing/test/instrumenter.spec.ts
@@ -2,7 +2,6 @@
 // Licensed under the MIT license.
 
 import { assert } from "chai";
-import { Context } from "mocha";
 import { Instrumenter, TracingSpan, TracingSpanContext } from "../src/interfaces";
 import {
   createDefaultInstrumenter,
@@ -46,19 +45,6 @@ describe("Instrumenter", () => {
         const expectedText = "expected";
         const result = instrumenter.withContext(createTracingContext(), () => expectedText);
         assert.equal(result, expectedText);
-      });
-
-      it("sets `this` correctly", function (this: Context) {
-        // eslint-disable-next-line @typescript-eslint/no-this-alias
-        const that = this;
-
-        instrumenter.withContext(
-          createTracingContext(),
-          function (this: Context) {
-            assert.strictEqual(this, that);
-          },
-          this
-        );
       });
     });
 

--- a/sdk/core/core-tracing/test/interfaces.spec.ts
+++ b/sdk/core/core-tracing/test/interfaces.spec.ts
@@ -10,10 +10,10 @@ describe("Interface compatibility", () => {
   describe("OperationTracingOptions", () => {
     it("is compatible with core-auth", () => {
       const tracingOptions: coreTracing.OperationTracingOptions = {
-        tracingContext: createTracingContext({})
+        tracingContext: createTracingContext({}),
       };
       const authOptions: coreAuth.GetTokenOptions = {
-        tracingOptions
+        tracingOptions,
       };
       assert.ok(authOptions.tracingOptions);
     });

--- a/sdk/core/core-tracing/test/tracingClient.spec.ts
+++ b/sdk/core/core-tracing/test/tracingClient.spec.ts
@@ -4,10 +4,14 @@
 import { assert } from "chai";
 import { Context } from "mocha";
 import sinon from "sinon";
-import { Instrumenter, TracingSpan, TracingContext, TracingClient } from "../src/interfaces";
-import { NoOpInstrumenter, NoOpSpan, useInstrumenter } from "../src/instrumenter";
-import { createTracingClient, TracingClientImpl } from "../src/tracingClient";
-import { knownContextKeys, createTracingContext } from "../src/tracingContext";
+import { Instrumenter, TracingClient, TracingContext, TracingSpan } from "../src/interfaces";
+import {
+  createDefaultInstrumenter,
+  createDefaultTracingSpan,
+  useInstrumenter,
+} from "../src/instrumenter";
+import { createTracingClient } from "../src/tracingClient";
+import { createTracingContext, knownContextKeys } from "../src/tracingContext";
 
 describe("TracingClient", () => {
   let instrumenter: Instrumenter;
@@ -17,15 +21,15 @@ describe("TracingClient", () => {
   const expectedNamespace = "Microsoft.Test";
 
   beforeEach(() => {
-    instrumenter = new NoOpInstrumenter();
-    span = new NoOpSpan();
+    instrumenter = createDefaultInstrumenter();
+    span = createDefaultTracingSpan();
     context = createTracingContext();
 
     useInstrumenter(instrumenter);
     client = createTracingClient({
       namespace: expectedNamespace,
       packageName: "test-package",
-      packageVersion: "1.0.0"
+      packageVersion: "1.0.0",
     });
   });
 
@@ -40,7 +44,7 @@ describe("TracingClient", () => {
       instrumenter.startSpan = () => {
         return {
           span,
-          tracingContext: context
+          tracingContext: context,
         };
       };
       const setAttributeSpy = sinon.spy(span, "setAttribute");
@@ -73,7 +77,7 @@ describe("TracingClient", () => {
     it("does not override existing namespace on context", () => {
       context = createTracingContext().setValue(knownContextKeys.Namespace, "Existing.Namespace");
       const { updatedOptions } = client.startSpan("test", {
-        tracingOptions: { tracingContext: context }
+        tracingOptions: { tracingContext: context },
       });
       assert.equal(
         updatedOptions.tracingOptions?.tracingContext?.getValue(knownContextKeys.Namespace),
@@ -96,7 +100,7 @@ describe("TracingClient", () => {
       instrumenter.startSpan = () => {
         return {
           span,
-          tracingContext: context
+          tracingContext: context,
         };
       };
       const setAttributeSpy = sinon.spy(span, "setAttribute");
@@ -111,7 +115,7 @@ describe("TracingClient", () => {
 
     it("passes options and span to callback", async () => {
       await client.withSpan(spanName, { foo: "foo", bar: "bar" } as any, (options, currentSpan) => {
-        assert.instanceOf(currentSpan, NoOpSpan);
+        assert.exists(currentSpan);
         assert.exists(options);
         assert.equal(options.foo, "foo");
         assert.equal(options.bar, "bar");
@@ -120,7 +124,7 @@ describe("TracingClient", () => {
     });
 
     it("promisifies synchronous functions", async () => {
-      const result = await (client as TracingClientImpl).withSpan(spanName, {}, () => {
+      const result = await client.withSpan(spanName, {}, () => {
         return 5;
       });
       assert.equal(result, 5);
@@ -140,8 +144,8 @@ describe("TracingClient", () => {
         spanName,
         {
           tracingOptions: {
-            tracingContext: parentContext
-          }
+            tracingContext: parentContext,
+          },
         },
         (updatedOptions) => {
           assert.strictEqual(updatedOptions.tracingOptions.tracingContext.getValue(key), value);
@@ -149,7 +153,7 @@ describe("TracingClient", () => {
       );
     });
 
-    it("sets `this` correctly", async function(this: Context) {
+    it("sets `this` correctly", async function (this: Context) {
       // eslint-disable-next-line @typescript-eslint/no-this-alias
       const that = this;
 
@@ -171,7 +175,7 @@ describe("TracingClient", () => {
         instrumenter.startSpan = () => {
           return {
             span,
-            tracingContext: context
+            tracingContext: context,
           };
         };
         const setStatusSpy = sinon.spy(span, "setStatus");
@@ -188,7 +192,7 @@ describe("TracingClient", () => {
         instrumenter.startSpan = () => {
           return {
             span,
-            tracingContext: context
+            tracingContext: context,
           };
         };
         const setStatusSpy = sinon.spy(span, "setStatus");

--- a/sdk/core/core-tracing/test/tracingClient.spec.ts
+++ b/sdk/core/core-tracing/test/tracingClient.spec.ts
@@ -2,7 +2,6 @@
 // Licensed under the MIT license.
 
 import { assert } from "chai";
-import { Context } from "mocha";
 import sinon from "sinon";
 import { Instrumenter, TracingClient, TracingContext, TracingSpan } from "../src/interfaces";
 import {
@@ -152,21 +151,6 @@ describe("TracingClient", () => {
         (updatedOptions) => {
           assert.strictEqual(updatedOptions.tracingOptions.tracingContext.getValue(key), value);
         }
-      );
-    });
-
-    it("sets `this` correctly", async function (this: Context) {
-      // eslint-disable-next-line @typescript-eslint/no-this-alias
-      const that = this;
-
-      await client.withSpan(
-        spanName,
-        {},
-        () => {
-          assert.strictEqual(this, that);
-        },
-        {},
-        this
       );
     });
 

--- a/sdk/core/core-tracing/test/tracingClient.spec.ts
+++ b/sdk/core/core-tracing/test/tracingClient.spec.ts
@@ -85,9 +85,11 @@ describe("TracingClient", () => {
       );
     });
 
-    it("returns the same context in options", () => {
-      const { updatedOptions, tracingContext } = client.startSpan("test");
-      assert.strictEqual(updatedOptions.tracingOptions!.tracingContext, tracingContext);
+    it("Returns tracingContext in updatedOptions", () => {
+      let { updatedOptions } = client.startSpan("test");
+      assert.exists(updatedOptions.tracingOptions?.tracingContext);
+      updatedOptions = client.startSpan("test", updatedOptions).updatedOptions;
+      assert.exists(updatedOptions.tracingOptions?.tracingContext);
     });
   });
 

--- a/sdk/core/core-tracing/test/tracingContext.spec.ts
+++ b/sdk/core/core-tracing/test/tracingContext.spec.ts
@@ -2,9 +2,9 @@
 // Licensed under the MIT license.
 
 import { assert } from "chai";
-import { NoOpSpan } from "../src/instrumenter";
+import { createDefaultTracingSpan } from "../src/instrumenter";
 import { createTracingClient } from "../src/tracingClient";
-import { TracingContextImpl, knownContextKeys, createTracingContext } from "../src/tracingContext";
+import { TracingContextImpl, createTracingContext, knownContextKeys } from "../src/tracingContext";
 
 describe("TracingContext", () => {
   describe("TracingContextImpl", () => {
@@ -97,12 +97,12 @@ describe("TracingContext", () => {
 
     it("can add known attributes", () => {
       const client = createTracingClient({ namespace: "test", packageName: "test" });
-      const span = new NoOpSpan();
+      const span = createDefaultTracingSpan();
       const namespace = "test-namespace";
       const newContext = createTracingContext({
         client,
         span,
-        namespace
+        namespace,
       });
       assert.strictEqual(newContext.getValue(knownContextKeys.Client), client);
       assert.strictEqual(newContext.getValue(knownContextKeys.Namespace), namespace);

--- a/sdk/instrumentation/instrumentation-opentelemetry/karma.conf.js
+++ b/sdk/instrumentation/instrumentation-opentelemetry/karma.conf.js
@@ -8,10 +8,10 @@ const {
   jsonRecordingFilterFunction,
   isPlaybackMode,
   isSoftRecordMode,
-  isRecordMode
+  isRecordMode,
 } = require("@azure-tools/test-recorder");
 
-module.exports = function(config) {
+module.exports = function (config) {
   config.set({
     // base path that will be used to resolve all patterns (eg. files, exclude)
     basePath: "./",
@@ -31,13 +31,13 @@ module.exports = function(config) {
       "karma-coverage",
       "karma-junit-reporter",
       "karma-json-to-file-reporter",
-      "karma-json-preprocessor"
+      "karma-json-preprocessor",
     ],
 
     // list of files / patterns to load in the browser
     files: [
       "dist-test/index.browser.js",
-      { pattern: "dist-test/index.browser.js.map", type: "html", included: false, served: true }
+      { pattern: "dist-test/index.browser.js.map", type: "html", included: false, served: true },
     ].concat(isPlaybackMode() || isSoftRecordMode() ? ["recordings/browsers/**/*.json"] : []),
 
     // list of files / patterns to exclude
@@ -47,7 +47,7 @@ module.exports = function(config) {
     // available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
     preprocessors: {
       "**/*.js": ["env"],
-      "recordings/browsers/**/*.json": ["json"]
+      "recordings/browsers/**/*.json": ["json"],
       // IMPORTANT: COMMENT following line if you want to debug in your browsers!!
       // Preprocess source file to calculate code coverage, however this will make source file unreadable
       //"dist-test/index.browser.js": ["coverage"]
@@ -63,7 +63,7 @@ module.exports = function(config) {
     coverageReporter: {
       // specify a common output directory
       dir: "coverage-browser/",
-      reporters: [{ type: "json", subdir: ".", file: "coverage.json" }]
+      reporters: [{ type: "json", subdir: ".", file: "coverage.json" }],
     },
 
     junitReporter: {
@@ -73,12 +73,12 @@ module.exports = function(config) {
       useBrowserName: false, // add browser name to report and classes names
       nameFormatter: undefined, // function (browser, result) to customize the name attribute in xml testcase element
       classNameFormatter: undefined, // function (browser, result) to customize the classname attribute in xml testcase element
-      properties: {} // key value pair of properties to add to the <properties> section of the report
+      properties: {}, // key value pair of properties to add to the <properties> section of the report
     },
 
     jsonToFileReporter: {
       filter: jsonRecordingFilterFunction,
-      outputPath: "."
+      outputPath: ".",
     },
 
     // web server port
@@ -100,8 +100,8 @@ module.exports = function(config) {
     customLaunchers: {
       ChromeHeadlessNoSandbox: {
         base: "ChromeHeadless",
-        flags: ["--no-sandbox", "--disable-web-security"]
-      }
+        flags: ["--no-sandbox", "--disable-web-security"],
+      },
     },
 
     // Continuous Integration mode
@@ -116,15 +116,15 @@ module.exports = function(config) {
     browserDisconnectTimeout: 10000,
     browserDisconnectTolerance: 3,
     browserConsoleLogOptions: {
-      terminal: !isRecordMode()
+      terminal: !isRecordMode(),
     },
 
     client: {
       mocha: {
         // change Karma's debug.html to the mocha web reporter
         reporter: "html",
-        timeout: "600000"
-      }
-    }
+        timeout: "600000",
+      },
+    },
   });
 };

--- a/sdk/instrumentation/instrumentation-opentelemetry/package.json
+++ b/sdk/instrumentation/instrumentation-opentelemetry/package.json
@@ -114,7 +114,7 @@
     "mocha": "^7.1.1",
     "mocha-junit-reporter": "^1.18.0",
     "nyc": "^14.0.0",
-    "prettier": "^1.16.4",
+    "prettier": "^2.5.1",
     "rimraf": "^3.0.0",
     "rollup": "^1.16.3",
     "sinon": "^12.0.1",

--- a/sdk/instrumentation/instrumentation-opentelemetry/src/instrumentation.browser.ts
+++ b/sdk/instrumentation/instrumentation-opentelemetry/src/instrumentation.browser.ts
@@ -4,7 +4,7 @@
 import {
   Instrumentation,
   InstrumentationBase,
-  InstrumentationConfig
+  InstrumentationConfig,
 } from "@opentelemetry/instrumentation";
 import { SDK_VERSION } from "./constants";
 import { useInstrumenter } from "@azure/core-tracing";

--- a/sdk/instrumentation/instrumentation-opentelemetry/src/instrumentation.ts
+++ b/sdk/instrumentation/instrumentation-opentelemetry/src/instrumentation.ts
@@ -6,9 +6,9 @@ import {
   InstrumentationBase,
   InstrumentationConfig,
   InstrumentationModuleDefinition,
-  InstrumentationNodeModuleDefinition
+  InstrumentationNodeModuleDefinition,
 } from "@opentelemetry/instrumentation";
-import type * as coreTracing from "@azure/core-tracing"
+import type * as coreTracing from "@azure/core-tracing";
 import { OpenTelemetryInstrumenter } from "./instrumenter";
 import { SDK_VERSION } from "./constants";
 
@@ -26,24 +26,25 @@ class AzureSDKInstrumentation extends InstrumentationBase {
   }
   /**
    * Entrypoint for the module registration.
-   * 
+   *
    * @returns The patched \@azure/core-tracing module after setting its instrumenter.
    */
   protected init():
     | void
     | InstrumentationModuleDefinition<typeof coreTracing>
     | InstrumentationModuleDefinition<typeof coreTracing>[] {
-    const result: InstrumentationModuleDefinition<typeof coreTracing> = new InstrumentationNodeModuleDefinition(
-      "@azure/core-tracing",
-      ["^1.0.0-preview.14", "^1.0.0"],
-      (moduleExports) => {
-        if (typeof moduleExports.useInstrumenter === "function") {
-          moduleExports.useInstrumenter(new OpenTelemetryInstrumenter());
-        }
+    const result: InstrumentationModuleDefinition<typeof coreTracing> =
+      new InstrumentationNodeModuleDefinition(
+        "@azure/core-tracing",
+        ["^1.0.0-preview.14", "^1.0.0"],
+        (moduleExports) => {
+          if (typeof moduleExports.useInstrumenter === "function") {
+            moduleExports.useInstrumenter(new OpenTelemetryInstrumenter());
+          }
 
-        return moduleExports;
-      }
-    );
+          return moduleExports;
+        }
+      );
     // Needed to support 1.0.0-preview.14
     result.includePrerelease = true;
     return result;
@@ -55,7 +56,7 @@ class AzureSDKInstrumentation extends InstrumentationBase {
  *
  * When registerd, any Azure data plane package will begin emitting tracing spans for internal calls
  * as well as network calls
- * 
+ *
  * Example usage:
  * ```ts
  * const openTelemetryInstrumentation = require("@opentelemetry/instrumentation");
@@ -69,6 +70,8 @@ class AzureSDKInstrumentation extends InstrumentationBase {
  * As OpenTelemetry instrumentations rely on patching required modules, you should register
  * this instrumentation as early as possible and before loading any Azure Client Libraries.
  */
-export function createAzureInstrumentation(options: AzureSDKInstrumentationOptions = {}): Instrumentation {
+export function createAzureInstrumentation(
+  options: AzureSDKInstrumentationOptions = {}
+): Instrumentation {
   return new AzureSDKInstrumentation(options);
 }

--- a/sdk/instrumentation/instrumentation-opentelemetry/src/instrumenter.ts
+++ b/sdk/instrumentation/instrumentation-opentelemetry/src/instrumenter.ts
@@ -41,10 +41,14 @@ export class OpenTelemetryInstrumenter implements Instrumenter {
   >(
     tracingContext: TracingContext,
     callback: Callback,
-    callbackThis?: ThisParameterType<Callback>,
     ...callbackArgs: CallbackArgs
   ): ReturnType<Callback> {
-    return context.with(tracingContext, callback, callbackThis, ...callbackArgs);
+    return context.with(
+      tracingContext,
+      callback,
+      /** Assume caller will bind `this` or use arrow functions */ undefined,
+      ...callbackArgs
+    );
   }
 
   parseTraceparentHeader(traceparentHeader: string): TracingSpanContext | undefined {

--- a/sdk/instrumentation/instrumentation-opentelemetry/src/instrumenter.ts
+++ b/sdk/instrumentation/instrumentation-opentelemetry/src/instrumenter.ts
@@ -6,7 +6,7 @@ import {
   InstrumenterSpanOptions,
   TracingContext,
   TracingSpan,
-  TracingSpanContext
+  TracingSpanContext,
 } from "@azure/core-tracing";
 
 import { trace, context } from "@opentelemetry/api";
@@ -16,7 +16,7 @@ import {
   toTracestateHeader,
   toTraceparentHeader,
   toSpanOptions,
-  fromTraceparentHeader
+  fromTraceparentHeader,
 } from "./transformations";
 
 export class OpenTelemetryInstrumenter implements Instrumenter {
@@ -32,7 +32,7 @@ export class OpenTelemetryInstrumenter implements Instrumenter {
 
     return {
       span: new OpenTelemetrySpanWrapper(span),
-      tracingContext: trace.setSpan(ctx, span)
+      tracingContext: trace.setSpan(ctx, span),
     };
   }
   withContext<

--- a/sdk/instrumentation/instrumentation-opentelemetry/src/transformations.ts
+++ b/sdk/instrumentation/instrumentation-opentelemetry/src/transformations.ts
@@ -5,7 +5,7 @@ import {
   InstrumenterSpanOptions,
   TracingSpanContext,
   TracingSpanKind,
-  TracingSpanLink
+  TracingSpanLink,
 } from "@azure/core-tracing";
 import {
   Link,
@@ -15,7 +15,7 @@ import {
   SpanKind,
   SpanOptions,
   TraceFlags,
-  TraceState
+  TraceState,
 } from "@opentelemetry/api";
 
 import { TRACEPARENT_HEADER_VERSION } from "./constants";
@@ -56,9 +56,9 @@ function toOpenTelemetryLinks(spanLinks: TracingSpanLink[] = []): Link[] {
     return {
       context: {
         ...tracingSpanLink.spanContext,
-        traceState: tracingSpanLink.spanContext.traceState as TraceState
+        traceState: tracingSpanLink.spanContext.traceState as TraceState,
       },
-      attributes: toOpenTelemetrySpanAttributes(tracingSpanLink.attributes)
+      attributes: toOpenTelemetrySpanAttributes(tracingSpanLink.attributes),
     };
   });
 }
@@ -98,7 +98,7 @@ export function toSpanOptions(spanOptions?: InstrumenterSpanOptions): SpanOption
   return {
     attributes,
     kind,
-    links
+    links,
   };
 }
 
@@ -156,7 +156,7 @@ export function fromTraceparentHeader(traceparentHeader: string): SpanContext | 
   const spanContext: SpanContext = {
     spanId,
     traceId,
-    traceFlags
+    traceFlags,
   };
 
   return spanContext;

--- a/sdk/instrumentation/instrumentation-opentelemetry/test/public/instrumenter.spec.ts
+++ b/sdk/instrumentation/instrumentation-opentelemetry/test/public/instrumenter.spec.ts
@@ -28,7 +28,7 @@ describe("OpenTelemetryInstrumenter", () => {
         assert.deepEqual(tracingSpanIdentifier, {
           traceId,
           spanId,
-          traceFlags: TraceFlags.SAMPLED
+          traceFlags: TraceFlags.SAMPLED,
         });
       });
 
@@ -67,13 +67,13 @@ describe("OpenTelemetryInstrumenter", () => {
         const spanContext: TracingSpanContext = {
           spanId: "2222222222222222",
           traceId: "11111111111111111111111111111111",
-          traceFlags: TraceFlags.SAMPLED
+          traceFlags: TraceFlags.SAMPLED,
         };
         const expectedTraceParentHeader = `00-11111111111111111111111111111111-2222222222222222-01`;
 
         const headers = instrumenter.createRequestHeaders(spanContext);
         assert.deepEqual(headers, {
-          traceparent: expectedTraceParentHeader
+          traceparent: expectedTraceParentHeader,
         });
       });
 
@@ -83,7 +83,7 @@ describe("OpenTelemetryInstrumenter", () => {
             spanId: "2222222222222222",
             traceId: "11111111111111111111111111111111",
             traceFlags: TraceFlags.NONE,
-            traceState: new TraceState()
+            traceState: new TraceState(),
           };
           spanContext.traceState = spanContext.traceState!.set("foo", "bar");
 
@@ -94,7 +94,7 @@ describe("OpenTelemetryInstrumenter", () => {
 
           assert.deepEqual(headers, {
             traceparent: expectedTraceParentHeader,
-            tracestate: expectedTraceStateHeader
+            tracestate: expectedTraceStateHeader,
           });
         });
       });
@@ -104,7 +104,7 @@ describe("OpenTelemetryInstrumenter", () => {
           const spanContext: SpanContext = {
             spanId: "2222222222222222",
             traceId: "11111111111111111111111111111111",
-            traceFlags: TraceFlags.NONE
+            traceFlags: TraceFlags.NONE,
           };
 
           const headers = instrumenter.createRequestHeaders(spanContext);
@@ -119,7 +119,7 @@ describe("OpenTelemetryInstrumenter", () => {
             spanId: "2222222222222222",
             traceId: "11111111111111111111111111111111",
             traceFlags: TraceFlags.NONE,
-            traceState: new TraceState()
+            traceState: new TraceState(),
           };
 
           const headers = instrumenter.createRequestHeaders(spanContext);
@@ -135,7 +135,7 @@ describe("OpenTelemetryInstrumenter", () => {
           spanId: "2222222222222222",
           traceId: "",
           traceFlags: TraceFlags.NONE,
-          traceState: new TraceState()
+          traceState: new TraceState(),
         };
 
         const headers = instrumenter.createRequestHeaders(spanContext);
@@ -148,7 +148,7 @@ describe("OpenTelemetryInstrumenter", () => {
           spanId: "",
           traceId: "11111111111111111111111111111111",
           traceFlags: TraceFlags.NONE,
-          traceState: new TraceState()
+          traceState: new TraceState(),
         };
 
         const headers = instrumenter.createRequestHeaders(spanContext);
@@ -162,7 +162,7 @@ describe("OpenTelemetryInstrumenter", () => {
             spanId: "",
             traceId: "11111111111111111111111111111111",
             traceFlags: TraceFlags.NONE,
-            traceState: new TraceState()
+            traceState: new TraceState(),
           };
           spanContext.traceState = spanContext.traceState!.set("foo", "bar");
 
@@ -211,7 +211,7 @@ describe("OpenTelemetryInstrumenter", () => {
 
         const { tracingContext } = instrumenter.startSpan("test", {
           tracingContext: currentContext,
-          packageName
+          packageName,
         });
 
         assert.equal(tracingContext.getValue(Symbol.for("foo")), "bar");
@@ -222,7 +222,7 @@ describe("OpenTelemetryInstrumenter", () => {
 
         const { span, tracingContext } = instrumenter.startSpan("test", {
           tracingContext: currentContext,
-          packageName
+          packageName,
         });
 
         assert.equal(trace.getSpan(tracingContext), unwrap(span));
@@ -241,7 +241,7 @@ describe("OpenTelemetryInstrumenter", () => {
       it("sets span on the context", () => {
         const { span, tracingContext } = instrumenter.startSpan("test", {
           packageName,
-          packageVersion
+          packageVersion,
         });
 
         assert.equal(trace.getSpan(tracingContext), unwrap(span));
@@ -252,12 +252,12 @@ describe("OpenTelemetryInstrumenter", () => {
       it("passes attributes to started span", () => {
         const spanAttributes = {
           attr1: "val1",
-          attr2: "val2"
+          attr2: "val2",
         };
         const { span } = instrumenter.startSpan("test", {
           spanAttributes,
           packageName,
-          packageVersion
+          packageVersion,
         });
 
         assert.deepEqual(unwrap(span).attributes, spanAttributes);
@@ -267,7 +267,7 @@ describe("OpenTelemetryInstrumenter", () => {
         it("maps spanKind correctly", () => {
           const { span } = instrumenter.startSpan("test", {
             packageName,
-            spanKind: "client"
+            spanKind: "client",
           });
           assert.equal(unwrap(span).kind, SpanKind.CLIENT);
         });
@@ -281,7 +281,7 @@ describe("OpenTelemetryInstrumenter", () => {
         it("defaults spanKind to INTERNAL if an invalid spanKind is provided", () => {
           const { span } = instrumenter.startSpan("test", {
             packageName,
-            spanKind: "foo" as TracingSpanKind
+            spanKind: "foo" as TracingSpanKind,
           });
           assert.equal(unwrap(span).kind, SpanKind.INTERNAL);
         });
@@ -295,10 +295,10 @@ describe("OpenTelemetryInstrumenter", () => {
             {
               spanContext: linkedSpan.spanContext,
               attributes: {
-                attr1: "value1"
-              }
-            }
-          ]
+                attr1: "value1",
+              },
+            },
+          ],
         });
 
         const links = unwrap(span).links;
@@ -306,19 +306,19 @@ describe("OpenTelemetryInstrumenter", () => {
 
         assert.deepEqual(links[0], {
           attributes: {
-            attr1: "value1"
+            attr1: "value1",
           },
           context: {
             ...linkedSpan.spanContext,
-            traceState: undefined
-          }
+            traceState: undefined,
+          },
         });
       });
     });
   });
 
   describe("#withContext", () => {
-    it("passes the correct arguments to OpenTelemetry", function(this: Context) {
+    it("passes the correct arguments to OpenTelemetry", function (this: Context) {
       const contextSpy = sinon.spy(context, "with");
       // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
       const callback = (arg1: number) => arg1 + 42;
@@ -329,17 +329,17 @@ describe("OpenTelemetryInstrumenter", () => {
       assert.isTrue(contextSpy.calledWith(activeContext, callback, undefined, callbackArg));
     });
 
-    it("works when caller binds `this`", function(this: Context) {
+    it("works when caller binds `this`", function (this: Context) {
       // a bit of a silly test but demonstrates how to bind `this` correctly
       // and ensures the behavior does not regress
 
       // Function syntax
-      instrumenter.withContext(context.active(), function(this: any) {
+      instrumenter.withContext(context.active(), function (this: any) {
         assert.isUndefined(this);
       });
       instrumenter.withContext(
         context.active(),
-        function(this: any) {
+        function (this: any) {
           assert.equal(this, 42);
         }.bind(42)
       );

--- a/sdk/instrumentation/instrumentation-opentelemetry/test/public/util/testSpan.ts
+++ b/sdk/instrumentation/instrumentation-opentelemetry/test/public/util/testSpan.ts
@@ -11,7 +11,7 @@ import {
   SpanStatusCode,
   SpanAttributeValue,
   Span,
-  Link
+  Link,
 } from "@opentelemetry/api";
 
 /**
@@ -91,7 +91,7 @@ export class TestSpan implements Span {
     this.startTime = startTime;
     this.parentSpanId = parentSpanId;
     this.status = {
-      code: SpanStatusCode.UNSET
+      code: SpanStatusCode.UNSET,
     };
     this.endCalled = false;
     this._context = context;

--- a/sdk/instrumentation/instrumentation-opentelemetry/test/public/util/testTracer.ts
+++ b/sdk/instrumentation/instrumentation-opentelemetry/test/public/util/testTracer.ts
@@ -10,7 +10,7 @@ import {
   Context,
   context,
   Tracer,
-  trace
+  trace,
 } from "@opentelemetry/api";
 
 /**
@@ -99,7 +99,7 @@ export class TestTracer implements Tracer {
       const spanId = span.spanContext().spanId;
       const node: SpanGraphNode = {
         name: span.name,
-        children: []
+        children: [],
       };
       nodeMap.set(spanId, node);
       if (span.parentSpanId) {
@@ -116,7 +116,7 @@ export class TestTracer implements Tracer {
     }
 
     return {
-      roots
+      roots,
     };
   }
 
@@ -141,7 +141,7 @@ export class TestTracer implements Tracer {
     const spanContext: SpanContext = {
       traceId,
       spanId: this.getNextSpanId(),
-      traceFlags: TraceFlags.NONE
+      traceFlags: TraceFlags.NONE,
     };
     const span = new TestSpan(
       this,

--- a/sdk/test-utils/test-utils/src/tracing/mockInstrumenter.ts
+++ b/sdk/test-utils/test-utils/src/tracing/mockInstrumenter.ts
@@ -68,11 +68,10 @@ export class MockInstrumenter implements Instrumenter {
   >(
     context: TracingContext,
     callback: Callback,
-    callbackThis?: ThisParameterType<Callback>,
     ...callbackArgs: CallbackArgs
   ): ReturnType<Callback> {
     this.contextStack.push(context);
-    return Promise.resolve(callback.call(callbackThis, ...callbackArgs)).finally(() => {
+    return Promise.resolve(callback(...callbackArgs)).finally(() => {
       this.contextStack.pop();
     }) as ReturnType<Callback>;
   }


### PR DESCRIPTION
## What

- Avoid classes in core-tracing as well as the usage of `this`
- Avoid returning the new context in two places, only return it as part of the updatedOptions
- Avoid `this` magic for callbacks and expect callers to handle `this` correctly
- Upgrade to prettier 2.0

## Why

- We should use factory functions where we can. We already do this, but by relying on closure instead of `this` we can avoid a lot of the pitfalls. I left instrumentation package alone for now, and focused on core-tracing
- Ideally there would be a single source of truth here. By returning tracingContext both separately _and_ as the updated options bag it's not clear that it is the same context
- `this` is easy to get wrong, and can be unreliable depending the type of function used. Instead of trying to apply it correctly, just call the function using the normal function invocation and expect callers to bind / use arrow functions if needed
- Finally, this is a good thing to do as we're upgrading prettier across the board

## TODO

In a separate PR I will address the following feedback:
- Naming conventions for @azure/instrumentation-opentelemetry package
- Make it obvious that tracingContext is immutable
- Explore mockist approach to testing
