### PR TITLE
[sort-imports] enforce ```sort-imports``` rule in ```core-xml```

### DIFF
--- a/sdk/core/core-xml/.eslintrc.json
+++ b/sdk/core/core-xml/.eslintrc.json
@@ -1,0 +1,7 @@
+{
+  "plugins": ["@azure/azure-sdk"],
+  "extends": ["plugin:@azure/azure-sdk/azure-sdk-base"],
+  "rules": {
+    "sort-imports": "error"
+  }
+}

--- a/sdk/core/core-xml/src/xml.ts
+++ b/sdk/core/core-xml/src/xml.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { XMLBuilder, XMLValidator, XMLParser } from "fast-xml-parser";
+import { XMLBuilder, XMLParser, XMLValidator } from "fast-xml-parser";
 import { XML_ATTRKEY, XML_CHARKEY, XmlOptions } from "./xml.common";
 
 function getCommonOptions(options: XmlOptions) {


### PR DESCRIPTION
This PR changes the subdirectory's linting rule to ```"sort-imports": "error"```, and fixes any respective linting errors.

This affects the directory under ```sdk/core/core-xml```.