### PR TITLE
[sort-imports] enforce ```sort-imports``` rule in ```mock-hub```

### DIFF
--- a/sdk/eventhub/mock-hub/.eslintrc.json
+++ b/sdk/eventhub/mock-hub/.eslintrc.json
@@ -1,0 +1,7 @@
+{
+  "plugins": ["@azure/azure-sdk"],
+  "extends": ["plugin:@azure/azure-sdk/azure-sdk-base"],
+  "rules": {
+    "sort-imports": "error"
+  }
+}


### PR DESCRIPTION
This PR changes the subdirectory's linting rule to ```"sort-imports": "error"```, and fixes any respective linting errors.

This affects the directory under ```sdk/eventhub/mock-hub```.