### PR TITLE
[Identity] Fixing certificate test inconsistencies, including min-max live tests.

### DIFF
--- a/sdk/identity/identity/test/public/node/clientCertificateCredential.spec.ts
+++ b/sdk/identity/identity/test/public/node/clientCertificateCredential.spec.ts
@@ -4,6 +4,7 @@
 /* eslint-disable @typescript-eslint/no-non-null-asserted-optional-chain */
 
 import * as path from "path";
+import fs from "fs";
 import { assert } from "chai";
 import { AbortController } from "@azure/abort-controller";
 import { env, isPlaybackMode, delay, isLiveMode } from "@azure-tools/test-recorder";
@@ -83,6 +84,11 @@ describe("ClientCertificateCredential", function () {
   });
 
   it("allows cancelling the authentication", async function () {
+    if (!fs.existsSync(certificatePath)) {
+      // In min-max tests, the certificate file can't be found.
+      console.log("Failed to locate the certificate file. Skipping.");
+      this.skip();
+    }
     const credential = new ClientCertificateCredential(env.AZURE_TENANT_ID, env.AZURE_CLIENT_ID, {
       certificatePath,
     });

--- a/sdk/identity/identity/test/public/node/clientCertificateCredential.spec.ts
+++ b/sdk/identity/identity/test/public/node/clientCertificateCredential.spec.ts
@@ -84,7 +84,7 @@ describe("ClientCertificateCredential", function () {
     assert.ok(token?.expiresOnTimestamp! > Date.now());
   });
 
-  it("allows cancelling the authentication", async function () {
+  it("allows cancelling the authentication", async function (this: Context) {
     if (!fs.existsSync(certificatePath)) {
       // In min-max tests, the certificate file can't be found.
       console.log("Failed to locate the certificate file. Skipping.");

--- a/sdk/identity/identity/test/public/node/clientCertificateCredential.spec.ts
+++ b/sdk/identity/identity/test/public/node/clientCertificateCredential.spec.ts
@@ -4,6 +4,7 @@
 /* eslint-disable @typescript-eslint/no-non-null-asserted-optional-chain */
 
 import * as path from "path";
+import fs from "fs";
 import { assert } from "chai";
 import { AbortController } from "@azure/abort-controller";
 import { env, isPlaybackMode, delay, isLiveMode } from "@azure-tools/test-recorder";
@@ -84,6 +85,11 @@ describe("ClientCertificateCredential", function () {
   });
 
   it("allows cancelling the authentication", async function () {
+    if (!fs.existsSync(certificatePath)) {
+      // In min-max tests, the certificate file can't be found.
+      console.log("Failed to locate the certificate file. Skipping.");
+      this.skip();
+    }
     const credential = new ClientCertificateCredential(
       env.AZURE_TENANT_ID,
       env.AZURE_CLIENT_ID,
@@ -114,7 +120,6 @@ describe("ClientCertificateCredential", function () {
     } catch (e) {
       error = e;
     }
-    console.log("ERROR DETAILS", error);
     assert.equal(error?.name, "CredentialUnavailableError");
     assert.ok(error?.message.includes("could not resolve endpoints"));
   });

--- a/sdk/identity/identity/test/public/node/clientCertificateCredential.spec.ts
+++ b/sdk/identity/identity/test/public/node/clientCertificateCredential.spec.ts
@@ -107,6 +107,7 @@ describe("ClientCertificateCredential", function () {
     } catch (e) {
       error = e;
     }
+    console.log("ERROR DETAILS", error);
     assert.equal(error?.name, "CredentialUnavailableError");
     assert.ok(error?.message.includes("could not resolve endpoints"));
   });


### PR DESCRIPTION
**Packages impacted by this PR:**

- Azure Identity.

**Describe the problem that is addressed by this PR:**

We’re seeing min max tests fail for Identity on our nightly CI pipelines. After debugging this, Karishma spotted that our tests were unable to find the fake certificate. This PR skips the test if the certificate can’t be found. It also replaces the HTTP client with a client that will never resolve before the abort signal is aborted.