### PR TITLE
[@azure/search-documents] Change EndPoint in TestResources Json

### DIFF
--- a/sdk/search/search-documents/test/public/utils/recordedClient.ts
+++ b/sdk/search/search-documents/test/public/utils/recordedClient.ts
@@ -61,20 +61,7 @@ export function createClients<IndexModel>(
   indexName: string,
   serviceVersion: string
 ): Clients<IndexModel> {
-  let endPoint: string = "https://endpoint";
-
-  switch (testEnv.AZURE_AUTHORITY_HOST) {
-    case "https://login.microsoftonline.us":
-      endPoint = process.env.USENDPOINT ?? "https://endpoint";
-      break;
-    case "https://login.chinacloudapi.cn":
-      endPoint = process.env.CHINAENDPOINT ?? "https://endpoint";
-      break;
-    default:
-      endPoint = process.env.ENDPOINT ?? "https://endpoint";
-      break;
-  }
-
+  const endPoint: string = process.env.ENDPOINT ?? "https://endpoint";
   const credential = new AzureKeyCredential(testEnv.SEARCH_API_ADMIN_KEY);
   const searchClient = new SearchClient<IndexModel>(endPoint, indexName, credential, {
     serviceVersion,

--- a/sdk/search/test-resources.json
+++ b/sdk/search/test-resources.json
@@ -15,6 +15,13 @@
       "metadata": {
         "description": "SKU for search resource. The default is 'basic'"
       }
+    },
+    "searchEndpointSuffix": {
+      "type": "string",
+      "defaultValue": "search.azure.net",
+      "metadata": {
+        "description": "Endpoint suffix for the search resource. Defaults to 'search.azure.net'"
+      }
     }
   },
   "variables": {},
@@ -47,7 +54,7 @@
     },
     "ENDPOINT": {
       "type": "string",
-      "value": "[concat('https://', parameters('baseName'), parameters('searchEndpointSuffix'))]"
+      "value": "[concat('https://', parameters('baseName'), '.', parameters('searchEndpointSuffix'))]"
     }
   }
 }

--- a/sdk/search/test-resources.json
+++ b/sdk/search/test-resources.json
@@ -47,15 +47,7 @@
     },
     "ENDPOINT": {
       "type": "string",
-      "value": "[concat('https://', parameters('baseName'), '.search.windows.net')]"
-    },
-    "CHINAENDPOINT": {
-      "type": "string",
-      "value": "[concat('https://', parameters('baseName'), '.search.azure.cn')]"
-    },
-    "USENDPOINT": {
-      "type": "string",
-      "value": "[concat('https://', parameters('baseName'), '.search.azure.us')]"
+      "value": "[concat('https://', parameters('baseName'), parameters('searchEndpointSuffix'))]"
     }
   }
 }

--- a/sdk/search/test-resources.json
+++ b/sdk/search/test-resources.json
@@ -18,9 +18,9 @@
     },
     "searchEndpointSuffix": {
       "type": "string",
-      "defaultValue": "search.azure.net",
+      "defaultValue": "search.windows.net",
       "metadata": {
-        "description": "Endpoint suffix for the search resource. Defaults to 'search.azure.net'"
+        "description": "Endpoint suffix for the search resource. Defaults to 'search.windows.net'"
       }
     }
   },


### PR DESCRIPTION
**Checklists** 
- [X] Added impacted package name to the issue description

**Packages impacted by this PR:**
@azure/search-documents

**Issues associated with this PR:**
https://github.com/Azure/azure-sdk-for-js/issues/17577

**Describe the problem that is addressed by this PR:**
This PR addresses the issue of updating search-documents tests to handle sovereign cloud endpoints dynamically. Earlier, this was done by adding 2 different endpoints (one for US and one for China). Ben has suggested a better approach where we can use just one endpoint and choose the suffix dynamically.

**What are the possible designs available to address the problem**
No detailed design. This approach is already used in .NET SDK and we are following the same here. 

**If there are more than one possible design, why was the one in this PR chosen?**
N/A

**Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
None

**Are there test cases added in this PR?**_(If not, why?)_
This is just updating the Json file and no seperate test cases are required.

**Provide a list of related PRs**_(if any)_
https://github.com/Azure/azure-sdk-for-js/pull/19781

**Command used to generate this PR:**_(Applicable only to SDK release request PRs)_
N/A

@benbp Please review and approve the PR.
