### PR TITLE
[KeyVault] - Enable multi-version tests for KV certificates

### DIFF
--- a/sdk/keyvault/keyvault-certificates/package.json
+++ b/sdk/keyvault/keyvault-certificates/package.json
@@ -50,7 +50,7 @@
     "clean": "rimraf dist-esm dist-test types *.tgz *.log samples/typescript/dist",
     "execute:samples": "dev-tool samples run samples-dev",
     "extract-api": "tsc -p . && api-extractor run --local",
-    "format": "prettier --write --config ../../../.prettierrc.json --ignore-path ../../../.prettierignore \"src/**/*.ts\" \"samples/*.ts\" \"test/**/*.ts\" \"samples-dev/**/*.ts\" \"*.{js,json}\"",
+    "format": "prettier --write --config ../../../.prettierrc.json --ignore-path ../../../.prettierignore \"src/**/*.ts\" \"samples-dev/*.ts\" \"test/**/*.ts\" \"samples-dev/**/*.ts\" \"*.{js,json}\"",
     "generate:client": "autorest --typescript swagger/README.md",
     "integration-test:browser": "karma start --single-run",
     "integration-test:node": "nyc mocha -r esm --require source-map-support/register --reporter ../../../common/tools/mocha-multi-reporter.js --timeout 350000 --full-trace \"dist-esm/**/*.spec.js\"",

--- a/sdk/keyvault/keyvault-certificates/platform-matrix.json
+++ b/sdk/keyvault/keyvault-certificates/platform-matrix.json
@@ -1,0 +1,20 @@
+{
+  "include": [
+    {
+      "Agent": {
+        "ubuntu-20.04": {
+          "OSVmImage": "MMSUbuntu20.04",
+          "Pool": "azsdk-pool-mms-ubuntu-2004-general"
+        }
+      },
+      "TestType": "node",
+      "NodeTestVersion": "16.x",
+      "ServiceVersion": ["7.0", "7.1", "7.2"]
+    }
+  ],
+  "displayNames": {
+    "7.0": "service_version_7_0",
+    "7.1": "service_version_7_1",
+    "7.2": "service_version_7_2"
+  }
+}

--- a/sdk/keyvault/keyvault-certificates/test/internal/challengeBasedAuthenticationPolicy.spec.ts
+++ b/sdk/keyvault/keyvault-certificates/test/internal/challengeBasedAuthenticationPolicy.spec.ts
@@ -5,6 +5,7 @@ import { assert } from "chai";
 import { Context } from "mocha";
 import { createSandbox } from "sinon";
 import { env, Recorder } from "@azure-tools/test-recorder";
+import { getServiceVersion } from "../utils/utils.common";
 
 import {
   AuthenticationChallengeCache,
@@ -37,7 +38,7 @@ describe("Challenge based authentication tests", () => {
   };
 
   beforeEach(async function (this: Context) {
-    const authentication = await authenticate(this);
+    const authentication = await authenticate(this, getServiceVersion());
     certificateSuffix = authentication.suffix;
     client = authentication.client;
     testClient = authentication.testClient;

--- a/sdk/keyvault/keyvault-certificates/test/public/CRUD.spec.ts
+++ b/sdk/keyvault/keyvault-certificates/test/public/CRUD.spec.ts
@@ -18,6 +18,7 @@ import { CertificateClient } from "../../src";
 import { assertThrowsAbortError } from "../utils/utils.common";
 import { testPollerProperties } from "../utils/recorderUtils";
 import { authenticate } from "../utils/testAuthentication";
+import { getServiceVersion } from "../utils/utils.common";
 import TestClient from "../utils/testClient";
 
 describe("Certificates client - create, read, update and delete", () => {
@@ -36,7 +37,7 @@ describe("Certificates client - create, read, update and delete", () => {
   };
 
   beforeEach(async function (this: Context) {
-    const authentication = await authenticate(this);
+    const authentication = await authenticate(this, getServiceVersion());
     suffix = authentication.suffix;
     client = authentication.client;
     testClient = authentication.testClient;

--- a/sdk/keyvault/keyvault-certificates/test/public/list.spec.ts
+++ b/sdk/keyvault/keyvault-certificates/test/public/list.spec.ts
@@ -11,6 +11,7 @@ import { CertificateClient } from "../../src";
 import { assertThrowsAbortError } from "../utils/utils.common";
 import { testPollerProperties } from "../utils/recorderUtils";
 import { authenticate } from "../utils/testAuthentication";
+import { getServiceVersion } from "../utils/utils.common";
 import TestClient from "../utils/testClient";
 
 const { expect } = chai;
@@ -28,7 +29,7 @@ describe("Certificates client - list certificates in various ways", () => {
   };
 
   beforeEach(async function (this: Context) {
-    const authentication = await authenticate(this);
+    const authentication = await authenticate(this, getServiceVersion());
     suffix = authentication.suffix;
     client = authentication.client;
     testClient = authentication.testClient;

--- a/sdk/keyvault/keyvault-certificates/test/public/lro.create.spec.ts
+++ b/sdk/keyvault/keyvault-certificates/test/public/lro.create.spec.ts
@@ -9,6 +9,7 @@ import { env, Recorder } from "@azure-tools/test-recorder";
 import { CertificateClient, KeyVaultCertificate, DefaultCertificatePolicy } from "../../src";
 import { testPollerProperties } from "../utils/recorderUtils";
 import { authenticate } from "../utils/testAuthentication";
+import { getServiceVersion } from "../utils/utils.common";
 import TestClient from "../utils/testClient";
 
 describe("Certificates client - LRO - create", () => {
@@ -19,7 +20,7 @@ describe("Certificates client - LRO - create", () => {
   let recorder: Recorder;
 
   beforeEach(async function (this: Context) {
-    const authentication = await authenticate(this);
+    const authentication = await authenticate(this, getServiceVersion());
     certificateSuffix = authentication.suffix;
     client = authentication.client;
     testClient = authentication.testClient;

--- a/sdk/keyvault/keyvault-certificates/test/public/lro.delete.spec.ts
+++ b/sdk/keyvault/keyvault-certificates/test/public/lro.delete.spec.ts
@@ -9,6 +9,7 @@ import { env, Recorder } from "@azure-tools/test-recorder";
 import { CertificateClient, DeletedCertificate, DefaultCertificatePolicy } from "../../src";
 import { testPollerProperties } from "../utils/recorderUtils";
 import { authenticate } from "../utils/testAuthentication";
+import { getServiceVersion } from "../utils/utils.common";
 import TestClient from "../utils/testClient";
 
 describe("Certificates client - lro - delete", () => {
@@ -19,7 +20,7 @@ describe("Certificates client - lro - delete", () => {
   let recorder: Recorder;
 
   beforeEach(async function (this: Context) {
-    const authentication = await authenticate(this);
+    const authentication = await authenticate(this, getServiceVersion());
     certificateSuffix = authentication.suffix;
     client = authentication.client;
     testClient = authentication.testClient;

--- a/sdk/keyvault/keyvault-certificates/test/public/lro.operation.spec.ts
+++ b/sdk/keyvault/keyvault-certificates/test/public/lro.operation.spec.ts
@@ -13,6 +13,7 @@ import {
 } from "../../src";
 import { testPollerProperties } from "../utils/recorderUtils";
 import { authenticate } from "../utils/testAuthentication";
+import { getServiceVersion } from "../utils/utils.common";
 import TestClient from "../utils/testClient";
 
 describe("Certificates client - LRO - certificate operation", () => {
@@ -23,7 +24,7 @@ describe("Certificates client - LRO - certificate operation", () => {
   let recorder: Recorder;
 
   beforeEach(async function (this: Context) {
-    const authentication = await authenticate(this);
+    const authentication = await authenticate(this, getServiceVersion());
     certificateSuffix = authentication.suffix;
     client = authentication.client;
     testClient = authentication.testClient;

--- a/sdk/keyvault/keyvault-certificates/test/public/lro.recover.spec.ts
+++ b/sdk/keyvault/keyvault-certificates/test/public/lro.recover.spec.ts
@@ -10,6 +10,7 @@ import { CertificateClient, DeletedCertificate, DefaultCertificatePolicy } from 
 import { assertThrowsAbortError } from "../utils/utils.common";
 import { testPollerProperties } from "../utils/recorderUtils";
 import { authenticate } from "../utils/testAuthentication";
+import { getServiceVersion } from "../utils/utils.common";
 import TestClient from "../utils/testClient";
 
 describe("Certificates client - LRO - recoverDelete", () => {
@@ -20,7 +21,7 @@ describe("Certificates client - LRO - recoverDelete", () => {
   let recorder: Recorder;
 
   beforeEach(async function (this: Context) {
-    const authentication = await authenticate(this);
+    const authentication = await authenticate(this, getServiceVersion());
     certificateSuffix = authentication.suffix;
     client = authentication.client;
     testClient = authentication.testClient;

--- a/sdk/keyvault/keyvault-certificates/test/public/mergeAndImport.spec.ts
+++ b/sdk/keyvault/keyvault-certificates/test/public/mergeAndImport.spec.ts
@@ -13,6 +13,7 @@ import { CertificateClient } from "../../src";
 import { base64ToUint8Array, stringToUint8Array } from "../../src/utils";
 import { testPollerProperties } from "../utils/recorderUtils";
 import { authenticate } from "../utils/testAuthentication";
+import { getServiceVersion } from "../utils/utils.common";
 import TestClient from "../utils/testClient";
 
 describe("Certificates client - merge and import certificates", () => {
@@ -26,7 +27,7 @@ describe("Certificates client - merge and import certificates", () => {
   let secretClient: SecretClient;
 
   beforeEach(async function (this: Context) {
-    const authentication = await authenticate(this);
+    const authentication = await authenticate(this, getServiceVersion());
     suffix = authentication.suffix;
     client = authentication.client;
     testClient = authentication.testClient;

--- a/sdk/keyvault/keyvault-certificates/test/public/recoverBackupRestore.spec.ts
+++ b/sdk/keyvault/keyvault-certificates/test/public/recoverBackupRestore.spec.ts
@@ -10,6 +10,7 @@ import { CertificateClient } from "../../src";
 import { testPollerProperties } from "../utils/recorderUtils";
 import { assertThrowsAbortError } from "../utils/utils.common";
 import { authenticate } from "../utils/testAuthentication";
+import { getServiceVersion } from "../utils/utils.common";
 import TestClient from "../utils/testClient";
 
 describe("Certificates client - restore certificates and recover backups", () => {
@@ -25,7 +26,7 @@ describe("Certificates client - restore certificates and recover backups", () =>
   };
 
   beforeEach(async function (this: Context) {
-    const authentication = await authenticate(this);
+    const authentication = await authenticate(this, getServiceVersion());
     suffix = authentication.suffix;
     client = authentication.client;
     testClient = authentication.testClient;

--- a/sdk/keyvault/keyvault-certificates/test/utils/testAuthentication.ts
+++ b/sdk/keyvault/keyvault-certificates/test/utils/testAuthentication.ts
@@ -11,7 +11,7 @@ import { Context } from "mocha";
 
 export async function authenticate(
   that: Context,
-  serviceVersion?: ReturnType<typeof getServiceVersion>
+  serviceVersion: ReturnType<typeof getServiceVersion>
 ): Promise<any> {
   const suffix = uniqueString();
   const recorderEnvSetup: RecorderEnvironmentSetup = {

--- a/sdk/keyvault/keyvault-certificates/test/utils/testAuthentication.ts
+++ b/sdk/keyvault/keyvault-certificates/test/utils/testAuthentication.ts
@@ -5,10 +5,14 @@ import { ClientSecretCredential } from "@azure/identity";
 import { CertificateClient } from "../../src";
 import { uniqueString } from "./recorderUtils";
 import { env, record, RecorderEnvironmentSetup } from "@azure-tools/test-recorder";
+import { getServiceVersion } from "./utils.common";
 import TestClient from "./testClient";
 import { Context } from "mocha";
 
-export async function authenticate(that: Context): Promise<any> {
+export async function authenticate(
+  that: Context,
+  serviceVersion?: ReturnType<typeof getServiceVersion>
+): Promise<any> {
   const suffix = uniqueString();
   const recorderEnvSetup: RecorderEnvironmentSetup = {
     replaceableVariables: {
@@ -45,7 +49,7 @@ export async function authenticate(that: Context): Promise<any> {
     throw new Error("Missing KEYVAULT_URI environment variable.");
   }
 
-  const client = new CertificateClient(keyVaultUrl, credential);
+  const client = new CertificateClient(keyVaultUrl, credential, { serviceVersion });
   const testClient = new TestClient(client);
 
   return { recorder, client, credential, testClient, suffix, keyVaultUrl };

--- a/sdk/keyvault/keyvault-certificates/test/utils/utils.common.ts
+++ b/sdk/keyvault/keyvault-certificates/test/utils/utils.common.ts
@@ -3,6 +3,8 @@
 
 import { env } from "@azure-tools/test-recorder";
 import { assert } from "chai";
+import { SupportedVersions, supports, TestFunctionWrapper } from "@azure/test-utils";
+import { LATEST_API_VERSION, CertificateClientOptions } from "../../src/certificatesModels";
 
 export function getKeyvaultName(): string {
   const keyVaultEnvVarName = "KEYVAULT_NAME";
@@ -28,4 +30,32 @@ export async function assertThrowsAbortError(cb: () => Promise<any>): Promise<vo
   if (passed) {
     throw new Error("Expected cb to throw an AbortError");
   }
+}
+
+/**
+ * The known API versions that we support.
+ */
+export const serviceVersions = ["7.0", "7.1", "7.2", "7.3-preview"] as const;
+
+/**
+ * Fetches the service version to test against. This version could be configured as part of CI
+ * and then passed through the environment in order to support testing prior service versions.
+ * @returns - The service version to test
+ */
+export function getServiceVersion(): NonNullable<CertificateClientOptions["serviceVersion"]> {
+  return env.SERVICE_VERSION || LATEST_API_VERSION;
+}
+
+/**
+ * A convenience wrapper allowing us to limit service versions without using the `versionsToTest` wrapper.
+ *
+ * @param supportedVersions - The {@link SupportedVersions} to limit this test against.
+ * @param serviceVersion - The service version we want to test support for. If omitted we will default to the version returned from {@link getServiceVersion}.
+ * @returns A Mocha Wrapper which will skip or execute the chained tests depending the currently tested service version and the supported versions.
+ */
+export function onVersions(
+  supportedVersions: SupportedVersions,
+  serviceVersion?: CertificateClientOptions["serviceVersion"]
+): TestFunctionWrapper {
+  return supports(serviceVersion || getServiceVersion(), supportedVersions, serviceVersions);
 }

--- a/sdk/keyvault/keyvault-certificates/tests.yml
+++ b/sdk/keyvault/keyvault-certificates/tests.yml
@@ -6,6 +6,11 @@ stages:
       PackageName: "@azure/keyvault-certificates"
       ServiceDirectory: keyvault
       TimeoutInMinutes: 90
+      AdditionalMatrixConfigs:
+         - Name: Keyvault_live_test_base
+           Path: sdk/keyvault/keyvault-certificates/platform-matrix.json
+           Selection: sparse
+           GenerateVMJobs: true
       EnvVars:
         AZURE_CLIENT_ID: $(aad-azure-sdk-test-client-id)
         AZURE_TENANT_ID: $(aad-azure-sdk-test-tenant-id)


### PR DESCRIPTION
## What

- Add support for multi-version testing for keyvault-certificates

## Why

Our commitment is to support the last N versions of the KeyVault service. To ensure neither we nor the service introduce breaking changes to prior versions, multi-version test support was added. We ported keys over and have already reaped the benefits of version based filtering.

This commit adds the same support for keyvault-certificates

Resolves #17890