### PR TITLE
[Perf] Decrease default perf test duration to 1 second

### DIFF
--- a/sdk/test-utils/perf/runAllTests.ts
+++ b/sdk/test-utils/perf/runAllTests.ts
@@ -11,10 +11,9 @@ function spawn(command: string) {
 
 function runTest(testClassName: string, options: string = "") {
   console.log("\n");
-  if (options === "") {
-    options = `--warmup 0 --iterations 1 --duration 1`;
-  }
-  spawn(`ts-node ./test/index.spec.ts ${testClassName} ${options}`);
+  spawn(
+    `ts-node ./test/index.spec.ts ${testClassName} --warmup 0 --iterations 1 --duration 1 ${options}`
+  );
 }
 
 allTests.forEach(({ testClass, options }) => {

--- a/sdk/test-utils/perf/src/options.ts
+++ b/sdk/test-utils/perf/src/options.ts
@@ -95,7 +95,7 @@ export const defaultPerfOptions: PerfOptionDictionary<DefaultPerfOptions> = {
   duration: {
     description: "When to stop calling tests at all",
     shortName: "d",
-    defaultValue: 1,
+    defaultValue: 10,
   },
   warmup: {
     description: "Duration of warmup in seconds",

--- a/sdk/test-utils/perf/src/options.ts
+++ b/sdk/test-utils/perf/src/options.ts
@@ -95,7 +95,7 @@ export const defaultPerfOptions: PerfOptionDictionary<DefaultPerfOptions> = {
   duration: {
     description: "When to stop calling tests at all",
     shortName: "d",
-    defaultValue: 10,
+    defaultValue: 1,
   },
   warmup: {
     description: "Duration of warmup in seconds",


### PR DESCRIPTION
**Checklists** 
- [x] Added impacted package name to the issue description

**Packages impacted by this PR:**
- Perf tests
- All packages using perf tests

**Issues associated with this PR:**

- Fixes #19453 

**Describe the problem that is addressed by this PR:**

The current default duration of 10 seconds is quite long. Slowing this down to 1 second should be OK and will make the build faster. If a longer perf test duration is required, the duration option can be specified manually.