### PR TITLE
[Identity] Refactoring the HTTP request mocking to be easier to understand in context

### DIFF
--- a/sdk/identity/identity/test/httpRequests.browser.ts
+++ b/sdk/identity/identity/test/httpRequests.browser.ts
@@ -4,14 +4,9 @@
 import * as sinon from "sinon";
 import { setLogLevel, AzureLogger, getLogLevel, AzureLogLevel } from "@azure/logger";
 import { RestError } from "@azure/core-rest-pipeline";
-import { AccessToken } from "@azure/core-auth";
+import { AccessToken, GetTokenOptions, TokenCredential } from "@azure/core-auth";
 import { getError } from "./authTestUtils";
-import {
-  IdentityTestContext,
-  SendCredentialRequests,
-  RawTestResponse,
-  TestResponse,
-} from "./httpRequestsCommon";
+import { IdentityTestContext, RawTestResponse, TestResponse } from "./httpRequestsCommon";
 
 /**
  * Helps specify a different number of responses for Node and for the browser.
@@ -40,42 +35,53 @@ export function prepareMSALResponses(): RawTestResponse[] {
  * that may expect more than one response (or error) from more than one endpoint.
  * @internal
  */
-export async function prepareIdentityTests({
-  replaceLogger,
-  logLevel,
-}: {
-  replaceLogger?: boolean;
-  logLevel?: AzureLogLevel;
-}): Promise<IdentityTestContext> {
-  const sandbox = sinon.createSandbox();
-  const clock = sandbox.useFakeTimers();
-  const oldLogLevel = getLogLevel();
-  const oldLogger = AzureLogger.log;
-  const logMessages: string[] = [];
+export class IdentityTest implements IdentityTestContext {
+  public sandbox: sinon.SinonSandbox;
+  public clock: sinon.SinonFakeTimers;
+  public oldLogLevel: AzureLogLevel | undefined;
+  public oldLogger: any;
+  public logMessages: string[];
+  public server: sinon.SinonFakeServer;
+  public requests: sinon.SinonFakeXMLHttpRequest[];
+  public responses: RawTestResponse[];
 
-  if (logLevel) {
-    setLogLevel(logLevel);
+  constructor({ replaceLogger, logLevel }: { replaceLogger?: boolean; logLevel?: AzureLogLevel }) {
+    this.sandbox = sinon.createSandbox();
+    this.clock = this.sandbox.useFakeTimers();
+    this.oldLogLevel = getLogLevel();
+    this.oldLogger = AzureLogger.log;
+    this.logMessages = [];
+
+    /**
+     * Browser specific code.
+     * Sets up a fake server that will be used to answer any outgoing request.
+     */
+    this.server = this.sandbox.useFakeServer();
+    this.requests = [];
+    this.responses = [];
+
+    if (logLevel) {
+      setLogLevel(logLevel);
+    }
+
+    if (replaceLogger) {
+      AzureLogger.log = (args) => {
+        this.logMessages.push(args);
+      };
+    }
   }
 
-  if (replaceLogger) {
-    AzureLogger.log = (args) => {
-      logMessages.push(args);
-    };
+  async restore(): Promise<void> {
+    this.sandbox.restore();
+    AzureLogger.log = this.oldLogger;
+    setLogLevel(this.oldLogLevel);
   }
-
-  /**
-   * Browser specific code.
-   * Sets up a fake server that will be used to answer any outgoing request.
-   */
-  const server = sandbox.useFakeServer();
-  const requests: sinon.SinonFakeXMLHttpRequest[] = [];
-  const responses: RawTestResponse[] = [];
 
   /**
    * Wraps a credential's getToken in a mocked environment, then returns the results from the request,
    * including potentially an AccessToken, an error and the list of outgoing requests in a simplified format.
    */
-  async function sendIndividualRequest<T>(
+  async sendIndividualRequest<T>(
     sendPromise: () => Promise<T | null>,
     { response }: { response: TestResponse }
   ): Promise<T | null> {
@@ -83,43 +89,58 @@ export async function prepareIdentityTests({
      * Both keeps track of the outgoing requests,
      * and ensures each request answers with each received response, in order.
      */
-    server.respondWith((xhr) => {
-      requests.push(xhr);
+    this.server.respondWith((xhr) => {
+      this.requests.push(xhr);
       xhr.respond(response.statusCode, response.headers, response.body);
     });
     const promise = sendPromise();
-    server.respond();
-    await clock.runAllAsync();
+    this.server.respond();
+    await this.clock.runAllAsync();
     return promise;
   }
 
   /**
    * Wraps the outgoing request in a mocked environment, then returns the error that results from the request.
    */
-  async function sendIndividualRequestAndGetError<T>(
+  async sendIndividualRequestAndGetError<T>(
     sendPromise: () => Promise<T | null>,
     response: { response: TestResponse }
   ): Promise<Error> {
-    return getError(sendIndividualRequest(sendPromise, response));
+    return getError(this.sendIndividualRequest(sendPromise, response));
   }
 
   /**
    * Wraps a credential's getToken in a mocked environment, then returns the results from the request.
    */
-  const sendCredentialRequests: SendCredentialRequests = async ({
+  async sendCredentialRequests({
     scopes,
     getTokenOptions,
     credential,
     insecureResponses = [],
     secureResponses = [],
-  }) => {
-    responses.push(...[...insecureResponses, ...secureResponses]);
-    server.respondWith((xhr) => {
-      requests.push(xhr);
-      if (!responses.length) {
+  }: {
+    scopes: string | string[];
+    getTokenOptions?: GetTokenOptions;
+    credential: TokenCredential;
+    insecureResponses?: RawTestResponse[];
+    secureResponses?: RawTestResponse[];
+  }): Promise<{
+    result: AccessToken | null;
+    error?: RestError;
+    requests: {
+      url: string;
+      body: string;
+      method: string;
+      headers: Record<string, string>;
+    }[];
+  }> {
+    this.responses.push(...[...insecureResponses, ...secureResponses]);
+    this.server.respondWith((xhr) => {
+      this.requests.push(xhr);
+      if (!this.responses.length) {
         throw new Error("No responses to send");
       }
-      const { response, error } = responses.shift()!;
+      const { response, error } = this.responses.shift()!;
       if (response) {
         xhr.respond(response.statusCode, response.headers, response.body);
       } else if (error) {
@@ -137,8 +158,8 @@ export async function prepareIdentityTests({
       // We need the promises to begin triggering, so the server has something to respond to,
       // and only then we can wait for all of the async processes to finish.
       const promise = credential.getToken(scopes, getTokenOptions);
-      server.respond();
-      await clock.runAllAsync();
+      this.server.respond();
+      await this.clock.runAllAsync();
       result = await promise;
     } catch (e) {
       error = e;
@@ -147,7 +168,7 @@ export async function prepareIdentityTests({
     return {
       result,
       error,
-      requests: requests.map((request) => {
+      requests: this.requests.map((request) => {
         return {
           url: request.url,
           body: request.requestBody,
@@ -156,21 +177,5 @@ export async function prepareIdentityTests({
         };
       }),
     };
-  };
-
-  return {
-    clock,
-    logMessages,
-    oldLogLevel,
-    sandbox,
-    oldLogger,
-    async restore() {
-      sandbox.restore();
-      AzureLogger.log = oldLogger;
-      setLogLevel(oldLogLevel);
-    },
-    sendIndividualRequest,
-    sendIndividualRequestAndGetError,
-    sendCredentialRequests,
-  };
+  }
 }

--- a/sdk/identity/identity/test/httpRequests.browser.ts
+++ b/sdk/identity/identity/test/httpRequests.browser.ts
@@ -6,7 +6,7 @@ import { setLogLevel, AzureLogger, getLogLevel, AzureLogLevel } from "@azure/log
 import { RestError } from "@azure/core-rest-pipeline";
 import { AccessToken, GetTokenOptions, TokenCredential } from "@azure/core-auth";
 import { getError } from "./authTestUtils";
-import { IdentityTestContext, RawTestResponse, TestResponse } from "./httpRequestsCommon";
+import { IdentityTestContextInterface, RawTestResponse, TestResponse } from "./httpRequestsCommon";
 
 /**
  * Helps specify a different number of responses for Node and for the browser.
@@ -35,7 +35,7 @@ export function prepareMSALResponses(): RawTestResponse[] {
  * that may expect more than one response (or error) from more than one endpoint.
  * @internal
  */
-export class IdentityTest implements IdentityTestContext {
+export class IdentityTestContext implements IdentityTestContextInterface {
   public sandbox: sinon.SinonSandbox;
   public clock: sinon.SinonFakeTimers;
   public oldLogLevel: AzureLogLevel | undefined;

--- a/sdk/identity/identity/test/httpRequests.ts
+++ b/sdk/identity/identity/test/httpRequests.ts
@@ -7,13 +7,12 @@ import * as http from "http";
 import { ClientRequest, IncomingHttpHeaders, IncomingMessage } from "http";
 import { PassThrough } from "stream";
 import { RestError } from "@azure/core-rest-pipeline";
-import { setLogLevel, AzureLogger, getLogLevel, AzureLogLevel, Debugger } from "@azure/logger";
+import { setLogLevel, AzureLogger, getLogLevel, AzureLogLevel } from "@azure/logger";
 import { getError } from "./authTestUtils";
 import {
   createResponse,
-  IdentityTestContext,
+  IdentityTestContextInterface,
   RawTestResponse,
-  SendCredentialRequests,
   TestResponse,
 } from "./httpRequestsCommon";
 import { AccessToken, GetTokenOptions, TokenCredential } from "../src";
@@ -96,7 +95,7 @@ export function prepareMSALResponses(): RawTestResponse[] {
  * that may expect more than one response (or error) from more than one endpoint.
  * @internal
  */
-export class IdentityTest implements IdentityTestContext {
+export class IdentityTestContext implements IdentityTestContextInterface {
   public sandbox: Sinon.SinonSandbox;
   public clock: Sinon.SinonFakeTimers;
   public oldLogLevel: AzureLogLevel | undefined;
@@ -160,7 +159,7 @@ export class IdentityTest implements IdentityTestContext {
   /**
    * Helps replace the <provider>.request() method with one we can control.
    */
-  registerResponses(
+  public registerResponses(
     provider: "http" | "https",
     responses: { response?: TestResponse; error?: RestError }[],
     spies: sinon.SinonSpy[]

--- a/sdk/identity/identity/test/httpRequests.ts
+++ b/sdk/identity/identity/test/httpRequests.ts
@@ -171,6 +171,10 @@ export class IdentityTestContext implements IdentityTestContextInterface {
       const fakeRequest = (options: string | URL | http.RequestOptions, resolve: any) => {
         totalOptions.push(options as http.RequestOptions);
 
+        if (!responses.length) {
+          throw new Error("No responses left.");
+        }
+
         const { response, error } = responses.shift()!;
         if (error) {
           throw error;

--- a/sdk/identity/identity/test/httpRequestsCommon.ts
+++ b/sdk/identity/identity/test/httpRequestsCommon.ts
@@ -72,7 +72,7 @@ export type SendCredentialRequests = (options: {
  * This is the returned value of the `prepareIdentityTests` function that is both available in Node.js and in the browser.
  * @internal
  */
-export interface IdentityTestContext {
+export interface IdentityTestContextInterface {
   sandbox: sinon.SinonSandbox;
   clock: sinon.SinonFakeTimers;
   logMessages: string[];

--- a/sdk/identity/identity/test/internal/node/azureApplicationCredential.spec.ts
+++ b/sdk/identity/identity/test/internal/node/azureApplicationCredential.spec.ts
@@ -4,17 +4,12 @@
 import { assert } from "chai";
 import { RestError } from "@azure/core-rest-pipeline";
 import { AzureApplicationCredential } from "../../../src/credentials/azureApplicationCredential";
-import { prepareIdentityTests } from "../../httpRequests";
-import {
-  createResponse,
-  IdentityTestContext,
-  SendCredentialRequests,
-} from "../../httpRequestsCommon";
+import { IdentityTestContext } from "../../httpRequests";
+import { createResponse, IdentityTestContextInterface } from "../../httpRequestsCommon";
 
 describe("AzureApplicationCredential testing Managed Identity (internal)", function () {
   let envCopy: string = "";
-  let testContext: IdentityTestContext;
-  let sendCredentialRequests: SendCredentialRequests;
+  let testContext: IdentityTestContextInterface;
 
   beforeEach(async () => {
     envCopy = JSON.stringify(process.env);
@@ -22,8 +17,7 @@ describe("AzureApplicationCredential testing Managed Identity (internal)", funct
     delete process.env.MSI_SECRET;
     delete process.env.AZURE_CLIENT_SECRET;
     delete process.env.AZURE_TENANT_ID;
-    testContext = await prepareIdentityTests({});
-    sendCredentialRequests = testContext.sendCredentialRequests;
+    testContext = new IdentityTestContext({});
   });
   afterEach(async () => {
     const env = JSON.parse(envCopy);
@@ -37,7 +31,7 @@ describe("AzureApplicationCredential testing Managed Identity (internal)", funct
   it("returns error when no MSI is available", async function () {
     process.env.AZURE_CLIENT_ID = "errclient";
 
-    const { error } = await sendCredentialRequests({
+    const { error } = await testContext.sendCredentialRequests({
       scopes: ["scopes"],
       credential: new AzureApplicationCredential(),
       insecureResponses: [
@@ -57,7 +51,7 @@ describe("AzureApplicationCredential testing Managed Identity (internal)", funct
 
     const errorMessage = "ManagedIdentityCredential authentication failed.";
 
-    const { error } = await sendCredentialRequests({
+    const { error } = await testContext.sendCredentialRequests({
       scopes: ["scopes"],
       credential: new AzureApplicationCredential(),
       insecureResponses: [
@@ -76,7 +70,7 @@ describe("AzureApplicationCredential testing Managed Identity (internal)", funct
       statusCode: 408,
     });
 
-    const { error } = await sendCredentialRequests({
+    const { error } = await testContext.sendCredentialRequests({
       scopes: ["scopes"],
       credential: new AzureApplicationCredential(),
       insecureResponses: [
@@ -93,7 +87,7 @@ describe("AzureApplicationCredential testing Managed Identity (internal)", funct
     process.env.MSI_ENDPOINT = "https://endpoint";
     process.env.MSI_SECRET = "secret";
 
-    const authDetails = await sendCredentialRequests({
+    const authDetails = await testContext.sendCredentialRequests({
       scopes: ["https://service/.default"],
       credential: new AzureApplicationCredential(),
       secureResponses: [

--- a/sdk/identity/identity/test/internal/node/onBehalfOfCredential.spec.ts
+++ b/sdk/identity/identity/test/internal/node/onBehalfOfCredential.spec.ts
@@ -5,20 +5,14 @@ import * as path from "path";
 import { assert } from "chai";
 import { isNode } from "@azure/core-util";
 import { OnBehalfOfCredential } from "../../../src";
-import {
-  createResponse,
-  IdentityTestContext,
-  SendCredentialRequests,
-} from "../../httpRequestsCommon";
-import { prepareIdentityTests, prepareMSALResponses } from "../../httpRequests";
+import { createResponse, IdentityTestContextInterface } from "../../httpRequestsCommon";
+import { IdentityTestContext, prepareMSALResponses } from "../../httpRequests";
 
 describe("OnBehalfOfCredential", function () {
-  let testContext: IdentityTestContext;
-  let sendCredentialRequests: SendCredentialRequests;
+  let testContext: IdentityTestContextInterface;
 
   beforeEach(async function () {
-    testContext = await prepareIdentityTests({ replaceLogger: true, logLevel: "verbose" });
-    sendCredentialRequests = testContext.sendCredentialRequests;
+    testContext = await new IdentityTestContext({ replaceLogger: true, logLevel: "verbose" });
   });
   afterEach(async function () {
     if (isNode) {
@@ -40,7 +34,7 @@ describe("OnBehalfOfCredential", function () {
         message.match("Initialized MSAL's On-Behalf-Of flow")
       ).length;
 
-    const authDetails = await sendCredentialRequests({
+    const authDetails = await testContext.sendCredentialRequests({
       scopes: ["https://test/.default"],
       credential,
       secureResponses: [
@@ -73,7 +67,7 @@ describe("OnBehalfOfCredential", function () {
         message.match("Initialized MSAL's On-Behalf-Of flow")
       ).length;
 
-    const authDetails = await sendCredentialRequests({
+    const authDetails = await testContext.sendCredentialRequests({
       scopes: ["https://test/.default"],
       credential,
       secureResponses: [

--- a/sdk/identity/identity/test/public/browser/clientSecretCredential.spec.ts
+++ b/sdk/identity/identity/test/public/browser/clientSecretCredential.spec.ts
@@ -3,27 +3,21 @@
 
 import { ClientSecretCredential } from "../../../src";
 import { assertClientCredentials } from "../../authTestUtils";
-import { prepareIdentityTests } from "../../httpRequests";
-import {
-  createResponse,
-  IdentityTestContext,
-  SendCredentialRequests,
-} from "../../httpRequestsCommon";
+import { IdentityTestContext } from "../../httpRequests";
+import { createResponse, IdentityTestContextInterface } from "../../httpRequestsCommon";
 
 describe("ClientSecretCredential", function () {
-  let testContext: IdentityTestContext;
-  let sendCredentialRequests: SendCredentialRequests;
+  let testContext: IdentityTestContextInterface;
 
   beforeEach(async function () {
-    testContext = await prepareIdentityTests({});
-    sendCredentialRequests = testContext.sendCredentialRequests;
+    testContext = new IdentityTestContext({});
   });
   afterEach(async function () {
     await testContext.restore();
   });
 
   it("sends an authorization request with the given credentials", async () => {
-    const authDetails = await sendCredentialRequests({
+    const authDetails = await testContext.sendCredentialRequests({
       scopes: ["scope"],
       credential: new ClientSecretCredential("tenant", "client", "secret"),
       secureResponses: [

--- a/sdk/identity/identity/test/public/browser/usernamePasswordCredential.spec.ts
+++ b/sdk/identity/identity/test/public/browser/usernamePasswordCredential.spec.ts
@@ -4,20 +4,14 @@
 import { assert } from "chai";
 import { assertClientCredentials } from "../../authTestUtils";
 import { UsernamePasswordCredential } from "../../../src";
-import {
-  createResponse,
-  IdentityTestContext,
-  SendCredentialRequests,
-} from "../../httpRequestsCommon";
-import { prepareIdentityTests } from "../../httpRequests";
+import { createResponse, IdentityTestContextInterface } from "../../httpRequestsCommon";
+import { IdentityTestContext } from "../../httpRequests";
 
 describe("UsernamePasswordCredential", function () {
-  let testContext: IdentityTestContext;
-  let sendCredentialRequests: SendCredentialRequests;
+  let testContext: IdentityTestContextInterface;
 
   beforeEach(async function () {
-    testContext = await prepareIdentityTests({});
-    sendCredentialRequests = testContext.sendCredentialRequests;
+    testContext = new IdentityTestContext({});
   });
   afterEach(async function () {
     await testContext.restore();
@@ -26,7 +20,7 @@ describe("UsernamePasswordCredential", function () {
   it("sends an authorization request with the given username and password", async () => {
     const password = "p@55wOrd";
 
-    const authDetails = await sendCredentialRequests({
+    const authDetails = await testContext.sendCredentialRequests({
       scopes: ["scope"],
       credential: new UsernamePasswordCredential("tenant", "client", "user@domain.com", password),
       secureResponses: [


### PR DESCRIPTION
**Checklists** 
- [x] Added impacted package name to the issue description

**Packages impacted by this PR:**

Identity.

**Issues associated with this PR:**

Fixes #19420

**Describe the problem that is addressed by this PR:**

Identity tests rely on some functions that mock the internals of our HTTP clients to extract the outgoing requests and responses, so that we can mock the responses, and later match the network behavior based to our expectations. These functions are rather complex at the moment.

**What are the possible designs available to address the problem**

Refactoring in my mind means minimal efforts that slowly reduce technical debt over time.

With that in mind, I think the most immediate way to improve this design is **to move it from a closure to a class**.

Closures are not that common in our SDK, in comparison to classes, which are everywhere.

Classes also help identify the context from which the variable come better than closures (the `this.name` is easier to contextualize than just `name`).

My intuition tells me there are many more improvements I could make, but I don’t know how much time it will take me, so I am budgeting this PR to be the fastest approach that could yield a meaningful improvement rather than a thorough overwrite.