### PR TITLE
[tracing] - Remove spanContext from our public API

### DIFF
--- a/sdk/core/core-tracing/review/core-tracing.api.md
+++ b/sdk/core/core-tracing/review/core-tracing.api.md
@@ -10,7 +10,7 @@ export function createTracingClient(options: TracingClientOptions): TracingClien
 // @public
 export interface Instrumenter {
     createRequestHeaders(tracingContext?: TracingContext): Record<string, string>;
-    parseTraceparentHeader(traceparentHeader: string): TracingSpanContext | undefined;
+    parseTraceparentHeader(traceparentHeader: string): TracingContext | undefined;
     startSpan(name: string, spanOptions: InstrumenterSpanOptions): {
         span: TracingSpan;
         tracingContext: TracingContext;
@@ -41,7 +41,7 @@ export type SpanStatus = {
 // @public
 export interface TracingClient {
     createRequestHeaders(tracingContext?: TracingContext): Record<string, string>;
-    parseTraceparentHeader(traceparentHeader: string): TracingSpanContext | undefined;
+    parseTraceparentHeader(traceparentHeader: string): TracingContext | undefined;
     startSpan<Options extends {
         tracingOptions?: OperationTracingOptions;
     }>(name: string, operationOptions?: Options, spanOptions?: TracingSpanOptions): {
@@ -75,15 +75,6 @@ export interface TracingSpan {
     recordException(exception: Error | string): void;
     setAttribute(name: string, value: unknown): void;
     setStatus(status: SpanStatus): void;
-    spanContext(): TracingSpanContext;
-}
-
-// @public
-export interface TracingSpanContext {
-    spanId: string;
-    traceFlags: number;
-    traceId: string;
-    traceState?: unknown;
 }
 
 // @public
@@ -94,7 +85,7 @@ export interface TracingSpanLink {
     attributes?: {
         [key: string]: unknown;
     };
-    spanContext: TracingSpanContext;
+    tracingContext: TracingContext;
 }
 
 // @public

--- a/sdk/core/core-tracing/src/index.ts
+++ b/sdk/core/core-tracing/src/index.ts
@@ -10,7 +10,6 @@ export {
   TracingClientOptions,
   TracingContext,
   TracingSpan,
-  TracingSpanContext,
   TracingSpanKind,
   TracingSpanLink,
   TracingSpanOptions,

--- a/sdk/core/core-tracing/src/instrumenter.ts
+++ b/sdk/core/core-tracing/src/instrumenter.ts
@@ -1,27 +1,13 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import {
-  Instrumenter,
-  InstrumenterSpanOptions,
-  TracingContext,
-  TracingSpan,
-  TracingSpanContext,
-} from "./interfaces";
+import { Instrumenter, InstrumenterSpanOptions, TracingContext, TracingSpan } from "./interfaces";
 import { createTracingContext } from "./tracingContext";
 
 export function createDefaultTracingSpan(): TracingSpan {
   return {
     end: () => {
       // noop
-    },
-    spanContext() {
-      // The world could always use more zeroes.
-      return {
-        spanId: "00000000-0000-0000-0000-000000000000",
-        traceId: "00000000-0000-0000-0000-000000000000",
-        traceFlags: 0x0,
-      };
     },
     isRecording: () => false,
     recordException: () => {
@@ -41,7 +27,7 @@ export function createDefaultInstrumenter(): Instrumenter {
     createRequestHeaders: (): Record<string, string> => {
       return {};
     },
-    parseTraceparentHeader: (): TracingSpanContext | undefined => {
+    parseTraceparentHeader: (): TracingContext | undefined => {
       return undefined;
     },
     startSpan: (

--- a/sdk/core/core-tracing/src/interfaces.ts
+++ b/sdk/core/core-tracing/src/interfaces.ts
@@ -76,7 +76,7 @@ export interface TracingClient {
    * @param traceparentHeader - The traceparent header to parse.
    * @returns An implementation-specific identifier for the span.
    */
-  parseTraceparentHeader(traceparentHeader: string): TracingSpanContext | undefined;
+  parseTraceparentHeader(traceparentHeader: string): TracingContext | undefined;
 
   /**
    * Creates a set of request headers to propagate tracing information to a backend.
@@ -114,28 +114,10 @@ export interface TracingSpanOptions {
 
 /** A pointer from the current {@link TracingSpan} to another span in the same or a different trace. */
 export interface TracingSpanLink {
-  /** The {@link TracingSpanContext} to link to. */
-  spanContext: TracingSpanContext;
+  /** The {@link TracingContext} containing the span context to link to. */
+  tracingContext: TracingContext;
   /** A set of attributes on the link. */
   attributes?: { [key: string]: unknown };
-}
-
-/**
- * A unique, serializable identifier for a span.
- */
-export interface TracingSpanContext {
-  /** The span UUID within the trace. */
-  spanId: string;
-  /** The trace UUID. */
-  traceId: string;
-  /**
-   * https://www.w3.org/TR/trace-context/#trace-flags
-   */
-  traceFlags: number;
-  /**
-   * An implementation-specific value representing system-specific trace info to serialize.
-   */
-  traceState?: unknown;
 }
 
 /**
@@ -174,7 +156,7 @@ export interface Instrumenter {
    * Provides an implementation-specific method to parse a {@link https://www.w3.org/TR/trace-context/#traceparent-header}
    * into a {@link TracingSpanContext} which can be used to link non-parented spans together.
    */
-  parseTraceparentHeader(traceparentHeader: string): TracingSpanContext | undefined;
+  parseTraceparentHeader(traceparentHeader: string): TracingContext | undefined;
   /**
    * Provides an implementation-specific method to serialize a {@link TracingSpan} to a set of headers.
    * @param tracingContext - The context containing the span to serialize.
@@ -248,9 +230,6 @@ export interface TracingSpan {
    * Depending on the span implementation, this may return false if the span is not being sampled.
    */
   isRecording(): boolean;
-
-  /** Returns the {@link TracingSpanContext} - an immutable, serializable span identifier. */
-  spanContext(): TracingSpanContext;
 }
 
 /** An immutable context bag of tracing values for the current operation. */

--- a/sdk/core/core-tracing/src/tracingClient.ts
+++ b/sdk/core/core-tracing/src/tracingClient.ts
@@ -7,7 +7,6 @@ import {
   TracingClientOptions,
   TracingContext,
   TracingSpan,
-  TracingSpanContext,
   TracingSpanOptions,
 } from "./interfaces";
 import { getInstrumenter } from "./instrumenter";
@@ -98,7 +97,7 @@ export function createTracingClient(options: TracingClientOptions): TracingClien
    * @param traceparentHeader - The traceparent header to parse.
    * @returns An implementation-specific identifier for the span.
    */
-  function parseTraceparentHeader(traceparentHeader: string): TracingSpanContext | undefined {
+  function parseTraceparentHeader(traceparentHeader: string): TracingContext | undefined {
     return getInstrumenter().parseTraceparentHeader(traceparentHeader);
   }
 

--- a/sdk/core/core-tracing/test/instrumenter.spec.ts
+++ b/sdk/core/core-tracing/test/instrumenter.spec.ts
@@ -72,11 +72,6 @@ describe("Instrumenter", () => {
       span.setStatus({ status: "success" });
       span.setAttribute("foo", "bar");
       span.recordException(new Error("test"));
-      assert.deepEqual(span.spanContext(), {
-        spanId: "00000000-0000-0000-0000-000000000000",
-        traceId: "00000000-0000-0000-0000-000000000000",
-        traceFlags: 0x0,
-      });
       span.end();
       assert.isFalse(span.isRecording());
     });

--- a/sdk/instrumentation/opentelemetry-instrumentation-azure-sdk/src/instrumenter.ts
+++ b/sdk/instrumentation/opentelemetry-instrumentation-azure-sdk/src/instrumenter.ts
@@ -6,7 +6,6 @@ import {
   InstrumenterSpanOptions,
   TracingContext,
   TracingSpan,
-  TracingSpanContext,
 } from "@azure/core-tracing";
 
 import { trace, context, defaultTextMapGetter, defaultTextMapSetter } from "@opentelemetry/api";
@@ -50,19 +49,17 @@ export class OpenTelemetryInstrumenter implements Instrumenter {
     );
   }
 
-  parseTraceparentHeader(traceparentHeader: string): TracingSpanContext | undefined {
-    const newContext = propagator.extract(
+  parseTraceparentHeader(traceparentHeader: string): TracingContext {
+    return propagator.extract(
       context.active(),
       { traceparent: traceparentHeader },
       defaultTextMapGetter
     );
-    return trace.getSpanContext(newContext);
   }
 
   createRequestHeaders(tracingContext?: TracingContext): Record<string, string> {
     const headers: Record<string, string> = {};
     propagator.inject(tracingContext || context.active(), headers, defaultTextMapSetter);
-
     return headers;
   }
 }

--- a/sdk/instrumentation/opentelemetry-instrumentation-azure-sdk/src/spanWrapper.ts
+++ b/sdk/instrumentation/opentelemetry-instrumentation-azure-sdk/src/spanWrapper.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { SpanStatus, TracingSpan, TracingSpanContext } from "@azure/core-tracing";
+import { SpanStatus, TracingSpan } from "@azure/core-tracing";
 import { Span, SpanStatusCode, SpanAttributeValue } from "@opentelemetry/api";
 
 export class OpenTelemetrySpanWrapper implements TracingSpan {
@@ -40,10 +40,6 @@ export class OpenTelemetrySpanWrapper implements TracingSpan {
 
   isRecording(): boolean {
     return this._span.isRecording();
-  }
-
-  spanContext(): TracingSpanContext {
-    return this._span.spanContext();
   }
 
   /**

--- a/sdk/instrumentation/opentelemetry-instrumentation-azure-sdk/src/transformations.ts
+++ b/sdk/instrumentation/opentelemetry-instrumentation-azure-sdk/src/transformations.ts
@@ -8,7 +8,7 @@ import {
   SpanAttributes,
   SpanKind,
   SpanOptions,
-  TraceState,
+  trace,
 } from "@opentelemetry/api";
 
 /**
@@ -43,15 +43,16 @@ type SpanKindMapping = {
  * @returns A set of {@link Link}s
  */
 function toOpenTelemetryLinks(spanLinks: TracingSpanLink[] = []): Link[] {
-  return spanLinks.map((tracingSpanLink) => {
-    return {
-      context: {
-        ...tracingSpanLink.spanContext,
-        traceState: tracingSpanLink.spanContext.traceState as TraceState,
-      },
-      attributes: toOpenTelemetrySpanAttributes(tracingSpanLink.attributes),
-    };
-  });
+  return spanLinks.reduce((acc, tracingSpanLink) => {
+    const spanContext = trace.getSpanContext(tracingSpanLink.tracingContext);
+    if (spanContext) {
+      acc.push({
+        context: spanContext,
+        attributes: toOpenTelemetrySpanAttributes(tracingSpanLink.attributes),
+      });
+    }
+    return acc;
+  }, [] as Link[]);
 }
 
 /**

--- a/sdk/instrumentation/opentelemetry-instrumentation-azure-sdk/test/public/spanWrapper.spec.ts
+++ b/sdk/instrumentation/opentelemetry-instrumentation-azure-sdk/test/public/spanWrapper.spec.ts
@@ -90,10 +90,4 @@ describe("OpenTelemetrySpanWrapper", () => {
       assert.equal(span.isRecording(), otSpan.isRecording());
     });
   });
-
-  describe("#spanContext", () => {
-    it("returns the wrapped span context", () => {
-      assert.deepEqual(span.spanContext(), otSpan.spanContext());
-    });
-  });
 });

--- a/sdk/test-utils/test-utils/src/tracing/chaiAzureTrace.ts
+++ b/sdk/test-utils/test-utils/src/tracing/chaiAzureTrace.ts
@@ -4,6 +4,7 @@
 import { OperationTracingOptions, useInstrumenter } from "@azure/core-tracing";
 import { assert } from "chai";
 import { MockInstrumenter } from "./mockInstrumenter";
+import { MockTracingSpan } from "./mockTracingSpan";
 import { SpanGraph, SpanGraphNode } from "./spanGraphModel";
 
 /**
@@ -68,7 +69,7 @@ async function supportsTracing<
   } as Options;
   await callback.call(thisArg, newOptions);
   rootSpan.end();
-  const spanGraph = getSpanGraph(rootSpan.spanContext().traceId, instrumenter);
+  const spanGraph = getSpanGraph((rootSpan as MockTracingSpan).spanContext().traceId, instrumenter);
   assert.equal(spanGraph.roots.length, 1, "There should be just one root span");
   assert.equal(spanGraph.roots[0].name, "root");
   assert.strictEqual(

--- a/sdk/test-utils/test-utils/src/tracing/chaiAzureTrace.ts
+++ b/sdk/test-utils/test-utils/src/tracing/chaiAzureTrace.ts
@@ -69,7 +69,7 @@ async function supportsTracing<
   } as Options;
   await callback.call(thisArg, newOptions);
   rootSpan.end();
-  const spanGraph = getSpanGraph((rootSpan as MockTracingSpan).spanContext().traceId, instrumenter);
+  const spanGraph = getSpanGraph((rootSpan as MockTracingSpan).traceId, instrumenter);
   assert.equal(spanGraph.roots.length, 1, "There should be just one root span");
   assert.equal(spanGraph.roots[0].name, "root");
   assert.strictEqual(
@@ -96,22 +96,22 @@ async function supportsTracing<
  */
 function getSpanGraph(traceId: string, instrumenter: MockInstrumenter): SpanGraph {
   const traceSpans = instrumenter.startedSpans.filter((span) => {
-    return span.spanContext().traceId === traceId;
+    return span.traceId === traceId;
   });
 
   const roots: SpanGraphNode[] = [];
   const nodeMap: Map<string, SpanGraphNode> = new Map<string, SpanGraphNode>();
 
   for (const span of traceSpans) {
-    const spanId = span.spanContext().spanId;
+    const spanId = span.spanId;
     const node: SpanGraphNode = {
       name: span.name,
       children: [],
     };
     nodeMap.set(spanId, node);
 
-    if (span.parentSpan()?.spanContext().spanId) {
-      const parentSpan = span.parentSpan()?.spanContext().spanId;
+    if (span.parentSpan()?.spanId) {
+      const parentSpan = span.parentSpan()?.spanId;
       const parent = nodeMap.get(parentSpan!);
       if (!parent) {
         throw new Error(

--- a/sdk/test-utils/test-utils/src/tracing/mockInstrumenter.ts
+++ b/sdk/test-utils/test-utils/src/tracing/mockInstrumenter.ts
@@ -43,7 +43,7 @@ export class MockInstrumenter implements Instrumenter {
     const parentSpan = tracingContext.getValue(spanKey) as MockTracingSpan | undefined;
     let traceId;
     if (parentSpan) {
-      traceId = parentSpan.spanContext().traceId;
+      traceId = parentSpan.traceId;
     } else {
       traceId = this.getNextTraceId();
     }

--- a/sdk/test-utils/test-utils/src/tracing/mockInstrumenter.ts
+++ b/sdk/test-utils/test-utils/src/tracing/mockInstrumenter.ts
@@ -6,7 +6,6 @@ import {
   InstrumenterSpanOptions,
   TracingContext,
   TracingSpan,
-  TracingSpanContext,
 } from "@azure/core-tracing";
 import { MockContext, spanKey } from "./mockContext";
 import { MockTracingSpan } from "./mockTracingSpan";
@@ -41,7 +40,7 @@ export class MockInstrumenter implements Instrumenter {
     spanOptions?: InstrumenterSpanOptions
   ): { span: TracingSpan; tracingContext: TracingContext } {
     const tracingContext = spanOptions?.tracingContext || this.currentContext();
-    const parentSpan = tracingContext.getValue(spanKey) as TracingSpan | undefined;
+    const parentSpan = tracingContext.getValue(spanKey) as MockTracingSpan | undefined;
     let traceId;
     if (parentSpan) {
       traceId = parentSpan.spanContext().traceId;
@@ -54,7 +53,13 @@ export class MockInstrumenter implements Instrumenter {
       traceId: traceId,
       traceFlags: 0,
     };
-    const span = new MockTracingSpan(name, spanContext, tracingContext, spanOptions);
+    const span = new MockTracingSpan(
+      name,
+      spanContext.traceId,
+      spanContext.spanId,
+      tracingContext,
+      spanOptions
+    );
     let context: TracingContext = new MockContext(tracingContext);
     context = context.setValue(spanKey, span);
 
@@ -76,7 +81,7 @@ export class MockInstrumenter implements Instrumenter {
     }) as ReturnType<Callback>;
   }
 
-  parseTraceparentHeader(_traceparentHeader: string): TracingSpanContext | undefined {
+  parseTraceparentHeader(_traceparentHeader: string): TracingContext | undefined {
     return;
   }
 

--- a/sdk/test-utils/test-utils/src/tracing/mockTracingSpan.ts
+++ b/sdk/test-utils/test-utils/src/tracing/mockTracingSpan.ts
@@ -6,7 +6,6 @@ import {
   SpanStatus,
   TracingSpanOptions,
   TracingSpanKind,
-  TracingSpanContext,
   TracingContext,
 } from "@azure/core-tracing";
 import { spanKey } from "./mockContext";
@@ -28,23 +27,29 @@ export class MockTracingSpan implements TracingSpan {
    */
   tracingContext?: TracingContext;
 
+  private _spanContext: { spanId: string; traceId: string };
+
   /**
    *
    * @param name - Name of the current span
-   * @param spanContext - A unique, serializable identifier for a span {@link TracingSpanContext}
+   * @param spanContext - A unique, serializable identifier for a span
    * @param tracingContext - Existing or parent tracing context
    * @param spanOptions - Options to configure the newly created span {@link TracingSpanOptions}
    */
   constructor(
     name: string,
-    spanContext: TracingSpanContext,
+    traceId: string,
+    spanId: string,
     tracingContext?: TracingContext,
     spanOptions?: TracingSpanOptions
   ) {
     this.name = name;
     this.spanKind = spanOptions?.spanKind;
     this.tracingContext = tracingContext;
-    this._spanContext = spanContext;
+    this._spanContext = {
+      spanId,
+      traceId,
+    };
   }
 
   spanStatus?: SpanStatus;
@@ -72,8 +77,7 @@ export class MockTracingSpan implements TracingSpan {
     return this.tracingContext?.getValue(spanKey) as MockTracingSpan;
   }
 
-  private _spanContext: TracingSpanContext;
-  spanContext() {
+  spanContext(): { spanId: string; traceId: string } {
     return this._spanContext;
   }
 }

--- a/sdk/test-utils/test-utils/src/tracing/mockTracingSpan.ts
+++ b/sdk/test-utils/test-utils/src/tracing/mockTracingSpan.ts
@@ -27,7 +27,15 @@ export class MockTracingSpan implements TracingSpan {
    */
   tracingContext?: TracingContext;
 
-  private _spanContext: { spanId: string; traceId: string };
+  /**
+   * The generated ID of the span within a given trace
+   */
+  spanId: string;
+
+  /**
+   * The ID of the trace this span belongs to
+   */
+  traceId: string;
 
   /**
    *
@@ -46,10 +54,8 @@ export class MockTracingSpan implements TracingSpan {
     this.name = name;
     this.spanKind = spanOptions?.spanKind;
     this.tracingContext = tracingContext;
-    this._spanContext = {
-      spanId,
-      traceId,
-    };
+    this.traceId = traceId;
+    this.spanId = spanId;
   }
 
   spanStatus?: SpanStatus;
@@ -75,9 +81,5 @@ export class MockTracingSpan implements TracingSpan {
 
   parentSpan(): MockTracingSpan | undefined {
     return this.tracingContext?.getValue(spanKey) as MockTracingSpan;
-  }
-
-  spanContext(): { spanId: string; traceId: string } {
-    return this._spanContext;
   }
 }

--- a/sdk/test-utils/test-utils/test/tracing/mockTracingSpan.spec.ts
+++ b/sdk/test-utils/test-utils/test/tracing/mockTracingSpan.spec.ts
@@ -8,11 +8,7 @@ describe("TestTracingSpan", function () {
   let subject: MockTracingSpan;
 
   beforeEach(() => {
-    subject = new MockTracingSpan("test", {
-      spanId: "spanId",
-      traceId: "traceId",
-      traceFlags: 0,
-    });
+    subject = new MockTracingSpan("test", "traceId", "spanId");
   });
 
   it("records status correctly", function () {


### PR DESCRIPTION
Taken from https://github.com/Azure/azure-sdk-for-js/pull/19734#discussion_r780539434 - this demonstrates what that might look like

This PR removes `TracingSpanContext` from our public types and relies on TracingContext and runtime checks to serialize and deserialize a TracingSpan