### PR TITLE
[sort-imports] enforce ```sort-imports``` rule in ```data-tables```

### DIFF
--- a/sdk/tables/data-tables/.eslintrc.json
+++ b/sdk/tables/data-tables/.eslintrc.json
@@ -2,6 +2,7 @@
   "plugins": ["@azure/azure-sdk"],
   "extends": ["plugin:@azure/azure-sdk/azure-sdk-base"],
   "rules": {
-    "@typescript-eslint/ban-types": "warn"
+    "@typescript-eslint/ban-types": "warn",
+    "sort-imports": "error"
   }
 }

--- a/sdk/tables/data-tables/src/TableTransaction.ts
+++ b/sdk/tables/data-tables/src/TableTransaction.ts
@@ -9,7 +9,7 @@ import {
   TableTransactionResponse,
   TransactionAction,
   UpdateMode,
-  UpdateTableEntityOptions
+  UpdateTableEntityOptions,
 } from "./models";
 import {
   NamedKeyCredential,
@@ -17,14 +17,14 @@ import {
   TokenCredential,
   isNamedKeyCredential,
   isSASCredential,
-  isTokenCredential
+  isTokenCredential,
 } from "@azure/core-auth";
 import {
   OperationOptions,
   ServiceClient,
   ServiceClientOptions,
   serializationPolicy,
-  serializationPolicyName
+  serializationPolicyName,
 } from "@azure/core-client";
 import {
   Pipeline,
@@ -32,14 +32,17 @@ import {
   PipelineResponse,
   RestError,
   createHttpHeaders,
-  createPipelineRequest
+  createPipelineRequest,
 } from "@azure/core-rest-pipeline";
-import { getInitialTransactionBody, getTransactionHttpRequestBody } from "./utils/transactionHelpers";
+import {
+  getInitialTransactionBody,
+  getTransactionHttpRequestBody,
+} from "./utils/transactionHelpers";
 import {
   transactionHeaderFilterPolicy,
   transactionHeaderFilterPolicyName,
   transactionRequestAssemblePolicy,
-  transactionRequestAssemblePolicyName
+  transactionRequestAssemblePolicyName,
 } from "./TablePolicies";
 import { STORAGE_SCOPE } from "./utils/constants";
 import { SpanStatusCode } from "@azure/core-tracing";

--- a/sdk/tables/data-tables/src/TableTransaction.ts
+++ b/sdk/tables/data-tables/src/TableTransaction.ts
@@ -4,12 +4,12 @@
 import {
   DeleteTableEntityOptions,
   TableEntity,
+  TableServiceClientOptions,
   TableTransactionEntityResponse,
   TableTransactionResponse,
   TransactionAction,
   UpdateMode,
-  UpdateTableEntityOptions,
-  TableServiceClientOptions,
+  UpdateTableEntityOptions
 } from "./models";
 import {
   NamedKeyCredential,
@@ -17,14 +17,14 @@ import {
   TokenCredential,
   isNamedKeyCredential,
   isSASCredential,
-  isTokenCredential,
+  isTokenCredential
 } from "@azure/core-auth";
 import {
   OperationOptions,
   ServiceClient,
-  serializationPolicy,
-  serializationPolicyName,
   ServiceClientOptions,
+  serializationPolicy,
+  serializationPolicyName
 } from "@azure/core-client";
 import {
   Pipeline,
@@ -32,18 +32,16 @@ import {
   PipelineResponse,
   RestError,
   createHttpHeaders,
-  createPipelineRequest,
+  createPipelineRequest
 } from "@azure/core-rest-pipeline";
-import {
-  getInitialTransactionBody,
-  getTransactionHttpRequestBody,
-} from "./utils/transactionHelpers";
+import { getInitialTransactionBody, getTransactionHttpRequestBody } from "./utils/transactionHelpers";
 import {
   transactionHeaderFilterPolicy,
   transactionHeaderFilterPolicyName,
   transactionRequestAssemblePolicy,
-  transactionRequestAssemblePolicyName,
+  transactionRequestAssemblePolicyName
 } from "./TablePolicies";
+import { STORAGE_SCOPE } from "./utils/constants";
 import { SpanStatusCode } from "@azure/core-tracing";
 import { TableClientLike } from "./utils/internalModels";
 import { TableServiceErrorOdataError } from "./generated";
@@ -53,7 +51,6 @@ import { getAuthorizationHeader } from "./tablesNamedCredentialPolicy";
 import { getTransactionHeaders } from "./utils/transactionHeaders";
 import { isCosmosEndpoint } from "./utils/isCosmosEndpoint";
 import { signURLWithSAS } from "./tablesSASTokenPolicy";
-import { STORAGE_SCOPE } from "./utils/constants";
 
 /**
  * Helper to build a list of transaction actions

--- a/sdk/tables/data-tables/test/internal/browser/generateSas.browser.spec.ts
+++ b/sdk/tables/data-tables/test/internal/browser/generateSas.browser.spec.ts
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { assert } from "chai";
 import { AzureNamedKeyCredential, generateTableSas } from "../../../src";
+import { assert } from "chai";
 
 // This file is empty as sas generation is not supported in browsers
 describe("generateSas Browser", () => {

--- a/sdk/tables/data-tables/test/internal/node/generateSas.spec.ts
+++ b/sdk/tables/data-tables/test/internal/node/generateSas.spec.ts
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { assert } from "chai";
-import { AzureNamedKeyCredential, generateAccountSas, generateTableSas } from "../../../src";
 import * as sinon from "sinon";
+import { AzureNamedKeyCredential, generateAccountSas, generateTableSas } from "../../../src";
+import { assert } from "chai";
 
 describe("SAS generation", function () {
   describe("generateTableSAS", () => {

--- a/sdk/tables/data-tables/test/internal/tableTransaction.spec.ts
+++ b/sdk/tables/data-tables/test/internal/tableTransaction.spec.ts
@@ -2,14 +2,14 @@
 // Licensed under the MIT license.
 
 import {
+  HttpClient,
   PipelineResponse,
   createHttpHeaders,
-  createPipelineRequest,
-  HttpClient,
+  createPipelineRequest
 } from "@azure/core-rest-pipeline";
-import { assert } from "chai";
+import { TableTransaction, parseTransactionResponse } from "../../src/TableTransaction";
 import { TableClient } from "../../src/TableClient";
-import { parseTransactionResponse, TableTransaction } from "../../src/TableTransaction";
+import { assert } from "chai";
 
 describe("TableTransaction", () => {
   describe("parseTransactionResponse", () => {

--- a/sdk/tables/data-tables/test/internal/tableTransaction.spec.ts
+++ b/sdk/tables/data-tables/test/internal/tableTransaction.spec.ts
@@ -5,7 +5,7 @@ import {
   HttpClient,
   PipelineResponse,
   createHttpHeaders,
-  createPipelineRequest
+  createPipelineRequest,
 } from "@azure/core-rest-pipeline";
 import { TableTransaction, parseTransactionResponse } from "../../src/TableTransaction";
 import { TableClient } from "../../src/TableClient";


### PR DESCRIPTION
This PR reinforces the changes made in #19055 by changing the subdirectory's linting rule to ```"sort-imports": "error"```.

This affects the directory under ```sdk/tables/data-tables```.