### PR TITLE
[core-tracing] Fix the return type of withSpan

### DIFF
--- a/sdk/core/core-tracing/review/core-tracing.api.md
+++ b/sdk/core/core-tracing/review/core-tracing.api.md
@@ -5,11 +5,6 @@
 ```ts
 
 // @public
-export type AwaitedLike<T> = T extends {
-    then(onfulfilled: infer F): any;
-} ? F extends (value: infer V) => any ? AwaitedLike<V> : never : T;
-
-// @public
 export function createTracingClient(options: TracingClientOptions): TracingClient;
 
 // @public
@@ -34,6 +29,11 @@ export interface InstrumenterSpanOptions extends TracingSpanOptions {
 export interface OperationTracingOptions {
     tracingContext?: TracingContext;
 }
+
+// @public
+export type Resolved<T> = T extends {
+    then(onfulfilled: infer F): any;
+} ? F extends (value: infer V) => any ? Resolved<V> : never : T;
 
 // @public
 export type SpanStatus = SpanStatusSuccess | SpanStatusError;
@@ -62,7 +62,7 @@ export interface TracingClient {
     withContext<CallbackArgs extends unknown[], Callback extends (...args: CallbackArgs) => ReturnType<Callback>>(context: TracingContext, callback: Callback, ...callbackArgs: CallbackArgs): ReturnType<Callback>;
     withSpan<Options extends {
         tracingOptions?: OperationTracingOptions;
-    }, Callback extends (updatedOptions: Options, span: Omit<TracingSpan, "end">) => ReturnType<Callback>>(name: string, operationOptions: Options, callback: Callback, spanOptions?: TracingSpanOptions): Promise<AwaitedLike<ReturnType<Callback>>>;
+    }, Callback extends (updatedOptions: Options, span: Omit<TracingSpan, "end">) => ReturnType<Callback>>(name: string, operationOptions: Options, callback: Callback, spanOptions?: TracingSpanOptions): Promise<Resolved<ReturnType<Callback>>>;
 }
 
 // @public

--- a/sdk/core/core-tracing/review/core-tracing.api.md
+++ b/sdk/core/core-tracing/review/core-tracing.api.md
@@ -5,6 +5,11 @@
 ```ts
 
 // @public
+export type AwaitedLike<T> = T extends object & {
+    then(onfulfilled: infer F): any;
+} ? F extends (value: infer V) => any ? AwaitedLike<V> : never : T;
+
+// @public
 export function createTracingClient(options: TracingClientOptions): TracingClient;
 
 // @public
@@ -57,7 +62,7 @@ export interface TracingClient {
     withContext<CallbackArgs extends unknown[], Callback extends (...args: CallbackArgs) => ReturnType<Callback>>(context: TracingContext, callback: Callback, ...callbackArgs: CallbackArgs): ReturnType<Callback>;
     withSpan<Options extends {
         tracingOptions?: OperationTracingOptions;
-    }, Callback extends (updatedOptions: Options, span: Omit<TracingSpan, "end">) => ReturnType<Callback>>(name: string, operationOptions: Options, callback: Callback, spanOptions?: TracingSpanOptions): Promise<ReturnType<Callback>>;
+    }, Callback extends (updatedOptions: Options, span: Omit<TracingSpan, "end">) => ReturnType<Callback>>(name: string, operationOptions: Options, callback: Callback, spanOptions?: TracingSpanOptions): Promise<AwaitedLike<ReturnType<Callback>>>;
 }
 
 // @public

--- a/sdk/core/core-tracing/review/core-tracing.api.md
+++ b/sdk/core/core-tracing/review/core-tracing.api.md
@@ -5,7 +5,7 @@
 ```ts
 
 // @public
-export type AwaitedLike<T> = T extends object & {
+export type AwaitedLike<T> = T extends {
     then(onfulfilled: infer F): any;
 } ? F extends (value: infer V) => any ? AwaitedLike<V> : never : T;
 

--- a/sdk/core/core-tracing/src/index.ts
+++ b/sdk/core/core-tracing/src/index.ts
@@ -2,10 +2,10 @@
 // Licensed under the MIT license.
 
 export {
-  AwaitedLike,
   Instrumenter,
   InstrumenterSpanOptions,
   OperationTracingOptions,
+  Resolved,
   SpanStatus,
   SpanStatusError,
   SpanStatusSuccess,

--- a/sdk/core/core-tracing/src/index.ts
+++ b/sdk/core/core-tracing/src/index.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 export {
+  AwaitedLike,
   Instrumenter,
   InstrumenterSpanOptions,
   OperationTracingOptions,

--- a/sdk/core/core-tracing/src/interfaces.ts
+++ b/sdk/core/core-tracing/src/interfaces.ts
@@ -5,9 +5,9 @@
  * A narrower version of TypeScript 4.5's Awaited type which Recursively
  * unwraps the "awaited type", emulating the behavior of `await`.
  */
-export type AwaitedLike<T> = T extends { then(onfulfilled: infer F): any } // `await` only unwraps object types with a callable `then`. Non-object types are not unwrapped
+export type Resolved<T> = T extends { then(onfulfilled: infer F): any } // `await` only unwraps object types with a callable `then`. Non-object types are not unwrapped
   ? F extends (value: infer V) => any // if the argument to `then` is callable, extracts the first argument
-    ? AwaitedLike<V> // recursively unwrap the value
+    ? Resolved<V> // recursively unwrap the value
     : never // the argument to `then` was not callable
   : T; // non-object or non-thenable
 
@@ -44,7 +44,7 @@ export interface TracingClient {
     operationOptions: Options,
     callback: Callback,
     spanOptions?: TracingSpanOptions
-  ): Promise<AwaitedLike<ReturnType<Callback>>>;
+  ): Promise<Resolved<ReturnType<Callback>>>;
   /**
    * Starts a given span but does not set it as the active span.
    *

--- a/sdk/core/core-tracing/src/interfaces.ts
+++ b/sdk/core/core-tracing/src/interfaces.ts
@@ -5,8 +5,7 @@
  * A narrower version of TypeScript 4.5's Awaited type which Recursively
  * unwraps the "awaited type", emulating the behavior of `await`.
  */
-// eslint-disable-next-line @typescript-eslint/ban-types -- I want to stay consistent with TypeScript 4.5's Awaited type
-export type AwaitedLike<T> = T extends object & { then(onfulfilled: infer F): any } // `await` only unwraps object types with a callable `then`. Non-object types are not unwrapped
+export type AwaitedLike<T> = T extends { then(onfulfilled: infer F): any } // `await` only unwraps object types with a callable `then`. Non-object types are not unwrapped
   ? F extends (value: infer V) => any // if the argument to `then` is callable, extracts the first argument
     ? AwaitedLike<V> // recursively unwrap the value
     : never // the argument to `then` was not callable

--- a/sdk/core/core-tracing/src/interfaces.ts
+++ b/sdk/core/core-tracing/src/interfaces.ts
@@ -5,6 +5,7 @@
  * A narrower version of TypeScript 4.5's Awaited type which Recursively
  * unwraps the "awaited type", emulating the behavior of `await`.
  */
+// eslint-disable-next-line @typescript-eslint/ban-types -- I want to stay consistent with TypeScript 4.5's Awaited type
 export type AwaitedLike<T> = T extends object & { then(onfulfilled: infer F): any } // `await` only unwraps object types with a callable `then`. Non-object types are not unwrapped
   ? F extends (value: infer V) => any // if the argument to `then` is callable, extracts the first argument
     ? AwaitedLike<V> // recursively unwrap the value

--- a/sdk/core/core-tracing/src/interfaces.ts
+++ b/sdk/core/core-tracing/src/interfaces.ts
@@ -2,6 +2,16 @@
 // Licensed under the MIT license.
 
 /**
+ * A narrower version of TypeScript 4.5's Awaited type which Recursively
+ * unwraps the "awaited type", emulating the behavior of `await`.
+ */
+export type AwaitedLike<T> = T extends object & { then(onfulfilled: infer F): any } // `await` only unwraps object types with a callable `then`. Non-object types are not unwrapped
+  ? F extends (value: infer V) => any // if the argument to `then` is callable, extracts the first argument
+    ? AwaitedLike<V> // recursively unwrap the value
+    : never // the argument to `then` was not callable
+  : T; // non-object or non-thenable
+
+/**
  * Represents a client that can integrate with the currently configured {@link Instrumenter}.
  *
  * Create an instance using {@link createTracingClient}.
@@ -11,6 +21,8 @@ export interface TracingClient {
    * Wraps a callback in a tracing span, calls the callback, and closes the span.
    *
    * This is the primary interface for using Tracing and will handle error recording as well as setting the status on the span.
+   *
+   * Both synchronous and asynchronous functions will be awaited in order to reflect the result of the callback on the span.
    *
    * Example:
    *
@@ -32,7 +44,7 @@ export interface TracingClient {
     operationOptions: Options,
     callback: Callback,
     spanOptions?: TracingSpanOptions
-  ): Promise<ReturnType<Callback>>;
+  ): Promise<AwaitedLike<ReturnType<Callback>>>;
   /**
    * Starts a given span but does not set it as the active span.
    *

--- a/sdk/core/core-tracing/src/tracingClient.ts
+++ b/sdk/core/core-tracing/src/tracingClient.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 
 import {
-  AwaitedLike,
+  Resolved,
   OperationTracingOptions,
   TracingClient,
   TracingClientOptions,
@@ -65,7 +65,7 @@ export function createTracingClient(options: TracingClientOptions): TracingClien
     operationOptions: Options,
     callback: Callback,
     spanOptions?: TracingSpanOptions
-  ): Promise<AwaitedLike<ReturnType<Callback>>> {
+  ): Promise<Resolved<ReturnType<Callback>>> {
     const { span, updatedOptions } = startSpan(name, operationOptions, spanOptions);
     try {
       const result = await withContext(updatedOptions.tracingOptions!.tracingContext!, () =>

--- a/sdk/core/core-tracing/src/tracingClient.ts
+++ b/sdk/core/core-tracing/src/tracingClient.ts
@@ -2,8 +2,8 @@
 // Licensed under the MIT license.
 
 import {
-  Resolved,
   OperationTracingOptions,
+  Resolved,
   TracingClient,
   TracingClientOptions,
   TracingContext,

--- a/sdk/core/core-tracing/src/tracingClient.ts
+++ b/sdk/core/core-tracing/src/tracingClient.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 import {
+  AwaitedLike,
   OperationTracingOptions,
   TracingClient,
   TracingClientOptions,
@@ -64,14 +65,14 @@ export function createTracingClient(options: TracingClientOptions): TracingClien
     operationOptions: Options,
     callback: Callback,
     spanOptions?: TracingSpanOptions
-  ): Promise<ReturnType<Callback>> {
+  ): Promise<AwaitedLike<ReturnType<Callback>>> {
     const { span, updatedOptions } = startSpan(name, operationOptions, spanOptions);
     try {
       const result = await withContext(updatedOptions.tracingOptions!.tracingContext!, () =>
         Promise.resolve(callback(updatedOptions, span))
       );
       span.setStatus({ status: "success" });
-      return result;
+      return result as ReturnType<typeof withSpan>;
     } catch (err) {
       span.setStatus({ status: "error", error: err });
       throw err;


### PR DESCRIPTION
### Packages impacted by this PR
@azure/core-tracing

### Issues associated with this PR
N/A - created after discussion with some team members

### Describe the problem that is addressed by this PR
`withSpan` is meant to await some user-provided callback and set the appropriate
status on the created span before closing it. Because we have no way of knowing
whether the callback is sync or async we must promisify it first. Up until now that
meant that the return type of a promise-returning callback was
`Promise<Promise<...>>` which does not reflect the reality that `await` will
recursively unwrap promises. That meant that the consumer must also either
`await` or mark the function as `async` in order to avoid a return-type
mismatch.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?
The solution here is to introduce an `AwaitedLike` type which is a narrower
version of TypeScript 4.5's `Awaited` type. Because our min-bar is lower we
cannot take advantage of this new type yet, so I introduced something like it
which can be replaced with the broader type once we support TS >= 4.5.

### Are there test cases added in this PR? _(If not, why?)_
We already have test cases for this function for both sync and async callbacks,
as this is a pure type-change with no runtime behavior change no test cases are
needed

### Checklists
- [x] Added impacted package name to the issue description
- [x] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [x] Added a changelog (if necessary)
