### PR TITLE
Fixing cspell errors

### DIFF
--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -52,8 +52,7 @@
     "sdk/iot/iot-modelsrepository/review/**/*.md",
     "sdk/keyvault/keyvault-certificates/review/**/*.md",
     "sdk/keyvault/keyvault-keys/review/**/*.md",
-    "sdk/monitor/monitor-query/review/**/*.md",
-    "sdk/search/search-documents/review/**/*.md"
+    "sdk/monitor/monitor-query/review/**/*.md"
   ],
   "words": [
     "adfs",
@@ -150,6 +149,31 @@
       "words": [
         "RAGRS",
         "Uncommited"
+      ]
+    },
+    {
+      "filename": "sdk/search/search-documents/review/**/*.md",
+      "words": [
+        "odatatype",
+        "Decompounder",
+        "Createor",
+        "Unprocessable",
+        "Adls",
+        "adlsgen",
+        "Piqd",
+        "kstem",
+        "Sorani",
+        "sorani",
+        "kstem",
+        "bangla",
+        "Bokmaal",
+        "nysiis",
+        "koelner",
+        "Phonetik",
+        "haase",
+        "reranker",
+        "lovins",
+        "Rslp"
       ]
     }
   ]

--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -53,8 +53,7 @@
     "sdk/keyvault/keyvault-certificates/review/**/*.md",
     "sdk/keyvault/keyvault-keys/review/**/*.md",
     "sdk/monitor/monitor-query/review/**/*.md",
-    "sdk/search/search-documents/review/**/*.md",
-    "sdk/storage/storage-blob/review/**/*.md"
+    "sdk/search/search-documents/review/**/*.md"
   ],
   "words": [
     "adfs",
@@ -144,6 +143,13 @@
       "filename": "sdk/storage/storage-file-share/review/**/*.md",
       "words": [
         "Mibps"
+      ]
+    },
+    {
+      "filename": "sdk/storage/storage-blob/review/**/*.md",
+      "words": [
+        "RAGRS",
+        "Uncommited"
       ]
     }
   ]

--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -114,8 +114,8 @@
       "filename": "eng/pipelines",
       "words": [
         "azuresdkartifacts",
-        "gdnbaselines",
-        "policheck"
+        "policheck",
+        "gdnbaselines"
       ]
     },
     {

--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -48,7 +48,6 @@
     "sdk/cosmosdb/cosmos/review/**/*.md",
     "sdk/digitaltwins/digital-twins-core/review/**/*.md",
     "sdk/formrecognizer/ai-form-recognizer/review/**/*.md",
-    "sdk/identity/identity/review/**/*.md",
     "sdk/iot/iot-modelsrepository/review/**/*.md"
   ],
   "words": [
@@ -109,7 +108,8 @@
     "usgovtexas",
     "usgovvirginia",
     "Vertica",
-    "westus"
+    "westus",
+    "Unencrypted"
   ],
   "allowCompoundWords": true,
   "overrides": [

--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -41,8 +41,6 @@
     "sdk/synapse/synapse-managed-private-endpoints/review/*.md",
     "sdk/synapse/synapse-monitoring/review/*.md",
     "sdk/synapse/synapse-spark/review/*.md",
-    "sdk/communication/communication-common/review/**/*.md",
-    "sdk/iot/iot-modelsrepository/review/**/*.md"
   ],
   "words": [
     "adfs",
@@ -242,6 +240,19 @@
         "Illumos",
         "mipsle",
         "riscv"
+      ]
+    },
+    {
+      "filename": "sdk/communication/communication-common/review/**/*.md",
+      "words": [
+        "gcch"
+      ]
+    },
+    {
+      "filename": "sdk/iot/iot-modelsrepository/review/**/*.md",
+      "words": [
+        "Dtmi",
+        "dtmis"
       ]
     }
   ]

--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -100,6 +100,7 @@
     "uksouth",
     "ukwest",
     "undelete",
+    "Unencrypted",
     "unpartitioned",
     "unref",
     "usdodcentral",
@@ -108,8 +109,7 @@
     "usgovtexas",
     "usgovvirginia",
     "Vertica",
-    "westus",
-    "Unencrypted"
+    "westus"
   ],
   "allowCompoundWords": true,
   "overrides": [
@@ -117,22 +117,22 @@
       "filename": "eng/pipelines",
       "words": [
         "azuresdkartifacts",
-        "policheck",
-        "gdnbaselines"
+        "gdnbaselines",
+        "policheck"
       ]
     },
     {
       "filename": "sdk/videoanalyzer/video-analyzer-edge/review/**/*.md",
       "words": [
-        "Onvif",
-        "onvif",
-        "Grpc",
-        "Abgr",
         "abgr",
-        "Argb",
+        "Abgr",
         "argb",
+        "Argb",
+        "bgra",
         "Bgra",
-        "bgra"
+        "Grpc",
+        "onvif",
+        "Onvif"
       ]
     },
     {
@@ -151,26 +151,26 @@
     {
       "filename": "sdk/search/search-documents/review/**/*.md",
       "words": [
-        "odatatype",
-        "Decompounder",
-        "Createor",
-        "Unprocessable",
         "Adls",
         "adlsgen",
-        "Piqd",
-        "kstem",
-        "Sorani",
-        "sorani",
-        "kstem",
         "bangla",
         "Bokmaal",
-        "nysiis",
-        "koelner",
-        "Phonetik",
+        "Createor",
+        "Decompounder",
         "haase",
-        "reranker",
+        "koelner",
+        "kstem",
+        "kstem",
         "lovins",
-        "Rslp"
+        "nysiis",
+        "odatatype",
+        "Phonetik",
+        "Piqd",
+        "reranker",
+        "Rslp",
+        "sorani",
+        "Sorani",
+        "Unprocessable"
       ]
     },
     {
@@ -184,17 +184,17 @@
       "words": [
         "ECHSM",
         "RSAHSM",
-        "Rsnull",
-        "RSNULL"
+        "RSNULL",
+        "Rsnull"
       ]
     },
     {
       "filename": "sdk/keyvault/keyvault-certificates/review/**/*.md",
       "words": [
-        "upns",
         "ECHSM",
+        "ekus",
         "RSAHSM",
-        "ekus"
+        "upns"
       ]
     }
   ]

--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -70,6 +70,7 @@
     "lcov",
     "lcovonly",
     "Lucene",
+    "Mibps",
     "mkdir",
     "mkdirp",
     "mongodb",
@@ -99,6 +100,7 @@
     "undelete",
     "Unencrypted",
     "unpartitioned",
+    "Unprocessable",
     "unref",
     "usdodcentral",
     "usdodeast",
@@ -133,12 +135,6 @@
       ]
     },
     {
-      "filename": "sdk/storage/storage-file-share/review/**/*.md",
-      "words": [
-        "Mibps"
-      ]
-    },
-    {
       "filename": "sdk/storage/storage-blob/review/**/*.md",
       "words": [
         "RAGRS",
@@ -166,8 +162,7 @@
         "reranker",
         "Rslp",
         "sorani",
-        "Sorani",
-        "Unprocessable"
+        "Sorani"
       ]
     },
     {

--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -41,7 +41,6 @@
     "sdk/synapse/synapse-managed-private-endpoints/review/*.md",
     "sdk/synapse/synapse-monitoring/review/*.md",
     "sdk/synapse/synapse-spark/review/*.md",
-    "sdk/attestation/attestation/review/**/*.md",
     "sdk/communication/communication-common/review/**/*.md",
     "sdk/containerregistry/container-registry/review/**/*.md",
     "sdk/core/core-amqp/review/**/*.md",
@@ -216,6 +215,17 @@
         "xmin",
         "ymax",
         "ymin"
+      ]
+    },
+    {
+      "filename": "sdk/attestation/attestation/review/**/*.md",
+      "words": [
+        "qeidcertshash",
+        "qeidcrlhash",
+        "qeidhash",
+        "tcbinfocertshash",
+        "tcbinfocrlhash",
+        "tcbinfohash"
       ]
     }
   ]

--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -46,7 +46,6 @@
     "sdk/containerregistry/container-registry/review/**/*.md",
     "sdk/core/core-amqp/review/**/*.md",
     "sdk/cosmosdb/cosmos/review/**/*.md",
-    "sdk/digitaltwins/digital-twins-core/review/**/*.md",
     "sdk/formrecognizer/ai-form-recognizer/review/**/*.md",
     "sdk/iot/iot-modelsrepository/review/**/*.md"
   ],
@@ -195,6 +194,13 @@
         "ekus",
         "RSAHSM",
         "upns"
+      ]
+    },
+    {
+      "filename": "sdk/digitaltwins/digital-twins-core/review/**/*.md",
+      "words": [
+        "dtdl",
+        "dependecies"
       ]
     }
   ]

--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -133,8 +133,7 @@
     {
       "filename": "sdk/storage/storage-blob/review/**/*.md",
       "words": [
-        "RAGRS",
-        "Uncommited"
+        "RAGRS"
       ]
     },
     {
@@ -144,7 +143,6 @@
         "adlsgen",
         "bangla",
         "Bokmaal",
-        "Createor",
         "Decompounder",
         "haase",
         "koelner",
@@ -159,12 +157,6 @@
         "Rslp",
         "sorani",
         "Sorani"
-      ]
-    },
-    {
-      "filename": "sdk/monitor/monitor-query/review/**/*.md",
-      "words": [
-        "fourty"
       ]
     },
     {
@@ -188,15 +180,13 @@
     {
       "filename": "sdk/digitaltwins/digital-twins-core/review/**/*.md",
       "words": [
-        "dtdl",
-        "dependecies"
+        "dtdl"
       ]
     },
     {
       "filename": "sdk/cosmosdb/cosmos/review/**/*.md",
       "words": [
         "colls",
-        "Funtion",
         "Parition",
         "pkranges",
         "sproc",
@@ -253,6 +243,36 @@
       "words": [
         "Dtmi",
         "dtmis"
+      ]
+    },
+    {
+      "filename": "sdk/storage/storage-blob/review/storage-blob.api.md",
+      "words": [
+        "Uncommited"
+      ]
+    },
+    {
+      "filename": "sdk/search/search-documents/review/search-documents.api.md",
+      "words": [
+        "Createor"
+      ]
+    },
+    {
+      "filename": "sdk/monitor/monitor-query/reviewmonitor-query.api.md",
+      "words": [
+        "fourty"
+      ]
+    },
+    {
+      "filename": "sdk/digitaltwins/digital-twins-core/review/digital-twins-core.api.md",
+      "words": [
+        "dependecies"
+      ]
+    },
+    {
+      "filename": "sdk/cosmosdb/cosmos/review/cosmos.api.md",
+      "words": [
+        "Funtion"
       ]
     }
   ]

--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -50,8 +50,7 @@
     "sdk/formrecognizer/ai-form-recognizer/review/**/*.md",
     "sdk/identity/identity/review/**/*.md",
     "sdk/iot/iot-modelsrepository/review/**/*.md",
-    "sdk/keyvault/keyvault-certificates/review/**/*.md",
-    "sdk/keyvault/keyvault-keys/review/**/*.md"
+    "sdk/keyvault/keyvault-certificates/review/**/*.md"
   ],
   "words": [
     "adfs",
@@ -179,6 +178,15 @@
       "filename": "sdk/monitor/monitor-query/review/**/*.md",
       "words": [
         "fourty"
+      ]
+    },
+    {
+      "filename": "sdk/keyvault/keyvault-keys/review/**/*.md",
+      "words": [
+        "ECHSM",
+        "RSAHSM",
+        "Rsnull",
+        "RSNULL"
       ]
     }
   ]

--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -54,8 +54,7 @@
     "sdk/keyvault/keyvault-keys/review/**/*.md",
     "sdk/monitor/monitor-query/review/**/*.md",
     "sdk/search/search-documents/review/**/*.md",
-    "sdk/storage/storage-blob/review/**/*.md",
-    "sdk/storage/storage-file-share/review/**/*.md"
+    "sdk/storage/storage-blob/review/**/*.md"
   ],
   "words": [
     "adfs",
@@ -139,6 +138,12 @@
         "argb",
         "Bgra",
         "bgra"
+      ]
+    },
+    {
+      "filename": "sdk/storage/storage-file-share/review/**/*.md",
+      "words": [
+        "Mibps"
       ]
     }
   ]

--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -55,8 +55,7 @@
     "sdk/monitor/monitor-query/review/**/*.md",
     "sdk/search/search-documents/review/**/*.md",
     "sdk/storage/storage-blob/review/**/*.md",
-    "sdk/storage/storage-file-share/review/**/*.md",
-    "sdk/videoanalyzer/video-analyzer-edge/review/**/*.md"
+    "sdk/storage/storage-file-share/review/**/*.md"
   ],
   "words": [
     "adfs",
@@ -126,6 +125,20 @@
         "azuresdkartifacts",
         "policheck",
         "gdnbaselines"
+      ]
+    },
+    {
+      "filename": "sdk/videoanalyzer/video-analyzer-edge/review/**/*.md",
+      "words": [
+        "Onvif",
+        "onvif",
+        "Grpc",
+        "Abgr",
+        "abgr",
+        "Argb",
+        "argb",
+        "Bgra",
+        "bgra"
       ]
     }
   ]

--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -214,8 +214,8 @@
         "udfs",
         "xmax",
         "xmin",
-        "ymax"
-        "ymin",
+        "ymax",
+        "ymin"
       ]
     }
   ]

--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -44,7 +44,6 @@
     "sdk/communication/communication-common/review/**/*.md",
     "sdk/containerregistry/container-registry/review/**/*.md",
     "sdk/core/core-amqp/review/**/*.md",
-    "sdk/formrecognizer/ai-form-recognizer/review/**/*.md",
     "sdk/iot/iot-modelsrepository/review/**/*.md"
   ],
   "words": [
@@ -97,6 +96,7 @@
     "uaecentral",
     "uksouth",
     "ukwest",
+    "Uncapitalize",
     "undelete",
     "Unencrypted",
     "unpartitioned",
@@ -221,6 +221,12 @@
         "tcbinfocertshash",
         "tcbinfocrlhash",
         "tcbinfohash"
+      ]
+    },
+    {
+      "filename": "sdk/formrecognizer/ai-form-recognizer/review/**/*.md",
+      "words": [
+        "WDLABCD"
       ]
     }
   ]

--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -51,8 +51,7 @@
     "sdk/identity/identity/review/**/*.md",
     "sdk/iot/iot-modelsrepository/review/**/*.md",
     "sdk/keyvault/keyvault-certificates/review/**/*.md",
-    "sdk/keyvault/keyvault-keys/review/**/*.md",
-    "sdk/monitor/monitor-query/review/**/*.md"
+    "sdk/keyvault/keyvault-keys/review/**/*.md"
   ],
   "words": [
     "adfs",
@@ -174,6 +173,12 @@
         "reranker",
         "lovins",
         "Rslp"
+      ]
+    },
+    {
+      "filename": "sdk/monitor/monitor-query/review/**/*.md",
+      "words": [
+        "fourty"
       ]
     }
   ]

--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -42,7 +42,6 @@
     "sdk/synapse/synapse-monitoring/review/*.md",
     "sdk/synapse/synapse-spark/review/*.md",
     "sdk/communication/communication-common/review/**/*.md",
-    "sdk/containerregistry/container-registry/review/**/*.md",
     "sdk/iot/iot-modelsrepository/review/**/*.md"
   ],
   "words": [
@@ -234,6 +233,15 @@
         "EHOSTDOWN",
         "ENONET",
         "sastoken"
+      ]
+    },
+    {
+      "filename": "sdk/containerregistry/container-registry/review/**/*.md",
+      "words": [
+        "illumos",
+        "Illumos",
+        "mipsle",
+        "riscv"
       ]
     }
   ]

--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -49,8 +49,7 @@
     "sdk/digitaltwins/digital-twins-core/review/**/*.md",
     "sdk/formrecognizer/ai-form-recognizer/review/**/*.md",
     "sdk/identity/identity/review/**/*.md",
-    "sdk/iot/iot-modelsrepository/review/**/*.md",
-    "sdk/keyvault/keyvault-certificates/review/**/*.md"
+    "sdk/iot/iot-modelsrepository/review/**/*.md"
   ],
   "words": [
     "adfs",
@@ -187,6 +186,15 @@
         "RSAHSM",
         "Rsnull",
         "RSNULL"
+      ]
+    },
+    {
+      "filename": "sdk/keyvault/keyvault-certificates/review/**/*.md",
+      "words": [
+        "upns",
+        "ECHSM",
+        "RSAHSM",
+        "ekus"
       ]
     }
   ]

--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -258,7 +258,7 @@
       ]
     },
     {
-      "filename": "sdk/monitor/monitor-query/reviewmonitor-query.api.md",
+      "filename": "sdk/monitor/monitor-query/review/monitor-query.api.md",
       "words": [
         "fourty"
       ]

--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -43,7 +43,6 @@
     "sdk/synapse/synapse-spark/review/*.md",
     "sdk/communication/communication-common/review/**/*.md",
     "sdk/containerregistry/container-registry/review/**/*.md",
-    "sdk/core/core-amqp/review/**/*.md",
     "sdk/iot/iot-modelsrepository/review/**/*.md"
   ],
   "words": [
@@ -227,6 +226,14 @@
       "filename": "sdk/formrecognizer/ai-form-recognizer/review/**/*.md",
       "words": [
         "WDLABCD"
+      ]
+    },
+    {
+      "filename": "sdk/core/core-amqp/review/**/*.md",
+      "words": [
+        "EHOSTDOWN",
+        "ENONET",
+        "sastoken"
       ]
     }
   ]

--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -45,7 +45,6 @@
     "sdk/communication/communication-common/review/**/*.md",
     "sdk/containerregistry/container-registry/review/**/*.md",
     "sdk/core/core-amqp/review/**/*.md",
-    "sdk/cosmosdb/cosmos/review/**/*.md",
     "sdk/formrecognizer/ai-form-recognizer/review/**/*.md",
     "sdk/iot/iot-modelsrepository/review/**/*.md"
   ],
@@ -201,6 +200,22 @@
       "words": [
         "dtdl",
         "dependecies"
+      ]
+    },
+    {
+      "filename": "sdk/cosmosdb/cosmos/review/**/*.md",
+      "words": [
+        "colls",
+        "Funtion",
+        "Parition",
+        "pkranges",
+        "sproc",
+        "sprocs",
+        "udfs",
+        "xmax",
+        "xmin",
+        "ymax"
+        "ymin",
       ]
     }
   ]


### PR DESCRIPTION
### Packages impacted by this PR
This PR is related to the cspell tool, and all of the changes are in `.vscode/cspell.json`.

### Issues associated with this PR
Series of issues regarding spelling errors found by cspell:
- https://github.com/Azure/azure-sdk-for-js/issues/18976
- https://github.com/Azure/azure-sdk-for-js/issues/18975
- https://github.com/Azure/azure-sdk-for-js/issues/18974
- https://github.com/Azure/azure-sdk-for-js/issues/18973
- https://github.com/Azure/azure-sdk-for-js/issues/18972
- https://github.com/Azure/azure-sdk-for-js/issues/18971
- https://github.com/Azure/azure-sdk-for-js/issues/18970
- https://github.com/Azure/azure-sdk-for-js/issues/18968
- https://github.com/Azure/azure-sdk-for-js/issues/18966
- https://github.com/Azure/azure-sdk-for-js/issues/18965
- https://github.com/Azure/azure-sdk-for-js/issues/18961
- https://github.com/Azure/azure-sdk-for-js/issues/18967
- https://github.com/Azure/azure-sdk-for-js/issues/18964
- https://github.com/Azure/azure-sdk-for-js/issues/18963
- https://github.com/Azure/azure-sdk-for-js/issues/18962
- https://github.com/Azure/azure-sdk-for-js/issues/18969

### Describe the problem that is addressed by this PR
Spell check scanning of packages listed above detected spelling errors in their public API surface. Many of those errors are false positives, which have been added to the `.vscode/cspell.json` file in order to ignore them. However, since all of those packages are already in GA, we cannot make changes to fix the actual spelling errors. For this reason, all of them have been listed in the file to be ignored as well.

To keep track of these actual errors, here is a table of them:
| Package | Spelling errors ignored|
| ----------- | ----------- |
| @azure/storage-blob | Uncommited |
| @azure/search-documents| Createor |
| @azure/monitor-query | fourty |
| @azure/digital-twins-core | dependecies |
| @azure/cosmos | Funtion |

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?

In this PR, I decided to use the `override` approach listed in the [Spell Checking the Azure SDK](https://github.com/Azure/azure-sdk-tools/blob/main/doc/common/spellcheck.md) guide. The main reason is because most of the false positives were specific words for the service or sdk, that are very likely to not be present in any other package. For example, the words "abgr","bgra", and "onvif" are specific video related terms.

 There were certain words with a broader meaning that are likely to be used in different packages, like "Unencrypted" or "Mibps". For these words, I added them under the main `words` dictionary.

Another reasons to have the words scoped to each file is to keep track of where they are being used, and to prevent the actual spelling errors from being ignored in other packages.

### Are there test cases added in this PR? _(If not, why?)_
Does not apply for this PR.

### Checklists
- [X] Added impacted package name to the issue description
- [X] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [X] Added a changelog (if necessary)
