### PR TITLE
[sort-imports] enforce ```sort-imports``` rule in ```keyvault-admin```

### DIFF
--- a/sdk/keyvault/keyvault-admin/.eslintrc.json
+++ b/sdk/keyvault/keyvault-admin/.eslintrc.json
@@ -3,8 +3,9 @@
   "extends": ["plugin:@azure/azure-sdk/azure-sdk-base"],
   "ignorePatterns": ["src/generated"],
   "rules": {
-    "@typescript-eslint/no-this-alias": "off",
     "@azure/azure-sdk/ts-package-json-module": "warn",
-    "no-use-before-define": "warn"
+    "@typescript-eslint/no-this-alias": "off",
+    "no-use-before-define": "warn",
+    "sort-imports": "error"
   }
 }


### PR DESCRIPTION
This PR reinforces the changes made in #19128 by changing the subdirectory's linting rule to ```"sort-imports": "error"```.

This affects the directory under ```sdk/keyvault/keyvault-admin```.