### PR TITLE
[eventgrid][servicebus] - Update tests to reflect tracingPolicy changes

### DIFF
--- a/sdk/core/core-http/CHANGELOG.md
+++ b/sdk/core/core-http/CHANGELOG.md
@@ -8,6 +8,9 @@
 
 ### Bugs Fixed
 
+- Updated our tracing span names to conform to the [OpenTelemetry Specification](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/http.md#name)
+  - New HTTP spans will use the `HTTP <VERB>` convention instead of using the URL path.
+
 ### Other Changes
 
 ## 2.2.3 (2022-01-06)

--- a/sdk/core/core-http/CHANGELOG.md
+++ b/sdk/core/core-http/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Bugs Fixed
 
-- Updated our tracing span names to conform to the [OpenTelemetry Specification](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/http.md#name)
+- Updated the HTTP tracing span names to conform to the [OpenTelemetry Specification](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/http.md#name). [#19838](https://github.com/Azure/azure-sdk-for-js/pull/19838)
   - New HTTP spans will use the `HTTP <VERB>` convention instead of using the URL path.
 
 ### Other Changes

--- a/sdk/core/core-rest-pipeline/CHANGELOG.md
+++ b/sdk/core/core-rest-pipeline/CHANGELOG.md
@@ -8,6 +8,9 @@
 
 ### Bugs Fixed
 
+- Updated our tracing span names to conform to the [OpenTelemetry Specification](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/http.md#name)
+  - New HTTP spans will use the `HTTP <VERB>` convention instead of using the URL path.
+
 ### Other Changes
 
 ## 1.4.0 (2022-01-06)

--- a/sdk/core/core-rest-pipeline/CHANGELOG.md
+++ b/sdk/core/core-rest-pipeline/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Bugs Fixed
 
-- Updated our tracing span names to conform to the [OpenTelemetry Specification](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/http.md#name)
+- Updated the HTTP tracing span names to conform to the [OpenTelemetry Specification](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/http.md#name). [#19838](https://github.com/Azure/azure-sdk-for-js/pull/19838)
   - New HTTP spans will use the `HTTP <VERB>` convention instead of using the URL path.
 
 ### Other Changes

--- a/sdk/eventgrid/eventgrid/test/public/eventGridClient.spec.ts
+++ b/sdk/eventgrid/eventgrid/test/public/eventGridClient.spec.ts
@@ -239,7 +239,6 @@ describe("EventGridPublisherClient", function (this: Suite) {
       assert.equal(spans.length, 3);
       assert.equal(spans[0].name, "root");
       assert.equal(spans[1].name, "Azure.Data.EventGrid.EventGridPublisherClient-send");
-      assert.equal(spans[2].name, "HTTP POST");
 
       resetTracer();
     });

--- a/sdk/eventgrid/eventgrid/test/public/eventGridClient.spec.ts
+++ b/sdk/eventgrid/eventgrid/test/public/eventGridClient.spec.ts
@@ -239,7 +239,7 @@ describe("EventGridPublisherClient", function (this: Suite) {
       assert.equal(spans.length, 3);
       assert.equal(spans[0].name, "root");
       assert.equal(spans[1].name, "Azure.Data.EventGrid.EventGridPublisherClient-send");
-      assert.equal(spans[2].name, "/api/events");
+      assert.equal(spans[2].name, "HTTP POST");
 
       resetTracer();
     });

--- a/sdk/servicebus/service-bus/test/internal/operationOptionsForATOM.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/operationOptionsForATOM.spec.ts
@@ -264,7 +264,7 @@ describe("Operation Options", () => {
                     children: [
                       {
                         children: [],
-                        name: "/$namespaceinfo",
+                        name: "HTTP GET",
                       },
                     ],
                     name: "Azure.ServiceBus.ServiceBusAdministrationClient-getResource",


### PR DESCRIPTION
**Checklists** 
- [x] Added impacted package name to the issue description

**Packages impacted by this PR:** 
@azure/event-grid, @azure/service-bus

**Describe the problem that is addressed by this PR:**
In order to conform to the OTel spec and allow for easier aggregations we
updated tracing policy to name the span `HTTP <method>` instead of `<path>`.
Unfortunately we missed a few tests, so this updates those tests to reflect the
core changes.

While editing these tests, I realized I never added CHANGELOG entries for the original
change. This PR addresses that as well.

**Provide a list of related PRs**_(if any)_
#19838

Resolves #19887
Resolves #19885 
