### PR TITLE
[dev-tool] Throw error when proxy fails to start

### DIFF
--- a/sdk/core/ci.yml
+++ b/sdk/core/ci.yml
@@ -35,6 +35,7 @@ extends:
   template: ../../eng/pipelines/templates/stages/archetype-sdk-client.yml
   parameters:
     ServiceDirectory: core
+    TestProxy: true
     Artifacts:
       - name: azure-abort-controller
         safeName: azureabortcontroller


### PR DESCRIPTION
**Checklists** 
- [x] Added impacted package name to the issue description

**Packages impacted by this PR:**


**Issues associated with this PR:**
- Resolves #19725 

**Describe the problem that is addressed by this PR:**

When running tests using the test proxy, if the proxy tool image fails to start, the tool would exit successfully without outputting a useful error. This could happen if, for example, the Docker daemon is not running (this has happened to me a few times). This PR throws an error when the command to start the proxy tool outputs a nonzero exit code. This error will aid with debugging.
