### PR TITLE
[sort-imports] enforce ```sort-imports``` rule in ```core-http```

### DIFF
--- a/sdk/core/core-http/.eslintrc.json
+++ b/sdk/core/core-http/.eslintrc.json
@@ -6,6 +6,7 @@
     "@azure/azure-sdk/ts-apiextractor-json-types": "off",
     "@azure/azure-sdk/ts-package-json-types": "off",
     "@azure/azure-sdk/ts-package-json-module": "off",
-    "@azure/azure-sdk/ts-package-json-files-required": "off"
+    "@azure/azure-sdk/ts-package-json-files-required": "off",
+    "sort-imports": "error"
   }
 }


### PR DESCRIPTION
This PR reinforces the changes made in #19212 by changing the subdirectory's linting rule to ```"sort-imports": "error"```.

This affects the directory under ```sdk/core/core-http```.