### PR TITLE
[KeyVault] - Added immutable flag to key release policy

### DIFF
--- a/sdk/keyvault/keyvault-keys/CHANGELOG.md
+++ b/sdk/keyvault/keyvault-keys/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Features Added
 
+- Added `KeyReleasePolicy#immutable` flag to support immutable release policies. Once a release policy is marked as immutable, it can no longer be modified.
+
 ### Breaking Changes
 
 ### Bugs Fixed

--- a/sdk/keyvault/keyvault-keys/recordings/browsers/keys_client__create_read_update_and_delete_operations_releasekey/recording_errors_when_updating_an_immutable_release_policy.json
+++ b/sdk/keyvault/keyvault-keys/recordings/browsers/keys_client__create_read_update_and_delete_operations_releasekey/recording_errors_when_updating_an_immutable_release_policy.json
@@ -1,0 +1,133 @@
+{
+ "recordings": [
+  {
+   "method": "GET",
+   "url": "https://skr_attestation.azure.net//generate-test-token",
+   "query": {},
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"token\":\"eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6IjYybHRKM0dSa3hWVC1fdkQ2dWJ4LWdHWUZIWU5pWE1WZ29sSzU5NzEyVzAiLCJqa3UiOiJodHRwczovL21hbGVnZWltbXV0YWJsZTJzaXRlLmF6dXJld2Vic2l0ZXMubmV0L2tleXMifQ.eyJpc3MiOiJodHRwczovL21hbGVnZWltbXV0YWJsZTJzaXRlLmF6dXJld2Vic2l0ZXMubmV0LyIsInNkay10ZXN0Ijp0cnVlLCJ4LW1zLWluaXR0aW1lIjp7fSwieC1tcy1ydW50aW1lIjp7ImtleXMiOlt7Imt0eSI6IlJTQSIsImtpZCI6ImZha2UtcmVsZWFzZS1rZXkiLCJ1c2UiOiJlbmMiLCJlIjoiQVFBQiIsIm4iOiJuaVNVajF1OC1MTEpVNUlyQmJhUjRvZlRoNWdpdjN1eGt1OWNCX01RUmZnb245WW5MdmtpS1V1b1lWaHljNW5TNlBlVGdSdTE3eTU3MUUtU3BidTF2Qm1iUDhQVXEwOTlLS085YTAxTzJCVFVaU0xFRWljdEgtcDl4Z293ck5ibFVUUndydGxKTEFaelBwTmt3eFpRcVp2Tk5XVVdPWEZSVDNHdE1XZjhUeVIzUGVKUTNBeVdqRFRXZlhuNzA1MzVoM3RWWFlfUkN3emZiSm93SUxsT21QSV9qYVpKb2dYLXRzTUM4WVl6YnRIQ1FCYVItX21yS3puQmtodUpQRW0zZWRwSWJGSWNaNmR1a2tneDFBVDNWeHlNTExZNEdyX3dQOU1Pc3paTHRSa0xidjJkcWl0TEtjTmpZclVEM002aUhQRHM4S3hsTUVDOGUtV2E0eVhVaXcifV19LCJtYWEtZWhkIjoic2RrLXRlc3QiLCJpYXQiOjE2NDMyNDMxNjQsImV4cCI6MTY0Mzg0Nzk2NH0.rPB5v_dqjxbACcSNa6E6GYJ0sKAQGRXTBK2ORh3uHyAqA-dY2A8qMG5YIsSGu9fEgGzcuzrZWQ_drXDuh7XT9QaLvQcB9Sf8hneNIxH0Ta1g0ZT_zRSThogUenkTQkrjCNT_NP8XEZEzkNkiVxHoqkyyeF6bEXC4J2oQqIeDaS7dVo8kAUSIguk8HpEg8-1l6lyHyqi2b6dRRweOL6i1vum7mWH-nARTzhHSgWw-9S16EMwgrecnkRbDChzlks5UkY2H9xjX7CUguu9y9KKnS-FNE_5pudTZrTmKxNKEttQXyFWvFAS92e43zDDjHJpINNip_QRitLRsYkj4LqctVw\"}",
+   "responseHeaders": {
+    "content-length": "1321",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Thu, 27 Jan 2022 00:26:03 GMT",
+    "etag": "W/\"529-Vb6JWe49+bPeOvodsLjMDMMZXJ0\"",
+    "x-powered-by": "Express"
+   }
+  },
+  {
+   "method": "POST",
+   "url": "https://keyvault_name.vault.azure.net/keys/immutablerelease164324316470603193/create",
+   "query": {
+    "api-version": "7.3-preview"
+   },
+   "requestBody": "",
+   "status": 401,
+   "response": "{\"error\":{\"code\":\"Unauthorized\",\"message\":\"AKV10000: Request is missing a Bearer or PoP token.\"}}",
+   "responseHeaders": {
+    "cache-control": "no-cache",
+    "content-length": "97",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Thu, 27 Jan 2022 00:26:04 GMT",
+    "expires": "-1",
+    "pragma": "no-cache",
+    "strict-transport-security": "max-age=31536000;includeSubDomains",
+    "www-authenticate": "Bearer authorization=\"https://login.windows.net/12345678-1234-1234-1234-123456789012\", resource=\"https://vault.azure.net\"",
+    "x-content-type-options": "nosniff",
+    "x-ms-client-request-id": "125ae0a6-2110-45ef-b1b5-6fbae734d8ee",
+    "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=50.35.229.43;act_addr_fam=InterNetwork;",
+    "x-ms-keyvault-region": "westus2",
+    "x-ms-keyvault-service-version": "1.9.264.2",
+    "x-ms-request-id": "fbd62c14-39bb-48bf-8fe0-0e06e33ed5b2",
+    "x-powered-by": "ASP.NET"
+   }
+  },
+  {
+   "method": "POST",
+   "url": "https://login.microsoftonline.com/12345678-1234-1234-1234-123456789012/oauth2/v2.0/token",
+   "query": {},
+   "requestBody": "response_type=token&grant_type=client_credentials&client_id=azure_client_id&client_secret=azure_client_secret&scope=https%3A%2F%2Fsanitized%2F",
+   "status": 200,
+   "response": "{\"token_type\":\"Bearer\",\"expires_in\":86399,\"ext_expires_in\":86399,\"access_token\":\"access_token\"}",
+   "responseHeaders": {
+    "cache-control": "no-store, no-cache",
+    "content-length": "1315",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Thu, 27 Jan 2022 00:26:03 GMT",
+    "expires": "-1",
+    "nel": "{\"report_to\":\"network-errors\",\"max_age\":86400,\"success_fraction\":0.001,\"failure_fraction\":1.0}",
+    "p3p": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\"",
+    "pragma": "no-cache",
+    "referrer-policy": "strict-origin-when-cross-origin",
+    "report-to": "{\"group\":\"network-errors\",\"max_age\":86400,\"endpoints\":[{\"url\":\"https://identity.nel.measure.office.net/api/report?catId=GW+estsfd+est\"}]}",
+    "strict-transport-security": "max-age=31536000; includeSubDomains",
+    "x-content-type-options": "nosniff",
+    "x-ms-ests-server": "2.1.12381.21 - WUS2 ProdSlices",
+    "x-ms-request-id": "8a6baa24-2c78-4c1c-8eaf-f009af920900"
+   }
+  },
+  {
+   "method": "POST",
+   "url": "https://keyvault_name.vault.azure.net/keys/immutablerelease164324316470603193/create",
+   "query": {
+    "api-version": "7.3-preview"
+   },
+   "requestBody": "{\"kty\":\"RSA-HSM\",\"key_ops\":[\"encrypt\",\"decrypt\"],\"attributes\":{\"exportable\":true},\"release_policy\":{\"immutable\":true,\"data\":\"eyJhbnlPZiI6W3siYWxsT2YiOlt7ImNsYWltIjoic2RrLXRlc3QiLCJlcXVhbHMiOiJ0cnVlIn1dLCJhdXRob3JpdHkiOiJodHRwczovL3Nrcl9hdHRlc3RhdGlvbi5henVyZS5uZXQvIn1dLCJ2ZXJzaW9uIjoiMS4wLjAifQ\"}}",
+   "status": 200,
+   "response": "{\"key\":{\"kid\":\"https://keyvault_name.vault.azure.net/keys/immutablerelease164324316470603193/509b54f2152c48469c12e06595985d4e\",\"kty\":\"RSA-HSM\",\"key_ops\":[\"encrypt\",\"decrypt\"],\"n\":\"tFw_OcUC3OpLj6SZ2HerJF7RuWOF7g3yke-G0Qp0M4lZaurq5FDzixPoqiU1U-IYy6j_Kin2-x4N6t7lmaMK0hoFh_IWn4YW2hXSw3OxptpmT5QTel8yvz3V062TQPVaolPYiBfImODvIowmP1Snkw9CzaiIyf2F58gva61zVj28ZO-1rAMUWuJhMhixJCnkSfUpoomdZR-Okh6RCueCkec_vZT_227CRm_OGyiJTwMRiB8Q_CEMQnP2mII7gZ_C-u-IsRiV4oTIxDCI9doQGKNdECsBA0-c5FInEiepZk6s9M0U52u1m4dlx9SyP_TCx-diHG2SXD3opohs9e40-w\",\"e\":\"AAEAAQ\"},\"attributes\":{\"enabled\":true,\"created\":1643243165,\"updated\":1643243165,\"recoveryLevel\":\"CustomizedRecoverable+Purgeable\",\"recoverableDays\":7,\"exportable\":true},\"release_policy\":{\"contentType\":\"application/json; charset=utf-8\",\"data\":\"eyJ2ZXJzaW9uIjoiMS4wLjAiLCJhbnlPZiI6W3siYXV0aG9yaXR5IjoiaHR0cHM6Ly9za3JfYXR0ZXN0YXRpb24uYXp1cmUubmV0LyIsImFsbE9mIjpbeyJjbGFpbSI6InNkay10ZXN0IiwiZXF1YWxzIjoidHJ1ZSJ9XX1dfQ\",\"immutable\":true}}",
+   "responseHeaders": {
+    "cache-control": "no-cache",
+    "content-length": "982",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Thu, 27 Jan 2022 00:26:05 GMT",
+    "expires": "-1",
+    "pragma": "no-cache",
+    "strict-transport-security": "max-age=31536000;includeSubDomains",
+    "x-content-type-options": "nosniff",
+    "x-ms-client-request-id": "125ae0a6-2110-45ef-b1b5-6fbae734d8ee",
+    "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=50.35.229.43;act_addr_fam=InterNetwork;",
+    "x-ms-keyvault-rbac-assignment-id": "0b7bb9bd-b488-5634-b80b-e2b4c4bd48cd",
+    "x-ms-keyvault-rbac-cache": "ra_age=1355;da_age=7613;rd_age=7613;brd_age=6107;ra_notif_age=1662;dec_lev=2;",
+    "x-ms-keyvault-region": "westus2",
+    "x-ms-keyvault-service-version": "1.9.264.2",
+    "x-ms-request-id": "414e91e6-f36f-4fbb-9eed-349d6cac82cf",
+    "x-powered-by": "ASP.NET"
+   }
+  },
+  {
+   "method": "PATCH",
+   "url": "https://keyvault_name.vault.azure.net/keys/immutablerelease164324316470603193/",
+   "query": {
+    "api-version": "7.3-preview"
+   },
+   "requestBody": "{\"attributes\":{},\"release_policy\":{\"immutable\":true,\"data\":\"eyJhbnlPZiI6W3siYW55T2YiOlt7ImNsYWltIjoic2RrLXRlc3QiLCJlcXVhbHMiOiJmYWxzZSJ9XSwiYXV0aG9yaXR5IjoiaHR0cHM6Ly9za3JfYXR0ZXN0YXRpb24uYXp1cmUubmV0LyJ9XSwidmVyc2lvbiI6IjEuMCJ9\"}}",
+   "status": 400,
+   "response": "{\"error\":{\"code\":\"BadParameter\",\"message\":\"AKV.SKR.1020: Immutable Key Release Policy cannot be modified.\"}}",
+   "responseHeaders": {
+    "cache-control": "no-cache",
+    "content-length": "108",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Thu, 27 Jan 2022 00:26:06 GMT",
+    "expires": "-1",
+    "pragma": "no-cache",
+    "strict-transport-security": "max-age=31536000;includeSubDomains",
+    "x-content-type-options": "nosniff",
+    "x-ms-client-request-id": "e935a810-1fbc-4b30-9f0a-85891f766fcd",
+    "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=50.35.229.43;act_addr_fam=InterNetwork;",
+    "x-ms-keyvault-rbac-assignment-id": "0b7bb9bd-b488-5634-b80b-e2b4c4bd48cd",
+    "x-ms-keyvault-rbac-cache": "ra_age=1356;da_age=7614;rd_age=7614;brd_age=6108;ra_notif_age=1663;dec_lev=1;",
+    "x-ms-keyvault-region": "westus2",
+    "x-ms-keyvault-service-version": "1.9.264.2",
+    "x-ms-request-id": "c98b7b3d-9b70-4b85-a4b1-dc293528d4c6",
+    "x-powered-by": "ASP.NET"
+   }
+  }
+ ],
+ "uniqueTestInfo": {
+  "uniqueName": {
+   "immutablerelease": "immutablerelease164324316470603193"
+  },
+  "newDate": {}
+ },
+ "hash": "8b272c69990aec75985f8afdc7061ca4"
+}

--- a/sdk/keyvault/keyvault-keys/recordings/node/keys_client__create_read_update_and_delete_operations_releasekey/recording_errors_when_updating_an_immutable_release_policy.js
+++ b/sdk/keyvault/keyvault-keys/recordings/node/keys_client__create_read_update_and_delete_operations_releasekey/recording_errors_when_updating_an_immutable_release_policy.js
@@ -1,0 +1,244 @@
+let nock = require('nock');
+
+module.exports.hash = "e97f1dfeea8e9af2bdefa65e65864790";
+
+module.exports.testInfo = {"uniqueName":{"immutablerelease":"immutablerelease164324315726004693"},"newDate":{}}
+
+nock('https://skr_attestation.azure.net:443', {"encodedQueryParams":true})
+  .get('//generate-test-token')
+  .reply(200, {"token":"eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6IjYybHRKM0dSa3hWVC1fdkQ2dWJ4LWdHWUZIWU5pWE1WZ29sSzU5NzEyVzAiLCJqa3UiOiJodHRwczovL21hbGVnZWltbXV0YWJsZTJzaXRlLmF6dXJld2Vic2l0ZXMubmV0L2tleXMifQ.eyJpc3MiOiJodHRwczovL21hbGVnZWltbXV0YWJsZTJzaXRlLmF6dXJld2Vic2l0ZXMubmV0LyIsInNkay10ZXN0Ijp0cnVlLCJ4LW1zLWluaXR0aW1lIjp7fSwieC1tcy1ydW50aW1lIjp7ImtleXMiOlt7Imt0eSI6IlJTQSIsImtpZCI6ImZha2UtcmVsZWFzZS1rZXkiLCJ1c2UiOiJlbmMiLCJlIjoiQVFBQiIsIm4iOiJwWkxQcllyRWVNZFR6a2F6TVhNOEpZWkF1R0Zmc290VjdKVEhvYTFDQUVRVXR0MkxPc29aM1lKZ2o2TE5tajBaUFk2ZHdRWU1BNXBXSkhSQkM3cXBBY2xBb1VNalJ3cmZuUGZ5aFBaMWM1OEo3VTB2czNzeHktSG1lMl94eEtsUHNzYVZ2b1haNXEwYVp4RXhxYnlWQXZZekZSVl9JS1Z5bUxDaXhzalZmaEE4azBkWXdaeU9UYzVxQkFiTnlwU0tXb2NSd0c0UTdMZTVGeUtCRDB5eVJJTUFkazhQdjVsOHV0b2dMcEVMakRLZERQcTJuTE9iZ1NMRTFKSjlNUHdvQVRaaHZMbE1fV3lYODFocGs1NWp2Y1JoZzAzcUtyUVE2OFNBZ1pZeFN5QktVYWxDa3loSVB1RmVic1lIeWFFUXZGbTNPa2hfdlcwMzZuSTQ3U2x4UVEifV19LCJtYWEtZWhkIjoic2RrLXRlc3QiLCJpYXQiOjE2NDMyNDMxNTYsImV4cCI6MTY0Mzg0Nzk1Nn0.mW_9PdjNEXw8_62KeeN_LW_DL-cMWuEXazg3RtToFv8go4iGg5bZWDVTSjEd2ToU80Pc1EA7IB_o6vimNpZWb7a3irZQfTHYXvljpj5NV_xJ3piY_neNSi-Fojskyd3Kuih5oJOjvQPE_aWiBpbU1_3knE8w-X7TRcfCGdS1COpooxObYD2tIQE8On3M0c1WnihrMJ5opNoKK_2DnSDHWbjZagOWsQ5J0Du68hV0J6jHDD0f5gQ-tE8Eje2Bcx3PkZrsgiBVzdfCbTNUquqyOmWBRHC1WC-hFnfk2ybbba31xDDPc-uBD1f3AEMSQSguyAx9f-y6gD-2vEPtXPz1wg"}, [
+  'Content-Length',
+  '1321',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'ETag',
+  'W/"529-AAmzVN1XDmKC9ghr6gpRoJh8t+M"',
+  'X-Powered-By',
+  'Express',
+  'Set-Cookie',
+  'ARRAffinity=619d5cd37d5df35ce07c198c9a607841d32e50136529316925bc0449d5dc307e;Path=/;HttpOnly;Secure;Domain=skr_attestation.azure.net',
+  'Set-Cookie',
+  'ARRAffinitySameSite=619d5cd37d5df35ce07c198c9a607841d32e50136529316925bc0449d5dc307e;Path=/;HttpOnly;SameSite=None;Secure;Domain=skr_attestation.azure.net',
+  'Date',
+  'Thu, 27 Jan 2022 00:25:56 GMT',
+  'Connection',
+  'close'
+]);
+
+nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
+  .post('/keys/immutablerelease164324315726004693/create')
+  .query(true)
+  .reply(401, {"error":{"code":"Unauthorized","message":"AKV10000: Request is missing a Bearer or PoP token."}}, [
+  'Cache-Control',
+  'no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Length',
+  '97',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'WWW-Authenticate',
+  'Bearer authorization="https://login.windows.net/12345678-1234-1234-1234-123456789012", resource="https://vault.azure.net"',
+  'x-ms-keyvault-region',
+  'westus2',
+  'x-ms-client-request-id',
+  '81d2405d-bf75-4675-9649-c0b8a0c1efff',
+  'x-ms-request-id',
+  '869b4f9e-3148-4a7b-a2b2-8c532c752a7a',
+  'x-ms-keyvault-service-version',
+  '1.9.264.2',
+  'x-ms-keyvault-network-info',
+  'conn_type=Ipv4;addr=50.35.229.43;act_addr_fam=InterNetwork;',
+  'X-Powered-By',
+  'ASP.NET',
+  'Strict-Transport-Security',
+  'max-age=31536000;includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Date',
+  'Thu, 27 Jan 2022 00:25:56 GMT'
+]);
+
+nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
+  .get('/common/discovery/instance')
+  .query(true)
+  .reply(200, {"tenant_discovery_endpoint":"https://login.microsoftonline.com/12345678-1234-1234-1234-123456789012/v2.0/.well-known/openid-configuration","api-version":"1.1","metadata":[{"preferred_network":"login.microsoftonline.com","preferred_cache":"login.windows.net","aliases":["login.microsoftonline.com","login.windows.net","login.microsoft.com","sts.windows.net"]},{"preferred_network":"login.partner.microsoftonline.cn","preferred_cache":"login.partner.microsoftonline.cn","aliases":["login.partner.microsoftonline.cn","login.chinacloudapi.cn"]},{"preferred_network":"login.microsoftonline.de","preferred_cache":"login.microsoftonline.de","aliases":["login.microsoftonline.de"]},{"preferred_network":"login.microsoftonline.us","preferred_cache":"login.microsoftonline.us","aliases":["login.microsoftonline.us","login.usgovcloudapi.net"]},{"preferred_network":"login-us.microsoftonline.com","preferred_cache":"login-us.microsoftonline.com","aliases":["login-us.microsoftonline.com"]}]}, [
+  'Cache-Control',
+  'max-age=86400, private',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Access-Control-Allow-Origin',
+  '*',
+  'Access-Control-Allow-Methods',
+  'GET, OPTIONS',
+  'P3P',
+  'CP="DSP CUR OTPi IND OTRi ONL FIN"',
+  'x-ms-request-id',
+  '2a05c435-525f-4b81-a831-d8f082d1d600',
+  'x-ms-ests-server',
+  '2.1.12261.22 - SCUS ProdSlices',
+  'Set-Cookie',
+  'fpc=Ah7n2UgkIXhIm3ad91RlIaA; expires=Sat, 26-Feb-2022 00:25:57 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'Set-Cookie',
+  'esctx=AQABAAAAAAD--DLA3VO7QrddgJg7WevrXVik3wp-eVppHSHcE00JgeuQXGb8Fun1LlixwXvussFS3iAVxEe8baKdSyz1i_hVu6ptMk6S2xVSt0pUoNoXH2Nq4sKC_qrQVA4ZvdRQmUQ3C0H6SVJr73_bQeS1t6C4CI9tCkxaAogZPxv9qMu4bCLWTybmamsndNsN4Ymio74gAA; domain=.login.microsoftonline.com; path=/; secure; HttpOnly; SameSite=None',
+  'Set-Cookie',
+  'x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly',
+  'Set-Cookie',
+  'stsservicecookie=estsfd; path=/; secure; samesite=none; httponly',
+  'Date',
+  'Thu, 27 Jan 2022 00:25:56 GMT',
+  'Content-Length',
+  '980'
+]);
+
+nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
+  .get('/12345678-1234-1234-1234-123456789012/v2.0/.well-known/openid-configuration')
+  .reply(200, {"token_endpoint":"https://login.microsoftonline.com/12345678-1234-1234-1234-123456789012/oauth2/v2.0/token","token_endpoint_auth_methods_supported":["client_secret_post","private_key_jwt","client_secret_basic"],"jwks_uri":"https://login.microsoftonline.com/12345678-1234-1234-1234-123456789012/discovery/v2.0/keys","response_modes_supported":["query","fragment","form_post"],"subject_types_supported":["pairwise"],"id_token_signing_alg_values_supported":["RS256"],"response_types_supported":["code","id_token","code id_token","id_token token"],"scopes_supported":["openid","profile","email","offline_access"],"issuer":"https://login.microsoftonline.com/12345678-1234-1234-1234-123456789012/v2.0","request_uri_parameter_supported":false,"userinfo_endpoint":"https://graph.microsoft.com/oidc/userinfo","authorization_endpoint":"https://login.microsoftonline.com/12345678-1234-1234-1234-123456789012/oauth2/v2.0/authorize","device_authorization_endpoint":"https://login.microsoftonline.com/12345678-1234-1234-1234-123456789012/oauth2/v2.0/devicecode","http_logout_supported":true,"frontchannel_logout_supported":true,"end_session_endpoint":"https://login.microsoftonline.com/12345678-1234-1234-1234-123456789012/oauth2/v2.0/logout","claims_supported":["sub","iss","cloud_instance_name","cloud_instance_host_name","cloud_graph_host_name","msgraph_host","aud","exp","iat","auth_time","acr","nonce","preferred_username","name","tid","ver","at_hash","c_hash","email"],"kerberos_endpoint":"https://login.microsoftonline.com/12345678-1234-1234-1234-123456789012/kerberos","tenant_region_scope":"WW","cloud_instance_name":"microsoftonline.com","cloud_graph_host_name":"graph.windows.net","msgraph_host":"graph.microsoft.com","rbac_url":"https://pas.windows.net"}, [
+  'Cache-Control',
+  'max-age=86400, private',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Access-Control-Allow-Origin',
+  '*',
+  'Access-Control-Allow-Methods',
+  'GET, OPTIONS',
+  'P3P',
+  'CP="DSP CUR OTPi IND OTRi ONL FIN"',
+  'x-ms-request-id',
+  'bf9272a6-c51f-4182-930d-e85db17fb300',
+  'x-ms-ests-server',
+  '2.1.12381.20 - SCUS ProdSlices',
+  'Set-Cookie',
+  'fpc=AsRhkoSPkC9MtG62dWPouBs; expires=Sat, 26-Feb-2022 00:25:57 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'Set-Cookie',
+  'esctx=AQABAAAAAAD--DLA3VO7QrddgJg7WevriEIoTWyr4E_Xr9bbLz7EDCq4Df3RMNCrbQ_2m0P3UsJomXhit3pFFdeupNiDVqOpmgcPhZ_Uz2IOuJt-9NjZQyZkY_LzzPo8RHJ-0v-MVeqbX3334CvAmItSpp31w62cTcfOqkEPvhFrl5CqhJakfbVGPnwBjWPu-BSowTvNgMMgAA; domain=.login.microsoftonline.com; path=/; secure; HttpOnly; SameSite=None',
+  'Set-Cookie',
+  'x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly',
+  'Set-Cookie',
+  'stsservicecookie=estsfd; path=/; secure; samesite=none; httponly',
+  'Date',
+  'Thu, 27 Jan 2022 00:25:56 GMT',
+  'Content-Length',
+  '1753'
+]);
+
+nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
+  .post('/12345678-1234-1234-1234-123456789012/oauth2/v2.0/token', "client_id=azure_client_id&scope=https%3A%2F%2Fsanitized%2F&grant_type=client_credentials&x-client-SKU=msal.js.node&x-client-VER=1.4.0&x-client-OS=linux&x-client-CPU=x64&x-ms-lib-capability=retry-after, h429&x-client-current-telemetry=5|771,2,,,|,&x-client-last-telemetry=5|0|||0,0&client-request-id=1d7b1a6c-8560-4f1d-940a-e5ee5872a027&client_secret=azure_client_secret&claims=%7B%22access_token%22%3A%7B%22xms_cc%22%3A%7B%22values%22%3A%5B%22cp1%22%5D%7D%7D%7D")
+  .reply(200, {"token_type":"Bearer","expires_in":86399,"ext_expires_in":86399,"access_token":"access_token"}, [
+  'Cache-Control',
+  'no-store, no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'P3P',
+  'CP="DSP CUR OTPi IND OTRi ONL FIN"',
+  'x-ms-request-id',
+  'a60a590f-1ef5-4951-ac92-684a74f14500',
+  'x-ms-ests-server',
+  '2.1.12381.20 - NCUS ProdSlices',
+  'x-ms-clitelem',
+  '1,0,0,,',
+  'Set-Cookie',
+  'fpc=Anle2XEa-ypCqlgaVvpyKeLiImrFAQAAAJTdg9kOAAAA; expires=Sat, 26-Feb-2022 00:25:57 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'Set-Cookie',
+  'x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly',
+  'Set-Cookie',
+  'stsservicecookie=estsfd; path=/; secure; samesite=none; httponly',
+  'Date',
+  'Thu, 27 Jan 2022 00:25:56 GMT',
+  'Content-Length',
+  '1315'
+]);
+
+nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
+  .post('/keys/immutablerelease164324315726004693/create', {"kty":"RSA-HSM","key_ops":["encrypt","decrypt"],"attributes":{"exportable":true},"release_policy":{"immutable":true,"data":"eyJhbnlPZiI6W3siYWxsT2YiOlt7ImNsYWltIjoic2RrLXRlc3QiLCJlcXVhbHMiOiJ0cnVlIn1dLCJhdXRob3JpdHkiOiJodHRwczovL3Nrcl9hdHRlc3RhdGlvbi5henVyZS5uZXQvIn1dLCJ2ZXJzaW9uIjoiMS4wLjAifQ"}})
+  .query(true)
+  .reply(200, {"key":{"kid":"https://keyvault_name.vault.azure.net/keys/immutablerelease164324315726004693/6825c4e6414e44288f2188fbc0fa6a83","kty":"RSA-HSM","key_ops":["encrypt","decrypt"],"n":"tW-exH9m5cGOkEhlnDbNfekox-qRY9ik129IFXCzVSJ3rT-EvuFrvEfEg31lg2aUcPthA5mkcyQK63r84q5-lgSAhy3RurpF38THuSgdOtR7124Moh2Xmxi7dvX5EK0HUYECalKdYBYInPCSFNn9munJe1wqmReFTE-r_sgkCznliiHHgt2WXNBZv0UvB8T4P9XTngz4gEXtEpM2X8om77NgjfNZ6b8TqreBRcHIzGHgOJYZiJbigMBOkvajFlxH9qjPcsNgrzSB1GTq5Xh-mF62h5zRPWcAJ2WvO6q7_qEBAvVcG-ilQjYW-EJCP1gKxpc4AoaJpin-YSfDM6tqbQ","e":"AAEAAQ"},"attributes":{"enabled":true,"created":1643243158,"updated":1643243158,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7,"exportable":true},"release_policy":{"contentType":"application/json; charset=utf-8","data":"eyJ2ZXJzaW9uIjoiMS4wLjAiLCJhbnlPZiI6W3siYXV0aG9yaXR5IjoiaHR0cHM6Ly9za3JfYXR0ZXN0YXRpb24uYXp1cmUubmV0LyIsImFsbE9mIjpbeyJjbGFpbSI6InNkay10ZXN0IiwiZXF1YWxzIjoidHJ1ZSJ9XX1dfQ","immutable":true}}, [
+  'Cache-Control',
+  'no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'x-ms-keyvault-region',
+  'westus2',
+  'x-ms-client-request-id',
+  '81d2405d-bf75-4675-9649-c0b8a0c1efff',
+  'x-ms-request-id',
+  '3654926c-9306-4558-8277-e8c628078893',
+  'x-ms-keyvault-service-version',
+  '1.9.264.2',
+  'x-ms-keyvault-network-info',
+  'conn_type=Ipv4;addr=50.35.229.43;act_addr_fam=InterNetwork;',
+  'x-ms-keyvault-rbac-assignment-id',
+  '0b7bb9bd-b488-5634-b80b-e2b4c4bd48cd',
+  'x-ms-keyvault-rbac-cache',
+  'ra_age=1348;da_age=7606;rd_age=7606;brd_age=6100;ra_notif_age=1655;dec_lev=2;',
+  'X-Powered-By',
+  'ASP.NET',
+  'Strict-Transport-Security',
+  'max-age=31536000;includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Date',
+  'Thu, 27 Jan 2022 00:25:58 GMT',
+  'Content-Length',
+  '982'
+]);
+
+nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
+  .patch('/keys/immutablerelease164324315726004693/', {"attributes":{},"release_policy":{"immutable":true,"data":"eyJhbnlPZiI6W3siYW55T2YiOlt7ImNsYWltIjoic2RrLXRlc3QiLCJlcXVhbHMiOiJmYWxzZSJ9XSwiYXV0aG9yaXR5IjoiaHR0cHM6Ly9za3JfYXR0ZXN0YXRpb24uYXp1cmUubmV0LyJ9XSwidmVyc2lvbiI6IjEuMCJ9"}})
+  .query(true)
+  .reply(400, {"error":{"code":"BadParameter","message":"AKV.SKR.1020: Immutable Key Release Policy cannot be modified."}}, [
+  'Cache-Control',
+  'no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Length',
+  '108',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'x-ms-keyvault-region',
+  'westus2',
+  'x-ms-client-request-id',
+  '3aa3b281-2b8a-4bfa-a3a0-1300fad5ccb9',
+  'x-ms-request-id',
+  '8315bc52-75a8-4ad0-a84f-695e79083b11',
+  'x-ms-keyvault-service-version',
+  '1.9.264.2',
+  'x-ms-keyvault-network-info',
+  'conn_type=Ipv4;addr=50.35.229.43;act_addr_fam=InterNetwork;',
+  'x-ms-keyvault-rbac-assignment-id',
+  '0b7bb9bd-b488-5634-b80b-e2b4c4bd48cd',
+  'x-ms-keyvault-rbac-cache',
+  'ra_age=1349;da_age=7607;rd_age=7607;brd_age=6101;ra_notif_age=1656;dec_lev=1;',
+  'X-Powered-By',
+  'ASP.NET',
+  'Strict-Transport-Security',
+  'max-age=31536000;includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Date',
+  'Thu, 27 Jan 2022 00:25:58 GMT'
+]);

--- a/sdk/keyvault/keyvault-keys/review/keyvault-keys.api.md
+++ b/sdk/keyvault/keyvault-keys/review/keyvault-keys.api.md
@@ -301,6 +301,7 @@ export interface KeyProperties {
 export interface KeyReleasePolicy {
     contentType?: string;
     encodedPolicy?: Uint8Array;
+    immutable?: boolean;
 }
 
 // @public

--- a/sdk/keyvault/keyvault-keys/src/cryptographyClientModels.ts
+++ b/sdk/keyvault/keyvault-keys/src/cryptographyClientModels.ts
@@ -8,7 +8,6 @@ import {
   JsonWebKeyCurveName as KeyCurveName,
   KnownJsonWebKeyCurveName as KnownKeyCurveNames,
   JsonWebKeyEncryptionAlgorithm as EncryptionAlgorithm,
-  KnownJsonWebKeyEncryptionAlgorithm as KnownEncryptionAlgorithms,
   JsonWebKeySignatureAlgorithm as SignatureAlgorithm,
   KnownJsonWebKeySignatureAlgorithm as KnownSignatureAlgorithms,
 } from "./generated/models";
@@ -17,10 +16,43 @@ export {
   KeyCurveName,
   KnownKeyCurveNames,
   EncryptionAlgorithm,
-  KnownEncryptionAlgorithms,
   SignatureAlgorithm,
   KnownSignatureAlgorithms,
 };
+
+/** Known values of {@link EncryptionAlgorithm} that the service accepts. */
+export enum KnownEncryptionAlgorithms {
+  /** Encryption Algorithm - RSA-OAEP */
+  RSAOaep = "RSA-OAEP",
+  /** Encryption Algorithm - RSA-OAEP-256 */
+  RSAOaep256 = "RSA-OAEP-256",
+  /** Encryption Algorithm - RSA1_5 */
+  RSA15 = "RSA1_5",
+  /** Encryption Algorithm - A128GCM */
+  A128GCM = "A128GCM",
+  /** Encryption Algorithm - A192GCM */
+  A192GCM = "A192GCM",
+  /** Encryption Algorithm - A256GCM */
+  A256GCM = "A256GCM",
+  /** Encryption Algorithm - A128KW */
+  A128KW = "A128KW",
+  /** Encryption Algorithm - A192KW */
+  A192KW = "A192KW",
+  /** Encryption Algorithm - A256KW */
+  A256KW = "A256KW",
+  /** Encryption Algorithm - A128CBC */
+  A128CBC = "A128CBC",
+  /** Encryption Algorithm - A192CBC */
+  A192CBC = "A192CBC",
+  /** Encryption Algorithm - A256CBC */
+  A256CBC = "A256CBC",
+  /** Encryption Algorithm - A128CBCPAD */
+  A128Cbcpad = "A128CBCPAD",
+  /** Encryption Algorithm - A192CBCPAD */
+  A192Cbcpad = "A192CBCPAD",
+  /** Encryption Algorithm - A256CBCPAD */
+  A256Cbcpad = "A256CBCPAD",
+}
 
 /**
  * Supported algorithms for key wrapping/unwrapping

--- a/sdk/keyvault/keyvault-keys/src/generated/keyVaultClient.ts
+++ b/sdk/keyvault/keyvault-keys/src/generated/keyVaultClient.ts
@@ -14,63 +14,63 @@ import {
   KeyVaultClientOptionalParams,
   ApiVersion73Preview,
   JsonWebKeyType,
-  KeyVaultClientCreateKeyOptionalParams,
-  KeyVaultClientCreateKeyResponse,
-  KeyVaultClientRotateKeyOptionalParams,
-  KeyVaultClientRotateKeyResponse,
+  CreateKeyOptionalParams,
+  CreateKeyResponse,
+  RotateKeyOptionalParams,
+  RotateKeyResponse,
   JsonWebKey,
-  KeyVaultClientImportKeyOptionalParams,
-  KeyVaultClientImportKeyResponse,
-  KeyVaultClientDeleteKeyOptionalParams,
-  KeyVaultClientDeleteKeyResponse,
-  KeyVaultClientUpdateKeyOptionalParams,
-  KeyVaultClientUpdateKeyResponse,
-  KeyVaultClientGetKeyOptionalParams,
-  KeyVaultClientGetKeyResponse,
-  KeyVaultClientGetKeyVersionsOptionalParams,
-  KeyVaultClientGetKeyVersionsResponse,
-  KeyVaultClientGetKeysOptionalParams,
-  KeyVaultClientGetKeysResponse,
-  KeyVaultClientBackupKeyOptionalParams,
-  KeyVaultClientBackupKeyResponse,
-  KeyVaultClientRestoreKeyOptionalParams,
-  KeyVaultClientRestoreKeyResponse,
+  ImportKeyOptionalParams,
+  ImportKeyResponse,
+  DeleteKeyOptionalParams,
+  DeleteKeyResponse,
+  UpdateKeyOptionalParams,
+  UpdateKeyResponse,
+  GetKeyOptionalParams,
+  GetKeyResponse,
+  GetKeyVersionsOptionalParams,
+  GetKeyVersionsResponse,
+  GetKeysOptionalParams,
+  GetKeysResponse,
+  BackupKeyOptionalParams,
+  BackupKeyResponse,
+  RestoreKeyOptionalParams,
+  RestoreKeyResponse,
   JsonWebKeyEncryptionAlgorithm,
-  KeyVaultClientEncryptOptionalParams,
-  KeyVaultClientEncryptResponse,
-  KeyVaultClientDecryptOptionalParams,
-  KeyVaultClientDecryptResponse,
+  EncryptOptionalParams,
+  EncryptResponse,
+  DecryptOptionalParams,
+  DecryptResponse,
   JsonWebKeySignatureAlgorithm,
-  KeyVaultClientSignOptionalParams,
-  KeyVaultClientSignResponse,
-  KeyVaultClientVerifyOptionalParams,
-  KeyVaultClientVerifyResponse,
-  KeyVaultClientWrapKeyOptionalParams,
-  KeyVaultClientWrapKeyResponse,
-  KeyVaultClientUnwrapKeyOptionalParams,
-  KeyVaultClientUnwrapKeyResponse,
-  KeyVaultClientReleaseOptionalParams,
-  KeyVaultClientReleaseResponse,
-  KeyVaultClientGetDeletedKeysOptionalParams,
-  KeyVaultClientGetDeletedKeysResponse,
-  KeyVaultClientGetDeletedKeyOptionalParams,
-  KeyVaultClientGetDeletedKeyResponse,
-  KeyVaultClientPurgeDeletedKeyOptionalParams,
-  KeyVaultClientRecoverDeletedKeyOptionalParams,
-  KeyVaultClientRecoverDeletedKeyResponse,
-  KeyVaultClientGetKeyRotationPolicyOptionalParams,
-  KeyVaultClientGetKeyRotationPolicyResponse,
+  SignOptionalParams,
+  SignResponse,
+  VerifyOptionalParams,
+  VerifyResponse,
+  WrapKeyOptionalParams,
+  WrapKeyResponse,
+  UnwrapKeyOptionalParams,
+  UnwrapKeyResponse,
+  ReleaseOptionalParams,
+  ReleaseResponse,
+  GetDeletedKeysOptionalParams,
+  GetDeletedKeysResponse,
+  GetDeletedKeyOptionalParams,
+  GetDeletedKeyResponse,
+  PurgeDeletedKeyOptionalParams,
+  RecoverDeletedKeyOptionalParams,
+  RecoverDeletedKeyResponse,
+  GetKeyRotationPolicyOptionalParams,
+  GetKeyRotationPolicyResponse,
   KeyRotationPolicy,
-  KeyVaultClientUpdateKeyRotationPolicyOptionalParams,
-  KeyVaultClientUpdateKeyRotationPolicyResponse,
-  KeyVaultClientGetRandomBytesOptionalParams,
-  KeyVaultClientGetRandomBytesResponse,
-  KeyVaultClientGetKeyVersionsNextOptionalParams,
-  KeyVaultClientGetKeyVersionsNextResponse,
-  KeyVaultClientGetKeysNextOptionalParams,
-  KeyVaultClientGetKeysNextResponse,
-  KeyVaultClientGetDeletedKeysNextOptionalParams,
-  KeyVaultClientGetDeletedKeysNextResponse
+  UpdateKeyRotationPolicyOptionalParams,
+  UpdateKeyRotationPolicyResponse,
+  GetRandomBytesOptionalParams,
+  GetRandomBytesResponse,
+  GetKeyVersionsNextOptionalParams,
+  GetKeyVersionsNextResponse,
+  GetKeysNextOptionalParams,
+  GetKeysNextResponse,
+  GetDeletedKeysNextOptionalParams,
+  GetDeletedKeysNextResponse
 } from "./models";
 
 export class KeyVaultClient extends KeyVaultClientContext {
@@ -99,8 +99,8 @@ export class KeyVaultClient extends KeyVaultClientContext {
     vaultBaseUrl: string,
     keyName: string,
     kty: JsonWebKeyType,
-    options?: KeyVaultClientCreateKeyOptionalParams
-  ): Promise<KeyVaultClientCreateKeyResponse> {
+    options?: CreateKeyOptionalParams
+  ): Promise<CreateKeyResponse> {
     const operationArguments: coreHttp.OperationArguments = {
       vaultBaseUrl,
       keyName,
@@ -110,7 +110,7 @@ export class KeyVaultClient extends KeyVaultClientContext {
     return this.sendOperationRequest(
       operationArguments,
       createKeyOperationSpec
-    ) as Promise<KeyVaultClientCreateKeyResponse>;
+    ) as Promise<CreateKeyResponse>;
   }
 
   /**
@@ -123,8 +123,8 @@ export class KeyVaultClient extends KeyVaultClientContext {
   rotateKey(
     vaultBaseUrl: string,
     keyName: string,
-    options?: KeyVaultClientRotateKeyOptionalParams
-  ): Promise<KeyVaultClientRotateKeyResponse> {
+    options?: RotateKeyOptionalParams
+  ): Promise<RotateKeyResponse> {
     const operationArguments: coreHttp.OperationArguments = {
       vaultBaseUrl,
       keyName,
@@ -133,7 +133,7 @@ export class KeyVaultClient extends KeyVaultClientContext {
     return this.sendOperationRequest(
       operationArguments,
       rotateKeyOperationSpec
-    ) as Promise<KeyVaultClientRotateKeyResponse>;
+    ) as Promise<RotateKeyResponse>;
   }
 
   /**
@@ -149,8 +149,8 @@ export class KeyVaultClient extends KeyVaultClientContext {
     vaultBaseUrl: string,
     keyName: string,
     key: JsonWebKey,
-    options?: KeyVaultClientImportKeyOptionalParams
-  ): Promise<KeyVaultClientImportKeyResponse> {
+    options?: ImportKeyOptionalParams
+  ): Promise<ImportKeyResponse> {
     const operationArguments: coreHttp.OperationArguments = {
       vaultBaseUrl,
       keyName,
@@ -160,7 +160,7 @@ export class KeyVaultClient extends KeyVaultClientContext {
     return this.sendOperationRequest(
       operationArguments,
       importKeyOperationSpec
-    ) as Promise<KeyVaultClientImportKeyResponse>;
+    ) as Promise<ImportKeyResponse>;
   }
 
   /**
@@ -175,8 +175,8 @@ export class KeyVaultClient extends KeyVaultClientContext {
   deleteKey(
     vaultBaseUrl: string,
     keyName: string,
-    options?: KeyVaultClientDeleteKeyOptionalParams
-  ): Promise<KeyVaultClientDeleteKeyResponse> {
+    options?: DeleteKeyOptionalParams
+  ): Promise<DeleteKeyResponse> {
     const operationArguments: coreHttp.OperationArguments = {
       vaultBaseUrl,
       keyName,
@@ -185,7 +185,7 @@ export class KeyVaultClient extends KeyVaultClientContext {
     return this.sendOperationRequest(
       operationArguments,
       deleteKeyOperationSpec
-    ) as Promise<KeyVaultClientDeleteKeyResponse>;
+    ) as Promise<DeleteKeyResponse>;
   }
 
   /**
@@ -201,8 +201,8 @@ export class KeyVaultClient extends KeyVaultClientContext {
     vaultBaseUrl: string,
     keyName: string,
     keyVersion: string,
-    options?: KeyVaultClientUpdateKeyOptionalParams
-  ): Promise<KeyVaultClientUpdateKeyResponse> {
+    options?: UpdateKeyOptionalParams
+  ): Promise<UpdateKeyResponse> {
     const operationArguments: coreHttp.OperationArguments = {
       vaultBaseUrl,
       keyName,
@@ -212,7 +212,7 @@ export class KeyVaultClient extends KeyVaultClientContext {
     return this.sendOperationRequest(
       operationArguments,
       updateKeyOperationSpec
-    ) as Promise<KeyVaultClientUpdateKeyResponse>;
+    ) as Promise<UpdateKeyResponse>;
   }
 
   /**
@@ -228,8 +228,8 @@ export class KeyVaultClient extends KeyVaultClientContext {
     vaultBaseUrl: string,
     keyName: string,
     keyVersion: string,
-    options?: KeyVaultClientGetKeyOptionalParams
-  ): Promise<KeyVaultClientGetKeyResponse> {
+    options?: GetKeyOptionalParams
+  ): Promise<GetKeyResponse> {
     const operationArguments: coreHttp.OperationArguments = {
       vaultBaseUrl,
       keyName,
@@ -239,7 +239,7 @@ export class KeyVaultClient extends KeyVaultClientContext {
     return this.sendOperationRequest(
       operationArguments,
       getKeyOperationSpec
-    ) as Promise<KeyVaultClientGetKeyResponse>;
+    ) as Promise<GetKeyResponse>;
   }
 
   /**
@@ -252,8 +252,8 @@ export class KeyVaultClient extends KeyVaultClientContext {
   getKeyVersions(
     vaultBaseUrl: string,
     keyName: string,
-    options?: KeyVaultClientGetKeyVersionsOptionalParams
-  ): Promise<KeyVaultClientGetKeyVersionsResponse> {
+    options?: GetKeyVersionsOptionalParams
+  ): Promise<GetKeyVersionsResponse> {
     const operationArguments: coreHttp.OperationArguments = {
       vaultBaseUrl,
       keyName,
@@ -262,7 +262,7 @@ export class KeyVaultClient extends KeyVaultClientContext {
     return this.sendOperationRequest(
       operationArguments,
       getKeyVersionsOperationSpec
-    ) as Promise<KeyVaultClientGetKeyVersionsResponse>;
+    ) as Promise<GetKeyVersionsResponse>;
   }
 
   /**
@@ -275,8 +275,8 @@ export class KeyVaultClient extends KeyVaultClientContext {
    */
   getKeys(
     vaultBaseUrl: string,
-    options?: KeyVaultClientGetKeysOptionalParams
-  ): Promise<KeyVaultClientGetKeysResponse> {
+    options?: GetKeysOptionalParams
+  ): Promise<GetKeysResponse> {
     const operationArguments: coreHttp.OperationArguments = {
       vaultBaseUrl,
       options: coreHttp.operationOptionsToRequestOptionsBase(options || {})
@@ -284,7 +284,7 @@ export class KeyVaultClient extends KeyVaultClientContext {
     return this.sendOperationRequest(
       operationArguments,
       getKeysOperationSpec
-    ) as Promise<KeyVaultClientGetKeysResponse>;
+    ) as Promise<GetKeysResponse>;
   }
 
   /**
@@ -305,8 +305,8 @@ export class KeyVaultClient extends KeyVaultClientContext {
   backupKey(
     vaultBaseUrl: string,
     keyName: string,
-    options?: KeyVaultClientBackupKeyOptionalParams
-  ): Promise<KeyVaultClientBackupKeyResponse> {
+    options?: BackupKeyOptionalParams
+  ): Promise<BackupKeyResponse> {
     const operationArguments: coreHttp.OperationArguments = {
       vaultBaseUrl,
       keyName,
@@ -315,7 +315,7 @@ export class KeyVaultClient extends KeyVaultClientContext {
     return this.sendOperationRequest(
       operationArguments,
       backupKeyOperationSpec
-    ) as Promise<KeyVaultClientBackupKeyResponse>;
+    ) as Promise<BackupKeyResponse>;
   }
 
   /**
@@ -336,8 +336,8 @@ export class KeyVaultClient extends KeyVaultClientContext {
   restoreKey(
     vaultBaseUrl: string,
     keyBundleBackup: Uint8Array,
-    options?: KeyVaultClientRestoreKeyOptionalParams
-  ): Promise<KeyVaultClientRestoreKeyResponse> {
+    options?: RestoreKeyOptionalParams
+  ): Promise<RestoreKeyResponse> {
     const operationArguments: coreHttp.OperationArguments = {
       vaultBaseUrl,
       keyBundleBackup,
@@ -346,7 +346,7 @@ export class KeyVaultClient extends KeyVaultClientContext {
     return this.sendOperationRequest(
       operationArguments,
       restoreKeyOperationSpec
-    ) as Promise<KeyVaultClientRestoreKeyResponse>;
+    ) as Promise<RestoreKeyResponse>;
   }
 
   /**
@@ -370,8 +370,8 @@ export class KeyVaultClient extends KeyVaultClientContext {
     keyVersion: string,
     algorithm: JsonWebKeyEncryptionAlgorithm,
     value: Uint8Array,
-    options?: KeyVaultClientEncryptOptionalParams
-  ): Promise<KeyVaultClientEncryptResponse> {
+    options?: EncryptOptionalParams
+  ): Promise<EncryptResponse> {
     const operationArguments: coreHttp.OperationArguments = {
       vaultBaseUrl,
       keyName,
@@ -383,7 +383,7 @@ export class KeyVaultClient extends KeyVaultClientContext {
     return this.sendOperationRequest(
       operationArguments,
       encryptOperationSpec
-    ) as Promise<KeyVaultClientEncryptResponse>;
+    ) as Promise<EncryptResponse>;
   }
 
   /**
@@ -405,8 +405,8 @@ export class KeyVaultClient extends KeyVaultClientContext {
     keyVersion: string,
     algorithm: JsonWebKeyEncryptionAlgorithm,
     value: Uint8Array,
-    options?: KeyVaultClientDecryptOptionalParams
-  ): Promise<KeyVaultClientDecryptResponse> {
+    options?: DecryptOptionalParams
+  ): Promise<DecryptResponse> {
     const operationArguments: coreHttp.OperationArguments = {
       vaultBaseUrl,
       keyName,
@@ -418,7 +418,7 @@ export class KeyVaultClient extends KeyVaultClientContext {
     return this.sendOperationRequest(
       operationArguments,
       decryptOperationSpec
-    ) as Promise<KeyVaultClientDecryptResponse>;
+    ) as Promise<DecryptResponse>;
   }
 
   /**
@@ -439,8 +439,8 @@ export class KeyVaultClient extends KeyVaultClientContext {
     keyVersion: string,
     algorithm: JsonWebKeySignatureAlgorithm,
     value: Uint8Array,
-    options?: KeyVaultClientSignOptionalParams
-  ): Promise<KeyVaultClientSignResponse> {
+    options?: SignOptionalParams
+  ): Promise<SignResponse> {
     const operationArguments: coreHttp.OperationArguments = {
       vaultBaseUrl,
       keyName,
@@ -452,7 +452,7 @@ export class KeyVaultClient extends KeyVaultClientContext {
     return this.sendOperationRequest(
       operationArguments,
       signOperationSpec
-    ) as Promise<KeyVaultClientSignResponse>;
+    ) as Promise<SignResponse>;
   }
 
   /**
@@ -477,8 +477,8 @@ export class KeyVaultClient extends KeyVaultClientContext {
     algorithm: JsonWebKeySignatureAlgorithm,
     digest: Uint8Array,
     signature: Uint8Array,
-    options?: KeyVaultClientVerifyOptionalParams
-  ): Promise<KeyVaultClientVerifyResponse> {
+    options?: VerifyOptionalParams
+  ): Promise<VerifyResponse> {
     const operationArguments: coreHttp.OperationArguments = {
       vaultBaseUrl,
       keyName,
@@ -491,7 +491,7 @@ export class KeyVaultClient extends KeyVaultClientContext {
     return this.sendOperationRequest(
       operationArguments,
       verifyOperationSpec
-    ) as Promise<KeyVaultClientVerifyResponse>;
+    ) as Promise<VerifyResponse>;
   }
 
   /**
@@ -514,8 +514,8 @@ export class KeyVaultClient extends KeyVaultClientContext {
     keyVersion: string,
     algorithm: JsonWebKeyEncryptionAlgorithm,
     value: Uint8Array,
-    options?: KeyVaultClientWrapKeyOptionalParams
-  ): Promise<KeyVaultClientWrapKeyResponse> {
+    options?: WrapKeyOptionalParams
+  ): Promise<WrapKeyResponse> {
     const operationArguments: coreHttp.OperationArguments = {
       vaultBaseUrl,
       keyName,
@@ -527,7 +527,7 @@ export class KeyVaultClient extends KeyVaultClientContext {
     return this.sendOperationRequest(
       operationArguments,
       wrapKeyOperationSpec
-    ) as Promise<KeyVaultClientWrapKeyResponse>;
+    ) as Promise<WrapKeyResponse>;
   }
 
   /**
@@ -548,8 +548,8 @@ export class KeyVaultClient extends KeyVaultClientContext {
     keyVersion: string,
     algorithm: JsonWebKeyEncryptionAlgorithm,
     value: Uint8Array,
-    options?: KeyVaultClientUnwrapKeyOptionalParams
-  ): Promise<KeyVaultClientUnwrapKeyResponse> {
+    options?: UnwrapKeyOptionalParams
+  ): Promise<UnwrapKeyResponse> {
     const operationArguments: coreHttp.OperationArguments = {
       vaultBaseUrl,
       keyName,
@@ -561,7 +561,7 @@ export class KeyVaultClient extends KeyVaultClientContext {
     return this.sendOperationRequest(
       operationArguments,
       unwrapKeyOperationSpec
-    ) as Promise<KeyVaultClientUnwrapKeyResponse>;
+    ) as Promise<UnwrapKeyResponse>;
   }
 
   /**
@@ -578,8 +578,8 @@ export class KeyVaultClient extends KeyVaultClientContext {
     keyName: string,
     keyVersion: string,
     targetAttestationToken: string,
-    options?: KeyVaultClientReleaseOptionalParams
-  ): Promise<KeyVaultClientReleaseResponse> {
+    options?: ReleaseOptionalParams
+  ): Promise<ReleaseResponse> {
     const operationArguments: coreHttp.OperationArguments = {
       vaultBaseUrl,
       keyName,
@@ -590,7 +590,7 @@ export class KeyVaultClient extends KeyVaultClientContext {
     return this.sendOperationRequest(
       operationArguments,
       releaseOperationSpec
-    ) as Promise<KeyVaultClientReleaseResponse>;
+    ) as Promise<ReleaseResponse>;
   }
 
   /**
@@ -604,8 +604,8 @@ export class KeyVaultClient extends KeyVaultClientContext {
    */
   getDeletedKeys(
     vaultBaseUrl: string,
-    options?: KeyVaultClientGetDeletedKeysOptionalParams
-  ): Promise<KeyVaultClientGetDeletedKeysResponse> {
+    options?: GetDeletedKeysOptionalParams
+  ): Promise<GetDeletedKeysResponse> {
     const operationArguments: coreHttp.OperationArguments = {
       vaultBaseUrl,
       options: coreHttp.operationOptionsToRequestOptionsBase(options || {})
@@ -613,7 +613,7 @@ export class KeyVaultClient extends KeyVaultClientContext {
     return this.sendOperationRequest(
       operationArguments,
       getDeletedKeysOperationSpec
-    ) as Promise<KeyVaultClientGetDeletedKeysResponse>;
+    ) as Promise<GetDeletedKeysResponse>;
   }
 
   /**
@@ -627,8 +627,8 @@ export class KeyVaultClient extends KeyVaultClientContext {
   getDeletedKey(
     vaultBaseUrl: string,
     keyName: string,
-    options?: KeyVaultClientGetDeletedKeyOptionalParams
-  ): Promise<KeyVaultClientGetDeletedKeyResponse> {
+    options?: GetDeletedKeyOptionalParams
+  ): Promise<GetDeletedKeyResponse> {
     const operationArguments: coreHttp.OperationArguments = {
       vaultBaseUrl,
       keyName,
@@ -637,7 +637,7 @@ export class KeyVaultClient extends KeyVaultClientContext {
     return this.sendOperationRequest(
       operationArguments,
       getDeletedKeyOperationSpec
-    ) as Promise<KeyVaultClientGetDeletedKeyResponse>;
+    ) as Promise<GetDeletedKeyResponse>;
   }
 
   /**
@@ -651,7 +651,7 @@ export class KeyVaultClient extends KeyVaultClientContext {
   purgeDeletedKey(
     vaultBaseUrl: string,
     keyName: string,
-    options?: KeyVaultClientPurgeDeletedKeyOptionalParams
+    options?: PurgeDeletedKeyOptionalParams
   ): Promise<coreHttp.RestResponse> {
     const operationArguments: coreHttp.OperationArguments = {
       vaultBaseUrl,
@@ -676,8 +676,8 @@ export class KeyVaultClient extends KeyVaultClientContext {
   recoverDeletedKey(
     vaultBaseUrl: string,
     keyName: string,
-    options?: KeyVaultClientRecoverDeletedKeyOptionalParams
-  ): Promise<KeyVaultClientRecoverDeletedKeyResponse> {
+    options?: RecoverDeletedKeyOptionalParams
+  ): Promise<RecoverDeletedKeyResponse> {
     const operationArguments: coreHttp.OperationArguments = {
       vaultBaseUrl,
       keyName,
@@ -686,7 +686,7 @@ export class KeyVaultClient extends KeyVaultClientContext {
     return this.sendOperationRequest(
       operationArguments,
       recoverDeletedKeyOperationSpec
-    ) as Promise<KeyVaultClientRecoverDeletedKeyResponse>;
+    ) as Promise<RecoverDeletedKeyResponse>;
   }
 
   /**
@@ -699,8 +699,8 @@ export class KeyVaultClient extends KeyVaultClientContext {
   getKeyRotationPolicy(
     vaultBaseUrl: string,
     keyName: string,
-    options?: KeyVaultClientGetKeyRotationPolicyOptionalParams
-  ): Promise<KeyVaultClientGetKeyRotationPolicyResponse> {
+    options?: GetKeyRotationPolicyOptionalParams
+  ): Promise<GetKeyRotationPolicyResponse> {
     const operationArguments: coreHttp.OperationArguments = {
       vaultBaseUrl,
       keyName,
@@ -709,7 +709,7 @@ export class KeyVaultClient extends KeyVaultClientContext {
     return this.sendOperationRequest(
       operationArguments,
       getKeyRotationPolicyOperationSpec
-    ) as Promise<KeyVaultClientGetKeyRotationPolicyResponse>;
+    ) as Promise<GetKeyRotationPolicyResponse>;
   }
 
   /**
@@ -724,8 +724,8 @@ export class KeyVaultClient extends KeyVaultClientContext {
     vaultBaseUrl: string,
     keyName: string,
     keyRotationPolicy: KeyRotationPolicy,
-    options?: KeyVaultClientUpdateKeyRotationPolicyOptionalParams
-  ): Promise<KeyVaultClientUpdateKeyRotationPolicyResponse> {
+    options?: UpdateKeyRotationPolicyOptionalParams
+  ): Promise<UpdateKeyRotationPolicyResponse> {
     const operationArguments: coreHttp.OperationArguments = {
       vaultBaseUrl,
       keyName,
@@ -735,7 +735,7 @@ export class KeyVaultClient extends KeyVaultClientContext {
     return this.sendOperationRequest(
       operationArguments,
       updateKeyRotationPolicyOperationSpec
-    ) as Promise<KeyVaultClientUpdateKeyRotationPolicyResponse>;
+    ) as Promise<UpdateKeyRotationPolicyResponse>;
   }
 
   /**
@@ -747,8 +747,8 @@ export class KeyVaultClient extends KeyVaultClientContext {
   getRandomBytes(
     vaultBaseUrl: string,
     count: number,
-    options?: KeyVaultClientGetRandomBytesOptionalParams
-  ): Promise<KeyVaultClientGetRandomBytesResponse> {
+    options?: GetRandomBytesOptionalParams
+  ): Promise<GetRandomBytesResponse> {
     const operationArguments: coreHttp.OperationArguments = {
       vaultBaseUrl,
       count,
@@ -757,7 +757,7 @@ export class KeyVaultClient extends KeyVaultClientContext {
     return this.sendOperationRequest(
       operationArguments,
       getRandomBytesOperationSpec
-    ) as Promise<KeyVaultClientGetRandomBytesResponse>;
+    ) as Promise<GetRandomBytesResponse>;
   }
 
   /**
@@ -771,8 +771,8 @@ export class KeyVaultClient extends KeyVaultClientContext {
     vaultBaseUrl: string,
     keyName: string,
     nextLink: string,
-    options?: KeyVaultClientGetKeyVersionsNextOptionalParams
-  ): Promise<KeyVaultClientGetKeyVersionsNextResponse> {
+    options?: GetKeyVersionsNextOptionalParams
+  ): Promise<GetKeyVersionsNextResponse> {
     const operationArguments: coreHttp.OperationArguments = {
       vaultBaseUrl,
       keyName,
@@ -782,7 +782,7 @@ export class KeyVaultClient extends KeyVaultClientContext {
     return this.sendOperationRequest(
       operationArguments,
       getKeyVersionsNextOperationSpec
-    ) as Promise<KeyVaultClientGetKeyVersionsNextResponse>;
+    ) as Promise<GetKeyVersionsNextResponse>;
   }
 
   /**
@@ -794,8 +794,8 @@ export class KeyVaultClient extends KeyVaultClientContext {
   getKeysNext(
     vaultBaseUrl: string,
     nextLink: string,
-    options?: KeyVaultClientGetKeysNextOptionalParams
-  ): Promise<KeyVaultClientGetKeysNextResponse> {
+    options?: GetKeysNextOptionalParams
+  ): Promise<GetKeysNextResponse> {
     const operationArguments: coreHttp.OperationArguments = {
       vaultBaseUrl,
       nextLink,
@@ -804,7 +804,7 @@ export class KeyVaultClient extends KeyVaultClientContext {
     return this.sendOperationRequest(
       operationArguments,
       getKeysNextOperationSpec
-    ) as Promise<KeyVaultClientGetKeysNextResponse>;
+    ) as Promise<GetKeysNextResponse>;
   }
 
   /**
@@ -816,8 +816,8 @@ export class KeyVaultClient extends KeyVaultClientContext {
   getDeletedKeysNext(
     vaultBaseUrl: string,
     nextLink: string,
-    options?: KeyVaultClientGetDeletedKeysNextOptionalParams
-  ): Promise<KeyVaultClientGetDeletedKeysNextResponse> {
+    options?: GetDeletedKeysNextOptionalParams
+  ): Promise<GetDeletedKeysNextResponse> {
     const operationArguments: coreHttp.OperationArguments = {
       vaultBaseUrl,
       nextLink,
@@ -826,7 +826,7 @@ export class KeyVaultClient extends KeyVaultClientContext {
     return this.sendOperationRequest(
       operationArguments,
       getDeletedKeysNextOperationSpec
-    ) as Promise<KeyVaultClientGetDeletedKeysNextResponse>;
+    ) as Promise<GetDeletedKeysNextResponse>;
   }
 }
 // Operation Specifications

--- a/sdk/keyvault/keyvault-keys/src/generated/keyVaultClient.ts
+++ b/sdk/keyvault/keyvault-keys/src/generated/keyVaultClient.ts
@@ -49,8 +49,6 @@ import {
   KeyVaultClientWrapKeyResponse,
   KeyVaultClientUnwrapKeyOptionalParams,
   KeyVaultClientUnwrapKeyResponse,
-  KeyVaultClientExportOptionalParams,
-  KeyVaultClientExportResponse,
   KeyVaultClientReleaseOptionalParams,
   KeyVaultClientReleaseResponse,
   KeyVaultClientGetDeletedKeysOptionalParams,
@@ -567,52 +565,26 @@ export class KeyVaultClient extends KeyVaultClientContext {
   }
 
   /**
-   * The export key operation is applicable to all key types. The target key must be marked exportable.
-   * This operation requires the keys/export permission.
-   * @param vaultBaseUrl The vault name, for example https://myvault.vault.azure.net.
-   * @param keyName The name of the key to get.
-   * @param keyVersion Adding the version parameter retrieves a specific version of a key.
-   * @param options The options parameters.
-   */
-  export(
-    vaultBaseUrl: string,
-    keyName: string,
-    keyVersion: string,
-    options?: KeyVaultClientExportOptionalParams
-  ): Promise<KeyVaultClientExportResponse> {
-    const operationArguments: coreHttp.OperationArguments = {
-      vaultBaseUrl,
-      keyName,
-      keyVersion,
-      options: coreHttp.operationOptionsToRequestOptionsBase(options || {})
-    };
-    return this.sendOperationRequest(
-      operationArguments,
-      exportOperationSpec
-    ) as Promise<KeyVaultClientExportResponse>;
-  }
-
-  /**
    * The release key operation is applicable to all key types. The target key must be marked exportable.
    * This operation requires the keys/release permission.
    * @param vaultBaseUrl The vault name, for example https://myvault.vault.azure.net.
    * @param keyName The name of the key to get.
    * @param keyVersion Adding the version parameter retrieves a specific version of a key.
-   * @param target The attestation assertion for the target of the key release.
+   * @param targetAttestationToken The attestation assertion for the target of the key release.
    * @param options The options parameters.
    */
   release(
     vaultBaseUrl: string,
     keyName: string,
     keyVersion: string,
-    target: string,
+    targetAttestationToken: string,
     options?: KeyVaultClientReleaseOptionalParams
   ): Promise<KeyVaultClientReleaseResponse> {
     const operationArguments: coreHttp.OperationArguments = {
       vaultBaseUrl,
       keyName,
       keyVersion,
-      target,
+      targetAttestationToken,
       options: coreHttp.operationOptionsToRequestOptionsBase(options || {})
     };
     return this.sendOperationRequest(
@@ -1246,35 +1218,6 @@ const unwrapKeyOperationSpec: coreHttp.OperationSpec = {
   mediaType: "json",
   serializer
 };
-const exportOperationSpec: coreHttp.OperationSpec = {
-  path: "/keys/{key-name}/{key-version}/export",
-  httpMethod: "POST",
-  responses: {
-    200: {
-      bodyMapper: Mappers.KeyBundle
-    },
-    default: {
-      bodyMapper: Mappers.KeyVaultError
-    }
-  },
-  requestBody: {
-    parameterPath: {
-      wrappingKey: ["options", "wrappingKey"],
-      wrappingKid: ["options", "wrappingKid"],
-      enc: ["options", "enc"]
-    },
-    mapper: { ...Mappers.KeyExportParameters, required: true }
-  },
-  queryParameters: [Parameters.apiVersion],
-  urlParameters: [
-    Parameters.vaultBaseUrl,
-    Parameters.keyName1,
-    Parameters.keyVersion
-  ],
-  headerParameters: [Parameters.contentType, Parameters.accept],
-  mediaType: "json",
-  serializer
-};
 const releaseOperationSpec: coreHttp.OperationSpec = {
   path: "/keys/{key-name}/{key-version}/release",
   httpMethod: "POST",
@@ -1288,7 +1231,7 @@ const releaseOperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: {
     parameterPath: {
-      target: ["target"],
+      targetAttestationToken: ["targetAttestationToken"],
       nonce: ["options", "nonce"],
       enc: ["options", "enc"]
     },

--- a/sdk/keyvault/keyvault-keys/src/generated/keyVaultClientContext.ts
+++ b/sdk/keyvault/keyvault-keys/src/generated/keyVaultClientContext.ts
@@ -34,7 +34,7 @@ export class KeyVaultClientContext extends coreHttp.ServiceClient {
     }
 
     const defaultUserAgent = `azsdk-js-${packageName.replace(
-      "@azure/",
+      /@.*\//,
       ""
     )}/${packageVersion} ${coreHttp.getDefaultUserAgentValue()}`;
 

--- a/sdk/keyvault/keyvault-keys/src/generated/models/index.ts
+++ b/sdk/keyvault/keyvault-keys/src/generated/models/index.ts
@@ -556,41 +556,27 @@ export enum KnownJsonWebKeyCurveName {
  * **P-256**: The NIST P-256 elliptic curve, AKA SECG curve SECP256R1. \
  * **P-384**: The NIST P-384 elliptic curve, AKA SECG curve SECP384R1. \
  * **P-521**: The NIST P-521 elliptic curve, AKA SECG curve SECP521R1. \
- * **P-256K**: The SECG SECP256K1 elliptic curve.
+ * **P-256K**: The SECG SECP256K1 elliptic curve. \
+ * **Ed25519**: The Ed25519 Edwards curve.
  */
 export type JsonWebKeyCurveName = string;
 
 /** Known values of {@link JsonWebKeyEncryptionAlgorithm} that the service accepts. */
 export enum KnownJsonWebKeyEncryptionAlgorithm {
-  /** Encryption Algorithm - RSA-OAEP */
   RSAOaep = "RSA-OAEP",
-  /** Encryption Algorithm - RSA-OAEP-256 */
   RSAOaep256 = "RSA-OAEP-256",
-  /** Encryption Algorithm - RSA1_5 */
   RSA15 = "RSA1_5",
-  /** Encryption Algorithm - A128GCM */
   A128GCM = "A128GCM",
-  /** Encryption Algorithm - A192GCM */
   A192GCM = "A192GCM",
-  /** Encryption Algorithm - A256GCM */
   A256GCM = "A256GCM",
-  /** Encryption Algorithm - A128KW */
   A128KW = "A128KW",
-  /** Encryption Algorithm - A192KW */
   A192KW = "A192KW",
-  /** Encryption Algorithm - A256KW */
   A256KW = "A256KW",
-  /** Encryption Algorithm - A128CBC */
   A128CBC = "A128CBC",
-  /** Encryption Algorithm - A192CBC */
   A192CBC = "A192CBC",
-  /** Encryption Algorithm - A256CBC */
   A256CBC = "A256CBC",
-  /** Encryption Algorithm - A128CBCPAD */
   A128Cbcpad = "A128CBCPAD",
-  /** Encryption Algorithm - A192CBCPAD */
   A192Cbcpad = "A192CBCPAD",
-  /** Encryption Algorithm - A256CBCPAD */
   A256Cbcpad = "A256CBCPAD"
 }
 
@@ -683,8 +669,7 @@ export type KeyEncryptionAlgorithm = string;
 export type ActionType = "Rotate" | "Notify";
 
 /** Optional parameters. */
-export interface KeyVaultClientCreateKeyOptionalParams
-  extends coreHttp.OperationOptions {
+export interface CreateKeyOptionalParams extends coreHttp.OperationOptions {
   /** The key size in bits. For example: 2048, 3072, or 4096 for RSA. */
   keySize?: number;
   /** The public exponent for a RSA key. */
@@ -702,7 +687,7 @@ export interface KeyVaultClientCreateKeyOptionalParams
 }
 
 /** Contains response data for the createKey operation. */
-export type KeyVaultClientCreateKeyResponse = KeyBundle & {
+export type CreateKeyResponse = KeyBundle & {
   /** The underlying HTTP response. */
   _response: coreHttp.HttpResponse & {
     /** The response body as text (string format) */
@@ -714,11 +699,10 @@ export type KeyVaultClientCreateKeyResponse = KeyBundle & {
 };
 
 /** Optional parameters. */
-export interface KeyVaultClientRotateKeyOptionalParams
-  extends coreHttp.OperationOptions {}
+export interface RotateKeyOptionalParams extends coreHttp.OperationOptions {}
 
 /** Contains response data for the rotateKey operation. */
-export type KeyVaultClientRotateKeyResponse = KeyBundle & {
+export type RotateKeyResponse = KeyBundle & {
   /** The underlying HTTP response. */
   _response: coreHttp.HttpResponse & {
     /** The response body as text (string format) */
@@ -730,8 +714,7 @@ export type KeyVaultClientRotateKeyResponse = KeyBundle & {
 };
 
 /** Optional parameters. */
-export interface KeyVaultClientImportKeyOptionalParams
-  extends coreHttp.OperationOptions {
+export interface ImportKeyOptionalParams extends coreHttp.OperationOptions {
   /** Whether to import as a hardware key (HSM) or software key. */
   hsm?: boolean;
   /** The key management attributes. */
@@ -743,7 +726,7 @@ export interface KeyVaultClientImportKeyOptionalParams
 }
 
 /** Contains response data for the importKey operation. */
-export type KeyVaultClientImportKeyResponse = KeyBundle & {
+export type ImportKeyResponse = KeyBundle & {
   /** The underlying HTTP response. */
   _response: coreHttp.HttpResponse & {
     /** The response body as text (string format) */
@@ -755,11 +738,10 @@ export type KeyVaultClientImportKeyResponse = KeyBundle & {
 };
 
 /** Optional parameters. */
-export interface KeyVaultClientDeleteKeyOptionalParams
-  extends coreHttp.OperationOptions {}
+export interface DeleteKeyOptionalParams extends coreHttp.OperationOptions {}
 
 /** Contains response data for the deleteKey operation. */
-export type KeyVaultClientDeleteKeyResponse = DeletedKeyBundle & {
+export type DeleteKeyResponse = DeletedKeyBundle & {
   /** The underlying HTTP response. */
   _response: coreHttp.HttpResponse & {
     /** The response body as text (string format) */
@@ -771,8 +753,7 @@ export type KeyVaultClientDeleteKeyResponse = DeletedKeyBundle & {
 };
 
 /** Optional parameters. */
-export interface KeyVaultClientUpdateKeyOptionalParams
-  extends coreHttp.OperationOptions {
+export interface UpdateKeyOptionalParams extends coreHttp.OperationOptions {
   /** Json web key operations. For more information on possible key operations, see JsonWebKeyOperation. */
   keyOps?: JsonWebKeyOperation[];
   /** The attributes of a key managed by the key vault service. */
@@ -784,7 +765,7 @@ export interface KeyVaultClientUpdateKeyOptionalParams
 }
 
 /** Contains response data for the updateKey operation. */
-export type KeyVaultClientUpdateKeyResponse = KeyBundle & {
+export type UpdateKeyResponse = KeyBundle & {
   /** The underlying HTTP response. */
   _response: coreHttp.HttpResponse & {
     /** The response body as text (string format) */
@@ -796,11 +777,10 @@ export type KeyVaultClientUpdateKeyResponse = KeyBundle & {
 };
 
 /** Optional parameters. */
-export interface KeyVaultClientGetKeyOptionalParams
-  extends coreHttp.OperationOptions {}
+export interface GetKeyOptionalParams extends coreHttp.OperationOptions {}
 
 /** Contains response data for the getKey operation. */
-export type KeyVaultClientGetKeyResponse = KeyBundle & {
+export type GetKeyResponse = KeyBundle & {
   /** The underlying HTTP response. */
   _response: coreHttp.HttpResponse & {
     /** The response body as text (string format) */
@@ -812,14 +792,14 @@ export type KeyVaultClientGetKeyResponse = KeyBundle & {
 };
 
 /** Optional parameters. */
-export interface KeyVaultClientGetKeyVersionsOptionalParams
+export interface GetKeyVersionsOptionalParams
   extends coreHttp.OperationOptions {
   /** Maximum number of results to return in a page. If not specified the service will return up to 25 results. */
   maxresults?: number;
 }
 
 /** Contains response data for the getKeyVersions operation. */
-export type KeyVaultClientGetKeyVersionsResponse = KeyListResult & {
+export type GetKeyVersionsResponse = KeyListResult & {
   /** The underlying HTTP response. */
   _response: coreHttp.HttpResponse & {
     /** The response body as text (string format) */
@@ -831,14 +811,13 @@ export type KeyVaultClientGetKeyVersionsResponse = KeyListResult & {
 };
 
 /** Optional parameters. */
-export interface KeyVaultClientGetKeysOptionalParams
-  extends coreHttp.OperationOptions {
+export interface GetKeysOptionalParams extends coreHttp.OperationOptions {
   /** Maximum number of results to return in a page. If not specified the service will return up to 25 results. */
   maxresults?: number;
 }
 
 /** Contains response data for the getKeys operation. */
-export type KeyVaultClientGetKeysResponse = KeyListResult & {
+export type GetKeysResponse = KeyListResult & {
   /** The underlying HTTP response. */
   _response: coreHttp.HttpResponse & {
     /** The response body as text (string format) */
@@ -850,11 +829,10 @@ export type KeyVaultClientGetKeysResponse = KeyListResult & {
 };
 
 /** Optional parameters. */
-export interface KeyVaultClientBackupKeyOptionalParams
-  extends coreHttp.OperationOptions {}
+export interface BackupKeyOptionalParams extends coreHttp.OperationOptions {}
 
 /** Contains response data for the backupKey operation. */
-export type KeyVaultClientBackupKeyResponse = BackupKeyResult & {
+export type BackupKeyResponse = BackupKeyResult & {
   /** The underlying HTTP response. */
   _response: coreHttp.HttpResponse & {
     /** The response body as text (string format) */
@@ -866,11 +844,10 @@ export type KeyVaultClientBackupKeyResponse = BackupKeyResult & {
 };
 
 /** Optional parameters. */
-export interface KeyVaultClientRestoreKeyOptionalParams
-  extends coreHttp.OperationOptions {}
+export interface RestoreKeyOptionalParams extends coreHttp.OperationOptions {}
 
 /** Contains response data for the restoreKey operation. */
-export type KeyVaultClientRestoreKeyResponse = KeyBundle & {
+export type RestoreKeyResponse = KeyBundle & {
   /** The underlying HTTP response. */
   _response: coreHttp.HttpResponse & {
     /** The response body as text (string format) */
@@ -882,8 +859,7 @@ export type KeyVaultClientRestoreKeyResponse = KeyBundle & {
 };
 
 /** Optional parameters. */
-export interface KeyVaultClientEncryptOptionalParams
-  extends coreHttp.OperationOptions {
+export interface EncryptOptionalParams extends coreHttp.OperationOptions {
   /** Initialization vector for symmetric algorithms. */
   iv?: Uint8Array;
   /** Additional data to authenticate but not encrypt/decrypt when using authenticated crypto algorithms. */
@@ -893,7 +869,7 @@ export interface KeyVaultClientEncryptOptionalParams
 }
 
 /** Contains response data for the encrypt operation. */
-export type KeyVaultClientEncryptResponse = KeyOperationResult & {
+export type EncryptResponse = KeyOperationResult & {
   /** The underlying HTTP response. */
   _response: coreHttp.HttpResponse & {
     /** The response body as text (string format) */
@@ -905,8 +881,7 @@ export type KeyVaultClientEncryptResponse = KeyOperationResult & {
 };
 
 /** Optional parameters. */
-export interface KeyVaultClientDecryptOptionalParams
-  extends coreHttp.OperationOptions {
+export interface DecryptOptionalParams extends coreHttp.OperationOptions {
   /** Initialization vector for symmetric algorithms. */
   iv?: Uint8Array;
   /** Additional data to authenticate but not encrypt/decrypt when using authenticated crypto algorithms. */
@@ -916,7 +891,7 @@ export interface KeyVaultClientDecryptOptionalParams
 }
 
 /** Contains response data for the decrypt operation. */
-export type KeyVaultClientDecryptResponse = KeyOperationResult & {
+export type DecryptResponse = KeyOperationResult & {
   /** The underlying HTTP response. */
   _response: coreHttp.HttpResponse & {
     /** The response body as text (string format) */
@@ -928,11 +903,10 @@ export type KeyVaultClientDecryptResponse = KeyOperationResult & {
 };
 
 /** Optional parameters. */
-export interface KeyVaultClientSignOptionalParams
-  extends coreHttp.OperationOptions {}
+export interface SignOptionalParams extends coreHttp.OperationOptions {}
 
 /** Contains response data for the sign operation. */
-export type KeyVaultClientSignResponse = KeyOperationResult & {
+export type SignResponse = KeyOperationResult & {
   /** The underlying HTTP response. */
   _response: coreHttp.HttpResponse & {
     /** The response body as text (string format) */
@@ -944,11 +918,10 @@ export type KeyVaultClientSignResponse = KeyOperationResult & {
 };
 
 /** Optional parameters. */
-export interface KeyVaultClientVerifyOptionalParams
-  extends coreHttp.OperationOptions {}
+export interface VerifyOptionalParams extends coreHttp.OperationOptions {}
 
 /** Contains response data for the verify operation. */
-export type KeyVaultClientVerifyResponse = KeyVerifyResult & {
+export type VerifyResponse = KeyVerifyResult & {
   /** The underlying HTTP response. */
   _response: coreHttp.HttpResponse & {
     /** The response body as text (string format) */
@@ -960,8 +933,7 @@ export type KeyVaultClientVerifyResponse = KeyVerifyResult & {
 };
 
 /** Optional parameters. */
-export interface KeyVaultClientWrapKeyOptionalParams
-  extends coreHttp.OperationOptions {
+export interface WrapKeyOptionalParams extends coreHttp.OperationOptions {
   /** Initialization vector for symmetric algorithms. */
   iv?: Uint8Array;
   /** Additional data to authenticate but not encrypt/decrypt when using authenticated crypto algorithms. */
@@ -971,7 +943,7 @@ export interface KeyVaultClientWrapKeyOptionalParams
 }
 
 /** Contains response data for the wrapKey operation. */
-export type KeyVaultClientWrapKeyResponse = KeyOperationResult & {
+export type WrapKeyResponse = KeyOperationResult & {
   /** The underlying HTTP response. */
   _response: coreHttp.HttpResponse & {
     /** The response body as text (string format) */
@@ -983,8 +955,7 @@ export type KeyVaultClientWrapKeyResponse = KeyOperationResult & {
 };
 
 /** Optional parameters. */
-export interface KeyVaultClientUnwrapKeyOptionalParams
-  extends coreHttp.OperationOptions {
+export interface UnwrapKeyOptionalParams extends coreHttp.OperationOptions {
   /** Initialization vector for symmetric algorithms. */
   iv?: Uint8Array;
   /** Additional data to authenticate but not encrypt/decrypt when using authenticated crypto algorithms. */
@@ -994,7 +965,7 @@ export interface KeyVaultClientUnwrapKeyOptionalParams
 }
 
 /** Contains response data for the unwrapKey operation. */
-export type KeyVaultClientUnwrapKeyResponse = KeyOperationResult & {
+export type UnwrapKeyResponse = KeyOperationResult & {
   /** The underlying HTTP response. */
   _response: coreHttp.HttpResponse & {
     /** The response body as text (string format) */
@@ -1006,8 +977,7 @@ export type KeyVaultClientUnwrapKeyResponse = KeyOperationResult & {
 };
 
 /** Optional parameters. */
-export interface KeyVaultClientReleaseOptionalParams
-  extends coreHttp.OperationOptions {
+export interface ReleaseOptionalParams extends coreHttp.OperationOptions {
   /** A client provided nonce for freshness. */
   nonce?: string;
   /** The encryption algorithm to use to protected the exported key material */
@@ -1015,7 +985,7 @@ export interface KeyVaultClientReleaseOptionalParams
 }
 
 /** Contains response data for the release operation. */
-export type KeyVaultClientReleaseResponse = KeyReleaseResult & {
+export type ReleaseResponse = KeyReleaseResult & {
   /** The underlying HTTP response. */
   _response: coreHttp.HttpResponse & {
     /** The response body as text (string format) */
@@ -1027,14 +997,14 @@ export type KeyVaultClientReleaseResponse = KeyReleaseResult & {
 };
 
 /** Optional parameters. */
-export interface KeyVaultClientGetDeletedKeysOptionalParams
+export interface GetDeletedKeysOptionalParams
   extends coreHttp.OperationOptions {
   /** Maximum number of results to return in a page. If not specified the service will return up to 25 results. */
   maxresults?: number;
 }
 
 /** Contains response data for the getDeletedKeys operation. */
-export type KeyVaultClientGetDeletedKeysResponse = DeletedKeyListResult & {
+export type GetDeletedKeysResponse = DeletedKeyListResult & {
   /** The underlying HTTP response. */
   _response: coreHttp.HttpResponse & {
     /** The response body as text (string format) */
@@ -1046,11 +1016,11 @@ export type KeyVaultClientGetDeletedKeysResponse = DeletedKeyListResult & {
 };
 
 /** Optional parameters. */
-export interface KeyVaultClientGetDeletedKeyOptionalParams
+export interface GetDeletedKeyOptionalParams
   extends coreHttp.OperationOptions {}
 
 /** Contains response data for the getDeletedKey operation. */
-export type KeyVaultClientGetDeletedKeyResponse = DeletedKeyBundle & {
+export type GetDeletedKeyResponse = DeletedKeyBundle & {
   /** The underlying HTTP response. */
   _response: coreHttp.HttpResponse & {
     /** The response body as text (string format) */
@@ -1062,15 +1032,15 @@ export type KeyVaultClientGetDeletedKeyResponse = DeletedKeyBundle & {
 };
 
 /** Optional parameters. */
-export interface KeyVaultClientPurgeDeletedKeyOptionalParams
+export interface PurgeDeletedKeyOptionalParams
   extends coreHttp.OperationOptions {}
 
 /** Optional parameters. */
-export interface KeyVaultClientRecoverDeletedKeyOptionalParams
+export interface RecoverDeletedKeyOptionalParams
   extends coreHttp.OperationOptions {}
 
 /** Contains response data for the recoverDeletedKey operation. */
-export type KeyVaultClientRecoverDeletedKeyResponse = KeyBundle & {
+export type RecoverDeletedKeyResponse = KeyBundle & {
   /** The underlying HTTP response. */
   _response: coreHttp.HttpResponse & {
     /** The response body as text (string format) */
@@ -1082,11 +1052,11 @@ export type KeyVaultClientRecoverDeletedKeyResponse = KeyBundle & {
 };
 
 /** Optional parameters. */
-export interface KeyVaultClientGetKeyRotationPolicyOptionalParams
+export interface GetKeyRotationPolicyOptionalParams
   extends coreHttp.OperationOptions {}
 
 /** Contains response data for the getKeyRotationPolicy operation. */
-export type KeyVaultClientGetKeyRotationPolicyResponse = KeyRotationPolicy & {
+export type GetKeyRotationPolicyResponse = KeyRotationPolicy & {
   /** The underlying HTTP response. */
   _response: coreHttp.HttpResponse & {
     /** The response body as text (string format) */
@@ -1098,11 +1068,11 @@ export type KeyVaultClientGetKeyRotationPolicyResponse = KeyRotationPolicy & {
 };
 
 /** Optional parameters. */
-export interface KeyVaultClientUpdateKeyRotationPolicyOptionalParams
+export interface UpdateKeyRotationPolicyOptionalParams
   extends coreHttp.OperationOptions {}
 
 /** Contains response data for the updateKeyRotationPolicy operation. */
-export type KeyVaultClientUpdateKeyRotationPolicyResponse = KeyRotationPolicy & {
+export type UpdateKeyRotationPolicyResponse = KeyRotationPolicy & {
   /** The underlying HTTP response. */
   _response: coreHttp.HttpResponse & {
     /** The response body as text (string format) */
@@ -1114,11 +1084,11 @@ export type KeyVaultClientUpdateKeyRotationPolicyResponse = KeyRotationPolicy & 
 };
 
 /** Optional parameters. */
-export interface KeyVaultClientGetRandomBytesOptionalParams
+export interface GetRandomBytesOptionalParams
   extends coreHttp.OperationOptions {}
 
 /** Contains response data for the getRandomBytes operation. */
-export type KeyVaultClientGetRandomBytesResponse = RandomBytes & {
+export type GetRandomBytesResponse = RandomBytes & {
   /** The underlying HTTP response. */
   _response: coreHttp.HttpResponse & {
     /** The response body as text (string format) */
@@ -1130,14 +1100,14 @@ export type KeyVaultClientGetRandomBytesResponse = RandomBytes & {
 };
 
 /** Optional parameters. */
-export interface KeyVaultClientGetKeyVersionsNextOptionalParams
+export interface GetKeyVersionsNextOptionalParams
   extends coreHttp.OperationOptions {
   /** Maximum number of results to return in a page. If not specified the service will return up to 25 results. */
   maxresults?: number;
 }
 
 /** Contains response data for the getKeyVersionsNext operation. */
-export type KeyVaultClientGetKeyVersionsNextResponse = KeyListResult & {
+export type GetKeyVersionsNextResponse = KeyListResult & {
   /** The underlying HTTP response. */
   _response: coreHttp.HttpResponse & {
     /** The response body as text (string format) */
@@ -1149,14 +1119,13 @@ export type KeyVaultClientGetKeyVersionsNextResponse = KeyListResult & {
 };
 
 /** Optional parameters. */
-export interface KeyVaultClientGetKeysNextOptionalParams
-  extends coreHttp.OperationOptions {
+export interface GetKeysNextOptionalParams extends coreHttp.OperationOptions {
   /** Maximum number of results to return in a page. If not specified the service will return up to 25 results. */
   maxresults?: number;
 }
 
 /** Contains response data for the getKeysNext operation. */
-export type KeyVaultClientGetKeysNextResponse = KeyListResult & {
+export type GetKeysNextResponse = KeyListResult & {
   /** The underlying HTTP response. */
   _response: coreHttp.HttpResponse & {
     /** The response body as text (string format) */
@@ -1168,14 +1137,14 @@ export type KeyVaultClientGetKeysNextResponse = KeyListResult & {
 };
 
 /** Optional parameters. */
-export interface KeyVaultClientGetDeletedKeysNextOptionalParams
+export interface GetDeletedKeysNextOptionalParams
   extends coreHttp.OperationOptions {
   /** Maximum number of results to return in a page. If not specified the service will return up to 25 results. */
   maxresults?: number;
 }
 
 /** Contains response data for the getDeletedKeysNext operation. */
-export type KeyVaultClientGetDeletedKeysNextResponse = DeletedKeyListResult & {
+export type GetDeletedKeysNextResponse = DeletedKeyListResult & {
   /** The underlying HTTP response. */
   _response: coreHttp.HttpResponse & {
     /** The response body as text (string format) */

--- a/sdk/keyvault/keyvault-keys/src/generated/models/index.ts
+++ b/sdk/keyvault/keyvault-keys/src/generated/models/index.ts
@@ -50,6 +50,8 @@ export interface Attributes {
 export interface KeyReleasePolicy {
   /** Content type and version of key release policy */
   contentType?: string;
+  /** Defines the mutability state of the policy. Once marked immutable, this flag cannot be reset and the policy cannot be changed under any circumstances. */
+  immutable?: boolean;
   /** Blob encoding the policy rules under which the key can be released. */
   encodedPolicy?: Uint8Array;
 }
@@ -260,20 +262,10 @@ export interface KeyVerifyResult {
   readonly value?: boolean;
 }
 
-/** The export key parameters. */
-export interface KeyExportParameters {
-  /** The export key encryption Json web key. This key MUST be a RSA key that supports encryption. */
-  wrappingKey?: JsonWebKey;
-  /** The export key encryption key identifier. This key MUST be a RSA key that supports encryption. */
-  wrappingKid?: string;
-  /** The encryption algorithm to use to protected the exported key material */
-  enc?: KeyEncryptionAlgorithm;
-}
-
 /** The release key parameters. */
 export interface KeyReleaseParameters {
   /** The attestation assertion for the target of the key release. */
-  target: string;
+  targetAttestationToken: string;
   /** A client provided nonce for freshness. */
   nonce?: string;
   /** The encryption algorithm to use to protected the exported key material */
@@ -326,9 +318,9 @@ export interface LifetimeActions {
 
 /** A condition to be satisfied for an action to be executed. */
 export interface LifetimeActionsTrigger {
-  /** Time after creation to attempt rotate. It will be in ISO 8601 format. Example: 90 days : "P90D" */
+  /** Time after creation to attempt to rotate. It only applies to rotate. It will be in ISO 8601 duration format. Example: 90 days : "P90D" */
   timeAfterCreate?: string;
-  /** Time before expiry to attempt rotate. It will be in ISO 8601 format. Example: 90 days : "P90D" */
+  /** Time before expiry to attempt to rotate or notify. It will be in ISO 8601 duration format. Example: 90 days : "P90D" */
   timeBeforeExpiry?: string;
 }
 
@@ -363,7 +355,7 @@ export interface GetRandomBytesRequest {
 /** The get random bytes response object containing the bytes. */
 export interface RandomBytes {
   /** The bytes encoded as a base64url string. */
-  value?: Uint8Array;
+  value: Uint8Array;
 }
 
 /** Properties of the key pair backing a certificate. */
@@ -378,6 +370,16 @@ export interface KeyProperties {
   reuseKey?: boolean;
   /** Elliptic curve name. For valid values, see JsonWebKeyCurveName. */
   curve?: JsonWebKeyCurveName;
+}
+
+/** The export key parameters. */
+export interface KeyExportParameters {
+  /** The export key encryption Json web key. This key MUST be a RSA key that supports encryption. */
+  wrappingKey?: JsonWebKey;
+  /** The export key encryption key identifier. This key MUST be a RSA key that supports encryption. */
+  wrappingKid?: string;
+  /** The encryption algorithm to use to protected the exported key material */
+  enc?: KeyEncryptionAlgorithm;
 }
 
 /** The attributes of a key managed by the key vault service. */
@@ -1000,29 +1002,6 @@ export type KeyVaultClientUnwrapKeyResponse = KeyOperationResult & {
 
     /** The response body as parsed JSON or XML */
     parsedBody: KeyOperationResult;
-  };
-};
-
-/** Optional parameters. */
-export interface KeyVaultClientExportOptionalParams
-  extends coreHttp.OperationOptions {
-  /** The export key encryption Json web key. This key MUST be a RSA key that supports encryption. */
-  wrappingKey?: JsonWebKey;
-  /** The export key encryption key identifier. This key MUST be a RSA key that supports encryption. */
-  wrappingKid?: string;
-  /** The encryption algorithm to use to protected the exported key material */
-  enc?: KeyEncryptionAlgorithm;
-}
-
-/** Contains response data for the export operation. */
-export type KeyVaultClientExportResponse = KeyBundle & {
-  /** The underlying HTTP response. */
-  _response: coreHttp.HttpResponse & {
-    /** The response body as text (string format) */
-    bodyAsText: string;
-
-    /** The response body as parsed JSON or XML */
-    parsedBody: KeyBundle;
   };
 };
 

--- a/sdk/keyvault/keyvault-keys/src/generated/models/mappers.ts
+++ b/sdk/keyvault/keyvault-keys/src/generated/models/mappers.ts
@@ -127,6 +127,12 @@ export const KeyReleasePolicy: coreHttp.CompositeMapper = {
           name: "String"
         }
       },
+      immutable: {
+        serializedName: "immutable",
+        type: {
+          name: "Boolean"
+        }
+      },
       encodedPolicy: {
         serializedName: "data",
         type: {
@@ -672,40 +678,12 @@ export const KeyVerifyResult: coreHttp.CompositeMapper = {
   }
 };
 
-export const KeyExportParameters: coreHttp.CompositeMapper = {
-  type: {
-    name: "Composite",
-    className: "KeyExportParameters",
-    modelProperties: {
-      wrappingKey: {
-        serializedName: "wrappingKey",
-        type: {
-          name: "Composite",
-          className: "JsonWebKey"
-        }
-      },
-      wrappingKid: {
-        serializedName: "wrappingKid",
-        type: {
-          name: "String"
-        }
-      },
-      enc: {
-        serializedName: "enc",
-        type: {
-          name: "String"
-        }
-      }
-    }
-  }
-};
-
 export const KeyReleaseParameters: coreHttp.CompositeMapper = {
   type: {
     name: "Composite",
     className: "KeyReleaseParameters",
     modelProperties: {
-      target: {
+      targetAttestationToken: {
         constraints: {
           MinLength: 1
         },
@@ -927,6 +905,7 @@ export const RandomBytes: coreHttp.CompositeMapper = {
     modelProperties: {
       value: {
         serializedName: "value",
+        required: true,
         type: {
           name: "Base64Url"
         }
@@ -966,6 +945,34 @@ export const KeyProperties: coreHttp.CompositeMapper = {
       },
       curve: {
         serializedName: "crv",
+        type: {
+          name: "String"
+        }
+      }
+    }
+  }
+};
+
+export const KeyExportParameters: coreHttp.CompositeMapper = {
+  type: {
+    name: "Composite",
+    className: "KeyExportParameters",
+    modelProperties: {
+      wrappingKey: {
+        serializedName: "wrappingKey",
+        type: {
+          name: "Composite",
+          className: "JsonWebKey"
+        }
+      },
+      wrappingKid: {
+        serializedName: "wrappingKid",
+        type: {
+          name: "String"
+        }
+      },
+      enc: {
+        serializedName: "enc",
         type: {
           name: "String"
         }

--- a/sdk/keyvault/keyvault-keys/src/generated/models/parameters.ts
+++ b/sdk/keyvault/keyvault-keys/src/generated/models/parameters.ts
@@ -19,7 +19,6 @@ import {
   KeyOperationsParameters as KeyOperationsParametersMapper,
   KeySignParameters as KeySignParametersMapper,
   KeyVerifyParameters as KeyVerifyParametersMapper,
-  KeyExportParameters as KeyExportParametersMapper,
   KeyReleaseParameters as KeyReleaseParametersMapper,
   KeyRotationPolicy as KeyRotationPolicyMapper,
   GetRandomBytesRequest as GetRandomBytesRequestMapper
@@ -262,23 +261,8 @@ export const signature: OperationParameter = {
   mapper: KeyVerifyParametersMapper
 };
 
-export const wrappingKey: OperationParameter = {
-  parameterPath: ["options", "wrappingKey"],
-  mapper: KeyExportParametersMapper
-};
-
-export const wrappingKid: OperationParameter = {
-  parameterPath: ["options", "wrappingKid"],
-  mapper: KeyExportParametersMapper
-};
-
-export const enc: OperationParameter = {
-  parameterPath: ["options", "enc"],
-  mapper: KeyExportParametersMapper
-};
-
-export const target: OperationParameter = {
-  parameterPath: "target",
+export const targetAttestationToken: OperationParameter = {
+  parameterPath: "targetAttestationToken",
   mapper: KeyReleaseParametersMapper
 };
 
@@ -287,7 +271,7 @@ export const nonce: OperationParameter = {
   mapper: KeyReleaseParametersMapper
 };
 
-export const enc1: OperationParameter = {
+export const enc: OperationParameter = {
   parameterPath: ["options", "enc"],
   mapper: KeyReleaseParametersMapper
 };

--- a/sdk/keyvault/keyvault-keys/src/index.ts
+++ b/sdk/keyvault/keyvault-keys/src/index.ts
@@ -20,7 +20,7 @@ import { PollerLike, PollOperationState } from "@azure/core-lro";
 import {
   DeletionRecoveryLevel,
   KnownDeletionRecoveryLevel,
-  KeyVaultClientGetKeysOptionalParams,
+  GetKeysOptionalParams,
   KnownJsonWebKeyType,
 } from "./generated/models";
 import { KeyVaultClient } from "./generated/keyVaultClient";
@@ -909,7 +909,7 @@ export class KeyClient {
     options?: ListPropertiesOfKeyVersionsOptions
   ): AsyncIterableIterator<KeyProperties[]> {
     if (continuationState.continuationToken == null) {
-      const optionsComplete: KeyVaultClientGetKeysOptionalParams = {
+      const optionsComplete: GetKeysOptionalParams = {
         maxresults: continuationState.maxPageSize,
         ...options,
       };
@@ -1001,7 +1001,7 @@ export class KeyClient {
     options?: ListPropertiesOfKeysOptions
   ): AsyncIterableIterator<KeyProperties[]> {
     if (continuationState.continuationToken == null) {
-      const optionsComplete: KeyVaultClientGetKeysOptionalParams = {
+      const optionsComplete: GetKeysOptionalParams = {
         maxresults: continuationState.maxPageSize,
         ...options,
       };
@@ -1089,7 +1089,7 @@ export class KeyClient {
     options?: ListDeletedKeysOptions
   ): AsyncIterableIterator<DeletedKey[]> {
     if (continuationState.continuationToken == null) {
-      const optionsComplete: KeyVaultClientGetKeysOptionalParams = {
+      const optionsComplete: GetKeysOptionalParams = {
         maxresults: continuationState.maxPageSize,
         ...options,
       };

--- a/sdk/keyvault/keyvault-keys/src/keysModels.ts
+++ b/sdk/keyvault/keyvault-keys/src/keysModels.ts
@@ -287,6 +287,9 @@ export interface KeyReleasePolicy {
 
   /** Blob encoding the policy rules under which the key can be released. */
   encodedPolicy?: Uint8Array;
+
+  /** Marks a release policy as immutable. An immutable release policy cannot be changed or updated after marked immutable. */
+  immutable?: boolean;
 }
 
 /**

--- a/sdk/keyvault/keyvault-keys/swagger/README.md
+++ b/sdk/keyvault/keyvault-keys/swagger/README.md
@@ -16,7 +16,7 @@ disable-async-iterators: true
 api-version-parameter: choice
 package-version: 4.4.0-beta.4
 use-extension:
-  "@autorest/typescript": "6.0.0-beta.5"
+  "@autorest/typescript": "6.0.0-beta.15"
 ```
 
 ## Customizations for Track 2 Generator

--- a/sdk/keyvault/keyvault-keys/swagger/README.md
+++ b/sdk/keyvault/keyvault-keys/swagger/README.md
@@ -9,12 +9,14 @@ generate-metadata: false
 add-credentials: false
 use-core-v2: false
 license-header: MICROSOFT_MIT_NO_VERSION
-input-file: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/f4a4badda9e19dca5cab216f3dd8b45362aeb90b/specification/keyvault/data-plane/Microsoft.KeyVault/preview/7.3-preview/keys.json
+input-file: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/b7d6b00a7f388f048772ea249114a63773312538/specification/keyvault/data-plane/Microsoft.KeyVault/preview/7.3-preview/keys.json
 output-folder: ../
 source-code-folder-path: ./src/generated
 disable-async-iterators: true
 api-version-parameter: choice
 package-version: 4.4.0-beta.4
+use-extension:
+  "@autorest/typescript": "6.0.0-beta.5"
 ```
 
 ## Customizations for Track 2 Generator

--- a/sdk/keyvault/keyvault-keys/test/public/keyClient.hsm.spec.ts
+++ b/sdk/keyvault/keyvault-keys/test/public/keyClient.hsm.spec.ts
@@ -182,44 +182,6 @@ onVersions({ minVer: "7.2" }).describe(
         );
       });
 
-      it.only("errors when updating an immutable release policy", async () => {
-        const keyName = recorder.getUniqueName("immutablerelease");
-        const createdKey = await hsmClient.createKey(keyName, "RSA", {
-          exportable: true,
-          releasePolicy: { encodedPolicy: encodedReleasePolicy, immutable: true },
-          keyOps: ["encrypt", "decrypt"],
-        });
-
-        const newReleasePolicy = {
-          anyOf: [
-            {
-              anyOf: [
-                {
-                  claim: "sdk-test",
-                  equals: "false",
-                },
-              ],
-              authority: env.AZURE_KEYVAULT_ATTESTATION_URI,
-            },
-          ],
-          version: "1.0",
-        };
-
-        const updatedKey = await hsmClient.updateKeyProperties(createdKey.name, {
-          releasePolicy: {
-            encodedPolicy: stringToUint8Array(JSON.stringify(newReleasePolicy)),
-            immutable: true,
-          },
-        });
-
-        assert.exists(updatedKey.properties.releasePolicy?.encodedPolicy);
-        const decodedReleasePolicy = JSON.parse(
-          uint8ArrayToString(updatedKey.properties.releasePolicy!.encodedPolicy!)
-        );
-
-        assert.equal(decodedReleasePolicy.anyOf[0].anyOf[0].equals, "false");
-      });
-
       it("errors when a key has a release policy but is not exportable", async () => {
         const keyName = recorder.getUniqueName("policynonexportable");
         await assert.isRejected(

--- a/sdk/keyvault/keyvault-keys/test/public/keyClient.hsm.spec.ts
+++ b/sdk/keyvault/keyvault-keys/test/public/keyClient.hsm.spec.ts
@@ -182,6 +182,44 @@ onVersions({ minVer: "7.2" }).describe(
         );
       });
 
+      it.only("errors when updating an immutable release policy", async () => {
+        const keyName = recorder.getUniqueName("immutablerelease");
+        const createdKey = await hsmClient.createKey(keyName, "RSA", {
+          exportable: true,
+          releasePolicy: { encodedPolicy: encodedReleasePolicy, immutable: true },
+          keyOps: ["encrypt", "decrypt"],
+        });
+
+        const newReleasePolicy = {
+          anyOf: [
+            {
+              anyOf: [
+                {
+                  claim: "sdk-test",
+                  equals: "false",
+                },
+              ],
+              authority: env.AZURE_KEYVAULT_ATTESTATION_URI,
+            },
+          ],
+          version: "1.0",
+        };
+
+        const updatedKey = await hsmClient.updateKeyProperties(createdKey.name, {
+          releasePolicy: {
+            encodedPolicy: stringToUint8Array(JSON.stringify(newReleasePolicy)),
+            immutable: true,
+          },
+        });
+
+        assert.exists(updatedKey.properties.releasePolicy?.encodedPolicy);
+        const decodedReleasePolicy = JSON.parse(
+          uint8ArrayToString(updatedKey.properties.releasePolicy!.encodedPolicy!)
+        );
+
+        assert.equal(decodedReleasePolicy.anyOf[0].anyOf[0].equals, "false");
+      });
+
       it("errors when a key has a release policy but is not exportable", async () => {
         const keyName = recorder.getUniqueName("policynonexportable");
         await assert.isRejected(

--- a/sdk/keyvault/keyvault-keys/test/public/keyClient.spec.ts
+++ b/sdk/keyvault/keyvault-keys/test/public/keyClient.spec.ts
@@ -610,7 +610,7 @@ describe("Keys client - create, read, update and delete operations", () => {
       );
     });
 
-    it.only("errors when updating an immutable release policy", async () => {
+    it("errors when updating an immutable release policy", async () => {
       const keyName = recorder.getUniqueName("immutablerelease");
       const createdKey = await client.createRsaKey(keyName, {
         exportable: true,


### PR DESCRIPTION
### Packages impacted by this PR
@azure/keyvault-keys

### Issues associated with this PR
Resolves #19857

### Describe the problem that is addressed by this PR
Now that this flag has been added we can regenerate code and add support for
immutable key release policies. Once a policy is marked immutable it can no
longer be modified.

### Are there test cases added in this PR? _(If not, why?)_
Yes, I debated whether I should also add a test case for "create a key, then
update the release policy to be immutable, then try to change it" but it
wouldn't drive any code so I skipped it.

Do note that since MHSM does not currently support this flag I was unable to add
a test for it for MHSM, but I will create an issue to add that in later.

### Checklists
- [x] Added impacted package name to the issue description
- [x] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [x] Added a changelog (if necessary)
