### PR TITLE
[sort-imports] enforce ```sort-imports``` rule in ```core-client```

### DIFF
--- a/sdk/core/core-client/.eslintrc.json
+++ b/sdk/core/core-client/.eslintrc.json
@@ -1,0 +1,7 @@
+{
+  "plugins": ["@azure/azure-sdk"],
+  "extends": ["plugin:@azure/azure-sdk/azure-sdk-base"],
+  "rules": {
+    "sort-imports": "error"
+  }
+}

--- a/sdk/core/core-client/src/authorizeRequestOnClaimChallenge.ts
+++ b/sdk/core/core-client/src/authorizeRequestOnClaimChallenge.ts
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { GetTokenOptions } from "@azure/core-auth";
 import { AuthorizeRequestOnChallengeOptions } from "@azure/core-rest-pipeline";
+import { GetTokenOptions } from "@azure/core-auth";
 import { createClientLogger } from "@azure/logger";
 import { decodeStringToString } from "./base64";
 

--- a/sdk/core/core-client/src/deserializationPolicy.ts
+++ b/sdk/core/core-client/src/deserializationPolicy.ts
@@ -2,22 +2,22 @@
 // Licensed under the MIT license.
 
 import {
-  PipelineResponse,
-  PipelineRequest,
-  SendRequest,
-  PipelinePolicy,
-  RestError,
-} from "@azure/core-rest-pipeline";
-import {
+  FullOperationResponse,
   OperationRequest,
   OperationResponseMap,
-  FullOperationResponse,
   OperationSpec,
-  SerializerOptions,
-  XmlOptions,
-  XML_CHARKEY,
   RequiredSerializerOptions,
+  SerializerOptions,
+  XML_CHARKEY,
+  XmlOptions,
 } from "./interfaces";
+import {
+  PipelinePolicy,
+  PipelineRequest,
+  PipelineResponse,
+  RestError,
+  SendRequest,
+} from "@azure/core-rest-pipeline";
 import { MapperTypeNames } from "./serializer";
 import { getOperationRequestInfo } from "./operationHelpers";
 

--- a/sdk/core/core-client/src/interfaceHelpers.ts
+++ b/sdk/core/core-client/src/interfaceHelpers.ts
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+import { OperationParameter, OperationSpec } from "./interfaces";
 import { MapperTypeNames } from "./serializer";
-import { OperationSpec, OperationParameter } from "./interfaces";
 
 /**
  * Gets the list of status codes for streaming responses.

--- a/sdk/core/core-client/src/interfaces.ts
+++ b/sdk/core/core-client/src/interfaces.ts
@@ -1,16 +1,16 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { AbortSignalLike } from "@azure/abort-controller";
-import { OperationTracingOptions } from "@azure/core-tracing";
 import {
+  HttpClient,
   HttpMethods,
+  PipelineOptions,
+  PipelineRequest,
   PipelineResponse,
   TransferProgressEvent,
-  PipelineRequest,
-  PipelineOptions,
-  HttpClient,
 } from "@azure/core-rest-pipeline";
+import { AbortSignalLike } from "@azure/abort-controller";
+import { OperationTracingOptions } from "@azure/core-tracing";
 
 /**
  * Default key used to access the XML attributes.

--- a/sdk/core/core-client/src/operationHelpers.ts
+++ b/sdk/core/core-client/src/operationHelpers.ts
@@ -2,13 +2,13 @@
 // Licensed under the MIT license.
 
 import {
+  CompositeMapper,
+  Mapper,
   OperationArguments,
   OperationParameter,
-  Mapper,
-  CompositeMapper,
-  ParameterPath,
-  OperationRequestInfo,
   OperationRequest,
+  OperationRequestInfo,
+  ParameterPath,
 } from "./interfaces";
 
 /**

--- a/sdk/core/core-client/src/pipeline.ts
+++ b/sdk/core/core-client/src/pipeline.ts
@@ -1,15 +1,15 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { TokenCredential } from "@azure/core-auth";
+import { DeserializationPolicyOptions, deserializationPolicy } from "./deserializationPolicy";
 import {
   InternalPipelineOptions,
   Pipeline,
-  createPipelineFromOptions,
   bearerTokenAuthenticationPolicy,
+  createPipelineFromOptions,
 } from "@azure/core-rest-pipeline";
-import { deserializationPolicy, DeserializationPolicyOptions } from "./deserializationPolicy";
-import { serializationPolicy, SerializationPolicyOptions } from "./serializationPolicy";
+import { SerializationPolicyOptions, serializationPolicy } from "./serializationPolicy";
+import { TokenCredential } from "@azure/core-auth";
 
 /**
  * Options for creating a Pipeline to use with ServiceClient.

--- a/sdk/core/core-client/src/serializationPolicy.ts
+++ b/sdk/core/core-client/src/serializationPolicy.ts
@@ -1,24 +1,24 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { PipelineResponse, SendRequest, PipelinePolicy } from "@azure/core-rest-pipeline";
 import {
-  OperationRequest,
-  SerializerOptions,
-  XmlOptions,
-  XML_CHARKEY,
-  RequiredSerializerOptions,
-  OperationArguments,
-  XML_ATTRKEY,
-  OperationSpec,
   DictionaryMapper,
+  OperationArguments,
+  OperationRequest,
+  OperationSpec,
+  RequiredSerializerOptions,
+  SerializerOptions,
+  XML_ATTRKEY,
+  XML_CHARKEY,
+  XmlOptions,
 } from "./interfaces";
-import { MapperTypeNames } from "./serializer";
-import { getPathStringFromParameter } from "./interfaceHelpers";
+import { PipelinePolicy, PipelineResponse, SendRequest } from "@azure/core-rest-pipeline";
 import {
   getOperationArgumentValueFromParameter,
   getOperationRequestInfo,
 } from "./operationHelpers";
+import { MapperTypeNames } from "./serializer";
+import { getPathStringFromParameter } from "./interfaceHelpers";
 
 /**
  * The programmatic identifier of the serializationPolicy.

--- a/sdk/core/core-client/src/serializer.ts
+++ b/sdk/core/core-client/src/serializer.ts
@@ -1,23 +1,23 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { isDuration, isValidUuid } from "./utils";
 import * as base64 from "./base64";
 import {
-  Serializer,
+  BaseMapper,
+  CompositeMapper,
+  DictionaryMapper,
+  EnumMapper,
   Mapper,
   MapperConstraints,
-  DictionaryMapper,
-  SequenceMapper,
-  CompositeMapper,
   PolymorphicDiscriminator,
-  EnumMapper,
-  BaseMapper,
-  SerializerOptions,
-  XML_CHARKEY,
-  XML_ATTRKEY,
   RequiredSerializerOptions,
+  SequenceMapper,
+  Serializer,
+  SerializerOptions,
+  XML_ATTRKEY,
+  XML_CHARKEY,
 } from "./interfaces";
+import { isDuration, isValidUuid } from "./utils";
 
 class SerializerImpl implements Serializer {
   constructor(

--- a/sdk/core/core-client/src/serviceClient.ts
+++ b/sdk/core/core-client/src/serviceClient.ts
@@ -1,26 +1,26 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { TokenCredential } from "@azure/core-auth";
+import {
+  CommonClientOptions,
+  OperationArguments,
+  OperationRequest,
+  OperationSpec,
+} from "./interfaces";
 import {
   HttpClient,
+  Pipeline,
   PipelineRequest,
   PipelineResponse,
-  Pipeline,
   createPipelineRequest,
 } from "@azure/core-rest-pipeline";
-import {
-  OperationArguments,
-  OperationSpec,
-  OperationRequest,
-  CommonClientOptions,
-} from "./interfaces";
-import { getStreamingResponseStatusCodes } from "./interfaceHelpers";
-import { getRequestUrl } from "./urlHelpers";
+import { TokenCredential } from "@azure/core-auth";
+import { createClientPipeline } from "./pipeline";
 import { flattenResponse } from "./utils";
 import { getCachedDefaultHttpClient } from "./httpClientCache";
 import { getOperationRequestInfo } from "./operationHelpers";
-import { createClientPipeline } from "./pipeline";
+import { getRequestUrl } from "./urlHelpers";
+import { getStreamingResponseStatusCodes } from "./interfaceHelpers";
 
 /**
  * Options to be provided while creating the client.

--- a/sdk/core/core-client/src/urlHelpers.ts
+++ b/sdk/core/core-client/src/urlHelpers.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
-import { OperationSpec, OperationArguments, QueryCollectionFormat } from "./interfaces";
+
+import { OperationArguments, OperationSpec, QueryCollectionFormat } from "./interfaces";
 import { getOperationArgumentValueFromParameter } from "./operationHelpers";
 import { getPathStringFromParameter } from "./interfaceHelpers";
 

--- a/sdk/core/core-client/test/authorizeRequestOnClaimChallenge.spec.ts
+++ b/sdk/core/core-client/test/authorizeRequestOnClaimChallenge.spec.ts
@@ -3,18 +3,18 @@
 
 import { AccessToken, GetTokenOptions, TokenCredential } from "@azure/core-auth";
 import {
+  HttpClient,
+  PipelineResponse,
   bearerTokenAuthenticationPolicy,
   createEmptyPipeline,
   createHttpHeaders,
   createPipelineRequest,
-  HttpClient,
-  PipelineResponse,
 } from "@azure/core-rest-pipeline";
-import { assert } from "chai";
 import {
   authorizeRequestOnClaimChallenge,
   parseCAEChallenge,
 } from "../src/authorizeRequestOnClaimChallenge";
+import { assert } from "chai";
 import { encodeString } from "../src/base64";
 
 describe("authorizeRequestOnClaimChallenge", function () {

--- a/sdk/core/core-client/test/browser/serializer.spec.ts
+++ b/sdk/core/core-client/test/browser/serializer.spec.ts
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+import { Mapper, createSerializer } from "../../src";
 import { assert } from "chai";
-import { createSerializer, Mapper } from "../../src";
 
 describe("Serializer (browser specific)", function () {
   describe("serialize", function () {

--- a/sdk/core/core-client/test/deserializationPolicy.spec.ts
+++ b/sdk/core/core-client/test/deserializationPolicy.spec.ts
@@ -1,26 +1,26 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { assert } from "chai";
 import * as sinon from "sinon";
 import {
-  deserializationPolicy,
-  OperationSpec,
-  OperationRequest,
-  createSerializer,
   CompositeMapper,
   FullOperationResponse,
+  OperationRequest,
+  OperationSpec,
   SerializerOptions,
+  createSerializer,
+  deserializationPolicy,
 } from "../src";
 import {
-  createPipelineRequest,
   PipelineResponse,
-  createHttpHeaders,
-  SendRequest,
   RawHttpHeaders,
+  SendRequest,
+  createHttpHeaders,
+  createPipelineRequest,
 } from "@azure/core-rest-pipeline";
-import { parseXML } from "@azure/core-xml";
+import { assert } from "chai";
 import { getOperationRequestInfo } from "../src/operationHelpers";
+import { parseXML } from "@azure/core-xml";
 
 describe("deserializationPolicy", function () {
   it(`should not modify a request that has no request body mapper`, async function () {

--- a/sdk/core/core-client/test/serializationPolicy.spec.ts
+++ b/sdk/core/core-client/test/serializationPolicy.spec.ts
@@ -1,12 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+import { MapperTypeNames, createSerializer } from "../src";
+import { serializeHeaders, serializeRequestBody } from "../src/serializationPolicy";
+import { Mappers } from "./testMappers1";
 import { assert } from "chai";
 import { createPipelineRequest } from "@azure/core-rest-pipeline";
 import { stringifyXML } from "@azure/core-xml";
-import { createSerializer, MapperTypeNames } from "../src";
-import { serializeRequestBody, serializeHeaders } from "../src/serializationPolicy";
-import { Mappers } from "./testMappers1";
 
 describe("serializationPolicy", function () {
   describe("serializeRequestBody()", () => {

--- a/sdk/core/core-client/test/serializer.spec.ts
+++ b/sdk/core/core-client/test/serializer.spec.ts
@@ -1,17 +1,17 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { assert } from "chai";
+import * as MediaMappers from "./testMappers2";
 import {
-  createSerializer,
-  Mapper,
-  EnumMapper,
-  SequenceMapper,
-  DictionaryMapper,
   CompositeMapper,
+  DictionaryMapper,
+  EnumMapper,
+  Mapper,
+  SequenceMapper,
+  createSerializer,
 } from "../src";
 import { Mappers } from "./testMappers1";
-import * as MediaMappers from "./testMappers2";
+import { assert } from "chai";
 
 const Serializer = createSerializer(Mappers);
 const valid_uuid = "ceaafd1e-f936-429f-bbfc-82ee75dddc33";

--- a/sdk/core/core-client/test/serviceClient.spec.ts
+++ b/sdk/core/core-client/test/serviceClient.spec.ts
@@ -1,40 +1,39 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { assert } from "chai";
 import {
-  ServiceClient,
-  OperationRequest,
-  createSerializer,
+  CompositeMapper,
   DictionaryMapper,
-  QueryCollectionFormat,
-  ParameterPath,
+  FullOperationResponse,
+  Mapper,
   MapperTypeNames,
   OperationArguments,
-  Mapper,
-  CompositeMapper,
-  OperationSpec,
-  serializationPolicy,
-  FullOperationResponse,
   OperationQueryParameter,
+  OperationRequest,
+  OperationSpec,
+  ParameterPath,
+  QueryCollectionFormat,
+  ServiceClient,
+  createSerializer,
+  serializationPolicy,
 } from "../src";
 import {
-  createHttpHeaders,
-  createEmptyPipeline,
   HttpClient,
-  createPipelineRequest,
   PipelineRequest,
   RestError,
+  createEmptyPipeline,
+  createHttpHeaders,
+  createPipelineRequest,
 } from "@azure/core-rest-pipeline";
-
 import {
   getOperationArgumentValueFromParameter,
   getOperationRequestInfo,
 } from "../src/operationHelpers";
-import { deserializationPolicy } from "../src/deserializationPolicy";
 import { TokenCredential } from "@azure/core-auth";
-import { getCachedDefaultHttpClient } from "../src/httpClientCache";
+import { assert } from "chai";
 import { assertServiceClientResponse } from "./utils/serviceClient";
+import { deserializationPolicy } from "../src/deserializationPolicy";
+import { getCachedDefaultHttpClient } from "../src/httpClientCache";
 
 describe("ServiceClient", function () {
   describe("Auth scopes", () => {

--- a/sdk/core/core-client/test/urlHelpers.spec.ts
+++ b/sdk/core/core-client/test/urlHelpers.spec.ts
@@ -1,14 +1,14 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { assert } from "chai";
-import { getRequestUrl, appendQueryParams } from "../src/urlHelpers";
 import {
+  OperationQueryParameter,
   OperationSpec,
   OperationURLParameter,
   createSerializer,
-  OperationQueryParameter,
 } from "../src";
+import { appendQueryParams, getRequestUrl } from "../src/urlHelpers";
+import { assert } from "chai";
 
 describe("getRequestUrl", function () {
   const urlParameter: OperationURLParameter = {

--- a/sdk/core/core-client/test/utils/serviceClient.ts
+++ b/sdk/core/core-client/test/utils/serviceClient.ts
@@ -1,23 +1,23 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { assert } from "chai";
 import {
-  createEmptyPipeline,
-  createHttpHeaders,
-  HttpClient,
-  HttpHeaders,
-  HttpMethods,
-} from "@azure/core-rest-pipeline";
-import {
-  createSerializer,
-  deserializationPolicy,
   FullOperationResponse,
   OperationRequest,
   OperationResponseMap,
   Serializer,
   ServiceClient,
+  createSerializer,
+  deserializationPolicy,
 } from "../../src";
+import {
+  HttpClient,
+  HttpHeaders,
+  HttpMethods,
+  createEmptyPipeline,
+  createHttpHeaders,
+} from "@azure/core-rest-pipeline";
+import { assert } from "chai";
 
 /**
  * Representation of a Service Client test case where the response status is 200.


### PR DESCRIPTION
This PR changes the subdirectory's linting rule to ```"sort-imports": "error"```, and fixes any respective linting errors.

This affects the directory under ```sdk/core/core-client```.