### PR TITLE
Use fixed version of colors

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@types/node": "^12.0.0",
     "@types/nodegit": "^0.22.5",
     "@types/yargs": "^11.0.0",
-    "colors": "^1.3.2",
+    "colors": "1.4.0",
     "fs": "^0.0.1-security",
     "gulp": "^4.0.2",
     "js-yaml": "^3.12.0",


### PR DESCRIPTION
The new released package `colors` has bugs and it's treated as malicious codes in pipeline component detection. So we should use a fixed version.
related issue: https://github.com/Marak/colors.js/issues/285