### PR TITLE
Set correct content length in requests for uploading operations

### DIFF
--- a/sdk/storage/storage-blob/CHANGELOG.md
+++ b/sdk/storage/storage-blob/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Set correct content length in requests for uploading operations to avoid unexpected failure if customized content length is incorrect.
+
 ### Other Changes
 
 ## 12.9.0-beta.3 (2022-02-11)

--- a/sdk/storage/storage-blob/src/policies/StorageSharedKeyCredentialPolicy.ts
+++ b/sdk/storage/storage-blob/src/policies/StorageSharedKeyCredentialPolicy.ts
@@ -39,7 +39,11 @@ export class StorageSharedKeyCredentialPolicy extends CredentialPolicy {
   protected signRequest(request: WebResource): WebResource {
     request.headers.set(HeaderConstants.X_MS_DATE, new Date().toUTCString());
 
-    if (request.body && typeof request.body === "string" && request.body.length > 0) {
+    if (
+      request.body &&
+      (typeof request.body === "string" || (request.body as Buffer) !== undefined) &&
+      request.body.length > 0
+    ) {
       request.headers.set(HeaderConstants.CONTENT_LENGTH, Buffer.byteLength(request.body));
     }
 

--- a/sdk/storage/storage-file-datalake/CHANGELOG.md
+++ b/sdk/storage/storage-file-datalake/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Bugs Fixed
 
 - Fixed a bug where customized `ProxyOptions` is overwrited by a default one when initializing `DataLakeServiceClient` with connection string.
+- Set correct content length in requests for uploading operations to avoid unexpected failure if customized content length is incorrect.
 
 ### Other Changes
 

--- a/sdk/storage/storage-file-datalake/src/policies/StorageSharedKeyCredentialPolicy.ts
+++ b/sdk/storage/storage-file-datalake/src/policies/StorageSharedKeyCredentialPolicy.ts
@@ -39,7 +39,11 @@ export class StorageSharedKeyCredentialPolicy extends CredentialPolicy {
   protected signRequest(request: WebResource): WebResource {
     request.headers.set(HeaderConstants.X_MS_DATE, new Date().toUTCString());
 
-    if (request.body && typeof request.body === "string" && request.body.length > 0) {
+    if (
+      request.body &&
+      (typeof request.body === "string" || (request.body as Buffer) !== undefined) &&
+      request.body.length > 0
+    ) {
       request.headers.set(HeaderConstants.CONTENT_LENGTH, Buffer.byteLength(request.body));
     }
 

--- a/sdk/storage/storage-file-share/CHANGELOG.md
+++ b/sdk/storage/storage-file-share/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Set correct content length in requests for uploading operations to avoid unexpected failure if customized content length is incorrect.
+
 ### Other Changes
 
 ## 12.9.0-beta.3 (2022-02-11)

--- a/sdk/storage/storage-file-share/src/policies/StorageSharedKeyCredentialPolicy.ts
+++ b/sdk/storage/storage-file-share/src/policies/StorageSharedKeyCredentialPolicy.ts
@@ -39,7 +39,11 @@ export class StorageSharedKeyCredentialPolicy extends CredentialPolicy {
   protected signRequest(request: WebResource): WebResource {
     request.headers.set(HeaderConstants.X_MS_DATE, new Date().toUTCString());
 
-    if (request.body && typeof request.body === "string" && request.body.length > 0) {
+    if (
+      request.body &&
+      (typeof request.body === "string" || (request.body as Buffer) !== undefined) &&
+      request.body.length > 0
+    ) {
       request.headers.set(HeaderConstants.CONTENT_LENGTH, Buffer.byteLength(request.body));
     }
 


### PR DESCRIPTION
Set correct content length in requests for uploading operations to avoid unexpected failure if customized content length is incorrect.
