### PR TITLE
[core] - Use correct span names for tracing policies

### DIFF
--- a/sdk/core/core-http/src/policies/tracingPolicy.ts
+++ b/sdk/core/core-http/src/policies/tracingPolicy.ts
@@ -86,11 +86,11 @@ export class TracingPolicy extends BaseRequestPolicy {
 
   tryCreateSpan(request: WebResourceLike): Span | undefined {
     try {
-      const path = URLBuilder.parse(request.url).getPath() || "/";
+      const scheme = URLBuilder.parse(request.url).getScheme() || "https";
 
       // Passing spanOptions as part of tracingOptions to maintain compatibility @azure/core-tracing@preview.13 and earlier.
       // We can pass this as a separate parameter once we upgrade to the latest core-tracing.
-      const { span } = createSpan(path, {
+      const { span } = createSpan(`${scheme.toUpperCase()} ${request.method}`, {
         tracingOptions: {
           spanOptions: {
             ...(request as any).spanOptions,

--- a/sdk/core/core-http/src/policies/tracingPolicy.ts
+++ b/sdk/core/core-http/src/policies/tracingPolicy.ts
@@ -16,7 +16,6 @@ import {
   isSpanContextValid,
 } from "@azure/core-tracing";
 import { HttpOperationResponse } from "../httpOperationResponse";
-import { URLBuilder } from "../url";
 import { WebResourceLike } from "../webResource";
 import { logger } from "../log";
 
@@ -86,11 +85,9 @@ export class TracingPolicy extends BaseRequestPolicy {
 
   tryCreateSpan(request: WebResourceLike): Span | undefined {
     try {
-      const scheme = URLBuilder.parse(request.url).getScheme() || "https";
-
       // Passing spanOptions as part of tracingOptions to maintain compatibility @azure/core-tracing@preview.13 and earlier.
       // We can pass this as a separate parameter once we upgrade to the latest core-tracing.
-      const { span } = createSpan(`${scheme.toUpperCase()} ${request.method}`, {
+      const { span } = createSpan(`HTTP ${request.method}`, {
         tracingOptions: {
           spanOptions: {
             ...(request as any).spanOptions,

--- a/sdk/core/core-http/test/policies/tracingPolicyTests.ts
+++ b/sdk/core/core-http/test/policies/tracingPolicyTests.ts
@@ -225,7 +225,7 @@ describe("tracingPolicy", function () {
     await policy.sendRequest(request);
     assert.lengthOf(mockTracer.getStartedSpans(), 1);
     const span = mockTracer.getStartedSpans()[0];
-    assert.equal(span.getName(), "HTTPS POST");
+    assert.equal(span.getName(), "HTTP POST");
     assert.equal(span.getAttribute("az.namespace"), "test");
     assert.equal(span.getAttribute("http.method"), "POST");
     assert.equal(span.getAttribute("http.url"), request.url);

--- a/sdk/core/core-rest-pipeline/src/policies/tracingPolicy.ts
+++ b/sdk/core/core-rest-pipeline/src/policies/tracingPolicy.ts
@@ -80,11 +80,12 @@ function tryCreateSpan(request: PipelineRequest, userAgent?: string): Span | und
     };
 
     const url = new URL(request.url);
-    const path = url.pathname || "/";
+    // "https:" => "HTTPS"
+    const protocol = url.protocol.substr(0, url.protocol.length - 1).toUpperCase();
 
     // Passing spanOptions as part of tracingOptions to maintain compatibility @azure/core-tracing@preview.13 and earlier.
     // We can pass this as a separate parameter once we upgrade to the latest core-tracing.
-    const { span } = createSpan(path, {
+    const { span } = createSpan(`${protocol} ${request.method}`, {
       tracingOptions: { ...request.tracingOptions, spanOptions: createSpanOptions },
     });
 

--- a/sdk/core/core-rest-pipeline/src/policies/tracingPolicy.ts
+++ b/sdk/core/core-rest-pipeline/src/policies/tracingPolicy.ts
@@ -80,6 +80,7 @@ function tryCreateSpan(request: PipelineRequest, userAgent?: string): Span | und
 
     // Passing spanOptions as part of tracingOptions to maintain compatibility @azure/core-tracing@preview.13 and earlier.
     // We can pass this as a separate parameter once we upgrade to the latest core-tracing.
+    // As per spec, we do not need to differentiate between HTTP and HTTPS in span name.
     const { span } = createSpan(`HTTP ${request.method}`, {
       tracingOptions: { ...request.tracingOptions, spanOptions: createSpanOptions },
     });

--- a/sdk/core/core-rest-pipeline/src/policies/tracingPolicy.ts
+++ b/sdk/core/core-rest-pipeline/src/policies/tracingPolicy.ts
@@ -12,7 +12,6 @@ import {
 import { SpanKind } from "@azure/core-tracing";
 import { PipelineResponse, PipelineRequest, SendRequest } from "../interfaces";
 import { PipelinePolicy } from "../pipeline";
-import { URL } from "../util/url";
 import { getUserAgentValue } from "../util/userAgent";
 import { logger } from "../log";
 
@@ -79,13 +78,9 @@ function tryCreateSpan(request: PipelineRequest, userAgent?: string): Span | und
       kind: SpanKind.CLIENT,
     };
 
-    const url = new URL(request.url);
-    // "https:" => "HTTPS"
-    const protocol = url.protocol.substr(0, url.protocol.length - 1).toUpperCase();
-
     // Passing spanOptions as part of tracingOptions to maintain compatibility @azure/core-tracing@preview.13 and earlier.
     // We can pass this as a separate parameter once we upgrade to the latest core-tracing.
-    const { span } = createSpan(`${protocol} ${request.method}`, {
+    const { span } = createSpan(`HTTP ${request.method}`, {
       tracingOptions: { ...request.tracingOptions, spanOptions: createSpanOptions },
     });
 

--- a/sdk/core/core-rest-pipeline/test/tracingPolicy.spec.ts
+++ b/sdk/core/core-rest-pipeline/test/tracingPolicy.spec.ts
@@ -88,7 +88,7 @@ export class MockSpan implements Span {
     return this;
   }
 
-  getName() {
+  getName(): string {
     return this.name;
   }
 

--- a/sdk/core/core-rest-pipeline/test/tracingPolicy.spec.ts
+++ b/sdk/core/core-rest-pipeline/test/tracingPolicy.spec.ts
@@ -237,7 +237,7 @@ describe("tracingPolicy", function () {
 
     assert.lengthOf(mockTracer.getStartedSpans(), 1);
     const span = mockTracer.getStartedSpans()[0];
-    assert.equal(span.getName(), "HTTPS POST");
+    assert.equal(span.getName(), "HTTP POST");
     assert.equal(span.getAttribute("az.namespace"), "test");
     assert.equal(span.getAttribute("http.method"), "POST");
     assert.equal(span.getAttribute("http.url"), request.url);
@@ -350,7 +350,6 @@ describe("tracingPolicy", function () {
     assert.lengthOf(mockTracer.getStartedSpans(), 1);
     const span = mockTracer.getStartedSpans()[0];
     assert.isTrue(span.didEnd());
-    assert.equal(span.getName(), "HTTPS PUT");
     assert.deepEqual(span.getStatus(), { code: SpanStatusCode.OK });
 
     const expectedFlag = "01";

--- a/sdk/storage/storage-blob/test/blobclient.spec.ts
+++ b/sdk/storage/storage-blob/test/blobclient.spec.ts
@@ -737,7 +737,7 @@ describe("BlobClient", () => {
               name: "Azure.Storage.Blob.BlobClient-download",
               children: [
                 {
-                  name: "HTTPS GET",
+                  name: "HTTP GET",
                   children: [],
                 },
               ],

--- a/sdk/storage/storage-blob/test/blobclient.spec.ts
+++ b/sdk/storage/storage-blob/test/blobclient.spec.ts
@@ -728,7 +728,6 @@ describe("BlobClient", () => {
     assert.strictEqual(rootSpans.length, 1, "Should only have one root span.");
     assert.strictEqual(rootSpan, rootSpans[0], "The root span should match what was passed in.");
 
-    const urlPath = URLBuilder.parse(blobClient.url).getPath() || "";
     const expectedGraph: SpanGraph = {
       roots: [
         {
@@ -738,7 +737,7 @@ describe("BlobClient", () => {
               name: "Azure.Storage.Blob.BlobClient-download",
               children: [
                 {
-                  name: urlPath,
+                  name: "HTTPS GET",
                   children: [],
                 },
               ],

--- a/sdk/storage/storage-blob/test/containerclient.spec.ts
+++ b/sdk/storage/storage-blob/test/containerclient.spec.ts
@@ -12,7 +12,6 @@ import {
 } from "./utils";
 import { record, Recorder } from "@azure-tools/test-recorder";
 import { getYieldedValue } from "@azure/test-utils";
-import { URLBuilder } from "@azure/core-http";
 import {
   ContainerClient,
   BlockBlobTier,
@@ -764,7 +763,6 @@ describe("ContainerClient", () => {
     assert.strictEqual(rootSpans.length, 1, "Should only have one root span.");
     assert.strictEqual(rootSpan, rootSpans[0], "The root span should match what was passed in.");
 
-    const urlPath = URLBuilder.parse(blockBlobClient.url).getPath() || "";
     const expectedGraph: SpanGraph = {
       roots: [
         {
@@ -777,7 +775,7 @@ describe("ContainerClient", () => {
                   name: "Azure.Storage.Blob.BlockBlobClient-upload",
                   children: [
                     {
-                      name: urlPath,
+                      name: "HTTPS PUT",
                       children: [],
                     },
                   ],

--- a/sdk/storage/storage-blob/test/containerclient.spec.ts
+++ b/sdk/storage/storage-blob/test/containerclient.spec.ts
@@ -775,7 +775,7 @@ describe("ContainerClient", () => {
                   name: "Azure.Storage.Blob.BlockBlobClient-upload",
                   children: [
                     {
-                      name: "HTTPS PUT",
+                      name: "HTTP PUT",
                       children: [],
                     },
                   ],

--- a/sdk/storage/storage-file-datalake/test/filesystemclient.spec.ts
+++ b/sdk/storage/storage-file-datalake/test/filesystemclient.spec.ts
@@ -19,7 +19,6 @@ import {
   getGenericDataLakeServiceClient,
   recorderEnvSetup,
 } from "./utils";
-import { URLBuilder } from "@azure/core-http";
 import { Context } from "mocha";
 
 describe("DataLakeFileSystemClient", () => {
@@ -74,7 +73,6 @@ describe("DataLakeFileSystemClient", () => {
     assert.strictEqual(rootSpans.length, 1, "Should only have one root span.");
     assert.strictEqual(rootSpan, rootSpans[0], "The root span should match what was passed in.");
 
-    const urlPath = URLBuilder.parse(fileSystemClient.url).getPath() || "";
     const expectedGraph: SpanGraph = {
       roots: [
         {
@@ -87,7 +85,7 @@ describe("DataLakeFileSystemClient", () => {
                   name: "Azure.Storage.Blob.ContainerClient-setMetadata",
                   children: [
                     {
-                      name: urlPath,
+                      name: "HTTP PUT",
                       children: [],
                     },
                   ],

--- a/sdk/storage/storage-file-datalake/test/pathclient.spec.ts
+++ b/sdk/storage/storage-file-datalake/test/pathclient.spec.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 
 import { AbortController } from "@azure/abort-controller";
-import { isNode, URLBuilder, delay } from "@azure/core-http";
+import { isNode, delay } from "@azure/core-http";
 import { SpanGraph, setTracer } from "@azure/test-utils";
 import { record, Recorder } from "@azure-tools/test-recorder";
 import { setSpan, context } from "@azure/core-tracing";
@@ -164,7 +164,6 @@ describe("DataLakePathClient", () => {
     assert.strictEqual(rootSpans.length, 1, "Should only have one root span.");
     assert.strictEqual(rootSpan, rootSpans[0], "The root span should match what was passed in.");
 
-    const urlPath = URLBuilder.parse(fileClient.url).getPath() || "";
     const expectedGraph: SpanGraph = {
       roots: [
         {
@@ -177,7 +176,7 @@ describe("DataLakePathClient", () => {
                   name: "Azure.Storage.Blob.BlobClient-download",
                   children: [
                     {
-                      name: urlPath,
+                      name: "HTTP GET",
                       children: [],
                     },
                   ],

--- a/sdk/storage/storage-file-share/test/directoryclient.spec.ts
+++ b/sdk/storage/storage-file-share/test/directoryclient.spec.ts
@@ -8,7 +8,6 @@ import { record, Recorder } from "@azure-tools/test-recorder";
 import { DirectoryCreateResponse } from "../src/generated/src/models";
 import { truncatedISO8061Date } from "../src/utils/utils.common";
 import { SpanGraph, setTracer, getYieldedValue } from "@azure/test-utils";
-import { URLBuilder } from "@azure/core-http";
 import { MockPolicyFactory } from "./utils/MockPolicyFactory";
 import { Pipeline } from "../src/Pipeline";
 import { setSpan, context } from "@azure/core-tracing";
@@ -740,8 +739,6 @@ describe("DirectoryClient", () => {
     assert.strictEqual(rootSpans.length, 1, "Should only have one root span.");
     assert.strictEqual(rootSpan, rootSpans[0], "The root span should match what was passed in.");
 
-    const subDirPath = URLBuilder.parse(subDirClient.url).getPath() || "";
-
     const expectedGraph: SpanGraph = {
       roots: [
         {
@@ -754,7 +751,7 @@ describe("DirectoryClient", () => {
                   name: "Azure.Storage.File.ShareDirectoryClient-create",
                   children: [
                     {
-                      name: subDirPath,
+                      name: "HTTP PUT",
                       children: [],
                     },
                   ],
@@ -768,7 +765,7 @@ describe("DirectoryClient", () => {
                   name: "Azure.Storage.File.ShareFileClient-create",
                   children: [
                     {
-                      name: "HTTP POST",
+                      name: "HTTP PUT",
                       children: [],
                     },
                   ],
@@ -779,7 +776,7 @@ describe("DirectoryClient", () => {
               name: "Azure.Storage.File.ShareFileClient-getProperties",
               children: [
                 {
-                  name: "HTTP GET",
+                  name: "HTTP HEAD",
                   children: [],
                 },
               ],
@@ -802,7 +799,7 @@ describe("DirectoryClient", () => {
               name: "Azure.Storage.File.ShareFileClient-getProperties",
               children: [
                 {
-                  name: "HTTP GET",
+                  name: "HTTP HEAD",
                   children: [],
                 },
               ],

--- a/sdk/storage/storage-file-share/test/directoryclient.spec.ts
+++ b/sdk/storage/storage-file-share/test/directoryclient.spec.ts
@@ -741,7 +741,6 @@ describe("DirectoryClient", () => {
     assert.strictEqual(rootSpan, rootSpans[0], "The root span should match what was passed in.");
 
     const subDirPath = URLBuilder.parse(subDirClient.url).getPath() || "";
-    const filePath = URLBuilder.parse(fileClient.url).getPath() || "";
 
     const expectedGraph: SpanGraph = {
       roots: [
@@ -769,7 +768,7 @@ describe("DirectoryClient", () => {
                   name: "Azure.Storage.File.ShareFileClient-create",
                   children: [
                     {
-                      name: filePath,
+                      name: "HTTP POST",
                       children: [],
                     },
                   ],
@@ -780,7 +779,7 @@ describe("DirectoryClient", () => {
               name: "Azure.Storage.File.ShareFileClient-getProperties",
               children: [
                 {
-                  name: filePath,
+                  name: "HTTP GET",
                   children: [],
                 },
               ],
@@ -792,7 +791,7 @@ describe("DirectoryClient", () => {
                   name: "Azure.Storage.File.ShareFileClient-delete",
                   children: [
                     {
-                      name: filePath,
+                      name: "HTTP DELETE",
                       children: [],
                     },
                   ],
@@ -803,7 +802,7 @@ describe("DirectoryClient", () => {
               name: "Azure.Storage.File.ShareFileClient-getProperties",
               children: [
                 {
-                  name: filePath,
+                  name: "HTTP GET",
                   children: [],
                 },
               ],
@@ -812,7 +811,7 @@ describe("DirectoryClient", () => {
               name: "Azure.Storage.File.ShareDirectoryClient-delete",
               children: [
                 {
-                  name: subDirPath,
+                  name: "HTTP DELETE",
                   children: [],
                 },
               ],

--- a/sdk/storage/storage-file-share/test/fileclient.spec.ts
+++ b/sdk/storage/storage-file-share/test/fileclient.spec.ts
@@ -816,8 +816,6 @@ describe("FileClient", () => {
     assert.strictEqual(rootSpans.length, 1, "Should only have one root span.");
     assert.strictEqual(rootSpan, rootSpans[0], "The root span should match what was passed in.");
 
-    const urlPath = URLBuilder.parse(fileClient.url).getPath() || "";
-
     const expectedGraph: SpanGraph = {
       roots: [
         {
@@ -827,7 +825,7 @@ describe("FileClient", () => {
               name: "Azure.Storage.File.ShareFileClient-create",
               children: [
                 {
-                  name: urlPath,
+                  name: "HTTP PUT",
                   children: [],
                 },
               ],

--- a/sdk/storage/storage-queue/test/queueclient.spec.ts
+++ b/sdk/storage/storage-queue/test/queueclient.spec.ts
@@ -6,7 +6,7 @@ import { getQSU, getSASConnectionStringFromEnvironment } from "./utils";
 import { QueueClient, QueueServiceClient } from "../src";
 import { setSpan, context } from "@azure/core-tracing";
 import { SpanGraph, setTracer } from "@azure/test-utils";
-import { URLBuilder, RestError } from "@azure/core-http";
+import { RestError } from "@azure/core-http";
 import { Recorder, record } from "@azure-tools/test-recorder";
 import { recorderEnvSetup } from "./utils/testutils.common";
 import { Context } from "mocha";
@@ -209,8 +209,6 @@ describe("QueueClient", () => {
     assert.strictEqual(rootSpans.length, 1, "Should only have one root span.");
     assert.strictEqual(rootSpan, rootSpans[0], "The root span should match what was passed in.");
 
-    const urlPath = URLBuilder.parse(queueClient.url).getPath() || "";
-
     const expectedGraph: SpanGraph = {
       roots: [
         {
@@ -220,7 +218,7 @@ describe("QueueClient", () => {
               name: "Azure.Storage.Queue.QueueClient-getProperties",
               children: [
                 {
-                  name: urlPath,
+                  name: "HTTP GET",
                   children: [],
                 },
               ],


### PR DESCRIPTION
## What

- Use `HTTP <METHOD>` for tracingPolicy span names

## Why

As per the [spec and guidelines](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/http.md#name), we should ideally use generic, low cardinality
span names for aggregation, analysis, etc.

This PR updates both our policies to conform to the guidelines. While these
tracing policies are going to change very soon, having this in place now (and
the tests) ensures we won't regress this when we change to the new tracing APIs.

Resolves #17973
