### PR TITLE
[sort-imports] enforce ```sort-imports``` rule in ```core-tracing```

### DIFF
--- a/sdk/core/core-tracing/.eslintrc.json
+++ b/sdk/core/core-tracing/.eslintrc.json
@@ -3,6 +3,7 @@
   "extends": ["plugin:@azure/azure-sdk/azure-sdk-base"],
   "rules": {
     "@azure/azure-sdk/ts-no-const-enums": "off",
-    "@azure/azure-sdk/ts-versioning-semver": "warn"
+    "@azure/azure-sdk/ts-versioning-semver": "warn",
+    "sort-imports": "error"
   }
 }

--- a/sdk/core/core-tracing/test/instrumenter.spec.ts
+++ b/sdk/core/core-tracing/test/instrumenter.spec.ts
@@ -1,15 +1,15 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { assert } from "chai";
 import { Instrumenter, TracingSpan } from "../src/interfaces";
 import {
   createDefaultInstrumenter,
   createDefaultTracingSpan,
   getInstrumenter,
-  useInstrumenter,
+  useInstrumenter
 } from "../src/instrumenter";
 import { createTracingContext, knownContextKeys } from "../src/tracingContext";
+import { assert } from "chai";
 
 describe("Instrumenter", () => {
   describe("NoOpInstrumenter", () => {

--- a/sdk/core/core-tracing/test/instrumenter.spec.ts
+++ b/sdk/core/core-tracing/test/instrumenter.spec.ts
@@ -6,7 +6,7 @@ import {
   createDefaultInstrumenter,
   createDefaultTracingSpan,
   getInstrumenter,
-  useInstrumenter
+  useInstrumenter,
 } from "../src/instrumenter";
 import { createTracingContext, knownContextKeys } from "../src/tracingContext";
 import { assert } from "chai";

--- a/sdk/core/core-tracing/test/interfaces.spec.ts
+++ b/sdk/core/core-tracing/test/interfaces.spec.ts
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+import * as coreAuth from "@azure/core-auth";
+import * as coreTracing from "../src";
 import { assert } from "chai";
 import { createTracingContext } from "../src/tracingContext";
-import * as coreTracing from "../src";
-import * as coreAuth from "@azure/core-auth";
 
 describe("Interface compatibility", () => {
   describe("OperationTracingOptions", () => {

--- a/sdk/core/core-tracing/test/tracingClient.spec.ts
+++ b/sdk/core/core-tracing/test/tracingClient.spec.ts
@@ -1,16 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import {
-  Instrumenter,
-  TracingClient,
-  TracingContext,
-  TracingSpan
-} from "../src/interfaces";
+import { Instrumenter, TracingClient, TracingContext, TracingSpan } from "../src/interfaces";
 import {
   createDefaultInstrumenter,
   createDefaultTracingSpan,
-  useInstrumenter
+  useInstrumenter,
 } from "../src/instrumenter";
 import { createTracingContext, knownContextKeys } from "../src/tracingContext";
 import { assert } from "chai";

--- a/sdk/core/core-tracing/test/tracingClient.spec.ts
+++ b/sdk/core/core-tracing/test/tracingClient.spec.ts
@@ -1,16 +1,21 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { assert } from "chai";
-import sinon from "sinon";
-import { Instrumenter, TracingClient, TracingContext, TracingSpan } from "../src/interfaces";
+import {
+  Instrumenter,
+  TracingClient,
+  TracingContext,
+  TracingSpan
+} from "../src/interfaces";
 import {
   createDefaultInstrumenter,
   createDefaultTracingSpan,
-  useInstrumenter,
+  useInstrumenter
 } from "../src/instrumenter";
-import { createTracingClient } from "../src/tracingClient";
 import { createTracingContext, knownContextKeys } from "../src/tracingContext";
+import { assert } from "chai";
+import { createTracingClient } from "../src/tracingClient";
+import sinon from "sinon";
 
 describe("TracingClient", () => {
   let instrumenter: Instrumenter;

--- a/sdk/core/core-tracing/test/tracingContext.spec.ts
+++ b/sdk/core/core-tracing/test/tracingContext.spec.ts
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+import { TracingContextImpl, createTracingContext, knownContextKeys } from "../src/tracingContext";
 import { assert } from "chai";
 import { createDefaultTracingSpan } from "../src/instrumenter";
 import { createTracingClient } from "../src/tracingClient";
-import { TracingContextImpl, createTracingContext, knownContextKeys } from "../src/tracingContext";
 
 describe("TracingContext", () => {
   describe("TracingContextImpl", () => {


### PR DESCRIPTION
This PR reinforces the changes made in #19033 by changing the subdirectory's linting rule to ```"sort-imports": "error"```.

This affects the directory under ```sdk/core/core-tracing```.