### PR TITLE
[EventGrid] Update System events and prepare for Jan release

### DIFF
--- a/sdk/eventgrid/eventgrid/CHANGELOG.md
+++ b/sdk/eventgrid/eventgrid/CHANGELOG.md
@@ -1,14 +1,33 @@
 # Release History
 
-## 4.5.1 (Unreleased)
+## 4.6.0 (2022-01-11)
 
 ### Features Added
 
-### Breaking Changes
+- Added a new property to `AcsRecordingChunkInfo` (for the `Microsoft.Communication.RecordingFileStatusUpdated` system event):
+- `deleteLocation`
 
-### Bugs Fixed
+- Added new properties to `ContainerRegistryArtifactEventData` and `ContainerRegistryEventData` (for the `Microsoft.ContainerRegistry.{ChartDeleted|ChartPushed|ImagePushed|ImageDeleted}` system events):
 
-### Other Changes
+  - `connectedRegistry`
+  - `location`
+
+- Added new properties to `AcsRecordingFileStatusUpdatedEventData` (for the `Microsoft.Communication.RecordingFileStatusUpdated` system event):
+
+  - `recordingChannelType`
+  - `recordingContentType`
+  - `recordingFormatType`
+
+### Key Bug Fixes
+
+- The TypeScript typings for events from Azure Resource Manager were incorrect. The following properties had their types changed:
+
+  - `authorization`
+  - `claims`
+  - `httpRequest`
+
+Previously, these properties were typed as `string` but the underlying events from the service actually contained objects. Customers using `isSystemEvent` with TypeScript will
+now see compliation issues if they try to treat these properties as strings (previously, the code would fail at runtime).
 
 ## 4.5.0 (2021-10-05)
 

--- a/sdk/eventgrid/eventgrid/package.json
+++ b/sdk/eventgrid/eventgrid/package.json
@@ -3,7 +3,7 @@
   "sdk-type": "client",
   "author": "Microsoft Corporation",
   "description": "An isomorphic client library for the Azure Event Grid service.",
-  "version": "4.5.1",
+  "version": "4.6.0",
   "keywords": [
     "node",
     "azure",

--- a/sdk/eventgrid/eventgrid/review/eventgrid.api.md
+++ b/sdk/eventgrid/eventgrid/review/eventgrid.api.md
@@ -158,6 +158,7 @@ export type AcsChatThreadWithUserDeletedEventData = AcsChatThreadEventBase & {
 // @public
 export interface AcsRecordingChunkInfo {
     contentLocation: string;
+    deleteLocation: string;
     documentId: string;
     endReason: string;
     index: number;
@@ -166,7 +167,10 @@ export interface AcsRecordingChunkInfo {
 
 // @public
 export interface AcsRecordingFileStatusUpdatedEventData {
+    recordingChannelType: RecordingChannelType;
+    recordingContentType: RecordingContentType;
     recordingDurationMs: number;
+    recordingFormatType: RecordingFormatType;
     recordingStartTime: string;
     recordingStorageInfo: AcsRecordingStorageInfo;
     sessionEndReason: string;
@@ -359,7 +363,9 @@ export interface CommunicationUserIdentifierModel {
 // @public
 export interface ContainerRegistryArtifactEventData {
     action: string;
+    connectedRegistry: ContainerRegistryEventConnectedRegistry;
     id: string;
+    location: string;
     target: ContainerRegistryArtifactEventTarget;
     timestamp: string;
 }
@@ -387,10 +393,17 @@ export interface ContainerRegistryEventActor {
 }
 
 // @public
+export interface ContainerRegistryEventConnectedRegistry {
+    name: string;
+}
+
+// @public
 export interface ContainerRegistryEventData {
     action: string;
     actor: ContainerRegistryEventActor;
+    connectedRegistry: ContainerRegistryEventConnectedRegistry;
     id: string;
+    location: string;
     request: ContainerRegistryEventRequest;
     source: ContainerRegistryEventSource;
     target: ContainerRegistryEventTarget;
@@ -1072,11 +1085,22 @@ export interface PolicyInsightsPolicyStateDeletedEventData {
 }
 
 // @public
+export type RecordingChannelType = string;
+
+// @public
+export type RecordingContentType = string;
+
+// @public
+export type RecordingFormatType = string;
+
+// @public
 export interface ResourceActionCancelEventData {
-    authorization: string;
-    claims: string;
+    authorization: ResourceAuthorization;
+    claims: {
+        [propertyName: string]: string;
+    };
     correlationId: string;
-    httpRequest: string;
+    httpRequest: ResourceHttpRequest;
     operationName: string;
     resourceGroup: string;
     resourceProvider: string;
@@ -1088,10 +1112,12 @@ export interface ResourceActionCancelEventData {
 
 // @public
 export interface ResourceActionFailureEventData {
-    authorization: string;
-    claims: string;
+    authorization: ResourceAuthorization;
+    claims: {
+        [propertyName: string]: string;
+    };
     correlationId: string;
-    httpRequest: string;
+    httpRequest: ResourceHttpRequest;
     operationName: string;
     resourceGroup: string;
     resourceProvider: string;
@@ -1103,10 +1129,12 @@ export interface ResourceActionFailureEventData {
 
 // @public
 export interface ResourceActionSuccessEventData {
-    authorization: string;
-    claims: string;
+    authorization: ResourceAuthorization;
+    claims: {
+        [propertyName: string]: string;
+    };
     correlationId: string;
-    httpRequest: string;
+    httpRequest: ResourceHttpRequest;
     operationName: string;
     resourceGroup: string;
     resourceProvider: string;
@@ -1117,11 +1145,22 @@ export interface ResourceActionSuccessEventData {
 }
 
 // @public
+export interface ResourceAuthorization {
+    action: string;
+    evidence: {
+        [propertyName: string]: string;
+    };
+    scope: string;
+}
+
+// @public
 export interface ResourceDeleteCancelEventData {
-    authorization: string;
-    claims: string;
+    authorization: ResourceAuthorization;
+    claims: {
+        [propertyName: string]: string;
+    };
     correlationId: string;
-    httpRequest: string;
+    httpRequest: ResourceHttpRequest;
     operationName: string;
     resourceGroup: string;
     resourceProvider: string;
@@ -1133,10 +1172,12 @@ export interface ResourceDeleteCancelEventData {
 
 // @public
 export interface ResourceDeleteFailureEventData {
-    authorization: string;
-    claims: string;
+    authorization: ResourceAuthorization;
+    claims: {
+        [propertyName: string]: string;
+    };
     correlationId: string;
-    httpRequest: string;
+    httpRequest: ResourceHttpRequest;
     operationName: string;
     resourceGroup: string;
     resourceProvider: string;
@@ -1148,10 +1189,12 @@ export interface ResourceDeleteFailureEventData {
 
 // @public
 export interface ResourceDeleteSuccessEventData {
-    authorization: string;
-    claims: string;
+    authorization: ResourceAuthorization;
+    claims: {
+        [propertyName: string]: string;
+    };
     correlationId: string;
-    httpRequest: string;
+    httpRequest: ResourceHttpRequest;
     operationName: string;
     resourceGroup: string;
     resourceProvider: string;
@@ -1162,11 +1205,21 @@ export interface ResourceDeleteSuccessEventData {
 }
 
 // @public
+export interface ResourceHttpRequest {
+    clientIpAddress: string;
+    clientRequestId: string;
+    method: string;
+    url: string;
+}
+
+// @public
 export interface ResourceWriteCancelEventData {
-    authorization: string;
-    claims: string;
+    authorization: ResourceAuthorization;
+    claims: {
+        [propertyName: string]: string;
+    };
     correlationId: string;
-    httpRequest: string;
+    httpRequest: ResourceHttpRequest;
     operationName: string;
     resourceGroup: string;
     resourceProvider: string;
@@ -1178,10 +1231,12 @@ export interface ResourceWriteCancelEventData {
 
 // @public
 export interface ResourceWriteFailureEventData {
-    authorization: string;
-    claims: string;
+    authorization: ResourceAuthorization;
+    claims: {
+        [propertyName: string]: string;
+    };
     correlationId: string;
-    httpRequest: string;
+    httpRequest: ResourceHttpRequest;
     operationName: string;
     resourceGroup: string;
     resourceProvider: string;
@@ -1193,10 +1248,12 @@ export interface ResourceWriteFailureEventData {
 
 // @public
 export interface ResourceWriteSuccessEventData {
-    authorization: string;
-    claims: string;
+    authorization: ResourceAuthorization;
+    claims: {
+        [propertyName: string]: string;
+    };
     correlationId: string;
-    httpRequest: string;
+    httpRequest: ResourceHttpRequest;
     operationName: string;
     resourceGroup: string;
     resourceProvider: string;
@@ -1681,7 +1738,6 @@ export interface WebSlotSwapWithPreviewStartedEventData {
     requestId: string;
     verb: string;
 }
-
 
 // (No @packageDocumentation comment for this package)
 

--- a/sdk/eventgrid/eventgrid/src/generated/generatedClientContext.ts
+++ b/sdk/eventgrid/eventgrid/src/generated/generatedClientContext.ts
@@ -26,7 +26,7 @@ export class GeneratedClientContext extends coreClient.ServiceClient {
       requestContentType: "application/json; charset=utf-8"
     };
 
-    const packageDetails = `azsdk-js-eventgrid/4.5.1`;
+    const packageDetails = `azsdk-js-eventgrid/4.6.0`;
     const userAgentPrefix =
       options.userAgentOptions && options.userAgentOptions.userAgentPrefix
         ? `${options.userAgentOptions.userAgentPrefix} ${packageDetails}`

--- a/sdk/eventgrid/eventgrid/src/generated/models/index.ts
+++ b/sdk/eventgrid/eventgrid/src/generated/models/index.ts
@@ -316,13 +316,35 @@ export interface ResourceWriteSuccessEventData {
   /** The status of the operation. */
   status: string;
   /** The requested authorization for the operation. */
-  authorization: string;
+  authorization: ResourceAuthorization;
   /** The properties of the claims. */
-  claims: string;
+  claims: { [propertyName: string]: string };
   /** An operation ID used for troubleshooting. */
   correlationId: string;
   /** The details of the operation. */
-  httpRequest: string;
+  httpRequest: ResourceHttpRequest;
+}
+
+/** The details of the authorization for the resource. */
+export interface ResourceAuthorization {
+  /** The scope of the authorization. */
+  scope: string;
+  /** The action being requested. */
+  action: string;
+  /** The evidence for the authorization. */
+  evidence: { [propertyName: string]: string };
+}
+
+/** The details of the HTTP request. */
+export interface ResourceHttpRequest {
+  /** The client request ID. */
+  clientRequestId: string;
+  /** The client IP address. */
+  clientIpAddress: string;
+  /** The request method. */
+  method: string;
+  /** The url used in the request. */
+  url: string;
 }
 
 /** Schema of the Data property of an EventGridEvent for a Microsoft.Resources.ResourceWriteFailure event. This is raised when a resource create or update operation fails. */
@@ -342,13 +364,13 @@ export interface ResourceWriteFailureEventData {
   /** The status of the operation. */
   status: string;
   /** The requested authorization for the operation. */
-  authorization: string;
+  authorization: ResourceAuthorization;
   /** The properties of the claims. */
-  claims: string;
+  claims: { [propertyName: string]: string };
   /** An operation ID used for troubleshooting. */
   correlationId: string;
   /** The details of the operation. */
-  httpRequest: string;
+  httpRequest: ResourceHttpRequest;
 }
 
 /** Schema of the Data property of an EventGridEvent for a Microsoft.Resources.ResourceWriteCancel event. This is raised when a resource create or update operation is canceled. */
@@ -368,13 +390,13 @@ export interface ResourceWriteCancelEventData {
   /** The status of the operation. */
   status: string;
   /** The requested authorization for the operation. */
-  authorization: string;
+  authorization: ResourceAuthorization;
   /** The properties of the claims. */
-  claims: string;
+  claims: { [propertyName: string]: string };
   /** An operation ID used for troubleshooting. */
   correlationId: string;
   /** The details of the operation. */
-  httpRequest: string;
+  httpRequest: ResourceHttpRequest;
 }
 
 /** Schema of the Data property of an EventGridEvent for a Microsoft.Resources.ResourceDeleteSuccess event. This is raised when a resource delete operation succeeds. */
@@ -394,13 +416,13 @@ export interface ResourceDeleteSuccessEventData {
   /** The status of the operation. */
   status: string;
   /** The requested authorization for the operation. */
-  authorization: string;
+  authorization: ResourceAuthorization;
   /** The properties of the claims. */
-  claims: string;
+  claims: { [propertyName: string]: string };
   /** An operation ID used for troubleshooting. */
   correlationId: string;
   /** The details of the operation. */
-  httpRequest: string;
+  httpRequest: ResourceHttpRequest;
 }
 
 /** Schema of the Data property of an EventGridEvent for a Microsoft.Resources.ResourceDeleteFailure event. This is raised when a resource delete operation fails. */
@@ -420,13 +442,13 @@ export interface ResourceDeleteFailureEventData {
   /** The status of the operation. */
   status: string;
   /** The requested authorization for the operation. */
-  authorization: string;
+  authorization: ResourceAuthorization;
   /** The properties of the claims. */
-  claims: string;
+  claims: { [propertyName: string]: string };
   /** An operation ID used for troubleshooting. */
   correlationId: string;
   /** The details of the operation. */
-  httpRequest: string;
+  httpRequest: ResourceHttpRequest;
 }
 
 /** Schema of the Data property of an EventGridEvent for a Microsoft.Resources.ResourceDeleteCancel event. This is raised when a resource delete operation is canceled. */
@@ -446,13 +468,13 @@ export interface ResourceDeleteCancelEventData {
   /** The status of the operation. */
   status: string;
   /** The requested authorization for the operation. */
-  authorization: string;
+  authorization: ResourceAuthorization;
   /** The properties of the claims. */
-  claims: string;
+  claims: { [propertyName: string]: string };
   /** An operation ID used for troubleshooting. */
   correlationId: string;
   /** The details of the operation. */
-  httpRequest: string;
+  httpRequest: ResourceHttpRequest;
 }
 
 /** Schema of the Data property of an EventGridEvent for a Microsoft.Resources.ResourceActionSuccess event. This is raised when a resource action operation succeeds. */
@@ -472,13 +494,13 @@ export interface ResourceActionSuccessEventData {
   /** The status of the operation. */
   status: string;
   /** The requested authorization for the operation. */
-  authorization: string;
+  authorization: ResourceAuthorization;
   /** The properties of the claims. */
-  claims: string;
+  claims: { [propertyName: string]: string };
   /** An operation ID used for troubleshooting. */
   correlationId: string;
   /** The details of the operation. */
-  httpRequest: string;
+  httpRequest: ResourceHttpRequest;
 }
 
 /** Schema of the Data property of an EventGridEvent for a Microsoft.Resources.ResourceActionFailure event. This is raised when a resource action operation fails. */
@@ -498,13 +520,13 @@ export interface ResourceActionFailureEventData {
   /** The status of the operation. */
   status: string;
   /** The requested authorization for the operation. */
-  authorization: string;
+  authorization: ResourceAuthorization;
   /** The properties of the claims. */
-  claims: string;
+  claims: { [propertyName: string]: string };
   /** An operation ID used for troubleshooting. */
   correlationId: string;
   /** The details of the operation. */
-  httpRequest: string;
+  httpRequest: ResourceHttpRequest;
 }
 
 /** Schema of the Data property of an EventGridEvent for a Microsoft.Resources.ResourceActionCancel event. This is raised when a resource action operation is canceled. */
@@ -524,13 +546,13 @@ export interface ResourceActionCancelEventData {
   /** The status of the operation. */
   status: string;
   /** The requested authorization for the operation. */
-  authorization: string;
+  authorization: ResourceAuthorization;
   /** The properties of the claims. */
-  claims: string;
+  claims: { [propertyName: string]: string };
   /** An operation ID used for troubleshooting. */
   correlationId: string;
   /** The details of the operation. */
-  httpRequest: string;
+  httpRequest: ResourceHttpRequest;
 }
 
 /** Schema of the Data property of an EventGridEvent for a Microsoft.EventGrid.SubscriptionValidationEvent event. */
@@ -664,6 +686,8 @@ export interface ContainerRegistryEventData {
   timestamp: string;
   /** The action that encompasses the provided event. */
   action: string;
+  /** The location of the event. */
+  location: string;
   /** The target of the event. */
   target: ContainerRegistryEventTarget;
   /** The request that generated the event. */
@@ -672,6 +696,8 @@ export interface ContainerRegistryEventData {
   actor: ContainerRegistryEventActor;
   /** The registry node that generated the event. Put differently, while the actor initiates the event, the source generates it. */
   source: ContainerRegistryEventSource;
+  /** The connected registry information if the event is generated by a connected registry. */
+  connectedRegistry: ContainerRegistryEventConnectedRegistry;
 }
 
 /** The target of the event. */
@@ -720,6 +746,12 @@ export interface ContainerRegistryEventSource {
   instanceID: string;
 }
 
+/** The connected registry information if the event is generated by a connected registry. */
+export interface ContainerRegistryEventConnectedRegistry {
+  /** The name of the connected registry that generated this event. */
+  name: string;
+}
+
 /** The content of the event request message. */
 export interface ContainerRegistryArtifactEventData {
   /** The event ID. */
@@ -728,8 +760,12 @@ export interface ContainerRegistryArtifactEventData {
   timestamp: string;
   /** The action that encompasses the provided event. */
   action: string;
+  /** The location of the event. */
+  location: string;
   /** The target of the event. */
   target: ContainerRegistryArtifactEventTarget;
+  /** The connected registry information if the event is generated by a connected registry. */
+  connectedRegistry: ContainerRegistryEventConnectedRegistry;
 }
 
 /** The target of the event. */
@@ -1261,7 +1297,7 @@ export interface MediaLiveEventTrackDiscontinuityDetectedEventData {
   readonly discontinuityGap: string;
 }
 
-/** Channel Archive heartbeat event data. Schema of the data property of an EventGridEvent for a Microsoft.Media.LiveEventChannelArchiveHeartbeatEventData event. */
+/** Channel Archive heartbeat event data. Schema of the data property of an EventGridEvent for a Microsoft.Media.LiveEventChannelArchiveHeartbeat event. */
 export interface MediaLiveEventChannelArchiveHeartbeatEventData {
   /**
    * Gets the channel latency in ms.
@@ -2013,6 +2049,12 @@ export interface AcsRecordingFileStatusUpdatedEventData {
   recordingStartTime: string;
   /** The recording duration in milliseconds */
   recordingDurationMs: number;
+  /** The recording content type- AudioVideo, or Audio */
+  recordingContentType: RecordingContentType;
+  /** The recording  channel type - Mixed, Unmixed */
+  recordingChannelType: RecordingChannelType;
+  /** The recording format type - Mp4, Mp3, Wav */
+  recordingFormatType: RecordingFormatType;
   /** The reason for ending recording session */
   sessionEndReason: string;
 }
@@ -2035,6 +2077,8 @@ export interface AcsRecordingChunkInfo {
   metadataLocation: string;
   /** The location of the content for this chunk */
   contentLocation: string;
+  /** The location to delete all chunk storage */
+  deleteLocation: string;
 }
 
 /** Schema of the Data property of an EventGridEvent for a Microsoft.PolicyInsights.PolicyStateCreated event. */
@@ -2604,6 +2648,56 @@ export const enum KnownCommunicationCloudEnvironmentModel {
  * **gcch**
  */
 export type CommunicationCloudEnvironmentModel = string;
+
+/** Known values of {@link RecordingContentType} that the service accepts. */
+export const enum KnownRecordingContentType {
+  AudioVideo = "AudioVideo",
+  Audio = "Audio"
+}
+
+/**
+ * Defines values for RecordingContentType. \
+ * {@link KnownRecordingContentType} can be used interchangeably with RecordingContentType,
+ *  this enum contains the known values that the service supports.
+ * ### Known values supported by the service
+ * **AudioVideo** \
+ * **Audio**
+ */
+export type RecordingContentType = string;
+
+/** Known values of {@link RecordingChannelType} that the service accepts. */
+export const enum KnownRecordingChannelType {
+  Mixed = "Mixed",
+  Unmixed = "Unmixed"
+}
+
+/**
+ * Defines values for RecordingChannelType. \
+ * {@link KnownRecordingChannelType} can be used interchangeably with RecordingChannelType,
+ *  this enum contains the known values that the service supports.
+ * ### Known values supported by the service
+ * **Mixed** \
+ * **Unmixed**
+ */
+export type RecordingChannelType = string;
+
+/** Known values of {@link RecordingFormatType} that the service accepts. */
+export const enum KnownRecordingFormatType {
+  Wav = "Wav",
+  Mp3 = "Mp3",
+  Mp4 = "Mp4"
+}
+
+/**
+ * Defines values for RecordingFormatType. \
+ * {@link KnownRecordingFormatType} can be used interchangeably with RecordingFormatType,
+ *  this enum contains the known values that the service supports.
+ * ### Known values supported by the service
+ * **Wav** \
+ * **Mp3** \
+ * **Mp4**
+ */
+export type RecordingFormatType = string;
 /** Defines values for MediaJobState. */
 export type MediaJobState =
   | "Canceled"

--- a/sdk/eventgrid/eventgrid/src/generated/models/mappers.ts
+++ b/sdk/eventgrid/eventgrid/src/generated/models/mappers.ts
@@ -982,16 +982,17 @@ export const ResourceWriteSuccessEventData: coreClient.CompositeMapper = {
       },
       authorization: {
         serializedName: "authorization",
-        required: true,
         type: {
-          name: "String"
+          name: "Composite",
+          className: "ResourceAuthorization"
         }
       },
       claims: {
         serializedName: "claims",
         required: true,
         type: {
-          name: "String"
+          name: "Dictionary",
+          value: { type: { name: "String" } }
         }
       },
       correlationId: {
@@ -1003,6 +1004,74 @@ export const ResourceWriteSuccessEventData: coreClient.CompositeMapper = {
       },
       httpRequest: {
         serializedName: "httpRequest",
+        type: {
+          name: "Composite",
+          className: "ResourceHttpRequest"
+        }
+      }
+    }
+  }
+};
+
+export const ResourceAuthorization: coreClient.CompositeMapper = {
+  type: {
+    name: "Composite",
+    className: "ResourceAuthorization",
+    modelProperties: {
+      scope: {
+        serializedName: "scope",
+        required: true,
+        type: {
+          name: "String"
+        }
+      },
+      action: {
+        serializedName: "action",
+        required: true,
+        type: {
+          name: "String"
+        }
+      },
+      evidence: {
+        serializedName: "evidence",
+        required: true,
+        type: {
+          name: "Dictionary",
+          value: { type: { name: "String" } }
+        }
+      }
+    }
+  }
+};
+
+export const ResourceHttpRequest: coreClient.CompositeMapper = {
+  type: {
+    name: "Composite",
+    className: "ResourceHttpRequest",
+    modelProperties: {
+      clientRequestId: {
+        serializedName: "clientRequestId",
+        required: true,
+        type: {
+          name: "String"
+        }
+      },
+      clientIpAddress: {
+        serializedName: "clientIpAddress",
+        required: true,
+        type: {
+          name: "String"
+        }
+      },
+      method: {
+        serializedName: "method",
+        required: true,
+        type: {
+          name: "String"
+        }
+      },
+      url: {
+        serializedName: "url",
         required: true,
         type: {
           name: "String"
@@ -1068,16 +1137,17 @@ export const ResourceWriteFailureEventData: coreClient.CompositeMapper = {
       },
       authorization: {
         serializedName: "authorization",
-        required: true,
         type: {
-          name: "String"
+          name: "Composite",
+          className: "ResourceAuthorization"
         }
       },
       claims: {
         serializedName: "claims",
         required: true,
         type: {
-          name: "String"
+          name: "Dictionary",
+          value: { type: { name: "String" } }
         }
       },
       correlationId: {
@@ -1089,9 +1159,9 @@ export const ResourceWriteFailureEventData: coreClient.CompositeMapper = {
       },
       httpRequest: {
         serializedName: "httpRequest",
-        required: true,
         type: {
-          name: "String"
+          name: "Composite",
+          className: "ResourceHttpRequest"
         }
       }
     }
@@ -1154,16 +1224,17 @@ export const ResourceWriteCancelEventData: coreClient.CompositeMapper = {
       },
       authorization: {
         serializedName: "authorization",
-        required: true,
         type: {
-          name: "String"
+          name: "Composite",
+          className: "ResourceAuthorization"
         }
       },
       claims: {
         serializedName: "claims",
         required: true,
         type: {
-          name: "String"
+          name: "Dictionary",
+          value: { type: { name: "String" } }
         }
       },
       correlationId: {
@@ -1175,9 +1246,9 @@ export const ResourceWriteCancelEventData: coreClient.CompositeMapper = {
       },
       httpRequest: {
         serializedName: "httpRequest",
-        required: true,
         type: {
-          name: "String"
+          name: "Composite",
+          className: "ResourceHttpRequest"
         }
       }
     }
@@ -1240,16 +1311,17 @@ export const ResourceDeleteSuccessEventData: coreClient.CompositeMapper = {
       },
       authorization: {
         serializedName: "authorization",
-        required: true,
         type: {
-          name: "String"
+          name: "Composite",
+          className: "ResourceAuthorization"
         }
       },
       claims: {
         serializedName: "claims",
         required: true,
         type: {
-          name: "String"
+          name: "Dictionary",
+          value: { type: { name: "String" } }
         }
       },
       correlationId: {
@@ -1261,9 +1333,9 @@ export const ResourceDeleteSuccessEventData: coreClient.CompositeMapper = {
       },
       httpRequest: {
         serializedName: "httpRequest",
-        required: true,
         type: {
-          name: "String"
+          name: "Composite",
+          className: "ResourceHttpRequest"
         }
       }
     }
@@ -1326,16 +1398,17 @@ export const ResourceDeleteFailureEventData: coreClient.CompositeMapper = {
       },
       authorization: {
         serializedName: "authorization",
-        required: true,
         type: {
-          name: "String"
+          name: "Composite",
+          className: "ResourceAuthorization"
         }
       },
       claims: {
         serializedName: "claims",
         required: true,
         type: {
-          name: "String"
+          name: "Dictionary",
+          value: { type: { name: "String" } }
         }
       },
       correlationId: {
@@ -1347,9 +1420,9 @@ export const ResourceDeleteFailureEventData: coreClient.CompositeMapper = {
       },
       httpRequest: {
         serializedName: "httpRequest",
-        required: true,
         type: {
-          name: "String"
+          name: "Composite",
+          className: "ResourceHttpRequest"
         }
       }
     }
@@ -1412,16 +1485,17 @@ export const ResourceDeleteCancelEventData: coreClient.CompositeMapper = {
       },
       authorization: {
         serializedName: "authorization",
-        required: true,
         type: {
-          name: "String"
+          name: "Composite",
+          className: "ResourceAuthorization"
         }
       },
       claims: {
         serializedName: "claims",
         required: true,
         type: {
-          name: "String"
+          name: "Dictionary",
+          value: { type: { name: "String" } }
         }
       },
       correlationId: {
@@ -1433,9 +1507,9 @@ export const ResourceDeleteCancelEventData: coreClient.CompositeMapper = {
       },
       httpRequest: {
         serializedName: "httpRequest",
-        required: true,
         type: {
-          name: "String"
+          name: "Composite",
+          className: "ResourceHttpRequest"
         }
       }
     }
@@ -1498,16 +1572,17 @@ export const ResourceActionSuccessEventData: coreClient.CompositeMapper = {
       },
       authorization: {
         serializedName: "authorization",
-        required: true,
         type: {
-          name: "String"
+          name: "Composite",
+          className: "ResourceAuthorization"
         }
       },
       claims: {
         serializedName: "claims",
         required: true,
         type: {
-          name: "String"
+          name: "Dictionary",
+          value: { type: { name: "String" } }
         }
       },
       correlationId: {
@@ -1519,9 +1594,9 @@ export const ResourceActionSuccessEventData: coreClient.CompositeMapper = {
       },
       httpRequest: {
         serializedName: "httpRequest",
-        required: true,
         type: {
-          name: "String"
+          name: "Composite",
+          className: "ResourceHttpRequest"
         }
       }
     }
@@ -1584,16 +1659,17 @@ export const ResourceActionFailureEventData: coreClient.CompositeMapper = {
       },
       authorization: {
         serializedName: "authorization",
-        required: true,
         type: {
-          name: "String"
+          name: "Composite",
+          className: "ResourceAuthorization"
         }
       },
       claims: {
         serializedName: "claims",
         required: true,
         type: {
-          name: "String"
+          name: "Dictionary",
+          value: { type: { name: "String" } }
         }
       },
       correlationId: {
@@ -1605,9 +1681,9 @@ export const ResourceActionFailureEventData: coreClient.CompositeMapper = {
       },
       httpRequest: {
         serializedName: "httpRequest",
-        required: true,
         type: {
-          name: "String"
+          name: "Composite",
+          className: "ResourceHttpRequest"
         }
       }
     }
@@ -1670,16 +1746,17 @@ export const ResourceActionCancelEventData: coreClient.CompositeMapper = {
       },
       authorization: {
         serializedName: "authorization",
-        required: true,
         type: {
-          name: "String"
+          name: "Composite",
+          className: "ResourceAuthorization"
         }
       },
       claims: {
         serializedName: "claims",
         required: true,
         type: {
-          name: "String"
+          name: "Dictionary",
+          value: { type: { name: "String" } }
         }
       },
       correlationId: {
@@ -1691,9 +1768,9 @@ export const ResourceActionCancelEventData: coreClient.CompositeMapper = {
       },
       httpRequest: {
         serializedName: "httpRequest",
-        required: true,
         type: {
-          name: "String"
+          name: "Composite",
+          className: "ResourceHttpRequest"
         }
       }
     }
@@ -2068,6 +2145,13 @@ export const ContainerRegistryEventData: coreClient.CompositeMapper = {
           name: "String"
         }
       },
+      location: {
+        serializedName: "location",
+        required: true,
+        type: {
+          name: "String"
+        }
+      },
       target: {
         serializedName: "target",
         type: {
@@ -2094,6 +2178,13 @@ export const ContainerRegistryEventData: coreClient.CompositeMapper = {
         type: {
           name: "Composite",
           className: "ContainerRegistryEventSource"
+        }
+      },
+      connectedRegistry: {
+        serializedName: "connectedRegistry",
+        type: {
+          name: "Composite",
+          className: "ContainerRegistryEventConnectedRegistry"
         }
       }
     }
@@ -2241,6 +2332,22 @@ export const ContainerRegistryEventSource: coreClient.CompositeMapper = {
   }
 };
 
+export const ContainerRegistryEventConnectedRegistry: coreClient.CompositeMapper = {
+  type: {
+    name: "Composite",
+    className: "ContainerRegistryEventConnectedRegistry",
+    modelProperties: {
+      name: {
+        serializedName: "name",
+        required: true,
+        type: {
+          name: "String"
+        }
+      }
+    }
+  }
+};
+
 export const ContainerRegistryArtifactEventData: coreClient.CompositeMapper = {
   type: {
     name: "Composite",
@@ -2267,11 +2374,25 @@ export const ContainerRegistryArtifactEventData: coreClient.CompositeMapper = {
           name: "String"
         }
       },
+      location: {
+        serializedName: "location",
+        required: true,
+        type: {
+          name: "String"
+        }
+      },
       target: {
         serializedName: "target",
         type: {
           name: "Composite",
           className: "ContainerRegistryArtifactEventTarget"
+        }
+      },
+      connectedRegistry: {
+        serializedName: "connectedRegistry",
+        type: {
+          name: "Composite",
+          className: "ContainerRegistryEventConnectedRegistry"
         }
       }
     }
@@ -5767,6 +5888,27 @@ export const AcsRecordingFileStatusUpdatedEventData: coreClient.CompositeMapper 
           name: "Number"
         }
       },
+      recordingContentType: {
+        serializedName: "recordingContentType",
+        required: true,
+        type: {
+          name: "String"
+        }
+      },
+      recordingChannelType: {
+        serializedName: "recordingChannelType",
+        required: true,
+        type: {
+          name: "String"
+        }
+      },
+      recordingFormatType: {
+        serializedName: "recordingFormatType",
+        required: true,
+        type: {
+          name: "String"
+        }
+      },
       sessionEndReason: {
         serializedName: "sessionEndReason",
         required: true,
@@ -5835,6 +5977,13 @@ export const AcsRecordingChunkInfo: coreClient.CompositeMapper = {
       },
       contentLocation: {
         serializedName: "contentLocation",
+        required: true,
+        type: {
+          name: "String"
+        }
+      },
+      deleteLocation: {
+        serializedName: "deleteLocation",
         required: true,
         type: {
           name: "String"

--- a/sdk/eventgrid/eventgrid/src/index.ts
+++ b/sdk/eventgrid/eventgrid/src/index.ts
@@ -204,4 +204,10 @@ export {
   StorageAsyncOperationInitiatedEventData,
   StorageBlobTierChangedEventData,
   StorageBlobInventoryPolicyCompletedEventData,
+  RecordingChannelType,
+  RecordingContentType,
+  RecordingFormatType,
+  ResourceAuthorization,
+  ResourceHttpRequest,
+  ContainerRegistryEventConnectedRegistry,
 } from "./generated/models";

--- a/sdk/eventgrid/eventgrid/swagger/README.md
+++ b/sdk/eventgrid/eventgrid/swagger/README.md
@@ -7,7 +7,7 @@
 ```yaml
 require: "https://github.com/Azure/azure-rest-api-specs/blob/397017728a17dd50b6755e7de0d283b93562a634/specification/eventgrid/data-plane/readme.md"
 package-name: "@azure/eventgrid"
-package-version: "4.5.1"
+package-version: "4.6.0"
 title: GeneratedClient
 description: EventGrid Client
 generate-metadata: false

--- a/sdk/eventgrid/eventgrid/swagger/README.md
+++ b/sdk/eventgrid/eventgrid/swagger/README.md
@@ -5,7 +5,7 @@
 ## Configuration
 
 ```yaml
-require: "https://github.com/Azure/azure-rest-api-specs/blob/b6f4a619bd310870334edd79eaec2d4bfeabdbbe/specification/eventgrid/data-plane/readme.md"
+require: "https://github.com/Azure/azure-rest-api-specs/blob/397017728a17dd50b6755e7de0d283b93562a634/specification/eventgrid/data-plane/readme.md"
 package-name: "@azure/eventgrid"
 package-version: "4.5.1"
 title: GeneratedClient


### PR DESCRIPTION
 This change pulls in the latest changes from the
 `azure-rest-api-specs` repository for system events in Azure.
 
 While no new events have been added with this release, some events now
 have additional properties (the service teams which produce these
 events now provide additional information in each event).
 
 In addition, it fixes an issue we had with some of the Azure Resource
 Manager events. We discovered that the event schemas for these events
 was authored incorrectly and said some properties were of type
 "string" instead of either a rich object or a map of strings to
 strings.
 
 A customer discovered this for .NET and that caused us to do some
 investigation with the service team to discover that the specification
 was wrong and get it corrected.
 
 This is a breaking change for code which is written in typescript and
 which uses any of these impacted properties because the underlying
 type has changed from string to something else. However, any code
 which previously was written against the old typings would have
 *failed* at runtime with a type error, so in practice anyone who gets
 an issue is now correctly discovering a bug in their program at
 compile time now instead of runtime.
 
 To prevent these issues in the future, we've been working closely with
 the service team to introduce guard rails that ensure the events
 services publish correspond to the schemas they have published.