### PR TITLE
[iot-modelsrepository] Remove unnecesary dependency on recorder

### DIFF
--- a/sdk/iot/iot-modelsrepository/package.json
+++ b/sdk/iot/iot-modelsrepository/package.json
@@ -74,7 +74,6 @@
   "devDependencies": {
     "@azure/dev-tool": "^1.0.0",
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
-    "@azure-tools/test-recorder": "^1.0.0",
     "@microsoft/api-extractor": "^7.18.11",
     "@types/chai": "^4.1.6",
     "@types/mocha": "^7.0.2",


### PR DESCRIPTION
### Packages impacted by this PR

- `@azure/iot-modelsrepository`

### Issues associated with this PR

* #19859 

### Describe the problem that is addressed by this PR

This package's tests don't need the recorder. Removing the dependency.