### PR TITLE
[AppConfig][Test] Fix integration test failure

### DIFF
--- a/sdk/appconfiguration/app-configuration/test/internal/node/package.spec.ts
+++ b/sdk/appconfiguration/app-configuration/test/internal/node/package.spec.ts
@@ -19,7 +19,7 @@ describe("packagejson related tests", () => {
     try {
       // For integration tests
       packageJsonContents = JSON.parse(
-        fs.readFileSync(path.join(__dirname, "../../../package.json"), { encoding: "utf-8" })
+        fs.readFileSync(path.join(__dirname, "../../../../package.json"), { encoding: "utf-8" })
       );
     } catch (e) {
       // For unit tests

--- a/sdk/appconfiguration/app-configuration/test/internal/node/package.spec.ts
+++ b/sdk/appconfiguration/app-configuration/test/internal/node/package.spec.ts
@@ -24,7 +24,7 @@ describe("packagejson related tests", () => {
     } catch (e) {
       // For unit tests
       packageJsonContents = JSON.parse(
-        fs.readFileSync(path.join(__dirname, "../../package.json"), { encoding: "utf-8" })
+        fs.readFileSync(path.join(__dirname, "../../../package.json"), { encoding: "utf-8" })
       );
     }
 


### PR DESCRIPTION
in PR #19713, this test (package.spec.ts) was moved into `node` sub folder, and the
relative path is updated for the `unit-test` case but not the `integration-test`
case.  The fix wasn't enough, but PR unit-test ended passing because the old relative 
path of `../../../` for integration tests matched for unit-test.

This PR fixes the relative path for both now.