### PR TITLE
[Text Analytics] Remove includes of esnext

### DIFF
--- a/sdk/textanalytics/ai-text-analytics/package.json
+++ b/sdk/textanalytics/ai-text-analytics/package.json
@@ -86,7 +86,6 @@
   "sideEffects": false,
   "autoPublish": false,
   "dependencies": {
-    "@azure/core-asynciterator-polyfill": "^1.0.0",
     "@azure/core-auth": "^1.3.0",
     "@azure/core-client": "^1.0.0",
     "@azure/core-rest-pipeline": "^1.1.0",

--- a/sdk/textanalytics/ai-text-analytics/src/dom.d.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/dom.d.ts
@@ -1,4 +1,0 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT license.
-
-/// <reference lib="dom" />

--- a/sdk/textanalytics/ai-text-analytics/src/index.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/index.ts
@@ -1,10 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-/// <reference lib="esnext.asynciterable" />
-
-import "@azure/core-asynciterator-polyfill";
-
 export { AzureKeyCredential } from "@azure/core-auth";
 
 export {

--- a/sdk/textanalytics/ai-text-analytics/test/public/utils/recordedClient.ts
+++ b/sdk/textanalytics/ai-text-analytics/test/public/utils/recordedClient.ts
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-/// <reference lib="esnext.asynciterable" />
-
 import { Context } from "mocha";
 
 import { env, Recorder, record, RecorderEnvironmentSetup } from "@azure-tools/test-recorder";


### PR DESCRIPTION
In before, esnext was needed to be imported because it has definitions for async iterators that @types/node@8 did not have. Now, we support NodeJS v12 and up which includes ES2019 that includes ES2018 that includes the async iterators stuff. Thanks @witemple-msft for pointing that out!

The PR also does the following:
- deletes `src/dom.d.ts`. I am not sure why it exists in the first place but it is not referenced anywhere.
- removes use of `@azure/core-asynciterator-polyfill`. It was needed for older versions of NodeJS that we no longer support.