### PR TITLE
[sort-imports] enforce ```sort-imports``` rule in ```core-crypto```

### DIFF
--- a/sdk/core/core-crypto/.eslintrc.json
+++ b/sdk/core/core-crypto/.eslintrc.json
@@ -1,10 +1,6 @@
 {
-  "plugins": [
-    "@azure/azure-sdk"
-  ],
-  "extends": [
-    "plugin:@azure/azure-sdk/azure-sdk-base"
-  ],
+  "plugins": ["@azure/azure-sdk"],
+  "extends": ["plugin:@azure/azure-sdk/azure-sdk-base"],
   "rules": {
     "sort-imports": "error"
   }

--- a/sdk/core/core-crypto/.eslintrc.json
+++ b/sdk/core/core-crypto/.eslintrc.json
@@ -1,0 +1,11 @@
+{
+  "plugins": [
+    "@azure/azure-sdk"
+  ],
+  "extends": [
+    "plugin:@azure/azure-sdk/azure-sdk-base"
+  ],
+  "rules": {
+    "sort-imports": "error"
+  }
+}


### PR DESCRIPTION
This PR reinforces the changes made in #19036 by changing the subdirectory's linting rule to ```"sort-imports": "error"```.

This affects the directory under ```sdk/core/core-crypto```.