### PR TITLE
[sort-imports] enforce ```sort-imports``` rule in ```mixed-reality-authentication```

### DIFF
--- a/sdk/mixedreality/mixed-reality-authentication/.eslintrc.json
+++ b/sdk/mixedreality/mixed-reality-authentication/.eslintrc.json
@@ -1,0 +1,7 @@
+{
+  "plugins": ["@azure/azure-sdk"],
+  "extends": ["plugin:@azure/azure-sdk/azure-sdk-base"],
+  "rules": {
+    "sort-imports": "error"
+  }
+}

--- a/sdk/mixedreality/mixed-reality-authentication/src/mixedRealityStsClient.ts
+++ b/sdk/mixedreality/mixed-reality-authentication/src/mixedRealityStsClient.ts
@@ -1,17 +1,17 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { InternalClientPipelineOptions } from "@azure/core-client";
-import { bearerTokenAuthenticationPolicy } from "@azure/core-rest-pipeline";
-import { TokenCredential, AccessToken, AzureKeyCredential } from "@azure/core-auth";
+import { AccessToken, AzureKeyCredential, TokenCredential } from "@azure/core-auth";
 import {
+  GetTokenOptionalParams,
   MixedRealityStsRestClient,
   MixedRealityStsRestClientOptionalParams,
-  GetTokenOptionalParams,
 } from "./generated";
 import { GetTokenOptions, MixedRealityStsClientOptions } from "./models/options";
+import { InternalClientPipelineOptions } from "@azure/core-client";
 import { MixedRealityAccountKeyCredential } from "./models/auth";
 import { SpanStatusCode } from "@azure/core-tracing";
+import { bearerTokenAuthenticationPolicy } from "@azure/core-rest-pipeline";
 import { constructAuthenticationEndpointFromDomain } from "./util/authenticationEndpoint";
 import { createSpan } from "./tracing";
 import { generateCvBase } from "./util/cv";

--- a/sdk/mixedreality/mixed-reality-authentication/src/models/auth.ts
+++ b/sdk/mixedreality/mixed-reality-authentication/src/models/auth.ts
@@ -2,8 +2,8 @@
 // Licensed under the MIT license.
 
 import {
-  AzureKeyCredential,
   AccessToken,
+  AzureKeyCredential,
   GetTokenOptions,
   TokenCredential,
 } from "@azure/core-auth";


### PR DESCRIPTION
This PR reinforces the changes made in #19137 by changing the subdirectory's linting rule to ```"sort-imports": "error"```.

This affects the directory under ```sdk/mixedreality/mixed-reality-authentication```. 