### PR TITLE
[KeyVault] - Enable multi-version tests for KV admin

### DIFF
--- a/sdk/keyvault/keyvault-admin/platform-matrix.json
+++ b/sdk/keyvault/keyvault-admin/platform-matrix.json
@@ -8,23 +8,16 @@
           "ArmTemplateParameters": "@{ enableHsm = $true }"
         }
       },
-      "TestType": "node",
-      "NodeTestVersion": "12.x"
-    },
-    {
-      "Agent": {
-        "ubuntu-20.04_ManagedHSM": {
-          "OSVmImage": "MMSUbuntu20.04",
-          "Pool": "azsdk-pool-mms-ubuntu-2004-general",
-          "ArmTemplateParameters": "@{ enableHsm = $true }"
+      "Versions": {
+        "12.x": {
+          "NodeTestVersion": "12.x"
+        },
+        "16.x_service_version_7_2": {
+          "NodeTestVersion": "16.x",
+          "ServiceVersion": "7.2"
         }
       },
-      "TestType": "node",
-      "NodeTestVersion": "16.x",
-      "ServiceVersion": ["7.2"]
+      "TestType": "node"
     }
-  ],
-  "displayNames": {
-    "7.2": "service_version_7_2"
-  }
+  ]
 }

--- a/sdk/keyvault/keyvault-admin/platform-matrix.json
+++ b/sdk/keyvault/keyvault-admin/platform-matrix.json
@@ -9,7 +9,13 @@
         }
       },
       "TestType": "node",
-      "NodeTestVersion": "12.x"
+      "NodeTestVersion": "12.x",
+      "ServiceVersion": ["7.0", "7.1", "7.2"]
     }
-  ]
+  ],
+  "displayNames": {
+    "7.0": "service_version_7_0",
+    "7.1": "service_version_7_1",
+    "7.2": "service_version_7_2"
+  }
 }

--- a/sdk/keyvault/keyvault-admin/platform-matrix.json
+++ b/sdk/keyvault/keyvault-admin/platform-matrix.json
@@ -10,12 +10,10 @@
       },
       "TestType": "node",
       "NodeTestVersion": "12.x",
-      "ServiceVersion": ["7.0", "7.1", "7.2"]
+      "ServiceVersion": ["7.2"]
     }
   ],
   "displayNames": {
-    "7.0": "service_version_7_0",
-    "7.1": "service_version_7_1",
     "7.2": "service_version_7_2"
   }
 }

--- a/sdk/keyvault/keyvault-admin/platform-matrix.json
+++ b/sdk/keyvault/keyvault-admin/platform-matrix.json
@@ -9,7 +9,18 @@
         }
       },
       "TestType": "node",
-      "NodeTestVersion": "12.x",
+      "NodeTestVersion": "12.x"
+    },
+    {
+      "Agent": {
+        "ubuntu-20.04_ManagedHSM": {
+          "OSVmImage": "MMSUbuntu20.04",
+          "Pool": "azsdk-pool-mms-ubuntu-2004-general",
+          "ArmTemplateParameters": "@{ enableHsm = $true }"
+        }
+      },
+      "TestType": "node",
+      "NodeTestVersion": "16.x",
       "ServiceVersion": ["7.2"]
     }
   ],

--- a/sdk/keyvault/keyvault-admin/test/public/accessControlClient.aborts.spec.ts
+++ b/sdk/keyvault/keyvault-admin/test/public/accessControlClient.aborts.spec.ts
@@ -5,7 +5,7 @@ import { env, Recorder } from "@azure-tools/test-recorder";
 import { AbortController } from "@azure/abort-controller";
 
 import { KeyVaultAccessControlClient } from "../../src";
-import { assertThrowsAbortError } from "../utils/common";
+import { assertThrowsAbortError, getServiceVersion } from "../utils/common";
 import { authenticate } from "../utils/authentication";
 
 describe("Aborting KeyVaultAccessControlClient's requests", () => {
@@ -15,7 +15,7 @@ describe("Aborting KeyVaultAccessControlClient's requests", () => {
   const globalScope = "/";
 
   beforeEach(async function () {
-    const authentication = await authenticate(this);
+    const authentication = await authenticate(this, getServiceVersion());
     client = authentication.accessControlClient;
     recorder = authentication.recorder;
     generateFakeUUID = authentication.generateFakeUUID;

--- a/sdk/keyvault/keyvault-admin/test/public/accessControlClient.spec.ts
+++ b/sdk/keyvault/keyvault-admin/test/public/accessControlClient.spec.ts
@@ -15,6 +15,7 @@ import {
 } from "../../src";
 import { authenticate } from "../utils/authentication";
 import { supportsTracing } from "../utils/supportsTracing";
+import { getServiceVersion } from "../utils/common";
 
 describe("KeyVaultAccessControlClient", () => {
   let client: KeyVaultAccessControlClient;
@@ -23,7 +24,7 @@ describe("KeyVaultAccessControlClient", () => {
   const globalScope = "/";
 
   beforeEach(async function () {
-    const authentication = await authenticate(this);
+    const authentication = await authenticate(this, getServiceVersion());
     client = authentication.accessControlClient;
     recorder = authentication.recorder;
     generateFakeUUID = authentication.generateFakeUUID;

--- a/sdk/keyvault/keyvault-admin/test/public/backupClient.abort.spec.ts
+++ b/sdk/keyvault/keyvault-admin/test/public/backupClient.abort.spec.ts
@@ -7,7 +7,7 @@ import { AbortController } from "@azure/abort-controller";
 import { KeyVaultBackupClient } from "../../src";
 import { authenticate } from "../utils/authentication";
 import { testPollerProperties } from "../utils/recorder";
-import { assertThrowsAbortError, getSasToken } from "../utils/common";
+import { assertThrowsAbortError, getSasToken, getServiceVersion } from "../utils/common";
 
 describe("Aborting KeyVaultBackupClient's requests", () => {
   let client: KeyVaultBackupClient;
@@ -18,7 +18,7 @@ describe("Aborting KeyVaultBackupClient's requests", () => {
   let generateFakeUUID: () => string;
 
   beforeEach(async function () {
-    const authentication = await authenticate(this);
+    const authentication = await authenticate(this, getServiceVersion());
     client = authentication.backupClient;
     recorder = authentication.recorder;
     generateFakeUUID = authentication.generateFakeUUID;

--- a/sdk/keyvault/keyvault-admin/test/public/backupClient.spec.ts
+++ b/sdk/keyvault/keyvault-admin/test/public/backupClient.spec.ts
@@ -9,7 +9,7 @@ import { isPlaybackMode, Recorder } from "@azure-tools/test-recorder";
 import { KeyVaultBackupClient } from "../../src";
 import { authenticate } from "../utils/authentication";
 import { testPollerProperties } from "../utils/recorder";
-import { getSasToken } from "../utils/common";
+import { getSasToken, getServiceVersion } from "../utils/common";
 import { delay } from "@azure/core-util";
 import { assert } from "chai";
 import { KeyClient } from "@azure/keyvault-keys";
@@ -23,7 +23,7 @@ describe("KeyVaultBackupClient", () => {
   let blobSasToken: string;
 
   beforeEach(async function () {
-    const authentication = await authenticate(this);
+    const authentication = await authenticate(this, getServiceVersion());
     client = authentication.backupClient;
     keyClient = authentication.keyClient;
     recorder = authentication.recorder;

--- a/sdk/keyvault/keyvault-admin/test/utils/authentication.ts
+++ b/sdk/keyvault/keyvault-admin/test/utils/authentication.ts
@@ -5,12 +5,16 @@ import { ClientSecretCredential } from "@azure/identity";
 import { env, isPlaybackMode, record, RecorderEnvironmentSetup } from "@azure-tools/test-recorder";
 import { KeyClient } from "@azure/keyvault-keys";
 import { v4 as uuidv4 } from "uuid";
+import { Context } from "mocha";
 
 import { KeyVaultAccessControlClient, KeyVaultBackupClient } from "../../src";
 import { uniqueString } from "./recorder";
-import { getEnvironmentVariable } from "./common";
+import { getEnvironmentVariable, getServiceVersion } from "./common";
 
-export async function authenticate(that: any): Promise<any> {
+export async function authenticate(
+  that: Context,
+  serviceVersion: ReturnType<typeof getServiceVersion>
+): Promise<any> {
   const generatedUUIDs: string[] = [];
   function generateFakeUUID(): string {
     if (isPlaybackMode()) {
@@ -69,9 +73,11 @@ export async function authenticate(that: any): Promise<any> {
 
   const keyVaultHsmUrl = getEnvironmentVariable("AZURE_MANAGEDHSM_URI");
 
-  const accessControlClient = new KeyVaultAccessControlClient(keyVaultHsmUrl, credential);
-  const keyClient = new KeyClient(keyVaultHsmUrl, credential);
-  const backupClient = new KeyVaultBackupClient(keyVaultHsmUrl, credential);
+  const accessControlClient = new KeyVaultAccessControlClient(keyVaultHsmUrl, credential, {
+    serviceVersion,
+  });
+  const keyClient = new KeyClient(keyVaultHsmUrl, credential, { serviceVersion });
+  const backupClient = new KeyVaultBackupClient(keyVaultHsmUrl, credential, { serviceVersion });
 
   return { recorder, accessControlClient, backupClient, keyClient, suffix, generateFakeUUID };
 }

--- a/sdk/keyvault/keyvault-admin/test/utils/common.ts
+++ b/sdk/keyvault/keyvault-admin/test/utils/common.ts
@@ -64,7 +64,7 @@ export function getSasToken() {
 /**
  * The known API versions that we support.
  */
-export const serviceVersions = ["7.0", "7.1", "7.2", "7.3-preview"] as const;
+export const serviceVersions = ["7.2"] as const;
 
 /**
  * Fetches the service version to test against. This version could be configured as part of CI

--- a/sdk/keyvault/keyvault-admin/test/utils/common.ts
+++ b/sdk/keyvault/keyvault-admin/test/utils/common.ts
@@ -4,9 +4,7 @@
 import { assert } from "chai";
 import { env } from "@azure-tools/test-recorder";
 import { SupportedVersions, supports, TestFunctionWrapper } from "@azure/test-utils";
-import { LATEST_API_VERSION } from "../../src/constants";
-import { AccessControlClientOptions } from "../../src/accessControlModels";
-import { KeyVaultBackupClientOptions } from "../../src/backupClientModels";
+import { LATEST_API_VERSION, SUPPORTED_API_VERSIONS } from "../../src/constants";
 
 export async function assertThrowsAbortError(cb: () => Promise<any>): Promise<void> {
   let passed = false;
@@ -71,9 +69,7 @@ export const serviceVersions = ["7.2"] as const;
  * and then passed through the environment in order to support testing prior service versions.
  * @returns - The service version to test
  */
-export function getServiceVersion(): NonNullable<
-  (AccessControlClientOptions | KeyVaultBackupClientOptions)["serviceVersion"]
-> {
+export function getServiceVersion(): SUPPORTED_API_VERSIONS {
   return env.SERVICE_VERSION || LATEST_API_VERSION;
 }
 
@@ -86,7 +82,7 @@ export function getServiceVersion(): NonNullable<
  */
 export function onVersions(
   supportedVersions: SupportedVersions,
-  serviceVersion?: (AccessControlClientOptions | KeyVaultBackupClientOptions)["serviceVersion"]
+  serviceVersion?: SUPPORTED_API_VERSIONS
 ): TestFunctionWrapper {
   return supports(serviceVersion || getServiceVersion(), supportedVersions, serviceVersions);
 }

--- a/sdk/keyvault/keyvault-admin/tests.yml
+++ b/sdk/keyvault/keyvault-admin/tests.yml
@@ -6,8 +6,8 @@ stages:
       PackageName: "@azure/keyvault-admin"
       ServiceDirectory: keyvault
       # KV HSM limitation prevents us from running live tests
-      # against multiple platforms in parallel (we're limited to a single
-      # instance per region per subscription) so we're only running
+      # against multiple platforms in parallel (we're limited to five
+      # instances per region per subscription) so we're only running
       # live tests against a single instance.
       Location: eastus2
       MatrixConfigs:

--- a/sdk/keyvault/keyvault-admin/tests.yml
+++ b/sdk/keyvault/keyvault-admin/tests.yml
@@ -15,6 +15,11 @@ stages:
           Path: sdk/keyvault/keyvault-admin/platform-matrix.json
           Selection: sparse
           GenerateVMJobs: true
+      AdditionalMatrixConfigs:
+        - Name: Keyvault_live_test_base
+          Path: sdk/keyvault/keyvault-admin/platform-matrix.json
+          Selection: sparse
+          GenerateVMJobs: true
       EnvVars:
         AZURE_CLIENT_ID: $(aad-azure-sdk-test-client-id)
         AZURE_TENANT_ID: $(aad-azure-sdk-test-tenant-id)

--- a/sdk/keyvault/keyvault-admin/tests.yml
+++ b/sdk/keyvault/keyvault-admin/tests.yml
@@ -15,11 +15,6 @@ stages:
           Path: sdk/keyvault/keyvault-admin/platform-matrix.json
           Selection: sparse
           GenerateVMJobs: true
-      AdditionalMatrixConfigs:
-        - Name: Keyvault_live_test_base
-          Path: sdk/keyvault/keyvault-admin/platform-matrix.json
-          Selection: sparse
-          GenerateVMJobs: true
       EnvVars:
         AZURE_CLIENT_ID: $(aad-azure-sdk-test-client-id)
         AZURE_TENANT_ID: $(aad-azure-sdk-test-tenant-id)


### PR DESCRIPTION
## What

- Add support for multi-version testing for keyvault-admin

## Why

Our commitment is to support the last N versions of the KeyVault service. To ensure neither we nor the service introduce breaking changes to prior versions, multi-version test support was added. We ported keys over and have already reaped the benefits of version based filtering.

This commit adds the same support for keyvault-admin

Resolves #19791