### PR TITLE
[azureBus] Typescript samples: fix type error & tsconfig.json

### DIFF
--- a/sdk/servicebus/service-bus/samples/v7/typescript/src/advanced/sessionRoundRobin.ts
+++ b/sdk/servicebus/service-bus/samples/v7/typescript/src/advanced/sessionRoundRobin.ts
@@ -95,7 +95,7 @@ async function receiveFromNextSession(serviceBusClient: ServiceBusClient): Promi
     ) {
       console.log(`INFO: no available sessions, sleeping for ${delayOnErrorMs}`);
     } else {
-      await processError(err, undefined);
+      await processError(<Error>err, undefined);
     }
 
     await delay(delayOnErrorMs);
@@ -128,7 +128,7 @@ async function receiveFromNextSession(serviceBusClient: ServiceBusClient): Promi
     await sessionFullyRead;
     await sessionClosed("idle_timeout", sessionReceiver.sessionId);
   } catch (err) {
-    await processError(err, sessionReceiver.sessionId);
+    await processError(<Error>err, sessionReceiver.sessionId);
     await sessionClosed("error", sessionReceiver.sessionId);
   } finally {
     await sessionReceiver.close();

--- a/sdk/servicebus/service-bus/samples/v7/typescript/tsconfig.json
+++ b/sdk/servicebus/service-bus/samples/v7/typescript/tsconfig.json
@@ -12,6 +12,6 @@
     "rootDir": "src"
   },
   "include": [
-    "src/**.ts"
+    "src/**/*.ts"
   ]
 }


### PR DESCRIPTION
### Packages impacted by this PR
[`servicebus/service-bus/samples/v7/typescript`](https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/servicebus/service-bus/samples/v7/typescript) 
### Issues associated with this PR
N/C

### Describe the problem that is addressed by this PR
1. With the latest typescript (version 4.5.*) , the `npm run build`failed because of compile error : 
```shell
src/advanced/sessionRoundRobin.ts:98:26 - error TS2345: Argument of type 'unknown' is not assignable to parameter of type 'Error'.
98       await processError(err, undefined);
```
I added "type assertion" to fix this compile error.

2.  The examples in [`advanced folder`](https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/servicebus/service-bus/samples/v7/typescript/src/advanced)  are not included in the compile process, so i updated the `tsconfig.json` to include them.
### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?
N/C

### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_
N/C

### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [*] Added impacted package name to the issue description
- [*] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [*] Added a changelog (if necessary)
