### PR TITLE
[CODEOWNERS] - Make primary package owner first

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -36,9 +36,9 @@
 # PRLabel: %Communication
 /sdk/communication/communication-identity/ @Azure/acs-identity-sdk 
 /sdk/communication/communication-chat/ @LuChen-Microsoft
-/sdk/communication/communication-phone-numbers/ @miguhern @danielav7 @whisper6284 @AlonsoMondal
+/sdk/communication/communication-phone-numbers/ @whisper6284 @miguhern @danielav7 @AlonsoMondal
 /sdk/communication/communication-network-traversal/ @AriZavala2
-/sdk/communication/communication-sms/ @RoyHerrod @arifibrahim4
+/sdk/communication/communication-sms/ @arifibrahim4 @RoyHerrod
 /sdk/communication/communication-short-codes/ @danielav7 @AlonsoMondal @ericasp16
 /sdk/communication/communication-common/ @Azure/acs-identity-sdk
 
@@ -58,10 +58,10 @@
 /sdk/digitaltwins/ @johngallardo @YoDaMa @olivakar
 
 # PRLabel: %Event Grid
-/sdk/eventgrid/ @xirzec @ellismg
+/sdk/eventgrid/ @ellismg @xirzec
 
 # PRLabel: %Event Hubs
-/sdk/eventhub/ @deyaaeldeen @jeremymeng @HarshaNalluru @ramya-rao-a
+/sdk/eventhub/ @jeremymeng @deyaaeldeen @HarshaNalluru @ramya-rao-a
 
 # PRLabel: %Azure.Identity
 /sdk/identity/ @sadasant @witemple-msft @schaabs
@@ -76,10 +76,10 @@
 /sdk/instrumentation/ @maorleger @joheredi
 
 # PRLabel: %Service Bus
-/sdk/servicebus/ @deyaaeldeen @jeremymeng @HarshaNalluru @ramya-rao-a @richardpark-msft 
+/sdk/servicebus/ @jeremymeng @deyaaeldeen @HarshaNalluru @ramya-rao-a
 
 # PRLabel: %Storage
-/sdk/storage/ @XiaoningLiu @jeremymeng @vinjiang @jiacfan @ljian3377 @EmmaZhu
+/sdk/storage/ @EmmaZhu @XiaoningLiu @jeremymeng @vinjiang @jiacfan @ljian3377
 
 # PRLabel: %Synapse
 /sdk/synapse/ @joheredi
@@ -100,7 +100,7 @@
 /sdk/documenttranslator/ @joheredi
 
 # PRLabel: %WebPubSub
-/sdk/web-pubsub/ @xirzec @bterlson @vicancy
+/sdk/web-pubsub/ @vicancy @xirzec @bterlson
 
 # PRLabel: %EngSys
 /sdk/template/ @praveenkuttappan @mikeharder @weshaggard @benbp
@@ -114,16 +114,16 @@
 /sdk/schemaregistry/ @deyaaeldeen @nguerrera
 
 # PRLabel: %Cognitive - Form Recognizer
-/sdk/formrecognizer/ @jeremymeng @witemple-msft
+/sdk/formrecognizer/ @witemple-msft @jeremymeng
 
 # PRLabel: %Cognitive - Metrics Advisor
-/sdk/metricsadvisor/ @jeremymeng @KarishmaGhiya
+/sdk/metricsadvisor/ @KarishmaGhiya @jeremymeng
 
 # PRLabel: %Cognitive - Anomaly Detector
 /sdk/anomalydetector/ @conhua @mengaims @juaduan @moreOver0
 
 # PRLabel: %Search
-/sdk/search/ @xirzec @sarangan12
+/sdk/search/ @sarangan12 @xirzec
 
 /sdk/applicationinsights/applicationinsights-query/ @divyajay @alongafni
 /sdk/operationalinsights/loganalytics/ @divyajay @alongafni


### PR DESCRIPTION
### Packages impacted by this PR
None

### Issues associated with this PR
Resolves #18210

### Describe the problem that is addressed by this PR
Today, vendors create issues and assign them based on a list that I provided
them. The problem is that it can easily get out of sync as nobody would know to
update it. I am working towards making CODEOWNERS the single source of truth for
package ownership. It needs to start with the primary owner listed first, so
that the vendors know who to assign it to.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?
I am going to be honest, this effort might not go anywhere. But it's not a
harmful thing to do. Besides, there's a bit of a chicken-and-egg problem right
now. CODEOWNER list ordering is not used by the vendors because it's not
ordered, but nobody will want to order it because the order has no impact.
Between this and the efforts engsys is putting in place to parse this file I am
hopeful we can get to a place where vendors can look at data derived from
CODEOWNERS.
