### PR TITLE
[eventhubs] - pass an interface to BlobCheckpointStore's constructor

### DIFF
--- a/sdk/eventhub/eventhubs-checkpointstore-blob/.eslintrc.json
+++ b/sdk/eventhub/eventhubs-checkpointstore-blob/.eslintrc.json
@@ -1,0 +1,4 @@
+{
+  "plugins": ["@azure/azure-sdk"],
+  "extends": ["plugin:@azure/azure-sdk/azure-sdk-base"]
+}

--- a/sdk/eventhub/eventhubs-checkpointstore-blob/CHANGELOG.md
+++ b/sdk/eventhub/eventhubs-checkpointstore-blob/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.1.0-beta.1 (Unreleased)
 
 ### Features Added
+
 - With the dropping of support for Node.js versions that are no longer in LTS, the dependency on `@types/node` has been updated to version 12. Read our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 - Updates all async methods on `BlobCheckpointStore` to accept
   an optional `options` parameter that can be used to pass in an
@@ -12,6 +13,8 @@
 ### Breaking Changes
 
 ### Key Bugs Fixed
+
+- Fixed a bug where `ContainerClient` could not passed to `BlobCheckpointStore` if the `ContainerClient` was created by another version of `@azure/storage-blob`.
 
 ## 1.0.1 (2020-08-03)
 

--- a/sdk/eventhub/eventhubs-checkpointstore-blob/package.json
+++ b/sdk/eventhub/eventhubs-checkpointstore-blob/package.json
@@ -59,6 +59,7 @@
   },
   "dependencies": {
     "@azure/abort-controller": "^1.0.0",
+    "@azure/core-paging": "^1.2.0",
     "@azure/event-hubs": "^5.8.0-beta.1",
     "@azure/logger": "^1.0.0",
     "@azure/storage-blob": "^12.8.0",

--- a/sdk/eventhub/eventhubs-checkpointstore-blob/review/eventhubs-checkpointstore-blob.api.md
+++ b/sdk/eventhub/eventhubs-checkpointstore-blob/review/eventhubs-checkpointstore-blob.api.md
@@ -30,12 +30,19 @@ export class BlobCheckpointStore implements CheckpointStore {
 }
 
 // @public
+export interface BlobClientLike {
+    getBlockBlobClient(): BlockBlobClientLike;
+}
+
+// @public
+export interface BlockBlobClientLike {
+    setMetadata(metadata?: Metadata, options?: BlobSetMetadataOptions): Promise<ContainerSetMetadataResponse>;
+    upload(body: HttpRequestBody, contentLength: number, options?: BlockBlobUploadOptions): Promise<BlockBlobUploadResponse>;
+}
+
+// @public
 export interface ContainerClientLike {
-    // Warning: (ae-forgotten-export) The symbol "BlobClientLike" needs to be exported by the entry point index.d.ts
-    //
-    // (undocumented)
     getBlobClient(blobName: string): BlobClientLike;
-    // (undocumented)
     listBlobsFlat(options?: ContainerListBlobsOptions): PagedAsyncIterableIterator<BlobItem, ContainerListBlobFlatSegmentResponse>;
 }
 

--- a/sdk/eventhub/eventhubs-checkpointstore-blob/review/eventhubs-checkpointstore-blob.api.md
+++ b/sdk/eventhub/eventhubs-checkpointstore-blob/review/eventhubs-checkpointstore-blob.api.md
@@ -5,19 +5,38 @@
 ```ts
 
 import { AzureLogger } from '@azure/logger';
+import { BlobItem } from '@azure/storage-blob';
+import { BlobSetMetadataOptions } from '@azure/storage-blob';
+import { BlockBlobUploadOptions } from '@azure/storage-blob';
+import { BlockBlobUploadResponse } from '@azure/storage-blob';
 import { Checkpoint } from '@azure/event-hubs';
 import { CheckpointStore } from '@azure/event-hubs';
-import { ContainerClient } from '@azure/storage-blob';
+import { ContainerListBlobFlatSegmentResponse } from '@azure/storage-blob';
+import { ContainerListBlobsOptions } from '@azure/storage-blob';
+import { ContainerSetMetadataResponse } from '@azure/storage-blob';
+import { HttpRequestBody } from '@azure/storage-blob';
+import { Metadata } from '@azure/storage-blob';
 import { OperationOptions } from '@azure/event-hubs';
+import { PagedAsyncIterableIterator } from '@azure/core-paging';
 import { PartitionOwnership } from '@azure/event-hubs';
 
 // @public
 export class BlobCheckpointStore implements CheckpointStore {
-    constructor(containerClient: ContainerClient);
+    constructor(containerClient: ContainerClientLike);
     claimOwnership(partitionOwnership: PartitionOwnership[], options?: OperationOptions): Promise<PartitionOwnership[]>;
     listCheckpoints(fullyQualifiedNamespace: string, eventHubName: string, consumerGroup: string, options?: OperationOptions): Promise<Checkpoint[]>;
     listOwnership(fullyQualifiedNamespace: string, eventHubName: string, consumerGroup: string, options?: OperationOptions): Promise<PartitionOwnership[]>;
     updateCheckpoint(checkpoint: Checkpoint, options?: OperationOptions): Promise<void>;
+}
+
+// @public
+export interface ContainerClientLike {
+    // Warning: (ae-forgotten-export) The symbol "BlobClientLike" needs to be exported by the entry point index.d.ts
+    //
+    // (undocumented)
+    getBlobClient(blobName: string): BlobClientLike;
+    // (undocumented)
+    listBlobsFlat(options?: ContainerListBlobsOptions): PagedAsyncIterableIterator<BlobItem, ContainerListBlobFlatSegmentResponse>;
 }
 
 // @public

--- a/sdk/eventhub/eventhubs-checkpointstore-blob/src/blobCheckpointStore.ts
+++ b/sdk/eventhub/eventhubs-checkpointstore-blob/src/blobCheckpointStore.ts
@@ -18,6 +18,10 @@ import { throwTypeErrorIfParameterMissing } from "./util/error";
 export class BlobCheckpointStore implements CheckpointStore {
   private _containerClient: ContainerClientLike;
 
+  /**
+   * Constructs a new instance of {@link BlobCheckpointStore}
+   * @param containerClient - An instance of a storage blob ContainerClient.
+   */
   constructor(containerClient: ContainerClientLike) {
     this._containerClient = containerClient;
   }

--- a/sdk/eventhub/eventhubs-checkpointstore-blob/src/blobCheckpointStore.ts
+++ b/sdk/eventhub/eventhubs-checkpointstore-blob/src/blobCheckpointStore.ts
@@ -7,17 +7,18 @@ import {
   Checkpoint,
   OperationOptions,
 } from "@azure/event-hubs";
-import { ContainerClient, Metadata, RestError, BlobSetMetadataResponse } from "@azure/storage-blob";
+import { Metadata, RestError, BlobSetMetadataResponse } from "@azure/storage-blob";
 import { logger, logErrorStackTrace } from "./log";
+import { ContainerClientLike } from "./storageBlobInterfaces";
 import { throwTypeErrorIfParameterMissing } from "./util/error";
 
 /**
  * An implementation of CheckpointStore that uses Azure Blob Storage to persist checkpoint data.
  */
 export class BlobCheckpointStore implements CheckpointStore {
-  private _containerClient: ContainerClient;
+  private _containerClient: ContainerClientLike;
 
-  constructor(containerClient: ContainerClient) {
+  constructor(containerClient: ContainerClientLike) {
     this._containerClient = containerClient;
   }
   /**

--- a/sdk/eventhub/eventhubs-checkpointstore-blob/src/index.ts
+++ b/sdk/eventhub/eventhubs-checkpointstore-blob/src/index.ts
@@ -3,5 +3,5 @@
 /// <reference lib="esnext.asynciterable" />
 
 export { BlobCheckpointStore } from "./blobCheckpointStore";
-export { ContainerClientLike } from "./storageBlobInterfaces";
+export { ContainerClientLike, BlobClientLike, BlockBlobClientLike } from "./storageBlobInterfaces";
 export { logger } from "./log";

--- a/sdk/eventhub/eventhubs-checkpointstore-blob/src/index.ts
+++ b/sdk/eventhub/eventhubs-checkpointstore-blob/src/index.ts
@@ -3,4 +3,5 @@
 /// <reference lib="esnext.asynciterable" />
 
 export { BlobCheckpointStore } from "./blobCheckpointStore";
+export { ContainerClientLike } from "./storageBlobInterfaces";
 export { logger } from "./log";

--- a/sdk/eventhub/eventhubs-checkpointstore-blob/src/storageBlobInterfaces.ts
+++ b/sdk/eventhub/eventhubs-checkpointstore-blob/src/storageBlobInterfaces.ts
@@ -1,0 +1,47 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import {
+  Metadata,
+  BlobItem,
+  ContainerListBlobFlatSegmentResponse,
+  ContainerListBlobsOptions,
+  BlockBlobUploadOptions,
+  BlockBlobUploadResponse,
+  HttpRequestBody,
+  BlobSetMetadataOptions,
+  ContainerSetMetadataResponse,
+} from "@azure/storage-blob";
+import { PagedAsyncIterableIterator } from "@azure/core-paging";
+
+/**
+ * An interface compatible with Storage Blob's BlobClient class.
+ */
+export interface BlobClientLike {
+  getBlockBlobClient(): BlockBlobClientLike;
+}
+
+/**
+ * An interface compatible with Storage Blob's ContainerClient class.
+ */
+export interface ContainerClientLike {
+  getBlobClient(blobName: string): BlobClientLike;
+  listBlobsFlat(
+    options?: ContainerListBlobsOptions
+  ): PagedAsyncIterableIterator<BlobItem, ContainerListBlobFlatSegmentResponse>;
+}
+
+/**
+ * An interface compatible with Storage Blob's BlockBlobClient class.
+ */
+export interface BlockBlobClientLike {
+  upload(
+    body: HttpRequestBody,
+    contentLength: number,
+    options?: BlockBlobUploadOptions
+  ): Promise<BlockBlobUploadResponse>;
+  setMetadata(
+    metadata?: Metadata,
+    options?: BlobSetMetadataOptions
+  ): Promise<ContainerSetMetadataResponse>;
+}

--- a/sdk/eventhub/eventhubs-checkpointstore-blob/src/storageBlobInterfaces.ts
+++ b/sdk/eventhub/eventhubs-checkpointstore-blob/src/storageBlobInterfaces.ts
@@ -15,9 +15,12 @@ import {
 import { PagedAsyncIterableIterator } from "@azure/core-paging";
 
 /**
- * An interface compatible with Storage Blob's BlobClient class.
+ * An interface compatible with an instance of {@link BlobClient}.
  */
 export interface BlobClientLike {
+  /**
+   * Creates a BlockBlobClient object.
+   */
   getBlockBlobClient(): BlockBlobClientLike;
 }
 
@@ -25,7 +28,14 @@ export interface BlobClientLike {
  * An interface compatible with Storage Blob's ContainerClient class.
  */
 export interface ContainerClientLike {
+  /**
+   * Creates a {@link BlobClient}
+   */
   getBlobClient(blobName: string): BlobClientLike;
+  /**
+   * Returns an async iterable iterator to list all the blobs
+   * under the specified account.
+   */
   listBlobsFlat(
     options?: ContainerListBlobsOptions
   ): PagedAsyncIterableIterator<BlobItem, ContainerListBlobFlatSegmentResponse>;
@@ -35,11 +45,17 @@ export interface ContainerClientLike {
  * An interface compatible with Storage Blob's BlockBlobClient class.
  */
 export interface BlockBlobClientLike {
+  /**
+   * Creates a new block blob, or updated the content of an existing block blob.
+   */
   upload(
     body: HttpRequestBody,
     contentLength: number,
     options?: BlockBlobUploadOptions
   ): Promise<BlockBlobUploadResponse>;
+  /**
+   * Sets user-defined metadata for the specified blob as one or more name-value pairs.
+   */
   setMetadata(
     metadata?: Metadata,
     options?: BlobSetMetadataOptions


### PR DESCRIPTION
### Packages impacted by this PR
@azure/eventhubs-checkpointstore-blob

### Issues associated with this PR
Issue #13667

### Describe the problem that is addressed by this PR
Because:
- BlobCheckpointStore's constructor takes a class (ContainerClient) as an argument 
- That class is defined in @azure/storage-blob
- ContainerClient contains private members

You cannot pass what would otherwise be a compatible ContainerClient instance to
BlobCheckpointStore unless it is successfully deduped by NPM, even across minor
versions. 

This causes compatibility issues for anyone who upgrades storage-blob.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?
I tried to get clever with mapped types, but ran into a few situations (These examples probably have a lot of mistakes, it was hard to keep them all in-place):

```ts
// Doesn't work because `getBlobClient` returns a class with private members as
// well so we need to recursively map return values to Public
type Public<T> = Pick<T, keyof T>;
type ContainerClientLike = Public<ContainerClient>

// Doesn't work because of PagedAsyncIterableIterator...
// Type 'Public<PagedAsyncIterableIterator<BlobItem, ContainerListBlobFlatSegmentResponse, PageSettings>>' must have a '[Symbol.asyncIterator]()' method that returns an async iterator.
type Public<T> = {
  [P in keyof T]: T[P] extends (...args: infer Params) => infer ReturnValue
    ? (...args: Params) => Public<ReturnValue>
    : T[P];
};

// Doesn't work because TypeScript wants to narrow one of the nested functions
// as such:
/*
        Types of property 'isDone' are incompatible.
          Type '() => boolean' is not assignable to type '(() => false) | (() => true)'.
            Type '() => boolean' is not assignable to type '() => false'.
              Type 'boolean' is not assignable to type 'false'.ts(2345)
*/
type Public<T> = {
    [P in keyof T]: T[P] extends (...args: infer Params) => infer ReturnValue
      ? ReturnValue extends Promise<infer PReturnValue> // for promises we need to return a promise of the public shape
        ? (...args: Params) => Promise<Public<PReturnValue>>
        : (...args: Params) => Public<ReturnValue> // otherwise we reutnr the public shape
      : T[P]; // not a function, so just the public property
  };

// Even if I was to get past this, I'd also have to map the _parameters_ of every function...
```
At which point I gave up and just copied the minimal interface needed to support
our calls

### Are there test cases added in this PR? _(If not, why?)_
No, the existing test cases already cover assignability

### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [x] Added impacted package name to the issue description
- [x] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [x] Added a changelog (if necessary)
