### PR TITLE
Fix CloudEvent JSON body parser issue and fix JSON api definition

### DIFF
--- a/sdk/web-pubsub/web-pubsub-express/CHANGELOG.md
+++ b/sdk/web-pubsub/web-pubsub-express/CHANGELOG.md
@@ -1,14 +1,11 @@
 # Release History
 
-## 1.0.1 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
+## 1.0.1 (2022-01-11)
 
 ### Bugs Fixed
 
-### Other Changes
+- Fix the `data` definition for `UserEventRequest` when `dataType` is `json`. When `dataType` is `json`, `data` is the JSON parsed result from request body, so the type of `data` depends on the user scenario.
+- Fix the CloudEvents parsing issue that now `data` also can be `boolean` or `number`.
 
 ## 1.0.0 (2021-11-11)
 

--- a/sdk/web-pubsub/web-pubsub-express/review/web-pubsub-express.api.md
+++ b/sdk/web-pubsub/web-pubsub-express/review/web-pubsub-express.api.md
@@ -65,7 +65,7 @@ export type UserEventRequest = {
     dataType: "text";
 } | {
     context: ConnectionContext;
-    data: any;
+    data: unknown;
     dataType: "json";
 } | {
     context: ConnectionContext;

--- a/sdk/web-pubsub/web-pubsub-express/review/web-pubsub-express.api.md
+++ b/sdk/web-pubsub/web-pubsub-express/review/web-pubsub-express.api.md
@@ -62,7 +62,11 @@ export interface DisconnectedRequest {
 export type UserEventRequest = {
     context: ConnectionContext;
     data: string;
-    dataType: "text" | "json";
+    dataType: "text";
+} | {
+    context: ConnectionContext;
+    data: any;
+    dataType: "json";
 } | {
     context: ConnectionContext;
     data: ArrayBuffer;

--- a/sdk/web-pubsub/web-pubsub-express/src/cloudEventsDispatcher.ts
+++ b/sdk/web-pubsub/web-pubsub-express/src/cloudEventsDispatcher.ts
@@ -16,14 +16,14 @@ import {
   ConnectionContext,
   ConnectResponseHandler,
   UserEventResponseHandler,
-  WebPubSubEventHandlerOptions
+  WebPubSubEventHandlerOptions,
 } from "./cloudEventsProtocols";
 
 enum EventType {
   Connect,
   Connected,
   Disconnected,
-  UserEvent
+  UserEvent,
 }
 
 function getConnectResponseHandler(
@@ -52,7 +52,7 @@ function getConnectResponseHandler(
     fail(code: 400 | 401 | 500, detail?: string): void {
       response.statusCode = code;
       response.end(detail ?? "");
-    }
+    },
   };
 
   return handler;
@@ -91,7 +91,7 @@ function getUserEventResponseHandler(
     fail(code: 400 | 401 | 500, detail?: string): void {
       response.statusCode = code;
       response.end(detail ?? "");
-    }
+    },
   };
   return handler;
 }
@@ -104,7 +104,7 @@ function getContext(ce: CloudEvent, origin: string): ConnectionContext {
     connectionId: ce["connectionid"] as string,
     eventName: ce["eventname"] as string,
     origin: origin,
-    states: utils.fromBase64JsonString(ce["connectionstate"] as string)
+    states: utils.fromBase64JsonString(ce["connectionstate"] as string),
   };
 
   // TODO: validation
@@ -267,13 +267,13 @@ export class CloudEventsDispatcher {
           userRequest = {
             context: getContext(receivedEvent, origin),
             data: Buffer.from(receivedEvent.data_base64, "base64"),
-            dataType: "binary"
+            dataType: "binary",
           };
         } else if (receivedEvent.data !== undefined) {
           userRequest = {
             context: getContext(receivedEvent, origin),
             data: receivedEvent.data as string,
-            dataType: utils.isJsonData(receivedEvent) ? "json" : "text"
+            dataType: utils.isJsonData(receivedEvent) ? "json" : "text",
           };
         } else {
           throw new Error("Unexpected data.");

--- a/sdk/web-pubsub/web-pubsub-express/src/cloudEventsDispatcher.ts
+++ b/sdk/web-pubsub/web-pubsub-express/src/cloudEventsDispatcher.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { HTTP, CloudEvent } from "cloudevents";
+import { CloudEvent } from "cloudevents";
 import { IncomingMessage, ServerResponse } from "http";
 import { URL } from "url";
 import { logger } from "./logger";
@@ -232,9 +232,7 @@ export class CloudEventsDispatcher {
         return false;
     }
 
-    const eventRequest = await utils.convertHttpToEvent(request);
-    const receivedEvent = HTTP.toEvent(eventRequest);
-
+    const receivedEvent = await utils.convertHttpToEvent(request);
     logger.verbose(receivedEvent);
 
     switch (eventType) {
@@ -275,9 +273,7 @@ export class CloudEventsDispatcher {
           userRequest = {
             context: getContext(receivedEvent, origin),
             data: receivedEvent.data as string,
-            dataType: receivedEvent.datacontenttype?.startsWith("application/json;")
-              ? "json"
-              : "text",
+            dataType: utils.isJsonData(receivedEvent) ? "json" : "text",
           };
         } else {
           throw new Error("Unexpected data.");

--- a/sdk/web-pubsub/web-pubsub-express/src/cloudEventsDispatcher.ts
+++ b/sdk/web-pubsub/web-pubsub-express/src/cloudEventsDispatcher.ts
@@ -16,14 +16,14 @@ import {
   ConnectionContext,
   ConnectResponseHandler,
   UserEventResponseHandler,
-  WebPubSubEventHandlerOptions,
+  WebPubSubEventHandlerOptions
 } from "./cloudEventsProtocols";
 
 enum EventType {
   Connect,
   Connected,
   Disconnected,
-  UserEvent,
+  UserEvent
 }
 
 function getConnectResponseHandler(
@@ -52,7 +52,7 @@ function getConnectResponseHandler(
     fail(code: 400 | 401 | 500, detail?: string): void {
       response.statusCode = code;
       response.end(detail ?? "");
-    },
+    }
   };
 
   return handler;
@@ -91,7 +91,7 @@ function getUserEventResponseHandler(
     fail(code: 400 | 401 | 500, detail?: string): void {
       response.statusCode = code;
       response.end(detail ?? "");
-    },
+    }
   };
   return handler;
 }
@@ -104,7 +104,7 @@ function getContext(ce: CloudEvent, origin: string): ConnectionContext {
     connectionId: ce["connectionid"] as string,
     eventName: ce["eventname"] as string,
     origin: origin,
-    states: utils.fromBase64JsonString(ce["connectionstate"] as string),
+    states: utils.fromBase64JsonString(ce["connectionstate"] as string)
   };
 
   // TODO: validation
@@ -267,13 +267,13 @@ export class CloudEventsDispatcher {
           userRequest = {
             context: getContext(receivedEvent, origin),
             data: Buffer.from(receivedEvent.data_base64, "base64"),
-            dataType: "binary",
+            dataType: "binary"
           };
         } else if (receivedEvent.data !== undefined) {
           userRequest = {
             context: getContext(receivedEvent, origin),
             data: receivedEvent.data as string,
-            dataType: utils.isJsonData(receivedEvent) ? "json" : "text",
+            dataType: utils.isJsonData(receivedEvent) ? "json" : "text"
           };
         } else {
           throw new Error("Unexpected data.");

--- a/sdk/web-pubsub/web-pubsub-express/src/cloudEventsProtocols.ts
+++ b/sdk/web-pubsub/web-pubsub-express/src/cloudEventsProtocols.ts
@@ -124,7 +124,22 @@ export type UserEventRequest =
       /**
        * The type of the data.
        */
-      dataType: "text" | "json";
+      dataType: "text";
+    }
+  | {
+      /**
+       * The context of current CloudEvents request.
+       */
+      context: ConnectionContext;
+
+      /**
+       * The content data.
+       */
+      data: any;
+      /**
+       * The type of the data.
+       */
+      dataType: "json";
     }
   | {
       /**
@@ -191,7 +206,7 @@ export interface UserEventResponseHandler {
   setState(name: string, value: unknown): void;
   /**
    * Return success response with data to be delivered to the client WebSocket connection.
-   * @param data - The payload data to be returned to the client.
+   * @param data - The payload data to be returned to the client. Stringify the message if it is a JSON object.
    * @param dataType - The type of the payload data.
    */
   success(data?: string | ArrayBuffer, dataType?: "binary" | "text" | "json"): void;

--- a/sdk/web-pubsub/web-pubsub-express/src/cloudEventsProtocols.ts
+++ b/sdk/web-pubsub/web-pubsub-express/src/cloudEventsProtocols.ts
@@ -133,9 +133,10 @@ export type UserEventRequest =
       context: ConnectionContext;
 
       /**
-       * The content data.
+       * The content data, when data type is `json`, the data is the result of JSON.parse, so the type of the data depends on user scenarios
        */
-      data: any;
+      data: unknown;
+
       /**
        * The type of the data.
        */

--- a/sdk/web-pubsub/web-pubsub-express/src/utils.ts
+++ b/sdk/web-pubsub/web-pubsub-express/src/utils.ts
@@ -43,7 +43,7 @@ export function getHttpHeader(req: IncomingMessage, key: string): string | undef
 export async function convertHttpToEvent(request: IncomingMessage): Promise<CloudEvent> {
   const normalized: Message = {
     headers: {},
-    body: "",
+    body: ""
   };
   if (request.headers) {
     for (const key in request.headers) {
@@ -69,21 +69,21 @@ export async function convertHttpToEvent(request: IncomingMessage): Promise<Clou
 }
 
 export function isJsonData(event: CloudEvent): boolean {
-  return event.datacontenttype?.startsWith("application/json;") === true ? true : false;
+  return Boolean(event.datacontenttype?.startsWith("application/json;"));
 }
 
 export function readRequestBody(req: IncomingMessage): Promise<string> {
-  return new Promise(function (resolve, reject) {
+  return new Promise(function(resolve, reject) {
     const chunks: any = [];
-    req.on("data", function (chunk) {
+    req.on("data", function(chunk) {
       chunks.push(chunk);
     });
-    req.on("end", function () {
+    req.on("end", function() {
       const buffer = Buffer.concat(chunks);
       resolve(buffer.toString());
     });
     // reject on request error
-    req.on("error", function (err) {
+    req.on("error", function(err) {
       // This is not a "Second reject", just a different sort of failure
       reject(err);
     });

--- a/sdk/web-pubsub/web-pubsub-express/src/utils.ts
+++ b/sdk/web-pubsub/web-pubsub-express/src/utils.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 
 import { IncomingMessage } from "http";
-import { Message } from "cloudevents";
+import { CloudEvent, HTTP, Message } from "cloudevents";
 
 function isJsonObject(obj: any): boolean {
   return obj && typeof obj === "object" && !Array.isArray(obj);
@@ -40,7 +40,7 @@ export function getHttpHeader(req: IncomingMessage, key: string): string | undef
   return value[0];
 }
 
-export async function convertHttpToEvent(request: IncomingMessage): Promise<Message> {
+export async function convertHttpToEvent(request: IncomingMessage): Promise<CloudEvent> {
   const normalized: Message = {
     headers: {},
     body: "",
@@ -56,8 +56,20 @@ export async function convertHttpToEvent(request: IncomingMessage): Promise<Mess
     }
   }
 
-  normalized.body = await readRequestBody(request);
-  return normalized;
+  const body = (normalized.body = await readRequestBody(request));
+  const receivedEvent = HTTP.toEvent(normalized);
+  if (isJsonData(receivedEvent)) {
+    // CloudEvent JSONParser wrap string with quotes however it is not the case for numbers or booleans
+    // https://github.com/cloudevents/sdk-javascript/blob/main/src/parsers.ts#L29
+    // We workaround it here by rewrite the parsed data property
+    receivedEvent.data = JSON.parse(body);
+  }
+
+  return receivedEvent;
+}
+
+export function isJsonData(event: CloudEvent) {
+  return event.datacontenttype?.startsWith("application/json;");
 }
 
 export function readRequestBody(req: IncomingMessage): Promise<string> {

--- a/sdk/web-pubsub/web-pubsub-express/src/utils.ts
+++ b/sdk/web-pubsub/web-pubsub-express/src/utils.ts
@@ -69,7 +69,7 @@ export async function convertHttpToEvent(request: IncomingMessage): Promise<Clou
 }
 
 export function isJsonData(event: CloudEvent): boolean {
-  return event.datacontenttype?.startsWith("application/json;");
+  return event.datacontenttype?.startsWith("application/json;") === true ? true : false;
 }
 
 export function readRequestBody(req: IncomingMessage): Promise<string> {

--- a/sdk/web-pubsub/web-pubsub-express/src/utils.ts
+++ b/sdk/web-pubsub/web-pubsub-express/src/utils.ts
@@ -68,7 +68,7 @@ export async function convertHttpToEvent(request: IncomingMessage): Promise<Clou
   return receivedEvent;
 }
 
-export function isJsonData(event: CloudEvent) {
+export function isJsonData(event: CloudEvent): boolean {
   return event.datacontenttype?.startsWith("application/json;");
 }
 

--- a/sdk/web-pubsub/web-pubsub-express/src/utils.ts
+++ b/sdk/web-pubsub/web-pubsub-express/src/utils.ts
@@ -43,7 +43,7 @@ export function getHttpHeader(req: IncomingMessage, key: string): string | undef
 export async function convertHttpToEvent(request: IncomingMessage): Promise<CloudEvent> {
   const normalized: Message = {
     headers: {},
-    body: ""
+    body: "",
   };
   if (request.headers) {
     for (const key in request.headers) {
@@ -73,17 +73,17 @@ export function isJsonData(event: CloudEvent): boolean {
 }
 
 export function readRequestBody(req: IncomingMessage): Promise<string> {
-  return new Promise(function(resolve, reject) {
+  return new Promise(function (resolve, reject) {
     const chunks: any = [];
-    req.on("data", function(chunk) {
+    req.on("data", function (chunk) {
       chunks.push(chunk);
     });
-    req.on("end", function() {
+    req.on("end", function () {
       const buffer = Buffer.concat(chunks);
       resolve(buffer.toString());
     });
     // reject on request error
-    req.on("error", function(err) {
+    req.on("error", function (err) {
       // This is not a "Second reject", just a different sort of failure
       reject(err);
     });

--- a/sdk/web-pubsub/web-pubsub-express/test/user.spec.ts
+++ b/sdk/web-pubsub/web-pubsub-express/test/user.spec.ts
@@ -62,6 +62,64 @@ describe("Can handle user event", function () {
     assert.isTrue(endSpy.notCalled);
   });
 
+  it("Should handle number requests", async function () {
+    const endSpy = sinon.spy(res.end);
+    buildRequest(req, "hub", "conn1");
+
+    const dispatcher = new CloudEventsDispatcher("hub", {
+      handleUserEvent: async (req, response) => {
+        assert.equal(req.dataType, "json");
+        assert.equal(typeof req.data, "json");
+        response.success();
+      },
+    });
+    const process = dispatcher.handleRequest(req, res);
+    mockBody(req, JSON.stringify(1));
+    const result = await process;
+
+    assert.isTrue(result);
+    assert.isTrue(endSpy.calledOnce);
+  });
+
+  it("Should handle complex object requests", async function () {
+    const endSpy = sinon.spy(res.end);
+    buildRequest(req, "hub", "conn1");
+
+    const dispatcher = new CloudEventsDispatcher("hub", {
+      handleUserEvent: async (req, response) => {
+        assert.equal(req.dataType, "json");
+        assert.equal(typeof req.data, "object");
+        assert.equal(req.data.a, 1);
+        response.success();
+      },
+    });
+    const process = dispatcher.handleRequest(req, res);
+    mockBody(req, JSON.stringify({ a: 1 }));
+    const result = await process;
+
+    assert.isTrue(result);
+    assert.isTrue(endSpy.calledOnce);
+  });
+
+  it("Should handle complex array requests", async function () {
+    const endSpy = sinon.spy(res.end);
+    buildRequest(req, "hub", "conn1");
+
+    const dispatcher = new CloudEventsDispatcher("hub", {
+      handleUserEvent: async (req, response) => {
+        assert.equal(req.dataType, "json");
+        assert.equal(typeof req.data, "array");
+        response.success();
+      },
+    });
+    const process = dispatcher.handleRequest(req, res);
+    mockBody(req, JSON.stringify([1, 2, 3]));
+    const result = await process;
+
+    assert.isTrue(result);
+    assert.isTrue(endSpy.calledOnce);
+  });
+
   it("Should response with 200 when option is not specified", async function () {
     const endSpy = sinon.spy(res, "end");
     buildRequest(req, "hub", "conn1");

--- a/sdk/web-pubsub/web-pubsub-express/test/user.spec.ts
+++ b/sdk/web-pubsub/web-pubsub-express/test/user.spec.ts
@@ -34,16 +34,16 @@ function mockBody(req: IncomingMessage, body: string): void {
   req.emit("end");
 }
 
-describe("Can handle user event", function() {
+describe("Can handle user event", function () {
   let req: IncomingMessage;
   let res: ServerResponse;
 
-  beforeEach(function() {
+  beforeEach(function () {
     req = new IncomingMessage(new Socket());
     res = new ServerResponse(req);
   });
 
-  it("Should not handle the request if request is not cloud events", async function() {
+  it("Should not handle the request if request is not cloud events", async function () {
     const endSpy = sinon.spy(res, "end");
     const dispatcher = new CloudEventsDispatcher("hub1");
     const result = await dispatcher.handleRequest(req, res);
@@ -51,7 +51,7 @@ describe("Can handle user event", function() {
     assert.isTrue(endSpy.notCalled);
   });
 
-  it("Should not handle the request if hub does not match", async function() {
+  it("Should not handle the request if hub does not match", async function () {
     const endSpy = sinon.spy(res, "end");
     buildRequest(req, "hub", "conn1");
 
@@ -61,7 +61,7 @@ describe("Can handle user event", function() {
     assert.isTrue(endSpy.notCalled);
   });
 
-  it("Should handle number requests", async function() {
+  it("Should handle number requests", async function () {
     const endSpy = sinon.spy(res, "end");
     buildRequest(req, "hub", "conn1");
 
@@ -71,7 +71,7 @@ describe("Can handle user event", function() {
         assert.equal(typeof request.data, "number");
         assert.strictEqual(1, request.data);
         response.success();
-      }
+      },
     });
     const process = dispatcher.handleRequest(req, res);
     mockBody(req, JSON.stringify(1));
@@ -82,7 +82,7 @@ describe("Can handle user event", function() {
     assert.isTrue(endSpy.calledOnce);
   });
 
-  it("Should handle boolean requests", async function() {
+  it("Should handle boolean requests", async function () {
     const endSpy = sinon.spy(res, "end");
     buildRequest(req, "hub", "conn1");
 
@@ -92,7 +92,7 @@ describe("Can handle user event", function() {
         assert.equal(typeof request.data, "boolean");
         assert.strictEqual(true, request.data);
         response.success();
-      }
+      },
     });
     const process = dispatcher.handleRequest(req, res);
     mockBody(req, JSON.stringify(true));
@@ -103,7 +103,7 @@ describe("Can handle user event", function() {
     assert.isTrue(endSpy.calledOnce);
   });
 
-  it("Should handle complex object requests", async function() {
+  it("Should handle complex object requests", async function () {
     const endSpy = sinon.spy(res, "end");
     buildRequest(req, "hub", "conn1");
 
@@ -113,7 +113,7 @@ describe("Can handle user event", function() {
         assert.equal(typeof request.data, "object");
         assert.equal((<{ a: number }>request.data).a, 1);
         response.success();
-      }
+      },
     });
     const process = dispatcher.handleRequest(req, res);
     mockBody(req, JSON.stringify({ a: 1 }));
@@ -123,7 +123,7 @@ describe("Can handle user event", function() {
     assert.isTrue(endSpy.calledOnce);
   });
 
-  it("Should handle complex array requests", async function() {
+  it("Should handle complex array requests", async function () {
     const endSpy = sinon.spy(res, "end");
     buildRequest(req, "hub", "conn1");
 
@@ -134,7 +134,7 @@ describe("Can handle user event", function() {
         assert.isTrue(Array.isArray(request.data));
         assert.deepEqual(request.data, [1, 2, 3]);
         response.success();
-      }
+      },
     });
     const process = dispatcher.handleRequest(req, res);
     mockBody(req, JSON.stringify([1, 2, 3]));
@@ -144,7 +144,7 @@ describe("Can handle user event", function() {
     assert.isTrue(endSpy.calledOnce);
   });
 
-  it("Should response with 200 when option is not specified", async function() {
+  it("Should response with 200 when option is not specified", async function () {
     const endSpy = sinon.spy(res, "end");
     buildRequest(req, "hub", "conn1");
 
@@ -155,7 +155,7 @@ describe("Can handle user event", function() {
     assert.equal(200, res.statusCode, "should be 200");
   });
 
-  it("Should response with 200 when handler is not specified", async function() {
+  it("Should response with 200 when handler is not specified", async function () {
     const endSpy = sinon.spy(res, "end");
     buildRequest(req, "hub", "conn1");
 
@@ -166,14 +166,14 @@ describe("Can handle user event", function() {
     assert.equal(200, res.statusCode, "should be 200");
   });
 
-  it("Should response with error when handler returns error", async function() {
+  it("Should response with error when handler returns error", async function () {
     const endSpy = sinon.spy(res, "end");
     buildRequest(req, "hub", "conn1");
 
     const dispatcher = new CloudEventsDispatcher("hub", {
       handleUserEvent: async (_, response) => {
         response.fail(500);
-      }
+      },
     });
     const process = dispatcher.handleRequest(req, res);
     mockBody(req, JSON.stringify({}));
@@ -183,14 +183,14 @@ describe("Can handle user event", function() {
     assert.equal(500, res.statusCode, "should be error");
   });
 
-  it("Should response with success when handler returns success", async function() {
+  it("Should response with success when handler returns success", async function () {
     const endSpy = sinon.spy(res, "end");
     buildRequest(req, "hub", "conn1");
 
     const dispatcher = new CloudEventsDispatcher("hub", {
       handleUserEvent: async (_, response) => {
         response.success();
-      }
+      },
     });
     const process = dispatcher.handleRequest(req, res);
     mockBody(req, JSON.stringify({}));
@@ -200,14 +200,14 @@ describe("Can handle user event", function() {
     assert.equal(200, res.statusCode, "should be success");
   });
 
-  it("Should response with success when returns success binary", async function() {
+  it("Should response with success when returns success binary", async function () {
     const endSpy = sinon.spy(res, "end");
     buildRequest(req, "hub", "conn1");
 
     const dispatcher = new CloudEventsDispatcher("hub", {
       handleUserEvent: async (_, response) => {
         response.success("a");
-      }
+      },
     });
     const process = dispatcher.handleRequest(req, res);
     mockBody(req, JSON.stringify({}));
@@ -218,14 +218,14 @@ describe("Can handle user event", function() {
     assert.equal("application/octet-stream", res.getHeader("content-type"), "should be binary");
   });
 
-  it("Should response with success when returns success text", async function() {
+  it("Should response with success when returns success text", async function () {
     const endSpy = sinon.spy(res, "end");
     buildRequest(req, "hub", "conn1");
 
     const dispatcher = new CloudEventsDispatcher("hub", {
       handleUserEvent: async (_, response) => {
         response.success("a", "text");
-      }
+      },
     });
     const process = dispatcher.handleRequest(req, res);
     mockBody(req, JSON.stringify({}));
@@ -236,14 +236,14 @@ describe("Can handle user event", function() {
     assert.equal("text/plain; charset=utf-8", res.getHeader("content-type"), "should be text");
   });
 
-  it("Should response with success when returns success json", async function() {
+  it("Should response with success when returns success json", async function () {
     const endSpy = sinon.spy(res, "end");
     buildRequest(req, "hub", "conn1");
 
     const dispatcher = new CloudEventsDispatcher("hub", {
       handleUserEvent: async (_, response) => {
         response.success("a", "json");
-      }
+      },
     });
     const process = dispatcher.handleRequest(req, res);
     mockBody(req, JSON.stringify({}));
@@ -258,7 +258,7 @@ describe("Can handle user event", function() {
     );
   });
 
-  it("Should be able to set connection state", async function() {
+  it("Should be able to set connection state", async function () {
     const endSpy = sinon.spy(res, "end");
     buildRequest(req, "hub", "conn1");
 
@@ -269,7 +269,7 @@ describe("Can handle user event", function() {
         response.setState("key1", "val3");
         response.setState("key3", "");
         response.success();
-      }
+      },
     });
     const process = dispatcher.handleRequest(req, res);
     mockBody(req, JSON.stringify({}));
@@ -283,7 +283,7 @@ describe("Can handle user event", function() {
         JSON.stringify({
           key1: "val3",
           key2: "val2",
-          key3: ""
+          key3: "",
         })
       ).toString("base64"),
       res.getHeader("ce-connectionState"),

--- a/sdk/web-pubsub/web-pubsub-express/test/user.spec.ts
+++ b/sdk/web-pubsub/web-pubsub-express/test/user.spec.ts
@@ -66,10 +66,10 @@ describe("Can handle user event", function () {
     buildRequest(req, "hub", "conn1");
 
     const dispatcher = new CloudEventsDispatcher("hub", {
-      handleUserEvent: async (req, response) => {
-        assert.equal(req.dataType, "json");
-        assert.equal(typeof req.data, "number");
-        assert.strictEqual(1, req.data);
+      handleUserEvent: async (request, response) => {
+        assert.equal(request.dataType, "json");
+        assert.equal(typeof request.data, "number");
+        assert.strictEqual(1, request.data);
         response.success();
       },
     });
@@ -87,10 +87,10 @@ describe("Can handle user event", function () {
     buildRequest(req, "hub", "conn1");
 
     const dispatcher = new CloudEventsDispatcher("hub", {
-      handleUserEvent: async (req, response) => {
-        assert.equal(req.dataType, "json");
-        assert.equal(typeof req.data, "boolean");
-        assert.strictEqual(true, req.data);
+      handleUserEvent: async (request, response) => {
+        assert.equal(request.dataType, "json");
+        assert.equal(typeof request.data, "boolean");
+        assert.strictEqual(true, request.data);
         response.success();
       },
     });
@@ -108,10 +108,10 @@ describe("Can handle user event", function () {
     buildRequest(req, "hub", "conn1");
 
     const dispatcher = new CloudEventsDispatcher("hub", {
-      handleUserEvent: async (req, response) => {
-        assert.equal(req.dataType, "json");
-        assert.equal(typeof req.data, "object");
-        assert.equal(req.data.a, 1);
+      handleUserEvent: async (request, response) => {
+        assert.equal(request.dataType, "json");
+        assert.equal(typeof request.data, "object");
+        assert.equal(request.data.a, 1);
         response.success();
       },
     });
@@ -128,11 +128,11 @@ describe("Can handle user event", function () {
     buildRequest(req, "hub", "conn1");
 
     const dispatcher = new CloudEventsDispatcher("hub", {
-      handleUserEvent: async (req, response) => {
-        assert.equal(req.dataType, "json");
-        assert.equal(typeof req.data, "object");
-        assert.isTrue(Array.isArray(req.data));
-        assert.deepEqual(req.data, [1, 2, 3]);
+      handleUserEvent: async (request, response) => {
+        assert.equal(request.dataType, "json");
+        assert.equal(typeof request.data, "object");
+        assert.isTrue(Array.isArray(request.data));
+        assert.deepEqual(request.data, [1, 2, 3]);
         response.success();
       },
     });

--- a/sdk/web-pubsub/web-pubsub-express/test/user.spec.ts
+++ b/sdk/web-pubsub/web-pubsub-express/test/user.spec.ts
@@ -44,8 +44,7 @@ describe("Can handle user event", function () {
   });
 
   it("Should not handle the request if request is not cloud events", async function () {
-    const endSpy = sinon.spy(res.end);
-
+    const endSpy = sinon.spy(res, "end");
     const dispatcher = new CloudEventsDispatcher("hub1");
     const result = await dispatcher.handleRequest(req, res);
     assert.isFalse(result);
@@ -53,7 +52,7 @@ describe("Can handle user event", function () {
   });
 
   it("Should not handle the request if hub does not match", async function () {
-    const endSpy = sinon.spy(res.end);
+    const endSpy = sinon.spy(res, "end");
     buildRequest(req, "hub", "conn1");
 
     const dispatcher = new CloudEventsDispatcher("hub1");
@@ -63,13 +62,14 @@ describe("Can handle user event", function () {
   });
 
   it("Should handle number requests", async function () {
-    const endSpy = sinon.spy(res.end);
+    const endSpy = sinon.spy(res, "end");
     buildRequest(req, "hub", "conn1");
 
     const dispatcher = new CloudEventsDispatcher("hub", {
       handleUserEvent: async (req, response) => {
         assert.equal(req.dataType, "json");
-        assert.equal(typeof req.data, "json");
+        assert.equal(typeof req.data, "number");
+        assert.strictEqual(1, req.data);
         response.success();
       },
     });
@@ -78,11 +78,33 @@ describe("Can handle user event", function () {
     const result = await process;
 
     assert.isTrue(result);
+    assert.equal(200, res.statusCode, "should be 200");
+    assert.isTrue(endSpy.calledOnce);
+  });
+
+  it("Should handle boolean requests", async function () {
+    const endSpy = sinon.spy(res, "end");
+    buildRequest(req, "hub", "conn1");
+
+    const dispatcher = new CloudEventsDispatcher("hub", {
+      handleUserEvent: async (req, response) => {
+        assert.equal(req.dataType, "json");
+        assert.equal(typeof req.data, "boolean");
+        assert.strictEqual(true, req.data);
+        response.success();
+      },
+    });
+    const process = dispatcher.handleRequest(req, res);
+    mockBody(req, JSON.stringify(true));
+    const result = await process;
+
+    assert.isTrue(result);
+    assert.equal(200, res.statusCode, "should be 200");
     assert.isTrue(endSpy.calledOnce);
   });
 
   it("Should handle complex object requests", async function () {
-    const endSpy = sinon.spy(res.end);
+    const endSpy = sinon.spy(res, "end");
     buildRequest(req, "hub", "conn1");
 
     const dispatcher = new CloudEventsDispatcher("hub", {
@@ -102,13 +124,15 @@ describe("Can handle user event", function () {
   });
 
   it("Should handle complex array requests", async function () {
-    const endSpy = sinon.spy(res.end);
+    const endSpy = sinon.spy(res, "end");
     buildRequest(req, "hub", "conn1");
 
     const dispatcher = new CloudEventsDispatcher("hub", {
       handleUserEvent: async (req, response) => {
         assert.equal(req.dataType, "json");
-        assert.equal(typeof req.data, "array");
+        assert.equal(typeof req.data, "object");
+        assert.isTrue(Array.isArray(req.data));
+        assert.deepEqual(req.data, [1, 2, 3]);
         response.success();
       },
     });

--- a/sdk/web-pubsub/web-pubsub-express/test/user.spec.ts
+++ b/sdk/web-pubsub/web-pubsub-express/test/user.spec.ts
@@ -34,16 +34,16 @@ function mockBody(req: IncomingMessage, body: string): void {
   req.emit("end");
 }
 
-describe("Can handle user event", function () {
+describe("Can handle user event", function() {
   let req: IncomingMessage;
   let res: ServerResponse;
 
-  beforeEach(function () {
+  beforeEach(function() {
     req = new IncomingMessage(new Socket());
     res = new ServerResponse(req);
   });
 
-  it("Should not handle the request if request is not cloud events", async function () {
+  it("Should not handle the request if request is not cloud events", async function() {
     const endSpy = sinon.spy(res, "end");
     const dispatcher = new CloudEventsDispatcher("hub1");
     const result = await dispatcher.handleRequest(req, res);
@@ -51,7 +51,7 @@ describe("Can handle user event", function () {
     assert.isTrue(endSpy.notCalled);
   });
 
-  it("Should not handle the request if hub does not match", async function () {
+  it("Should not handle the request if hub does not match", async function() {
     const endSpy = sinon.spy(res, "end");
     buildRequest(req, "hub", "conn1");
 
@@ -61,7 +61,7 @@ describe("Can handle user event", function () {
     assert.isTrue(endSpy.notCalled);
   });
 
-  it("Should handle number requests", async function () {
+  it("Should handle number requests", async function() {
     const endSpy = sinon.spy(res, "end");
     buildRequest(req, "hub", "conn1");
 
@@ -71,7 +71,7 @@ describe("Can handle user event", function () {
         assert.equal(typeof request.data, "number");
         assert.strictEqual(1, request.data);
         response.success();
-      },
+      }
     });
     const process = dispatcher.handleRequest(req, res);
     mockBody(req, JSON.stringify(1));
@@ -82,7 +82,7 @@ describe("Can handle user event", function () {
     assert.isTrue(endSpy.calledOnce);
   });
 
-  it("Should handle boolean requests", async function () {
+  it("Should handle boolean requests", async function() {
     const endSpy = sinon.spy(res, "end");
     buildRequest(req, "hub", "conn1");
 
@@ -92,7 +92,7 @@ describe("Can handle user event", function () {
         assert.equal(typeof request.data, "boolean");
         assert.strictEqual(true, request.data);
         response.success();
-      },
+      }
     });
     const process = dispatcher.handleRequest(req, res);
     mockBody(req, JSON.stringify(true));
@@ -103,7 +103,7 @@ describe("Can handle user event", function () {
     assert.isTrue(endSpy.calledOnce);
   });
 
-  it("Should handle complex object requests", async function () {
+  it("Should handle complex object requests", async function() {
     const endSpy = sinon.spy(res, "end");
     buildRequest(req, "hub", "conn1");
 
@@ -111,9 +111,9 @@ describe("Can handle user event", function () {
       handleUserEvent: async (request, response) => {
         assert.equal(request.dataType, "json");
         assert.equal(typeof request.data, "object");
-        assert.equal(request.data.a, 1);
+        assert.equal((<{ a: number }>request.data).a, 1);
         response.success();
-      },
+      }
     });
     const process = dispatcher.handleRequest(req, res);
     mockBody(req, JSON.stringify({ a: 1 }));
@@ -123,7 +123,7 @@ describe("Can handle user event", function () {
     assert.isTrue(endSpy.calledOnce);
   });
 
-  it("Should handle complex array requests", async function () {
+  it("Should handle complex array requests", async function() {
     const endSpy = sinon.spy(res, "end");
     buildRequest(req, "hub", "conn1");
 
@@ -134,7 +134,7 @@ describe("Can handle user event", function () {
         assert.isTrue(Array.isArray(request.data));
         assert.deepEqual(request.data, [1, 2, 3]);
         response.success();
-      },
+      }
     });
     const process = dispatcher.handleRequest(req, res);
     mockBody(req, JSON.stringify([1, 2, 3]));
@@ -144,7 +144,7 @@ describe("Can handle user event", function () {
     assert.isTrue(endSpy.calledOnce);
   });
 
-  it("Should response with 200 when option is not specified", async function () {
+  it("Should response with 200 when option is not specified", async function() {
     const endSpy = sinon.spy(res, "end");
     buildRequest(req, "hub", "conn1");
 
@@ -155,7 +155,7 @@ describe("Can handle user event", function () {
     assert.equal(200, res.statusCode, "should be 200");
   });
 
-  it("Should response with 200 when handler is not specified", async function () {
+  it("Should response with 200 when handler is not specified", async function() {
     const endSpy = sinon.spy(res, "end");
     buildRequest(req, "hub", "conn1");
 
@@ -166,14 +166,14 @@ describe("Can handle user event", function () {
     assert.equal(200, res.statusCode, "should be 200");
   });
 
-  it("Should response with error when handler returns error", async function () {
+  it("Should response with error when handler returns error", async function() {
     const endSpy = sinon.spy(res, "end");
     buildRequest(req, "hub", "conn1");
 
     const dispatcher = new CloudEventsDispatcher("hub", {
       handleUserEvent: async (_, response) => {
         response.fail(500);
-      },
+      }
     });
     const process = dispatcher.handleRequest(req, res);
     mockBody(req, JSON.stringify({}));
@@ -183,14 +183,14 @@ describe("Can handle user event", function () {
     assert.equal(500, res.statusCode, "should be error");
   });
 
-  it("Should response with success when handler returns success", async function () {
+  it("Should response with success when handler returns success", async function() {
     const endSpy = sinon.spy(res, "end");
     buildRequest(req, "hub", "conn1");
 
     const dispatcher = new CloudEventsDispatcher("hub", {
       handleUserEvent: async (_, response) => {
         response.success();
-      },
+      }
     });
     const process = dispatcher.handleRequest(req, res);
     mockBody(req, JSON.stringify({}));
@@ -200,14 +200,14 @@ describe("Can handle user event", function () {
     assert.equal(200, res.statusCode, "should be success");
   });
 
-  it("Should response with success when returns success binary", async function () {
+  it("Should response with success when returns success binary", async function() {
     const endSpy = sinon.spy(res, "end");
     buildRequest(req, "hub", "conn1");
 
     const dispatcher = new CloudEventsDispatcher("hub", {
       handleUserEvent: async (_, response) => {
         response.success("a");
-      },
+      }
     });
     const process = dispatcher.handleRequest(req, res);
     mockBody(req, JSON.stringify({}));
@@ -218,14 +218,14 @@ describe("Can handle user event", function () {
     assert.equal("application/octet-stream", res.getHeader("content-type"), "should be binary");
   });
 
-  it("Should response with success when returns success text", async function () {
+  it("Should response with success when returns success text", async function() {
     const endSpy = sinon.spy(res, "end");
     buildRequest(req, "hub", "conn1");
 
     const dispatcher = new CloudEventsDispatcher("hub", {
       handleUserEvent: async (_, response) => {
         response.success("a", "text");
-      },
+      }
     });
     const process = dispatcher.handleRequest(req, res);
     mockBody(req, JSON.stringify({}));
@@ -236,14 +236,14 @@ describe("Can handle user event", function () {
     assert.equal("text/plain; charset=utf-8", res.getHeader("content-type"), "should be text");
   });
 
-  it("Should response with success when returns success json", async function () {
+  it("Should response with success when returns success json", async function() {
     const endSpy = sinon.spy(res, "end");
     buildRequest(req, "hub", "conn1");
 
     const dispatcher = new CloudEventsDispatcher("hub", {
       handleUserEvent: async (_, response) => {
         response.success("a", "json");
-      },
+      }
     });
     const process = dispatcher.handleRequest(req, res);
     mockBody(req, JSON.stringify({}));
@@ -258,7 +258,7 @@ describe("Can handle user event", function () {
     );
   });
 
-  it("Should be able to set connection state", async function () {
+  it("Should be able to set connection state", async function() {
     const endSpy = sinon.spy(res, "end");
     buildRequest(req, "hub", "conn1");
 
@@ -269,7 +269,7 @@ describe("Can handle user event", function () {
         response.setState("key1", "val3");
         response.setState("key3", "");
         response.success();
-      },
+      }
     });
     const process = dispatcher.handleRequest(req, res);
     mockBody(req, JSON.stringify({}));
@@ -283,7 +283,7 @@ describe("Can handle user event", function () {
         JSON.stringify({
           key1: "val3",
           key2: "val2",
-          key3: "",
+          key3: ""
         })
       ).toString("base64"),
       res.getHeader("ce-connectionState"),


### PR DESCRIPTION
1. When dataType is `json`, the type of `data` is from `JSON.parse(requestBody)` so it can be any type.
2. CloudEvents package failed to handle the JSON body successfully so we parse the request body by our own when the type is `json`