### PR TITLE
[AnomalyDetector] Increase SDK version to resolve the release issues about last version

### DIFF
--- a/sdk/anomalydetector/ai-anomaly-detector/CHANGELOG.md
+++ b/sdk/anomalydetector/ai-anomaly-detector/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+## 3.0.0-beta.5 (2022-01-23)
+
+- Fix release issues
+
 ## 3.0.0-beta.4 (2022-01-18)
 
 - Introduced the new API `lastDetectAnomaly`

--- a/sdk/anomalydetector/ai-anomaly-detector/package.json
+++ b/sdk/anomalydetector/ai-anomaly-detector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/ai-anomaly-detector",
-  "version": "3.0.0-beta.4",
+  "version": "3.0.0-beta.5",
   "description": "An isomorphic client library for the Azure Anomaly Detector service.",
   "sdk-type": "client",
   "main": "dist/index.js",

--- a/sdk/anomalydetector/ai-anomaly-detector/src/constants.ts
+++ b/sdk/anomalydetector/ai-anomaly-detector/src/constants.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-export const SDK_VERSION: string = "3.0.0-beta.3";
+export const SDK_VERSION: string = "3.0.0-beta.5";
 
 export const DEFAULT_COGNITIVE_SCOPE = "https://cognitiveservices.azure.com/.default";
 

--- a/sdk/anomalydetector/ai-anomaly-detector/src/generated/anomalyDetectorContext.ts
+++ b/sdk/anomalydetector/ai-anomaly-detector/src/generated/anomalyDetectorContext.ts
@@ -10,7 +10,7 @@ import * as coreHttp from "@azure/core-http";
 import { AnomalyDetectorOptionalParams } from "./models";
 
 const packageName = "@azure/ai-form-recognizer";
-const packageVersion = "3.0.0-beta.4";
+const packageVersion = "3.0.0-beta.5";
 
 export class AnomalyDetectorContext extends coreHttp.ServiceClient {
   endpoint: string;


### PR DESCRIPTION
**Checklists** 
- [ ] Added impacted package name to the issue description

**Packages impacted by this PR:**
@azure/ai-anomaly-detector

**Issues associated with this PR:**
The last version packages were published through wrong release pipeline, so there are some release issues. We need to bump up the SDK version quickly and get things back on the right track.

**Describe the problem that is addressed by this PR:**
The last version packages were published through wrong release pipeline, so there are some release issues. We need to bump up the SDK version quickly and get things back on the right track.


**What are the possible designs available to address the problem**


**If there are more than one possible design, why was the one in this PR chosen?**


**Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_


**Are there test cases added in this PR?**_(If not, why?)_


**Provide a list of related PRs**_(if any)_


**Command used to generate this PR:**_(Applicable only to SDK release request PRs)_
