### PR TITLE
Update Rush version to 5.61.2

### DIFF
--- a/rush.json
+++ b/rush.json
@@ -14,7 +14,7 @@
    * path segment in the "$schema" field for all your Rush config files.  This will ensure
    * correct error-underlining and tab-completion for editors such as VS Code.
    */
-  "rushVersion": "5.55.1",
+  "rushVersion": "5.61.2",
   /**
    * The next field selects which package manager should be installed and determines its version.
    * Rush installs its own local copy of the package manager to ensure that your build process


### PR DESCRIPTION
### Issues associated with this PR
#20087

### Describe the problem that is addressed by this PR
Updating Rush to version `5.61.2` which is the latest as of today. Going through the changelog, I didn't find any changes that may impact our build process.