### PR TITLE
[core-http,core-rest-pipeline] allow logging `WWW-Authenticate` header

### DIFF
--- a/sdk/core/core-http/src/util/sanitizer.ts
+++ b/sdk/core/core-http/src/util/sanitizer.ts
@@ -63,6 +63,7 @@ const defaultAllowedHeaderNames = [
   "Server",
   "Transfer-Encoding",
   "User-Agent",
+  "WWW-Authenticate",
 ];
 
 const defaultAllowedQueryParameters: string[] = ["api-version"];

--- a/sdk/core/core-rest-pipeline/src/util/sanitizer.ts
+++ b/sdk/core/core-rest-pipeline/src/util/sanitizer.ts
@@ -66,6 +66,7 @@ const defaultAllowedHeaderNames = [
   "Server",
   "Transfer-Encoding",
   "User-Agent",
+  "WWW-Authenticate",
 ];
 
 const defaultAllowedQueryParameters: string[] = ["api-version"];


### PR DESCRIPTION
This PR adds "WWW-Authenticate" to the allowed logged header list.  It doesn't
contain sensitive or privacy information.