### PR TITLE
[Event Grid] Add Cloud Event adapter for Schema Registry Avro encoder

### DIFF
--- a/sdk/eventgrid/eventgrid/review/eventgrid.api.md
+++ b/sdk/eventgrid/eventgrid/review/eventgrid.api.md
@@ -345,6 +345,17 @@ export interface CloudEvent<T> {
 }
 
 // @public
+export interface CloudEventAdapterParameters {
+    dataschema?: string;
+    extensionAttributes?: Record<string, unknown>;
+    id?: string;
+    source: string;
+    subject?: string;
+    time?: Date;
+    type: string;
+}
+
+// @public
 export type CommunicationCloudEnvironmentModel = string;
 
 // @public
@@ -449,6 +460,9 @@ export interface ContainerServiceNewKubernetesVersionAvailableEventData {
     latestSupportedKubernetesVersion: string;
     lowestMinorKubernetesVersion: string;
 }
+
+// @public
+export function createCloudEventAdapter(params: CloudEventAdapterParameters): MessageAdapter<SendCloudEventInput<Uint8Array>>;
 
 // @public
 export interface DeviceConnectionStateEvent {
@@ -1037,6 +1051,18 @@ export interface MediaLiveEventTrackDiscontinuityDetectedEventData {
     readonly timescale: string;
     readonly trackName: string;
     readonly trackType: string;
+}
+
+// @public
+export interface MessageAdapter<MessageT> {
+    consumeMessage: (message: MessageT) => MessageWithMetadata;
+    produceMessage: (messageWithMetadata: MessageWithMetadata) => MessageT;
+}
+
+// @public
+export interface MessageWithMetadata {
+    body: Uint8Array;
+    contentType: string;
 }
 
 // @public

--- a/sdk/eventgrid/eventgrid/src/cloudEventAdapter.ts
+++ b/sdk/eventgrid/eventgrid/src/cloudEventAdapter.ts
@@ -1,0 +1,110 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { SendCloudEventInput } from "./models";
+
+/**
+ * A message with payload and content type fields
+ *
+ * This interface is hidden because it is already exported by `@azure/schema-registry-avro`
+ *
+ * @hidden
+ */
+export interface MessageWithMetadata {
+  /**
+   * The message's binary data
+   */
+  body: Uint8Array;
+  /**
+   * The message's content type
+   */
+  contentType: string;
+}
+
+/**
+ * A message adapter interface that specifies methods for producing and consuming
+ * messages with payloads and content type fields.
+ *
+ * This interface is hidden because it is already exported by `@azure/schema-registry-avro`
+ *
+ * @hidden
+ */
+export interface MessageAdapter<MessageT> {
+  /**
+   * defines how to create a message from a payload and a content type
+   */
+  produceMessage: (messageWithMetadata: MessageWithMetadata) => MessageT;
+  /**
+   * defines how to access the payload and the content type of a message
+   */
+  consumeMessage: (message: MessageT) => MessageWithMetadata;
+}
+
+/**
+ * Parameters to the `createCloudEventAdapter` function that creates a cloud event adapter.
+ */
+export interface CloudEventAdapterParameters {
+  /**
+   * Type of event related to the originating occurrence.
+   */
+  type: string;
+  /**
+   * Identifies the context in which an event happened. The combination of id and source must be unique for each distinct event.
+   */
+  source: string;
+  /**
+   * An identifier for the event. The combination of id and source must be unique for each distinct event. If an ID is not provided,
+   * a random UUID will be generated and used.
+   */
+  id?: string;
+  /**
+   * The time the event was generated. If not provided, the current time will be used.
+   */
+  time?: Date;
+  /**
+   * Identifies the schema that data adheres to.
+   */
+  dataschema?: string;
+  /**
+   * This describes the subject of the event in the context of the event producer (identified by source).
+   */
+  subject?: string;
+  /**
+   * Additional context attributes for the event. The Cloud Event specification refers to these as "extension attributes".
+   */
+  extensionAttributes?: Record<string, unknown>;
+}
+
+/**
+ * A function that constructs a cloud event adapter. That adapter can be used
+ * with `@azure/schema-registry-avro` to encode and decode data in cloud events.
+ *
+ * @param params - parameters to create the cloud event
+ * @returns A cloud event adapter that can produce and consume cloud events
+ */
+export function createCloudEventAdapter(
+  params: CloudEventAdapterParameters
+): MessageAdapter<SendCloudEventInput<Uint8Array>> {
+  return {
+    produceMessage: ({ body, contentType }: MessageWithMetadata) => {
+      return {
+        ...params,
+        data: body,
+        datacontenttype: contentType,
+      };
+    },
+    consumeMessage: (message: SendCloudEventInput<Uint8Array>): MessageWithMetadata => {
+      const { data: body, datacontenttype: contentType } = message;
+      if (body === undefined || !(body instanceof Uint8Array)) {
+        throw new Error("Expected the data field to defined and have a Uint8Array");
+      }
+      if (contentType === undefined) {
+        throw new Error("Expected the datacontenttype field to be defined");
+      }
+      return {
+        body,
+        contentType,
+      };
+    },
+  };
+}

--- a/sdk/eventgrid/eventgrid/src/index.ts
+++ b/sdk/eventgrid/eventgrid/src/index.ts
@@ -211,3 +211,5 @@ export {
   ResourceHttpRequest,
   ContainerRegistryEventConnectedRegistry,
 } from "./generated/models";
+
+export * from "./cloudEventAdapter";

--- a/sdk/schemaregistry/schema-registry-avro/samples-dev/withEventGrid.ts
+++ b/sdk/schemaregistry/schema-registry-avro/samples-dev/withEventGrid.ts
@@ -1,0 +1,111 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+/**
+ * @summary Send events to Event Grid with Avro-encoded payloads using the Cloud Events 1.0 Schema.
+ * @azsdk-weight 1
+ */
+
+import {
+  EventGridPublisherClient,
+  AzureKeyCredential,
+  createCloudEventAdapter,
+} from "@azure/eventgrid";
+import { DefaultAzureCredential } from "@azure/identity";
+import { SchemaDescription, SchemaRegistryClient } from "@azure/schema-registry";
+import { SchemaRegistryAvroEncoder } from "@azure/schema-registry-avro";
+import * as dotenv from "dotenv";
+
+// Load the .env file if it exists
+dotenv.config();
+
+// The fully qualified namespace for schema registry
+const schemaRegistryFullyQualifiedNamespace =
+  process.env["SCHEMA_REGISTRY_ENDPOINT"] || "<endpoint>";
+
+// The schema group to use for schema registeration or lookup
+const groupName = process.env["SCHEMA_REGISTRY_GROUP"] || "AzureSdkSampleGroup";
+
+// The URL of the endpoint of the Event Grid topic.
+const endpoint = process.env["EVENT_GRID_TOPIC_ENDPOINT"] || "";
+
+// You can find the access keys in the Azure portal.
+// Navigate to Settings > Access keys in your Event Grid topic's menu blade to see both access keys (you may use either).
+const accessKey = process.env["EEVENT_GRID_TOPIC_API_KEY"] || "";
+
+// Sample Avro Schema for user with first and last names
+const schemaObject = {
+  type: "record",
+  name: "User",
+  namespace: "com.azure.schemaregistry.samples",
+  fields: [
+    {
+      name: "firstName",
+      type: "string",
+    },
+    {
+      name: "lastName",
+      type: "string",
+    },
+  ],
+};
+
+// Matching TypeScript interface for schema
+interface User {
+  firstName: string;
+  lastName: string;
+}
+
+const schema = JSON.stringify(schemaObject);
+
+// Description of the schema for registration
+const schemaDescription: SchemaDescription = {
+  name: `${schemaObject.namespace}.${schemaObject.name}`,
+  groupName: groupName,
+  format: "Avro",
+  definition: schema,
+};
+
+export async function main(): Promise<void> {
+  // Create a new client
+  const schemaRegistryClient = new SchemaRegistryClient(
+    schemaRegistryFullyQualifiedNamespace,
+    new DefaultAzureCredential()
+  );
+
+  // Register the schema. This would generally have been done somewhere else.
+  // You can also skip this step and let `encodeMessageData` automatically register
+  // schemas using autoRegisterSchemas=true, but that is NOT recommended in production.
+  await schemaRegistryClient.registerSchema(schemaDescription);
+
+  // Create a new encoder backed by the client
+  const encoder = new SchemaRegistryAvroEncoder(schemaRegistryClient, {
+    groupName,
+    messageAdapter: createCloudEventAdapter({
+      type: "azure.sdk.eventgrid.samples.cloudevent",
+      source: "/azure/sdk/schemaregistry/samples/withEventGrid",
+    }),
+  });
+  // Create the client used to publish events to the Event Grid Service
+  const eventGridPublisherClient = new EventGridPublisherClient(
+    endpoint,
+    "CloudEvent",
+    new AzureKeyCredential(accessKey)
+  );
+
+  // Encode an object that matches the schema
+  const value: User = { firstName: "Joe", lastName: "Doe" };
+  const message = await encoder.encodeMessageData(value, schema);
+
+  console.log("Created message:");
+  console.log(JSON.stringify(message));
+
+  // Send an event with the Avro-encoded payload to the Event Grid Service,
+  // using the Cloud Event schema.
+  // A random ID will be generated for this event, since one is not provided.
+  await eventGridPublisherClient.send([message]);
+}
+
+main().catch((err) => {
+  console.error("The sample encountered an error:", err);
+});


### PR DESCRIPTION
This PR extends the work in https://github.com/Azure/azure-sdk-for-js/pull/19842 to Event Grid as well by defining an adapter factory for cloud events and adding a sample for using the new Avro encoder with cloud events.

This is meant as showing a proof of concept and to be merged after discussing timeline with @ellismg.