### PR TITLE
Ignore alternative code-workspace files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -154,3 +154,7 @@ swagger/*.json
 
 #autorest artifacts
 code-model-*
+
+# code workspaces
+*.code-workspace
+!/dataplane.code-workspace


### PR DESCRIPTION
This little `.gitignore` snippet is useful for folks that want to use custom code-workspace configurations for smaller sets of projects. It allows us to create alternative workspace files that will be ignored, while still tracking the default `dataplane.code-workspace` file.

Example: I have a `dev-tool.code-workspace` that only has dev-tool, `@azure/template`, and the eslint plugin in it for when I'm hacking on dev-tool. This will help folks create little workspaces for whatever they're currently working on.

CC @ramya-rao-a and @xirzec 