### PR TITLE
[core-http] Remove dependnecy on deprecated @types/node-fetch

### DIFF
--- a/sdk/core/core-http/package.json
+++ b/sdk/core/core-http/package.json
@@ -117,7 +117,6 @@
     "@azure/core-auth": "^1.3.0",
     "@azure/core-tracing": "1.0.0-preview.13",
     "@azure/logger": "^1.0.0",
-    "@types/node-fetch": "^2.5.0",
     "@types/tunnel": "^0.0.3",
     "form-data": "^4.0.0",
     "node-fetch": "^2.6.7",

--- a/sdk/core/core-http/src/node-fetch.d.ts
+++ b/sdk/core/core-http/src/node-fetch.d.ts
@@ -1,0 +1,29 @@
+declare module "node-fetch" {
+  import { Agent } from "http";
+
+  interface URLLike {
+    href: string;
+}
+  export type RequestInfo = string | URLLike | Request;
+  export interface RequestInit {
+    // whatwg/fetch standard options
+    body?: BodyInit | undefined;
+    headers?: HeadersInit | undefined;
+    method?: string | undefined;
+    redirect?: RequestRedirect | undefined;
+    signal?: AbortSignal | null | undefined;
+
+    // node-fetch extensions
+    agent?: Agent | ((parsedUrl: URL) => Agent) | undefined; // =null http.Agent instance, allows custom proxy, certificate etc.
+    compress?: boolean | undefined; // =true support gzip/deflate content encoding. false to disable
+    follow?: number | undefined; // =20 maximum redirect count. 0 to not follow redirect
+    size?: number | undefined; // =0 maximum response body size in bytes. 0 to disable
+    timeout?: number | undefined; // =0 req/res timeout in ms, it resets on redirect. 0 to disable (OS limit applies)
+
+    // node-fetch does not support mode, cache or credentials options
+}
+
+  export default function fetch(
+    url: RequestInfo,
+    init?: RequestInit
+): Promise<Response>;}


### PR DESCRIPTION
**Checklists** 
- [x] Added impacted package name to the issue description

**Packages impacted by this PR:**
@azure/core-http

**Describe the problem that is addressed by this PR:**
core-http depends on a types package that has been marked as deprecated

**What are the possible designs available to address the problem**
1. Shim needed types and drop dependency on the deprecated package
2. Keep dependency on the deprecated package

**If there are more than one possible design, why was the one in this PR chosen?**
Since the package is now deprecated there will be no additional fixes to it. So shimming locally the types we need will give us the chance to react to any changes needed.

**Are there test cases added in this PR?**_(If not, why?)_
N/A as this is a Types change only
