### PR TITLE
[App Config] skip secret reference sample

### DIFF
--- a/sdk/appconfiguration/app-configuration/package.json
+++ b/sdk/appconfiguration/app-configuration/package.json
@@ -146,6 +146,9 @@
     ],
     "requiredResources": {
       "Azure App Configuration account": "https://docs.microsoft.com/azure/azure-app-configuration/quickstart-aspnet-core-app?tabs=core5x#create-an-app-configuration-store"
-    }
+    },
+    "skip": [
+      "secretReference.js"
+    ]
   }
 }


### PR DESCRIPTION
Skipping the sample since it needs Key Vault and AAD resources as well along with the App Config resource.
It might be too costly to create the resource for just one sample.