### PR TITLE
Disable the feedback creation tests for AAD

### DIFF
--- a/sdk/metricsadvisor/ai-metrics-advisor/recordings/browsers/api_key_metricsadvisorclient_feedback/recording_creates_comment_feedback.json
+++ b/sdk/metricsadvisor/ai-metrics-advisor/recordings/browsers/api_key_metricsadvisorclient_feedback/recording_creates_comment_feedback.json
@@ -2,38 +2,38 @@
  "recordings": [
   {
    "method": "POST",
-   "url": "https://endpoint/metricsadvisor/v1.0/feedback/metric",
+   "url": "https://endpoint//metricsadvisor/v1.0/feedback/metric",
    "query": {},
    "requestBody": "{\"feedbackType\":\"Comment\",\"metricId\":\"189ff959-d9f4-45c7-a1e0-f87c9c7ca80f\",\"dimensionFilter\":{\"dimension\":{\"category\":\"Home & Garden\",\"region\":\"Cairo\"}},\"value\":{\"commentValue\":\"This is a comment\"}}",
    "status": 201,
    "response": "",
    "responseHeaders": {
-    "apim-request-id": "a38ac109-b827-489d-b3a0-68ebcfb834da",
+    "apim-request-id": "e1490a61-52eb-4bf0-a954-c7eed5465b42",
     "content-length": "0",
-    "date": "Mon, 08 Nov 2021 09:44:21 GMT",
-    "location": "https://endpoint/metricsadvisor/v1.0/feedback/metric/ee55af4c-0fdf-4b8e-92b0-29ddd99d6efc",
+    "date": "Sat, 08 Jan 2022 00:20:10 GMT",
+    "location": "https://endpoint//metricsadvisor/v1.0/feedback/metric/90b26cda-8ed2-4d7e-bd74-e13d3f1f0360",
     "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
     "x-content-type-options": "nosniff",
-    "x-envoy-upstream-service-time": "349",
-    "x-request-id": "a38ac109-b827-489d-b3a0-68ebcfb834da"
+    "x-envoy-upstream-service-time": "394",
+    "x-request-id": "e1490a61-52eb-4bf0-a954-c7eed5465b42"
    }
   },
   {
    "method": "GET",
-   "url": "https://endpoint/metricsadvisor/v1.0/feedback/metric/ee55af4c-0fdf-4b8e-92b0-29ddd99d6efc",
+   "url": "https://endpoint//metricsadvisor/v1.0/feedback/metric/90b26cda-8ed2-4d7e-bd74-e13d3f1f0360",
    "query": {},
    "requestBody": null,
    "status": 200,
-   "response": "{\"feedbackId\":\"ee55af4c-0fdf-4b8e-92b0-29ddd99d6efc\",\"createdTime\":\"2021-11-08T09:44:21.373Z\",\"userPrincipal\":\"kaghiya@microsoft.com\",\"metricId\":\"189ff959-d9f4-45c7-a1e0-f87c9c7ca80f\",\"dimensionFilter\":{\"dimension\":{\"region\":\"Cairo\",\"category\":\"Home & Garden\"}},\"feedbackType\":\"Comment\",\"value\":{\"commentValue\":\"This is a comment\"}}",
+   "response": "{\"feedbackId\":\"90b26cda-8ed2-4d7e-bd74-e13d3f1f0360\",\"createdTime\":\"2022-01-08T00:20:10.15Z\",\"userPrincipal\":\"kaghiya@microsoft.com\",\"metricId\":\"189ff959-d9f4-45c7-a1e0-f87c9c7ca80f\",\"dimensionFilter\":{\"dimension\":{\"region\":\"Cairo\",\"category\":\"Home & Garden\"}},\"feedbackType\":\"Comment\",\"value\":{\"commentValue\":\"This is a comment\"}}",
    "responseHeaders": {
-    "apim-request-id": "bc046f1d-9e51-4d3a-91bb-963a179aa99e",
-    "content-length": "332",
+    "apim-request-id": "7ee50329-d5a8-4c24-80cd-d74716678a34",
+    "content-length": "331",
     "content-type": "application/json; charset=utf-8",
-    "date": "Mon, 08 Nov 2021 09:44:21 GMT",
+    "date": "Sat, 08 Jan 2022 00:20:10 GMT",
     "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
     "x-content-type-options": "nosniff",
-    "x-envoy-upstream-service-time": "101",
-    "x-request-id": "bc046f1d-9e51-4d3a-91bb-963a179aa99e"
+    "x-envoy-upstream-service-time": "98",
+    "x-request-id": "7ee50329-d5a8-4c24-80cd-d74716678a34"
    }
   }
  ],
@@ -41,5 +41,5 @@
   "uniqueName": {},
   "newDate": {}
  },
- "hash": "9dae5a907caeda75c66ee9efe93ac5bf"
+ "hash": "fdf3442515c14611dda68e811815f236"
 }

--- a/sdk/metricsadvisor/ai-metrics-advisor/recordings/browsers/api_key_metricsadvisorclient_feedback/recording_creates_comment_feedback.json
+++ b/sdk/metricsadvisor/ai-metrics-advisor/recordings/browsers/api_key_metricsadvisorclient_feedback/recording_creates_comment_feedback.json
@@ -1,45 +1,45 @@
 {
- "recordings": [
-  {
-   "method": "POST",
-   "url": "https://endpoint//metricsadvisor/v1.0/feedback/metric",
-   "query": {},
-   "requestBody": "{\"feedbackType\":\"Comment\",\"metricId\":\"189ff959-d9f4-45c7-a1e0-f87c9c7ca80f\",\"dimensionFilter\":{\"dimension\":{\"category\":\"Home & Garden\",\"region\":\"Cairo\"}},\"value\":{\"commentValue\":\"This is a comment\"}}",
-   "status": 201,
-   "response": "",
-   "responseHeaders": {
-    "apim-request-id": "e1490a61-52eb-4bf0-a954-c7eed5465b42",
-    "content-length": "0",
-    "date": "Sat, 08 Jan 2022 00:20:10 GMT",
-    "location": "https://endpoint//metricsadvisor/v1.0/feedback/metric/90b26cda-8ed2-4d7e-bd74-e13d3f1f0360",
-    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
-    "x-content-type-options": "nosniff",
-    "x-envoy-upstream-service-time": "394",
-    "x-request-id": "e1490a61-52eb-4bf0-a954-c7eed5465b42"
-   }
+  "recordings": [
+    {
+      "method": "POST",
+      "url": "https://endpoint/metricsadvisor/v1.0/feedback/metric",
+      "query": {},
+      "requestBody": "{\"feedbackType\":\"Comment\",\"metricId\":\"189ff959-d9f4-45c7-a1e0-f87c9c7ca80f\",\"dimensionFilter\":{\"dimension\":{\"category\":\"Home & Garden\",\"region\":\"Cairo\"}},\"value\":{\"commentValue\":\"This is a comment\"}}",
+      "status": 201,
+      "response": "",
+      "responseHeaders": {
+        "apim-request-id": "e1490a61-52eb-4bf0-a954-c7eed5465b42",
+        "content-length": "0",
+        "date": "Sat, 08 Jan 2022 00:20:10 GMT",
+        "location": "https://endpoint/metricsadvisor/v1.0/feedback/metric/90b26cda-8ed2-4d7e-bd74-e13d3f1f0360",
+        "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "394",
+        "x-request-id": "e1490a61-52eb-4bf0-a954-c7eed5465b42"
+      }
+    },
+    {
+      "method": "GET",
+      "url": "https://endpoint/metricsadvisor/v1.0/feedback/metric/90b26cda-8ed2-4d7e-bd74-e13d3f1f0360",
+      "query": {},
+      "requestBody": null,
+      "status": 200,
+      "response": "{\"feedbackId\":\"90b26cda-8ed2-4d7e-bd74-e13d3f1f0360\",\"createdTime\":\"2022-01-08T00:20:10.15Z\",\"userPrincipal\":\"kaghiya@microsoft.com\",\"metricId\":\"189ff959-d9f4-45c7-a1e0-f87c9c7ca80f\",\"dimensionFilter\":{\"dimension\":{\"region\":\"Cairo\",\"category\":\"Home & Garden\"}},\"feedbackType\":\"Comment\",\"value\":{\"commentValue\":\"This is a comment\"}}",
+      "responseHeaders": {
+        "apim-request-id": "7ee50329-d5a8-4c24-80cd-d74716678a34",
+        "content-length": "331",
+        "content-type": "application/json; charset=utf-8",
+        "date": "Sat, 08 Jan 2022 00:20:10 GMT",
+        "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "98",
+        "x-request-id": "7ee50329-d5a8-4c24-80cd-d74716678a34"
+      }
+    }
+  ],
+  "uniqueTestInfo": {
+    "uniqueName": {},
+    "newDate": {}
   },
-  {
-   "method": "GET",
-   "url": "https://endpoint//metricsadvisor/v1.0/feedback/metric/90b26cda-8ed2-4d7e-bd74-e13d3f1f0360",
-   "query": {},
-   "requestBody": null,
-   "status": 200,
-   "response": "{\"feedbackId\":\"90b26cda-8ed2-4d7e-bd74-e13d3f1f0360\",\"createdTime\":\"2022-01-08T00:20:10.15Z\",\"userPrincipal\":\"kaghiya@microsoft.com\",\"metricId\":\"189ff959-d9f4-45c7-a1e0-f87c9c7ca80f\",\"dimensionFilter\":{\"dimension\":{\"region\":\"Cairo\",\"category\":\"Home & Garden\"}},\"feedbackType\":\"Comment\",\"value\":{\"commentValue\":\"This is a comment\"}}",
-   "responseHeaders": {
-    "apim-request-id": "7ee50329-d5a8-4c24-80cd-d74716678a34",
-    "content-length": "331",
-    "content-type": "application/json; charset=utf-8",
-    "date": "Sat, 08 Jan 2022 00:20:10 GMT",
-    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
-    "x-content-type-options": "nosniff",
-    "x-envoy-upstream-service-time": "98",
-    "x-request-id": "7ee50329-d5a8-4c24-80cd-d74716678a34"
-   }
-  }
- ],
- "uniqueTestInfo": {
-  "uniqueName": {},
-  "newDate": {}
- },
- "hash": "fdf3442515c14611dda68e811815f236"
+  "hash": "fdf3442515c14611dda68e811815f236"
 }

--- a/sdk/metricsadvisor/ai-metrics-advisor/recordings/browsers/api_key_metricsadvisorclient_feedback/recording_retrieves_comment_feedback.json
+++ b/sdk/metricsadvisor/ai-metrics-advisor/recordings/browsers/api_key_metricsadvisorclient_feedback/recording_retrieves_comment_feedback.json
@@ -1,27 +1,27 @@
 {
- "recordings": [
-  {
-   "method": "GET",
-   "url": "https://endpoint//metricsadvisor/v1.0/feedback/metric/90b26cda-8ed2-4d7e-bd74-e13d3f1f0360",
-   "query": {},
-   "requestBody": null,
-   "status": 200,
-   "response": "{\"feedbackId\":\"90b26cda-8ed2-4d7e-bd74-e13d3f1f0360\",\"createdTime\":\"2022-01-08T00:20:10.15Z\",\"userPrincipal\":\"kaghiya@microsoft.com\",\"metricId\":\"189ff959-d9f4-45c7-a1e0-f87c9c7ca80f\",\"dimensionFilter\":{\"dimension\":{\"region\":\"Cairo\",\"category\":\"Home & Garden\"}},\"feedbackType\":\"Comment\",\"value\":{\"commentValue\":\"This is a comment\"}}",
-   "responseHeaders": {
-    "apim-request-id": "6d28aba2-af5b-4ad3-9d30-6c51131cab1d",
-    "content-length": "331",
-    "content-type": "application/json; charset=utf-8",
-    "date": "Sat, 08 Jan 2022 00:20:10 GMT",
-    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
-    "x-content-type-options": "nosniff",
-    "x-envoy-upstream-service-time": "107",
-    "x-request-id": "6d28aba2-af5b-4ad3-9d30-6c51131cab1d"
-   }
-  }
- ],
- "uniqueTestInfo": {
-  "uniqueName": {},
-  "newDate": {}
- },
- "hash": "03dfc4f219634d1ee0047b1b3aeb288b"
+  "recordings": [
+    {
+      "method": "GET",
+      "url": "https://endpoint/metricsadvisor/v1.0/feedback/metric/90b26cda-8ed2-4d7e-bd74-e13d3f1f0360",
+      "query": {},
+      "requestBody": null,
+      "status": 200,
+      "response": "{\"feedbackId\":\"90b26cda-8ed2-4d7e-bd74-e13d3f1f0360\",\"createdTime\":\"2022-01-08T00:20:10.15Z\",\"userPrincipal\":\"kaghiya@microsoft.com\",\"metricId\":\"189ff959-d9f4-45c7-a1e0-f87c9c7ca80f\",\"dimensionFilter\":{\"dimension\":{\"region\":\"Cairo\",\"category\":\"Home & Garden\"}},\"feedbackType\":\"Comment\",\"value\":{\"commentValue\":\"This is a comment\"}}",
+      "responseHeaders": {
+        "apim-request-id": "6d28aba2-af5b-4ad3-9d30-6c51131cab1d",
+        "content-length": "331",
+        "content-type": "application/json; charset=utf-8",
+        "date": "Sat, 08 Jan 2022 00:20:10 GMT",
+        "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "107",
+        "x-request-id": "6d28aba2-af5b-4ad3-9d30-6c51131cab1d"
+      }
+    }
+  ],
+  "uniqueTestInfo": {
+    "uniqueName": {},
+    "newDate": {}
+  },
+  "hash": "03dfc4f219634d1ee0047b1b3aeb288b"
 }

--- a/sdk/metricsadvisor/ai-metrics-advisor/recordings/browsers/api_key_metricsadvisorclient_feedback/recording_retrieves_comment_feedback.json
+++ b/sdk/metricsadvisor/ai-metrics-advisor/recordings/browsers/api_key_metricsadvisorclient_feedback/recording_retrieves_comment_feedback.json
@@ -2,20 +2,20 @@
  "recordings": [
   {
    "method": "GET",
-   "url": "https://endpoint/metricsadvisor/v1.0/feedback/metric/ee55af4c-0fdf-4b8e-92b0-29ddd99d6efc",
+   "url": "https://endpoint//metricsadvisor/v1.0/feedback/metric/90b26cda-8ed2-4d7e-bd74-e13d3f1f0360",
    "query": {},
    "requestBody": null,
    "status": 200,
-   "response": "{\"feedbackId\":\"ee55af4c-0fdf-4b8e-92b0-29ddd99d6efc\",\"createdTime\":\"2021-11-08T09:44:21.373Z\",\"userPrincipal\":\"kaghiya@microsoft.com\",\"metricId\":\"189ff959-d9f4-45c7-a1e0-f87c9c7ca80f\",\"dimensionFilter\":{\"dimension\":{\"region\":\"Cairo\",\"category\":\"Home & Garden\"}},\"feedbackType\":\"Comment\",\"value\":{\"commentValue\":\"This is a comment\"}}",
+   "response": "{\"feedbackId\":\"90b26cda-8ed2-4d7e-bd74-e13d3f1f0360\",\"createdTime\":\"2022-01-08T00:20:10.15Z\",\"userPrincipal\":\"kaghiya@microsoft.com\",\"metricId\":\"189ff959-d9f4-45c7-a1e0-f87c9c7ca80f\",\"dimensionFilter\":{\"dimension\":{\"region\":\"Cairo\",\"category\":\"Home & Garden\"}},\"feedbackType\":\"Comment\",\"value\":{\"commentValue\":\"This is a comment\"}}",
    "responseHeaders": {
-    "apim-request-id": "9c49aff7-ea80-4708-a579-c820abd435be",
-    "content-length": "332",
+    "apim-request-id": "6d28aba2-af5b-4ad3-9d30-6c51131cab1d",
+    "content-length": "331",
     "content-type": "application/json; charset=utf-8",
-    "date": "Mon, 08 Nov 2021 09:44:21 GMT",
+    "date": "Sat, 08 Jan 2022 00:20:10 GMT",
     "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
     "x-content-type-options": "nosniff",
     "x-envoy-upstream-service-time": "107",
-    "x-request-id": "9c49aff7-ea80-4708-a579-c820abd435be"
+    "x-request-id": "6d28aba2-af5b-4ad3-9d30-6c51131cab1d"
    }
   }
  ],
@@ -23,5 +23,5 @@
   "uniqueName": {},
   "newDate": {}
  },
- "hash": "ba413a8b120fa2f04aa802269aa2823a"
+ "hash": "03dfc4f219634d1ee0047b1b3aeb288b"
 }

--- a/sdk/metricsadvisor/ai-metrics-advisor/recordings/node/api_key_metricsadvisorclient_feedback/recording_creates_comment_feedback.js
+++ b/sdk/metricsadvisor/ai-metrics-advisor/recordings/node/api_key_metricsadvisorclient_feedback/recording_creates_comment_feedback.js
@@ -1,51 +1,47 @@
 let nock = require('nock');
 
-module.exports.hash = "d4f6a0d4fb073072eccfefa2ca136f3f";
+module.exports.hash = "8948136c6d03be4d7f6bf4b239c40478";
 
 module.exports.testInfo = {"uniqueName":{},"newDate":{}}
 
-nock('https://endpoint/:443', {"encodedQueryParams":true})
+nock('https://endpoint:443', {"encodedQueryParams":true})
   .post('/metricsadvisor/v1.0/feedback/metric', {"feedbackType":"Comment","metricId":"189ff959-d9f4-45c7-a1e0-f87c9c7ca80f","dimensionFilter":{"dimension":{"category":"Home & Garden","region":"Cairo"}},"value":{"commentValue":"This is a comment"}})
   .reply(201, "", [
   'Content-Length',
   '0',
   'Location',
-  'https://endpoint/metricsadvisor/v1.0/feedback/metric/549e8d9e-f903-4219-a46b-1e8781500468',
+  'https://endpoint/metricsadvisor/v1.0/feedback/metric/fcdd6188-bc16-454f-957e-514661256435',
   'x-request-id',
-  'cc21e47a-c6d2-462c-a10f-dab72b12a467',
+  '3ea48501-79c6-4dab-ba4a-be70de8caaf2',
   'x-envoy-upstream-service-time',
-  '342',
+  '321',
   'apim-request-id',
-  'cc21e47a-c6d2-462c-a10f-dab72b12a467',
+  '3ea48501-79c6-4dab-ba4a-be70de8caaf2',
   'Strict-Transport-Security',
   'max-age=31536000; includeSubDomains; preload',
   'x-content-type-options',
   'nosniff',
   'Date',
-  'Sat, 08 Jan 2022 00:08:24 GMT',
-  'Connection',
-  'close'
+  'Sat, 08 Jan 2022 01:04:42 GMT'
 ]);
 
-nock('https://endpoint/:443', {"encodedQueryParams":true})
-  .get('/metricsadvisor/v1.0/feedback/metric/549e8d9e-f903-4219-a46b-1e8781500468')
-  .reply(200, {"feedbackId":"549e8d9e-f903-4219-a46b-1e8781500468","createdTime":"2022-01-08T00:08:24.84Z","userPrincipal":"kaghiya@microsoft.com","metricId":"189ff959-d9f4-45c7-a1e0-f87c9c7ca80f","dimensionFilter":{"dimension":{"region":"Cairo","category":"Home & Garden"}},"feedbackType":"Comment","value":{"commentValue":"This is a comment"}}, [
+nock('https://endpoint:443', {"encodedQueryParams":true})
+  .get('/metricsadvisor/v1.0/feedback/metric/fcdd6188-bc16-454f-957e-514661256435')
+  .reply(200, {"feedbackId":"fcdd6188-bc16-454f-957e-514661256435","createdTime":"2022-01-08T01:04:43.17Z","userPrincipal":"kaghiya@microsoft.com","metricId":"189ff959-d9f4-45c7-a1e0-f87c9c7ca80f","dimensionFilter":{"dimension":{"region":"Cairo","category":"Home & Garden"}},"feedbackType":"Comment","value":{"commentValue":"This is a comment"}}, [
   'Content-Length',
   '331',
   'Content-Type',
   'application/json; charset=utf-8',
   'x-request-id',
-  '9d3b46e7-34f4-41a5-b01c-9fd0a5c6b92a',
+  'f9ba7036-655e-4471-8d0a-72cbfde70040',
   'x-envoy-upstream-service-time',
-  '111',
+  '98',
   'apim-request-id',
-  '9d3b46e7-34f4-41a5-b01c-9fd0a5c6b92a',
+  'f9ba7036-655e-4471-8d0a-72cbfde70040',
   'Strict-Transport-Security',
   'max-age=31536000; includeSubDomains; preload',
   'x-content-type-options',
   'nosniff',
   'Date',
-  'Sat, 08 Jan 2022 00:08:24 GMT',
-  'Connection',
-  'close'
+  'Sat, 08 Jan 2022 01:04:42 GMT'
 ]);

--- a/sdk/metricsadvisor/ai-metrics-advisor/recordings/node/api_key_metricsadvisorclient_feedback/recording_creates_comment_feedback.js
+++ b/sdk/metricsadvisor/ai-metrics-advisor/recordings/node/api_key_metricsadvisorclient_feedback/recording_creates_comment_feedback.js
@@ -1,47 +1,51 @@
 let nock = require('nock');
 
-module.exports.hash = "6ff0d17bb67055a4ef5add7605c64970";
+module.exports.hash = "d4f6a0d4fb073072eccfefa2ca136f3f";
 
 module.exports.testInfo = {"uniqueName":{},"newDate":{}}
 
-nock('https://endpoint:443', {"encodedQueryParams":true})
+nock('https://endpoint/:443', {"encodedQueryParams":true})
   .post('/metricsadvisor/v1.0/feedback/metric', {"feedbackType":"Comment","metricId":"189ff959-d9f4-45c7-a1e0-f87c9c7ca80f","dimensionFilter":{"dimension":{"category":"Home & Garden","region":"Cairo"}},"value":{"commentValue":"This is a comment"}})
   .reply(201, "", [
   'Content-Length',
   '0',
   'Location',
-  'https://endpoint/metricsadvisor/v1.0/feedback/metric/f29c7d01-ff06-4548-9199-be5a7ff7c755',
+  'https://endpoint//metricsadvisor/v1.0/feedback/metric/549e8d9e-f903-4219-a46b-1e8781500468',
   'x-request-id',
-  '6449702e-3792-4112-8242-cbfade2e3c48',
+  'cc21e47a-c6d2-462c-a10f-dab72b12a467',
   'x-envoy-upstream-service-time',
-  '319',
+  '342',
   'apim-request-id',
-  '6449702e-3792-4112-8242-cbfade2e3c48',
+  'cc21e47a-c6d2-462c-a10f-dab72b12a467',
   'Strict-Transport-Security',
   'max-age=31536000; includeSubDomains; preload',
   'x-content-type-options',
   'nosniff',
   'Date',
-  'Tue, 16 Nov 2021 00:32:50 GMT'
+  'Sat, 08 Jan 2022 00:08:24 GMT',
+  'Connection',
+  'close'
 ]);
 
-nock('https://endpoint:443', {"encodedQueryParams":true})
-  .get('/metricsadvisor/v1.0/feedback/metric/f29c7d01-ff06-4548-9199-be5a7ff7c755')
-  .reply(200, {"feedbackId":"f29c7d01-ff06-4548-9199-be5a7ff7c755","createdTime":"2021-11-16T00:32:50.465Z","userPrincipal":"kaghiya@microsoft.com","metricId":"189ff959-d9f4-45c7-a1e0-f87c9c7ca80f","dimensionFilter":{"dimension":{"region":"Cairo","category":"Home & Garden"}},"feedbackType":"Comment","value":{"commentValue":"This is a comment"}}, [
+nock('https://endpoint/:443', {"encodedQueryParams":true})
+  .get('/metricsadvisor/v1.0/feedback/metric/549e8d9e-f903-4219-a46b-1e8781500468')
+  .reply(200, {"feedbackId":"549e8d9e-f903-4219-a46b-1e8781500468","createdTime":"2022-01-08T00:08:24.84Z","userPrincipal":"kaghiya@microsoft.com","metricId":"189ff959-d9f4-45c7-a1e0-f87c9c7ca80f","dimensionFilter":{"dimension":{"region":"Cairo","category":"Home & Garden"}},"feedbackType":"Comment","value":{"commentValue":"This is a comment"}}, [
   'Content-Length',
-  '332',
+  '331',
   'Content-Type',
   'application/json; charset=utf-8',
   'x-request-id',
-  'b1f48d37-766b-42ac-bfcb-4181b86e7845',
+  '9d3b46e7-34f4-41a5-b01c-9fd0a5c6b92a',
   'x-envoy-upstream-service-time',
-  '112',
+  '111',
   'apim-request-id',
-  'b1f48d37-766b-42ac-bfcb-4181b86e7845',
+  '9d3b46e7-34f4-41a5-b01c-9fd0a5c6b92a',
   'Strict-Transport-Security',
   'max-age=31536000; includeSubDomains; preload',
   'x-content-type-options',
   'nosniff',
   'Date',
-  'Tue, 16 Nov 2021 00:32:50 GMT'
+  'Sat, 08 Jan 2022 00:08:24 GMT',
+  'Connection',
+  'close'
 ]);

--- a/sdk/metricsadvisor/ai-metrics-advisor/recordings/node/api_key_metricsadvisorclient_feedback/recording_creates_comment_feedback.js
+++ b/sdk/metricsadvisor/ai-metrics-advisor/recordings/node/api_key_metricsadvisorclient_feedback/recording_creates_comment_feedback.js
@@ -10,7 +10,7 @@ nock('https://endpoint/:443', {"encodedQueryParams":true})
   'Content-Length',
   '0',
   'Location',
-  'https://endpoint//metricsadvisor/v1.0/feedback/metric/549e8d9e-f903-4219-a46b-1e8781500468',
+  'https://endpoint/metricsadvisor/v1.0/feedback/metric/549e8d9e-f903-4219-a46b-1e8781500468',
   'x-request-id',
   'cc21e47a-c6d2-462c-a10f-dab72b12a467',
   'x-envoy-upstream-service-time',

--- a/sdk/metricsadvisor/ai-metrics-advisor/recordings/node/api_key_metricsadvisorclient_feedback/recording_retrieves_comment_feedback.js
+++ b/sdk/metricsadvisor/ai-metrics-advisor/recordings/node/api_key_metricsadvisorclient_feedback/recording_retrieves_comment_feedback.js
@@ -4,7 +4,7 @@ module.exports.hash = "a02c571d82becd3f2077fa6b7c7d3774";
 
 module.exports.testInfo = {"uniqueName":{},"newDate":{}}
 
-nock('https://endpoint/:443', {"encodedQueryParams":true})
+nock('https://endpoint:443', {"encodedQueryParams":true})
   .get('/metricsadvisor/v1.0/feedback/metric/549e8d9e-f903-4219-a46b-1e8781500468')
   .reply(200, {"feedbackId":"549e8d9e-f903-4219-a46b-1e8781500468","createdTime":"2022-01-08T00:08:24.84Z","userPrincipal":"kaghiya@microsoft.com","metricId":"189ff959-d9f4-45c7-a1e0-f87c9c7ca80f","dimensionFilter":{"dimension":{"region":"Cairo","category":"Home & Garden"}},"feedbackType":"Comment","value":{"commentValue":"This is a comment"}}, [
   'Content-Length',

--- a/sdk/metricsadvisor/ai-metrics-advisor/recordings/node/api_key_metricsadvisorclient_feedback/recording_retrieves_comment_feedback.js
+++ b/sdk/metricsadvisor/ai-metrics-advisor/recordings/node/api_key_metricsadvisorclient_feedback/recording_retrieves_comment_feedback.js
@@ -1,28 +1,26 @@
 let nock = require('nock');
 
-module.exports.hash = "a02c571d82becd3f2077fa6b7c7d3774";
+module.exports.hash = "3c53229a0b55a669295c5611bc35a6e4";
 
 module.exports.testInfo = {"uniqueName":{},"newDate":{}}
 
 nock('https://endpoint:443', {"encodedQueryParams":true})
-  .get('/metricsadvisor/v1.0/feedback/metric/549e8d9e-f903-4219-a46b-1e8781500468')
-  .reply(200, {"feedbackId":"549e8d9e-f903-4219-a46b-1e8781500468","createdTime":"2022-01-08T00:08:24.84Z","userPrincipal":"kaghiya@microsoft.com","metricId":"189ff959-d9f4-45c7-a1e0-f87c9c7ca80f","dimensionFilter":{"dimension":{"region":"Cairo","category":"Home & Garden"}},"feedbackType":"Comment","value":{"commentValue":"This is a comment"}}, [
+  .get('/metricsadvisor/v1.0/feedback/metric/fcdd6188-bc16-454f-957e-514661256435')
+  .reply(200, {"feedbackId":"fcdd6188-bc16-454f-957e-514661256435","createdTime":"2022-01-08T01:04:43.17Z","userPrincipal":"kaghiya@microsoft.com","metricId":"189ff959-d9f4-45c7-a1e0-f87c9c7ca80f","dimensionFilter":{"dimension":{"region":"Cairo","category":"Home & Garden"}},"feedbackType":"Comment","value":{"commentValue":"This is a comment"}}, [
   'Content-Length',
   '331',
   'Content-Type',
   'application/json; charset=utf-8',
   'x-request-id',
-  '576bbc78-c27a-4ca6-84ac-c85028b55d33',
+  'bf4f8d8e-700f-4826-b813-ae26a694a3c8',
   'x-envoy-upstream-service-time',
-  '119',
+  '96',
   'apim-request-id',
-  '576bbc78-c27a-4ca6-84ac-c85028b55d33',
+  'bf4f8d8e-700f-4826-b813-ae26a694a3c8',
   'Strict-Transport-Security',
   'max-age=31536000; includeSubDomains; preload',
   'x-content-type-options',
   'nosniff',
   'Date',
-  'Sat, 08 Jan 2022 00:08:25 GMT',
-  'Connection',
-  'close'
+  'Sat, 08 Jan 2022 01:04:42 GMT'
 ]);

--- a/sdk/metricsadvisor/ai-metrics-advisor/recordings/node/api_key_metricsadvisorclient_feedback/recording_retrieves_comment_feedback.js
+++ b/sdk/metricsadvisor/ai-metrics-advisor/recordings/node/api_key_metricsadvisorclient_feedback/recording_retrieves_comment_feedback.js
@@ -1,26 +1,28 @@
 let nock = require('nock');
 
-module.exports.hash = "3c53229a0b55a669295c5611bc35a6e4";
+module.exports.hash = "a02c571d82becd3f2077fa6b7c7d3774";
 
 module.exports.testInfo = {"uniqueName":{},"newDate":{}}
 
-nock('https://endpoint:443', {"encodedQueryParams":true})
-  .get('/metricsadvisor/v1.0/feedback/metric/0a6ef604-8cb1-48aa-87a7-13b413a6ca03')
-  .reply(200, {"feedbackId":"0a6ef604-8cb1-48aa-87a7-13b413a6ca03","createdTime":"2021-11-08T09:38:31.415Z","userPrincipal":"kaghiya@microsoft.com","metricId":"189ff959-d9f4-45c7-a1e0-f87c9c7ca80f","dimensionFilter":{"dimension":{"region":"Cairo","category":"Home & Garden"}},"feedbackType":"Comment","value":{"commentValue":"This is a comment"}}, [
+nock('https://endpoint/:443', {"encodedQueryParams":true})
+  .get('/metricsadvisor/v1.0/feedback/metric/549e8d9e-f903-4219-a46b-1e8781500468')
+  .reply(200, {"feedbackId":"549e8d9e-f903-4219-a46b-1e8781500468","createdTime":"2022-01-08T00:08:24.84Z","userPrincipal":"kaghiya@microsoft.com","metricId":"189ff959-d9f4-45c7-a1e0-f87c9c7ca80f","dimensionFilter":{"dimension":{"region":"Cairo","category":"Home & Garden"}},"feedbackType":"Comment","value":{"commentValue":"This is a comment"}}, [
   'Content-Length',
-  '332',
+  '331',
   'Content-Type',
   'application/json; charset=utf-8',
   'x-request-id',
-  'b49b4637-0c8e-4a7c-9463-5f55500a106a',
+  '576bbc78-c27a-4ca6-84ac-c85028b55d33',
   'x-envoy-upstream-service-time',
-  '110',
+  '119',
   'apim-request-id',
-  'b49b4637-0c8e-4a7c-9463-5f55500a106a',
+  '576bbc78-c27a-4ca6-84ac-c85028b55d33',
   'Strict-Transport-Security',
   'max-age=31536000; includeSubDomains; preload',
   'x-content-type-options',
   'nosniff',
   'Date',
-  'Mon, 08 Nov 2021 09:38:31 GMT'
+  'Sat, 08 Jan 2022 00:08:25 GMT',
+  'Connection',
+  'close'
 ]);

--- a/sdk/metricsadvisor/ai-metrics-advisor/test/public/advisorclient.spec.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/test/public/advisorclient.spec.ts
@@ -517,7 +517,7 @@ matrix([[true, false]] as const, async (useAad) => {
         );
       });
 
-      describe.only("Feedback", async function () {
+      describe("Feedback", async function () {
         let createdFeedbackId: string;
         (useAad ? it.skip : it)("creates Anomaly feedback", async function () {
           const anomalyFeedback: MetricAnomalyFeedback = {

--- a/sdk/metricsadvisor/ai-metrics-advisor/test/public/advisorclient.spec.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/test/public/advisorclient.spec.ts
@@ -517,9 +517,9 @@ matrix([[true, false]] as const, async (useAad) => {
         );
       });
 
-      describe("Feedback", async function () {
+      (useAad ? describe.skip : describe)("Feedback", async function () {
         let createdFeedbackId: string;
-        (useAad ? it.skip : it)("creates Anomaly feedback", async function () {
+        it("creates Anomaly feedback", async function () {
           const anomalyFeedback: MetricAnomalyFeedback = {
             metricId: testEnv.METRICS_ADVISOR_AZURE_SQLSERVER_METRIC_ID_1,
             feedbackType: "Anomaly",
@@ -538,7 +538,7 @@ matrix([[true, false]] as const, async (useAad) => {
           }
         });
 
-        (useAad ? it.skip : it)("creates ChangePoint feedback", async function () {
+        it("creates ChangePoint feedback", async function () {
           const changePointFeedback: MetricChangePointFeedback = {
             metricId: testEnv.METRICS_ADVISOR_AZURE_SQLSERVER_METRIC_ID_1,
             feedbackType: "ChangePoint",
@@ -555,7 +555,7 @@ matrix([[true, false]] as const, async (useAad) => {
           }
         });
 
-        (useAad ? it.skip : it)("creates Period feedback", async function () {
+        it("creates Period feedback", async function () {
           const periodFeedback: MetricPeriodFeedback = {
             metricId: testEnv.METRICS_ADVISOR_AZURE_SQLSERVER_METRIC_ID_1,
             feedbackType: "Period",
@@ -574,7 +574,7 @@ matrix([[true, false]] as const, async (useAad) => {
           }
         });
 
-        (useAad ? it.skip : it)("creates Comment feedback", async function () {
+        it("creates Comment feedback", async function () {
           const expectedCommentFeedback: MetricCommentFeedback = {
             metricId: testEnv.METRICS_ADVISOR_AZURE_SQLSERVER_METRIC_ID_1,
             feedbackType: "Comment",
@@ -592,7 +592,7 @@ matrix([[true, false]] as const, async (useAad) => {
           }
         });
 
-        (useAad ? it.skip : it)("retrieves Comment feedback", async function () {
+        it("retrieves Comment feedback", async function () {
           const actual = await client.getFeedback(createdFeedbackId);
 
           assert.ok(actual.id, "Expecting valid feedback");

--- a/sdk/metricsadvisor/ai-metrics-advisor/test/public/advisorclient.spec.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/test/public/advisorclient.spec.ts
@@ -334,7 +334,6 @@ matrix([[true, false]] as const, async (useAad) => {
           new Date(Date.UTC(2021, 7, 5)),
           new Date(Date.UTC(2021, 11, 5))
         );
-        console.dir(data);
         assert.ok(data && data!.length === 2, "Expecting data for two time series");
         assert.equal(
           data![0].definition.metricId,
@@ -518,9 +517,9 @@ matrix([[true, false]] as const, async (useAad) => {
         );
       });
 
-      describe("Feedback", async function () {
+      describe.only("Feedback", async function () {
         let createdFeedbackId: string;
-        it.skip("creates Anomaly feedback", async function () {
+        (useAad ? it.skip : it)("creates Anomaly feedback", async function () {
           const anomalyFeedback: MetricAnomalyFeedback = {
             metricId: testEnv.METRICS_ADVISOR_AZURE_SQLSERVER_METRIC_ID_1,
             feedbackType: "Anomaly",
@@ -539,7 +538,7 @@ matrix([[true, false]] as const, async (useAad) => {
           }
         });
 
-        it("creates ChangePoint feedback", async function () {
+        (useAad ? it.skip : it)("creates ChangePoint feedback", async function () {
           const changePointFeedback: MetricChangePointFeedback = {
             metricId: testEnv.METRICS_ADVISOR_AZURE_SQLSERVER_METRIC_ID_1,
             feedbackType: "ChangePoint",
@@ -548,7 +547,6 @@ matrix([[true, false]] as const, async (useAad) => {
             dimensionKey: { category: "Home & Garden", region: "Cairo" },
           };
           const actual = await client.addFeedback(changePointFeedback);
-
           assert.ok(actual.id, "Expecting valid feedback");
           createdFeedbackId = actual.id!;
           assert.equal(actual.feedbackType, "ChangePoint");
@@ -557,7 +555,7 @@ matrix([[true, false]] as const, async (useAad) => {
           }
         });
 
-        it("creates Period feedback", async function () {
+        (useAad ? it.skip : it)("creates Period feedback", async function () {
           const periodFeedback: MetricPeriodFeedback = {
             metricId: testEnv.METRICS_ADVISOR_AZURE_SQLSERVER_METRIC_ID_1,
             feedbackType: "Period",
@@ -576,7 +574,7 @@ matrix([[true, false]] as const, async (useAad) => {
           }
         });
 
-        it.skip("creates Comment feedback", async function () {
+        (useAad ? it.skip : it)("creates Comment feedback", async function () {
           const expectedCommentFeedback: MetricCommentFeedback = {
             metricId: testEnv.METRICS_ADVISOR_AZURE_SQLSERVER_METRIC_ID_1,
             feedbackType: "Comment",
@@ -594,7 +592,7 @@ matrix([[true, false]] as const, async (useAad) => {
           }
         });
 
-        it.skip("retrieves Comment feedback", async function () {
+        (useAad ? it.skip : it)("retrieves Comment feedback", async function () {
           const actual = await client.getFeedback(createdFeedbackId);
 
           assert.ok(actual.id, "Expecting valid feedback");
@@ -605,7 +603,6 @@ matrix([[true, false]] as const, async (useAad) => {
           }
         });
 
-        // service issue, skipping for now
         it("lists Anomaly feedbacks", async function () {
           const iterator = client.listFeedback(
             testEnv.METRICS_ADVISOR_AZURE_SQLSERVER_METRIC_ID_1,

--- a/sdk/metricsadvisor/ai-metrics-advisor/test/public/util/recordedClients.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/test/public/util/recordedClients.ts
@@ -36,7 +36,7 @@ const replaceableVariables: { [k: string]: string } = {
   AZURE_TENANT_ID: "12345678-1234-1234-1234-123456789012",
   METRICS_ADVISOR_SUBSCRIPTION_KEY: "sub_key",
   METRICS_ADVISOR_API_KEY: "api_key",
-  METRICS_ADVISOR_ENDPOINT: "https://endpoint/",
+  METRICS_ADVISOR_ENDPOINT: "https://endpoint",
   METRICS_ADVISOR_AZURE_BLOB_CONNECTION_STRING: blobConnectionString,
   METRICS_ADVISOR_AZURE_BLOB_TEMPLATE: blobTemplate,
   METRICS_ADVISOR_AZURE_APPINSIGHTS_APPLICATION_ID: "appInsights_application",


### PR DESCRIPTION
- Disabling the feedback creation tests for AAD, as we are seeing these test failures across all languages. Have informed the service team, since it seems like a service-side issue.
- The feedback creation tests work fine with API key, so keeping them enabled
- updated the recorded endpoint variable to not include trailing slash