### PR TITLE
Update search-documents tests to handle sovereign cloud endpoints dynamically

### DIFF
--- a/sdk/search/search-documents/src/searchClient.ts
+++ b/sdk/search/search-documents/src/searchClient.ts
@@ -160,6 +160,7 @@ export class SearchClient<T> implements IndexDocumentsClient<T> {
         throw new Error(`Invalid Api Version: ${options.apiVersion}`);
       }
       this.serviceVersion = options.apiVersion;
+      this.apiVersion = options.apiVersion;
     }
 
     if (options.serviceVersion) {
@@ -167,6 +168,7 @@ export class SearchClient<T> implements IndexDocumentsClient<T> {
         throw new Error(`Invalid Service Version: ${options.serviceVersion}`);
       }
       this.serviceVersion = options.serviceVersion;
+      this.apiVersion = options.serviceVersion;
     }
 
     this.client = new GeneratedClient(

--- a/sdk/search/search-documents/src/searchIndexClient.ts
+++ b/sdk/search/search-documents/src/searchIndexClient.ts
@@ -150,6 +150,7 @@ export class SearchIndexClient {
         throw new Error(`Invalid Api Version: ${options.apiVersion}`);
       }
       this.serviceVersion = options.apiVersion;
+      this.apiVersion = options.apiVersion;
     }
 
     if (options.serviceVersion) {
@@ -157,6 +158,7 @@ export class SearchIndexClient {
         throw new Error(`Invalid Service Version: ${options.serviceVersion}`);
       }
       this.serviceVersion = options.serviceVersion;
+      this.apiVersion = options.serviceVersion;
     }
 
     this.client = new GeneratedClient(

--- a/sdk/search/search-documents/src/searchIndexerClient.ts
+++ b/sdk/search/search-documents/src/searchIndexerClient.ts
@@ -139,6 +139,7 @@ export class SearchIndexerClient {
         throw new Error(`Invalid Api Version: ${options.apiVersion}`);
       }
       this.serviceVersion = options.apiVersion;
+      this.apiVersion = options.apiVersion;
     }
 
     if (options.serviceVersion) {
@@ -146,6 +147,7 @@ export class SearchIndexerClient {
         throw new Error(`Invalid Service Version: ${options.serviceVersion}`);
       }
       this.serviceVersion = options.serviceVersion;
+      this.apiVersion = options.serviceVersion;
     }
 
     this.client = new GeneratedClient(

--- a/sdk/search/search-documents/test/public/utils/recordedClient.ts
+++ b/sdk/search/search-documents/test/public/utils/recordedClient.ts
@@ -61,23 +61,28 @@ export function createClients<IndexModel>(
   indexName: string,
   serviceVersion: string
 ): Clients<IndexModel> {
+  let endPoint: string = "https://endpoint";
+
   switch (testEnv.AZURE_AUTHORITY_HOST) {
     case "https://login.microsoftonline.us":
-      process.env.ENDPOINT = process.env.ENDPOINT!.toString().replace(".windows.net", ".azure.us");
+      endPoint = process.env.USENDPOINT ?? "https://endpoint";
       break;
     case "https://login.chinacloudapi.cn":
-      process.env.ENDPOINT = process.env.ENDPOINT!.toString().replace(".windows.net", ".azure.cn");
+      endPoint = process.env.CHINAENDPOINT ?? "https://endpoint";
+      break;
+    default:
+      endPoint = process.env.ENDPOINT ?? "https://endpoint";
       break;
   }
 
   const credential = new AzureKeyCredential(testEnv.SEARCH_API_ADMIN_KEY);
-  const searchClient = new SearchClient<IndexModel>(testEnv.ENDPOINT, indexName, credential, {
+  const searchClient = new SearchClient<IndexModel>(endPoint, indexName, credential, {
     serviceVersion,
   });
-  const indexClient = new SearchIndexClient(testEnv.ENDPOINT, credential, {
+  const indexClient = new SearchIndexClient(endPoint, credential, {
     serviceVersion,
   });
-  const indexerClient = new SearchIndexerClient(testEnv.ENDPOINT, credential, {
+  const indexerClient = new SearchIndexerClient(endPoint, credential, {
     serviceVersion,
   });
 

--- a/sdk/search/test-resources.json
+++ b/sdk/search/test-resources.json
@@ -48,6 +48,14 @@
     "ENDPOINT": {
       "type": "string",
       "value": "[concat('https://', parameters('baseName'), '.search.windows.net')]"
+    },
+    "CHINAENDPOINT": {
+      "type": "string",
+      "value": "[concat('https://', parameters('baseName'), '.search.azure.cn')]"
+    },
+    "USENDPOINT": {
+      "type": "string",
+      "value": "[concat('https://', parameters('baseName'), '.search.azure.us')]"
     }
   }
 }


### PR DESCRIPTION
This PR is to address the issue [17577](https://github.com/Azure/azure-sdk-for-js/issues/17577). Today, the endpoint is modified for US & China Endpoints within the test code. The test code should not be doing it. 

With this PR, the value is read from the template dynamically and the switch statement is removed.

@xirzec Please review and approve the PR