### PR TITLE
Add catch-all parameter to test resources script

### DIFF
--- a/eng/common/TestResources/New-TestResources.ps1
+++ b/eng/common/TestResources/New-TestResources.ps1
@@ -76,7 +76,17 @@ param (
     [switch] $Force,
 
     [Parameter()]
-    [switch] $OutFile
+    [switch] $OutFile,
+
+    [Parameter()]
+    [switch] $SuppressVsoCommands = ($null -eq $env:SYSTEM_TEAMPROJECTID),
+
+    # Captures any arguments not declared here (no parameter errors)
+    # This enables backwards compatibility with old script versions in
+    # hotfix branches if and when the dynamic subscription configuration
+    # secrets get updated to add new parameters.
+    [Parameter(ValueFromRemainingArguments = $true)]
+    $NewTestResourcesRemainingArguments
 )
 
 # By default stop for any error.


### PR DESCRIPTION
This updates the `New-TestResources.ps1` script to not fail when extra unused parameters are passed in. This prevents the script from breaking if new keys/values are added to the subscription config object in keyvault (which gets splatted onto the script parameters [here](https://github.com/Azure/azure-sdk-tools/blob/9241b1955ba261e24ce4614fe99e99cc08f2aa95/eng/common/TestResources/deploy-test-resources.yml#L55)). Currently this is a problem with historical versions of the script that get run as part of a backport to a hotfix/release branch, where the old version of the script is not compatible with the subscription configuration parameters.

For example, the addition of `ProvisionerApplicationOid` [here](https://github.com/Azure/azure-sdk-tools/pull/2592) is causing issues for live test pipeline runs using eng/common code older than the change as the parameter was also added to the subscription configuration.
