### PR TITLE
Fix two issues in blob changedfeed.

### DIFF
--- a/sdk/storage/storage-blob-changefeed/CHANGELOG.md
+++ b/sdk/storage/storage-blob-changefeed/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 12.0.0-preview.3 (Unreleased)
 
+### Bugs Fixed
+
+- Always returns continuation token in `BlobChangeFeedClient.listChanges` no matter whether it's the end of the current change feed.
+- Fixed an bug that there's chance `ChangeFeedFactory.create` cannot parse continution token correctly.
 
 ## 12.0.0-preview.2 (2020-09-08)
 

--- a/sdk/storage/storage-blob-changefeed/src/BlobChangeFeedClient.ts
+++ b/sdk/storage/storage-blob-changefeed/src/BlobChangeFeedClient.ts
@@ -228,9 +228,9 @@ export class BlobChangeFeedClient {
           eventPage.events.push(event);
         }
       }
-      if (changeFeed.hasNext()) {
-        eventPage.continuationToken = JSON.stringify(changeFeed.getCursor());
-      }
+
+      eventPage.continuationToken = JSON.stringify(changeFeed.getCursor());
+
       if (eventPage.events.length > 0) {
         yield eventPage;
       } else {

--- a/sdk/storage/storage-blob-changefeed/src/ChangeFeedFactory.ts
+++ b/sdk/storage/storage-blob-changefeed/src/ChangeFeedFactory.ts
@@ -71,7 +71,7 @@ export class ChangeFeedFactory {
         cursor = JSON.parse(continuationToken);
         ChangeFeedFactory.validateCursor(containerClient, cursor!);
         options.start = parseDateFromSegmentPath(cursor!.CurrentSegmentCursor.SegmentPath!);
-        options.end = new Date(cursor!.EndTime!);
+        options.end = cursor!.EndTime ? new Date(cursor!.EndTime!) : undefined;
       }
       // Round start and end time if we are not using the cursor.
       else {

--- a/sdk/storage/storage-blob-changefeed/test/blobchangefeedclient.spec.ts
+++ b/sdk/storage/storage-blob-changefeed/test/blobchangefeedclient.spec.ts
@@ -92,9 +92,9 @@ describe("BlobChangeFeedClient", async () => {
     assert.notEqual(event1.id, event.id);
 
     // fetch between time range
-    const start = new Date(Date.UTC(2020, 1, 21, 22, 30, 0)); // will be ignored
-    const end = new Date(Date.UTC(2020, 4, 8, 21, 10, 0)); // will be rounded to 22:00
-    const endRounded = new Date(Date.UTC(2020, 4, 8, 22, 0, 0));
+    const start = new Date(Date.UTC(2022, 1, 21, 22, 30, 0)); // will be ignored
+    const end = new Date(Date.UTC(2022, 4, 8, 21, 10, 0)); // will be rounded to 22:00
+    const endRounded = new Date(Date.UTC(2022, 4, 8, 22, 0, 0));
     const iter2 = changeFeedClient
       .listChanges({ start, end })
       .byPage({ continuationToken: nextPage1.value.continuationToken });

--- a/sdk/storage/storage-blob-changefeed/test/changefeed.spec.ts
+++ b/sdk/storage/storage-blob-changefeed/test/changefeed.spec.ts
@@ -228,6 +228,12 @@ describe("Change Feed", async () => {
     const event = await changeFeed.getChange();
     assert.equal(event, 3 as unknown as BlobChangeFeedEvent | undefined);
 
+    const changeFeed3 = await changeFeedFactory.create(
+      serviceClientStub as any,
+      JSON.stringify(changeFeed2.getCursor())
+    );
+    assert.ok(changeFeed3.hasNext());
+
     // lastConsumable changed
     blobClientStub.download.callsFake(() => {
       return new Promise((resolve) => {
@@ -236,9 +242,9 @@ describe("Change Feed", async () => {
     });
     segmentStubs[3].hasNext.returns(false);
     segmentStubs[3].getChange.resolves(undefined);
-    const changeFeed3 = await changeFeedFactory.create(serviceClientStub as any, continuation);
-    assert.ok(changeFeed3.hasNext());
-    const event2 = await changeFeed3.getChange();
+    const changeFeed4 = await changeFeedFactory.create(serviceClientStub as any, continuation);
+    assert.ok(changeFeed4.hasNext());
+    const event2 = await changeFeed4.getChange();
     assert.equal(event2, 4 as unknown as BlobChangeFeedEvent | undefined);
   });
 });


### PR DESCRIPTION
- Always returns continuation token in `BlobChangeFeedClient.listChanges` no matter whether it's the end of the current change feed.
- Fixed an bug that there's chance `ChangeFeedFactory.create` cannot parse continution token correctly.