### PR TITLE
[EventGrid] Update System events and prepare for Feb release

### DIFF
--- a/sdk/eventgrid/eventgrid/CHANGELOG.md
+++ b/sdk/eventgrid/eventgrid/CHANGELOG.md
@@ -1,21 +1,19 @@
 # Release History
 
-## 4.6.1 (Unreleased)
+## 4.7.0 (2022-02-08)
 
-### Features Added
+### Key Bug Fixes
 
-### Breaking Changes
-
-### Bugs Fixed
-
-### Other Changes
+- The TypeScript typings for two events have had small changes to accurately reflect the data sent by Azure.
+  - `Microsoft.EventHub.CaptureFileCreated`'s `fileurl` property is now correctly cased as `fileUrl`
+  - `Microsoft.Storage.DirectoryDeleted`'s `recursive` property has been changed from `boolean` to `string`. The service sets this property to the string `"true"` or `"false"`.
 
 ## 4.6.0 (2022-01-11)
 
 ### Features Added
 
 - Added a new property to `AcsRecordingChunkInfo` (for the `Microsoft.Communication.RecordingFileStatusUpdated` system event):
-  
+
   - `deleteLocation`
 
 - Added new properties to `ContainerRegistryArtifactEventData` and `ContainerRegistryEventData` (for the `Microsoft.ContainerRegistry.{ChartDeleted|ChartPushed|ImagePushed|ImageDeleted}` system events):

--- a/sdk/eventgrid/eventgrid/package.json
+++ b/sdk/eventgrid/eventgrid/package.json
@@ -3,7 +3,7 @@
   "sdk-type": "client",
   "author": "Microsoft Corporation",
   "description": "An isomorphic client library for the Azure Event Grid service.",
-  "version": "4.6.1",
+  "version": "4.7.0",
   "keywords": [
     "node",
     "azure",

--- a/sdk/eventgrid/eventgrid/review/eventgrid.api.md
+++ b/sdk/eventgrid/eventgrid/review/eventgrid.api.md
@@ -553,7 +553,7 @@ export type EventGridPublisherClientOptions = CommonClientOptions;
 export interface EventHubCaptureFileCreatedEventData {
     eventCount: number;
     fileType: string;
-    fileurl: string;
+    fileUrl: string;
     firstEnqueueTime: string;
     firstSequenceNumber: number;
     lastEnqueueTime: string;
@@ -1410,7 +1410,7 @@ export interface StorageDirectoryDeletedEventData {
     api: string;
     clientRequestId: string;
     identity: string;
-    recursive: boolean;
+    recursive: string;
     requestId: string;
     sequencer: string;
     storageDiagnostics: any;

--- a/sdk/eventgrid/eventgrid/src/generated/generatedClientContext.ts
+++ b/sdk/eventgrid/eventgrid/src/generated/generatedClientContext.ts
@@ -26,7 +26,7 @@ export class GeneratedClientContext extends coreClient.ServiceClient {
       requestContentType: "application/json; charset=utf-8"
     };
 
-    const packageDetails = `azsdk-js-eventgrid/4.6.1`;
+    const packageDetails = `azsdk-js-eventgrid/4.7.0`;
     const userAgentPrefix =
       options.userAgentOptions && options.userAgentOptions.userAgentPrefix
         ? `${options.userAgentOptions.userAgentPrefix} ${packageDetails}`

--- a/sdk/eventgrid/eventgrid/src/generated/models/index.ts
+++ b/sdk/eventgrid/eventgrid/src/generated/models/index.ts
@@ -140,7 +140,7 @@ export interface StorageDirectoryDeletedEventData {
   /** The path to the deleted directory. */
   url: string;
   /** Is this event for a recursive delete operation. */
-  recursive: boolean;
+  recursive: string;
   /** An opaque string value representing the logical sequence of events for any particular directory name. Users can use standard string comparison to understand the relative sequence of two events on the same directory name. */
   sequencer: string;
   /** The identity of the requester that triggered this event. */
@@ -280,7 +280,7 @@ export interface StorageBlobInventoryPolicyCompletedEventData {
 /** Schema of the Data property of an EventGridEvent for a Microsoft.EventHub.CaptureFileCreated event. */
 export interface EventHubCaptureFileCreatedEventData {
   /** The path to the capture file. */
-  fileurl: string;
+  fileUrl: string;
   /** The file type of the capture file. */
   fileType: string;
   /** The shard ID. */

--- a/sdk/eventgrid/eventgrid/src/generated/models/mappers.ts
+++ b/sdk/eventgrid/eventgrid/src/generated/models/mappers.ts
@@ -413,7 +413,7 @@ export const StorageDirectoryDeletedEventData: coreClient.CompositeMapper = {
         serializedName: "recursive",
         required: true,
         type: {
-          name: "Boolean"
+          name: "String"
         }
       },
       sequencer: {
@@ -859,8 +859,8 @@ export const EventHubCaptureFileCreatedEventData: coreClient.CompositeMapper = {
     name: "Composite",
     className: "EventHubCaptureFileCreatedEventData",
     modelProperties: {
-      fileurl: {
-        serializedName: "fileurl",
+      fileUrl: {
+        serializedName: "fileUrl",
         required: true,
         type: {
           name: "String"

--- a/sdk/eventgrid/eventgrid/swagger/README.md
+++ b/sdk/eventgrid/eventgrid/swagger/README.md
@@ -5,9 +5,9 @@
 ## Configuration
 
 ```yaml
-require: "https://github.com/Azure/azure-rest-api-specs/blob/397017728a17dd50b6755e7de0d283b93562a634/specification/eventgrid/data-plane/readme.md"
+require: "https://github.com/Azure/azure-rest-api-specs/blob/03da592cccfa0e52ccd6ecc53d232afda8a38c95/specification/eventgrid/data-plane/readme.md"
 package-name: "@azure/eventgrid"
-package-version: "4.6.1"
+package-version: "4.7.0"
 title: GeneratedClient
 description: EventGrid Client
 generate-metadata: false
@@ -125,4 +125,17 @@ directive:
           }
         }
       }
+```
+
+### Don't use x-ms-client-name for EventHub Event.
+
+The wire format for the event uses camel cassing and the `x-ms-client-name` attribute was added to the API Specification (in Azure/azure-rest-api-specs#17565) to work around an issue without introducing a breaking
+change. For JavaScript, we want to generate types that match the format of the wire events, so remove `x-ms-client-name`.
+
+```yaml
+directive:
+  - from: swagger-document
+    where: $.definitions.EventHubCaptureFileCreatedEventData
+    transform: >
+      delete $.properties.fileUrl["x-ms-client-name"]
 ```


### PR DESCRIPTION
This change pulls in the latest changes from the
`azure-rest-api-specs` repository for system events in Azure.

It fixes two issues with our typings for events (a property name was
incorrectly cased and another property was typed as a boolean when the
event delivered by the service uses a string (with the value of `true`
or `false`) instead of a boolean as might be expected.

This is a breaking change for code which is written in typescript and
which uses any of these impacted properties because the underlying
type has changed from string to something else. However, any code
which previously was written against the old typings would have
*failed* at runtime with a type error, so in practice anyone who gets
an issue is now correctly discovering a bug in their program at
compile time now instead of runtime.