### PR TITLE
PR Request Template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,29 @@
+
+**Checklists** 
+- [ ] Added impacted package name to the issue description
+
+**Packages impacted by this PR:**
+
+
+**Issues associated with this PR:**
+
+
+**Describe the problem that is addressed by this PR:**
+
+
+**What are the possible designs available to address the problem**
+
+
+**If there are more than one possible design, why was the one in this PR chosen?**
+
+
+**Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
+
+
+**Are there test cases added in this PR?**_(If not, why?)_
+
+
+**Provide a list of related PRs**_(if any)_
+
+
+**Command used to generate this PR:**_(Applicable only to SDK release request PRs)_


### PR DESCRIPTION
It seems github requires the default template under the parent .github folder. So, copying the file under PULL_REQUEST_TEMPLATE directory (similar to the .NET repository)

FIle is ame as https://github.com/Azure/azure-sdk-for-js/pull/19780

@sadasant Could you please approve this PR?