### PR TITLE
[core-xml] Fix root version node handling

### DIFF
--- a/sdk/core/core-xml/src/xml.ts
+++ b/sdk/core/core-xml/src/xml.ts
@@ -68,6 +68,12 @@ export async function parseXML(str: string, opts: XmlOptions = {}): Promise<any>
   const parser = new XMLParser(getParserOptions(opts));
   const parsedXml = parser.parse(unescapeHTML(str));
 
+  // Remove the <?xml version="..." ?> node.
+  // This is a change in behavior on fxp v4. Issue #424
+  if (parsedXml["?xml"]) {
+    delete parsedXml["?xml"];
+  }
+
   if (!opts.includeRoot) {
     for (const key of Object.keys(parsedXml)) {
       const value = parsedXml[key];

--- a/sdk/core/core-xml/test/xml.spec.ts
+++ b/sdk/core/core-xml/test/xml.spec.ts
@@ -511,6 +511,35 @@ describe("XML serializer", function () {
     });
   });
 
+  it("should parse xml with root <?xml?> element", async () => {
+    const str = `<?xml version="1.0" encoding="utf-8"?><SignedIdentifiers><SignedIdentifier><Id>null</Id></SignedIdentifier><SignedIdentifier><Id>empty</Id></SignedIdentifier><SignedIdentifier><Id>partial</Id><AccessPolicy><Permission>r</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>full</Id><AccessPolicy><Start>2021-07-08T09:10:09.0000000Z</Start><Expiry>2021-07-08T09:10:09.0000000Z</Expiry><Permission>r</Permission></AccessPolicy></SignedIdentifier></SignedIdentifiers>`;
+    const parsed = await parseXML(str);
+    assert.deepEqual(parsed, {
+      SignedIdentifier: [
+        {
+          Id: "null",
+        },
+        {
+          Id: "empty",
+        },
+        {
+          AccessPolicy: {
+            Permission: "r",
+          },
+          Id: "partial",
+        },
+        {
+          AccessPolicy: {
+            Expiry: "2021-07-08T09:10:09.0000000Z",
+            Permission: "r",
+            Start: "2021-07-08T09:10:09.0000000Z",
+          },
+          Id: "full",
+        },
+      ],
+    });
+  });
+
   it("should handle urlEncoded content", async () => {
     const input = `<entry xmlns="http://www.w3.org/2005/Atom"><id>https://daschulttest1.servicebus.windows.net/testQueuePath/?api-version=2017-04&amp;enrich=False</id><title type="text">testQueuePath</title><published>2018-10-09T19:56:34Z</published><updated>2018-10-09T19:56:35Z</updated><author><name>daschulttest1</name></author><link rel="self" href="https://daschulttest1.servicebus.windows.net/testQueuePath/?api-version=2017-04&amp;enrich=False"/><content type="application/xml"><QueueDescription xmlns="http://schemas.microsoft.com/netservices/2010/10/servicebus/connect" xmlns:i="http://www.w3.org/2001/XMLSchema-instance"><LockDuration>PT1M</LockDuration><MaxSizeInMegabytes>1024</MaxSizeInMegabytes><RequiresDuplicateDetection>false</RequiresDuplicateDetection><RequiresSession>false</RequiresSession><DefaultMessageTimeToLive>P14D</DefaultMessageTimeToLive><DeadLetteringOnMessageExpiration>false</DeadLetteringOnMessageExpiration><DuplicateDetectionHistoryTimeWindow>PT10M</DuplicateDetectionHistoryTimeWindow><MaxDeliveryCount>10</MaxDeliveryCount><EnableBatchedOperations>true</EnableBatchedOperations><SizeInBytes>0</SizeInBytes><MessageCount>0</MessageCount><IsAnonymousAccessible>false</IsAnonymousAccessible><AuthorizationRules></AuthorizationRules><Status>Active</Status><CreatedAt>2018-10-09T19:56:34.903Z</CreatedAt><UpdatedAt>2018-10-09T19:56:35.013Z</UpdatedAt><AccessedAt>0001-01-01T00:00:00Z</AccessedAt><SupportOrdering>true</SupportOrdering><CountDetails xmlns:d2p1="http://schemas.microsoft.com/netservices/2011/06/servicebus"><d2p1:ActiveMessageCount>0</d2p1:ActiveMessageCount><d2p1:DeadLetterMessageCount>0</d2p1:DeadLetterMessageCount><d2p1:ScheduledMessageCount>0</d2p1:ScheduledMessageCount><d2p1:TransferMessageCount>0</d2p1:TransferMessageCount><d2p1:TransferDeadLetterMessageCount>0</d2p1:TransferDeadLetterMessageCount></CountDetails><AutoDeleteOnIdle>P10675199DT2H48M5.4775807S</AutoDeleteOnIdle><EnablePartitioning>false</EnablePartitioning><EntityAvailabilityStatus>Available</EntityAvailabilityStatus><EnableExpress>false</EnableExpress></QueueDescription></content></entry>`;
     const parsed = await parseXML(input);


### PR DESCRIPTION
**Checklists** 
- [x] Added impacted package name to the issue description

**Packages impacted by this PR:**
@Azure/core-xml
@Azure/data-tables

**Issues associated with this PR:**
#20011 

**Describe the problem that is addressed by this PR:**
fast-xml-parser changed the way they handle the root <?xml node. In v3 they used to ignore it, now they add it to the model. This caused parsing to be incorrect impacting the tests in Tables SDK.

**What are the possible designs available to address the problem**
The fix I'm opting to is to detect the parsed "?xml" node and remove it from the parsed object before continuing.

**Are there test cases added in this PR?**_(If not, why?)_
Yes