### PR TITLE
[Identity] min-max tests failed because of inconsistent types loaded

### DIFF
--- a/sdk/identity/identity/test/public/node/clientCertificateCredential.spec.ts
+++ b/sdk/identity/identity/test/public/node/clientCertificateCredential.spec.ts
@@ -12,7 +12,7 @@ import { MsalTestCleanup, msalNodeTestSetup, testTracing } from "../../msalTestU
 import { ClientCertificateCredential } from "../../../src";
 import { Context } from "mocha";
 import { readFileSync } from "fs";
-import { PipelineRequest, PipelineResponse } from "@azure/core-rest-pipeline";
+import { PipelineResponse } from "@azure/core-rest-pipeline";
 
 const ASSET_PATH = "assets";
 
@@ -93,12 +93,10 @@ describe("ClientCertificateCredential", function () {
     const credential = new ClientCertificateCredential(
       env.AZURE_TENANT_ID,
       env.AZURE_CLIENT_ID,
-      {
-        certificatePath,
-      },
+      certificatePath,
       {
         httpClient: {
-          async sendRequest(_request: PipelineRequest): Promise<PipelineResponse> {
+          async sendRequest(): Promise<PipelineResponse> {
             await delay(100);
             throw new Error("Fake HTTP client.");
           },


### PR DESCRIPTION
**Checklists** 
- [x] Added impacted package name to the issue description

**Packages impacted by this PR:**

@azure/identity

**Describe the problem that is addressed by this PR:**

Even though we merged an update recently to fix min-max tests, https://github.com/Azure/azure-sdk-for-js/pull/19810 which we tested using the pipelines against that PR, nightly min-max tests ended up failing right afterwards. The error received was as follows:

```

node/clientCertificateCredential.spec.ts(93,24): error TS2769: No overload matches this call.
  Overload 1 of 2, '(tenantId: string, clientId: string, certificatePath: string, options?: ClientCertificateCredentialOptions | undefined): ClientCertificateCredential', gave the following error.
    Argument of type '{ certificatePath: string; }' is not assignable to parameter of type 'string'.
  Overload 2 of 2, '(tenantId: string, clientId: string, configuration: ClientCertificateCredentialPEMConfiguration, options?: ClientCertificateCredentialOptions | undefined): ClientCertificateCredential', gave the following error.
    Type '(_request: PipelineRequest) => Promise<PipelineResponse>' is not assignable to type 'SendRequest'.
      Types of parameters '_request' and 'request' are incompatible.
        Type 'import("/mnt/vss/_work/1/s/sdk/core/core-rest-pipeline/types/latest/core-rest-pipeline").PipelineRequest' is not assignable to type 'import("/mnt/vss/_work/1/s/common/temp/node_modules/.pnpm/@azure+core-rest-pipeline@1.4.0/node_modules/@azure/core-rest-pipeline/types/latest/core-rest-pipeline").PipelineRequest'.
          Types of property 'body' are incompatible.
            Type 'import("/mnt/vss/_work/1/s/sdk/core/core-rest-pipeline/types/latest/core-rest-pipeline").RequestBodyType | undefined' is not assignable to type 'import("/mnt/vss/_work/1/s/common/temp/node_modules/.pnpm/@azure+core-rest-pipeline@1.4.0/node_modules/@azure/core-rest-pipeline/types/latest/core-rest-pipeline").RequestBodyType | undefined'.
              Type 'ReadableStream<Uint8Array>' is not assignable to type 'RequestBodyType | undefined'.
                Type 'ReadableStream<Uint8Array>' is missing the following properties from type 'ReadableStream': readable, read, setEncoding, pause, and 22 more.
```

Having experienced similar issues in the past, I realized that this is likely because there are more than one copy of the same package loaded into TypeScript memory with a small version difference. Even if the types are identical, given that they don’t come from the same place, TypeScript can’t really assume they’re the same — that has been my experience in the past, at least.

So, my strategy was to find the simplest solution by perhaps removing an unnecessary type.

I followed the instructions to run min-max tests locally ([here](https://github.com/Azure/azure-sdk-for-js/tree/main/eng/tools/dependency-testing#setup-your-local-dev-environment-to-simulate-minmax-testing)). I reproduced the issue, then I was able to remove an unused parameter to fix it.