### PR TITLE
Upgrade prettier dev-dependency to v2.5.1 in test-utils

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -13307,13 +13307,13 @@ packages:
     dev: false
 
   file:projects/test-credential.tgz:
-    resolution: {integrity: sha512-dIUQJVvw4Gnx1Osn8Vj7n6nqoGnnQ8KV+b6fkYsdyovvWHNiNFhWK/OQ266RL82kLTxYavEKp6QXQQciJ1XnZA==, tarball: file:projects/test-credential.tgz}
+    resolution: {integrity: sha512-iEnhmTWqjqTfunF2+GRxZMJ4OvO2ek3Y0Mb/RcroAYf1B+/FWfYl0k48jg+uby0+EBT5xVa3+SfANBVgQAlN/g==, tarball: file:projects/test-credential.tgz}
     name: '@rush-temp/test-credential'
     version: 0.0.0
     dependencies:
       '@types/node': 12.20.38
       eslint: 7.32.0
-      prettier: 1.19.1
+      prettier: 2.5.1
       rimraf: 3.0.2
       rollup: 1.32.1
       typescript: 4.2.4
@@ -13322,7 +13322,7 @@ packages:
     dev: false
 
   file:projects/test-recorder-new.tgz:
-    resolution: {integrity: sha512-xEdkJC5rMO2mmrosjw15rNWHcxhh5uXxCdZskU9147jLdrePtr1kmPV64xnZf6GLjTndCpq9tJydQdWwbtIQ4g==, tarball: file:projects/test-recorder-new.tgz}
+    resolution: {integrity: sha512-SaWOH6ubcTbybPLHGNUDpnpejqqcrxBF9x8qJWcH29LqMf9bq2zJaDTjqLnZR+ZFi4geKD99EafcGTYUXQzCEA==, tarball: file:projects/test-recorder-new.tgz}
     name: '@rush-temp/test-recorder-new'
     version: 0.0.0
     dependencies:
@@ -13365,7 +13365,7 @@ packages:
       mock-require: 3.0.3
       npm-run-all: 4.1.5
       nyc: 15.1.0
-      prettier: 1.19.1
+      prettier: 2.5.1
       rimraf: 3.0.2
       rollup: 1.32.1
       rollup-plugin-shim: 1.0.0
@@ -13385,7 +13385,7 @@ packages:
     dev: false
 
   file:projects/test-recorder.tgz:
-    resolution: {integrity: sha512-z/9s2WuTY21k9477HxunczqlV10RdF5LRqldQZ7NVU4QXeakJpyGbs55FV5fEABACHIyYzBU3IUvp+uKOxEnLA==, tarball: file:projects/test-recorder.tgz}
+    resolution: {integrity: sha512-YVTZKhc57wqPtdwdRvUNEeT7fWFV9Z8biRjF+DNywqCbCLC6QY/gIy7+Cb7Lw9B+MVCPDxqW4r0dU4aFd4rBjA==, tarball: file:projects/test-recorder.tgz}
     name: '@rush-temp/test-recorder'
     version: 0.0.0
     dependencies:
@@ -13428,7 +13428,7 @@ packages:
       nock: 12.0.3
       npm-run-all: 4.1.5
       nyc: 15.1.0
-      prettier: 1.19.1
+      prettier: 2.5.1
       rimraf: 3.0.2
       rollup: 1.32.1
       rollup-plugin-shim: 1.0.0
@@ -13446,7 +13446,7 @@ packages:
     dev: false
 
   file:projects/test-utils-perf.tgz:
-    resolution: {integrity: sha512-eO/XaNwlnKeTn9jy1A0SpJpAZ8rztxeZU7LKQzOR6rqho1XiZX/N6zsCkAYiOLfvxJnRSqBlDGclKFf6U68xQw==, tarball: file:projects/test-utils-perf.tgz}
+    resolution: {integrity: sha512-O62R8KYXtyRFfZxEkDFh0GoSOi7M9RpWp4Hr4a337ZNCw1xZh94T1xOrLuC8Lgx7glixJv3OTm/1hYvsAVuhRg==, tarball: file:projects/test-utils-perf.tgz}
     name: '@rush-temp/test-utils-perf'
     version: 0.0.0
     dependencies:
@@ -13460,7 +13460,7 @@ packages:
       karma-env-preprocessor: 0.1.1
       minimist: 1.2.5
       node-fetch: 2.6.6
-      prettier: 1.19.1
+      prettier: 2.5.1
       rimraf: 3.0.2
       ts-node: 8.10.2_typescript@4.2.4
       tslib: 2.3.1
@@ -13473,7 +13473,7 @@ packages:
     dev: false
 
   file:projects/test-utils.tgz:
-    resolution: {integrity: sha512-mNAkFGRCdahoUfUgUBHK/rXrhHNsoD91poUZvHUzfF4V5Gf5+FJSetlGsuoN0loxj1ZFSLY88FvRmMDpAGAYmw==, tarball: file:projects/test-utils.tgz}
+    resolution: {integrity: sha512-lRA7wxoXX7NWHc36e1+U8RH2RQmoZlFm50QXbLBRXqr+A8eIi8u5lphwOZchx6UzOpv1AatfESPoxcp5n7iyzA==, tarball: file:projects/test-utils.tgz}
     name: '@rush-temp/test-utils'
     version: 0.0.0
     dependencies:
@@ -13492,7 +13492,7 @@ packages:
       karma-coverage: 2.1.0
       karma-env-preprocessor: 0.1.1
       mocha: 7.2.0
-      prettier: 1.19.1
+      prettier: 2.5.1
       rimraf: 3.0.2
       rollup: 1.32.1
       sinon: 9.2.4
@@ -13506,7 +13506,7 @@ packages:
     dev: false
 
   file:projects/testing-recorder-new.tgz:
-    resolution: {integrity: sha512-mdXZ9tCySJwZPY1AEBWEe2U+al31WEkYxH1NEziqnPjUDTHhHobXZ7SLt6IzIirAKaB7TC4/N6YFv6PPJYjR1w==, tarball: file:projects/testing-recorder-new.tgz}
+    resolution: {integrity: sha512-05oLLpWqsXhCMszzTOhm+TeCAFXH70Qld5TTY6BdKQBuXU2c60RzuGJRJK4C87u+v3On/mdfTzth6YG/iJmLOQ==, tarball: file:projects/testing-recorder-new.tgz}
     name: '@rush-temp/testing-recorder-new'
     version: 0.0.0
     dependencies:
@@ -13543,7 +13543,7 @@ packages:
       mock-require: 3.0.3
       npm-run-all: 4.1.5
       nyc: 15.1.0
-      prettier: 1.19.1
+      prettier: 2.5.1
       rimraf: 3.0.2
       rollup: 1.32.1
       typescript: 4.2.4

--- a/sdk/test-utils/perf/karma.conf.js
+++ b/sdk/test-utils/perf/karma.conf.js
@@ -2,7 +2,7 @@
 process.env.CHROME_BIN = require("puppeteer").executablePath();
 require("dotenv").config({ path: "../.env" });
 
-module.exports = function(config) {
+module.exports = function (config) {
   config.set({
     // base path that will be used to resolve all patterns (eg. files, exclude)
     basePath: "./",
@@ -16,7 +16,7 @@ module.exports = function(config) {
     // list of files / patterns to load in the browser
     files: [
       "dist-test/index.browser.js",
-      { pattern: "dist-test/index.browser.js.map", type: "html", included: false, served: true }
+      { pattern: "dist-test/index.browser.js.map", type: "html", included: false, served: true },
     ],
 
     // list of files / patterns to exclude
@@ -25,7 +25,7 @@ module.exports = function(config) {
     // preprocess matching files before serving them to the browser
     // available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
     preprocessors: {
-      "**/*.js": ["sourcemap", "env"]
+      "**/*.js": ["sourcemap", "env"],
       // IMPORTANT: COMMENT following line if you want to debug in your browsers!!
       // Preprocess source file to calculate code coverage, however this will make source file unreadable
       //"dist-test/index.browser.js": ["coverage"]
@@ -58,8 +58,8 @@ module.exports = function(config) {
     customLaunchers: {
       ChromeHeadlessNoSandbox: {
         base: "ChromeHeadless",
-        flags: ["--no-sandbox", "--disable-web-security"]
-      }
+        flags: ["--no-sandbox", "--disable-web-security"],
+      },
     },
 
     // Continuous Integration mode
@@ -76,6 +76,6 @@ module.exports = function(config) {
     browserConsoleLogOptions: {
       // We would usually hide the logs from the tests, but we don't need to do this inside of the recorder package because we are not recording the tests.
       // // terminal: process.env.TEST_MODE !== "record"
-    }
+    },
   });
 };

--- a/sdk/test-utils/perf/package.json
+++ b/sdk/test-utils/perf/package.json
@@ -77,7 +77,7 @@
     "karma-chrome-launcher": "^3.0.0",
     "karma-coverage": "^2.0.0",
     "karma-env-preprocessor": "^0.1.1",
-    "prettier": "^1.16.4",
+    "prettier": "^2.5.1",
     "rimraf": "^3.0.0",
     "typescript": "~4.2.0",
     "ts-node": "^8.3.0"

--- a/sdk/test-utils/perf/src/batchPerfTest.ts
+++ b/sdk/test-utils/perf/src/batchPerfTest.ts
@@ -5,7 +5,7 @@ import { AbortSignalLike, AbortController } from "@azure/abort-controller";
 import {
   TestProxyHttpClient,
   TestProxyHttpClientV1,
-  testProxyHttpPolicy
+  testProxyHttpPolicy,
 } from "./testProxyHttpClient";
 import { HttpClient } from "@azure/core-http";
 import { Pipeline } from "@azure/core-rest-pipeline";
@@ -15,9 +15,9 @@ import { PerfParallel } from "./parallel";
 /**
  * Enables writing perf tests where the number of operations are dynamic for the method/call being tested.
  */
-export abstract class BatchPerfTest<TOptions = Record<string, unknown>> extends PerfTestBase<
-  TOptions
-> {
+export abstract class BatchPerfTest<
+  TOptions = Record<string, unknown>
+> extends PerfTestBase<TOptions> {
   private readonly testProxy!: string;
   public testProxyHttpClient!: TestProxyHttpClient;
   public testProxyHttpClientV1!: TestProxyHttpClientV1;

--- a/sdk/test-utils/perf/src/options.ts
+++ b/sdk/test-utils/perf/src/options.ts
@@ -85,51 +85,51 @@ export interface DefaultPerfOptions {
 export const defaultPerfOptions: PerfOptionDictionary<DefaultPerfOptions> = {
   help: {
     description: "Shows all of the available options",
-    shortName: "h"
+    shortName: "h",
   },
   parallel: {
     description: "How many of the same test to call at the same time",
     shortName: "p",
-    defaultValue: 1
+    defaultValue: 1,
   },
   duration: {
     description: "When to stop calling tests at all",
     shortName: "d",
-    defaultValue: 10
+    defaultValue: 10,
   },
   warmup: {
     description: "Duration of warmup in seconds",
     shortName: "w",
-    defaultValue: 5
+    defaultValue: 5,
   },
   iterations: {
     description: "Times to repeat the whole process, after warmup",
     shortName: "i",
-    defaultValue: 1
+    defaultValue: 1,
   },
   "no-cleanup": {
-    description: "Disables test cleanup"
+    description: "Disables test cleanup",
   },
   "test-proxies": {
     description: "URIs of TestProxy servers (separated by ';')",
-    defaultValue: undefined
+    defaultValue: undefined,
   },
   insecure: {
     description:
       "Applied when test-proxies option is defined, connects with https(insecurely by disabling SSL validation)",
     shortName: "ins",
-    defaultValue: false
+    defaultValue: false,
   },
   "milliseconds-to-log": {
     description: "Log frequency in milliseconds",
     shortName: "mtl",
-    defaultValue: 1000
+    defaultValue: 1000,
   },
   "list-transitive-dependencies": {
     description: "List all dependencies, instead of only direct ones, before test run",
     shortName: "ltd",
-    defaultValue: false
-  }
+    defaultValue: false,
+  },
 };
 
 /**
@@ -173,7 +173,7 @@ export function parsePerfOption<TOptions>(
     result[optionName as keyof TOptions] = {
       ...option,
       longName,
-      value
+      value,
     };
   }
 
@@ -211,7 +211,7 @@ export function validateOptions<TOptions>(options: PerfOptionDictionary<TOptions
 function getBooleanOptionDetails<TOptions>(options: PerfOptionDictionary<TOptions>) {
   const booleanProps: { boolean: string[]; default: { [key: string]: boolean } } = {
     boolean: [],
-    default: {}
+    default: {},
   };
 
   for (const key in options) {

--- a/sdk/test-utils/perf/src/perfTestBase.ts
+++ b/sdk/test-utils/perf/src/perfTestBase.ts
@@ -8,7 +8,7 @@ import {
   DefaultPerfOptions,
   defaultPerfOptions,
   validateOptions,
-  ParsedPerfOptions
+  ParsedPerfOptions,
 } from "./options";
 import { PerfParallel } from "./parallel";
 import { AbortController } from "@azure/abort-controller";
@@ -40,7 +40,7 @@ export abstract class PerfTestBase<TOptions = Record<string, unknown>> {
     if (this.options) {
       validateOptions({
         ...this.options,
-        ...defaultPerfOptions
+        ...defaultPerfOptions,
       });
     }
 
@@ -54,7 +54,7 @@ export abstract class PerfTestBase<TOptions = Record<string, unknown>> {
     //   ```
     return parsePerfOption({
       ...this.options,
-      ...defaultPerfOptions
+      ...defaultPerfOptions,
     } as PerfOptionDictionary<TOptions & DefaultPerfOptions>);
   }
 

--- a/sdk/test-utils/perf/src/policy.ts
+++ b/sdk/test-utils/perf/src/policy.ts
@@ -3,7 +3,7 @@ import {
   RequestPolicy,
   RequestPolicyOptions,
   WebResource,
-  HttpOperationResponse
+  HttpOperationResponse,
 } from "@azure/core-http";
 import * as url from "url";
 

--- a/sdk/test-utils/perf/src/program.ts
+++ b/sdk/test-utils/perf/src/program.ts
@@ -7,7 +7,7 @@ import {
   PerfOptionDictionary,
   parsePerfOption,
   defaultPerfOptions,
-  DefaultPerfOptions
+  DefaultPerfOptions,
 } from "./options";
 import { PerfParallel } from "./parallel";
 import { exec } from "child_process";
@@ -103,19 +103,19 @@ export class PerfProgram {
     const weightedAverage = totalOperations / operationsPerSecond;
     console.log(
       `Completed ${totalOperations.toLocaleString(undefined, {
-        maximumFractionDigits: 0
+        maximumFractionDigits: 0,
       })} ` +
         `operations in a weighted-average of ` +
         `${weightedAverage.toLocaleString(undefined, {
           maximumFractionDigits: 2,
-          minimumFractionDigits: 2
+          minimumFractionDigits: 2,
         })}s ` +
         `(${operationsPerSecond.toLocaleString(undefined, {
-          maximumFractionDigits: 2
+          maximumFractionDigits: 2,
         })} ops/s, ` +
         `${secondsPerOperation.toLocaleString(undefined, {
           maximumFractionDigits: 3,
-          minimumFractionDigits: 3
+          minimumFractionDigits: 3,
         })} s/op)`
     );
   }
@@ -141,8 +141,9 @@ export class PerfProgram {
     // of operations running.
     const millisecondsToLog = Number(this.parsedDefaultOptions["milliseconds-to-log"].value);
     console.log(
-      `\n=== ${title} mode, iteration ${iterationIndex + 1}. Logs every ${millisecondsToLog /
-        1000}s ===`
+      `\n=== ${title} mode, iteration ${iterationIndex + 1}. Logs every ${
+        millisecondsToLog / 1000
+      }s ===`
     );
     console.log(`ElapsedTime\tCurrent\t\tTotal\t\tAverage`);
     let lastCompleted = 0;
@@ -177,7 +178,7 @@ export class PerfProgram {
       this.tests.map((test, i = 0) => {
         parallels[i] = {
           completedOperations: 0,
-          lastMillisecondsElapsed: 0
+          lastMillisecondsElapsed: 0,
         };
         return test.runAll(parallels[i], durationMilliseconds, abortController);
       })

--- a/sdk/test-utils/perf/src/testProxyHttpClient.ts
+++ b/sdk/test-utils/perf/src/testProxyHttpClient.ts
@@ -7,7 +7,7 @@ import {
   PipelinePolicy,
   PipelineRequest,
   PipelineResponse,
-  SendRequest
+  SendRequest,
 } from "@azure/core-rest-pipeline";
 import { RequestOptions } from "http";
 import { Agent as HttpsAgent } from "https";
@@ -17,7 +17,7 @@ const paths = {
   playback: "/playback",
   record: "/record",
   start: "/start",
-  stop: "/stop"
+  stop: "/stop",
 };
 
 /**
@@ -126,7 +126,7 @@ export class TestProxyHttpClient {
   async startRecording(): Promise<void> {
     this.stateManager.validateState("starting-recording");
     const options = this._createRecordingRequestOptions({
-      path: paths.record + paths.start
+      path: paths.record + paths.start,
     });
     const rsp = await makeRequest(this._uri, options, this.insecure);
     if (rsp.statusCode !== 200) {
@@ -149,11 +149,11 @@ export class TestProxyHttpClient {
   async stopRecording(): Promise<void> {
     this.stateManager.validateState("stopping-recording");
     const options = this._createRecordingRequestOptions({
-      path: paths.record + paths.stop
+      path: paths.record + paths.stop,
     });
     options.headers = {
       ...options.headers,
-      "x-recording-id": this._recordingId
+      "x-recording-id": this._recordingId,
     };
     await makeRequest(this._uri, options, this.insecure);
     this.stateManager.setState("stopped-recording");
@@ -162,11 +162,11 @@ export class TestProxyHttpClient {
   async startPlayback(): Promise<void> {
     this.stateManager.validateState("starting-playback");
     const options = this._createRecordingRequestOptions({
-      path: paths.playback + paths.start
+      path: paths.playback + paths.start,
     });
     options.headers = {
       ...options.headers,
-      "x-recording-id": this._recordingId
+      "x-recording-id": this._recordingId,
     };
     const rsp = await makeRequest(this._uri, options, this.insecure);
     if (rsp.statusCode !== 200) {
@@ -189,12 +189,12 @@ export class TestProxyHttpClient {
   async stopPlayback(): Promise<void> {
     this.stateManager.validateState("stopping-playback");
     const options = this._createRecordingRequestOptions({
-      path: paths.playback + paths.stop
+      path: paths.playback + paths.stop,
     });
     options.headers = {
       ...options.headers,
       "x-recording-id": this._recordingId,
-      "x-purge-inmemory-recording": "true"
+      "x-purge-inmemory-recording": "true",
     };
     await makeRequest(this._uri, options, this.insecure);
     this._mode = "live";
@@ -206,7 +206,7 @@ export class TestProxyHttpClient {
     if (this._recordingId !== undefined) {
       options.headers = {
         ...options.headers,
-        "x-recording-id": this._recordingId
+        "x-recording-id": this._recordingId,
       };
     }
     return { ...options, method: "POST" };
@@ -226,7 +226,7 @@ export function testProxyHttpPolicy(
         modifiedRequest.agent = getCachedHttpsAgent(insecure);
       }
       return next(modifiedRequest);
-    }
+    },
   };
 }
 
@@ -251,10 +251,12 @@ class DefaultHttpClientCoreV1 extends DefaultHttpClient {
   }
 
   async prepareRequest(httpRequest: WebResourceLike): Promise<Partial<RequestInit>> {
-    const req: Partial<RequestInit & {
-      agent?: HttpsAgent;
-      compress?: boolean;
-    }> = await super.prepareRequest(httpRequest);
+    const req: Partial<
+      RequestInit & {
+        agent?: HttpsAgent;
+        compress?: boolean;
+      }
+    > = await super.prepareRequest(httpRequest);
     if (this.isHttps) {
       req.agent = getCachedHttpsAgent(this.insecure);
     }

--- a/sdk/test-utils/perf/src/utils.ts
+++ b/sdk/test-utils/perf/src/utils.ts
@@ -28,7 +28,7 @@ let cachedHttpsAgent: https.Agent;
 export const getCachedHttpsAgent = (insecure: boolean): https.Agent => {
   if (!cachedHttpsAgent) {
     cachedHttpsAgent = new https.Agent({
-      rejectUnauthorized: !insecure
+      rejectUnauthorized: !insecure,
       // TODO: Doesn't work currently
       // pfx: require("fs").readFileSync(
       //   "/workspaces/azure-sdk-for-js/eng/common/testproxy/dotnet-devcert.pfx"
@@ -66,7 +66,7 @@ export async function makeRequest(
         uri,
         {
           ...requestOptions,
-          agent: getCachedHttpsAgent(insecure)
+          agent: getCachedHttpsAgent(insecure),
         },
         resolve
       );

--- a/sdk/test-utils/perf/test/batch/mockReceiverTest.spec.ts
+++ b/sdk/test-utils/perf/test/batch/mockReceiverTest.spec.ts
@@ -16,15 +16,15 @@ export class MockReceiverTest extends BatchPerfTest<MockReceiverOptions> {
       description: "Required option",
       shortName: "min",
       longName: "minimum",
-      defaultValue: 5
+      defaultValue: 5,
     },
     "max-count": {
       required: true,
       description: "Required option",
       shortName: "max",
       longName: "maximum",
-      defaultValue: 50
-    }
+      defaultValue: 50,
+    },
   };
   constructor() {
     super();

--- a/sdk/test-utils/perf/test/declareTests.ts
+++ b/sdk/test-utils/perf/test/declareTests.ts
@@ -29,12 +29,12 @@ const tests: TestDefinition[] = [
   NodeFetchTest,
   {
     testClass: OptionsTest,
-    options: "--req some-string"
+    options: "--req some-string",
   },
   {
     testClass: PerfPolicyTest,
-    options: "--url http://bing.com/"
-  }
+    options: "--url http://bing.com/",
+  },
 ];
 
 // Normalize everything in the array above for export.

--- a/sdk/test-utils/perf/test/nodeFetch.spec.ts
+++ b/sdk/test-utils/perf/test/nodeFetch.spec.ts
@@ -12,7 +12,7 @@ interface NodeFetchOptions {
 
 export class NodeFetchTest extends PerfTest<NodeFetchOptions> {
   private static fetchOptions = {
-    agent: new http.Agent({ keepAlive: true })
+    agent: new http.Agent({ keepAlive: true }),
   };
 
   private url = "";
@@ -24,8 +24,8 @@ export class NodeFetchTest extends PerfTest<NodeFetchOptions> {
       shortName: "u",
       longName: "url",
       defaultValue: "http://www.example.org",
-      value: "http://www.example.org"
-    }
+      value: "http://www.example.org",
+    },
   };
 
   public setup(): void {

--- a/sdk/test-utils/perf/test/options.spec.ts
+++ b/sdk/test-utils/perf/test/options.spec.ts
@@ -20,33 +20,33 @@ interface OptionsTestOptions {
 export class OptionsTest extends PerfTest<OptionsTestOptions> {
   public options: PerfOptionDictionary<OptionsTestOptions> = {
     "non-req": {
-      description: "Non-required option"
+      description: "Non-required option",
     },
     "non-req-short": {
       description: "Non-required option with short name",
-      shortName: "nro"
+      shortName: "nro",
     },
     "non-req-default": {
       description: "Non-required option with default value",
-      defaultValue: 10
+      defaultValue: 10,
     },
     req: {
       required: true,
-      description: "Required option"
+      description: "Required option",
     },
     "req-short": {
       description: "Required option with short name",
-      shortName: "ro"
+      shortName: "ro",
     },
     "req-default": {
       description: "Required option with default value",
-      defaultValue: 10
+      defaultValue: 10,
     },
     longName: {
       description: "Option with long name specified in option body",
       longName: "long-name",
-      defaultValue: "ln"
-    }
+      defaultValue: "ln",
+    },
   };
   public minimistResult: MinimistParsedArgs;
 

--- a/sdk/test-utils/perf/test/perfPolicy.spec.ts
+++ b/sdk/test-utils/perf/test/perfPolicy.spec.ts
@@ -7,7 +7,7 @@ import {
   WebResource,
   HttpOperationResponse,
   HttpHeaders,
-  RequestPolicyOptions
+  RequestPolicyOptions,
 } from "@azure/core-http";
 
 interface PerfPolicyOptions {
@@ -17,7 +17,7 @@ interface PerfPolicyOptions {
 const defaultResponse = {
   status: 200,
   request: new WebResource(),
-  headers: new HttpHeaders()
+  headers: new HttpHeaders(),
 };
 
 /**
@@ -29,8 +29,8 @@ export class PerfPolicyTest extends PerfTest<PerfPolicyOptions> {
     url: {
       required: true,
       description: "URL that will replace any request's original targeted URL",
-      shortName: "u"
-    }
+      shortName: "u",
+    },
   };
   async run(): Promise<void> {
     const urlOption = this.parsedOptions.url.value;
@@ -65,7 +65,7 @@ export class PerfPolicyTest extends PerfTest<PerfPolicyOptions> {
         }
 
         return defaultResponse;
-      }
+      },
     };
 
     const policy = new PerfPolicy(

--- a/sdk/test-utils/perf/test/serviceClientGet.spec.ts
+++ b/sdk/test-utils/perf/test/serviceClientGet.spec.ts
@@ -21,14 +21,14 @@ export class ServiceClientGetTest extends PerfTest<ServiceClientGetOptions> {
       description:
         "Extra requests to send on first run.  " +
         "Simulates SDKs which require extra requests (like authentication) on first API call.",
-      defaultValue: 0
+      defaultValue: 0,
     },
     url: {
       required: true,
       description: "URL to retrieve",
       shortName: "u",
-      longName: "url"
-    }
+      longName: "url",
+    },
   };
 
   constructor() {
@@ -41,7 +41,7 @@ export class ServiceClientGetTest extends PerfTest<ServiceClientGetOptions> {
     this.request = createPipelineRequest({
       allowInsecureConnection: true,
       streamResponseStatusCodes: new Set([200]),
-      url: url
+      url: url,
     });
 
     if (insecure && url.toLowerCase().startsWith("https:")) {

--- a/sdk/test-utils/perf/test/setupCleanup.spec.ts
+++ b/sdk/test-utils/perf/test/setupCleanup.spec.ts
@@ -14,7 +14,7 @@ export class SetupCleanupTest extends PerfTest {
     globalSetup: 0,
     globalCleanup: 0,
     setup: 0,
-    cleanup: 0
+    cleanup: 0,
   };
 
   public globalSetup(): void {

--- a/sdk/test-utils/recorder-new/karma.conf.js
+++ b/sdk/test-utils/recorder-new/karma.conf.js
@@ -5,7 +5,7 @@ require("dotenv").config({ path: "../.env" });
 
 process.env.RECORDINGS_RELATIVE_PATH = relativeRecordingsPath();
 
-module.exports = function(config) {
+module.exports = function (config) {
   config.set({
     // base path that will be used to resolve all patterns (eg. files, exclude)
     basePath: "./",
@@ -25,13 +25,13 @@ module.exports = function(config) {
       "karma-coverage",
       "karma-sourcemap-loader",
       "karma-junit-reporter",
-      "karma-json-preprocessor"
+      "karma-json-preprocessor",
     ],
 
     // list of files / patterns to load in the browser
     files: [
       "dist-test/index.browser.js",
-      { pattern: "dist-test/index.browser.js.map", type: "html", included: false, served: true }
+      { pattern: "dist-test/index.browser.js.map", type: "html", included: false, served: true },
     ],
 
     // list of files / patterns to exclude
@@ -40,7 +40,7 @@ module.exports = function(config) {
     // preprocess matching files before serving them to the browser
     // available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
     preprocessors: {
-      "**/*.js": ["sourcemap", "env"]
+      "**/*.js": ["sourcemap", "env"],
       // IMPORTANT: COMMENT following line if you want to debug in your browsers!!
       // Preprocess source file to calculate code coverage, however this will make source file unreadable
       // "dist-test/index.browser.js": ["coverage"]
@@ -63,8 +63,8 @@ module.exports = function(config) {
         { type: "json", subdir: ".", file: "coverage.json" },
         { type: "lcovonly", subdir: ".", file: "lcov.info" },
         { type: "html", subdir: "html" },
-        { type: "cobertura", subdir: ".", file: "cobertura-coverage.xml" }
-      ]
+        { type: "cobertura", subdir: ".", file: "cobertura-coverage.xml" },
+      ],
     },
 
     junitReporter: {
@@ -74,7 +74,7 @@ module.exports = function(config) {
       useBrowserName: false, // add browser name to report and classes names
       nameFormatter: undefined, // function (browser, result) to customize the name attribute in xml testcase element
       classNameFormatter: undefined, // function (browser, result) to customize the classname attribute in xml testcase element
-      properties: {} // key value pair of properties to add to the <properties> section of the report
+      properties: {}, // key value pair of properties to add to the <properties> section of the report
     },
 
     // web server port
@@ -99,8 +99,8 @@ module.exports = function(config) {
     customLaunchers: {
       ChromeHeadlessNoSandbox: {
         base: "ChromeHeadless",
-        flags: ["--no-sandbox", "--disable-web-security"]
-      }
+        flags: ["--no-sandbox", "--disable-web-security"],
+      },
     },
 
     // Continuous Integration mode
@@ -119,8 +119,8 @@ module.exports = function(config) {
       mocha: {
         // change Karma's debug.html to the mocha web reporter
         reporter: "html",
-        timeout: "600000"
-      }
-    }
+        timeout: "600000",
+      },
+    },
   });
 };

--- a/sdk/test-utils/recorder-new/package.json
+++ b/sdk/test-utils/recorder-new/package.json
@@ -113,7 +113,7 @@
     "mock-require": "^3.0.3",
     "npm-run-all": "^4.1.5",
     "nyc": "^15.0.0",
-    "prettier": "^1.16.4",
+    "prettier": "^2.5.1",
     "rimraf": "^3.0.0",
     "rollup": "^1.16.3",
     "rollup-plugin-shim": "^1.0.0",

--- a/sdk/test-utils/recorder-new/src/index.ts
+++ b/sdk/test-utils/recorder-new/src/index.ts
@@ -8,7 +8,7 @@ export {
   RecorderStartOptions,
   isLiveMode,
   isPlaybackMode,
-  isRecordMode
+  isRecordMode,
 } from "./utils/utils";
 export { env } from "./utils/env";
 export { delay } from "./utils/delay";

--- a/sdk/test-utils/recorder-new/src/recorder.ts
+++ b/sdk/test-utils/recorder-new/src/recorder.ts
@@ -10,7 +10,7 @@ import {
   PipelinePolicy,
   PipelineRequest,
   PipelineResponse,
-  SendRequest
+  SendRequest,
 } from "@azure/core-rest-pipeline";
 import {
   ensureExistence,
@@ -21,7 +21,7 @@ import {
   once,
   RecorderError,
   RecorderStartOptions,
-  RecordingStateManager
+  RecordingStateManager,
 } from "./utils/utils";
 import { Test } from "mocha";
 import { sessionFilePath } from "./utils/sessionFilePath";
@@ -35,7 +35,7 @@ import {
   HttpClient as HttpClientCoreV1,
   HttpOperationResponse,
   WebResource,
-  WebResourceLike
+  WebResourceLike,
 } from "@azure/core-http";
 
 /**
@@ -140,7 +140,7 @@ export class Recorder {
       if (ensureExistence(this.httpClient, "TestProxyHttpClient.httpClient")) {
         const rsp = await this.httpClient.sendRequest({
           ...req,
-          allowInsecureConnection: true
+          allowInsecureConnection: true,
         });
         if (rsp.status !== 200) {
           throw new RecorderError("Start request failed.");
@@ -187,7 +187,7 @@ export class Recorder {
       if (ensureExistence(this.httpClient, "TestProxyHttpClient.httpClient")) {
         const rsp = await this.httpClient.sendRequest({
           ...req,
-          allowInsecureConnection: true
+          allowInsecureConnection: true,
         });
         if (rsp.status !== 200) {
           throw new RecorderError("Stop request failed.");
@@ -264,7 +264,7 @@ export class Recorder {
       ): Promise<PipelineResponse> => {
         this.redirectRequest(request);
         return next(request);
-      }
+      },
     };
   }
 
@@ -278,7 +278,7 @@ export class Recorder {
       sendRequest: async (request: WebResourceLike): Promise<HttpOperationResponse> => {
         this.redirectRequest(request);
         return client.sendRequest(request);
-      }
+      },
     };
   }
 

--- a/sdk/test-utils/recorder-new/src/sanitizer.ts
+++ b/sdk/test-utils/recorder-new/src/sanitizer.ts
@@ -9,7 +9,7 @@ import {
   RecorderError,
   RegexSanitizer,
   sanitizerKeywordMapping,
-  SanitizerOptions
+  SanitizerOptions,
 } from "./utils/utils";
 
 /**
@@ -37,7 +37,7 @@ export class Sanitizer {
       }
       const rsp = await this.httpClient.sendRequest({
         ...req,
-        allowInsecureConnection: true
+        allowInsecureConnection: true,
       });
       if (rsp.status !== 200) {
         throw new RecorderError("Info request failed.");
@@ -65,14 +65,16 @@ export class Sanitizer {
     }
 
     await Promise.all(
-      ([
-        // The following sanitizers have similar request bodies and this abstraction avoids duplication
-        "generalRegexSanitizers",
-        "bodyKeySanitizers",
-        "bodyRegexSanitizers",
-        "headerRegexSanitizers",
-        "uriRegexSanitizers"
-      ] as const).map((prop) => {
+      (
+        [
+          // The following sanitizers have similar request bodies and this abstraction avoids duplication
+          "generalRegexSanitizers",
+          "bodyKeySanitizers",
+          "bodyRegexSanitizers",
+          "headerRegexSanitizers",
+          "uriRegexSanitizers",
+        ] as const
+      ).map((prop) => {
         const replacers = options[prop];
         if (replacers) {
           return Promise.all(
@@ -83,7 +85,7 @@ export class Sanitizer {
                   "bodyKeySanitizers",
                   "bodyRegexSanitizers",
                   "generalRegexSanitizers",
-                  "uriRegexSanitizers"
+                  "uriRegexSanitizers",
                 ].includes(prop) &&
                 !replacer.regex
               ) {
@@ -94,7 +96,7 @@ export class Sanitizer {
               }
               return this.addSanitizer({
                 sanitizer: sanitizerKeywordMapping[prop],
-                body: JSON.stringify(replacer)
+                body: JSON.stringify(replacer),
               });
             })
           );
@@ -103,16 +105,18 @@ export class Sanitizer {
     );
 
     await Promise.all(
-      ([
-        // The following sanitizers have similar request bodies and this abstraction avoids duplication
-        "resetSanitizer",
-        "oAuthResponseSanitizer"
-      ] as const).map((prop) => {
+      (
+        [
+          // The following sanitizers have similar request bodies and this abstraction avoids duplication
+          "resetSanitizer",
+          "oAuthResponseSanitizer",
+        ] as const
+      ).map((prop) => {
         // TODO: Test
         if (options[prop]) {
           return this.addSanitizer({
             sanitizer: sanitizerKeywordMapping[prop],
-            body: undefined
+            body: undefined,
           });
         } else return;
       })
@@ -122,8 +126,8 @@ export class Sanitizer {
       this.addSanitizer({
         sanitizer: "RemoveHeaderSanitizer",
         body: JSON.stringify({
-          headersForRemoval: options.removeHeaderSanitizer.headersForRemoval.toString()
-        })
+          headersForRemoval: options.removeHeaderSanitizer.headersForRemoval.toString(),
+        }),
       });
     }
 
@@ -135,8 +139,8 @@ export class Sanitizer {
             sanitizer: "ContinuationSanitizer",
             body: JSON.stringify({
               ...replacer,
-              resetAfterFirst: replacer.resetAfterFirst.toString()
-            })
+              resetAfterFirst: replacer.resetAfterFirst.toString(),
+            }),
           })
         )
       );
@@ -145,7 +149,7 @@ export class Sanitizer {
     if (options.uriSubscriptionIdSanitizer) {
       await this.addSanitizer({
         sanitizer: "UriSubscriptionIdSanitizer",
-        body: JSON.stringify(options.uriSubscriptionIdSanitizer)
+        body: JSON.stringify(options.uriSubscriptionIdSanitizer),
       });
     }
   }
@@ -165,7 +169,7 @@ export class Sanitizer {
       throw new RecorderError(
         `Attempted to add an invalid sanitizer - ${JSON.stringify({
           actualConnString: actualConnString,
-          fakeConnString: fakeConnString
+          fakeConnString: fakeConnString,
         })}`
       );
     }
@@ -174,7 +178,7 @@ export class Sanitizer {
     await this.addSanitizers({
       generalRegexSanitizers: Object.entries(pairsMatched).map(([key, value]) => {
         return { value, regex: key };
-      })
+      }),
     });
   }
 
@@ -201,7 +205,7 @@ export class Sanitizer {
       }
       const rsp = await this.httpClient.sendRequest({
         ...req,
-        allowInsecureConnection: true
+        allowInsecureConnection: true,
       });
       if (rsp.status !== 200) {
         throw new RecorderError("addSanitizer request failed.");

--- a/sdk/test-utils/recorder-new/src/utils/env.browser.ts
+++ b/sdk/test-utils/recorder-new/src/utils/env.browser.ts
@@ -3,4 +3,4 @@
 
 // In the browser, we load the env variables with the help of karma.conf.js
 
-export const env = ((window as unknown) as { __env__: typeof process.env }).__env__;
+export const env = (window as unknown as { __env__: typeof process.env }).__env__;

--- a/sdk/test-utils/recorder-new/src/utils/envSetupForPlayback.ts
+++ b/sdk/test-utils/recorder-new/src/utils/envSetupForPlayback.ts
@@ -31,7 +31,7 @@ export async function handleEnvSetup(
         }
       }
       await sanitizer.addSanitizers({
-        generalRegexSanitizers
+        generalRegexSanitizers,
       });
     }
   }

--- a/sdk/test-utils/recorder-new/src/utils/paths.ts
+++ b/sdk/test-utils/recorder-new/src/utils/paths.ts
@@ -15,5 +15,5 @@ export const paths = {
   available: "/available",
   active: "/active",
   reset: "/reset",
-  setMatcher: "/setMatcher"
+  setMatcher: "/setMatcher",
 };

--- a/sdk/test-utils/recorder-new/src/utils/utils.ts
+++ b/sdk/test-utils/recorder-new/src/utils/utils.ts
@@ -83,7 +83,7 @@ export const sanitizerKeywordMapping: Record<
   removeHeaderSanitizer: "RemoveHeaderSanitizer",
   resetSanitizer: "Reset",
   uriRegexSanitizers: "UriRegexSanitizer",
-  uriSubscriptionIdSanitizer: "UriSubscriptionIdSanitizer"
+  uriSubscriptionIdSanitizer: "UriSubscriptionIdSanitizer",
 };
 
 /**

--- a/sdk/test-utils/recorder-new/test/sanitizers.spec.ts
+++ b/sdk/test-utils/recorder-new/test/sanitizers.spec.ts
@@ -19,7 +19,7 @@ import { getTestServerUrl, makeRequestAndVerifyResponse, setTestMode } from "./u
       setTestMode(mode);
     });
 
-    beforeEach(async function() {
+    beforeEach(async function () {
       recorder = new Recorder(this.currentTest);
       client = new ServiceClient({ baseUri: getTestServerUrl() });
       recorder.configureClient(client);
@@ -35,14 +35,14 @@ import { getTestServerUrl, makeRequestAndVerifyResponse, setTestMode } from "./u
         const fakeSecretInfo = "fake_secret_info";
         await recorder.start({
           envSetupForPlayback: {
-            SECRET_INFO: fakeSecretInfo
-          }
+            SECRET_INFO: fakeSecretInfo,
+          },
         }); // Adds generalRegexSanitizers by default based on envSetupForPlayback
         await makeRequestAndVerifyResponse(
           client,
           {
             path: `/sample_response/${env.SECRET_INFO}`,
-            method: "GET"
+            method: "GET",
           },
           { val: "I am the answer!" }
         );
@@ -53,9 +53,9 @@ import { getTestServerUrl, makeRequestAndVerifyResponse, setTestMode } from "./u
           envSetupForPlayback: {},
           sanitizerOptions: {
             removeHeaderSanitizer: {
-              headersForRemoval: ["ETag", "Date"]
-            }
-          }
+              headersForRemoval: ["ETag", "Date"],
+            },
+          },
         });
         await makeRequestAndVerifyResponse(
           client,
@@ -74,18 +74,18 @@ import { getTestServerUrl, makeRequestAndVerifyResponse, setTestMode } from "./u
               {
                 jsonPath: "$.secret_info", // Handles the request body
                 regex: secretValue,
-                value: fakeSecretValue
+                value: fakeSecretValue,
               },
               {
                 jsonPath: "$.bodyProvided.secret_info", // Handles the response body
                 regex: secretValue,
-                value: fakeSecretValue
-              }
-            ]
-          }
+                value: fakeSecretValue,
+              },
+            ],
+          },
         });
         const reqBody = {
-          secret_info: isPlaybackMode() ? fakeSecretValue : secretValue
+          secret_info: isPlaybackMode() ? fakeSecretValue : secretValue,
         };
         await makeRequestAndVerifyResponse(
           client,
@@ -93,7 +93,7 @@ import { getTestServerUrl, makeRequestAndVerifyResponse, setTestMode } from "./u
             path: `/api/sample_request_body`,
             body: JSON.stringify(reqBody),
             method: "POST",
-            headers: [{ headerName: "Content-Type", value: "application/json" }]
+            headers: [{ headerName: "Content-Type", value: "application/json" }],
           },
           { bodyProvided: reqBody }
         );
@@ -109,10 +109,10 @@ import { getTestServerUrl, makeRequestAndVerifyResponse, setTestMode } from "./u
               {
                 regex: "(.*)&SECRET=(?<secret_content>[^&]*)&(.*)",
                 value: fakeSecretValue,
-                groupForReplace: "secret_content"
-              }
-            ]
-          }
+                groupForReplace: "secret_content",
+              },
+            ],
+          },
         });
         const reqBody = `non_secret=i'm_no_secret&SECRET=${
           isPlaybackMode() ? fakeSecretValue : secretValue
@@ -123,7 +123,7 @@ import { getTestServerUrl, makeRequestAndVerifyResponse, setTestMode } from "./u
             path: `/api/sample_request_body`,
             body: reqBody,
             method: "POST",
-            headers: [{ headerName: "Content-Type", value: "text/plain" }]
+            headers: [{ headerName: "Content-Type", value: "text/plain" }],
           },
           { bodyProvided: reqBody }
         );
@@ -138,10 +138,10 @@ import { getTestServerUrl, makeRequestAndVerifyResponse, setTestMode } from "./u
             uriRegexSanitizers: [
               {
                 regex: secretEndpoint,
-                value: fakeEndpoint
-              }
-            ]
-          }
+                value: fakeEndpoint,
+              },
+            ],
+          },
         });
         const pathToHit = `/api/sample_request_body`;
         await makeRequestAndVerifyResponse(
@@ -151,7 +151,7 @@ import { getTestServerUrl, makeRequestAndVerifyResponse, setTestMode } from "./u
               ? getTestServerUrl().replace(secretEndpoint, fakeEndpoint) + pathToHit
               : undefined,
             path: pathToHit,
-            method: "POST"
+            method: "POST",
           },
           { bodyProvided: {} }
         );
@@ -164,15 +164,15 @@ import { getTestServerUrl, makeRequestAndVerifyResponse, setTestMode } from "./u
           envSetupForPlayback: {},
           sanitizerOptions: {
             uriSubscriptionIdSanitizer: {
-              value: fakeId
-            }
-          }
+              value: fakeId,
+            },
+          },
         });
         await makeRequestAndVerifyResponse(
           client,
           {
             path: `/subscriptions/${isPlaybackMode() ? fakeId : id}`,
-            method: "GET"
+            method: "GET",
           },
           { val: "I am the answer!" }
         );
@@ -187,10 +187,10 @@ import { getTestServerUrl, makeRequestAndVerifyResponse, setTestMode } from "./u
               {
                 key: "your_uuid",
                 method: "guid", // What is this method exactly?
-                resetAfterFirst: false
-              }
-            ]
-          }
+                resetAfterFirst: false,
+              },
+            ],
+          },
         });
         // What if the id is part of the response body and not response headers?
 
@@ -198,7 +198,7 @@ import { getTestServerUrl, makeRequestAndVerifyResponse, setTestMode } from "./u
           client,
           {
             path: `/api/sample_uuid_in_header`,
-            method: "GET"
+            method: "GET",
           },
           undefined
         );
@@ -211,9 +211,9 @@ import { getTestServerUrl, makeRequestAndVerifyResponse, setTestMode } from "./u
             headers: [
               {
                 headerName: "your_uuid",
-                value: firstResponse.headers.get("your_uuid") || ""
-              }
-            ]
+                value: firstResponse.headers.get("your_uuid") || "",
+              },
+            ],
           },
           { val: "abc" }
         );
@@ -227,17 +227,17 @@ import { getTestServerUrl, makeRequestAndVerifyResponse, setTestMode } from "./u
             headerRegexSanitizers: [
               {
                 key: "your_uuid",
-                value: sanitizedValue
-              }
-            ]
-          }
+                value: sanitizedValue,
+              },
+            ],
+          },
         });
 
         await makeRequestAndVerifyResponse(
           client,
           {
             path: `/api/sample_uuid_in_header`,
-            method: "GET"
+            method: "GET",
           },
           undefined
         );
@@ -270,10 +270,10 @@ import { getTestServerUrl, makeRequestAndVerifyResponse, setTestMode } from "./u
               {
                 regex: "(.*)&SECRET=(?<secret_content>[^&]*)&(.*)",
                 value: fakeSecretValue,
-                groupForReplace: "secret_content"
-              }
-            ]
-          }
+                groupForReplace: "secret_content",
+              },
+            ],
+          },
         });
         const reqBody = `non_secret=i'm_no_secret&SECRET=${
           isPlaybackMode() ? fakeSecretValue : secretValue
@@ -284,13 +284,13 @@ import { getTestServerUrl, makeRequestAndVerifyResponse, setTestMode } from "./u
             path: `/api/sample_request_body`,
             body: reqBody,
             method: "POST",
-            headers: [{ headerName: "Content-Type", value: "text/plain" }]
+            headers: [{ headerName: "Content-Type", value: "text/plain" }],
           },
           { bodyProvided: reqBody }
         );
 
         await recorder.addSanitizers({
-          resetSanitizer: true
+          resetSanitizer: true,
         });
 
         const reqBodyAfterReset = `non_secret=i'm_no_secret&SECRET=${secretValue}&random=random`;
@@ -301,7 +301,7 @@ import { getTestServerUrl, makeRequestAndVerifyResponse, setTestMode } from "./u
             path: `/api/sample_request_body`,
             body: reqBodyAfterReset,
             method: "POST",
-            headers: [{ headerName: "Content-Type", value: "text/plain" }]
+            headers: [{ headerName: "Content-Type", value: "text/plain" }],
           },
           { bodyProvided: reqBodyAfterReset }
         );
@@ -317,34 +317,34 @@ import { getTestServerUrl, makeRequestAndVerifyResponse, setTestMode } from "./u
         {
           options: {
             connectionStringSanitizers: [
-              { actualConnString: undefined, fakeConnString: "a=b;c=d" }
+              { actualConnString: undefined, fakeConnString: "a=b;c=d" },
             ],
-            generalRegexSanitizers: [{ regex: undefined, value: "fake-value" }]
+            generalRegexSanitizers: [{ regex: undefined, value: "fake-value" }],
           },
           title: "all sanitizers are undefined",
-          type: "negative"
+          type: "negative",
         },
         {
           options: {
             connectionStringSanitizers: [
               { actualConnString: undefined, fakeConnString: "a=b;c=d" },
-              { actualConnString: "1=2,3=4", fakeConnString: "a=b;c=d" }
+              { actualConnString: "1=2,3=4", fakeConnString: "a=b;c=d" },
             ],
-            generalRegexSanitizers: [{ regex: undefined, value: "fake-value" }]
+            generalRegexSanitizers: [{ regex: undefined, value: "fake-value" }],
           },
           title: "partial sanitizers are undefined",
-          type: "negative"
+          type: "negative",
         },
         {
           options: {
             connectionStringSanitizers: [
-              { actualConnString: "1=2,3=4", fakeConnString: "a=b;c=d" }
+              { actualConnString: "1=2,3=4", fakeConnString: "a=b;c=d" },
             ],
-            generalRegexSanitizers: [{ regex: "value", value: "fake-value" }]
+            generalRegexSanitizers: [{ regex: "value", value: "fake-value" }],
           },
           title: "all sanitizers are defined",
-          type: "positive"
-        }
+          type: "positive",
+        },
       ];
 
       cases.forEach((testCase) => {

--- a/sdk/test-utils/recorder-new/test/testProxyClient.spec.ts
+++ b/sdk/test-utils/recorder-new/test/testProxyClient.spec.ts
@@ -5,7 +5,7 @@ import {
   createHttpHeaders,
   HttpClient,
   PipelineRequest,
-  PipelineResponse
+  PipelineResponse,
 } from "@azure/core-rest-pipeline";
 import { expect } from "chai";
 import { env, Recorder } from "../src";
@@ -25,7 +25,7 @@ describe("TestProxyClient functions", () => {
   let client: Recorder;
   let clientHttpClient: HttpClient;
   let testContext: Mocha.Test | undefined;
-  beforeEach(function() {
+  beforeEach(function () {
     client = new Recorder(this.currentTest);
     clientHttpClient = client["httpClient"] as HttpClient;
     testContext = this.currentTest;
@@ -42,11 +42,11 @@ describe("TestProxyClient functions", () => {
     withCredentials: false,
     requestId: "abcd",
     timeout: 0,
-    allowInsecureConnection: false
+    allowInsecureConnection: false,
   };
 
   describe("redirectRequest method", () => {
-    it("request unchanged if not playback or record modes", function() {
+    it("request unchanged if not playback or record modes", function () {
       env.TEST_MODE = "live";
       testRedirectedRequest(
         client,
@@ -56,13 +56,13 @@ describe("TestProxyClient functions", () => {
     });
 
     ["record", "playback"].forEach((testMode) => {
-      it(`${testMode} mode: ` + "request unchanged if `x-recording-id` in headers", function() {
+      it(`${testMode} mode: ` + "request unchanged if `x-recording-id` in headers", function () {
         env.TEST_MODE = testMode;
         testRedirectedRequest(
           client,
           () => ({
             ...initialRequest,
-            headers: createHttpHeaders({ "x-recording-id": "dummy-recording-id" })
+            headers: createHttpHeaders({ "x-recording-id": "dummy-recording-id" }),
           }),
           (req) => req
         );
@@ -70,7 +70,7 @@ describe("TestProxyClient functions", () => {
 
       it(
         `${testMode} mode: ` + "url and headers get updated if no `x-recording-id` in headers",
-        function() {
+        function () {
           env.TEST_MODE = testMode;
           client = new Recorder(testContext);
           client.recordingId = "dummy-recording-id";
@@ -79,7 +79,7 @@ describe("TestProxyClient functions", () => {
             client,
             () => ({
               ...initialRequest,
-              headers: createHttpHeaders({})
+              headers: createHttpHeaders({}),
             }),
             (req) => {
               if (!client.recordingId) {
@@ -92,9 +92,9 @@ describe("TestProxyClient functions", () => {
                 headers: createHttpHeaders({
                   "x-recording-upstream-base-uri": initialRequest.url,
                   "x-recording-id": client.recordingId,
-                  "x-recording-mode": getTestMode()
+                  "x-recording-mode": getTestMode(),
                 }),
-                allowInsecureConnection: !isLiveMode()
+                allowInsecureConnection: !isLiveMode(),
               };
             }
           );
@@ -104,7 +104,7 @@ describe("TestProxyClient functions", () => {
   });
 
   describe("start method", () => {
-    it("nothing happens if not playback or record modes", async function() {
+    it("nothing happens if not playback or record modes", async function () {
       env.TEST_MODE = "live";
       clientHttpClient.sendRequest = (): Promise<PipelineResponse> => {
         throw new Error("should not have reached here");
@@ -115,14 +115,14 @@ describe("TestProxyClient functions", () => {
     ["record", "playback"].forEach((testMode) => {
       it(
         `${testMode} mode: ` + "succeeds in playback or record modes and gets a recordingId",
-        async function() {
+        async function () {
           env.TEST_MODE = testMode;
           const recordingId = "dummy-recording-id";
           clientHttpClient.sendRequest = (): Promise<PipelineResponse> => {
             return Promise.resolve({
               status: 200,
               headers: createHttpHeaders({ "x-recording-id": recordingId }),
-              request: initialRequest
+              request: initialRequest,
             });
           };
           await client.start({ envSetupForPlayback: {} });
@@ -130,14 +130,14 @@ describe("TestProxyClient functions", () => {
         }
       );
 
-      it("throws if not received a 200 status code", async function() {
+      it("throws if not received a 200 status code", async function () {
         env.TEST_MODE = testMode;
         const recordingId = "dummy-recording-id";
         clientHttpClient.sendRequest = (): Promise<PipelineResponse> => {
           return Promise.resolve({
             status: 404,
             headers: createHttpHeaders({ "x-recording-id": recordingId }),
-            request: initialRequest
+            request: initialRequest,
           });
         };
         try {
@@ -149,13 +149,13 @@ describe("TestProxyClient functions", () => {
         }
       });
 
-      it("throws if not received a recording id upon 200 status code", async function() {
+      it("throws if not received a recording id upon 200 status code", async function () {
         env.TEST_MODE = testMode;
         clientHttpClient.sendRequest = (): Promise<PipelineResponse> => {
           return Promise.resolve({
             status: 200,
             headers: createHttpHeaders({}),
-            request: initialRequest
+            request: initialRequest,
           });
         };
         try {
@@ -172,7 +172,7 @@ describe("TestProxyClient functions", () => {
   });
 
   describe("stop method", () => {
-    it("nothing happens if not playback or record modes", async function() {
+    it("nothing happens if not playback or record modes", async function () {
       env.TEST_MODE = "live";
       clientHttpClient.sendRequest = (): Promise<PipelineResponse> => {
         throw new Error("should not have reached here");
@@ -183,13 +183,13 @@ describe("TestProxyClient functions", () => {
     ["record", "playback"].forEach((testMode) => {
       it(
         `${testMode} mode: ` + "fails in playback or record modes if no recordingId",
-        async function() {
+        async function () {
           env.TEST_MODE = testMode;
           clientHttpClient.sendRequest = (): Promise<PipelineResponse> => {
             return Promise.resolve({
               status: 200,
               headers: createHttpHeaders(),
-              request: initialRequest
+              request: initialRequest,
             });
           };
           client["stateManager"].state = "started";
@@ -205,13 +205,13 @@ describe("TestProxyClient functions", () => {
         }
       );
 
-      it("throws if status code is not 200", async function() {
+      it("throws if status code is not 200", async function () {
         env.TEST_MODE = testMode;
         clientHttpClient.sendRequest = (): Promise<PipelineResponse> => {
           return Promise.resolve({
             status: 401,
             headers: createHttpHeaders(),
-            request: initialRequest
+            request: initialRequest,
           });
         };
         client.recordingId = "dummy-id";
@@ -225,13 +225,13 @@ describe("TestProxyClient functions", () => {
         }
       });
 
-      it("succeeds in playback or record modes", async function() {
+      it("succeeds in playback or record modes", async function () {
         env.TEST_MODE = testMode;
         clientHttpClient.sendRequest = (): Promise<PipelineResponse> => {
           return Promise.resolve({
             status: 200,
             headers: createHttpHeaders(),
-            request: initialRequest
+            request: initialRequest,
           });
         };
         client.recordingId = "dummy-id";
@@ -288,8 +288,8 @@ describe("TestProxyClient functions", () => {
   });
 });
 
-describe("State Manager", function() {
-  it("throws error if started twice", function() {
+describe("State Manager", function () {
+  it("throws error if started twice", function () {
     const manager = new RecordingStateManager();
     manager.state = "started";
     try {
@@ -303,7 +303,7 @@ describe("State Manager", function() {
     }
   });
 
-  it("throws error if stopped twice", function() {
+  it("throws error if stopped twice", function () {
     const manager = new RecordingStateManager();
     try {
       manager.state = "stopped";

--- a/sdk/test-utils/recorder-new/test/testProxyTests.spec.ts
+++ b/sdk/test-utils/recorder-new/test/testProxyTests.spec.ts
@@ -18,7 +18,7 @@ import { getTestServerUrl, makeRequestAndVerifyResponse, setTestMode } from "./u
       setTestMode(mode);
     });
 
-    beforeEach(async function() {
+    beforeEach(async function () {
       recorder = new Recorder(this.currentTest);
       client = new ServiceClient({ baseUri: getTestServerUrl() });
       recorder.configureClient(client);
@@ -47,7 +47,7 @@ import { getTestServerUrl, makeRequestAndVerifyResponse, setTestMode } from "./u
             "random-1",
             `random-${Math.ceil(Math.random() * 1000 + 1000)}`
           )}`,
-          method: "GET"
+          method: "GET",
         },
         { val: "I am the answer!" }
       );
@@ -55,7 +55,7 @@ import { getTestServerUrl, makeRequestAndVerifyResponse, setTestMode } from "./u
         client,
         {
           path: `/sample_response/${recorder.variable("random-2", "known-string")}`,
-          method: "GET"
+          method: "GET",
         },
         { val: "I am the answer!" }
       );
@@ -77,7 +77,7 @@ import { getTestServerUrl, makeRequestAndVerifyResponse, setTestMode } from "./u
             path: `/sample_response`,
             body,
             method: "GET",
-            headers: [{ headerName: "Content-Type", value: "text/plain" }]
+            headers: [{ headerName: "Content-Type", value: "text/plain" }],
           },
           { val: "abc" }
         );
@@ -89,7 +89,7 @@ import { getTestServerUrl, makeRequestAndVerifyResponse, setTestMode } from "./u
 
         const testHeader = {
           headerName: `X-Test-Header-${isPlaybackMode() ? "Playback" : "Record"}`,
-          value: isPlaybackMode() ? "playback" : "record"
+          value: isPlaybackMode() ? "playback" : "record",
         };
 
         await makeRequestAndVerifyResponse(
@@ -98,7 +98,7 @@ import { getTestServerUrl, makeRequestAndVerifyResponse, setTestMode } from "./u
             path: `/sample_response`,
             body: "body",
             method: "GET",
-            headers: [{ headerName: "Content-Type", value: "text/plain" }, testHeader]
+            headers: [{ headerName: "Content-Type", value: "text/plain" }, testHeader],
           },
           { val: "abc" }
         );

--- a/sdk/test-utils/recorder-new/test/utils/server.ts
+++ b/sdk/test-utils/recorder-new/test/utils/server.ts
@@ -26,11 +26,11 @@ app.get(`/subscriptions/:secret_info`, (_, res) => {
   res.send({ val: "I am the answer!" });
 });
 
-app.post("/api/sample_request_body", function(req, res) {
+app.post("/api/sample_request_body", function (req, res) {
   res.send({ bodyProvided: req.body });
 });
 
-app.get("/api/sample_uuid_in_header", function(_, res) {
+app.get("/api/sample_uuid_in_header", function (_, res) {
   res.header("your_uuid", uuidv4());
   res.send();
 });

--- a/sdk/test-utils/recorder-new/test/utils/utils.ts
+++ b/sdk/test-utils/recorder-new/test/utils/utils.ts
@@ -44,7 +44,7 @@ export async function makeRequestAndVerifyResponse(
     url: request.url ?? getTestServerUrl() + request.path,
     body: request.body,
     method: request.method,
-    allowInsecureConnection: isLiveMode()
+    allowInsecureConnection: isLiveMode(),
   });
   request.headers?.forEach(({ headerName, value }) => {
     req.headers.set(headerName, value);

--- a/sdk/test-utils/recorder/karma.conf.js
+++ b/sdk/test-utils/recorder/karma.conf.js
@@ -2,7 +2,7 @@
 process.env.CHROME_BIN = require("puppeteer").executablePath();
 require("dotenv").config({ path: "../.env" });
 
-module.exports = function(config) {
+module.exports = function (config) {
   config.set({
     // base path that will be used to resolve all patterns (eg. files, exclude)
     basePath: "./",
@@ -22,13 +22,13 @@ module.exports = function(config) {
       "karma-coverage",
       "karma-sourcemap-loader",
       "karma-junit-reporter",
-      "karma-json-preprocessor"
+      "karma-json-preprocessor",
     ],
 
     // list of files / patterns to load in the browser
     files: [
       "dist-test/index.browser.js",
-      { pattern: "dist-test/index.browser.js.map", type: "html", included: false, served: true }
+      { pattern: "dist-test/index.browser.js.map", type: "html", included: false, served: true },
     ],
 
     // list of files / patterns to exclude
@@ -37,7 +37,7 @@ module.exports = function(config) {
     // preprocess matching files before serving them to the browser
     // available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
     preprocessors: {
-      "**/*.js": ["sourcemap", "env"]
+      "**/*.js": ["sourcemap", "env"],
       // IMPORTANT: COMMENT following line if you want to debug in your browsers!!
       // Preprocess source file to calculate code coverage, however this will make source file unreadable
       // "dist-test/index.browser.js": ["coverage"]
@@ -60,8 +60,8 @@ module.exports = function(config) {
         { type: "json", subdir: ".", file: "coverage.json" },
         { type: "lcovonly", subdir: ".", file: "lcov.info" },
         { type: "html", subdir: "html" },
-        { type: "cobertura", subdir: ".", file: "cobertura-coverage.xml" }
-      ]
+        { type: "cobertura", subdir: ".", file: "cobertura-coverage.xml" },
+      ],
     },
 
     junitReporter: {
@@ -71,7 +71,7 @@ module.exports = function(config) {
       useBrowserName: false, // add browser name to report and classes names
       nameFormatter: undefined, // function (browser, result) to customize the name attribute in xml testcase element
       classNameFormatter: undefined, // function (browser, result) to customize the classname attribute in xml testcase element
-      properties: {} // key value pair of properties to add to the <properties> section of the report
+      properties: {}, // key value pair of properties to add to the <properties> section of the report
     },
 
     // web server port
@@ -96,8 +96,8 @@ module.exports = function(config) {
     customLaunchers: {
       ChromeHeadlessNoSandbox: {
         base: "ChromeHeadless",
-        flags: ["--no-sandbox", "--disable-web-security"]
-      }
+        flags: ["--no-sandbox", "--disable-web-security"],
+      },
     },
 
     // Continuous Integration mode
@@ -120,8 +120,8 @@ module.exports = function(config) {
       mocha: {
         // change Karma's debug.html to the mocha web reporter
         reporter: "html",
-        timeout: "600000"
-      }
-    }
+        timeout: "600000",
+      },
+    },
   });
 };

--- a/sdk/test-utils/recorder/package.json
+++ b/sdk/test-utils/recorder/package.json
@@ -106,7 +106,7 @@
     "mock-require": "^3.0.3",
     "npm-run-all": "^4.1.5",
     "nyc": "^15.0.0",
-    "prettier": "^1.16.4",
+    "prettier": "^2.5.1",
     "rimraf": "^3.0.0",
     "rollup": "^1.16.3",
     "rollup-plugin-shim": "^1.0.0",

--- a/sdk/test-utils/recorder/src/baseRecorder.ts
+++ b/sdk/test-utils/recorder/src/baseRecorder.ts
@@ -7,11 +7,11 @@ import {
   RecorderEnvironmentSetup,
   filterSecretsFromStrings,
   filterSecretsRecursivelyFromJSON,
-  generateTestRecordingFilePath
+  generateTestRecordingFilePath,
 } from "./utils";
 import {
   defaultRequestBodyTransforms,
-  RequestBodyTransformsType
+  RequestBodyTransformsType,
 } from "./utils/requestBodyTransform";
 
 type InternalRecorderEnvironmentSetup = RecorderEnvironmentSetup & {
@@ -53,7 +53,7 @@ export abstract class BaseRecorder {
     replaceableVariables: {},
     customizationsOnRecordings: [],
     queryParametersToSkip: [],
-    requestBodyTransformations: defaultRequestBodyTransforms
+    requestBodyTransformations: defaultRequestBodyTransforms,
   };
   protected hash: string;
   private defaultCustomizationsOnRecordings = defaultCustomizationsOnRecordings;
@@ -109,21 +109,21 @@ export abstract class BaseRecorder {
     this.environmentSetup = {
       replaceableVariables: {
         ...this.environmentSetup.replaceableVariables,
-        ...environmentSetup.replaceableVariables
+        ...environmentSetup.replaceableVariables,
       },
       customizationsOnRecordings: [
         ...this.environmentSetup.customizationsOnRecordings,
-        ...environmentSetup.customizationsOnRecordings
+        ...environmentSetup.customizationsOnRecordings,
       ],
       queryParametersToSkip: [
         ...this.environmentSetup.queryParametersToSkip,
-        ...environmentSetup.queryParametersToSkip
+        ...environmentSetup.queryParametersToSkip,
       ],
       requestBodyTransformations: {
         // TODO: Concat with the requestBodyTransformations once exposed
         stringTransforms: this.environmentSetup.requestBodyTransformations?.stringTransforms,
-        jsonTransforms: this.environmentSetup.requestBodyTransformations?.jsonTransforms
-      }
+        jsonTransforms: this.environmentSetup.requestBodyTransformations?.jsonTransforms,
+      },
     };
   }
 

--- a/sdk/test-utils/recorder/src/basekarma.conf.ts
+++ b/sdk/test-utils/recorder/src/basekarma.conf.ts
@@ -21,7 +21,7 @@ import fs from "fs-extra";
  *   content: string;
  * }} browserRecordingJsonObject
  */
-export const jsonRecordingFilterFunction = function(browserRecordingJsonObject: {
+export const jsonRecordingFilterFunction = function (browserRecordingJsonObject: {
   writeFile: boolean;
   path: string;
   content: string;

--- a/sdk/test-utils/recorder/src/createRecorder.browser.ts
+++ b/sdk/test-utils/recorder/src/createRecorder.browser.ts
@@ -10,12 +10,12 @@ import {
   RecorderEnvironmentSetup,
   windowLens,
   isRecordMode,
-  isPlaybackMode
+  isPlaybackMode,
 } from "./utils";
 import { customConsoleLog } from "./customConsoleLog";
 import {
   applyRequestBodyTransformations,
-  applyRequestBodyTransformationsOnFixture
+  applyRequestBodyTransformationsOnFixture,
 } from "./utils/requestBodyTransform";
 
 // To better understand how this class works, it's necessary to comprehend how HTTP async requests are made:
@@ -69,7 +69,7 @@ export class NiseRecorder extends BaseRecorder {
       status: request.status,
       response:
         request.response instanceof Blob ? await blobToString(request.response) : request.response,
-      responseHeaders: responseHeaders
+      responseHeaders: responseHeaders,
     });
   }
 
@@ -130,21 +130,21 @@ export class NiseRecorder extends BaseRecorder {
     // Our intent is to override the request's 'onreadystatechange' function so we can create a recording once the response is ready
     // We can only override 'onreadystatechange' AFTER the 'send' function is called because we need to make sure our implementation won't be overridden by the client
     // But we can only override 'send' AFTER the 'open' function is called because the filter we set above makes Nise override it in 'open' body
-    xhr.onCreate = function(req: any) {
+    xhr.onCreate = function (req: any) {
       // We'll override the 'open' function, so we need to store a handle to its original implementation
       const reqOpen = req.open;
-      req.open = function() {
+      req.open = function () {
         // Here we are calling the original 'open' function to make sure everything is set up correctly (HTTP method, url, filters)
         reqOpen.apply(req, arguments);
 
         // We'll override the 'send' function, so we need to store a handle to its original implementation
         // We can already override it because we know 'open' has already been called
         const reqSend = req.send;
-        req.send = function(data: any) {
+        req.send = function (data: any) {
           // We'll override the 'onreadystatechange' function, so we need to store a handle to its original implementation
           // Now we can finally override 'onreadystatechange' because 'send' has already been called
           const reqStateChange = req.onreadystatechange;
-          req.onreadystatechange = function() {
+          req.onreadystatechange = function () {
             // .readyState property returns the state an XMLHttpRequest client is in
             // readyState = 4 refers to the completion of the operation.
             // This could mean that either the data transfer has been completed successfully or failed.
@@ -178,19 +178,19 @@ export class NiseRecorder extends BaseRecorder {
     this.recordings = windowLens.get([
       "__json__",
       "recordings/" + this.relativeTestRecordingFilePath,
-      "recordings"
+      "recordings",
     ]);
     this.uniqueTestInfo = windowLens.get([
       "__json__",
       "recordings/" + this.relativeTestRecordingFilePath,
-      "uniqueTestInfo"
+      "uniqueTestInfo",
     ]);
 
     // 'onCreate' function is called when a new fake XMLHttpRequest object (req) is created
-    xhr.onCreate = function(req: any) {
+    xhr.onCreate = function (req: any) {
       // We'll override the 'send' function, so we need to store a handle to its original implementation
       const reqSend = req.send;
-      req.send = async function(data: any) {
+      req.send = async function (data: any) {
         // Here we're calling the original send method. Nise will make the request wait for a mock response that we'll send later
         reqSend.call(req, data);
 
@@ -200,7 +200,7 @@ export class NiseRecorder extends BaseRecorder {
           method: req.method,
           url: parsedUrl.url,
           query: parsedUrl.query,
-          requestBody: data instanceof Blob ? await blobToString(data) : data
+          requestBody: data instanceof Blob ? await blobToString(data) : data,
         };
 
         // We look through our recordings to find a match to the current request
@@ -259,8 +259,8 @@ export class NiseRecorder extends BaseRecorder {
           content: {
             recordings: this.recordings,
             uniqueTestInfo: this.uniqueTestInfo,
-            hash: this.hash
-          }
+            hash: this.hash,
+          },
         })
       );
     } else if (isPlaybackMode()) {

--- a/sdk/test-utils/recorder/src/createRecorder.ts
+++ b/sdk/test-utils/recorder/src/createRecorder.ts
@@ -21,7 +21,7 @@ export class NockRecorder extends BaseRecorder {
   public record(recorderEnvironmentSetup: RecorderEnvironmentSetup): void {
     super.init(recorderEnvironmentSetup);
     nock.recorder.rec({
-      dont_print: true
+      dont_print: true,
     });
   }
 
@@ -76,7 +76,7 @@ export class NockRecorder extends BaseRecorder {
       }
 
       const file = fs.createWriteStream("./recordings/" + this.relativeTestRecordingFilePath, {
-        flags: "w"
+        flags: "w",
       });
 
       // Some tests expect errors to happen and, if a writing error is thrown in one of these tests, it may be captured in a catch block by accident,

--- a/sdk/test-utils/recorder/src/customConsoleLog.ts
+++ b/sdk/test-utils/recorder/src/customConsoleLog.ts
@@ -46,7 +46,7 @@ export function customConsoleLog() {
       window.console.hasOwnProperty(method) &&
       typeof (window.console as any)[method] === "function"
     ) {
-      (window.console as any)[method] = function(obj: any) {
+      (window.console as any)[method] = function (obj: any) {
         try {
           if (!JSON.parse(obj).writeFile) {
             // If the JSON string doesn't contain `.writeFile` property,

--- a/sdk/test-utils/recorder/src/defaultCustomizations.ts
+++ b/sdk/test-utils/recorder/src/defaultCustomizations.ts
@@ -5,7 +5,7 @@ import {
   maskAccessTokenInBrowserRecording,
   maskAccessTokenInNockFixture,
   sanitizeScopeUrl,
-  setDefaultRetryAfterIntervalInNockFixture
+  setDefaultRetryAfterIntervalInNockFixture,
 } from "./utils";
 
 export const defaultCustomizationsForNodeRecordings = [
@@ -20,12 +20,12 @@ export const defaultCustomizationsForNodeRecordings = [
   // Sanitizes the scope url in the request bodies to clean false positives in cred-scan reports
   sanitizeScopeUrl,
   // Make Retry-After interval to be zero
-  setDefaultRetryAfterIntervalInNockFixture
+  setDefaultRetryAfterIntervalInNockFixture,
 ];
 
 export const defaultCustomizationsForBrowserRecordings = [
   // Masks "access_token"s in the json response from the recording if any exists.
-  maskAccessTokenInBrowserRecording
+  maskAccessTokenInBrowserRecording,
 ];
 
 /**

--- a/sdk/test-utils/recorder/src/index.ts
+++ b/sdk/test-utils/recorder/src/index.ts
@@ -9,7 +9,7 @@ export {
   isRecordMode,
   isLiveMode,
   isSoftRecordMode,
-  RecorderEnvironmentSetup
+  RecorderEnvironmentSetup,
 } from "./utils";
 export { pluginForIdentitySDK, pluginForClientSecretCredentialTests } from "./utils/msalAuth.node";
 export { jsonRecordingFilterFunction } from "./basekarma.conf";

--- a/sdk/test-utils/recorder/src/recorder.ts
+++ b/sdk/test-utils/recorder/src/recorder.ts
@@ -10,7 +10,7 @@ import {
   env,
   isSoftRecordMode,
   testHasChanged,
-  stripNewLines
+  stripNewLines,
 } from "./utils";
 import { setEnvironmentVariables } from "./baseRecorder";
 import { createRecorder } from "./createRecorder";
@@ -148,7 +148,7 @@ export function record(
   // If TEST_MODE=live, hits the live-service and no recordings are generated.
 
   return {
-    stop: async function() {
+    stop: async function () {
       // We check wether we're on record or playback inside of the recorder's stop method.
       if (recorder) {
         await recorder.stop();
@@ -160,7 +160,7 @@ export function record(
      * @param runtime Can either be `"node"` or `"browser"` or `undefined`
      * @param reason Reason for skipping the test
      */
-    skip: function(runtime?: "node" | "browser", reason?: string): void {
+    skip: function (runtime?: "node" | "browser", reason?: string): void {
       if (!reason) reason = "Reason to skip the test is not specified";
       // 1. skipping the test only in node
       // 2. skipping the test only in browser
@@ -181,7 +181,7 @@ export function record(
         }
       }
     },
-    getUniqueName: function(prefix: string, label?: string): string {
+    getUniqueName: function (prefix: string, label?: string): string {
       let name: string;
       if (!label) {
         label = prefix;
@@ -208,7 +208,7 @@ export function record(
       }
       return name;
     },
-    newDate: function(label: string): Date {
+    newDate: function (label: string): Date {
       let date: Date;
       if (isRecordMode()) {
         date = new Date();
@@ -230,6 +230,6 @@ export function record(
         date = new Date();
       }
       return date;
-    }
+    },
   };
 }

--- a/sdk/test-utils/recorder/src/utils/index.ts
+++ b/sdk/test-utils/recorder/src/utils/index.ts
@@ -93,11 +93,7 @@ export function isPlaybackMode() {
 export function encodeRFC3986(str: string): string {
   return encodeURIComponent(str).replace(
     /[!'()*]/g,
-    (x) =>
-      `%${x
-        .charCodeAt(0)
-        .toString(16)
-        .toUpperCase()}`
+    (x) => `%${x.charCodeAt(0).toString(16).toUpperCase()}`
   );
 }
 
@@ -328,7 +324,7 @@ export function parseUrl(url: string): any {
   }, {});
   return {
     url: cleanUrl,
-    query
+    query,
   };
 }
 

--- a/sdk/test-utils/recorder/src/utils/msalAuth.node.ts
+++ b/sdk/test-utils/recorder/src/utils/msalAuth.node.ts
@@ -36,7 +36,7 @@ export const pluginForClientSecretCredentialTests = (tenantId: string = env.AZUR
         token_type: "Bearer",
         expires_in: 86399,
         ext_expires_in: 86399,
-        access_token: "access_token"
+        access_token: "access_token",
       });
   }
 };
@@ -58,7 +58,7 @@ export const pluginForIdentitySDK = () => {
       refresh_token: "refresh_token",
       id_token:
         "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6IjFMVE16YWtpaGlSbGFfOHoyQkVKVlhlV01xbyJ9.eyJ2ZXIiOiIyLjAiLCJpc3MiOiJodHRwczovL2xvZ2luLm1pY3Jvc29mdG9ubGluZS5jb20vOTE4ODA0MGQtNmM2Ny00YzViLWIxMTItMzZhMzA0YjY2ZGFkL3YyLjAiLCJzdWIiOiJBQUFBQUFBQUFBQUFBQUFBQUFBQUFJa3pxRlZyU2FTYUZIeTc4MmJidGFRIiwiYXVkIjoiNmNiMDQwMTgtYTNmNS00NmE3LWI5OTUtOTQwYzc4ZjVhZWYzIiwiZXhwIjoxNTM2MzYxNDExLCJpYXQiOjE1MzYyNzQ3MTEsIm5iZiI6MTUzNjI3NDcxMSwibmFtZSI6IkFiZSBMaW5jb2xuIiwicHJlZmVycmVkX3VzZXJuYW1lIjoiQWJlTGlAbWljcm9zb2Z0LmNvbSIsIm9pZCI6IjAwMDAwMDAwLTAwMDAtMDAwMC02NmYzLTMzMzJlY2E3ZWE4MSIsInRpZCI6IjMzMzgwNDBkLTZjNjctNGM1Yi1iMTEyLTM2YTMwNGI2NmRhZCIsIm5vbmNlIjoiMTIzNTIzIiwiYWlvIjoiRGYyVVZYTDFpeCFsTUNXTVNPSkJjRmF0emNHZnZGR2hqS3Y4cTVnMHg3MzJkUjVNQjVCaXN2R1FPN1lXQnlqZDhpUURMcSFlR2JJRGFreXA1bW5PcmNkcUhlWVNubHRlcFFtUnA2QUlaOGpZIn0=.1AFWW-Ck5nROwSlltm7GzZvDwUkqvhSQpm55TQsmVo9Y59cLhRXpvB8n-55HCr9Z6G_31_UbeUkoz612I2j_Sm9FFShSDDjoaLQr54CreGIJvjtmS3EkK9a7SJBbcpL1MpUtlfygow39tFjY7EVNW9plWUvRrTgVk7lYLprvfzw-CIqw3gHC-T7IK_m_xkr08INERBtaecwhTeN4chPC4W3jdmw_lIxzC48YoQ0dB1L9-ImX98Egypfrlbm0IBL5spFzL6JDZIRRJOu8vecJvj1mq-IUhGt0MacxX8jdxYLP-KUu2d9MbNKpCKJuZ7p8gwTL5B7NlUdh_dmSviPWrw",
-      client_info: "eyJ1aWQiOiIxMjMtdGVzdC11aWQiLCJ1dGlkIjoiNDU2LXRlc3QtdXRpZCJ9"
+      client_info: "eyJ1aWQiOiIxMjMtdGVzdC11aWQiLCJ1dGlkIjoiNDU2LXRlc3QtdXRpZCJ9",
     });
   // Above id_token and client_info are straight from the msal tests
   // Reference - https://github.com/AzureAD/microsoft-authentication-library-for-js/blob/926f1c2ba0598575e23dfd8cdd8b79fa3a3d19ff/lib/msal-browser/test/utils/BrowserProtocolUtils.spec.ts#L73

--- a/sdk/test-utils/recorder/src/utils/requestBodyTransform.ts
+++ b/sdk/test-utils/recorder/src/utils/requestBodyTransform.ts
@@ -18,7 +18,7 @@ export type RequestBodyTransformsType = {
  */
 export const defaultRequestBodyTransforms: Required<RequestBodyTransformsType> = {
   stringTransforms: [(body: string) => (isBrowser() ? sanitizeScopeUrl(body) : body)],
-  jsonTransforms: []
+  jsonTransforms: [],
 };
 
 /**
@@ -122,7 +122,7 @@ export function applyRequestBodyTransformationsOnFixture(
           requestBody: applyRequestBodyTransformations(
             fixture.requestBody,
             requestBodyTransformations
-          )
+          ),
         };
         return updatedFixture;
       } else {

--- a/sdk/test-utils/recorder/src/utils/windowLens.ts
+++ b/sdk/test-utils/recorder/src/utils/windowLens.ts
@@ -27,5 +27,5 @@ export const windowLens: {
       root[propertyPath[0]] = {};
     }
     return this.set(propertyPath.slice(1), propertyValue, root[propertyPath[0]]);
-  }
+  },
 };

--- a/sdk/test-utils/recorder/test/browser/recorder.spec.ts
+++ b/sdk/test-utils/recorder/test/browser/recorder.spec.ts
@@ -23,10 +23,10 @@ async function helloWorldRequest(): Promise<string> {
 
 const recorderEnvSetup: RecorderEnvironmentSetup = {
   replaceableVariables: {
-    PATH: "/replaced"
+    PATH: "/replaced",
   },
   customizationsOnRecordings: [],
-  queryParametersToSkip: []
+  queryParametersToSkip: [],
 };
 
 /**
@@ -52,7 +52,7 @@ describe("The recorder's public API, on a browser", () => {
     windowLens.set(["__json__"], undefined);
   });
 
-  it("should record a simple test", async function() {
+  it("should record a simple test", async function () {
     // Setting up the record mode, and the PATH environment variable.
     windowLens.set(["__env__", "TEST_MODE"], "record");
     windowLens.set(["__env__", "PATH"], "/to/replace");
@@ -61,7 +61,7 @@ describe("The recorder's public API, on a browser", () => {
     xhrMock.setup();
     xhrMock.get("/to/replace", {
       status: 200,
-      body: expectedHttpResponse
+      body: expectedHttpResponse,
     });
 
     // Before starting the recorder, we need to make a copy of the original XHR object, so that we can
@@ -88,7 +88,7 @@ describe("The recorder's public API, on a browser", () => {
       ...this.currentTest,
       file: "test/recorder.browser.spec.ts",
       // For this test, we don't care what's the content of the recorded function.
-      fn: getNoOpFunction()
+      fn: getNoOpFunction(),
     });
 
     const recorder = record(fakeThis, recorderEnvSetup);
@@ -115,21 +115,20 @@ describe("The recorder's public API, on a browser", () => {
       // TODO: Find a way to capture the complete output.
       JSON.stringify({
         writeFile: true,
-        path:
-          "./recordings/browsers/the_recorders_public_api_on_a_browser/recording_should_record_a_simple_test.json",
+        path: "./recordings/browsers/the_recorders_public_api_on_a_browser/recording_should_record_a_simple_test.json",
         content: {
           recordings: [],
           uniqueTestInfo: {
             uniqueName: {},
-            newDate: {}
+            newDate: {},
           },
-          hash: MD5(getNoOpFunction().toString())
-        }
+          hash: MD5(getNoOpFunction().toString()),
+        },
       })
     );
   });
 
-  it("should playback a simple test", async function() {
+  it("should playback a simple test", async function () {
     // Setting up the playback mode.
     // The PATH environment variable is not needed on playback.
     // The recorder will assume that it is in playback mode by default.
@@ -139,17 +138,17 @@ describe("The recorder's public API, on a browser", () => {
     windowLens.set(
       [
         "__json__",
-        "recordings/browsers/the_recorders_public_api_on_a_browser/recording_should_playback_a_simple_test.json"
+        "recordings/browsers/the_recorders_public_api_on_a_browser/recording_should_playback_a_simple_test.json",
       ],
       {
         recordings: [
           {
             method: "GET",
             url: "/replaced",
-            response: expectedHttpResponse
-          }
+            response: expectedHttpResponse,
+          },
         ],
-        uniqueTestInfo: { uniqueName: {}, newDate: {} }
+        uniqueTestInfo: { uniqueName: {}, newDate: {} },
       }
     );
 
@@ -160,7 +159,7 @@ describe("The recorder's public API, on a browser", () => {
       ...this.currentTest,
       file: "test/recorder.browser.spec.ts",
       // For this test, we don't care what's the content of the recorded function.
-      fn: getNoOpFunction()
+      fn: getNoOpFunction(),
     });
 
     const recorder = record(fakeThis, recorderEnvSetup);
@@ -173,7 +172,7 @@ describe("The recorder's public API, on a browser", () => {
     await recorder.stop();
   });
 
-  it("soft-record should re-record a simple outdated test", async function() {
+  it("soft-record should re-record a simple outdated test", async function () {
     // Setting up the playback mode.
     // The PATH environment variable is not needed on playback.
     windowLens.set(["__env__", "TEST_MODE"], "soft-record");
@@ -183,18 +182,18 @@ describe("The recorder's public API, on a browser", () => {
     windowLens.set(
       [
         "__json__",
-        "recordings/browsers/the_recorders_public_api_on_a_browser/recording_softrecord_should_rerecord_a_simple_outdated_test.json"
+        "recordings/browsers/the_recorders_public_api_on_a_browser/recording_softrecord_should_rerecord_a_simple_outdated_test.json",
       ],
       {
         recordings: [
           {
             method: "GET",
             url: "/replaced",
-            response: expectedHttpResponse
-          }
+            response: expectedHttpResponse,
+          },
         ],
         uniqueTestInfo: { uniqueName: {}, newDate: {} },
-        hash: "fake old hash"
+        hash: "fake old hash",
       }
     );
 
@@ -202,7 +201,7 @@ describe("The recorder's public API, on a browser", () => {
     xhrMock.setup();
     xhrMock.get("/to/replace", {
       status: 200,
-      body: expectedHttpResponse
+      body: expectedHttpResponse,
     });
 
     // Before starting the recorder, we need to make a copy of the original XHR object, so that we can
@@ -231,7 +230,7 @@ describe("The recorder's public API, on a browser", () => {
       file: "test/recorder.browser.spec.ts",
       // The hash in our expected recording is made out of an empty function.
       // This function has something inside, which means it has changed.
-      fn: getAnotherNoOpFunction()
+      fn: getAnotherNoOpFunction(),
     });
 
     const recorder = record(fakeThis, recorderEnvSetup);
@@ -260,21 +259,20 @@ describe("The recorder's public API, on a browser", () => {
       // TODO: Find a way to capture the complete output.
       JSON.stringify({
         writeFile: true,
-        path:
-          "./recordings/browsers/the_recorders_public_api_on_a_browser/recording_softrecord_should_rerecord_a_simple_outdated_test.json",
+        path: "./recordings/browsers/the_recorders_public_api_on_a_browser/recording_softrecord_should_rerecord_a_simple_outdated_test.json",
         content: {
           recordings: [],
           uniqueTestInfo: {
             uniqueName: {},
-            newDate: {}
+            newDate: {},
           },
-          hash: MD5(getAnotherNoOpFunction().toString())
-        }
+          hash: MD5(getAnotherNoOpFunction().toString()),
+        },
       })
     );
   });
 
-  it("soft-record should skip a simple unchanged test", async function() {
+  it("soft-record should skip a simple unchanged test", async function () {
     // Setting up the playback mode.
     // The PATH environment variable is not needed on playback.
     windowLens.set(["__env__", "TEST_MODE"], "soft-record");
@@ -283,19 +281,19 @@ describe("The recorder's public API, on a browser", () => {
     windowLens.set(
       [
         "__json__",
-        "recordings/browsers/the_recorders_public_api_on_a_browser/recording_softrecord_should_skip_a_simple_unchanged_test.json"
+        "recordings/browsers/the_recorders_public_api_on_a_browser/recording_softrecord_should_skip_a_simple_unchanged_test.json",
       ],
       {
         recordings: [
           {
             method: "GET",
             url: "/replaced",
-            response: expectedHttpResponse
-          }
+            response: expectedHttpResponse,
+          },
         ],
         uniqueTestInfo: { uniqueName: {}, newDate: {} },
         // This is the expected hash
-        hash: MD5(getNoOpFunction().toString())
+        hash: MD5(getNoOpFunction().toString()),
       }
     );
 
@@ -308,7 +306,7 @@ describe("The recorder's public API, on a browser", () => {
       file: "test/recorder.browser.spec.ts",
       // The hash in our expected recording is made out of an empty function.
       // This function is empty, which means it remains the same.
-      fn: getNoOpFunction()
+      fn: getNoOpFunction(),
     });
 
     // We have to mock this.skip in order to confirm that the recorder has called it.

--- a/sdk/test-utils/recorder/test/browser/utils.spec.ts
+++ b/sdk/test-utils/recorder/test/browser/utils.spec.ts
@@ -4,12 +4,12 @@ import {
   stripNewLines,
   windowLens,
   isContentTypeInBrowserRecording,
-  maskAccessTokenInBrowserRecording
+  maskAccessTokenInBrowserRecording,
 } from "../../src/utils";
 import { expect } from "chai";
 import {
   applyRequestBodyTransformationsOnFixture,
-  defaultRequestBodyTransforms
+  defaultRequestBodyTransforms,
 } from "../../src/utils/requestBodyTransform";
 
 describe("Browser utils", () => {
@@ -32,7 +32,7 @@ describe("Browser utils", () => {
   });
 
   describe("testHasChanged", () => {
-    it("Should not crash if the recorded file doesn't exist", function() {
+    it("Should not crash if the recorded file doesn't exist", function () {
       const testSuiteTitle = this.test!.parent!.fullTitle();
       const testTitle = this.test!.title;
 
@@ -46,14 +46,14 @@ describe("Browser utils", () => {
       );
     });
 
-    it("Should return true if the older hash doesn't exist", function() {
+    it("Should return true if the older hash doesn't exist", function () {
       const platform = "browsers";
       const testSuiteTitle = this.test!.parent!.fullTitle();
       const testTitle = this.test!.title;
       const filePath = generateTestRecordingFilePath(platform, testSuiteTitle, testTitle);
 
       windowLens.set(["__json__"], {
-        ["recordings/" + filePath]: {}
+        ["recordings/" + filePath]: {},
       });
 
       // We won't be testing whether MD5 works or not.
@@ -98,9 +98,9 @@ describe("Browser utils", () => {
               "strict-transport-security": "max-age=31536000; includeSubDomains",
               "x-content-type-options": "nosniff",
               "x-ms-ests-server": "2.1.11562.10 - SCUS ProdSlices",
-              "x-ms-request-id": "a81f6417-0fc8-4fd4-80ea-9c9e58f9d600"
-            }
-          }
+              "x-ms-request-id": "a81f6417-0fc8-4fd4-80ea-9c9e58f9d600",
+            },
+          },
         ],
         output: [
           {
@@ -124,10 +124,10 @@ describe("Browser utils", () => {
               "strict-transport-security": "max-age=31536000; includeSubDomains",
               "x-content-type-options": "nosniff",
               "x-ms-ests-server": "2.1.11562.10 - SCUS ProdSlices",
-              "x-ms-request-id": "a81f6417-0fc8-4fd4-80ea-9c9e58f9d600"
-            }
-          }
-        ]
+              "x-ms-request-id": "a81f6417-0fc8-4fd4-80ea-9c9e58f9d600",
+            },
+          },
+        ],
       },
       {
         name: `mask "access_token"s in json response`,
@@ -144,9 +144,9 @@ describe("Browser utils", () => {
             responseHeaders: {
               "content-length": "1315",
               "content-type": "application/json; charset=utf-8",
-              date: "Tue, 16 Feb 2021 18:21:34 GMT"
-            }
-          }
+              date: "Tue, 16 Feb 2021 18:21:34 GMT",
+            },
+          },
         ],
         output: [
           {
@@ -161,10 +161,10 @@ describe("Browser utils", () => {
             responseHeaders: {
               "content-length": "1315",
               "content-type": "application/json; charset=utf-8",
-              date: "Tue, 16 Feb 2021 18:21:34 GMT"
-            }
-          }
-        ]
+              date: "Tue, 16 Feb 2021 18:21:34 GMT",
+            },
+          },
+        ],
       },
       {
         name: `doesn't mask "access_token"s in json response since the content-type is not application/json`,
@@ -181,9 +181,9 @@ describe("Browser utils", () => {
             responseHeaders: {
               "content-length": "1315",
               "content-type": "something; charset=utf-8",
-              date: "Tue, 16 Feb 2021 18:21:34 GMT"
-            }
-          }
+              date: "Tue, 16 Feb 2021 18:21:34 GMT",
+            },
+          },
         ],
         output: [
           {
@@ -198,10 +198,10 @@ describe("Browser utils", () => {
             responseHeaders: {
               "content-length": "1315",
               "content-type": "something; charset=utf-8",
-              date: "Tue, 16 Feb 2021 18:21:34 GMT"
-            }
-          }
-        ]
+              date: "Tue, 16 Feb 2021 18:21:34 GMT",
+            },
+          },
+        ],
       },
       {
         name: `no impact on other recordings`,
@@ -210,27 +210,27 @@ describe("Browser utils", () => {
             method: "PUT",
             url: "https://fakestorageaccount.blob.core.windows.net/container159218753534504901",
             query: {
-              restype: "container"
+              restype: "container",
             },
             requestBody: null,
             status: 201,
             response: "",
-            responseHeaders: {}
-          }
+            responseHeaders: {},
+          },
         ],
         output: [
           {
             method: "PUT",
             url: "https://fakestorageaccount.blob.core.windows.net/container159218753534504901",
             query: {
-              restype: "container"
+              restype: "container",
             },
             requestBody: null,
             status: 201,
             response: "",
-            responseHeaders: {}
-          }
-        ]
+            responseHeaders: {},
+          },
+        ],
       },
       {
         name: `no impact on the recording with json content type but no json response`,
@@ -245,9 +245,9 @@ describe("Browser utils", () => {
             responseHeaders: {
               "content-security-policy": "default-src 'self'",
               "content-type": "application/json; charset=utf-8",
-              "strict-transport-security": "max-age=31536000; includeSubDomains"
-            }
-          }
+              "strict-transport-security": "max-age=31536000; includeSubDomains",
+            },
+          },
         ],
         output: [
           {
@@ -260,11 +260,11 @@ describe("Browser utils", () => {
             responseHeaders: {
               "content-security-policy": "default-src 'self'",
               "content-type": "application/json; charset=utf-8",
-              "strict-transport-security": "max-age=31536000; includeSubDomains"
-            }
-          }
-        ]
-      }
+              "strict-transport-security": "max-age=31536000; includeSubDomains",
+            },
+          },
+        ],
+      },
     ].forEach((test) => {
       it(test.name, () => {
         expect(maskAccessTokenInBrowserRecording(test.input as any)).to.deep.equal(
@@ -291,11 +291,11 @@ describe("Browser utils", () => {
           responseHeaders: {
             "content-length": "1315",
             "content-type": "avro/binary",
-            date: "Tue, 16 Feb 2021 18:21:34 GMT"
-          }
+            date: "Tue, 16 Feb 2021 18:21:34 GMT",
+          },
         },
         expectedContentTypes: ["avro/binary"],
-        output: true
+        output: true,
       },
       {
         name: `"avro/binary" matches with an array of expected content types`,
@@ -311,11 +311,11 @@ describe("Browser utils", () => {
           responseHeaders: {
             "content-length": "1315",
             "content-type": "avro/binary",
-            date: "Tue, 16 Feb 2021 18:21:34 GMT"
-          }
+            date: "Tue, 16 Feb 2021 18:21:34 GMT",
+          },
         },
         expectedContentTypes: ["avro/binary", "application/xml"],
-        output: true
+        output: true,
       },
       {
         name: `"text/plain" should not match with an array of different content types`,
@@ -331,11 +331,11 @@ describe("Browser utils", () => {
           responseHeaders: {
             "content-length": "1315",
             "content-type": "text/plain",
-            date: "Tue, 16 Feb 2021 18:21:34 GMT"
-          }
+            date: "Tue, 16 Feb 2021 18:21:34 GMT",
+          },
         },
         expectedContentTypes: ["avro/binary", "application/xml"],
-        output: false
+        output: false,
       },
       {
         name: "application/json; charset=utf-8",
@@ -351,12 +351,12 @@ describe("Browser utils", () => {
           responseHeaders: {
             "content-length": "1315",
             "content-type": "application/json; charset=utf-8",
-            date: "Tue, 16 Feb 2021 18:21:34 GMT"
-          }
+            date: "Tue, 16 Feb 2021 18:21:34 GMT",
+          },
         },
         expectedContentTypes: ["application/json;charset=utf-8"],
-        output: true
-      }
+        output: true,
+      },
     ].forEach((test) => {
       it(test.name, () => {
         expect(isContentTypeInBrowserRecording(test.input, test.expectedContentTypes)).to.equal(
@@ -381,11 +381,11 @@ describe("Browser utils", () => {
           response: '{"token_type":"Bearer","access_token":"access_token"}',
           responseHeaders: {
             "content-length": "1317",
-            date: "Fri, 21 May 2021 20:27:39 GMT"
-          }
+            date: "Fri, 21 May 2021 20:27:39 GMT",
+          },
         },
         finalRequestBody:
-          "response_type=token&client_secret=azure_client_secret&scope=https%3A%2F%2Fsanitized%2F"
+          "response_type=token&client_secret=azure_client_secret&scope=https%3A%2F%2Fsanitized%2F",
       },
       {
         title: "scope at the middle of the request body gets replaced",
@@ -397,11 +397,11 @@ describe("Browser utils", () => {
           response: '{"token_type":"Bearer","access_token":"access_token"}',
           responseHeaders: {
             "content-length": "1317",
-            date: "Fri, 21 May 2021 20:27:39 GMT"
-          }
+            date: "Fri, 21 May 2021 20:27:39 GMT",
+          },
         },
         finalRequestBody:
-          "response_type=token&client_secret=azure_client_secret&scope=https%3A%2F%2Fsanitized%2F&abc=123"
+          "response_type=token&client_secret=azure_client_secret&scope=https%3A%2F%2Fsanitized%2F&abc=123",
       },
       {
         title: "unchanged for body with no scope",
@@ -412,11 +412,11 @@ describe("Browser utils", () => {
           response: '{"token_type":"Bearer","access_token":"access_token"}',
           responseHeaders: {
             "content-length": "1317",
-            date: "Fri, 21 May 2021 20:27:39 GMT"
-          }
+            date: "Fri, 21 May 2021 20:27:39 GMT",
+          },
         },
-        finalRequestBody: "response_type=token&client_secret=azure_client_secret"
-      }
+        finalRequestBody: "response_type=token&client_secret=azure_client_secret",
+      },
     ].forEach((testCase) => {
       it(`${testCase.title}`, () => {
         expect(

--- a/sdk/test-utils/recorder/test/node/recorder.spec.ts
+++ b/sdk/test-utils/recorder/test/node/recorder.spec.ts
@@ -46,14 +46,14 @@ async function helloWorldRequest(): Promise<string> {
 
 const recorderEnvSetup: RecorderEnvironmentSetup = {
   replaceableVariables: {
-    SERVER_ADDRESS: "http://127.0.0.1:1337"
+    SERVER_ADDRESS: "http://127.0.0.1:1337",
   },
   customizationsOnRecordings: [],
-  queryParametersToSkip: []
+  queryParametersToSkip: [],
 };
 
 describe("The recorder's public API, on NodeJS", () => {
-  beforeEach(function() {
+  beforeEach(function () {
     // These tests do make files in the recordings folder.
     // For that reason, we make sure these files are deleted before testing.
     const fs = require("fs");
@@ -72,13 +72,13 @@ describe("The recorder's public API, on NodeJS", () => {
     delete process.env.SERVER_ADDRESS;
   });
 
-  it("should record a simple test", async function() {
+  it("should record a simple test", async function () {
     process.env.TEST_MODE = "record";
     process.env.SERVER_ADDRESS = "http://127.0.0.1:8080";
 
     // We create a very simple HTTP server that serves some content at a specific port.
     const http = require("http");
-    const server = http.createServer(function(_: any, res: any) {
+    const server = http.createServer(function (_: any, res: any) {
       res.write(expectedHttpResponse);
       res.end();
     });
@@ -90,7 +90,7 @@ describe("The recorder's public API, on NodeJS", () => {
     const fakeThis: TestContextInterface = new TestContext(this.test! as TestContextTest, {
       ...this.currentTest,
       file: __filename,
-      fn: emptyFunction
+      fn: emptyFunction,
     });
 
     const recorder = record(fakeThis, recorderEnvSetup);
@@ -122,7 +122,7 @@ describe("The recorder's public API, on NodeJS", () => {
     );
   });
 
-  it("should playback a simple test", async function() {
+  it("should playback a simple test", async function () {
     // The recorder will assume that it is in playback mode by default.
     // process.env.TEST_MODE = "playback";
 
@@ -139,7 +139,7 @@ describe("The recorder's public API, on NodeJS", () => {
     const fakeThis: TestContextInterface = new TestContext(this.test! as TestContextTest, {
       ...this.currentTest,
       file: __filename,
-      fn: emptyFunction
+      fn: emptyFunction,
     });
 
     const recorder = record(fakeThis, recorderEnvSetup);
@@ -151,7 +151,7 @@ describe("The recorder's public API, on NodeJS", () => {
     await recorder.stop();
   });
 
-  it("soft-record should re-record a simple outdated test", async function() {
+  it("soft-record should re-record a simple outdated test", async function () {
     process.env.TEST_MODE = "soft-record";
     process.env.SERVER_ADDRESS = "http://127.0.0.1:8080";
 
@@ -164,7 +164,7 @@ describe("The recorder's public API, on NodeJS", () => {
 
     // We create a very simple HTTP server that serves some content at a specific port.
     const http = require("http");
-    const server = http.createServer(function(_: any, res: any) {
+    const server = http.createServer(function (_: any, res: any) {
       res.write(expectedHttpResponse);
       res.end();
     });
@@ -181,7 +181,7 @@ describe("The recorder's public API, on NodeJS", () => {
     const fakeThis: TestContextInterface = new TestContext(this.test! as TestContextTest, {
       ...this.currentTest,
       file: __filename,
-      fn: changedTestFunction
+      fn: changedTestFunction,
     });
 
     const recorder = record(fakeThis, recorderEnvSetup);
@@ -217,7 +217,7 @@ describe("The recorder's public API, on NodeJS", () => {
     expect(recordingWithoutDate).to.equal(expectedRecordingWithUpdatedHash);
   });
 
-  it("soft-record should skip a simple unchanged test", async function() {
+  it("soft-record should skip a simple unchanged test", async function () {
     process.env.TEST_MODE = "soft-record";
 
     // Making sure the expected recording actually exists before running playback.
@@ -236,7 +236,7 @@ describe("The recorder's public API, on NodeJS", () => {
       file: __filename,
       // The hash in our expected recording is made out of an empty function.
       // This function is empty, which means it remains the same.
-      fn: emptyFunction
+      fn: emptyFunction,
     });
 
     // We have to mock this.skip in order to confirm that the recorder has called it.

--- a/sdk/test-utils/recorder/test/node/utils.spec.ts
+++ b/sdk/test-utils/recorder/test/node/utils.spec.ts
@@ -8,7 +8,7 @@ import {
   isContentTypeInNockFixture,
   decodeHexEncodingIfExistsInNockFixture,
   handleSingleQuotesInUrlPath,
-  setDefaultRetryAfterIntervalInNockFixture
+  setDefaultRetryAfterIntervalInNockFixture,
 } from "../../src/utils";
 import { nodeRequireRecordingIfExists, findRecordingsFolderPath } from "../../src/utils/recordings";
 import chai, { expect } from "chai";
@@ -16,7 +16,7 @@ import { defaultCustomizationsOnRecordings } from "../../src/defaultCustomizatio
 
 describe("NodeJS utils", () => {
   describe("nodeRequireRecordingIfExists", () => {
-    it("should be able to load the contents of a recording file if the file exists", function() {
+    it("should be able to load the contents of a recording file if the file exists", function () {
       const mockFs = require("mock-fs");
       const mockRequire = require("mock-require");
 
@@ -26,7 +26,7 @@ describe("NodeJS utils", () => {
         "recordings/recording.json": "",
         "test/myTest.spec.ts": "",
         "../../sdk/": {},
-        "../../../rush.json": ""
+        "../../../rush.json": "",
       });
 
       const path = require("path");
@@ -34,12 +34,12 @@ describe("NodeJS utils", () => {
 
       // If rollup bundle is used to execute the tests - `dist-test/index.node.js`, `recordings` folder is present one level above.
       mockRequire("../recordings/recording.json", {
-        property: "value"
+        property: "value",
       });
 
       // If the dist-esm files are used to execute the tests - `dist-esm/test/node/utils.spec.js`, `recordings` folder is present three levels above.
       mockRequire("../../../recordings/recording.json", {
-        property: "value"
+        property: "value",
       });
 
       expect(nodeRequireRecordingIfExists("recording.json", testAbsolutePath).property).to.equal(
@@ -50,7 +50,7 @@ describe("NodeJS utils", () => {
       mockRequire.stopAll();
     });
 
-    it("should throw if the file at a given recording path doesn't exist", function() {
+    it("should throw if the file at a given recording path doesn't exist", function () {
       if (isBrowser()) {
         this.skip();
       }
@@ -64,7 +64,7 @@ describe("NodeJS utils", () => {
         recordings: {},
         "test/myTest.spec.ts": "",
         "../../sdk/": {},
-        "../../../rush.json": ""
+        "../../../rush.json": "",
       });
 
       const path = require("path");
@@ -89,7 +89,7 @@ describe("NodeJS utils", () => {
   });
 
   describe("testHasChanged", () => {
-    it("should not crash if the recorded file doesn't exist", function() {
+    it("should not crash if the recorded file doesn't exist", function () {
       const mockFs = require("mock-fs");
       const mockRequire = require("mock-require");
       const testSuiteTitle = this.test!.parent!.fullTitle();
@@ -101,7 +101,7 @@ describe("NodeJS utils", () => {
         recordings: {},
         "test/myTest.spec.ts": "",
         "../../sdk/": {},
-        "../../../rush.json": ""
+        "../../../rush.json": "",
       });
 
       // We won't be testing whether MD5 works or not.
@@ -116,7 +116,7 @@ describe("NodeJS utils", () => {
       mockRequire.stopAll();
     });
 
-    it("should return true if the older hash doesn't exist", function() {
+    it("should return true if the older hash doesn't exist", function () {
       const mockFs = require("mock-fs");
       const mockRequire = require("mock-require");
       const platform = "node";
@@ -130,7 +130,7 @@ describe("NodeJS utils", () => {
         [`recordings/${filePath}`]: "",
         "test/myTest.spec.ts": "",
         "../../sdk/": {},
-        "../../../rush.json": ""
+        "../../../rush.json": "",
       });
 
       mockRequire(`../recordings/${filePath}`, {});
@@ -147,7 +147,7 @@ describe("NodeJS utils", () => {
       mockRequire.stopAll();
     });
 
-    it("should return false if the older hash is the same as the new hash", function() {
+    it("should return false if the older hash is the same as the new hash", function () {
       const mockFs = require("mock-fs");
       const mockRequire = require("mock-require");
       const platform = "node";
@@ -161,19 +161,19 @@ describe("NodeJS utils", () => {
         [`recordings/${filePath}`]: "",
         "test/myTest.spec.ts": "",
         "../../sdk/": {},
-        "../../../rush.json": ""
+        "../../../rush.json": "",
       });
 
       // If rollup bundle is used to execute the tests - `dist-test/index.node.js`, `recordings` folder is present one level above.
       mockRequire(`../recordings/${filePath}`, {
         // We won't be testing whether MD5 works or not.
-        hash: "same old hash"
+        hash: "same old hash",
       });
 
       // If the dist-esm files are used to execute the tests - `dist-esm/test/node/utils.spec.js`, `recordings` folder is present three levels above.
       mockRequire(`../../../recordings/${filePath}`, {
         // We won't be testing whether MD5 works or not.
-        hash: "same old hash"
+        hash: "same old hash",
       });
 
       // We won't be testing whether MD5 works or not.
@@ -188,7 +188,7 @@ describe("NodeJS utils", () => {
       mockRequire.stopAll();
     });
 
-    it("should return true if the older hash is different than the new hash", function() {
+    it("should return true if the older hash is different than the new hash", function () {
       const mockFs = require("mock-fs");
       const mockRequire = require("mock-require");
       const platform = "node";
@@ -202,12 +202,12 @@ describe("NodeJS utils", () => {
         [`recordings/${filePath}`]: "",
         "test/myTest.spec.ts": "",
         "../../sdk/": {},
-        "../../../rush.json": ""
+        "../../../rush.json": "",
       });
 
       mockRequire(`../recordings/${filePath}`, {
         // We won't be testing whether MD5 works or not.
-        hash: "old hash"
+        hash: "old hash",
       });
 
       // We won't be testing whether MD5 works or not.
@@ -248,7 +248,7 @@ describe("NodeJS utils", () => {
   'avro/binary',
   'Last-Modified',
   'Thu, 20 Aug 2020 09:22:11 GMT',
-]);`
+]);`,
       },
       {
         name: `Hex encoding is not decoded for "something/else" content type`,
@@ -273,7 +273,7 @@ describe("NodeJS utils", () => {
   'something/else',
   'Last-Modified',
   'Thu, 20 Aug 2020 09:22:11 GMT',
-]);`
+]);`,
       },
       {
         name: `Hex encoding decodes for "avro/binary" content type even for partial success(status code 206)`,
@@ -298,7 +298,7 @@ describe("NodeJS utils", () => {
   'avro/binary',
   'Last-Modified',
   'Thu, 20 Aug 2020 09:22:11 GMT',
-]);`
+]);`,
       },
       {
         name: `Hex encoding is not decoded for non-successful status codes`,
@@ -323,8 +323,8 @@ describe("NodeJS utils", () => {
   'avro/binary',
   'Last-Modified',
   'Thu, 20 Aug 2020 09:22:11 GMT',
-]);`
-      }
+]);`,
+      },
     ].forEach((test) => {
       it(test.name, () => {
         chai.assert.equal(
@@ -352,7 +352,7 @@ describe("NodeJS utils", () => {
   'Thu, 20 Aug 2020 09:22:11 GMT',
 ]);`,
         expectedContentTypes: ["avro/binary"],
-        output: true
+        output: true,
       },
       {
         name: `"avro/binary" matches with an array of expected content types`,
@@ -368,7 +368,7 @@ describe("NodeJS utils", () => {
           'Thu, 20 Aug 2020 09:22:11 GMT',
         ]);`,
         expectedContentTypes: ["avro/binary", "application/xml"],
-        output: true
+        output: true,
       },
       {
         name: `"text/plain" should not match with an array of different content types`,
@@ -384,8 +384,8 @@ describe("NodeJS utils", () => {
           'Thu, 20 Aug 2020 09:22:11 GMT',
         ]);`,
         expectedContentTypes: ["avro/binary", "application/xml"],
-        output: false
-      }
+        output: false,
+      },
     ].forEach((test) => {
       it(test.name, () => {
         chai.assert.equal(
@@ -436,7 +436,7 @@ describe("NodeJS utils", () => {
           'Strict-Transport-Security',
           'max-age=31536000; includeSubDomains',
           'X-Content-Type-Options'
-        ]);`
+        ]);`,
       },
       {
         name: `modify scope url and do nothing else for json response without access_token`,
@@ -473,7 +473,7 @@ describe("NodeJS utils", () => {
           'Strict-Transport-Security',
           'max-age=31536000; includeSubDomains',
           'X-Content-Type-Options'
-        ]);`
+        ]);`,
       },
       {
         name: `do nothing for (unrelated) non JSON response`,
@@ -498,7 +498,7 @@ describe("NodeJS utils", () => {
           'text/plain',
           'Last-Modified',
           'Thu, 20 Aug 2020 09:22:11 GMT',
-        ]);`
+        ]);`,
       },
       {
         name: "do nothing for unrelated XML response",
@@ -537,8 +537,8 @@ describe("NodeJS utils", () => {
           '2019-02-02',
           'Date',
           'Tue, 03 Dec 2019 05:06:39 GMT' ]);
-        `
-      }
+        `,
+      },
     ].forEach((test) => {
       it(test.name, () => {
         let updatedFixture = test.input;
@@ -587,7 +587,7 @@ describe("NodeJS utils", () => {
   'max-age=31536000; includeSubDomains',
   'x-ms-request-id',
   '8fc80de9-0d11-4570-a62b-3e90ae6fd07c',
-]);`
+]);`,
       },
       {
         name: `has no effect if retry-after is absent`,
@@ -616,7 +616,7 @@ describe("NodeJS utils", () => {
   'max-age=31536000; includeSubDomains',
   'x-ms-request-id',
   '8fc80de9-0d11-4570-a62b-3e90ae6fd07c',
-]);`
+]);`,
       },
       {
         name: `unchanged if retry-after is 0 already`,
@@ -649,7 +649,7 @@ describe("NodeJS utils", () => {
   'max-age=31536000; includeSubDomains',
   'x-ms-request-id',
   '8fc80de9-0d11-4570-a62b-3e90ae6fd07c',
-]);`
+]);`,
       },
       {
         name: `unchanged if the value after the retry-after is not a number`,
@@ -682,8 +682,8 @@ describe("NodeJS utils", () => {
   'max-age=31536000; includeSubDomains',
   'x-ms-request-id',
   '8fc80de9-0d11-4570-a62b-3e90ae6fd07c',
-]);`
-      }
+]);`,
+      },
     ].forEach((test) => {
       it(test.name, () => {
         chai.assert.equal(
@@ -729,7 +729,7 @@ describe("NodeJS utils", () => {
                   .reply(200, "4f626a0131c2", [
                   'Transfer-Encoding',
                   'chunked'
-                ]);`
+                ]);`,
       },
       {
         name: `single quotes in delete request in the fixture with no request body`,
@@ -746,7 +746,7 @@ describe("NodeJS utils", () => {
                   .reply(200, "4f626a0131c2", [
                   'Transfer-Encoding',
                   'chunked'
-                ]);`
+                ]);`,
       },
       {
         name: `no single quotes in get request in the fixture`,
@@ -763,7 +763,7 @@ describe("NodeJS utils", () => {
                   .reply(200, "4f626a0131c2", [
                   'Transfer-Encoding',
                   'chunked'
-                ]);`
+                ]);`,
       },
       {
         name: `more than two single quotes in delete request in the fixture`,
@@ -780,8 +780,8 @@ describe("NodeJS utils", () => {
                   .reply(200, "4f626a0131c2", [
                   'Transfer-Encoding',
                   'chunked'
-                ]);`
-      }
+                ]);`,
+      },
       // {
       //   name: `no single quotes in the path and single quotes in the request body should not affect`,
       //   input: `nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})

--- a/sdk/test-utils/recorder/test/utils.spec.ts
+++ b/sdk/test-utils/recorder/test/utils.spec.ts
@@ -7,7 +7,7 @@ import {
   env,
   filterSecretsRecursivelyFromJSON,
   generateTestRecordingFilePath,
-  isHex
+  isHex,
 } from "../src/utils";
 import { setEnvironmentVariables } from "../src/baseRecorder";
 
@@ -36,7 +36,7 @@ describe("utils", () => {
         "%2B",
         "%2C",
         "%3B",
-        "%3D"
+        "%3D",
       ]);
     });
 
@@ -51,7 +51,7 @@ describe("utils", () => {
   describe("applyReplacementMap", () => {
     it("Should filter URI encoded secrets", () => {
       const env: NodeJS.ProcessEnv = {
-        SECRET: "(SECRET)"
+        SECRET: "(SECRET)",
       };
 
       const replacementMap: ReplacementMap = new Map();
@@ -65,7 +65,7 @@ describe("utils", () => {
 
     it("Should filter hostname of the plain URI", () => {
       const env: NodeJS.ProcessEnv = {
-        ENDPOINT: "https://azureaccount.net/"
+        ENDPOINT: "https://azureaccount.net/",
       };
 
       const replacementMap: ReplacementMap = new Map();
@@ -79,7 +79,7 @@ describe("utils", () => {
 
     it("Should filter hostname of the URI irrespective of `/` at the end", () => {
       const env: NodeJS.ProcessEnv = {
-        ENDPOINT: "https://azureaccount.net/"
+        ENDPOINT: "https://azureaccount.net/",
       };
 
       const replacementMap: ReplacementMap = new Map();
@@ -93,7 +93,7 @@ describe("utils", () => {
 
     it("Should filter hostname of the URI irrespective of the content succeeding the hostname", () => {
       const env: NodeJS.ProcessEnv = {
-        ENDPOINT: "https://azureaccount.net/queue/"
+        ENDPOINT: "https://azureaccount.net/queue/",
       };
 
       const replacementMap: ReplacementMap = new Map();
@@ -107,7 +107,7 @@ describe("utils", () => {
 
     it("Should filter raw secrets", () => {
       const env: NodeJS.ProcessEnv = {
-        ENDPOINT: "azure.com/url/"
+        ENDPOINT: "azure.com/url/",
       };
 
       const replacementMap: ReplacementMap = new Map();
@@ -122,7 +122,7 @@ describe("utils", () => {
     it("Should filter both, raw and URI encoded secrets", () => {
       const env: NodeJS.ProcessEnv = {
         SECRET: "(SECRET)",
-        ENDPOINT: "azure.com/url/"
+        ENDPOINT: "azure.com/url/",
       };
 
       const replacementMap: ReplacementMap = new Map();
@@ -137,7 +137,7 @@ describe("utils", () => {
 
     it("Should not apply unnecessary repeated replacements", () => {
       const env: NodeJS.ProcessEnv = {
-        AZURE_USERNAME: "username"
+        AZURE_USERNAME: "username",
       };
 
       const replacementMap: ReplacementMap = new Map();
@@ -155,7 +155,7 @@ describe("utils", () => {
     it("Should work with recordings of several lines", () => {
       const env: NodeJS.ProcessEnv = {
         SECRET: "(SECRET)",
-        ENDPOINT: "azure.com/url/"
+        ENDPOINT: "azure.com/url/",
       };
 
       const replacementMap: ReplacementMap = new Map();
@@ -188,7 +188,7 @@ ultramarine.com/url/PUBLIC
       const replacements: Array<(content: string) => string> = [
         (source: string): string => {
           return source.replace(/banana/i, "Bonobo's");
-        }
+        },
       ];
       const recording = "Banana Split";
       const appliedFunctions = applyReplacementFunctions(replacements, recording);
@@ -202,7 +202,7 @@ ultramarine.com/url/PUBLIC
         },
         (source: string): string => {
           return source.replace(/split/i, "Flex");
-        }
+        },
       ];
       const recording = "Banana Split";
       const appliedFunctions = applyReplacementFunctions(replacements, recording);
@@ -216,7 +216,7 @@ ultramarine.com/url/PUBLIC
         },
         (source: string): string => {
           return source.replace(/%28SECRET%29/g, "HIDDEN_SECRET");
-        }
+        },
       ];
       const recording = `
 All the combinations:
@@ -273,15 +273,15 @@ ultramarine.com/url/PUBLIC
               url: "https://azureaccount.net",
               query: {
                 marker: "/azureaccount/queue156816850373302116x2",
-                maxresults: "1"
+                maxresults: "1",
               },
               response:
                 '<?xml version="1.0" encoding="utf-8"?><EnumerationResults ServiceEndpoint="https://azureaccount.queue.core.windows.net/"><Prefix>queue156816850373302116</Prefix><Marker>/azureaccount/queue156816850373302116x2</Marker><MaxResults>1</MaxResults><Queues><Queue><Name>queue156816850373302116x2</Name><Metadata><key>val</key></Metadata></Queue></Queues><NextMarker /></EnumerationResults>',
               responseHeaders: {
-                server: "Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0"
-              }
-            }
-          ]
+                server: "Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0",
+              },
+            },
+          ],
         },
         replaceableVariables,
         [],
@@ -292,15 +292,15 @@ ultramarine.com/url/PUBLIC
               url: "https://fakestorageaccount.net",
               query: {
                 marker: "/fakestorageaccount/queue156816850373302116x2",
-                maxresults: "1"
+                maxresults: "1",
               },
               response:
                 '<?xml version="1.0" encoding="utf-8"?><EnumerationResults ServiceEndpoint="https://fakestorageaccount.queue.core.windows.net/"><Prefix>queue156816850373302116</Prefix><Marker>/fakestorageaccount/queue156816850373302116x2</Marker><MaxResults>1</MaxResults><Queues><Queue><Name>queue156816850373302116x2</Name><Metadata><key>val</key></Metadata></Queue></Queues><NextMarker /></EnumerationResults>',
               responseHeaders: {
-                server: "Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0"
-              }
-            }
-          ]
+                server: "Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0",
+              },
+            },
+          ],
         }
       );
     });
@@ -311,22 +311,22 @@ ultramarine.com/url/PUBLIC
           recording: [
             {
               response:
-                '{"token_type":"Bearer","expires_in":3599,"ext_expires_in":3599,"access_token":"eyJ0eXAiOiwN"}'
-            }
-          ]
+                '{"token_type":"Bearer","expires_in":3599,"ext_expires_in":3599,"access_token":"eyJ0eXAiOiwN"}',
+            },
+          ],
         },
         {},
         [
           (recording: any): any =>
-            recording.replace(/"access_token":"[^"]*"/g, `"access_token":"access_token"`)
+            recording.replace(/"access_token":"[^"]*"/g, `"access_token":"access_token"`),
         ],
         {
           recording: [
             {
               response:
-                '{"token_type":"Bearer","expires_in":3599,"ext_expires_in":3599,"access_token":"access_token"}'
-            }
-          ]
+                '{"token_type":"Bearer","expires_in":3599,"ext_expires_in":3599,"access_token":"access_token"}',
+            },
+          ],
         }
       );
     });
@@ -338,23 +338,23 @@ ultramarine.com/url/PUBLIC
         [
           {
             response:
-              '{"token_type":"Bearer","expires_in":3599,"ext_expires_in":3599,"access_token":"eyJ0eXAiOiwN"}'
+              '{"token_type":"Bearer","expires_in":3599,"ext_expires_in":3599,"access_token":"eyJ0eXAiOiwN"}',
           },
           { url: "http://bing.com" },
-          { ACCOUNT_NAME: "azureaccount" }
+          { ACCOUNT_NAME: "azureaccount" },
         ],
         replaceableVariables,
         [
           (recording: any): any =>
-            recording.replace(/"access_token":"[^"]*"/g, `"access_token":"access_token"`)
+            recording.replace(/"access_token":"[^"]*"/g, `"access_token":"access_token"`),
         ],
         [
           {
             response:
-              '{"token_type":"Bearer","expires_in":3599,"ext_expires_in":3599,"access_token":"access_token"}'
+              '{"token_type":"Bearer","expires_in":3599,"ext_expires_in":3599,"access_token":"access_token"}',
           },
           { url: "http://bing.com" },
-          { ACCOUNT_NAME: "fakestorageaccount" }
+          { ACCOUNT_NAME: "fakestorageaccount" },
         ]
       );
     });
@@ -363,16 +363,16 @@ ultramarine.com/url/PUBLIC
       verifyFilterFunctionForJson(
         {
           response:
-            '{"token_type":"Bearer","expires_in":3599,"ext_expires_in":3599,"access_token":"eyJ0eXAiOiwN"}'
+            '{"token_type":"Bearer","expires_in":3599,"ext_expires_in":3599,"access_token":"eyJ0eXAiOiwN"}',
         },
         {},
         [
           (recording: any): any =>
-            recording.replace(/"access_token":"[^"]*"/g, `"access_token":"access_token"`)
+            recording.replace(/"access_token":"[^"]*"/g, `"access_token":"access_token"`),
         ],
         {
           response:
-            '{"token_type":"Bearer","expires_in":3599,"ext_expires_in":3599,"access_token":"access_token"}'
+            '{"token_type":"Bearer","expires_in":3599,"ext_expires_in":3599,"access_token":"access_token"}',
         }
       );
     });
@@ -383,7 +383,7 @@ ultramarine.com/url/PUBLIC
         {},
         [
           (recording: any): any =>
-            recording.replace(/"access_token":"[^"]*"/g, `"access_token":"access_token"`)
+            recording.replace(/"access_token":"[^"]*"/g, `"access_token":"access_token"`),
         ],
         { access_token: "access_token" }
       );
@@ -395,7 +395,7 @@ ultramarine.com/url/PUBLIC
         {},
         [
           (recording: any): any =>
-            recording.replace(/"access_token":"[^"]*"/g, `"access_token":"access_token"`)
+            recording.replace(/"access_token":"[^"]*"/g, `"access_token":"access_token"`),
         ],
         JSON.stringify({ access_token: "access_token" })
       );
@@ -404,15 +404,15 @@ ultramarine.com/url/PUBLIC
     it("Should work for JSON content #7 - JSON.stringify-ed content - regex to be replaced is present as a key-value pair somewhere inside the tree in the JSON content", () => {
       verifyFilterFunctionForJson(
         JSON.stringify({
-          recording: [{ access_token: "eyJ0eXA75E_Q" }]
+          recording: [{ access_token: "eyJ0eXA75E_Q" }],
         }),
         {},
         [
           (recording: any): any =>
-            recording.replace(/"access_token":"[^"]*"/g, `"access_token":"access_token"`)
+            recording.replace(/"access_token":"[^"]*"/g, `"access_token":"access_token"`),
         ],
         JSON.stringify({
-          recording: [{ access_token: "access_token" }]
+          recording: [{ access_token: "access_token" }],
         })
       );
     });
@@ -443,7 +443,7 @@ ultramarine.com/url/PUBLIC
   });
 
   describe("generateTestRecordingFilePath", () => {
-    it("Should generate a properly formatted path on platform: Node", function() {
+    it("Should generate a properly formatted path on platform: Node", function () {
       const platform = "node";
       const testSuiteTitle = this.test!.parent!.fullTitle();
       const testTitle = this.test!.title;
@@ -453,7 +453,7 @@ ultramarine.com/url/PUBLIC
       );
     });
 
-    it("Should generate a properly formatted path on platform: Browsers", function() {
+    it("Should generate a properly formatted path on platform: Browsers", function () {
       const platform = "browsers";
       const testSuiteTitle = this.test!.parent!.fullTitle();
       const testTitle = this.test!.title;

--- a/sdk/test-utils/test-credential/package.json
+++ b/sdk/test-utils/test-credential/package.json
@@ -62,7 +62,7 @@
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
     "@types/node": "^12.0.0",
     "eslint": "^7.15.0",
-    "prettier": "^1.16.4",
+    "prettier": "^2.5.1",
     "rimraf": "^3.0.0",
     "rollup": "^1.16.3",
     "typescript": "~4.2.0"

--- a/sdk/test-utils/test-credential/src/noOpCredential.ts
+++ b/sdk/test-utils/test-credential/src/noOpCredential.ts
@@ -14,7 +14,7 @@ export class NoOpCredential implements TokenCredential {
   getToken(): Promise<AccessToken> {
     return Promise.resolve({
       token: "SecretPlaceholder",
-      expiresOnTimestamp: Date.now() + 86400 * 1000
+      expiresOnTimestamp: Date.now() + 86400 * 1000,
     });
   }
 }

--- a/sdk/test-utils/test-utils/package.json
+++ b/sdk/test-utils/test-utils/package.json
@@ -77,7 +77,7 @@
     "karma-chrome-launcher": "^3.0.0",
     "karma-coverage": "^2.0.0",
     "karma-env-preprocessor": "^0.1.1",
-    "prettier": "^1.16.4",
+    "prettier": "^2.5.1",
     "rimraf": "^3.0.0",
     "rollup": "^1.16.3",
     "sinon": "^9.0.2",

--- a/sdk/test-utils/test-utils/src/index.ts
+++ b/sdk/test-utils/test-utils/src/index.ts
@@ -6,7 +6,7 @@ export {
   versionsToTest,
   SupportedVersions,
   MultiVersionTestOptions,
-  TestFunctionWrapper
+  TestFunctionWrapper,
 } from "./multiVersion";
 
 export { matrix } from "./matrix";

--- a/sdk/test-utils/test-utils/src/multiVersion.ts
+++ b/sdk/test-utils/test-utils/src/multiVersion.ts
@@ -36,8 +36,9 @@ function skipReason(currentVersion: string, supported: SupportedVersions): strin
   if (supported instanceof Array) {
     return `skipping for version ${currentVersion} as it is not in the list [${supported.join()}]`;
   } else {
-    return `skipping for version ${currentVersion} as it is not in the range: [min ${supported.minVer ??
-      "<unspecified>"}, max ${supported.maxVer ?? "<unspecified>"}]`;
+    return `skipping for version ${currentVersion} as it is not in the range: [min ${
+      supported.minVer ?? "<unspecified>"
+    }, max ${supported.maxVer ?? "<unspecified>"}]`;
   }
 }
 
@@ -53,7 +54,7 @@ export function isVersionInSupportedRange(
   supported: SupportedVersions,
   allVersions: ReadonlyArray<string>
 ): { isSupported: boolean; skipReason?: string } {
-  const lessThanOrEqual = function(a: string, b: string) {
+  const lessThanOrEqual = function (a: string, b: string) {
     const idxA = allVersions.indexOf(a);
     const idxB = allVersions.indexOf(b);
     if (idxA === -1) {
@@ -77,7 +78,7 @@ export function isVersionInSupportedRange(
       // console.log(`  Skipping test on ${currentVersion}`);
       return {
         isSupported: false,
-        skipReason: skipReason(currentVersion, supported)
+        skipReason: skipReason(currentVersion, supported),
       };
     }
   } else {
@@ -95,7 +96,7 @@ export function isVersionInSupportedRange(
         // console.log(`  Skipping ${currentVersion} because it is out of range`);
         return {
           isSupported: false,
-          skipReason: skipReason(currentVersion, supported)
+          skipReason: skipReason(currentVersion, supported),
         };
       }
     } else if (supported.minVer) {
@@ -106,7 +107,7 @@ export function isVersionInSupportedRange(
         // console.log(`  Skip ${currentVersion} because it's below minVer`);
         return {
           isSupported: false,
-          skipReason: skipReason(currentVersion, supported)
+          skipReason: skipReason(currentVersion, supported),
         };
       }
     } else if (supported.maxVer) {
@@ -117,7 +118,7 @@ export function isVersionInSupportedRange(
         // console.log(`  Skip ${currentVersion} because it's above maxVer`);
         return {
           isSupported: false,
-          skipReason: skipReason(currentVersion, supported)
+          skipReason: skipReason(currentVersion, supported),
         };
       }
     } else {
@@ -142,14 +143,14 @@ export function supports(
   allVersions: ReadonlyArray<string>
 ): TestFunctionWrapper {
   const run = isVersionInSupportedRange(currentVersion, supported, allVersions);
-  const either = function(match: any, skip: any) {
+  const either = function (match: any, skip: any) {
     return run.isSupported
       ? match
       : isLiveMode()
       ? // only append skip reason to titles in live TEST_MODE.
         // Record and playback depends on titles for recording file names so keeping them
         // in order to be compatible with existing recordings.
-        function(title: string, fn: Mocha.Func | Mocha.AsyncFunc) {
+        function (title: string, fn: Mocha.Func | Mocha.AsyncFunc) {
           return skip(`${title} (${run.skipReason})`, fn);
         }
       : skip;
@@ -157,39 +158,39 @@ export function supports(
 
   const it = either(supports.global.it, supports.global.xit);
   Object.defineProperty(it, "only", {
-    value: either(supports.global.it.only, supports.global.xit)
+    value: either(supports.global.it.only, supports.global.xit),
   });
   Object.defineProperty(it, "skip", {
-    value: supports.global.it.skip
+    value: supports.global.it.skip,
   });
 
   // add current service version to suite titles in Live TEST_MODE
   // Record and playback depends on titles for recording file names so keeping them
   // in order to be compatible with existing recordings.
   const wrappedDescribe = isLiveMode()
-    ? function(title: string, fn: Mocha.Func | Mocha.AsyncFunc) {
+    ? function (title: string, fn: Mocha.Func | Mocha.AsyncFunc) {
         return supports.global.describe(`${title} (service version ${currentVersion})`, fn);
       }
     : supports.global.describe;
   const wrappedDescribeOnly = isLiveMode()
-    ? function(title: string, fn: Mocha.Func | Mocha.AsyncFunc) {
+    ? function (title: string, fn: Mocha.Func | Mocha.AsyncFunc) {
         return supports.global.describe.only(`${title} (service version ${currentVersion})`, fn);
       }
     : supports.global.describe.only;
 
   const describe = either(wrappedDescribe, supports.global.xdescribe);
   Object.defineProperty(describe, "only", {
-    value: either(wrappedDescribeOnly, supports.global.xdescribe)
+    value: either(wrappedDescribeOnly, supports.global.xdescribe),
   });
   Object.defineProperty(describe, "skip", {
-    value: supports.global.describe.skip
+    value: supports.global.describe.skip,
   });
 
   const chain: TestFunctionWrapper = {
     it,
     xit: supports.global.xit,
     describe,
-    xdescribe: supports.global.xdescribe
+    xdescribe: supports.global.xdescribe,
   };
 
   return chain;
@@ -242,7 +243,7 @@ export function versionsToTest(
   }
 
   toTest.forEach((serviceVersion) => {
-    const onVersions = function(supported: SupportedVersions) {
+    const onVersions = function (supported: SupportedVersions) {
       return supports(serviceVersion, supported, versions);
     };
     handler(serviceVersion, onVersions);

--- a/sdk/test-utils/test-utils/src/tracing/testSpan.ts
+++ b/sdk/test-utils/test-utils/src/tracing/testSpan.ts
@@ -10,7 +10,7 @@ import {
   SpanAttributes,
   SpanStatusCode,
   SpanAttributeValue,
-  Span
+  Span,
 } from "@azure/core-tracing";
 
 /**
@@ -79,7 +79,7 @@ export class TestSpan implements Span {
     this.startTime = startTime;
     this.parentSpanId = parentSpanId;
     this.status = {
-      code: SpanStatusCode.OK
+      code: SpanStatusCode.OK,
     };
     this.endCalled = false;
     this._context = context;

--- a/sdk/test-utils/test-utils/src/tracing/testTracer.ts
+++ b/sdk/test-utils/test-utils/src/tracing/testTracer.ts
@@ -10,7 +10,7 @@ import {
   Context as OTContext,
   context as otContext,
   getSpanContext,
-  Tracer
+  Tracer,
 } from "@azure/core-tracing";
 
 /**
@@ -99,7 +99,7 @@ export class TestTracer implements Tracer {
       const spanId = span.spanContext().spanId;
       const node: SpanGraphNode = {
         name: span.name,
-        children: []
+        children: [],
       };
       nodeMap.set(spanId, node);
       if (span.parentSpanId) {
@@ -116,7 +116,7 @@ export class TestTracer implements Tracer {
     }
 
     return {
-      roots
+      roots,
     };
   }
 
@@ -141,7 +141,7 @@ export class TestTracer implements Tracer {
     const spanContext: SpanContext = {
       traceId,
       spanId: this.getNextSpanId(),
-      traceFlags: TraceFlags.NONE
+      traceFlags: TraceFlags.NONE,
     };
     const span = new TestSpan(
       this,

--- a/sdk/test-utils/test-utils/test/multiVersion.spec.ts
+++ b/sdk/test-utils/test-utils/test/multiVersion.spec.ts
@@ -16,17 +16,18 @@ describe("Multi-service-version test support", () => {
       { currentVersion: "1.0", supported: { minVer: "1.1", maxVer: undefined }, expected: false },
       { currentVersion: "1.0", supported: { minVer: undefined, maxVer: "1.1" }, expected: true },
       { currentVersion: "1.1", supported: { minVer: undefined, maxVer: "1.1" }, expected: true },
-      { currentVersion: "1.2", supported: { minVer: undefined, maxVer: "1.1" }, expected: false }
+      { currentVersion: "1.2", supported: { minVer: undefined, maxVer: "1.1" }, expected: false },
     ].forEach((arg) => {
       const { currentVersion, supported, expected } = arg;
       let versions: string;
       if (supported instanceof Array) {
         versions = `[${supported.join()}]`;
       } else {
-        versions = `[min ${supported.minVer ?? "<unspecified>"}, max ${supported.maxVer ??
-          "<unspecified>"}]`;
+        versions = `[min ${supported.minVer ?? "<unspecified>"}, max ${
+          supported.maxVer ?? "<unspecified>"
+        }]`;
       }
-      it(`returns ${expected} for ${currentVersion} and supported versions ${versions}`, function() {
+      it(`returns ${expected} for ${currentVersion} and supported versions ${versions}`, function () {
         const result = isVersionInSupportedRange(currentVersion, supported, allVersions);
         assert.equal(result.isSupported, expected);
       });
@@ -36,49 +37,49 @@ describe("Multi-service-version test support", () => {
 
 const serviceVersions = ["7.0", "7.1"] as const;
 versionsToTest(serviceVersions, {}, (serviceVersion, onVersions) => {
-  describe("test suite 1", function() {
-    beforeEach(async function() {
+  describe("test suite 1", function () {
+    beforeEach(async function () {
       console.log(`creating test client for service version ${serviceVersion}`);
     });
 
-    afterEach(async function() {
+    afterEach(async function () {
       /** empty */
     });
 
-    it("test case 2", function() {
+    it("test case 2", function () {
       if (serviceVersion === "7.0") {
         console.log(`verifying behavior specific to ${serviceVersion}`);
       }
     });
 
-    describe("nested test suite 3a", function() {
-      it("nested test 4a", function() {
+    describe("nested test suite 3a", function () {
+      it("nested test 4a", function () {
         /** empty */
       });
     });
 
-    onVersions(["7.0"]).describe("nested test suite 3b", function() {
-      it("nested test 4b", function() {
+    onVersions(["7.0"]).describe("nested test suite 3b", function () {
+      it("nested test 4b", function () {
         assert.equal(serviceVersion, "7.0");
       });
     });
 
-    onVersions(["7.0"]).it("test case 5 only runs on 7.0", function() {
+    onVersions(["7.0"]).it("test case 5 only runs on 7.0", function () {
       assert.equal(serviceVersion, "7.0");
     });
 
-    onVersions({ minVer: "7.1" }).it("test case 6 only runs on 7.1", async function() {
+    onVersions({ minVer: "7.1" }).it("test case 6 only runs on 7.1", async function () {
       assert.notEqual(serviceVersion, "7.0");
     });
 
-    onVersions({ minVer: "7.1" }).it.skip("test case 7 should be skipped", async function() {
+    onVersions({ minVer: "7.1" }).it.skip("test case 7 should be skipped", async function () {
       throw new Error("Test should have been skipped.");
     });
   });
 
-  onVersions(["7.0"]).describe("test suite 2", async function() {
+  onVersions(["7.0"]).describe("test suite 2", async function () {
     console.log(`onVersions() can be added to top-level describe as well to have nicer test title`);
-    it("test case 8", function() {
+    it("test case 8", function () {
       assert.equal(serviceVersion, "7.0");
     });
   });

--- a/sdk/test-utils/testing-recorder-new/karma.conf.js
+++ b/sdk/test-utils/testing-recorder-new/karma.conf.js
@@ -5,7 +5,7 @@ require("dotenv").config({ path: "./.env" });
 
 process.env.RECORDINGS_RELATIVE_PATH = relativeRecordingsPath();
 
-module.exports = function(config) {
+module.exports = function (config) {
   config.set({
     // base path that will be used to resolve all patterns (eg. files, exclude)
     basePath: "./",
@@ -25,13 +25,13 @@ module.exports = function(config) {
       "karma-coverage",
       "karma-sourcemap-loader",
       "karma-junit-reporter",
-      "karma-json-preprocessor"
+      "karma-json-preprocessor",
     ],
 
     // list of files / patterns to load in the browser
     files: [
       "dist-test/index.browser.js",
-      { pattern: "dist-test/index.browser.js.map", type: "html", included: false, served: true }
+      { pattern: "dist-test/index.browser.js.map", type: "html", included: false, served: true },
     ],
 
     // list of files / patterns to exclude
@@ -44,7 +44,7 @@ module.exports = function(config) {
       // IMPORTANT: COMMENT following line if you want to debug in your browsers!!
       // Preprocess source file to calculate code coverage, however this will make source file unreadable
       // "dist-test/index.browser.js": ["coverage"],
-      "recordings/browsers/**/*.json": ["json"]
+      "recordings/browsers/**/*.json": ["json"],
     },
 
     // inject following environment values into browser testing with window.__env__
@@ -58,7 +58,7 @@ module.exports = function(config) {
       "AZURE_CLIENT_ID",
       "AZURE_CLIENT_SECRET",
       "AZURE_TENANT_ID",
-      "RECORDINGS_RELATIVE_PATH"
+      "RECORDINGS_RELATIVE_PATH",
     ],
 
     // test results reporter to use
@@ -73,8 +73,8 @@ module.exports = function(config) {
         { type: "json", subdir: ".", file: "coverage.json" },
         { type: "lcovonly", subdir: ".", file: "lcov.info" },
         { type: "html", subdir: "html" },
-        { type: "cobertura", subdir: ".", file: "cobertura-coverage.xml" }
-      ]
+        { type: "cobertura", subdir: ".", file: "cobertura-coverage.xml" },
+      ],
     },
 
     junitReporter: {
@@ -84,7 +84,7 @@ module.exports = function(config) {
       useBrowserName: false, // add browser name to report and classes names
       nameFormatter: undefined, // function (browser, result) to customize the name attribute in xml testcase element
       classNameFormatter: undefined, // function (browser, result) to customize the classname attribute in xml testcase element
-      properties: {} // key value pair of properties to add to the <properties> section of the report
+      properties: {}, // key value pair of properties to add to the <properties> section of the report
     },
 
     // web server port
@@ -107,8 +107,8 @@ module.exports = function(config) {
     customLaunchers: {
       ChromeHeadlessNoSandbox: {
         base: "ChromeHeadless",
-        flags: ["--no-sandbox", "--disable-web-security"]
-      }
+        flags: ["--no-sandbox", "--disable-web-security"],
+      },
     },
 
     // Continuous Integration mode
@@ -127,8 +127,8 @@ module.exports = function(config) {
       mocha: {
         // change Karma's debug.html to the mocha web reporter
         reporter: "html",
-        timeout: "600000"
-      }
-    }
+        timeout: "600000",
+      },
+    },
   });
 };

--- a/sdk/test-utils/testing-recorder-new/package.json
+++ b/sdk/test-utils/testing-recorder-new/package.json
@@ -96,7 +96,7 @@
     "mock-require": "^3.0.3",
     "npm-run-all": "^4.1.5",
     "nyc": "^15.0.0",
-    "prettier": "^1.16.4",
+    "prettier": "^2.5.1",
     "rimraf": "^3.0.0",
     "rollup": "^1.16.3",
     "typescript": "~4.2.0",

--- a/sdk/test-utils/testing-recorder-new/test/core-v1-test.spec.ts
+++ b/sdk/test-utils/testing-recorder-new/test/core-v1-test.spec.ts
@@ -10,8 +10,8 @@ const fakeSASUrl =
 
 const recorderOptions: RecorderStartOptions = {
   envSetupForPlayback: {
-    STORAGE_SAS_URL: fakeSASUrl
-  }
+    STORAGE_SAS_URL: fakeSASUrl,
+  },
 };
 
 const getSanitizerOptions = () => {
@@ -19,22 +19,20 @@ const getSanitizerOptions = () => {
     generalRegexSanitizers: [
       {
         regex: assertEnvironmentVariable("STORAGE_SAS_URL").split("/")[2],
-        value: fakeSASUrl.split("/")[2]
+        value: fakeSASUrl.split("/")[2],
       },
       {
-        regex: assertEnvironmentVariable("STORAGE_SAS_URL")
-          .split("/")[3]
-          .split("?")[1],
-        value: fakeSASUrl.split("/")[3].split("?")[1]
-      }
-    ]
+        regex: assertEnvironmentVariable("STORAGE_SAS_URL").split("/")[3].split("?")[1],
+        value: fakeSASUrl.split("/")[3].split("?")[1],
+      },
+    ],
   };
 };
 
 describe("Core V1 tests", () => {
   let recorder: Recorder;
 
-  beforeEach(async function() {
+  beforeEach(async function () {
     recorder = new Recorder(this.currentTest);
 
     await recorder.start(recorderOptions);
@@ -45,7 +43,7 @@ describe("Core V1 tests", () => {
     await recorder.stop();
   });
 
-  it("storage-queue create queue", async function() {
+  it("storage-queue create queue", async function () {
     const client = new QueueServiceClient(
       assertEnvironmentVariable("STORAGE_SAS_URL"),
       undefined,

--- a/sdk/test-utils/testing-recorder-new/test/core-v2-test.spec.ts
+++ b/sdk/test-utils/testing-recorder-new/test/core-v2-test.spec.ts
@@ -12,24 +12,24 @@ const sanitizerOptions: SanitizerOptions = {
   connectionStringSanitizers: [
     {
       actualConnString: env.TABLES_SAS_CONNECTION_STRING,
-      fakeConnString
-    }
+      fakeConnString,
+    },
   ],
   removeHeaderSanitizer: { headersForRemoval: ["X-Content-Type-Options"] },
-  generalRegexSanitizers: [{ regex: "abc", value: "fake_abc" }]
+  generalRegexSanitizers: [{ regex: "abc", value: "fake_abc" }],
 };
 
 const recorderOptions: RecorderStartOptions = {
   envSetupForPlayback: {
-    TABLES_SAS_CONNECTION_STRING: fakeConnString
+    TABLES_SAS_CONNECTION_STRING: fakeConnString,
   },
-  sanitizerOptions
+  sanitizerOptions,
 };
 
 describe("Core V2 tests", () => {
   let recorder: Recorder;
 
-  beforeEach(async function() {
+  beforeEach(async function () {
     recorder = new Recorder(this.currentTest);
     await recorder.start(recorderOptions);
   });
@@ -38,7 +38,7 @@ describe("Core V2 tests", () => {
     await recorder.stop();
   });
 
-  it("data-tables create entity", async function() {
+  it("data-tables create entity", async function () {
     const client = TableClient.fromConnectionString(
       assertEnvironmentVariable("TABLES_SAS_CONNECTION_STRING"),
       recorder.variable("table-name", `table${Math.ceil(Math.random() * 1000 + 1000)}`)

--- a/sdk/test-utils/testing-recorder-new/test/noOpCredentialTest.spec.ts
+++ b/sdk/test-utils/testing-recorder-new/test/noOpCredentialTest.spec.ts
@@ -13,16 +13,16 @@ const getRecorderStartOptions = (): RecorderStartOptions => {
       TABLES_URL: "https://fakeaccount.table.core.windows.net",
       AZURE_CLIENT_ID: "azure_client_id",
       AZURE_CLIENT_SECRET: "azure_client_secret",
-      AZURE_TENANT_ID: "azuretenantid"
+      AZURE_TENANT_ID: "azuretenantid",
     },
     sanitizerOptions: {
       bodyRegexSanitizers: [
         {
           regex: env.TABLES_URL ? encodeURIComponent(env.TABLES_URL) : undefined,
-          value: encodeURIComponent(`https://fakeaccount.table.core.windows.net`)
-        }
-      ]
-    }
+          value: encodeURIComponent(`https://fakeaccount.table.core.windows.net`),
+        },
+      ],
+    },
   };
 };
 
@@ -30,13 +30,13 @@ describe(`NoOp credential with Tables`, () => {
   let recorder: Recorder;
   let credential: TokenCredential;
 
-  beforeEach(async function() {
+  beforeEach(async function () {
     recorder = new Recorder(this.currentTest);
     await recorder.start(getRecorderStartOptions());
     credential = createTestCredential();
   });
 
-  afterEach(async function() {
+  afterEach(async function () {
     await recorder.stop();
   });
 

--- a/sdk/test-utils/testing-recorder-new/test/utils/utils.ts
+++ b/sdk/test-utils/testing-recorder-new/test/utils/utils.ts
@@ -16,7 +16,7 @@ export function createSimpleEntity(): TableEntity {
     stringTypeProperty4: stringValue,
     stringTypeProperty5: stringValue,
     stringTypeProperty6: stringValue,
-    stringTypeProperty7: stringValue
+    stringTypeProperty7: stringValue,
   };
 }
 


### PR DESCRIPTION
Solves: https://github.com/Azure/azure-sdk-for-js/issues/9329 for projects under `sdk/test-utils/`.
 
Upgraded `prettier` dev-dependency version to latest `2.5.1`.
Files were re-formatted as well. There are only format changes in this PR, no manual changes except for package.json files.
 
Main format changes with Prettier 2.x in this PR include:
- Trailing commas by default.
- Whitespace added after every `function` keyword.
