### PR TITLE
[sort-imports] enforce ```sort-imports``` rule in ```core-asynciterator-polyfill```

### DIFF
--- a/sdk/core/core-asynciterator-polyfill/.eslintrc.json
+++ b/sdk/core/core-asynciterator-polyfill/.eslintrc.json
@@ -14,6 +14,7 @@
     // list in `package.json`.
     "@azure/azure-sdk/ts-package-json-files-required": "off",
     // this package does not have type declaration file.
-    "@azure/azure-sdk/ts-package-json-types": "off"
+    "@azure/azure-sdk/ts-package-json-types": "off",
+    "sort-imports": "error"
   }
 }


### PR DESCRIPTION
This PR changes the subdirectory's linting rule to ```"sort-imports": "error"```.

This affects the directory under ```sdk/core/core-asynciterator-polyfill```.