### PR TITLE
fix: :arrow_up: CVE-2022-0235

### DIFF
--- a/sdk/core/core-http/package.json
+++ b/sdk/core/core-http/package.json
@@ -120,7 +120,7 @@
     "@types/node-fetch": "^2.5.0",
     "@types/tunnel": "^0.0.3",
     "form-data": "^4.0.0",
-    "node-fetch": "^2.6.6",
+    "node-fetch": "^2.6.7",
     "process": "^0.11.10",
     "tough-cookie": "^4.0.0",
     "tslib": "^2.2.0",


### PR DESCRIPTION
update node-fetch version 2.6.7 to fix [CVE-2022-0235](https://snyk.io/vuln/npm:node-fetch)


**Checklists** 
- [x] Added impacted package name to the issue description

**Packages impacted by this PR:**
@azure/core-http

**Issues associated with this PR:**

**Describe the problem that is addressed by this PR:**
fix [CVE-2022-0235](https://snyk.io/vuln/npm:node-fetch)

**What are the possible designs available to address the problem**


**If there are more than one possible design, why was the one in this PR chosen?**


**Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_


**Are there test cases added in this PR?**_(If not, why?)_


**Provide a list of related PRs**_(if any)_


**Command used to generate this PR:**_(Applicable only to SDK release request PRs)_
