### PR TITLE
[Event Grid] Headerless Matcher to not check the dynamic headers

### DIFF
--- a/sdk/eventgrid/eventgrid/test/public/eventGridClient.spec.ts
+++ b/sdk/eventgrid/eventgrid/test/public/eventGridClient.spec.ts
@@ -145,6 +145,7 @@ describe("EventGridPublisherClient", function (this: Suite) {
         "CloudEvent",
         "EVENT_GRID_CLOUD_EVENT_SCHEMA_API_KEY"
       ));
+      await recorder.setMatcher("HeaderlessMatcher");
     });
 
     afterEach(async function () {


### PR DESCRIPTION
Fixes https://github.com/azure/azure-sdk-for-js/issues/20343

```
[browser-tests]     #send (CloudEvent schema)
[browser-tests]       × sends a single event
[browser-tests]         Chrome Headless 93.0.4577.0 (Windows 10)
[browser-tests]       RestError: {"Message":"Unable to find a record for the request POST https://endpoint/api/events?api-version=2018-01-01\r\nHeader differences:\r\n    \u003CContent-Type\u003E values differ, request \u003Capplication/cloudevents-batch\u002Bjson; charset=utf-8\u003E, record \u003Capplication/cloudevents-batch\u002Bjson; charset=UTF-8\u003E\r\nBody differences:\r\n","Status":"NotFound"}
[browser-tests]           at handleErrorResponse$2 (../../core/core-client/src/deserializationPolicy.ts:254:15 <- dist-test/index.browser.js:18197:20)
[browser-tests]           at deserializeResponseBody$2 (../../core/core-client/src/deserializationPolicy.ts:166:4 <- dist-test/index.browser.js:18132:46)

```


```
// DIFF
request \u003Capplication/cloudevents-batch\u002Bjson; charset=utf-8\u003E, 
record \u003Capplication/cloudevents-batch\u002Bjson; charset=UTF-8\u003E
```

Headerless matcher doesn't match the headers in playback.
This should make the CI green.