### PR TITLE
[Monitor Query] fix the local time zone bug in the test

### DIFF
--- a/sdk/monitor/monitor-query/test/internal/unit/modelConverters.unittest.spec.ts
+++ b/sdk/monitor/monitor-query/test/internal/unit/modelConverters.unittest.spec.ts
@@ -354,8 +354,8 @@ describe("Model unit tests", () => {
 
     it("convertTimespanToInterval", () => {
       const res1 = convertTimespanToInterval({
-        startTime: new Date("2007-11-13T08:00:00"),
-        endTime: new Date("2007-11-16T08:00:00"),
+        startTime: new Date("2007-11-13T08:00:00Z"),
+        endTime: new Date("2007-11-16T08:00:00Z"),
       });
       assert.equal(res1, "2007-11-13T08:00:00.000Z/2007-11-16T08:00:00.000Z");
 


### PR DESCRIPTION
### Packages impacted by this PR

@azure/monitor-query
### Issues associated with this PR
No issue opened

### Describe the problem that is addressed by this PR
There was an issue with an internal unit test - `convertTimespanToInterval` where the date conversion to ISO string() made the string to get converted in UTC timezone causing the test to fail locally, since the timezone wasn't specified in the date and it took the local timezone as default. This issue wasn't seen on the CI as the local timezone for CI is UTC.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?
Not applicable

### Are there test cases added in this PR? _(If not, why?)_
This fixes the test case.