### PR TITLE
[sort-imports] enforce ```sort-imports``` rule in ```logger```

### DIFF
--- a/sdk/core/logger/.eslintrc.json
+++ b/sdk/core/logger/.eslintrc.json
@@ -1,0 +1,7 @@
+{
+  "plugins": ["@azure/azure-sdk"],
+  "extends": ["plugin:@azure/azure-sdk/azure-sdk-base"],
+  "rules": {
+    "sort-imports": "error"
+  }
+}


### PR DESCRIPTION
This PR reinforces the changes made in #19135 by changing the subdirectory's linting rule to ```"sort-imports": "error"```.

This affects the directory under ```sdk/core/logger```.