### PR TITLE
[sort-imports] enforce ```sort-imports``` rule in ```eslint-plugin-azure-sdk```

### DIFF
--- a/common/tools/eslint-plugin-azure-sdk/.eslintrc.json
+++ b/common/tools/eslint-plugin-azure-sdk/.eslintrc.json
@@ -34,6 +34,6 @@
     "no-redeclare": "error",
     "no-useless-escape": "off",
     "prefer-template": "error",
-    "sort-imports": "warn"
+    "sort-imports": "error"
   }
 }


### PR DESCRIPTION
This PR reinforces the changes made in #18951 by changing the subdirectory's linting rule to ```"sort-imports": "error"``` rather than ```"sort-imports": "warn"```.

This affects the directory under ```common/tools/eslint-plugin-azure-sdk```.