### PR TITLE
[sort-imports] enforce ```sort-imports``` rule in ```keyvault-common```

### DIFF
--- a/sdk/keyvault/keyvault-common/.eslintrc.json
+++ b/sdk/keyvault/keyvault-common/.eslintrc.json
@@ -13,6 +13,7 @@
     // this package does not have type declaration file.
     "@azure/azure-sdk/ts-package-json-types": "off",
     // this package does not have a homepage
-    "@azure/azure-sdk/ts-package-json-homepage": "off"
+    "@azure/azure-sdk/ts-package-json-homepage": "off",
+    "sort-imports": "error"
   }
 }


### PR DESCRIPTION
This PR reinforces the changes made in #19130 by changing the subdirectory's linting rule to ```"sort-imports": "error"```.

This affects the directory under ```sdk/keyvault/keyvault-common```.