### PR TITLE
[core-rest-pipeline] Add new signing phase

### DIFF
--- a/sdk/core/core-rest-pipeline/CHANGELOG.md
+++ b/sdk/core/core-rest-pipeline/CHANGELOG.md
@@ -1,15 +1,18 @@
 # Release History
 
-## 1.4.1 (Unreleased)
+## 1.5.0 (Unreleased)
 
 ### Features Added
+
+- Added new phase "Sign" for policies that sign the request for security purposes. [#20129](https://github.com/Azure/azure-sdk-for-js/pull/20129)
 
 ### Breaking Changes
 
 ### Bugs Fixed
 
 - Updated the HTTP tracing span names to conform to the [OpenTelemetry Specification](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/http.md#name). [#19838](https://github.com/Azure/azure-sdk-for-js/pull/19838)
-  - New HTTP spans will use the `HTTP <VERB>` convention instead of using the URL path.
+- New HTTP spans will use the `HTTP <VERB>` convention instead of using the URL path.
+- Addressed an issue where policy order might change in cases where there are no policies inside a phase specified by an "afterPhase" constraint. [#20129](https://github.com/Azure/azure-sdk-for-js/pull/20129)
 
 ### Other Changes
 

--- a/sdk/core/core-rest-pipeline/package.json
+++ b/sdk/core/core-rest-pipeline/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/core-rest-pipeline",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "description": "Isomorphic client library for making HTTP requests in node.js and browser.",
   "sdk-type": "client",
   "main": "dist/index.js",

--- a/sdk/core/core-rest-pipeline/review/core-rest-pipeline.api.md
+++ b/sdk/core/core-rest-pipeline/review/core-rest-pipeline.api.md
@@ -190,7 +190,7 @@ export interface PipelineOptions {
 }
 
 // @public
-export type PipelinePhase = "Deserialize" | "Serialize" | "Retry";
+export type PipelinePhase = "Deserialize" | "Serialize" | "Retry" | "Sign";
 
 // @public
 export interface PipelinePolicy {

--- a/sdk/core/core-rest-pipeline/src/pipeline.ts
+++ b/sdk/core/core-rest-pipeline/src/pipeline.ts
@@ -10,10 +10,11 @@ import { PipelineRequest, PipelineResponse, HttpClient, SendRequest } from "./in
  * 2. Policies not in a phase
  * 3. Deserialize Phase
  * 4. Retry Phase
+ * 5. Sign Phase
  */
-export type PipelinePhase = "Deserialize" | "Serialize" | "Retry";
+export type PipelinePhase = "Deserialize" | "Serialize" | "Retry" | "Sign";
 
-const ValidPhaseNames = new Set<PipelinePhase>(["Deserialize", "Serialize", "Retry"]);
+const ValidPhaseNames = new Set<PipelinePhase>(["Deserialize", "Serialize", "Retry", "Sign"]);
 
 /**
  * Options when adding a policy to the pipeline.
@@ -100,7 +101,13 @@ interface PolicyGraphNode {
   policy: PipelinePolicy;
   dependsOn: Set<PolicyGraphNode>;
   dependants: Set<PolicyGraphNode>;
-  afterPhase?: Set<PolicyGraphNode>;
+  afterPhase?: Phase;
+}
+
+interface Phase {
+  name: PipelinePhase | "None";
+  policies: Set<PolicyGraphNode>;
+  hasRun: boolean;
 }
 
 /**
@@ -194,6 +201,7 @@ class HttpPipeline implements Pipeline {
      * 2. Policies not in a phase
      * 3. Deserialize Phase
      * 4. Retry Phase
+     * 5. Sign Phase
      *
      * Within each phase, policies are executed in the order
      * they were added unless they were specified to execute
@@ -223,23 +231,34 @@ class HttpPipeline implements Pipeline {
     // Track all policies we know about.
     const policyMap: Map<string, PolicyGraphNode> = new Map<string, PolicyGraphNode>();
 
+    function createPhase(name: PipelinePhase | "None"): Phase {
+      return {
+        name,
+        policies: new Set<PolicyGraphNode>(),
+        hasRun: false,
+      };
+    }
+
     // Track policies for each phase.
-    const serializePhase = new Set<PolicyGraphNode>();
-    const noPhase = new Set<PolicyGraphNode>();
-    const deserializePhase = new Set<PolicyGraphNode>();
-    const retryPhase = new Set<PolicyGraphNode>();
+    const serializePhase = createPhase("Serialize");
+    const noPhase = createPhase("None");
+    const deserializePhase = createPhase("Deserialize");
+    const retryPhase = createPhase("Retry");
+    const signPhase = createPhase("Sign");
 
     // a list of phases in order
-    const orderedPhases = [serializePhase, noPhase, deserializePhase, retryPhase];
+    const orderedPhases = [serializePhase, noPhase, deserializePhase, retryPhase, signPhase];
 
-    // Small helper function to map phase name to each Set bucket.
-    function getPhase(phase: PipelinePhase | undefined): Set<PolicyGraphNode> {
+    // Small helper function to map phase name to each Phase
+    function getPhase(phase: PipelinePhase | undefined): Phase {
       if (phase === "Retry") {
         return retryPhase;
       } else if (phase === "Serialize") {
         return serializePhase;
       } else if (phase === "Deserialize") {
         return deserializePhase;
+      } else if (phase === "Sign") {
+        return signPhase;
       } else {
         return noPhase;
       }
@@ -263,7 +282,7 @@ class HttpPipeline implements Pipeline {
       }
       policyMap.set(policyName, node);
       const phase = getPhase(options.phase);
-      phase.add(node);
+      phase.policies.add(node);
     }
 
     // Now that each policy has a node, connect dependency references.
@@ -299,12 +318,15 @@ class HttpPipeline implements Pipeline {
       }
     }
 
-    function walkPhase(phase: Set<PolicyGraphNode>): void {
+    function walkPhase(phase: Phase): void {
+      phase.hasRun = true;
       // Sets iterate in insertion order
-      for (const node of phase) {
-        if (node.afterPhase && node.afterPhase.size) {
+      for (const node of phase.policies) {
+        if (node.afterPhase && (!node.afterPhase.hasRun || node.afterPhase.policies.size)) {
           // If this node is waiting on a phase to complete,
           // we need to skip it for now.
+          // Even if the phase is empty, we should wait for it
+          // to be walked to avoid re-ordering policies.
           continue;
         }
         if (node.dependsOn.size === 0) {
@@ -317,22 +339,17 @@ class HttpPipeline implements Pipeline {
             dependant.dependsOn.delete(node);
           }
           policyMap.delete(node.policy.name);
-          phase.delete(node);
+          phase.policies.delete(node);
         }
       }
     }
 
     function walkPhases(): void {
-      let noPhaseRan = false;
-
       for (const phase of orderedPhases) {
         walkPhase(phase);
-        if (phase === noPhase) {
-          noPhaseRan = true;
-        }
         // if the phase isn't complete
-        if (phase.size > 0 && phase !== noPhase) {
-          if (noPhaseRan === false) {
+        if (phase.policies.size > 0 && phase !== noPhase) {
+          if (!noPhase.hasRun) {
             // Try running noPhase to see if that unblocks this phase next tick.
             // This can happen if a phase that happens before noPhase
             // is waiting on a noPhase policy to complete.
@@ -345,13 +362,16 @@ class HttpPipeline implements Pipeline {
     }
 
     // Iterate until we've put every node in the result list.
+    let iteration = 0;
     while (policyMap.size > 0) {
+      iteration++;
       const initialResultLength = result.length;
       // Keep walking each phase in order until we can order every node.
       walkPhases();
-      // The result list *should* get at least one larger each time.
+      // The result list *should* get at least one larger each time
+      // after the first full pass.
       // Otherwise, we're going to loop forever.
-      if (result.length <= initialResultLength) {
+      if (result.length <= initialResultLength && iteration > 1) {
         throw new Error("Cannot satisfy policy dependencies due to requirements cycle.");
       }
     }

--- a/sdk/core/core-rest-pipeline/test/pipeline.spec.ts
+++ b/sdk/core/core-rest-pipeline/test/pipeline.spec.ts
@@ -165,17 +165,24 @@ describe("HttpsPipeline", function () {
       sendRequest: (request, next) => next(request),
       name: "test4",
     };
+    const testPolicy5: PipelinePolicy = {
+      sendRequest: (request, next) => next(request),
+      name: "test5",
+    };
     pipeline.addPolicy(testPolicy, { phase: "Retry" });
     pipeline.addPolicy(testPolicy2, { phase: "Serialize" });
     pipeline.addPolicy(testPolicy3);
     pipeline.addPolicy(testPolicy4, { phase: "Deserialize" });
+    pipeline.addPolicy(testPolicy5, { phase: "Sign" });
 
     const policies = pipeline.getOrderedPolicies();
-    assert.strictEqual(policies.length, 4);
-    assert.strictEqual(policies[0], testPolicy2);
-    assert.strictEqual(policies[1], testPolicy3);
-    assert.strictEqual(policies[2], testPolicy4);
-    assert.strictEqual(policies[3], testPolicy);
+    assert.deepStrictEqual(policies, [
+      testPolicy2,
+      testPolicy3,
+      testPolicy4,
+      testPolicy,
+      testPolicy5,
+    ]);
   });
 
   it("prevents phases from getting out of order", function () {
@@ -388,5 +395,32 @@ describe("HttpsPipeline", function () {
       const response = await pipeline.sendRequest(testHttpClient, request);
       assert.strictEqual(response.status, 200);
     });
+  });
+
+  it("afterPhase ordering occurs even when phase is empty", function () {
+    const pipeline = createEmptyPipeline();
+    const testPolicy: PipelinePolicy = {
+      sendRequest: (request, next) => next(request),
+      name: "test",
+    };
+    const testPolicy2: PipelinePolicy = {
+      sendRequest: (request, next) => next(request),
+      name: "test2",
+    };
+    pipeline.addPolicy(testPolicy, { afterPhase: "Retry" });
+    pipeline.addPolicy(testPolicy2);
+    const policies = pipeline.getOrderedPolicies();
+    assert.deepStrictEqual(policies, [testPolicy2, testPolicy]);
+  });
+
+  it("afterPhase should work on a single policy", function () {
+    const pipeline = createEmptyPipeline();
+    const testPolicy: PipelinePolicy = {
+      sendRequest: (request, next) => next(request),
+      name: "test",
+    };
+    pipeline.addPolicy(testPolicy, { afterPhase: "Retry" });
+    const policies = pipeline.getOrderedPolicies();
+    assert.deepStrictEqual(policies, [testPolicy]);
   });
 });


### PR DESCRIPTION
Also fix a bug where policy order might change when a phase is empty.


### Packages impacted by this PR

core-rest-pipeline

### Issues associated with this PR

https://github.com/Azure/azure-sdk-for-js/pull/19920#discussion_r794146397

### Describe the problem that is addressed by this PR

Currently, there is no notion of when signing should occur in the pipeline. This presents a problem for services that require requests to be signed, since certain policies (e.g. test proxy) want to occur post-signing.

This PR also fixes an issue I found whereby policy order might change in certain conditions. For example,

```ts
addPolicy(policy1, { afterPhase: "Retry" });
addPolicy(retry, { phase: "Retry" });
addPolicy(policy2);
```

The above will execute in the order: 2, Retry, 1. However, if there is no retry policy:

```ts
addPolicy(policy1, { afterPhase: "Retry" });
addPolicy(policy2);
```

This now executes in the order 1, 2. This is because of how "afterPhase" constraints were calculated, using only if the phase was empty. This design has been revisited to add the condition that the phase must be empty *and* have been executed at least once.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?

Not a really great way around this, short of having to have special knowledge of what policy names perform signing.

### Are there test cases added in this PR? ✅ 

### Provide a list of related PRs: #19920
