### PR TITLE
[Schema Registry Avro] Use LRU cache policy

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -15393,7 +15393,7 @@ packages:
     dev: false
 
   file:projects/schema-registry-avro.tgz:
-    resolution: {integrity: sha512-IPGluIGTS0D5gQtpTeLIHEI6s1yKKYEc13M2qRL7ZwmTebw3/8hMLHh//qSj9EoHJLgw8crHNRguILSBcGrvpw==, tarball: file:projects/schema-registry-avro.tgz}
+    resolution: {integrity: sha512-mrrtNCFDOLZ3DCxGpU9HuD0w0oveqTH8tTHPa4pnfNz+bhS8fgVA6bvQoT30/MrapBBJWSCNVybNWEVW3/BRZQ==, tarball: file:projects/schema-registry-avro.tgz}
     name: '@rush-temp/schema-registry-avro'
     version: 0.0.0
     dependencies:
@@ -15407,6 +15407,7 @@ packages:
       '@types/lru-cache': 5.1.1
       '@types/mocha': 7.0.2
       '@types/node': 12.20.42
+      '@types/uuid': 8.3.4
       avsc: 5.7.3
       buffer: 6.0.3
       chai: 4.3.4
@@ -15439,6 +15440,7 @@ packages:
       source-map-support: 0.5.21
       tslib: 2.3.1
       typescript: 4.2.4
+      uuid: 8.3.2
     transitivePeerDependencies:
       - bufferutil
       - debug

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -70,6 +70,7 @@ specifiers:
   '@rush-temp/arm-iothub': file:./projects/arm-iothub.tgz
   '@rush-temp/arm-keyvault': file:./projects/arm-keyvault.tgz
   '@rush-temp/arm-kubernetesconfiguration': file:./projects/arm-kubernetesconfiguration.tgz
+  '@rush-temp/arm-kusto': file:./projects/arm-kusto.tgz
   '@rush-temp/arm-labservices': file:./projects/arm-labservices.tgz
   '@rush-temp/arm-links': file:./projects/arm-links.tgz
   '@rush-temp/arm-loadtestservice': file:./projects/arm-loadtestservice.tgz
@@ -2089,6 +2090,10 @@ packages:
 
   /@types/long/4.0.1:
     resolution: {integrity: sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w==}
+    dev: false
+
+  /@types/lru-cache/5.1.1:
+    resolution: {integrity: sha512-ssE3Vlrys7sdIzs5LOxCzTVMsU7i9oa/IaW92wF32JFb3CVczqOkru2xspuKczHEbG3nvmPY7IFqVmGGHdNbYw==}
     dev: false
 
   /@types/md5/2.3.1:
@@ -8365,7 +8370,7 @@ packages:
     dev: false
 
   file:projects/agrifood-farming.tgz:
-    resolution: {integrity: sha512-tIbV71Sekmb01b/mAU9iH2ZNEe2nbzNTiGPFmlNRnGLOAEXkxRYdLDbSR26JEGicN3V76kUlOxbLl3wkCLHY+Q==, tarball: file:projects/agrifood-farming.tgz}
+    resolution: {integrity: sha512-JpQ+CMsdS6Lq2UVvWVtusmxuJgFKl8wsN9B0hmDFA9ZEcFD9Cu4V3FlHw8/OvMbTecY+c7ImUUNvPIqhSHgE4Q==, tarball: file:projects/agrifood-farming.tgz}
     name: '@rush-temp/agrifood-farming'
     version: 0.0.0
     dependencies:
@@ -13125,7 +13130,7 @@ packages:
     dev: false
 
   file:projects/core-http.tgz:
-    resolution: {integrity: sha512-dr/zKAzLJeqdjfjldg208kPRFEMAH6gtQCxlOVWj3j6aBWvXZLWYoH6DirE5GNgn3uQc6sWDfI58qL4w6hqmNQ==, tarball: file:projects/core-http.tgz}
+    resolution: {integrity: sha512-hNWQdd9zZmCEndn+4Bl3G0/90xrJnP8QjWHnB7gbiAJTfQHSW1rePvYICZi2X3IW+mtuqsJod+5kD2DF3F92vg==, tarball: file:projects/core-http.tgz}
     name: '@rush-temp/core-http'
     version: 0.0.0
     dependencies:
@@ -15388,7 +15393,7 @@ packages:
     dev: false
 
   file:projects/schema-registry-avro.tgz:
-    resolution: {integrity: sha512-nYoV4QCq4gGBjhk2hz9opui4CbCRNv3bcVGgDVCIqiso9PbCyWb6CqNqsSZyT7F2NIpVfGSNtElbrVDgx/2i/g==, tarball: file:projects/schema-registry-avro.tgz}
+    resolution: {integrity: sha512-IPGluIGTS0D5gQtpTeLIHEI6s1yKKYEc13M2qRL7ZwmTebw3/8hMLHh//qSj9EoHJLgw8crHNRguILSBcGrvpw==, tarball: file:projects/schema-registry-avro.tgz}
     name: '@rush-temp/schema-registry-avro'
     version: 0.0.0
     dependencies:
@@ -15399,6 +15404,7 @@ packages:
       '@rollup/plugin-replace': 2.4.2_rollup@1.32.1
       '@types/chai': 4.3.0
       '@types/chai-as-promised': 7.1.4
+      '@types/lru-cache': 5.1.1
       '@types/mocha': 7.0.2
       '@types/node': 12.20.42
       avsc: 5.7.3
@@ -15422,6 +15428,7 @@ packages:
       karma-mocha-reporter: 2.2.5_karma@6.3.11
       karma-source-map-support: 1.4.0
       karma-sourcemap-loader: 0.3.8
+      lru-cache: 6.0.0
       mocha: 7.2.0
       mocha-junit-reporter: 2.0.2_mocha@7.2.0
       nyc: 15.1.0
@@ -15441,7 +15448,7 @@ packages:
     dev: false
 
   file:projects/schema-registry.tgz:
-    resolution: {integrity: sha512-fucVewqXE8TZV5enQSHpfLRsx8+I+1w1Cec81+x0xHbAcEs0ykoXa7NCNYQMAPi+V0Pu99w+Hqmjsrbn1SK6yg==, tarball: file:projects/schema-registry.tgz}
+    resolution: {integrity: sha512-bC/6TQwVav+spG+JqNxPVKgzAgTI2cYjiU/y2+r3RXlD8Wv/w2p99jyDQGcB+nALLOPMDPUAszhc8iUgFUEwSw==, tarball: file:projects/schema-registry.tgz}
     name: '@rush-temp/schema-registry'
     version: 0.0.0
     dependencies:
@@ -15482,7 +15489,6 @@ packages:
     transitivePeerDependencies:
       - bufferutil
       - debug
-      - encoding
       - supports-color
       - utf-8-validate
     dev: false

--- a/sdk/schemaregistry/schema-registry-avro/CHANGELOG.md
+++ b/sdk/schemaregistry/schema-registry-avro/CHANGELOG.md
@@ -15,6 +15,7 @@
 ### Bugs Fixed
 
 ### Other Changes
+- The internal cache has been updated to be an LRU one with a max entries count of 128
 
 ## 1.0.0-beta.5 (2021-11-17)
 

--- a/sdk/schemaregistry/schema-registry-avro/package.json
+++ b/sdk/schemaregistry/schema-registry-avro/package.json
@@ -74,6 +74,7 @@
     "@azure/schema-registry": "1.0.2",
     "avsc": "^5.5.1",
     "buffer": "^6.0.0",
+    "lru-cache": "^6.0.0",
     "tslib": "^2.2.0"
   },
   "devDependencies": {
@@ -89,6 +90,7 @@
     "@rollup/plugin-replace": "^2.2.0",
     "@types/chai": "^4.1.6",
     "@types/chai-as-promised": "^7.1.0",
+    "@types/lru-cache": "~5.1.1",
     "@types/mocha": "^7.0.2",
     "@types/node": "^12.0.0",
     "chai": "^4.2.0",

--- a/sdk/schemaregistry/schema-registry-avro/package.json
+++ b/sdk/schemaregistry/schema-registry-avro/package.json
@@ -93,6 +93,7 @@
     "@types/lru-cache": "~5.1.1",
     "@types/mocha": "^7.0.2",
     "@types/node": "^12.0.0",
+    "@types/uuid": "^8.3.0",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
     "cross-env": "^7.0.2",
@@ -120,6 +121,7 @@
     "rollup": "^1.16.3",
     "rollup-plugin-shim": "^1.0.0",
     "source-map-support": "^0.5.9",
-    "typescript": "~4.2.0"
+    "typescript": "~4.2.0",
+    "uuid": "^8.3.0"
   }
 }

--- a/sdk/schemaregistry/schema-registry-avro/package.json
+++ b/sdk/schemaregistry/schema-registry-avro/package.json
@@ -90,7 +90,7 @@
     "@rollup/plugin-replace": "^2.2.0",
     "@types/chai": "^4.1.6",
     "@types/chai-as-promised": "^7.1.0",
-    "@types/lru-cache": "~5.1.1",
+    "@types/lru-cache": "^5.1.1",
     "@types/mocha": "^7.0.2",
     "@types/node": "^12.0.0",
     "@types/uuid": "^8.3.0",

--- a/sdk/schemaregistry/schema-registry-avro/src/schemaRegistryAvroEncoder.ts
+++ b/sdk/schemaregistry/schema-registry-avro/src/schemaRegistryAvroEncoder.ts
@@ -100,7 +100,7 @@ export class SchemaRegistryAvroEncoder<MessageT = MessageWithMetadata> {
     const writerSchemaId = getSchemaId(contentType);
     const writerSchema = await this.getSchema(writerSchemaId);
     if (readerSchema) {
-      const avscReaderSchema = this.getAvroTypeForSchema(readerSchema);
+      const avscReaderSchema = getAvroTypeForSchema(readerSchema);
       const resolver = avscReaderSchema.createResolver(writerSchema.type);
       return avscReaderSchema.fromBuffer(buffer, resolver, true);
     } else {
@@ -128,7 +128,7 @@ export class SchemaRegistryAvroEncoder<MessageT = MessageWithMetadata> {
       );
     }
 
-    const avroType = this.getAvroTypeForSchema(schemaResponse.definition);
+    const avroType = getAvroTypeForSchema(schemaResponse.definition);
     return this.cache(schemaId, schemaResponse.definition, avroType);
   }
 
@@ -138,7 +138,7 @@ export class SchemaRegistryAvroEncoder<MessageT = MessageWithMetadata> {
       return cached;
     }
 
-    const avroType = this.getAvroTypeForSchema(schema);
+    const avroType = getAvroTypeForSchema(schema);
     if (!avroType.name) {
       throw new Error("Schema must have a name.");
     }
@@ -181,10 +181,6 @@ export class SchemaRegistryAvroEncoder<MessageT = MessageWithMetadata> {
     this.cacheBySchemaDefinition.set(schema, entry);
     this.cacheById.set(id, entry);
     return entry;
-  }
-
-  private getAvroTypeForSchema(schema: string): avro.Type {
-    return avro.Type.forSchema(JSON.parse(schema), { omitRecordMethods: true });
   }
 }
 
@@ -260,4 +256,8 @@ function tryReadingPreambleFormat(buffer: Buffer): MessageWithMetadata {
     body: payloadBuffer,
     contentType: `${avroMimeType}+${schemaId}`,
   };
+}
+
+function getAvroTypeForSchema(schema: string): avro.Type {
+  return avro.Type.forSchema(JSON.parse(schema), { omitRecordMethods: true });
 }

--- a/sdk/schemaregistry/schema-registry-avro/test/schemaRegistryAvroEncoder.spec.ts
+++ b/sdk/schemaregistry/schema-registry-avro/test/schemaRegistryAvroEncoder.spec.ts
@@ -254,8 +254,10 @@ describe("SchemaRegistryAvroEncoder", function () {
       );
       if (i < entriesMaxCount) {
         assert.equal(encoder["cacheById"].length, i + 1);
+        assert.equal(encoder["cacheBySchemaDefinition"].length, i + 1);
       } else {
         assert.equal(encoder["cacheById"].length, entriesMaxCount);
+        assert.equal(encoder["cacheBySchemaDefinition"].length, entriesMaxCount);
       }
     }
   });

--- a/sdk/schemaregistry/schema-registry-avro/test/schemaRegistryAvroEncoder.spec.ts
+++ b/sdk/schemaregistry/schema-registry-avro/test/schemaRegistryAvroEncoder.spec.ts
@@ -224,34 +224,33 @@ describe("SchemaRegistryAvroEncoder", function () {
       }
       return result;
     }
+
     const registry = createTestRegistry();
     const encoder = await createTestEncoder(true, registry);
     const entriesMaxCount = encoder["cacheById"].max;
-    let i = 0;
     const itersCount = 2 * entriesMaxCount;
-    assert.isAtLeast(itersCount, entriesMaxCount);
+    assert.isAtLeast(itersCount, entriesMaxCount + 1);
+    let i = 0;
     for (; i < itersCount; ++i) {
       const field1 = makeRndStr(10);
       const field2 = makeRndStr(10);
-      const objStr = `{ "${field1}": "Nick", "${field2}": 42 }`;
-      await encoder.encodeMessageData(
-        JSON.parse(objStr),
-        JSON.stringify({
-          type: "record",
-          name: makeRndStr(8),
-          namespace: "com.azure.schemaregistry.samples",
-          fields: [
-            {
-              name: field1,
-              type: "string",
-            },
-            {
-              name: field2,
-              type: "int",
-            },
-          ],
-        })
-      );
+      const valueToBeEncoded = JSON.parse(`{ "${field1}": "Nick", "${field2}": 42 }`);
+      const schemaToEncodeWith = JSON.stringify({
+        type: "record",
+        name: makeRndStr(8),
+        namespace: "com.azure.schemaregistry.samples",
+        fields: [
+          {
+            name: field1,
+            type: "string",
+          },
+          {
+            name: field2,
+            type: "int",
+          },
+        ],
+      });
+      await encoder.encodeMessageData(valueToBeEncoded, schemaToEncodeWith);
       if (i < entriesMaxCount) {
         assert.equal(encoder["cacheById"].length, i + 1);
         assert.equal(encoder["cacheBySchemaDefinition"].length, i + 1);

--- a/sdk/schemaregistry/schema-registry-avro/test/utils/mockedRegistryClient.ts
+++ b/sdk/schemaregistry/schema-registry-avro/test/utils/mockedRegistryClient.ts
@@ -14,6 +14,7 @@ import {
 import { env, isLiveMode } from "@azure-tools/test-recorder";
 import { ClientSecretCredential } from "@azure/identity";
 import { testSchemaIds } from "./dummies";
+import { v4 as uuid } from "uuid";
 
 export function createTestRegistry(neverLive = false): SchemaRegistry {
   if (!neverLive && isLiveMode()) {
@@ -50,8 +51,8 @@ export function createTestRegistry(neverLive = false): SchemaRegistry {
     return result!.properties;
 
     function newId(): string {
-      if (idCounter === testSchemaIds.length) {
-        throw new Error("Out of IDs. Generate more GUIDs and paste them above.");
+      if (idCounter >= testSchemaIds.length) {
+        return uuid();
       }
       const id = testSchemaIds[idCounter];
       idCounter++;


### PR DESCRIPTION
### Packages impacted by this PR
`@azure/schema-registry-avro`

### Issues associated with this PR

Fixes https://github.com/Azure/azure-sdk-for-js/issues/20064

### Describe the problem that is addressed by this PR

Cache could grow unbounded and is a function of the unique schemas seen.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?

There're many cache designs but the architects recommended using LRU one with 128 max entries.

### Are there test cases added in this PR? _(If not, why?)_

Yes!

### Provide a list of related PRs _(if any)_

N/A

### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

N/A

### Checklists
- [x] Added impacted package name to the issue description
- [x] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [x] Added a changelog (if necessary)
