### PR TITLE
[sort-imports] enforce ```sort-imports``` rule in ```core-paging```

### DIFF
--- a/sdk/core/core-paging/.eslintrc.json
+++ b/sdk/core/core-paging/.eslintrc.json
@@ -4,6 +4,7 @@
   "rules": {
     // `package.json`'s sideEffects has to be true because this package loads a
     // polyfill.
-    "@azure/azure-sdk/ts-package-json-sideeffects": "off"
+    "@azure/azure-sdk/ts-package-json-sideeffects": "off",
+    "sort-imports": "error"
   }
 }


### PR DESCRIPTION
This PR reinforces the changes made in #19046 by changing the subdirectory's linting rule to ```"sort-imports": "error"```.

This affects the directory under ```sdk/core/core-paging```.