### PR TITLE
Exclude browser tests

### DIFF
--- a/sdk/tables/data-tables/package.json
+++ b/sdk/tables/data-tables/package.json
@@ -37,7 +37,7 @@
     "format": "prettier --write --config ../../../.prettierrc.json --ignore-path ../../../.prettierignore \"src/**/*.ts\" \"test/**/*.ts\" \"samples-dev/**/*.ts\" \"*.{js,json}\"",
     "generate:client": "autorest --typescript ./swagger/README.md",
     "integration-test:browser": "dev-tool run test:browser",
-    "integration-test:node": "dev-tool run test:node-js-input -- --timeout 5000000 'dist-esm/test/**/*.spec.js'",
+    "integration-test:node": "dev-tool run test:node-js-input -- --timeout 5000000 --exclude 'dist-esm/test/**/browser/*.spec.js' 'dist-esm/test/**/*.spec.js'",
     "integration-test": "npm run integration-test:node && npm run integration-test:browser",
     "lint:fix": "eslint package.json api-extractor.json src test --ext .ts --fix --fix-type [problem,suggestion]",
     "lint": "eslint package.json api-extractor.json src test --ext .ts",


### PR DESCRIPTION
### Packages impacted by this PR
@azure/data-tables

### Describe the problem that is addressed by this PR
Live tests are failing when running node in Windows. Dev-tool's browser filter doesn't seem to be picked up correctly by windows.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?
To mitigate the failure I'm adding an explicit exclude for browser tests in the integration-test:node command. On the side I'm investigating why the original filter in dev-tool doesn't work as expected

