### PR TITLE
[sort-imports] enforce ```sort-imports``` rule in ```abort-controller```

### DIFF
--- a/sdk/core/abort-controller/.eslintrc.json
+++ b/sdk/core/abort-controller/.eslintrc.json
@@ -2,6 +2,7 @@
   "plugins": ["@azure/azure-sdk"],
   "extends": ["plugin:@azure/azure-sdk/azure-sdk-base"],
   "rules": {
-    "@azure/azure-sdk/ts-package-json-types": "off"
+    "@azure/azure-sdk/ts-package-json-types": "off",
+    "sort-imports": "error"
   }
 }


### PR DESCRIPTION
This PR reinforces the changes made in #19212 by changing the subdirectory's linting rule to ```"sort-imports": "error"```.

This affects the directory under ```sdk/core/abort-controller```.