### PR TITLE
[@azure/search-documents] Adding new skills to the search-documents SDK

### DIFF
--- a/sdk/search/perf-tests/search-documents/package.json
+++ b/sdk/search/perf-tests/search-documents/package.json
@@ -9,7 +9,7 @@
   "license": "ISC",
   "dependencies": {
     "@azure/identity": "^2.0.1",
-    "@azure/search-documents": "11.3.0-beta.5",
+    "@azure/search-documents": "11.3.0-beta.6",
     "@azure/test-utils-perf": "^1.0.0",
     "dotenv": "^8.2.0"
   },

--- a/sdk/search/search-documents/CHANGELOG.md
+++ b/sdk/search/search-documents/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 11.3.0-beta.6 (Unreleased)
+## 11.3.0-beta.6 (2022-02-08)
 
 ### Features Added
 

--- a/sdk/search/search-documents/CHANGELOG.md
+++ b/sdk/search/search-documents/CHANGELOG.md
@@ -4,9 +4,7 @@
 
 ### Features Added
 
-### Breaking Changes
-
-### Bugs Fixed
+- Added new type of SearchIndexer skill - `AzureMachineLearningSkill`. Please refer [#20183](https://github.com/Azure/azure-sdk-for-js/pull/20183) for further details.
 
 ### Other Changes
 

--- a/sdk/search/search-documents/package.json
+++ b/sdk/search/search-documents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/search-documents",
-  "version": "11.3.0-beta.5",
+  "version": "11.3.0-beta.6",
   "description": "Azure client library to use Cognitive Search for node.js and browser.",
   "sdk-type": "client",
   "main": "dist/index.js",

--- a/sdk/search/search-documents/review/search-documents.api.md
+++ b/sdk/search/search-documents/review/search-documents.api.md
@@ -97,6 +97,17 @@ export interface AzureActiveDirectoryApplicationCredentials {
 export { AzureKeyCredential }
 
 // @public
+export type AzureMachineLearningSkill = BaseSearchIndexerSkill & {
+    odatatype: "#Microsoft.Skills.Custom.AmlSkill";
+    scoringUri?: string;
+    authenticationKey?: string;
+    resourceId?: string;
+    timeout?: string;
+    region?: string;
+    degreeOfParallelism?: number;
+};
+
+// @public
 export interface BaseCharFilter {
     name: string;
     odatatype: "#Microsoft.Azure.Search.MappingCharFilter" | "#Microsoft.Azure.Search.PatternReplaceCharFilter";
@@ -155,7 +166,7 @@ export interface BaseSearchIndexerSkill {
     description?: string;
     inputs: InputFieldMappingEntry[];
     name?: string;
-    odatatype: "#Microsoft.Skills.Util.ConditionalSkill" | "#Microsoft.Skills.Text.KeyPhraseExtractionSkill" | "#Microsoft.Skills.Vision.OcrSkill" | "#Microsoft.Skills.Vision.ImageAnalysisSkill" | "#Microsoft.Skills.Text.LanguageDetectionSkill" | "#Microsoft.Skills.Util.ShaperSkill" | "#Microsoft.Skills.Text.MergeSkill" | "#Microsoft.Skills.Text.EntityRecognitionSkill" | "#Microsoft.Skills.Text.SentimentSkill" | "#Microsoft.Skills.Text.V3.SentimentSkill" | "#Microsoft.Skills.Text.V3.EntityLinkingSkill" | "#Microsoft.Skills.Text.V3.EntityRecognitionSkill" | "#Microsoft.Skills.Text.PIIDetectionSkill" | "#Microsoft.Skills.Text.SplitSkill" | "#Microsoft.Skills.Text.CustomEntityLookupSkill" | "#Microsoft.Skills.Text.TranslationSkill" | "#Microsoft.Skills.Util.DocumentExtractionSkill" | "#Microsoft.Skills.Custom.WebApiSkill";
+    odatatype: "#Microsoft.Skills.Util.ConditionalSkill" | "#Microsoft.Skills.Text.KeyPhraseExtractionSkill" | "#Microsoft.Skills.Vision.OcrSkill" | "#Microsoft.Skills.Vision.ImageAnalysisSkill" | "#Microsoft.Skills.Text.LanguageDetectionSkill" | "#Microsoft.Skills.Util.ShaperSkill" | "#Microsoft.Skills.Text.MergeSkill" | "#Microsoft.Skills.Text.EntityRecognitionSkill" | "#Microsoft.Skills.Text.SentimentSkill" | "#Microsoft.Skills.Text.V3.SentimentSkill" | "#Microsoft.Skills.Text.V3.EntityLinkingSkill" | "#Microsoft.Skills.Text.V3.EntityRecognitionSkill" | "#Microsoft.Skills.Text.PIIDetectionSkill" | "#Microsoft.Skills.Text.SplitSkill" | "#Microsoft.Skills.Text.CustomEntityLookupSkill" | "#Microsoft.Skills.Text.TranslationSkill" | "#Microsoft.Skills.Util.DocumentExtractionSkill" | "#Microsoft.Skills.Custom.WebApiSkill" | "#Microsoft.Skills.Custom.AmlSkill";
     outputs: OutputFieldMappingEntry[];
 }
 
@@ -1140,6 +1151,7 @@ export enum KnownOcrSkillLanguage {
     SrLatn = "sr-Latn",
     Sv = "sv",
     Tr = "tr",
+    Unk = "unk",
     ZhHans = "zh-Hans",
     ZhHant = "zh-Hant"
 }
@@ -2058,7 +2070,7 @@ export interface SearchIndexerLimits {
 }
 
 // @public
-export type SearchIndexerSkill = ConditionalSkill | KeyPhraseExtractionSkill | OcrSkill | ImageAnalysisSkill | LanguageDetectionSkill | ShaperSkill | MergeSkill | EntityRecognitionSkill | SentimentSkill | SplitSkill | PIIDetectionSkill | EntityRecognitionSkillV3 | EntityLinkingSkill | SentimentSkillV3 | CustomEntityLookupSkill | TextTranslationSkill | DocumentExtractionSkill | WebApiSkill;
+export type SearchIndexerSkill = ConditionalSkill | KeyPhraseExtractionSkill | OcrSkill | ImageAnalysisSkill | LanguageDetectionSkill | ShaperSkill | MergeSkill | EntityRecognitionSkill | SentimentSkill | SplitSkill | PIIDetectionSkill | EntityRecognitionSkillV3 | EntityLinkingSkill | SentimentSkillV3 | CustomEntityLookupSkill | TextTranslationSkill | DocumentExtractionSkill | WebApiSkill | AzureMachineLearningSkill;
 
 // @public
 export interface SearchIndexerSkillset {

--- a/sdk/search/search-documents/src/constants.ts
+++ b/sdk/search/search-documents/src/constants.ts
@@ -1,4 +1,4 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-export const SDK_VERSION: string = "11.3.0-beta.5";
+export const SDK_VERSION: string = "11.3.0-beta.6";

--- a/sdk/search/search-documents/src/generated/data/models/index.ts
+++ b/sdk/search/search-documents/src/generated/data/models/index.ts
@@ -82,7 +82,7 @@ export interface AnswerResult {
   /** Describes unknown properties. The value of an unknown property can be of "any" type. */
   [property: string]: any;
   /**
-   * The score value represents how relevant the answer is to the the query relative to other answers returned for the query.
+   * The score value represents how relevant the answer is to the query relative to other answers returned for the query.
    * NOTE: This property will not be serialized. It can only be populated by the server.
    */
   readonly score: number;
@@ -532,9 +532,9 @@ export enum KnownQueryLanguage {
   ArJo = "ar-jo",
   /** Query language value for Danish (Denmark). */
   DaDk = "da-dk",
-  /** Query language value for Norwegian (Normway). */
+  /** Query language value for Norwegian (Norway). */
   NoNo = "no-no",
-  /** Query language value for Bulgarian (Bulgary). */
+  /** Query language value for Bulgarian (Bulgaria). */
   BgBg = "bg-bg",
   /** Query language value for Croatian (Croatia). */
   HrHr = "hr-hr",
@@ -650,8 +650,8 @@ export enum KnownQueryLanguage {
  * **ar-kw**: Query language value for Arabic (Kuwait). \
  * **ar-jo**: Query language value for Arabic (Jordan). \
  * **da-dk**: Query language value for Danish (Denmark). \
- * **no-no**: Query language value for Norwegian (Normway). \
- * **bg-bg**: Query language value for Bulgarian (Bulgary). \
+ * **no-no**: Query language value for Norwegian (Norway). \
+ * **bg-bg**: Query language value for Bulgarian (Bulgaria). \
  * **hr-hr**: Query language value for Croatian (Croatia). \
  * **hr-ba**: Query language value for Croatian (Bosnia and Herzegovina). \
  * **ms-my**: Query language value for Malay (Malaysia). \

--- a/sdk/search/search-documents/src/generated/data/searchClientContext.ts
+++ b/sdk/search/search-documents/src/generated/data/searchClientContext.ts
@@ -49,7 +49,7 @@ export class SearchClientContext extends coreClient.ServiceClient {
       requestContentType: "application/json; charset=utf-8"
     };
 
-    const packageDetails = `azsdk-js-search-documents/11.3.0-beta.5`;
+    const packageDetails = `azsdk-js-search-documents/11.3.0-beta.6`;
     const userAgentPrefix =
       options.userAgentOptions && options.userAgentOptions.userAgentPrefix
         ? `${options.userAgentOptions.userAgentPrefix} ${packageDetails}`

--- a/sdk/search/search-documents/src/generated/service/models/index.ts
+++ b/sdk/search/search-documents/src/generated/service/models/index.ts
@@ -38,7 +38,8 @@ export type SearchIndexerSkillUnion =
   | CustomEntityLookupSkill
   | TextTranslationSkill
   | DocumentExtractionSkill
-  | WebApiSkill;
+  | WebApiSkill
+  | AzureMachineLearningSkill;
 export type CognitiveServicesAccountUnion =
   | CognitiveServicesAccount
   | DefaultCognitiveServicesAccount
@@ -589,7 +590,8 @@ export interface SearchIndexerSkill {
     | "#Microsoft.Skills.Text.CustomEntityLookupSkill"
     | "#Microsoft.Skills.Text.TranslationSkill"
     | "#Microsoft.Skills.Util.DocumentExtractionSkill"
-    | "#Microsoft.Skills.Custom.WebApiSkill";
+    | "#Microsoft.Skills.Custom.WebApiSkill"
+    | "#Microsoft.Skills.Custom.AmlSkill";
   /** The name of the skill which uniquely identifies it within the skillset. A skill with no name defined will be given a default name of its 1-based index in the skills array, prefixed with the character '#'. */
   name?: string;
   /** The description of the skill which describes the inputs, outputs, and usage of the skill. */
@@ -1375,6 +1377,24 @@ export type WebApiSkill = SearchIndexerSkill & {
   /** The desired batch size which indicates number of documents. */
   batchSize?: number;
   /** If set, the number of parallel calls that can be made to the Web API. */
+  degreeOfParallelism?: number;
+};
+
+/** The AML skill allows you to extend AI enrichment with a custom Azure Machine Learning (AML) model. Once an AML model is trained and deployed, an AML skill integrates it into AI enrichment. */
+export type AzureMachineLearningSkill = SearchIndexerSkill & {
+  /** Polymorphic discriminator, which specifies the different types this object can be */
+  odatatype: "#Microsoft.Skills.Custom.AmlSkill";
+  /** (Required for no authentication or key authentication) The scoring URI of the AML service to which the JSON payload will be sent. Only the https URI scheme is allowed. */
+  scoringUri?: string;
+  /** (Required for key authentication) The key for the AML service. */
+  authenticationKey?: string;
+  /** (Required for token authentication). The Azure Resource Manager resource ID of the AML service. It should be in the format subscriptions/{guid}/resourceGroups/{resource-group-name}/Microsoft.MachineLearningServices/workspaces/{workspace-name}/services/{service_name}. */
+  resourceId?: string;
+  /** (Optional) When specified, indicates the timeout for the http client making the API call. */
+  timeout?: string;
+  /** (Optional for token authentication). The region the AML service is deployed in. */
+  region?: string;
+  /** (Optional) When specified, indicates the number of calls the indexer will make in parallel to the endpoint you have provided. You can decrease this value if your endpoint is failing under too high of a request load, or raise it if your endpoint is able to accept more requests and you would like an increase in the performance of the indexer. If not set, a default value of 5 is used. The degreeOfParallelism can be set to a maximum of 10 and a minimum of 1. */
   degreeOfParallelism?: number;
 };
 
@@ -2736,7 +2756,9 @@ export enum KnownOcrSkillLanguage {
   /** Serbian (Latin, Serbia) */
   SrLatn = "sr-Latn",
   /** Slovak */
-  Sk = "sk"
+  Sk = "sk",
+  /** Unknown.  If the language is explicitly set to "unk", the language will be auto-detected. */
+  Unk = "unk"
 }
 
 /**
@@ -2769,7 +2791,8 @@ export enum KnownOcrSkillLanguage {
  * **ro**: Romanian \
  * **sr-Cyrl**: Serbian (Cyrillic, Serbia) \
  * **sr-Latn**: Serbian (Latin, Serbia) \
- * **sk**: Slovak
+ * **sk**: Slovak \
+ * **unk**: Unknown.  If the language is explicitly set to "unk", the language will be auto-detected.
  */
 export type OcrSkillLanguage = string;
 

--- a/sdk/search/search-documents/src/generated/service/models/mappers.ts
+++ b/sdk/search/search-documents/src/generated/service/models/mappers.ts
@@ -3507,6 +3507,61 @@ export const WebApiSkill: coreClient.CompositeMapper = {
   }
 };
 
+export const AzureMachineLearningSkill: coreClient.CompositeMapper = {
+  serializedName: "#Microsoft.Skills.Custom.AmlSkill",
+  type: {
+    name: "Composite",
+    className: "AzureMachineLearningSkill",
+    uberParent: "SearchIndexerSkill",
+    polymorphicDiscriminator: SearchIndexerSkill.type.polymorphicDiscriminator,
+    modelProperties: {
+      ...SearchIndexerSkill.type.modelProperties,
+      scoringUri: {
+        serializedName: "uri",
+        nullable: true,
+        type: {
+          name: "String"
+        }
+      },
+      authenticationKey: {
+        serializedName: "key",
+        nullable: true,
+        type: {
+          name: "String"
+        }
+      },
+      resourceId: {
+        serializedName: "resourceId",
+        nullable: true,
+        type: {
+          name: "String"
+        }
+      },
+      timeout: {
+        serializedName: "timeout",
+        nullable: true,
+        type: {
+          name: "TimeSpan"
+        }
+      },
+      region: {
+        serializedName: "region",
+        nullable: true,
+        type: {
+          name: "String"
+        }
+      },
+      degreeOfParallelism: {
+        serializedName: "degreeOfParallelism",
+        nullable: true,
+        type: {
+          name: "Number"
+        }
+      }
+    }
+  }
+};
+
 export const DefaultCognitiveServicesAccount: coreClient.CompositeMapper = {
   serializedName: "#Microsoft.Azure.Search.DefaultCognitiveServices",
   type: {
@@ -5449,6 +5504,7 @@ export let discriminators = {
   "SearchIndexerSkill.#Microsoft.Skills.Text.TranslationSkill": TextTranslationSkill,
   "SearchIndexerSkill.#Microsoft.Skills.Util.DocumentExtractionSkill": DocumentExtractionSkill,
   "SearchIndexerSkill.#Microsoft.Skills.Custom.WebApiSkill": WebApiSkill,
+  "SearchIndexerSkill.#Microsoft.Skills.Custom.AmlSkill": AzureMachineLearningSkill,
   "CognitiveServicesAccount.#Microsoft.Azure.Search.DefaultCognitiveServices": DefaultCognitiveServicesAccount,
   "CognitiveServicesAccount.#Microsoft.Azure.Search.CognitiveServicesByKey": CognitiveServicesAccountKey,
   "ScoringFunction.distance": DistanceScoringFunction,

--- a/sdk/search/search-documents/src/generated/service/searchServiceClientContext.ts
+++ b/sdk/search/search-documents/src/generated/service/searchServiceClientContext.ts
@@ -43,7 +43,7 @@ export class SearchServiceClientContext extends coreClient.ServiceClient {
       requestContentType: "application/json; charset=utf-8"
     };
 
-    const packageDetails = `azsdk-js-search-documents/11.3.0-beta.5`;
+    const packageDetails = `azsdk-js-search-documents/11.3.0-beta.6`;
     const userAgentPrefix =
       options.userAgentOptions && options.userAgentOptions.userAgentPrefix
         ? `${options.userAgentOptions.userAgentPrefix} ${packageDetails}`

--- a/sdk/search/search-documents/src/index.ts
+++ b/sdk/search/search-documents/src/index.ts
@@ -228,6 +228,7 @@ export {
   SentimentSkillV3,
   TextTranslationSkill,
   WebApiSkill,
+  AzureMachineLearningSkill,
   SentimentSkillLanguage,
   KnownSentimentSkillLanguage,
   SplitSkillLanguage,

--- a/sdk/search/search-documents/src/serviceModels.ts
+++ b/sdk/search/search-documents/src/serviceModels.ts
@@ -62,6 +62,7 @@ import {
   DocumentExtractionSkill,
   TextTranslationSkill,
   WebApiSkill,
+  AzureMachineLearningSkill,
   DefaultCognitiveServicesAccount,
   CognitiveServicesAccountKey,
   HighWaterMarkChangeDetectionPolicy,
@@ -513,7 +514,8 @@ export type SearchIndexerSkill =
   | CustomEntityLookupSkill
   | TextTranslationSkill
   | DocumentExtractionSkill
-  | WebApiSkill;
+  | WebApiSkill
+  | AzureMachineLearningSkill;
 
 /**
  * Contains the possible cases for CognitiveServicesAccount.

--- a/sdk/search/search-documents/src/serviceUtils.ts
+++ b/sdk/search/search-documents/src/serviceUtils.ts
@@ -46,6 +46,7 @@ import {
   SentimentSkillV3,
   TextTranslationSkill,
   WebApiSkill,
+  AzureMachineLearningSkill,
   LuceneStandardAnalyzer,
   StopAnalyzer,
   PatternAnalyzer as GeneratedPatternAnalyzer,
@@ -147,6 +148,9 @@ export function convertSkillsToPublic(skills: SearchIndexerSkillUnion[]): Search
         break;
       case "#Microsoft.Skills.Util.DocumentExtractionSkill":
         result.push(skill as DocumentExtractionSkill);
+        break;
+      case "#Microsoft.Skills.Custom.AmlSkill":
+        result.push(skill as AzureMachineLearningSkill);
         break;
     }
   }

--- a/sdk/search/search-documents/swagger/Data.md
+++ b/sdk/search/search-documents/swagger/Data.md
@@ -10,7 +10,7 @@ generate-metadata: false
 license-header: MICROSOFT_MIT_NO_VERSION
 output-folder: ../
 source-code-folder-path: ./src/generated/data
-input-file: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/7a003b0aa0def1a454ff0844fa4c6a276bc1ee53/specification/search/data-plane/Azure.Search/preview/2021-04-30-Preview/searchindex.json
+input-file: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/932e261a870475e1a29115f62def7bb84e4d7b38/specification/search/data-plane/Azure.Search/preview/2021-04-30-Preview/searchindex.json
 add-credentials: false
 title: SearchClient
 use-extension:

--- a/sdk/search/search-documents/swagger/Service.md
+++ b/sdk/search/search-documents/swagger/Service.md
@@ -10,7 +10,7 @@ generate-metadata: false
 license-header: MICROSOFT_MIT_NO_VERSION
 output-folder: ../
 source-code-folder-path: ./src/generated/service
-input-file: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/7a003b0aa0def1a454ff0844fa4c6a276bc1ee53/specification/search/data-plane/Azure.Search/preview/2021-04-30-Preview/searchservice.json
+input-file: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/932e261a870475e1a29115f62def7bb84e4d7b38/specification/search/data-plane/Azure.Search/preview/2021-04-30-Preview/searchservice.json
 add-credentials: false
 use-extension:
   "@autorest/typescript": "6.0.0-beta.13"


### PR DESCRIPTION
### Packages impacted by this PR
@azure/search-documents

### Issues associated with this PR
None

### Describe the problem that is addressed by this PR
There is a new skill `AzureMachineLearningSkill` added to the search-documents service. The plan is for all the language SDKs to regenerate their SDKs and release a new version with this Skill. 

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?
This is a simple & straightforward regenerate and modification of custom layer.

### Are there test cases added in this PR? _(If not, why?)_
None. No special test cases are required for this simple addition.

### Provide a list of related PRs _(if any)_
None

### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_
1. `autorest --typescript swagger\Data.md`
2. `autorest --typescript swagger\Service.md`
3. `rushx build`

### Checklists
- [X] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [X] Added a changelog (if necessary)

@xirzec Please review and approve the PR