### PR TITLE
[sort-imports] enforce ```sort-imports``` rule in ```eventhubs-checkpointstore-table```

### DIFF
--- a/sdk/eventhub/eventhubs-checkpointstore-table/.eslintrc.json
+++ b/sdk/eventhub/eventhubs-checkpointstore-table/.eslintrc.json
@@ -1,10 +1,6 @@
 {
-  "plugins": [
-    "@azure/azure-sdk"
-  ],
-  "extends": [
-    "plugin:@azure/azure-sdk/azure-sdk-base"
-  ],
+  "plugins": ["@azure/azure-sdk"],
+  "extends": ["plugin:@azure/azure-sdk/azure-sdk-base"],
   "rules": {
     "sort-imports": "error"
   }

--- a/sdk/eventhub/eventhubs-checkpointstore-table/.eslintrc.json
+++ b/sdk/eventhub/eventhubs-checkpointstore-table/.eslintrc.json
@@ -1,0 +1,11 @@
+{
+  "plugins": [
+    "@azure/azure-sdk"
+  ],
+  "extends": [
+    "plugin:@azure/azure-sdk/azure-sdk-base"
+  ],
+  "rules": {
+    "sort-imports": "error"
+  }
+}


### PR DESCRIPTION
This PR reinforces the changes made in #19066 by changing the subdirectory's linting rule to ```"sort-imports": "error"```.

This affects the directory under ```sdk/eventhub/eventhubs-checkpointstore-table```.