### PR TITLE
[Container Registry] Make ContainerRegistryClientOptions extend from CommonClientOptions

### DIFF
--- a/sdk/containerregistry/container-registry/review/container-registry.api.md
+++ b/sdk/containerregistry/container-registry/review/container-registry.api.md
@@ -7,9 +7,9 @@
 /// <reference types="node" />
 /// <reference lib="esnext.asynciterable" />
 
+import { CommonClientOptions } from '@azure/core-client';
 import { OperationOptions } from '@azure/core-client';
 import { PagedAsyncIterableIterator } from '@azure/core-paging';
-import { PipelineOptions } from '@azure/core-rest-pipeline';
 import { TokenCredential } from '@azure/core-auth';
 
 // @public
@@ -69,7 +69,7 @@ export class ContainerRegistryClient {
 }
 
 // @public
-export interface ContainerRegistryClientOptions extends PipelineOptions {
+export interface ContainerRegistryClientOptions extends CommonClientOptions {
     audience?: string;
     serviceVersion?: "2021-07-01";
 }

--- a/sdk/containerregistry/container-registry/src/containerRegistryClient.ts
+++ b/sdk/containerregistry/container-registry/src/containerRegistryClient.ts
@@ -7,9 +7,8 @@ import { isTokenCredential, TokenCredential } from "@azure/core-auth";
 import {
   InternalPipelineOptions,
   bearerTokenAuthenticationPolicy,
-  PipelineOptions,
 } from "@azure/core-rest-pipeline";
-import { OperationOptions } from "@azure/core-client";
+import { CommonClientOptions, OperationOptions } from "@azure/core-client";
 
 import { SpanStatusCode } from "@azure/core-tracing";
 import "@azure/core-paging";
@@ -34,7 +33,7 @@ const LATEST_API_VERSION = "2021-07-01";
 /**
  * Client options used to configure Container Registry Repository API requests.
  */
-export interface ContainerRegistryClientOptions extends PipelineOptions {
+export interface ContainerRegistryClientOptions extends CommonClientOptions {
   /**
    * Gets or sets the audience to use for authentication with Azure Active Directory.
    * The authentication scope will be set from this audience.


### PR DESCRIPTION
### Packages impacted by this PR
- `@azure/container-registry`

### Issues associated with this PR
- Fixes #20275

### Describe the problem that is addressed by this PR

This PR makes the container registry client's ClientOptions extend from the correct interface.
