### PR TITLE
Migrate Template project to use CoreV2

### DIFF
--- a/sdk/template/template/package.json
+++ b/sdk/template/template/package.json
@@ -78,7 +78,8 @@
   "prettier": "@azure/eslint-plugin-azure-sdk/prettier.json",
   "dependencies": {
     "@azure/core-auth": "^1.3.0",
-    "@azure/core-http": "^2.0.0",
+    "@azure/core-client": "^1.3.0",
+    "@azure/core-rest-pipeline": "^1.3.0",
     "@azure/core-tracing": "1.0.0-preview.13",
     "@azure/logger": "^1.0.0",
     "tslib": "^2.2.0"

--- a/sdk/template/template/review/template.api.md
+++ b/sdk/template/template/review/template.api.md
@@ -4,9 +4,9 @@
 
 ```ts
 
-import { OperationOptions } from '@azure/core-http';
-import { PipelineOptions } from '@azure/core-http';
-import { TokenCredential } from '@azure/core-http';
+import { CommonClientOptions } from '@azure/core-client';
+import { OperationOptions } from '@azure/core-client';
+import { TokenCredential } from '@azure/core-auth';
 
 // @public
 export class ConfigurationClient {
@@ -16,7 +16,7 @@ export class ConfigurationClient {
 }
 
 // @public
-export interface ConfigurationClientOptions extends PipelineOptions {
+export interface ConfigurationClientOptions extends CommonClientOptions {
 }
 
 // @public (undocumented)
@@ -37,7 +37,6 @@ export interface ConfigurationSetting {
 export interface GetConfigurationSettingOptions extends OperationOptions {
     onlyIfChanged?: boolean;
 }
-
 
 // (No @packageDocumentation comment for this package)
 

--- a/sdk/template/template/src/generated/generatedClient.ts
+++ b/sdk/template/template/src/generated/generatedClient.ts
@@ -6,7 +6,7 @@
  * Changes may cause incorrect behavior and will be lost if the code is regenerated.
  */
 
-import * as coreHttp from "@azure/core-http";
+import * as coreClient from "@azure/core-client";
 import * as Parameters from "./models/parameters";
 import * as Mappers from "./models/mappers";
 import { GeneratedClientContext } from "./generatedClientContext";
@@ -50,7 +50,7 @@ import {
   GeneratedClientGetRevisionsNextResponse
 } from "./models";
 
-/** @hidden */
+/** @internal */
 export class GeneratedClient extends GeneratedClientContext {
   /**
    * Initializes a new instance of the GeneratedClient class.
@@ -68,13 +68,7 @@ export class GeneratedClient extends GeneratedClientContext {
   getKeys(
     options?: GeneratedClientGetKeysOptionalParams
   ): Promise<GeneratedClientGetKeysResponse> {
-    const operationArguments: coreHttp.OperationArguments = {
-      options: coreHttp.operationOptionsToRequestOptionsBase(options || {})
-    };
-    return this.sendOperationRequest(
-      operationArguments,
-      getKeysOperationSpec
-    ) as Promise<GeneratedClientGetKeysResponse>;
+    return this.sendOperationRequest({ options }, getKeysOperationSpec);
   }
 
   /**
@@ -84,13 +78,7 @@ export class GeneratedClient extends GeneratedClientContext {
   checkKeys(
     options?: GeneratedClientCheckKeysOptionalParams
   ): Promise<GeneratedClientCheckKeysResponse> {
-    const operationArguments: coreHttp.OperationArguments = {
-      options: coreHttp.operationOptionsToRequestOptionsBase(options || {})
-    };
-    return this.sendOperationRequest(
-      operationArguments,
-      checkKeysOperationSpec
-    ) as Promise<GeneratedClientCheckKeysResponse>;
+    return this.sendOperationRequest({ options }, checkKeysOperationSpec);
   }
 
   /**
@@ -100,13 +88,7 @@ export class GeneratedClient extends GeneratedClientContext {
   getKeyValues(
     options?: GeneratedClientGetKeyValuesOptionalParams
   ): Promise<GeneratedClientGetKeyValuesResponse> {
-    const operationArguments: coreHttp.OperationArguments = {
-      options: coreHttp.operationOptionsToRequestOptionsBase(options || {})
-    };
-    return this.sendOperationRequest(
-      operationArguments,
-      getKeyValuesOperationSpec
-    ) as Promise<GeneratedClientGetKeyValuesResponse>;
+    return this.sendOperationRequest({ options }, getKeyValuesOperationSpec);
   }
 
   /**
@@ -116,13 +98,7 @@ export class GeneratedClient extends GeneratedClientContext {
   checkKeyValues(
     options?: GeneratedClientCheckKeyValuesOptionalParams
   ): Promise<GeneratedClientCheckKeyValuesResponse> {
-    const operationArguments: coreHttp.OperationArguments = {
-      options: coreHttp.operationOptionsToRequestOptionsBase(options || {})
-    };
-    return this.sendOperationRequest(
-      operationArguments,
-      checkKeyValuesOperationSpec
-    ) as Promise<GeneratedClientCheckKeyValuesResponse>;
+    return this.sendOperationRequest({ options }, checkKeyValuesOperationSpec);
   }
 
   /**
@@ -134,14 +110,10 @@ export class GeneratedClient extends GeneratedClientContext {
     key: string,
     options?: GeneratedClientGetKeyValueOptionalParams
   ): Promise<GeneratedClientGetKeyValueResponse> {
-    const operationArguments: coreHttp.OperationArguments = {
-      key,
-      options: coreHttp.operationOptionsToRequestOptionsBase(options || {})
-    };
     return this.sendOperationRequest(
-      operationArguments,
+      { key, options },
       getKeyValueOperationSpec
-    ) as Promise<GeneratedClientGetKeyValueResponse>;
+    );
   }
 
   /**
@@ -153,14 +125,10 @@ export class GeneratedClient extends GeneratedClientContext {
     key: string,
     options?: GeneratedClientPutKeyValueOptionalParams
   ): Promise<GeneratedClientPutKeyValueResponse> {
-    const operationArguments: coreHttp.OperationArguments = {
-      key,
-      options: coreHttp.operationOptionsToRequestOptionsBase(options || {})
-    };
     return this.sendOperationRequest(
-      operationArguments,
+      { key, options },
       putKeyValueOperationSpec
-    ) as Promise<GeneratedClientPutKeyValueResponse>;
+    );
   }
 
   /**
@@ -172,14 +140,10 @@ export class GeneratedClient extends GeneratedClientContext {
     key: string,
     options?: GeneratedClientDeleteKeyValueOptionalParams
   ): Promise<GeneratedClientDeleteKeyValueResponse> {
-    const operationArguments: coreHttp.OperationArguments = {
-      key,
-      options: coreHttp.operationOptionsToRequestOptionsBase(options || {})
-    };
     return this.sendOperationRequest(
-      operationArguments,
+      { key, options },
       deleteKeyValueOperationSpec
-    ) as Promise<GeneratedClientDeleteKeyValueResponse>;
+    );
   }
 
   /**
@@ -191,14 +155,10 @@ export class GeneratedClient extends GeneratedClientContext {
     key: string,
     options?: GeneratedClientCheckKeyValueOptionalParams
   ): Promise<GeneratedClientCheckKeyValueResponse> {
-    const operationArguments: coreHttp.OperationArguments = {
-      key,
-      options: coreHttp.operationOptionsToRequestOptionsBase(options || {})
-    };
     return this.sendOperationRequest(
-      operationArguments,
+      { key, options },
       checkKeyValueOperationSpec
-    ) as Promise<GeneratedClientCheckKeyValueResponse>;
+    );
   }
 
   /**
@@ -208,13 +168,7 @@ export class GeneratedClient extends GeneratedClientContext {
   getLabels(
     options?: GeneratedClientGetLabelsOptionalParams
   ): Promise<GeneratedClientGetLabelsResponse> {
-    const operationArguments: coreHttp.OperationArguments = {
-      options: coreHttp.operationOptionsToRequestOptionsBase(options || {})
-    };
-    return this.sendOperationRequest(
-      operationArguments,
-      getLabelsOperationSpec
-    ) as Promise<GeneratedClientGetLabelsResponse>;
+    return this.sendOperationRequest({ options }, getLabelsOperationSpec);
   }
 
   /**
@@ -224,13 +178,7 @@ export class GeneratedClient extends GeneratedClientContext {
   checkLabels(
     options?: GeneratedClientCheckLabelsOptionalParams
   ): Promise<GeneratedClientCheckLabelsResponse> {
-    const operationArguments: coreHttp.OperationArguments = {
-      options: coreHttp.operationOptionsToRequestOptionsBase(options || {})
-    };
-    return this.sendOperationRequest(
-      operationArguments,
-      checkLabelsOperationSpec
-    ) as Promise<GeneratedClientCheckLabelsResponse>;
+    return this.sendOperationRequest({ options }, checkLabelsOperationSpec);
   }
 
   /**
@@ -242,14 +190,7 @@ export class GeneratedClient extends GeneratedClientContext {
     key: string,
     options?: GeneratedClientPutLockOptionalParams
   ): Promise<GeneratedClientPutLockResponse> {
-    const operationArguments: coreHttp.OperationArguments = {
-      key,
-      options: coreHttp.operationOptionsToRequestOptionsBase(options || {})
-    };
-    return this.sendOperationRequest(
-      operationArguments,
-      putLockOperationSpec
-    ) as Promise<GeneratedClientPutLockResponse>;
+    return this.sendOperationRequest({ key, options }, putLockOperationSpec);
   }
 
   /**
@@ -261,14 +202,7 @@ export class GeneratedClient extends GeneratedClientContext {
     key: string,
     options?: GeneratedClientDeleteLockOptionalParams
   ): Promise<GeneratedClientDeleteLockResponse> {
-    const operationArguments: coreHttp.OperationArguments = {
-      key,
-      options: coreHttp.operationOptionsToRequestOptionsBase(options || {})
-    };
-    return this.sendOperationRequest(
-      operationArguments,
-      deleteLockOperationSpec
-    ) as Promise<GeneratedClientDeleteLockResponse>;
+    return this.sendOperationRequest({ key, options }, deleteLockOperationSpec);
   }
 
   /**
@@ -278,13 +212,7 @@ export class GeneratedClient extends GeneratedClientContext {
   getRevisions(
     options?: GeneratedClientGetRevisionsOptionalParams
   ): Promise<GeneratedClientGetRevisionsResponse> {
-    const operationArguments: coreHttp.OperationArguments = {
-      options: coreHttp.operationOptionsToRequestOptionsBase(options || {})
-    };
-    return this.sendOperationRequest(
-      operationArguments,
-      getRevisionsOperationSpec
-    ) as Promise<GeneratedClientGetRevisionsResponse>;
+    return this.sendOperationRequest({ options }, getRevisionsOperationSpec);
   }
 
   /**
@@ -294,13 +222,7 @@ export class GeneratedClient extends GeneratedClientContext {
   checkRevisions(
     options?: GeneratedClientCheckRevisionsOptionalParams
   ): Promise<GeneratedClientCheckRevisionsResponse> {
-    const operationArguments: coreHttp.OperationArguments = {
-      options: coreHttp.operationOptionsToRequestOptionsBase(options || {})
-    };
-    return this.sendOperationRequest(
-      operationArguments,
-      checkRevisionsOperationSpec
-    ) as Promise<GeneratedClientCheckRevisionsResponse>;
+    return this.sendOperationRequest({ options }, checkRevisionsOperationSpec);
   }
 
   /**
@@ -312,14 +234,10 @@ export class GeneratedClient extends GeneratedClientContext {
     nextLink: string,
     options?: GeneratedClientGetKeysNextOptionalParams
   ): Promise<GeneratedClientGetKeysNextResponse> {
-    const operationArguments: coreHttp.OperationArguments = {
-      nextLink,
-      options: coreHttp.operationOptionsToRequestOptionsBase(options || {})
-    };
     return this.sendOperationRequest(
-      operationArguments,
+      { nextLink, options },
       getKeysNextOperationSpec
-    ) as Promise<GeneratedClientGetKeysNextResponse>;
+    );
   }
 
   /**
@@ -331,14 +249,10 @@ export class GeneratedClient extends GeneratedClientContext {
     nextLink: string,
     options?: GeneratedClientGetKeyValuesNextOptionalParams
   ): Promise<GeneratedClientGetKeyValuesNextResponse> {
-    const operationArguments: coreHttp.OperationArguments = {
-      nextLink,
-      options: coreHttp.operationOptionsToRequestOptionsBase(options || {})
-    };
     return this.sendOperationRequest(
-      operationArguments,
+      { nextLink, options },
       getKeyValuesNextOperationSpec
-    ) as Promise<GeneratedClientGetKeyValuesNextResponse>;
+    );
   }
 
   /**
@@ -350,14 +264,10 @@ export class GeneratedClient extends GeneratedClientContext {
     nextLink: string,
     options?: GeneratedClientGetLabelsNextOptionalParams
   ): Promise<GeneratedClientGetLabelsNextResponse> {
-    const operationArguments: coreHttp.OperationArguments = {
-      nextLink,
-      options: coreHttp.operationOptionsToRequestOptionsBase(options || {})
-    };
     return this.sendOperationRequest(
-      operationArguments,
+      { nextLink, options },
       getLabelsNextOperationSpec
-    ) as Promise<GeneratedClientGetLabelsNextResponse>;
+    );
   }
 
   /**
@@ -369,20 +279,16 @@ export class GeneratedClient extends GeneratedClientContext {
     nextLink: string,
     options?: GeneratedClientGetRevisionsNextOptionalParams
   ): Promise<GeneratedClientGetRevisionsNextResponse> {
-    const operationArguments: coreHttp.OperationArguments = {
-      nextLink,
-      options: coreHttp.operationOptionsToRequestOptionsBase(options || {})
-    };
     return this.sendOperationRequest(
-      operationArguments,
+      { nextLink, options },
       getRevisionsNextOperationSpec
-    ) as Promise<GeneratedClientGetRevisionsNextResponse>;
+    );
   }
 }
 // Operation Specifications
-const serializer = new coreHttp.Serializer(Mappers, /* isXml */ false);
+const serializer = coreClient.createSerializer(Mappers, /* isXml */ false);
 
-const getKeysOperationSpec: coreHttp.OperationSpec = {
+const getKeysOperationSpec: coreClient.OperationSpec = {
   path: "/keys",
   httpMethod: "GET",
   responses: {
@@ -403,7 +309,7 @@ const getKeysOperationSpec: coreHttp.OperationSpec = {
   ],
   serializer
 };
-const checkKeysOperationSpec: coreHttp.OperationSpec = {
+const checkKeysOperationSpec: coreClient.OperationSpec = {
   path: "/keys",
   httpMethod: "HEAD",
   responses: {
@@ -417,7 +323,7 @@ const checkKeysOperationSpec: coreHttp.OperationSpec = {
   headerParameters: [Parameters.syncToken, Parameters.acceptDatetime],
   serializer
 };
-const getKeyValuesOperationSpec: coreHttp.OperationSpec = {
+const getKeyValuesOperationSpec: coreClient.OperationSpec = {
   path: "/kv",
   httpMethod: "GET",
   responses: {
@@ -444,7 +350,7 @@ const getKeyValuesOperationSpec: coreHttp.OperationSpec = {
   ],
   serializer
 };
-const checkKeyValuesOperationSpec: coreHttp.OperationSpec = {
+const checkKeyValuesOperationSpec: coreClient.OperationSpec = {
   path: "/kv",
   httpMethod: "HEAD",
   responses: {
@@ -464,7 +370,7 @@ const checkKeyValuesOperationSpec: coreHttp.OperationSpec = {
   headerParameters: [Parameters.syncToken, Parameters.acceptDatetime],
   serializer
 };
-const getKeyValueOperationSpec: coreHttp.OperationSpec = {
+const getKeyValueOperationSpec: coreClient.OperationSpec = {
   path: "/kv/{key}",
   httpMethod: "GET",
   responses: {
@@ -487,7 +393,7 @@ const getKeyValueOperationSpec: coreHttp.OperationSpec = {
   ],
   serializer
 };
-const putKeyValueOperationSpec: coreHttp.OperationSpec = {
+const putKeyValueOperationSpec: coreClient.OperationSpec = {
   path: "/kv/{key}",
   httpMethod: "PUT",
   responses: {
@@ -512,7 +418,7 @@ const putKeyValueOperationSpec: coreHttp.OperationSpec = {
   mediaType: "json",
   serializer
 };
-const deleteKeyValueOperationSpec: coreHttp.OperationSpec = {
+const deleteKeyValueOperationSpec: coreClient.OperationSpec = {
   path: "/kv/{key}",
   httpMethod: "DELETE",
   responses: {
@@ -536,7 +442,7 @@ const deleteKeyValueOperationSpec: coreHttp.OperationSpec = {
   ],
   serializer
 };
-const checkKeyValueOperationSpec: coreHttp.OperationSpec = {
+const checkKeyValueOperationSpec: coreClient.OperationSpec = {
   path: "/kv/{key}",
   httpMethod: "HEAD",
   responses: {
@@ -555,7 +461,7 @@ const checkKeyValueOperationSpec: coreHttp.OperationSpec = {
   ],
   serializer
 };
-const getLabelsOperationSpec: coreHttp.OperationSpec = {
+const getLabelsOperationSpec: coreClient.OperationSpec = {
   path: "/labels",
   httpMethod: "GET",
   responses: {
@@ -581,7 +487,7 @@ const getLabelsOperationSpec: coreHttp.OperationSpec = {
   ],
   serializer
 };
-const checkLabelsOperationSpec: coreHttp.OperationSpec = {
+const checkLabelsOperationSpec: coreClient.OperationSpec = {
   path: "/labels",
   httpMethod: "HEAD",
   responses: {
@@ -600,7 +506,7 @@ const checkLabelsOperationSpec: coreHttp.OperationSpec = {
   headerParameters: [Parameters.syncToken, Parameters.acceptDatetime],
   serializer
 };
-const putLockOperationSpec: coreHttp.OperationSpec = {
+const putLockOperationSpec: coreClient.OperationSpec = {
   path: "/locks/{key}",
   httpMethod: "PUT",
   responses: {
@@ -622,7 +528,7 @@ const putLockOperationSpec: coreHttp.OperationSpec = {
   ],
   serializer
 };
-const deleteLockOperationSpec: coreHttp.OperationSpec = {
+const deleteLockOperationSpec: coreClient.OperationSpec = {
   path: "/locks/{key}",
   httpMethod: "DELETE",
   responses: {
@@ -644,7 +550,7 @@ const deleteLockOperationSpec: coreHttp.OperationSpec = {
   ],
   serializer
 };
-const getRevisionsOperationSpec: coreHttp.OperationSpec = {
+const getRevisionsOperationSpec: coreClient.OperationSpec = {
   path: "/revisions",
   httpMethod: "GET",
   responses: {
@@ -671,7 +577,7 @@ const getRevisionsOperationSpec: coreHttp.OperationSpec = {
   ],
   serializer
 };
-const checkRevisionsOperationSpec: coreHttp.OperationSpec = {
+const checkRevisionsOperationSpec: coreClient.OperationSpec = {
   path: "/revisions",
   httpMethod: "HEAD",
   responses: {
@@ -691,7 +597,7 @@ const checkRevisionsOperationSpec: coreHttp.OperationSpec = {
   headerParameters: [Parameters.syncToken, Parameters.acceptDatetime],
   serializer
 };
-const getKeysNextOperationSpec: coreHttp.OperationSpec = {
+const getKeysNextOperationSpec: coreClient.OperationSpec = {
   path: "{nextLink}",
   httpMethod: "GET",
   responses: {
@@ -712,7 +618,7 @@ const getKeysNextOperationSpec: coreHttp.OperationSpec = {
   ],
   serializer
 };
-const getKeyValuesNextOperationSpec: coreHttp.OperationSpec = {
+const getKeyValuesNextOperationSpec: coreClient.OperationSpec = {
   path: "{nextLink}",
   httpMethod: "GET",
   responses: {
@@ -739,7 +645,7 @@ const getKeyValuesNextOperationSpec: coreHttp.OperationSpec = {
   ],
   serializer
 };
-const getLabelsNextOperationSpec: coreHttp.OperationSpec = {
+const getLabelsNextOperationSpec: coreClient.OperationSpec = {
   path: "{nextLink}",
   httpMethod: "GET",
   responses: {
@@ -765,7 +671,7 @@ const getLabelsNextOperationSpec: coreHttp.OperationSpec = {
   ],
   serializer
 };
-const getRevisionsNextOperationSpec: coreHttp.OperationSpec = {
+const getRevisionsNextOperationSpec: coreClient.OperationSpec = {
   path: "{nextLink}",
   httpMethod: "GET",
   responses: {

--- a/sdk/template/template/src/generated/generatedClientContext.ts
+++ b/sdk/template/template/src/generated/generatedClientContext.ts
@@ -6,14 +6,11 @@
  * Changes may cause incorrect behavior and will be lost if the code is regenerated.
  */
 
-import * as coreHttp from "@azure/core-http";
+import * as coreClient from "@azure/core-client";
 import { GeneratedClientOptionalParams } from "./models";
 
-const packageName = "@azure/template";
-const packageVersion = "1.0.11-beta.1";
-
-/** @hidden */
-export class GeneratedClientContext extends coreHttp.ServiceClient {
+/** @internal */
+export class GeneratedClientContext extends coreClient.ServiceClient {
   endpoint: string;
   syncToken?: string;
   apiVersion: string;
@@ -32,18 +29,25 @@ export class GeneratedClientContext extends coreHttp.ServiceClient {
     if (!options) {
       options = {};
     }
+    const defaults: GeneratedClientOptionalParams = {
+      requestContentType: "application/json; charset=utf-8"
+    };
 
-    if (!options.userAgent) {
-      const defaultUserAgent = coreHttp.getDefaultUserAgentValue();
-      options.userAgent = `${packageName}/${packageVersion} ${defaultUserAgent}`;
-    }
+    const packageDetails = `azsdk-js-template/1.0.11-beta.1`;
+    const userAgentPrefix =
+      options.userAgentOptions && options.userAgentOptions.userAgentPrefix
+        ? `${options.userAgentOptions.userAgentPrefix} ${packageDetails}`
+        : `${packageDetails}`;
 
-    super(undefined, options);
-
-    this.requestContentType = "application/json; charset=utf-8";
-
-    this.baseUri = options.endpoint || "{endpoint}";
-
+    const optionsWithDefaults = {
+      ...defaults,
+      ...options,
+      userAgentOptions: {
+        userAgentPrefix
+      },
+      baseUri: options.endpoint || "{endpoint}"
+    };
+    super(optionsWithDefaults);
     // Parameter assignments
     this.endpoint = endpoint;
 

--- a/sdk/template/template/src/generated/models/index.ts
+++ b/sdk/template/template/src/generated/models/index.ts
@@ -6,7 +6,7 @@
  * Changes may cause incorrect behavior and will be lost if the code is regenerated.
  */
 
-import * as coreHttp from "@azure/core-http";
+import * as coreClient from "@azure/core-client";
 
 /** The result of a list request. */
 export interface KeyListResult {
@@ -218,7 +218,7 @@ export type SettingFields =
 
 /** Optional parameters. */
 export interface GeneratedClientGetKeysOptionalParams
-  extends coreHttp.OperationOptions {
+  extends coreClient.OperationOptions {
   /** A filter for the name of the returned keys. */
   name?: string;
   /** Instructs the server to return elements that appear after the element referred to by the specified token. */
@@ -229,22 +229,11 @@ export interface GeneratedClientGetKeysOptionalParams
 
 /** Contains response data for the getKeys operation. */
 export type GeneratedClientGetKeysResponse = GeneratedClientGetKeysHeaders &
-  KeyListResult & {
-    /** The underlying HTTP response. */
-    _response: coreHttp.HttpResponse & {
-      /** The response body as text (string format) */
-      bodyAsText: string;
-
-      /** The response body as parsed JSON or XML */
-      parsedBody: KeyListResult;
-      /** The parsed HTTP response headers. */
-      parsedHeaders: GeneratedClientGetKeysHeaders;
-    };
-  };
+  KeyListResult;
 
 /** Optional parameters. */
 export interface GeneratedClientCheckKeysOptionalParams
-  extends coreHttp.OperationOptions {
+  extends coreClient.OperationOptions {
   /** A filter for the name of the returned keys. */
   name?: string;
   /** Instructs the server to return elements that appear after the element referred to by the specified token. */
@@ -254,17 +243,11 @@ export interface GeneratedClientCheckKeysOptionalParams
 }
 
 /** Contains response data for the checkKeys operation. */
-export type GeneratedClientCheckKeysResponse = GeneratedClientCheckKeysHeaders & {
-  /** The underlying HTTP response. */
-  _response: coreHttp.HttpResponse & {
-    /** The parsed HTTP response headers. */
-    parsedHeaders: GeneratedClientCheckKeysHeaders;
-  };
-};
+export type GeneratedClientCheckKeysResponse = GeneratedClientCheckKeysHeaders;
 
 /** Optional parameters. */
 export interface GeneratedClientGetKeyValuesOptionalParams
-  extends coreHttp.OperationOptions {
+  extends coreClient.OperationOptions {
   /** Instructs the server to return elements that appear after the element referred to by the specified token. */
   after?: string;
   /** Requests the server to respond with the state of the resource at the specified time. */
@@ -279,22 +262,11 @@ export interface GeneratedClientGetKeyValuesOptionalParams
 
 /** Contains response data for the getKeyValues operation. */
 export type GeneratedClientGetKeyValuesResponse = GeneratedClientGetKeyValuesHeaders &
-  KeyValueListResult & {
-    /** The underlying HTTP response. */
-    _response: coreHttp.HttpResponse & {
-      /** The response body as text (string format) */
-      bodyAsText: string;
-
-      /** The response body as parsed JSON or XML */
-      parsedBody: KeyValueListResult;
-      /** The parsed HTTP response headers. */
-      parsedHeaders: GeneratedClientGetKeyValuesHeaders;
-    };
-  };
+  KeyValueListResult;
 
 /** Optional parameters. */
 export interface GeneratedClientCheckKeyValuesOptionalParams
-  extends coreHttp.OperationOptions {
+  extends coreClient.OperationOptions {
   /** Instructs the server to return elements that appear after the element referred to by the specified token. */
   after?: string;
   /** Requests the server to respond with the state of the resource at the specified time. */
@@ -308,17 +280,11 @@ export interface GeneratedClientCheckKeyValuesOptionalParams
 }
 
 /** Contains response data for the checkKeyValues operation. */
-export type GeneratedClientCheckKeyValuesResponse = GeneratedClientCheckKeyValuesHeaders & {
-  /** The underlying HTTP response. */
-  _response: coreHttp.HttpResponse & {
-    /** The parsed HTTP response headers. */
-    parsedHeaders: GeneratedClientCheckKeyValuesHeaders;
-  };
-};
+export type GeneratedClientCheckKeyValuesResponse = GeneratedClientCheckKeyValuesHeaders;
 
 /** Optional parameters. */
 export interface GeneratedClientGetKeyValueOptionalParams
-  extends coreHttp.OperationOptions {
+  extends coreClient.OperationOptions {
   /** Requests the server to respond with the state of the resource at the specified time. */
   acceptDatetime?: string;
   /** The label of the key-value to retrieve. */
@@ -333,22 +299,11 @@ export interface GeneratedClientGetKeyValueOptionalParams
 
 /** Contains response data for the getKeyValue operation. */
 export type GeneratedClientGetKeyValueResponse = GeneratedClientGetKeyValueHeaders &
-  ConfigurationSetting & {
-    /** The underlying HTTP response. */
-    _response: coreHttp.HttpResponse & {
-      /** The response body as text (string format) */
-      bodyAsText: string;
-
-      /** The response body as parsed JSON or XML */
-      parsedBody: ConfigurationSetting;
-      /** The parsed HTTP response headers. */
-      parsedHeaders: GeneratedClientGetKeyValueHeaders;
-    };
-  };
+  ConfigurationSetting;
 
 /** Optional parameters. */
 export interface GeneratedClientPutKeyValueOptionalParams
-  extends coreHttp.OperationOptions {
+  extends coreClient.OperationOptions {
   /** The label of the key-value to create. */
   label?: string;
   /** Used to perform an operation only if the targeted resource's etag matches the value provided. */
@@ -361,22 +316,11 @@ export interface GeneratedClientPutKeyValueOptionalParams
 
 /** Contains response data for the putKeyValue operation. */
 export type GeneratedClientPutKeyValueResponse = GeneratedClientPutKeyValueHeaders &
-  ConfigurationSetting & {
-    /** The underlying HTTP response. */
-    _response: coreHttp.HttpResponse & {
-      /** The response body as text (string format) */
-      bodyAsText: string;
-
-      /** The response body as parsed JSON or XML */
-      parsedBody: ConfigurationSetting;
-      /** The parsed HTTP response headers. */
-      parsedHeaders: GeneratedClientPutKeyValueHeaders;
-    };
-  };
+  ConfigurationSetting;
 
 /** Optional parameters. */
 export interface GeneratedClientDeleteKeyValueOptionalParams
-  extends coreHttp.OperationOptions {
+  extends coreClient.OperationOptions {
   /** The label of the key-value to delete. */
   label?: string;
   /** Used to perform an operation only if the targeted resource's etag matches the value provided. */
@@ -385,22 +329,11 @@ export interface GeneratedClientDeleteKeyValueOptionalParams
 
 /** Contains response data for the deleteKeyValue operation. */
 export type GeneratedClientDeleteKeyValueResponse = GeneratedClientDeleteKeyValueHeaders &
-  ConfigurationSetting & {
-    /** The underlying HTTP response. */
-    _response: coreHttp.HttpResponse & {
-      /** The response body as text (string format) */
-      bodyAsText: string;
-
-      /** The response body as parsed JSON or XML */
-      parsedBody: ConfigurationSetting;
-      /** The parsed HTTP response headers. */
-      parsedHeaders: GeneratedClientDeleteKeyValueHeaders;
-    };
-  };
+  ConfigurationSetting;
 
 /** Optional parameters. */
 export interface GeneratedClientCheckKeyValueOptionalParams
-  extends coreHttp.OperationOptions {
+  extends coreClient.OperationOptions {
   /** Requests the server to respond with the state of the resource at the specified time. */
   acceptDatetime?: string;
   /** The label of the key-value to retrieve. */
@@ -414,17 +347,11 @@ export interface GeneratedClientCheckKeyValueOptionalParams
 }
 
 /** Contains response data for the checkKeyValue operation. */
-export type GeneratedClientCheckKeyValueResponse = GeneratedClientCheckKeyValueHeaders & {
-  /** The underlying HTTP response. */
-  _response: coreHttp.HttpResponse & {
-    /** The parsed HTTP response headers. */
-    parsedHeaders: GeneratedClientCheckKeyValueHeaders;
-  };
-};
+export type GeneratedClientCheckKeyValueResponse = GeneratedClientCheckKeyValueHeaders;
 
 /** Optional parameters. */
 export interface GeneratedClientGetLabelsOptionalParams
-  extends coreHttp.OperationOptions {
+  extends coreClient.OperationOptions {
   /** A filter for the name of the returned labels. */
   name?: string;
   /** Instructs the server to return elements that appear after the element referred to by the specified token. */
@@ -437,22 +364,11 @@ export interface GeneratedClientGetLabelsOptionalParams
 
 /** Contains response data for the getLabels operation. */
 export type GeneratedClientGetLabelsResponse = GeneratedClientGetLabelsHeaders &
-  LabelListResult & {
-    /** The underlying HTTP response. */
-    _response: coreHttp.HttpResponse & {
-      /** The response body as text (string format) */
-      bodyAsText: string;
-
-      /** The response body as parsed JSON or XML */
-      parsedBody: LabelListResult;
-      /** The parsed HTTP response headers. */
-      parsedHeaders: GeneratedClientGetLabelsHeaders;
-    };
-  };
+  LabelListResult;
 
 /** Optional parameters. */
 export interface GeneratedClientCheckLabelsOptionalParams
-  extends coreHttp.OperationOptions {
+  extends coreClient.OperationOptions {
   /** A filter for the name of the returned labels. */
   name?: string;
   /** Instructs the server to return elements that appear after the element referred to by the specified token. */
@@ -464,17 +380,11 @@ export interface GeneratedClientCheckLabelsOptionalParams
 }
 
 /** Contains response data for the checkLabels operation. */
-export type GeneratedClientCheckLabelsResponse = GeneratedClientCheckLabelsHeaders & {
-  /** The underlying HTTP response. */
-  _response: coreHttp.HttpResponse & {
-    /** The parsed HTTP response headers. */
-    parsedHeaders: GeneratedClientCheckLabelsHeaders;
-  };
-};
+export type GeneratedClientCheckLabelsResponse = GeneratedClientCheckLabelsHeaders;
 
 /** Optional parameters. */
 export interface GeneratedClientPutLockOptionalParams
-  extends coreHttp.OperationOptions {
+  extends coreClient.OperationOptions {
   /** The label, if any, of the key-value to lock. */
   label?: string;
   /** Used to perform an operation only if the targeted resource's etag matches the value provided. */
@@ -485,22 +395,11 @@ export interface GeneratedClientPutLockOptionalParams
 
 /** Contains response data for the putLock operation. */
 export type GeneratedClientPutLockResponse = GeneratedClientPutLockHeaders &
-  ConfigurationSetting & {
-    /** The underlying HTTP response. */
-    _response: coreHttp.HttpResponse & {
-      /** The response body as text (string format) */
-      bodyAsText: string;
-
-      /** The response body as parsed JSON or XML */
-      parsedBody: ConfigurationSetting;
-      /** The parsed HTTP response headers. */
-      parsedHeaders: GeneratedClientPutLockHeaders;
-    };
-  };
+  ConfigurationSetting;
 
 /** Optional parameters. */
 export interface GeneratedClientDeleteLockOptionalParams
-  extends coreHttp.OperationOptions {
+  extends coreClient.OperationOptions {
   /** The label, if any, of the key-value to unlock. */
   label?: string;
   /** Used to perform an operation only if the targeted resource's etag matches the value provided. */
@@ -511,22 +410,11 @@ export interface GeneratedClientDeleteLockOptionalParams
 
 /** Contains response data for the deleteLock operation. */
 export type GeneratedClientDeleteLockResponse = GeneratedClientDeleteLockHeaders &
-  ConfigurationSetting & {
-    /** The underlying HTTP response. */
-    _response: coreHttp.HttpResponse & {
-      /** The response body as text (string format) */
-      bodyAsText: string;
-
-      /** The response body as parsed JSON or XML */
-      parsedBody: ConfigurationSetting;
-      /** The parsed HTTP response headers. */
-      parsedHeaders: GeneratedClientDeleteLockHeaders;
-    };
-  };
+  ConfigurationSetting;
 
 /** Optional parameters. */
 export interface GeneratedClientGetRevisionsOptionalParams
-  extends coreHttp.OperationOptions {
+  extends coreClient.OperationOptions {
   /** Instructs the server to return elements that appear after the element referred to by the specified token. */
   after?: string;
   /** Requests the server to respond with the state of the resource at the specified time. */
@@ -541,22 +429,11 @@ export interface GeneratedClientGetRevisionsOptionalParams
 
 /** Contains response data for the getRevisions operation. */
 export type GeneratedClientGetRevisionsResponse = GeneratedClientGetRevisionsHeaders &
-  KeyValueListResult & {
-    /** The underlying HTTP response. */
-    _response: coreHttp.HttpResponse & {
-      /** The response body as text (string format) */
-      bodyAsText: string;
-
-      /** The response body as parsed JSON or XML */
-      parsedBody: KeyValueListResult;
-      /** The parsed HTTP response headers. */
-      parsedHeaders: GeneratedClientGetRevisionsHeaders;
-    };
-  };
+  KeyValueListResult;
 
 /** Optional parameters. */
 export interface GeneratedClientCheckRevisionsOptionalParams
-  extends coreHttp.OperationOptions {
+  extends coreClient.OperationOptions {
   /** Instructs the server to return elements that appear after the element referred to by the specified token. */
   after?: string;
   /** Requests the server to respond with the state of the resource at the specified time. */
@@ -570,17 +447,11 @@ export interface GeneratedClientCheckRevisionsOptionalParams
 }
 
 /** Contains response data for the checkRevisions operation. */
-export type GeneratedClientCheckRevisionsResponse = GeneratedClientCheckRevisionsHeaders & {
-  /** The underlying HTTP response. */
-  _response: coreHttp.HttpResponse & {
-    /** The parsed HTTP response headers. */
-    parsedHeaders: GeneratedClientCheckRevisionsHeaders;
-  };
-};
+export type GeneratedClientCheckRevisionsResponse = GeneratedClientCheckRevisionsHeaders;
 
 /** Optional parameters. */
 export interface GeneratedClientGetKeysNextOptionalParams
-  extends coreHttp.OperationOptions {
+  extends coreClient.OperationOptions {
   /** A filter for the name of the returned keys. */
   name?: string;
   /** Instructs the server to return elements that appear after the element referred to by the specified token. */
@@ -591,22 +462,11 @@ export interface GeneratedClientGetKeysNextOptionalParams
 
 /** Contains response data for the getKeysNext operation. */
 export type GeneratedClientGetKeysNextResponse = GeneratedClientGetKeysNextHeaders &
-  KeyListResult & {
-    /** The underlying HTTP response. */
-    _response: coreHttp.HttpResponse & {
-      /** The response body as text (string format) */
-      bodyAsText: string;
-
-      /** The response body as parsed JSON or XML */
-      parsedBody: KeyListResult;
-      /** The parsed HTTP response headers. */
-      parsedHeaders: GeneratedClientGetKeysNextHeaders;
-    };
-  };
+  KeyListResult;
 
 /** Optional parameters. */
 export interface GeneratedClientGetKeyValuesNextOptionalParams
-  extends coreHttp.OperationOptions {
+  extends coreClient.OperationOptions {
   /** Instructs the server to return elements that appear after the element referred to by the specified token. */
   after?: string;
   /** Requests the server to respond with the state of the resource at the specified time. */
@@ -621,22 +481,11 @@ export interface GeneratedClientGetKeyValuesNextOptionalParams
 
 /** Contains response data for the getKeyValuesNext operation. */
 export type GeneratedClientGetKeyValuesNextResponse = GeneratedClientGetKeyValuesNextHeaders &
-  KeyValueListResult & {
-    /** The underlying HTTP response. */
-    _response: coreHttp.HttpResponse & {
-      /** The response body as text (string format) */
-      bodyAsText: string;
-
-      /** The response body as parsed JSON or XML */
-      parsedBody: KeyValueListResult;
-      /** The parsed HTTP response headers. */
-      parsedHeaders: GeneratedClientGetKeyValuesNextHeaders;
-    };
-  };
+  KeyValueListResult;
 
 /** Optional parameters. */
 export interface GeneratedClientGetLabelsNextOptionalParams
-  extends coreHttp.OperationOptions {
+  extends coreClient.OperationOptions {
   /** A filter for the name of the returned labels. */
   name?: string;
   /** Instructs the server to return elements that appear after the element referred to by the specified token. */
@@ -649,22 +498,11 @@ export interface GeneratedClientGetLabelsNextOptionalParams
 
 /** Contains response data for the getLabelsNext operation. */
 export type GeneratedClientGetLabelsNextResponse = GeneratedClientGetLabelsNextHeaders &
-  LabelListResult & {
-    /** The underlying HTTP response. */
-    _response: coreHttp.HttpResponse & {
-      /** The response body as text (string format) */
-      bodyAsText: string;
-
-      /** The response body as parsed JSON or XML */
-      parsedBody: LabelListResult;
-      /** The parsed HTTP response headers. */
-      parsedHeaders: GeneratedClientGetLabelsNextHeaders;
-    };
-  };
+  LabelListResult;
 
 /** Optional parameters. */
 export interface GeneratedClientGetRevisionsNextOptionalParams
-  extends coreHttp.OperationOptions {
+  extends coreClient.OperationOptions {
   /** Instructs the server to return elements that appear after the element referred to by the specified token. */
   after?: string;
   /** Requests the server to respond with the state of the resource at the specified time. */
@@ -679,22 +517,11 @@ export interface GeneratedClientGetRevisionsNextOptionalParams
 
 /** Contains response data for the getRevisionsNext operation. */
 export type GeneratedClientGetRevisionsNextResponse = GeneratedClientGetRevisionsNextHeaders &
-  KeyValueListResult & {
-    /** The underlying HTTP response. */
-    _response: coreHttp.HttpResponse & {
-      /** The response body as text (string format) */
-      bodyAsText: string;
-
-      /** The response body as parsed JSON or XML */
-      parsedBody: KeyValueListResult;
-      /** The parsed HTTP response headers. */
-      parsedHeaders: GeneratedClientGetRevisionsNextHeaders;
-    };
-  };
+  KeyValueListResult;
 
 /** Optional parameters. */
 export interface GeneratedClientOptionalParams
-  extends coreHttp.ServiceClientOptions {
+  extends coreClient.ServiceClientOptions {
   /** Used to guarantee real-time consistency between requests. */
   syncToken?: string;
   /** Api Version */

--- a/sdk/template/template/src/generated/models/mappers.ts
+++ b/sdk/template/template/src/generated/models/mappers.ts
@@ -6,9 +6,9 @@
  * Changes may cause incorrect behavior and will be lost if the code is regenerated.
  */
 
-import * as coreHttp from "@azure/core-http";
+import * as coreClient from "@azure/core-client";
 
-export const KeyListResult: coreHttp.CompositeMapper = {
+export const KeyListResult: coreClient.CompositeMapper = {
   type: {
     name: "Composite",
     className: "KeyListResult",
@@ -35,7 +35,7 @@ export const KeyListResult: coreHttp.CompositeMapper = {
   }
 };
 
-export const Key: coreHttp.CompositeMapper = {
+export const Key: coreClient.CompositeMapper = {
   type: {
     name: "Composite",
     className: "Key",
@@ -51,7 +51,7 @@ export const Key: coreHttp.CompositeMapper = {
   }
 };
 
-export const ErrorModel: coreHttp.CompositeMapper = {
+export const ErrorModel: coreClient.CompositeMapper = {
   type: {
     name: "Composite",
     className: "ErrorModel",
@@ -90,7 +90,7 @@ export const ErrorModel: coreHttp.CompositeMapper = {
   }
 };
 
-export const KeyValueListResult: coreHttp.CompositeMapper = {
+export const KeyValueListResult: coreClient.CompositeMapper = {
   type: {
     name: "Composite",
     className: "KeyValueListResult",
@@ -117,7 +117,7 @@ export const KeyValueListResult: coreHttp.CompositeMapper = {
   }
 };
 
-export const ConfigurationSetting: coreHttp.CompositeMapper = {
+export const ConfigurationSetting: coreClient.CompositeMapper = {
   type: {
     name: "Composite",
     className: "ConfigurationSetting",
@@ -176,7 +176,7 @@ export const ConfigurationSetting: coreHttp.CompositeMapper = {
   }
 };
 
-export const LabelListResult: coreHttp.CompositeMapper = {
+export const LabelListResult: coreClient.CompositeMapper = {
   type: {
     name: "Composite",
     className: "LabelListResult",
@@ -203,7 +203,7 @@ export const LabelListResult: coreHttp.CompositeMapper = {
   }
 };
 
-export const Label: coreHttp.CompositeMapper = {
+export const Label: coreClient.CompositeMapper = {
   type: {
     name: "Composite",
     className: "Label",
@@ -219,7 +219,7 @@ export const Label: coreHttp.CompositeMapper = {
   }
 };
 
-export const GeneratedClientGetKeysHeaders: coreHttp.CompositeMapper = {
+export const GeneratedClientGetKeysHeaders: coreClient.CompositeMapper = {
   type: {
     name: "Composite",
     className: "GeneratedClientGetKeysHeaders",
@@ -234,7 +234,7 @@ export const GeneratedClientGetKeysHeaders: coreHttp.CompositeMapper = {
   }
 };
 
-export const GeneratedClientCheckKeysHeaders: coreHttp.CompositeMapper = {
+export const GeneratedClientCheckKeysHeaders: coreClient.CompositeMapper = {
   type: {
     name: "Composite",
     className: "GeneratedClientCheckKeysHeaders",
@@ -249,7 +249,7 @@ export const GeneratedClientCheckKeysHeaders: coreHttp.CompositeMapper = {
   }
 };
 
-export const GeneratedClientGetKeyValuesHeaders: coreHttp.CompositeMapper = {
+export const GeneratedClientGetKeyValuesHeaders: coreClient.CompositeMapper = {
   type: {
     name: "Composite",
     className: "GeneratedClientGetKeyValuesHeaders",
@@ -264,7 +264,7 @@ export const GeneratedClientGetKeyValuesHeaders: coreHttp.CompositeMapper = {
   }
 };
 
-export const GeneratedClientCheckKeyValuesHeaders: coreHttp.CompositeMapper = {
+export const GeneratedClientCheckKeyValuesHeaders: coreClient.CompositeMapper = {
   type: {
     name: "Composite",
     className: "GeneratedClientCheckKeyValuesHeaders",
@@ -279,7 +279,7 @@ export const GeneratedClientCheckKeyValuesHeaders: coreHttp.CompositeMapper = {
   }
 };
 
-export const GeneratedClientGetKeyValueHeaders: coreHttp.CompositeMapper = {
+export const GeneratedClientGetKeyValueHeaders: coreClient.CompositeMapper = {
   type: {
     name: "Composite",
     className: "GeneratedClientGetKeyValueHeaders",
@@ -306,7 +306,7 @@ export const GeneratedClientGetKeyValueHeaders: coreHttp.CompositeMapper = {
   }
 };
 
-export const GeneratedClientPutKeyValueHeaders: coreHttp.CompositeMapper = {
+export const GeneratedClientPutKeyValueHeaders: coreClient.CompositeMapper = {
   type: {
     name: "Composite",
     className: "GeneratedClientPutKeyValueHeaders",
@@ -327,7 +327,7 @@ export const GeneratedClientPutKeyValueHeaders: coreHttp.CompositeMapper = {
   }
 };
 
-export const GeneratedClientDeleteKeyValueHeaders: coreHttp.CompositeMapper = {
+export const GeneratedClientDeleteKeyValueHeaders: coreClient.CompositeMapper = {
   type: {
     name: "Composite",
     className: "GeneratedClientDeleteKeyValueHeaders",
@@ -348,7 +348,7 @@ export const GeneratedClientDeleteKeyValueHeaders: coreHttp.CompositeMapper = {
   }
 };
 
-export const GeneratedClientCheckKeyValueHeaders: coreHttp.CompositeMapper = {
+export const GeneratedClientCheckKeyValueHeaders: coreClient.CompositeMapper = {
   type: {
     name: "Composite",
     className: "GeneratedClientCheckKeyValueHeaders",
@@ -375,7 +375,7 @@ export const GeneratedClientCheckKeyValueHeaders: coreHttp.CompositeMapper = {
   }
 };
 
-export const GeneratedClientGetLabelsHeaders: coreHttp.CompositeMapper = {
+export const GeneratedClientGetLabelsHeaders: coreClient.CompositeMapper = {
   type: {
     name: "Composite",
     className: "GeneratedClientGetLabelsHeaders",
@@ -390,7 +390,7 @@ export const GeneratedClientGetLabelsHeaders: coreHttp.CompositeMapper = {
   }
 };
 
-export const GeneratedClientCheckLabelsHeaders: coreHttp.CompositeMapper = {
+export const GeneratedClientCheckLabelsHeaders: coreClient.CompositeMapper = {
   type: {
     name: "Composite",
     className: "GeneratedClientCheckLabelsHeaders",
@@ -405,7 +405,7 @@ export const GeneratedClientCheckLabelsHeaders: coreHttp.CompositeMapper = {
   }
 };
 
-export const GeneratedClientPutLockHeaders: coreHttp.CompositeMapper = {
+export const GeneratedClientPutLockHeaders: coreClient.CompositeMapper = {
   type: {
     name: "Composite",
     className: "GeneratedClientPutLockHeaders",
@@ -426,7 +426,7 @@ export const GeneratedClientPutLockHeaders: coreHttp.CompositeMapper = {
   }
 };
 
-export const GeneratedClientDeleteLockHeaders: coreHttp.CompositeMapper = {
+export const GeneratedClientDeleteLockHeaders: coreClient.CompositeMapper = {
   type: {
     name: "Composite",
     className: "GeneratedClientDeleteLockHeaders",
@@ -447,7 +447,7 @@ export const GeneratedClientDeleteLockHeaders: coreHttp.CompositeMapper = {
   }
 };
 
-export const GeneratedClientGetRevisionsHeaders: coreHttp.CompositeMapper = {
+export const GeneratedClientGetRevisionsHeaders: coreClient.CompositeMapper = {
   type: {
     name: "Composite",
     className: "GeneratedClientGetRevisionsHeaders",
@@ -462,7 +462,7 @@ export const GeneratedClientGetRevisionsHeaders: coreHttp.CompositeMapper = {
   }
 };
 
-export const GeneratedClientCheckRevisionsHeaders: coreHttp.CompositeMapper = {
+export const GeneratedClientCheckRevisionsHeaders: coreClient.CompositeMapper = {
   type: {
     name: "Composite",
     className: "GeneratedClientCheckRevisionsHeaders",
@@ -477,7 +477,7 @@ export const GeneratedClientCheckRevisionsHeaders: coreHttp.CompositeMapper = {
   }
 };
 
-export const GeneratedClientGetKeysNextHeaders: coreHttp.CompositeMapper = {
+export const GeneratedClientGetKeysNextHeaders: coreClient.CompositeMapper = {
   type: {
     name: "Composite",
     className: "GeneratedClientGetKeysNextHeaders",
@@ -492,7 +492,7 @@ export const GeneratedClientGetKeysNextHeaders: coreHttp.CompositeMapper = {
   }
 };
 
-export const GeneratedClientGetKeyValuesNextHeaders: coreHttp.CompositeMapper = {
+export const GeneratedClientGetKeyValuesNextHeaders: coreClient.CompositeMapper = {
   type: {
     name: "Composite",
     className: "GeneratedClientGetKeyValuesNextHeaders",
@@ -507,7 +507,7 @@ export const GeneratedClientGetKeyValuesNextHeaders: coreHttp.CompositeMapper = 
   }
 };
 
-export const GeneratedClientGetLabelsNextHeaders: coreHttp.CompositeMapper = {
+export const GeneratedClientGetLabelsNextHeaders: coreClient.CompositeMapper = {
   type: {
     name: "Composite",
     className: "GeneratedClientGetLabelsNextHeaders",
@@ -522,7 +522,7 @@ export const GeneratedClientGetLabelsNextHeaders: coreHttp.CompositeMapper = {
   }
 };
 
-export const GeneratedClientGetRevisionsNextHeaders: coreHttp.CompositeMapper = {
+export const GeneratedClientGetRevisionsNextHeaders: coreClient.CompositeMapper = {
   type: {
     name: "Composite",
     className: "GeneratedClientGetRevisionsNextHeaders",

--- a/sdk/template/template/src/generated/models/parameters.ts
+++ b/sdk/template/template/src/generated/models/parameters.ts
@@ -9,9 +9,8 @@
 import {
   OperationParameter,
   OperationURLParameter,
-  OperationQueryParameter,
-  QueryCollectionFormat
-} from "@azure/core-http";
+  OperationQueryParameter
+} from "@azure/core-client";
 import { ConfigurationSetting as ConfigurationSettingMapper } from "../models/mappers";
 
 export const accept: OperationParameter = {
@@ -147,7 +146,7 @@ export const select: OperationQueryParameter = {
       }
     }
   },
-  collectionFormat: QueryCollectionFormat.Csv
+  collectionFormat: "CSV"
 };
 
 export const accept2: OperationParameter = {
@@ -239,7 +238,7 @@ export const select1: OperationQueryParameter = {
       }
     }
   },
-  collectionFormat: QueryCollectionFormat.Csv
+  collectionFormat: "CSV"
 };
 
 export const nextLink: OperationURLParameter = {

--- a/sdk/template/template/swagger/README.md
+++ b/sdk/template/template/swagger/README.md
@@ -18,8 +18,9 @@ add-credentials: false
 package-version: 1.0.11-beta.1
 disable-async-iterators: true
 hide-clients: true
+use-core-v2: true
 use-extension:
-  "@autorest/typescript": "6.0.0-dev.20210121.2"
+  "@autorest/typescript": "6.0.0-beta.13"
 ```
 
 ### Rename KeyValue to ConfigurationSetting


### PR DESCRIPTION
Solves: https://github.com/Azure/azure-sdk-for-js/issues/18044

This PR migrate `sdk/template/template` from using `@azure/core-http` to use `@azure/core-client` and `@azure/core-rest-pipeline`.

Followed [this migration guide] (https://github.com/Azure/autorest.typescript/wiki/%60core-http%60-dependency-migration-to-%60core-client%60-%60core-rest-pipeline%60)

More information about Azure Core V2 can be found [here](https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/core/core-rest-pipeline/documentation/core2.md).