### PR TITLE
[dev-tool] Remove the `openTelemetryCommonJs()` export

### DIFF
--- a/common/tools/dev-tool/src/config/rollup.base.config.ts
+++ b/common/tools/dev-tool/src/config/rollup.base.config.ts
@@ -16,51 +16,6 @@ interface PackageJson {
   devDependencies: Record<string, string>;
 }
 
-/**
- * Gets the proper configuration needed for rollup's commonJS plugin for @opentelemetry/api.
- *
- * NOTE: this manual configuration is only needed because OpenTelemetry uses an
- * __exportStar downleveled helper function to declare its exports which confuses
- * rollup's automatic discovery mechanism.
- *
- * @returns an object reference that can be `...`'d into your cjs() configuration.
- */
-export function openTelemetryCommonJs(): Record<string, string[]> {
-  const namedExports: Record<string, string[]> = {};
-
-  for (const key of ["@opentelemetry/api", "@azure/core-tracing/node_modules/@opentelemetry/api"]) {
-    namedExports[key] = [
-      "SpanKind",
-      "TraceFlags",
-      "getSpan",
-      "setSpan",
-      "SpanStatusCode",
-      "getSpanContext",
-      "setSpanContext",
-    ];
-  }
-
-  const releasedOpenTelemetryVersions = ["0.10.2", "1.0.0-rc.0"];
-
-  for (const version of releasedOpenTelemetryVersions) {
-    namedExports[
-      // working around a limitation in the rollup common.js plugin - it's not able to resolve these modules so the named exports listed above will not get applied. We have to drill down to the actual path.
-      `../../../common/temp/node_modules/.pnpm/@opentelemetry+api@${version}/node_modules/@opentelemetry/api/build/src/index.js`
-    ] = [
-      "SpanKind",
-      "TraceFlags",
-      "getSpan",
-      "setSpan",
-      "StatusCode",
-      "CanonicalCode",
-      "getSpanContext",
-      "setSpanContext",
-    ];
-  }
-
-  return namedExports;
-}
-
 // #region Warning Handler
 
 /**

--- a/sdk/communication/communication-chat/rollup.test.config.js
+++ b/sdk/communication/communication-chat/rollup.test.config.js
@@ -12,7 +12,52 @@ import multiEntry from "@rollup/plugin-multi-entry";
 import replace from "@rollup/plugin-replace";
 import sourcemaps from "rollup-plugin-sourcemaps";
 import shim from "rollup-plugin-shim";
-import { makeBrowserTestConfig, openTelemetryCommonJs } from "@azure/dev-tool/shared-config/rollup";
+import { makeBrowserTestConfig } from "@azure/dev-tool/shared-config/rollup";
+
+/**
+ * Gets the proper configuration needed for rollup's commonJS plugin for @opentelemetry/api.
+ *
+ * NOTE: this manual configuration is only needed because OpenTelemetry uses an
+ * __exportStar downleveled helper function to declare its exports which confuses
+ * rollup's automatic discovery mechanism.
+ *
+ * @returns an object reference that can be `...`'d into your cjs() configuration.
+ */
+export function openTelemetryCommonJs() {
+  const namedExports = {};
+
+  for (const key of ["@opentelemetry/api", "@azure/core-tracing/node_modules/@opentelemetry/api"]) {
+    namedExports[key] = [
+      "SpanKind",
+      "TraceFlags",
+      "getSpan",
+      "setSpan",
+      "SpanStatusCode",
+      "getSpanContext",
+      "setSpanContext",
+    ];
+  }
+
+  const releasedOpenTelemetryVersions = ["0.10.2", "1.0.0-rc.0"];
+
+  for (const version of releasedOpenTelemetryVersions) {
+    namedExports[
+      // working around a limitation in the rollup common.js plugin - it's not able to resolve these modules so the named exports listed above will not get applied. We have to drill down to the actual path.
+      `../../../common/temp/node_modules/.pnpm/@opentelemetry+api@${version}/node_modules/@opentelemetry/api/build/src/index.js`
+    ] = [
+      "SpanKind",
+      "TraceFlags",
+      "getSpan",
+      "setSpan",
+      "StatusCode",
+      "CanonicalCode",
+      "getSpanContext",
+      "setSpanContext",
+    ];
+  }
+
+  return namedExports;
+}
 
 function makeBrowserTestConfigPatch() {
   const config = { ...makeBrowserTestConfig(require("./package.json")) };

--- a/sdk/communication/communication-network-traversal/rollup.test.config.js
+++ b/sdk/communication/communication-network-traversal/rollup.test.config.js
@@ -11,7 +11,52 @@ import multiEntry from "@rollup/plugin-multi-entry";
 import replace from "@rollup/plugin-replace";
 import sourcemaps from "rollup-plugin-sourcemaps";
 import shim from "rollup-plugin-shim";
-import { makeBrowserTestConfig, openTelemetryCommonJs } from "@azure/dev-tool/shared-config/rollup";
+import { makeBrowserTestConfig } from "@azure/dev-tool/shared-config/rollup";
+
+/**
+ * Gets the proper configuration needed for rollup's commonJS plugin for @opentelemetry/api.
+ *
+ * NOTE: this manual configuration is only needed because OpenTelemetry uses an
+ * __exportStar downleveled helper function to declare its exports which confuses
+ * rollup's automatic discovery mechanism.
+ *
+ * @returns an object reference that can be `...`'d into your cjs() configuration.
+ */
+export function openTelemetryCommonJs() {
+  const namedExports = {};
+
+  for (const key of ["@opentelemetry/api", "@azure/core-tracing/node_modules/@opentelemetry/api"]) {
+    namedExports[key] = [
+      "SpanKind",
+      "TraceFlags",
+      "getSpan",
+      "setSpan",
+      "SpanStatusCode",
+      "getSpanContext",
+      "setSpanContext",
+    ];
+  }
+
+  const releasedOpenTelemetryVersions = ["0.10.2", "1.0.0-rc.0"];
+
+  for (const version of releasedOpenTelemetryVersions) {
+    namedExports[
+      // working around a limitation in the rollup common.js plugin - it's not able to resolve these modules so the named exports listed above will not get applied. We have to drill down to the actual path.
+      `../../../common/temp/node_modules/.pnpm/@opentelemetry+api@${version}/node_modules/@opentelemetry/api/build/src/index.js`
+    ] = [
+      "SpanKind",
+      "TraceFlags",
+      "getSpan",
+      "setSpan",
+      "StatusCode",
+      "CanonicalCode",
+      "getSpanContext",
+      "setSpanContext",
+    ];
+  }
+
+  return namedExports;
+}
 
 function makeBrowserTestConfigPatch() {
   const config = { ...makeBrowserTestConfig(require("./package.json")) };


### PR DESCRIPTION
It is a workaround for packages that uses older version of core-tracing
libraries. Now it only applies to two packages.  This PR removes the export from
`dev-tool` and have copies of the function in the two communication packages'
test rollup config instead.

Part of #17707
