### PR TITLE
Set "TestProxy: true" for template and identity pipelines

### DIFF
--- a/sdk/identity/ci.yml
+++ b/sdk/identity/ci.yml
@@ -25,6 +25,7 @@ extends:
   template: ../../eng/pipelines/templates/stages/archetype-sdk-client.yml
   parameters:
     ServiceDirectory: identity
+    TestProxy: true
     Artifacts:
       - name: azure-identity
         safeName: azureidentity

--- a/sdk/template/ci.yml
+++ b/sdk/template/ci.yml
@@ -25,6 +25,7 @@ extends:
   template: ../../eng/pipelines/templates/stages/archetype-sdk-client.yml
   parameters:
     ServiceDirectory: template
+    TestProxy: true
     Artifacts:
       - name: azure-template
         safeName: azuretemplate


### PR DESCRIPTION
### Packages impacted by this PR


### Issues associated with this PR


### Describe the problem that is addressed by this PR
Not packages, but pipelines that are running tests with the help of test proxy tool

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?
**Background:**
In the CI/pipelines, mac agents are not capable of installing/using the docker, so we instead go by installing the "dotnet tool" directly in those machines and use the proxy tool without the docker command.
For the pipeline to know that, we use this variable "TestProxy".

Setting it to true means, a job will be added to the pipeline to install/start the proxy tool and dump the logs(For all the OSes).

It is not set to true by default already because not all pipelines are using TestProxy, and running the tool adds an unnecessary cost.

So, setting the TestProxy to true should make failing pipelines green.
Add as is shown here https://github.com/Azure/azure-sdk-for-js/blob/d180f2660a919da80f7dd9ffea0def8e4cdb1229/sdk/test-utils/ci.yml#L29

### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [ ] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
