### PR TITLE
[servicebus] set receiver max listener limit to 1000

### DIFF
--- a/sdk/servicebus/service-bus/src/core/messageReceiver.ts
+++ b/sdk/servicebus/service-bus/src/core/messageReceiver.ts
@@ -204,11 +204,13 @@ export abstract class MessageReceiver extends LinkEntity<Receiver> {
     }
   }
 
-  protected createRheaLink(
+  protected async createRheaLink(
     options: ReceiverOptions,
     _abortSignal?: AbortSignalLike
   ): Promise<Receiver> {
-    return this._context.connection.createReceiver(options);
+    const receiver = await this._context.connection.createReceiver(options);
+    receiver.setMaxListeners(1000);
+    return receiver;
   }
 
   /**

--- a/sdk/servicebus/service-bus/src/session/messageSession.ts
+++ b/sdk/servicebus/service-bus/src/session/messageSession.ts
@@ -248,11 +248,13 @@ export class MessageSession extends LinkEntity<Receiver> {
     }
   }
 
-  protected createRheaLink(
+  protected async createRheaLink(
     options: ReceiverOptions,
     _abortSignal?: AbortSignalLike
   ): Promise<Receiver> {
-    return this._context.connection.createReceiver(options);
+    const receiver = await this._context.connection.createReceiver(options);
+    receiver.setMaxListeners(1000);
+    return receiver;
   }
 
   /**


### PR DESCRIPTION
**Issues associated with this PR:**
#12161

**Describe the problem that is addressed by this PR:**
During stress tests we are seeing warnings of 
```
MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 disconnected listeners added to [Connection]. Use emitter.setMaxListeners() to increase limit
```
When many sessions on a connection are closed but the removal of the listener hasn't caught up, we will see this warning because the default limit of 10 in NodeJS is too low.  The disconnected listeners DO get removed eventually.

This PR increases the max listener limiter for receiver to 1000.   We have done similar for the sender.

**What are the possible designs available to address the problem**
Another proposal is in PR https://github.com/amqp/rhea-promise/pull/78. It is however looks too complicated.

**If there are more than one possible design, why was the one in this PR chosen?**
This PR is simpler, and in line with what we are already doing for senders.
