### PR TITLE
[synapse-monitoring] Fix packaging issues

### DIFF
--- a/sdk/synapse/synapse-monitoring/package.json
+++ b/sdk/synapse/synapse-monitoring/package.json
@@ -24,7 +24,7 @@
     "node": ">=12.0.0"
   },
   "main": "./dist/index.js",
-  "module": "./dist-esm/src/index.js",
+  "module": "./dist-esm/index.js",
   "types": "./types/synapse-monitoring.d.ts",
   "devDependencies": {
     "typescript": "~4.2.0",
@@ -47,10 +47,10 @@
     "dist/**/*.js.map",
     "dist/**/*.d.ts",
     "dist/**/*.d.ts.map",
-    "esm/**/*.js",
-    "esm/**/*.js.map",
-    "esm/**/*.d.ts",
-    "esm/**/*.d.ts.map",
+    "dist-esm/**/*.js",
+    "dist-esm/**/*.js.map",
+    "dist-esm/**/*.d.ts",
+    "dist-esm/**/*.d.ts.map",
     "types/synapse-monitoring.d.ts",
     "README.md",
     "rollup.config.js",

--- a/sdk/synapse/synapse-monitoring/rollup.config.js
+++ b/sdk/synapse/synapse-monitoring/rollup.config.js
@@ -2,7 +2,6 @@ import rollup from "rollup";
 import nodeResolve from "rollup-plugin-node-resolve";
 import sourcemaps from "rollup-plugin-sourcemaps";
 import cjs from "@rollup/plugin-commonjs";
-import { openTelemetryCommonJs } from "@azure/dev-tool/shared-config/rollup";
 
 
 const ignoreKnownWarnings = (warning) => {
@@ -50,8 +49,7 @@ const config = {
     sourcemaps(),
     cjs({
       namedExports: {
-        assert: ["ok", "deepEqual", "equal", "fail", "deepStrictEqual", "strictEqual"],
-        ...openTelemetryCommonJs()
+        assert: ["ok", "deepEqual", "equal", "fail", "deepStrictEqual", "strictEqual"]
       }
     })
   ]

--- a/sdk/synapse/synapse-monitoring/tsconfig.json
+++ b/sdk/synapse/synapse-monitoring/tsconfig.json
@@ -3,7 +3,7 @@
     "module": "es6",
     "moduleResolution": "node",
     "strict": true,
-    "target": "es5",
+    "target": "es6",
     "sourceMap": true,
     "declarationMap": true,
     "esModuleInterop": true,


### PR DESCRIPTION
There are a few packaging issues:

* the path of "module" field is incorrect
* the ESM output folder should be `dist-esm` as specified in tsconfig.json

While on this I also updated the compilation target to `es6`, and removed the
`openTelemetryCommonJs()` that is no longer needed.


**Checklists** 
- [x] Added impacted package name to the issue description

**Issues associated with this PR:**
#17707

**Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
No, codegen works expected.  This lib is generated + manual work on top of it.

**Are there test cases added in this PR?**_(If not, why?)_
packaging issue, not applicable.

