### PR TITLE
[web-pubsub-express] Remove cloudevents dependency

### DIFF
--- a/sdk/web-pubsub/web-pubsub-express/CHANGELOG.md
+++ b/sdk/web-pubsub/web-pubsub-express/CHANGELOG.md
@@ -1,14 +1,14 @@
 # Release History
 
-## 1.0.2 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
+## 1.0.2 (2022-01-30)
 
 ### Bugs Fixed
 
+- Fix the issue that `UserEventRequest` failed to process request with content-type `application/octet-stream` correctly into `dataType` `binary`
+
 ### Other Changes
+
+- Remove `cloudevents` package dependency
 
 ## 1.0.1 (2022-01-11)
 

--- a/sdk/web-pubsub/web-pubsub-express/package.json
+++ b/sdk/web-pubsub/web-pubsub-express/package.json
@@ -56,8 +56,7 @@
   "sideEffects": false,
   "dependencies": {
     "tslib": "^2.2.0",
-    "@azure/logger": "^1.0.0",
-    "cloudevents": "^4.0.0"
+    "@azure/logger": "^1.0.0"
   },
   "devDependencies": {
     "@azure/dev-tool": "^1.0.0",

--- a/sdk/web-pubsub/web-pubsub-express/src/cloudEventsDispatcher.ts
+++ b/sdk/web-pubsub/web-pubsub-express/src/cloudEventsDispatcher.ts
@@ -1,19 +1,19 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+import * as utils from "./utils";
 import { IncomingMessage, ServerResponse } from "http";
 import { URL } from "url";
 import { logger } from "./logger";
-import * as utils from "./utils";
 
 import {
   ConnectRequest,
   ConnectResponse,
-  UserEventRequest,
-  DisconnectedRequest,
   ConnectedRequest,
   ConnectionContext,
   ConnectResponseHandler,
+  DisconnectedRequest,
+  UserEventRequest,
   UserEventResponseHandler,
   WebPubSubEventHandlerOptions,
 } from "./cloudEventsProtocols";
@@ -38,7 +38,7 @@ function getDataType(request: IncomingMessage): DataType {
     return DataType.None;
   }
 
-  var contentType = contentTypeheader.split(";")[0].trim();
+  const contentType = contentTypeheader.split(";")[0].trim();
   if (contentType === "application/json") {
     return DataType.Json;
   }

--- a/sdk/web-pubsub/web-pubsub-express/src/cloudEventsDispatcher.ts
+++ b/sdk/web-pubsub/web-pubsub-express/src/cloudEventsDispatcher.ts
@@ -298,7 +298,10 @@ export class CloudEventsDispatcher {
       case EventType.Disconnected: {
         // for unblocking events, we responds to the service as early as possible
         response.end();
-        const disconnectedRequest = await readSystemEventRequest<DisconnectedRequest>(request, origin);
+        const disconnectedRequest = await readSystemEventRequest<DisconnectedRequest>(
+          request,
+          origin
+        );
         logger.verbose(disconnectedRequest);
         this.eventHandler.onDisconnected!(disconnectedRequest);
         return true;

--- a/sdk/web-pubsub/web-pubsub-express/src/cloudEventsDispatcher.ts
+++ b/sdk/web-pubsub/web-pubsub-express/src/cloudEventsDispatcher.ts
@@ -39,7 +39,6 @@ function getDataType(request: IncomingMessage): DataType {
   }
 
   var contentType = contentTypeheader.split(";")[0].trim();
-  console.log(contentType);
   if (contentType === "application/json") {
     return DataType.Json;
   }

--- a/sdk/web-pubsub/web-pubsub-express/src/utils.ts
+++ b/sdk/web-pubsub/web-pubsub-express/src/utils.ts
@@ -28,26 +28,18 @@ export function fromBase64JsonString(base64String: string | undefined): Record<s
 
 export function getHttpHeader(req: IncomingMessage, key: string): string | undefined {
   if (!key) return undefined;
-  for (const header in req.headers) {
-    if (Object.prototype.hasOwnProperty.call(req.headers, header)) {
-      // ignore case
-      if (header.toUpperCase() === key.toUpperCase()) {
-        const value = req.headers[header];
 
-        if (value === undefined) {
-          return undefined;
-        }
+  // According to https://nodejs.org/api/http.html#http_class_http_incomingmessage, header names are always lower-cased
+  const value = req.headers[key.toLowerCase()];
 
-        if (typeof value === "string") {
-          return value;
-        }
-
-        return value[0];
-      }
-    }
+  if (value === undefined) {
+    return undefined;
+  }
+  if (typeof value === "string") {
+    return value;
   }
 
-  return undefined;
+  return value[0];
 }
 
 export function readRequestBody(req: IncomingMessage): Promise<Buffer> {

--- a/sdk/web-pubsub/web-pubsub-express/test/connect.spec.ts
+++ b/sdk/web-pubsub/web-pubsub-express/test/connect.spec.ts
@@ -16,7 +16,7 @@ function buildRequest(
   states?: string
 ): void {
   req.headers["webhook-request-origin"] = "xxx.webpubsub.azure.com";
-  req.headers["Content-Type"] = "application/json; charset=utf-8";
+  req.headers["content-type"] = "application/json; charset=utf-8";
   req.headers["ce-awpsversion"] = "1.0";
   req.headers["ce-specversion"] = "1.0";
   req.headers["ce-type"] = "azure.webpubsub.sys.connect";

--- a/sdk/web-pubsub/web-pubsub-express/test/connect.spec.ts
+++ b/sdk/web-pubsub/web-pubsub-express/test/connect.spec.ts
@@ -29,7 +29,7 @@ function buildRequest(
   req.headers["ce-connectionId"] = connectionId;
   req.headers["ce-hub"] = hub;
   req.headers["ce-event"] = "connect";
-  req.headers["ce-connectionState"] = states;
+  req.headers["ce-connectionstate"] = states;
 }
 
 function mockBody(req: IncomingMessage, body: string): void {

--- a/sdk/web-pubsub/web-pubsub-express/test/connected.spec.ts
+++ b/sdk/web-pubsub/web-pubsub-express/test/connected.spec.ts
@@ -14,7 +14,7 @@ function buildRequest(
   userId?: string
 ): void {
   req.headers["webhook-request-origin"] = "xxx.webpubsub.azure.com";
-  req.headers["Content-Type"] = "application/json; charset=utf-8";
+  req.headers["content-type"] = "application/json; charset=utf-8";
   req.headers["ce-awpsversion"] = "1.0";
   req.headers["ce-specversion"] = "1.0";
   req.headers["ce-type"] = "azure.webpubsub.user.connected";

--- a/sdk/web-pubsub/web-pubsub-express/test/disconnected.spec.ts
+++ b/sdk/web-pubsub/web-pubsub-express/test/disconnected.spec.ts
@@ -14,7 +14,7 @@ function buildRequest(
   userId?: string
 ): void {
   req.headers["webhook-request-origin"] = "xxx.webpubsub.azure.com";
-  req.headers["Content-Type"] = "application/json; charset=utf-8";
+  req.headers["content-type"] = "application/json; charset=utf-8";
   req.headers["ce-awpsversion"] = "1.0";
   req.headers["ce-specversion"] = "1.0";
   req.headers["ce-type"] = "azure.webpubsub.user.disconnected";

--- a/sdk/web-pubsub/web-pubsub-express/test/user.spec.ts
+++ b/sdk/web-pubsub/web-pubsub-express/test/user.spec.ts
@@ -15,7 +15,7 @@ function buildRequest(
   contentType?: string
 ): void {
   req.headers["webhook-request-origin"] = "xxx.webpubsub.azure.com";
-  req.headers["Content-Type"] = contentType ?? "application/json; charset=utf-8";
+  req.headers["content-type"] = contentType ?? "application/json; charset=utf-8";
   req.headers["ce-awpsversion"] = "1.0";
   req.headers["ce-specversion"] = "1.0";
   req.headers["ce-type"] = "azure.webpubsub.user.connect";


### PR DESCRIPTION
The cloudevents package does redundant parses to the request body and there is no need for this package to. So remove the dependency and parse the request following the reference doc https://docs.microsoft.com/en-us/azure/azure-web-pubsub/reference-cloud-events