### PR TITLE
update-readme.md-for-track1

### DIFF
--- a/sdk/advisor/arm-advisor/README.md
+++ b/sdk/advisor/arm-advisor/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for AdvisorManagementClient.
 
+> Please note, a newer package [@azure/arm-advisor](https://www.npmjs.com/package/@azure/arm-advisor) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge, and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/advisor/arm-advisor/README.md
+++ b/sdk/advisor/arm-advisor/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for AdvisorManagementClient.
 
-> ⚠️ This package @azure/arm-advisor with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
+> ⚠️ This package @azure/arm-advisor with versions lower than 3.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 3.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/advisor/arm-advisor/README.md
+++ b/sdk/advisor/arm-advisor/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for AdvisorManagementClient.
 
-> Please note, a newer package [@azure/arm-advisor](https://www.npmjs.com/package/@azure/arm-advisor) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-advisor with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/analysisservices/arm-analysisservices/README.md
+++ b/sdk/analysisservices/arm-analysisservices/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for AnalysisServicesManagementClient.
 
+> Please note, a newer package [@azure/arm-analysisservices](https://www.npmjs.com/package/@azure/arm-analysisservices) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/analysisservices/arm-analysisservices/README.md
+++ b/sdk/analysisservices/arm-analysisservices/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for AnalysisServicesManagementClient.
 
-> ⚠️ This package @azure/arm-analysisservices with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
+> ⚠️ This package @azure/arm-analysisservices with versions lower than 4.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 4.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/analysisservices/arm-analysisservices/README.md
+++ b/sdk/analysisservices/arm-analysisservices/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for AnalysisServicesManagementClient.
 
-> Please note, a newer package [@azure/arm-analysisservices](https://www.npmjs.com/package/@azure/arm-analysisservices) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-analysisservices with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/apimanagement/arm-apimanagement/README.md
+++ b/sdk/apimanagement/arm-apimanagement/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for ApiManagementClient.
 
-> Please note, a newer package [@azure/arm-apimanagement](https://www.npmjs.com/package/@azure/arm-apimanagement) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-apimanagement with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/apimanagement/arm-apimanagement/README.md
+++ b/sdk/apimanagement/arm-apimanagement/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for ApiManagementClient.
 
+> Please note, a newer package [@azure/arm-apimanagement](https://www.npmjs.com/package/@azure/arm-apimanagement) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/apimanagement/arm-apimanagement/README.md
+++ b/sdk/apimanagement/arm-apimanagement/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for ApiManagementClient.
 
-> ⚠️ This package @azure/arm-apimanagement with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
+> ⚠️ This package @azure/arm-apimanagement with versions lower than 8.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 8.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/appconfiguration/arm-appconfiguration/README.md
+++ b/sdk/appconfiguration/arm-appconfiguration/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for AppConfigurationManagementClient.
 
+> Please note, a newer package [@azure/arm-appconfiguration](https://www.npmjs.com/package/@azure/arm-appconfiguration) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/appconfiguration/arm-appconfiguration/README.md
+++ b/sdk/appconfiguration/arm-appconfiguration/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for AppConfigurationManagementClient.
 
-> ⚠️ This package @azure/arm-appconfiguration with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
+> ⚠️ This package @azure/arm-appconfiguration with versions lower than 3.0.0-beta.1 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 3.0.0-beta.1 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/appconfiguration/arm-appconfiguration/README.md
+++ b/sdk/appconfiguration/arm-appconfiguration/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for AppConfigurationManagementClient.
 
-> Please note, a newer package [@azure/arm-appconfiguration](https://www.npmjs.com/package/@azure/arm-appconfiguration) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-appconfiguration with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/applicationinsights/arm-appinsights/README.md
+++ b/sdk/applicationinsights/arm-appinsights/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for ApplicationInsightsManagementClient.
 
-> ⚠️ This package @azure/arm-appinsights with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
+> ⚠️ This package @azure/arm-appinsights with versions lower than 5.0.0-beta.1 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 5.0.0-beta.1 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/applicationinsights/arm-appinsights/README.md
+++ b/sdk/applicationinsights/arm-appinsights/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for ApplicationInsightsManagementClient.
 
-> Please note, a newer package [@azure/arm-appinsights](https://www.npmjs.com/package/@azure/arm-appinsights) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-appinsights with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/applicationinsights/arm-appinsights/README.md
+++ b/sdk/applicationinsights/arm-appinsights/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for ApplicationInsightsManagementClient.
 
+> Please note, a newer package [@azure/arm-appinsights](https://www.npmjs.com/package/@azure/arm-appinsights) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/appplatform/arm-appplatform/README.md
+++ b/sdk/appplatform/arm-appplatform/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for AppPlatformManagementClient.
 
-> Please note, a newer package [@azure/arm-appplatform](https://www.npmjs.com/package/@azure/arm-appplatform) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-appplatform with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/appplatform/arm-appplatform/README.md
+++ b/sdk/appplatform/arm-appplatform/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for AppPlatformManagementClient.
 
-> ⚠️ This package @azure/arm-appplatform with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
+> ⚠️ This package @azure/arm-appplatform with versions lower than 2.0.0-beta.1 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0-beta.1 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/appplatform/arm-appplatform/README.md
+++ b/sdk/appplatform/arm-appplatform/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for AppPlatformManagementClient.
 
+> Please note, a newer package [@azure/arm-appplatform](https://www.npmjs.com/package/@azure/arm-appplatform) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/appservice/arm-appservice-profile-2019-03-01-hybrid/README.md
+++ b/sdk/appservice/arm-appservice-profile-2019-03-01-hybrid/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for WebSiteManagementClient.
 
-> Please note, a newer package [@azure/arm-appservice-profile-2019-03-01-hybrid](https://www.npmjs.com/package/@azure/arm-appservice-profile-2019-03-01-hybrid) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-appservice-profile-2019-03-01-hybrid with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/appservice/arm-appservice-profile-2019-03-01-hybrid/README.md
+++ b/sdk/appservice/arm-appservice-profile-2019-03-01-hybrid/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for WebSiteManagementClient.
 
+> Please note, a newer package [@azure/arm-appservice-profile-2019-03-01-hybrid](https://www.npmjs.com/package/@azure/arm-appservice-profile-2019-03-01-hybrid) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
-- Latest versions of Safari, Chrome, Edge, and Firefox.
+- Latest versions of Safari, Chrome, Edge and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/appservice/arm-appservice-profile-2020-09-01-hybrid/README.md
+++ b/sdk/appservice/arm-appservice-profile-2020-09-01-hybrid/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for WebSiteManagementClient.
 
+> Please note, a newer package [@azure/arm-appservice-profile-2020-09-01-hybrid](https://www.npmjs.com/package/@azure/arm-appservice-profile-2020-09-01-hybrid) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
-- Latest versions of Safari, Chrome, Edge, and Firefox.
+- Latest versions of Safari, Chrome, Edge and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/appservice/arm-appservice-profile-2020-09-01-hybrid/README.md
+++ b/sdk/appservice/arm-appservice-profile-2020-09-01-hybrid/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for WebSiteManagementClient.
 
-> Please note, a newer package [@azure/arm-appservice-profile-2020-09-01-hybrid](https://www.npmjs.com/package/@azure/arm-appservice-profile-2020-09-01-hybrid) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-appservice-profile-2020-09-01-hybrid with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/appservice/arm-appservice/README.md
+++ b/sdk/appservice/arm-appservice/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for WebSiteManagementClient.
 
+> Please note, a newer package [@azure/arm-appservice](https://www.npmjs.com/package/@azure/arm-appservice) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/appservice/arm-appservice/README.md
+++ b/sdk/appservice/arm-appservice/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for WebSiteManagementClient.
 
-> Please note, a newer package [@azure/arm-appservice](https://www.npmjs.com/package/@azure/arm-appservice) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-appservice with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/appservice/arm-appservice/README.md
+++ b/sdk/appservice/arm-appservice/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for WebSiteManagementClient.
 
-> ⚠️ This package @azure/arm-appservice with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
+> ⚠️ This package @azure/arm-appservice with versions lower than 10.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 10.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/attestation/arm-attestation/README.md
+++ b/sdk/attestation/arm-attestation/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for AttestationManagementClient.
 
-> Please note, a newer package [@azure/arm-attestation](https://www.npmjs.com/package/@azure/arm-attestation) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-attestation with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/attestation/arm-attestation/README.md
+++ b/sdk/attestation/arm-attestation/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for AttestationManagementClient.
 
+> Please note, a newer package [@azure/arm-attestation](https://www.npmjs.com/package/@azure/arm-attestation) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge, and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/authorization/arm-authorization-profile-2019-03-01-hybrid/README.md
+++ b/sdk/authorization/arm-authorization-profile-2019-03-01-hybrid/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for AuthorizationManagementClient.
 
+> Please note, a newer package [@azure/arm-authorization-profile-2019-03-01-hybrid](https://www.npmjs.com/package/@azure/arm-authorization-profile-2019-03-01-hybrid) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge, and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/authorization/arm-authorization-profile-2019-03-01-hybrid/README.md
+++ b/sdk/authorization/arm-authorization-profile-2019-03-01-hybrid/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for AuthorizationManagementClient.
 
-> Please note, a newer package [@azure/arm-authorization-profile-2019-03-01-hybrid](https://www.npmjs.com/package/@azure/arm-authorization-profile-2019-03-01-hybrid) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-authorization-profile-2019-03-01-hybrid with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/authorization/arm-authorization-profile-2020-09-01-hybrid/README.md
+++ b/sdk/authorization/arm-authorization-profile-2020-09-01-hybrid/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for AuthorizationManagementClient.
 
+> Please note, a newer package [@azure/arm-authorization-profile-2020-09-01-hybrid](https://www.npmjs.com/package/@azure/arm-authorization-profile-2020-09-01-hybrid) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge, and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/authorization/arm-authorization-profile-2020-09-01-hybrid/README.md
+++ b/sdk/authorization/arm-authorization-profile-2020-09-01-hybrid/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for AuthorizationManagementClient.
 
-> Please note, a newer package [@azure/arm-authorization-profile-2020-09-01-hybrid](https://www.npmjs.com/package/@azure/arm-authorization-profile-2020-09-01-hybrid) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-authorization-profile-2020-09-01-hybrid with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/authorization/arm-authorization/README.md
+++ b/sdk/authorization/arm-authorization/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for AuthorizationManagementClient.
 
-> ⚠️ This package @azure/arm-authorization with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
+> ⚠️ This package @azure/arm-authorization with versions lower than 9.0.0-beta.1 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 9.0.0-beta.1 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/authorization/arm-authorization/README.md
+++ b/sdk/authorization/arm-authorization/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for AuthorizationManagementClient.
 
+> Please note, a newer package [@azure/arm-authorization](https://www.npmjs.com/package/@azure/arm-authorization) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge, and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/authorization/arm-authorization/README.md
+++ b/sdk/authorization/arm-authorization/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for AuthorizationManagementClient.
 
-> Please note, a newer package [@azure/arm-authorization](https://www.npmjs.com/package/@azure/arm-authorization) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-authorization with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/automation/arm-automation/README.md
+++ b/sdk/automation/arm-automation/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for AutomationClient.
 
-> Please note, a newer package [@azure/arm-automation](https://www.npmjs.com/package/@azure/arm-automation) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-automation with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/automation/arm-automation/README.md
+++ b/sdk/automation/arm-automation/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for AutomationClient.
 
-> ⚠️ This package @azure/arm-automation with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
+> ⚠️ This package @azure/arm-automation with versions lower than 10.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 10.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/automation/arm-automation/README.md
+++ b/sdk/automation/arm-automation/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for AutomationClient.
 
+> Please note, a newer package [@azure/arm-automation](https://www.npmjs.com/package/@azure/arm-automation) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge, and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/avs/arm-avs/README.md
+++ b/sdk/avs/arm-avs/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for AvsClient.
 
+> Please note, a newer package [@azure/arm-avs](https://www.npmjs.com/package/@azure/arm-avs) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
-- Latest versions of Safari, Chrome, Edge and Firefox.
+- Latest versions of Safari, Chrome, Edge, and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/avs/arm-avs/README.md
+++ b/sdk/avs/arm-avs/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for AvsClient.
 
-> ⚠️ This package @azure/arm-avs with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
+> ⚠️ This package @azure/arm-avs with versions lower than 3.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 3.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/avs/arm-avs/README.md
+++ b/sdk/avs/arm-avs/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for AvsClient.
 
-> Please note, a newer package [@azure/arm-avs](https://www.npmjs.com/package/@azure/arm-avs) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-avs with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/azurestack/arm-azurestack/README.md
+++ b/sdk/azurestack/arm-azurestack/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for AzureStackManagementClient.
 
-> ⚠️ This package @azure/arm-azurestack with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
+> ⚠️ This package @azure/arm-azurestack with versions lower than 3.0.0-beta.1 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 3.0.0-beta.1 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/azurestack/arm-azurestack/README.md
+++ b/sdk/azurestack/arm-azurestack/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for AzureStackManagementClient.
 
+> Please note, a newer package [@azure/arm-azurestack](https://www.npmjs.com/package/@azure/arm-azurestack) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge, and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/azurestack/arm-azurestack/README.md
+++ b/sdk/azurestack/arm-azurestack/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for AzureStackManagementClient.
 
-> Please note, a newer package [@azure/arm-azurestack](https://www.npmjs.com/package/@azure/arm-azurestack) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-azurestack with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/azurestackhci/arm-azurestackhci/README.md
+++ b/sdk/azurestackhci/arm-azurestackhci/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for AzureStackHCIClient.
 
-> Please note, a newer package [@azure/arm-azurestackhci](https://www.npmjs.com/package/@azure/arm-azurestackhci) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-azurestackhci with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/azurestackhci/arm-azurestackhci/README.md
+++ b/sdk/azurestackhci/arm-azurestackhci/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for AzureStackHCIClient.
 
+> Please note, a newer package [@azure/arm-azurestackhci](https://www.npmjs.com/package/@azure/arm-azurestackhci) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge, and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/batch/arm-batch/README.md
+++ b/sdk/batch/arm-batch/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for BatchManagementClient.
 
-> Please note, a newer package [@azure/arm-batch](https://www.npmjs.com/package/@azure/arm-batch) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-batch with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/batch/arm-batch/README.md
+++ b/sdk/batch/arm-batch/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for BatchManagementClient.
 
-> ⚠️ This package @azure/arm-batch with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
+> ⚠️ This package @azure/arm-batch with versions lower than 7.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 7.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/batch/arm-batch/README.md
+++ b/sdk/batch/arm-batch/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for BatchManagementClient.
 
+> Please note, a newer package [@azure/arm-batch](https://www.npmjs.com/package/@azure/arm-batch) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
-- Latest versions of Safari, Chrome, Edge and Firefox.
+- Latest versions of Safari, Chrome, Edge, and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/batchai/arm-batchai/README.md
+++ b/sdk/batchai/arm-batchai/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for BatchAIManagementClient.
 
-> Please note, a newer package [@azure/arm-batchai](https://www.npmjs.com/package/@azure/arm-batchai) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-batchai with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/batchai/arm-batchai/README.md
+++ b/sdk/batchai/arm-batchai/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for BatchAIManagementClient.
 
-> ⚠️ This package @azure/arm-batchai with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
+> ⚠️ This package @azure/arm-batchai with versions lower than 2.2.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.2.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/batchai/arm-batchai/README.md
+++ b/sdk/batchai/arm-batchai/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for BatchAIManagementClient.
 
+> Please note, a newer package [@azure/arm-batchai](https://www.npmjs.com/package/@azure/arm-batchai) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge, and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/billing/arm-billing/README.md
+++ b/sdk/billing/arm-billing/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for BillingManagementClient.
 
+> Please note, a newer package [@azure/arm-billing](https://www.npmjs.com/package/@azure/arm-billing) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge, and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/billing/arm-billing/README.md
+++ b/sdk/billing/arm-billing/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for BillingManagementClient.
 
-> ⚠️ This package @azure/arm-billing with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
+> ⚠️ This package @azure/arm-billing with versions lower than 4.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 4.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/billing/arm-billing/README.md
+++ b/sdk/billing/arm-billing/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for BillingManagementClient.
 
-> Please note, a newer package [@azure/arm-billing](https://www.npmjs.com/package/@azure/arm-billing) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-billing with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/botservice/arm-botservice/README.md
+++ b/sdk/botservice/arm-botservice/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for AzureBotService.
 
-> ⚠️ This package @azure/arm-botservice with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
+> ⚠️ This package @azure/arm-botservice with versions lower than 4.0.0-beta.1 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 4.0.0-beta.1 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/botservice/arm-botservice/README.md
+++ b/sdk/botservice/arm-botservice/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for AzureBotService.
 
-> Please note, a newer package [@azure/arm-botservice](https://www.npmjs.com/package/@azure/arm-botservice) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-botservice with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/botservice/arm-botservice/README.md
+++ b/sdk/botservice/arm-botservice/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for AzureBotService.
 
+> Please note, a newer package [@azure/arm-botservice](https://www.npmjs.com/package/@azure/arm-botservice) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
-- Latest versions of Safari, Chrome, Edge and Firefox.
+- Latest versions of Safari, Chrome, Edge, and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/cdn/arm-cdn/README.md
+++ b/sdk/cdn/arm-cdn/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for CdnManagementClient.
 
-> ⚠️ This package @azure/arm-cdn with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
+> ⚠️ This package @azure/arm-cdn with versions lower than 6.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 6.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/cdn/arm-cdn/README.md
+++ b/sdk/cdn/arm-cdn/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for CdnManagementClient.
 
-> Please note, a newer package [@azure/arm-cdn](https://www.npmjs.com/package/@azure/arm-cdn) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-cdn with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/cdn/arm-cdn/README.md
+++ b/sdk/cdn/arm-cdn/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for CdnManagementClient.
 
+> Please note, a newer package [@azure/arm-cdn](https://www.npmjs.com/package/@azure/arm-cdn) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge, and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/changeanalysis/arm-changeanalysis/README.md
+++ b/sdk/changeanalysis/arm-changeanalysis/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for AzureChangeAnalysisManagementClient.
 
-> Please note, a newer package [@azure/arm-changeanalysis](https://www.npmjs.com/package/@azure/arm-changeanalysis) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-changeanalysis with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/changeanalysis/arm-changeanalysis/README.md
+++ b/sdk/changeanalysis/arm-changeanalysis/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for AzureChangeAnalysisManagementClient.
 
+> Please note, a newer package [@azure/arm-changeanalysis](https://www.npmjs.com/package/@azure/arm-changeanalysis) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge, and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/cognitiveservices/arm-cognitiveservices/README.md
+++ b/sdk/cognitiveservices/arm-cognitiveservices/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for CognitiveServicesManagementClient.
 
-> Please note, a newer package [@azure/arm-cognitiveservices](https://www.npmjs.com/package/@azure/arm-cognitiveservices) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-cognitiveservices with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/cognitiveservices/arm-cognitiveservices/README.md
+++ b/sdk/cognitiveservices/arm-cognitiveservices/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for CognitiveServicesManagementClient.
 
-> ⚠️ This package @azure/arm-cognitiveservices with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
+> ⚠️ This package @azure/arm-cognitiveservices with versions lower than 7.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 7.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/cognitiveservices/arm-cognitiveservices/README.md
+++ b/sdk/cognitiveservices/arm-cognitiveservices/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for CognitiveServicesManagementClient.
 
+> Please note, a newer package [@azure/arm-cognitiveservices](https://www.npmjs.com/package/@azure/arm-cognitiveservices) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
-- Latest versions of Safari, Chrome, Edge and Firefox.
+- Latest versions of Safari, Chrome, Edge, and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/commerce/arm-commerce-profile-2020-09-01-hybrid/README.md
+++ b/sdk/commerce/arm-commerce-profile-2020-09-01-hybrid/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for UsageManagementClient.
 
-> Please note, a newer package [@azure/arm-commerce-profile-2020-09-01-hybrid](https://www.npmjs.com/package/@azure/arm-commerce-profile-2020-09-01-hybrid) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-commerce-profile-2020-09-01-hybrid with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/commerce/arm-commerce-profile-2020-09-01-hybrid/README.md
+++ b/sdk/commerce/arm-commerce-profile-2020-09-01-hybrid/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for UsageManagementClient.
 
+> Please note, a newer package [@azure/arm-commerce-profile-2020-09-01-hybrid](https://www.npmjs.com/package/@azure/arm-commerce-profile-2020-09-01-hybrid) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge, and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/commerce/arm-commerce/README.md
+++ b/sdk/commerce/arm-commerce/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for UsageManagementClient.
 
-> ⚠️ This package @azure/arm-commerce with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
+> ⚠️ This package @azure/arm-commerce with versions lower than 4.0.0-beta.1 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 4.0.0-beta.1 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/commerce/arm-commerce/README.md
+++ b/sdk/commerce/arm-commerce/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for UsageManagementClient.
 
+> Please note, a newer package [@azure/arm-commerce](https://www.npmjs.com/package/@azure/arm-commerce) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
-- Latest versions of Safari, Chrome, Edge and Firefox.
+- Latest versions of Safari, Chrome, Edge, and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/commerce/arm-commerce/README.md
+++ b/sdk/commerce/arm-commerce/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for UsageManagementClient.
 
-> Please note, a newer package [@azure/arm-commerce](https://www.npmjs.com/package/@azure/arm-commerce) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-commerce with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/communication/arm-communication/README.md
+++ b/sdk/communication/arm-communication/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for CommunicationServiceManagementClient.
 
-> Please note, a newer package [@azure/arm-communication](https://www.npmjs.com/package/@azure/arm-communication) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-communication with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/communication/arm-communication/README.md
+++ b/sdk/communication/arm-communication/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for CommunicationServiceManagementClient.
 
+> Please note, a newer package [@azure/arm-communication](https://www.npmjs.com/package/@azure/arm-communication) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge, and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/communication/arm-communication/README.md
+++ b/sdk/communication/arm-communication/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for CommunicationServiceManagementClient.
 
-> ⚠️ This package @azure/arm-communication with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
+> ⚠️ This package @azure/arm-communication with versions lower than 3.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 3.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/compute/arm-compute-profile-2019-03-01-hybrid/README.md
+++ b/sdk/compute/arm-compute-profile-2019-03-01-hybrid/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for ComputeManagementClient.
 
+> Please note, a newer package [@azure/arm-compute-profile-2019-03-01-hybrid](https://www.npmjs.com/package/@azure/arm-compute-profile-2019-03-01-hybrid) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge, and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/compute/arm-compute-profile-2019-03-01-hybrid/README.md
+++ b/sdk/compute/arm-compute-profile-2019-03-01-hybrid/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for ComputeManagementClient.
 
-> Please note, a newer package [@azure/arm-compute-profile-2019-03-01-hybrid](https://www.npmjs.com/package/@azure/arm-compute-profile-2019-03-01-hybrid) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-compute-profile-2019-03-01-hybrid with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/compute/arm-compute-profile-2020-09-01-hybrid/README.md
+++ b/sdk/compute/arm-compute-profile-2020-09-01-hybrid/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for ComputeManagementClient.
 
-> Please note, a newer package [@azure/arm-compute-profile-2020-09-01-hybrid](https://www.npmjs.com/package/@azure/arm-compute-profile-2020-09-01-hybrid) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-compute-profile-2020-09-01-hybrid with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/compute/arm-compute-profile-2020-09-01-hybrid/README.md
+++ b/sdk/compute/arm-compute-profile-2020-09-01-hybrid/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for ComputeManagementClient.
 
+> Please note, a newer package [@azure/arm-compute-profile-2020-09-01-hybrid](https://www.npmjs.com/package/@azure/arm-compute-profile-2020-09-01-hybrid) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge, and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/compute/arm-compute/README.md
+++ b/sdk/compute/arm-compute/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for ComputeManagementClient.
 
-> ⚠️ This package @azure/arm-compute with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
+> ⚠️ This package @azure/arm-compute with versions lower than 17.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 17.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/compute/arm-compute/README.md
+++ b/sdk/compute/arm-compute/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for ComputeManagementClient.
 
-> Please note, a newer package [@azure/arm-compute](https://www.npmjs.com/package/@azure/arm-compute) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-compute with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/compute/arm-compute/README.md
+++ b/sdk/compute/arm-compute/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for ComputeManagementClient.
 
+> Please note, a newer package [@azure/arm-compute](https://www.npmjs.com/package/@azure/arm-compute) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
-- Latest versions of Safari, Chrome, Edge and Firefox.
+- Latest versions of Safari, Chrome, Edge, and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/confluent/arm-confluent/README.md
+++ b/sdk/confluent/arm-confluent/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for ConfluentManagementClient.
 
+> Please note, a newer package [@azure/arm-confluent](https://www.npmjs.com/package/@azure/arm-confluent) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
-- Latest versions of Safari, Chrome, Edge and Firefox.
+- Latest versions of Safari, Chrome, Edge, and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/confluent/arm-confluent/README.md
+++ b/sdk/confluent/arm-confluent/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for ConfluentManagementClient.
 
-> Please note, a newer package [@azure/arm-confluent](https://www.npmjs.com/package/@azure/arm-confluent) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-confluent with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/confluent/arm-confluent/README.md
+++ b/sdk/confluent/arm-confluent/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for ConfluentManagementClient.
 
-> ⚠️ This package @azure/arm-confluent with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
+> ⚠️ This package @azure/arm-confluent with versions lower than 3.0.0-beta.1 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 3.0.0-beta.1 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/consumption/arm-consumption/README.md
+++ b/sdk/consumption/arm-consumption/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for ConsumptionManagementClient.
 
+> Please note, a newer package [@azure/arm-consumption](https://www.npmjs.com/package/@azure/arm-consumption) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
-- Latest versions of Safari, Chrome, Edge and Firefox.
+- Latest versions of Safari, Chrome, Edge, and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/consumption/arm-consumption/README.md
+++ b/sdk/consumption/arm-consumption/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for ConsumptionManagementClient.
 
-> Please note, a newer package [@azure/arm-consumption](https://www.npmjs.com/package/@azure/arm-consumption) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-consumption with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/consumption/arm-consumption/README.md
+++ b/sdk/consumption/arm-consumption/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for ConsumptionManagementClient.
 
-> ⚠️ This package @azure/arm-consumption with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
+> ⚠️ This package @azure/arm-consumption with versions lower than 9.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 9.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/containerinstance/arm-containerinstance/README.md
+++ b/sdk/containerinstance/arm-containerinstance/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for ContainerInstanceManagementClient.
 
-> Please note, a newer package [@azure/arm-containerinstance](https://www.npmjs.com/package/@azure/arm-containerinstance) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-containerinstance with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/containerinstance/arm-containerinstance/README.md
+++ b/sdk/containerinstance/arm-containerinstance/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for ContainerInstanceManagementClient.
 
+> Please note, a newer package [@azure/arm-containerinstance](https://www.npmjs.com/package/@azure/arm-containerinstance) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
-- Latest versions of Safari, Chrome, Edge and Firefox.
+- Latest versions of Safari, Chrome, Edge, and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/containerinstance/arm-containerinstance/README.md
+++ b/sdk/containerinstance/arm-containerinstance/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for ContainerInstanceManagementClient.
 
-> ⚠️ This package @azure/arm-containerinstance with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
+> ⚠️ This package @azure/arm-containerinstance with versions lower than 8.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 8.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/containerregistry/arm-containerregistry/README.md
+++ b/sdk/containerregistry/arm-containerregistry/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for ContainerRegistryManagementClient.
 
-> ⚠️ This package @azure/arm-containerregistry with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
+> ⚠️ This package @azure/arm-containerregistry with versions lower than 9.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 9.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/containerregistry/arm-containerregistry/README.md
+++ b/sdk/containerregistry/arm-containerregistry/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for ContainerRegistryManagementClient.
 
+> Please note, a newer package [@azure/arm-containerregistry](https://www.npmjs.com/package/@azure/arm-containerregistry) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
-- Latest versions of Safari, Chrome, Edge and Firefox.
+- Latest versions of Safari, Chrome, Edge, and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/containerregistry/arm-containerregistry/README.md
+++ b/sdk/containerregistry/arm-containerregistry/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for ContainerRegistryManagementClient.
 
-> Please note, a newer package [@azure/arm-containerregistry](https://www.npmjs.com/package/@azure/arm-containerregistry) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-containerregistry with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/containerservice/arm-containerservice/README.md
+++ b/sdk/containerservice/arm-containerservice/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for ContainerServiceClient.
 
-> ⚠️ This package @azure/arm-containerservice with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
+> ⚠️ This package @azure/arm-containerservice with versions lower than 15.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 15.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/containerservice/arm-containerservice/README.md
+++ b/sdk/containerservice/arm-containerservice/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for ContainerServiceClient.
 
-> Please note, a newer package [@azure/arm-containerservice](https://www.npmjs.com/package/@azure/arm-containerservice) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-containerservice with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/containerservice/arm-containerservice/README.md
+++ b/sdk/containerservice/arm-containerservice/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for ContainerServiceClient.
 
+> Please note, a newer package [@azure/arm-containerservice](https://www.npmjs.com/package/@azure/arm-containerservice) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
-- Latest versions of Safari, Chrome, Edge and Firefox.
+- Latest versions of Safari, Chrome, Edge, and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/cosmosdb/arm-cosmosdb/README.md
+++ b/sdk/cosmosdb/arm-cosmosdb/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for CosmosDBManagementClient.
 
+> Please note, a newer package [@azure/arm-cosmosdb](https://www.npmjs.com/package/@azure/arm-cosmosdb) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
-- Latest versions of Safari, Chrome, Edge and Firefox.
+- Latest versions of Safari, Chrome, Edge, and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/cosmosdb/arm-cosmosdb/README.md
+++ b/sdk/cosmosdb/arm-cosmosdb/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for CosmosDBManagementClient.
 
-> Please note, a newer package [@azure/arm-cosmosdb](https://www.npmjs.com/package/@azure/arm-cosmosdb) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-cosmosdb with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/cosmosdb/arm-cosmosdb/README.md
+++ b/sdk/cosmosdb/arm-cosmosdb/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for CosmosDBManagementClient.
 
-> ⚠️ This package @azure/arm-cosmosdb with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
+> ⚠️ This package @azure/arm-cosmosdb with versions lower than 15.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 15.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/customer-insights/arm-customerinsights/README.md
+++ b/sdk/customer-insights/arm-customerinsights/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for CustomerInsightsManagementClient.
 
-> ⚠️ This package @azure/arm-customerinsights with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
+> ⚠️ This package @azure/arm-customerinsights with versions lower than 4.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 4.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/customer-insights/arm-customerinsights/README.md
+++ b/sdk/customer-insights/arm-customerinsights/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for CustomerInsightsManagementClient.
 
-> Please note, a newer package [@azure/arm-customerinsights](https://www.npmjs.com/package/@azure/arm-customerinsights) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-customerinsights with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/customer-insights/arm-customerinsights/README.md
+++ b/sdk/customer-insights/arm-customerinsights/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for CustomerInsightsManagementClient.
 
+> Please note, a newer package [@azure/arm-customerinsights](https://www.npmjs.com/package/@azure/arm-customerinsights) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge, and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/databox/arm-databox/README.md
+++ b/sdk/databox/arm-databox/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for DataBoxManagementClient.
 
-> ⚠️ This package @azure/arm-databox with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
+> ⚠️ This package @azure/arm-databox with versions lower than 5.0.0-beta.1 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 5.0.0-beta.1 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/databox/arm-databox/README.md
+++ b/sdk/databox/arm-databox/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for DataBoxManagementClient.
 
-> Please note, a newer package [@azure/arm-databox](https://www.npmjs.com/package/@azure/arm-databox) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-databox with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/databox/arm-databox/README.md
+++ b/sdk/databox/arm-databox/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for DataBoxManagementClient.
 
+> Please note, a newer package [@azure/arm-databox](https://www.npmjs.com/package/@azure/arm-databox) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge, and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/databoxedge/arm-databoxedge-profile-2020-09-01-hybrid/README.md
+++ b/sdk/databoxedge/arm-databoxedge-profile-2020-09-01-hybrid/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for DataBoxEdgeManagementClient.
 
-> Please note, a newer package [@azure/arm-databoxedge-profile-2020-09-01-hybrid](https://www.npmjs.com/package/@azure/arm-databoxedge-profile-2020-09-01-hybrid) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-databoxedge-profile-2020-09-01-hybrid with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/databoxedge/arm-databoxedge-profile-2020-09-01-hybrid/README.md
+++ b/sdk/databoxedge/arm-databoxedge-profile-2020-09-01-hybrid/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for DataBoxEdgeManagementClient.
 
+> Please note, a newer package [@azure/arm-databoxedge-profile-2020-09-01-hybrid](https://www.npmjs.com/package/@azure/arm-databoxedge-profile-2020-09-01-hybrid) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge, and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/databoxedge/arm-databoxedge/README.md
+++ b/sdk/databoxedge/arm-databoxedge/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for DataBoxEdgeManagementClient.
 
+> Please note, a newer package [@azure/arm-databoxedge](https://www.npmjs.com/package/@azure/arm-databoxedge) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge, and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/databoxedge/arm-databoxedge/README.md
+++ b/sdk/databoxedge/arm-databoxedge/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for DataBoxEdgeManagementClient.
 
-> Please note, a newer package [@azure/arm-databoxedge](https://www.npmjs.com/package/@azure/arm-databoxedge) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-databoxedge with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/databricks/arm-databricks/README.md
+++ b/sdk/databricks/arm-databricks/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for AzureDatabricksManagementClient.
 
-> Please note, a newer package [@azure/arm-databricks](https://www.npmjs.com/package/@azure/arm-databricks) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-databricks with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/databricks/arm-databricks/README.md
+++ b/sdk/databricks/arm-databricks/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for AzureDatabricksManagementClient.
 
-> ⚠️ This package @azure/arm-databricks with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
+> ⚠️ This package @azure/arm-databricks with versions lower than 3.0.0-beta.1 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 3.0.0-beta.1 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/databricks/arm-databricks/README.md
+++ b/sdk/databricks/arm-databricks/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for AzureDatabricksManagementClient.
 
+> Please note, a newer package [@azure/arm-databricks](https://www.npmjs.com/package/@azure/arm-databricks) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
-- Latest versions of Safari, Chrome, Edge and Firefox.
+- Latest versions of Safari, Chrome, Edge, and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/datacatalog/arm-datacatalog/README.md
+++ b/sdk/datacatalog/arm-datacatalog/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for DataCatalogRestClient.
 
-> ⚠️ This package @azure/arm-datacatalog with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
+> ⚠️ This package @azure/arm-datacatalog with versions lower than 3.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 3.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/datacatalog/arm-datacatalog/README.md
+++ b/sdk/datacatalog/arm-datacatalog/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for DataCatalogRestClient.
 
+> Please note, a newer package [@azure/arm-datacatalog](https://www.npmjs.com/package/@azure/arm-datacatalog) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
-- Latest versions of Safari, Chrome, Edge and Firefox.
+- Latest versions of Safari, Chrome, Edge, and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/datacatalog/arm-datacatalog/README.md
+++ b/sdk/datacatalog/arm-datacatalog/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for DataCatalogRestClient.
 
-> Please note, a newer package [@azure/arm-datacatalog](https://www.npmjs.com/package/@azure/arm-datacatalog) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-datacatalog with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/datadog/arm-datadog/README.md
+++ b/sdk/datadog/arm-datadog/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for MicrosoftDatadogClient.
 
+> Please note, a newer package [@azure/arm-datadog](https://www.npmjs.com/package/@azure/arm-datadog) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge, and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/datadog/arm-datadog/README.md
+++ b/sdk/datadog/arm-datadog/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for MicrosoftDatadogClient.
 
-> ⚠️ This package @azure/arm-datadog with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
+> ⚠️ This package @azure/arm-datadog with versions lower than 3.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 3.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/datadog/arm-datadog/README.md
+++ b/sdk/datadog/arm-datadog/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for MicrosoftDatadogClient.
 
-> Please note, a newer package [@azure/arm-datadog](https://www.npmjs.com/package/@azure/arm-datadog) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-datadog with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/datafactory/arm-datafactory/README.md
+++ b/sdk/datafactory/arm-datafactory/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for DataFactoryManagementClient.
 
-> ⚠️ This package @azure/arm-datafactory with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
+> ⚠️ This package @azure/arm-datafactory with versions lower than 10.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 10.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/datafactory/arm-datafactory/README.md
+++ b/sdk/datafactory/arm-datafactory/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for DataFactoryManagementClient.
 
-> Please note, a newer package [@azure/arm-datafactory](https://www.npmjs.com/package/@azure/arm-datafactory) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-datafactory with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/datafactory/arm-datafactory/README.md
+++ b/sdk/datafactory/arm-datafactory/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for DataFactoryManagementClient.
 
+> Please note, a newer package [@azure/arm-datafactory](https://www.npmjs.com/package/@azure/arm-datafactory) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
-- Latest versions of Safari, Chrome, Edge and Firefox.
+- Latest versions of Safari, Chrome, Edge, and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/datalake-analytics/arm-datalake-analytics/README.md
+++ b/sdk/datalake-analytics/arm-datalake-analytics/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for DataLakeAnalyticsAccountManagementClient.
 
-> Please note, a newer package [@azure/arm-datalake-analytics](https://www.npmjs.com/package/@azure/arm-datalake-analytics) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-datalake-analytics with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/datalake-analytics/arm-datalake-analytics/README.md
+++ b/sdk/datalake-analytics/arm-datalake-analytics/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for DataLakeAnalyticsAccountManagementClient.
 
-> ⚠️ This package @azure/arm-datalake-analytics with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
+> ⚠️ This package @azure/arm-datalake-analytics with versions lower than 2.0.0-beta.1 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0-beta.1 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/datalake-analytics/arm-datalake-analytics/README.md
+++ b/sdk/datalake-analytics/arm-datalake-analytics/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for DataLakeAnalyticsAccountManagementClient.
 
+> Please note, a newer package [@azure/arm-datalake-analytics](https://www.npmjs.com/package/@azure/arm-datalake-analytics) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge, and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/datamigration/arm-datamigration/README.md
+++ b/sdk/datamigration/arm-datamigration/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for DataMigrationServiceClient.
 
+> Please note, a newer package [@azure/arm-datamigration](https://www.npmjs.com/package/@azure/arm-datamigration) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge, and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/datamigration/arm-datamigration/README.md
+++ b/sdk/datamigration/arm-datamigration/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for DataMigrationServiceClient.
 
-> Please note, a newer package [@azure/arm-datamigration](https://www.npmjs.com/package/@azure/arm-datamigration) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-datamigration with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/datamigration/arm-datamigration/README.md
+++ b/sdk/datamigration/arm-datamigration/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for DataMigrationServiceClient.
 
-> ⚠️ This package @azure/arm-datamigration with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
+> ⚠️ This package @azure/arm-datamigration with versions lower than 3.0.0-beta.1 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 3.0.0-beta.1 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/deploymentmanager/arm-deploymentmanager/README.md
+++ b/sdk/deploymentmanager/arm-deploymentmanager/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for AzureDeploymentManager.
 
+> Please note, a newer package [@azure/arm-deploymentmanager](https://www.npmjs.com/package/@azure/arm-deploymentmanager) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge, and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/deploymentmanager/arm-deploymentmanager/README.md
+++ b/sdk/deploymentmanager/arm-deploymentmanager/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for AzureDeploymentManager.
 
-> Please note, a newer package [@azure/arm-deploymentmanager](https://www.npmjs.com/package/@azure/arm-deploymentmanager) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-deploymentmanager with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/deploymentmanager/arm-deploymentmanager/README.md
+++ b/sdk/deploymentmanager/arm-deploymentmanager/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for AzureDeploymentManager.
 
-> ⚠️ This package @azure/arm-deploymentmanager with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
+> ⚠️ This package @azure/arm-deploymentmanager with versions lower than 4.0.0-beta.1 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 4.0.0-beta.1 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/deviceprovisioningservices/arm-deviceprovisioningservices/README.md
+++ b/sdk/deviceprovisioningservices/arm-deviceprovisioningservices/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for IotDpsClient.
 
+> Please note, a newer package [@azure/arm-deviceprovisioningservices](https://www.npmjs.com/package/@azure/arm-deviceprovisioningservices) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
-- Latest versions of Safari, Chrome, Edge and Firefox.
+- Latest versions of Safari, Chrome, Edge, and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/deviceprovisioningservices/arm-deviceprovisioningservices/README.md
+++ b/sdk/deviceprovisioningservices/arm-deviceprovisioningservices/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for IotDpsClient.
 
-> Please note, a newer package [@azure/arm-deviceprovisioningservices](https://www.npmjs.com/package/@azure/arm-deviceprovisioningservices) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-deviceprovisioningservices with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/deviceprovisioningservices/arm-deviceprovisioningservices/README.md
+++ b/sdk/deviceprovisioningservices/arm-deviceprovisioningservices/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for IotDpsClient.
 
-> ⚠️ This package @azure/arm-deviceprovisioningservices with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
+> ⚠️ This package @azure/arm-deviceprovisioningservices with versions lower than 4.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 4.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/devspaces/arm-devspaces/README.md
+++ b/sdk/devspaces/arm-devspaces/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for DevSpacesManagementClient.
 
+> Please note, a newer package [@azure/arm-devspaces](https://www.npmjs.com/package/@azure/arm-devspaces) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge, and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/devspaces/arm-devspaces/README.md
+++ b/sdk/devspaces/arm-devspaces/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for DevSpacesManagementClient.
 
-> Please note, a newer package [@azure/arm-devspaces](https://www.npmjs.com/package/@azure/arm-devspaces) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-devspaces with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/devtestlabs/arm-devtestlabs/README.md
+++ b/sdk/devtestlabs/arm-devtestlabs/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for DevTestLabsClient.
 
-> ⚠️ This package @azure/arm-devtestlabs with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
+> ⚠️ This package @azure/arm-devtestlabs with versions lower than 4.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 4.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/devtestlabs/arm-devtestlabs/README.md
+++ b/sdk/devtestlabs/arm-devtestlabs/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for DevTestLabsClient.
 
-> Please note, a newer package [@azure/arm-devtestlabs](https://www.npmjs.com/package/@azure/arm-devtestlabs) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-devtestlabs with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/devtestlabs/arm-devtestlabs/README.md
+++ b/sdk/devtestlabs/arm-devtestlabs/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for DevTestLabsClient.
 
+> Please note, a newer package [@azure/arm-devtestlabs](https://www.npmjs.com/package/@azure/arm-devtestlabs) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge, and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/digitaltwins/arm-digitaltwins/README.md
+++ b/sdk/digitaltwins/arm-digitaltwins/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for AzureDigitalTwinsManagementClient.
 
-> ⚠️ This package @azure/arm-digitaltwins with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
+> ⚠️ This package @azure/arm-digitaltwins with versions lower than 3.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 3.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/digitaltwins/arm-digitaltwins/README.md
+++ b/sdk/digitaltwins/arm-digitaltwins/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for AzureDigitalTwinsManagementClient.
 
+> Please note, a newer package [@azure/arm-digitaltwins](https://www.npmjs.com/package/@azure/arm-digitaltwins) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge, and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/digitaltwins/arm-digitaltwins/README.md
+++ b/sdk/digitaltwins/arm-digitaltwins/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for AzureDigitalTwinsManagementClient.
 
-> Please note, a newer package [@azure/arm-digitaltwins](https://www.npmjs.com/package/@azure/arm-digitaltwins) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-digitaltwins with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/dns/arm-dns-profile-2019-03-01-hybrid/README.md
+++ b/sdk/dns/arm-dns-profile-2019-03-01-hybrid/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for DnsManagementClient.
 
+> Please note, a newer package [@azure/arm-dns-profile-2019-03-01-hybrid](https://www.npmjs.com/package/@azure/arm-dns-profile-2019-03-01-hybrid) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge, and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/dns/arm-dns-profile-2019-03-01-hybrid/README.md
+++ b/sdk/dns/arm-dns-profile-2019-03-01-hybrid/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for DnsManagementClient.
 
-> Please note, a newer package [@azure/arm-dns-profile-2019-03-01-hybrid](https://www.npmjs.com/package/@azure/arm-dns-profile-2019-03-01-hybrid) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-dns-profile-2019-03-01-hybrid with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/dns/arm-dns-profile-2020-09-01-hybrid/README.md
+++ b/sdk/dns/arm-dns-profile-2020-09-01-hybrid/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for DnsManagementClient.
 
+> Please note, a newer package [@azure/arm-dns-profile-2020-09-01-hybrid](https://www.npmjs.com/package/@azure/arm-dns-profile-2020-09-01-hybrid) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge, and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/dns/arm-dns-profile-2020-09-01-hybrid/README.md
+++ b/sdk/dns/arm-dns-profile-2020-09-01-hybrid/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for DnsManagementClient.
 
-> Please note, a newer package [@azure/arm-dns-profile-2020-09-01-hybrid](https://www.npmjs.com/package/@azure/arm-dns-profile-2020-09-01-hybrid) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-dns-profile-2020-09-01-hybrid with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/dns/arm-dns/README.md
+++ b/sdk/dns/arm-dns/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for DnsManagementClient.
 
-> Please note, a newer package [@azure/arm-dns](https://www.npmjs.com/package/@azure/arm-dns) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-dns with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/dns/arm-dns/README.md
+++ b/sdk/dns/arm-dns/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for DnsManagementClient.
 
+> Please note, a newer package [@azure/arm-dns](https://www.npmjs.com/package/@azure/arm-dns) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge, and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/dns/arm-dns/README.md
+++ b/sdk/dns/arm-dns/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for DnsManagementClient.
 
-> ⚠️ This package @azure/arm-dns with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
+> ⚠️ This package @azure/arm-dns with versions lower than 5.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 5.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/domainservices/arm-domainservices/README.md
+++ b/sdk/domainservices/arm-domainservices/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for DomainservicesManagementClient.
 
-> ⚠️ This package @azure/arm-domainservices with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
+> ⚠️ This package @azure/arm-domainservices with versions lower than 4.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 4.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/domainservices/arm-domainservices/README.md
+++ b/sdk/domainservices/arm-domainservices/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for DomainservicesManagementClient.
 
-> Please note, a newer package [@azure/arm-domainservices](https://www.npmjs.com/package/@azure/arm-domainservices) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-domainservices with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/domainservices/arm-domainservices/README.md
+++ b/sdk/domainservices/arm-domainservices/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for DomainservicesManagementClient.
 
+> Please note, a newer package [@azure/arm-domainservices](https://www.npmjs.com/package/@azure/arm-domainservices) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge, and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/edgegateway/arm-edgegateway/README.md
+++ b/sdk/edgegateway/arm-edgegateway/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for DataBoxEdgeManagementClient.
 
+> Please note, a newer package [@azure/arm-edgegateway](https://www.npmjs.com/package/@azure/arm-edgegateway) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge, and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/edgegateway/arm-edgegateway/README.md
+++ b/sdk/edgegateway/arm-edgegateway/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for DataBoxEdgeManagementClient.
 
-> Please note, a newer package [@azure/arm-edgegateway](https://www.npmjs.com/package/@azure/arm-edgegateway) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-edgegateway with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/eventgrid/arm-eventgrid/README.md
+++ b/sdk/eventgrid/arm-eventgrid/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for EventGridManagementClient.
 
-> Please note, a newer package [@azure/arm-eventgrid](https://www.npmjs.com/package/@azure/arm-eventgrid) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-eventgrid with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/eventgrid/arm-eventgrid/README.md
+++ b/sdk/eventgrid/arm-eventgrid/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for EventGridManagementClient.
 
+> Please note, a newer package [@azure/arm-eventgrid](https://www.npmjs.com/package/@azure/arm-eventgrid) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
-- Latest versions of Safari, Chrome, Edge and Firefox.
+- Latest versions of Safari, Chrome, Edge, and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/eventgrid/arm-eventgrid/README.md
+++ b/sdk/eventgrid/arm-eventgrid/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for EventGridManagementClient.
 
-> ⚠️ This package @azure/arm-eventgrid with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
+> ⚠️ This package @azure/arm-eventgrid with versions lower than 13.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 13.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/eventhub/arm-eventhub-profile-2020-09-01-hybrid/README.md
+++ b/sdk/eventhub/arm-eventhub-profile-2020-09-01-hybrid/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for EventHubManagementClient.
 
+> Please note, a newer package [@azure/arm-eventhub-profile-2020-09-01-hybrid](https://www.npmjs.com/package/@azure/arm-eventhub-profile-2020-09-01-hybrid) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge, and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/eventhub/arm-eventhub-profile-2020-09-01-hybrid/README.md
+++ b/sdk/eventhub/arm-eventhub-profile-2020-09-01-hybrid/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for EventHubManagementClient.
 
-> Please note, a newer package [@azure/arm-eventhub-profile-2020-09-01-hybrid](https://www.npmjs.com/package/@azure/arm-eventhub-profile-2020-09-01-hybrid) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-eventhub-profile-2020-09-01-hybrid with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/eventhub/arm-eventhub/README.md
+++ b/sdk/eventhub/arm-eventhub/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for EventHubManagementClient.
 
+> Please note, a newer package [@azure/arm-eventhub](https://www.npmjs.com/package/@azure/arm-eventhub) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
-- Latest versions of Safari, Chrome, Edge and Firefox.
+- Latest versions of Safari, Chrome, Edge, and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/eventhub/arm-eventhub/README.md
+++ b/sdk/eventhub/arm-eventhub/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for EventHubManagementClient.
 
-> Please note, a newer package [@azure/arm-eventhub](https://www.npmjs.com/package/@azure/arm-eventhub) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-eventhub with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/eventhub/arm-eventhub/README.md
+++ b/sdk/eventhub/arm-eventhub/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for EventHubManagementClient.
 
-> ⚠️ This package @azure/arm-eventhub with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
+> ⚠️ This package @azure/arm-eventhub with versions lower than 5.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 5.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/features/arm-features/README.md
+++ b/sdk/features/arm-features/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for FeatureClient.
 
-> ⚠️ This package @azure/arm-features with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
+> ⚠️ This package @azure/arm-features with versions lower than 3.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 3.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/features/arm-features/README.md
+++ b/sdk/features/arm-features/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for FeatureClient.
 
+> Please note, a newer package [@azure/arm-features](https://www.npmjs.com/package/@azure/arm-features) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
-- Latest versions of Safari, Chrome, Edge and Firefox.
+- Latest versions of Safari, Chrome, Edge, and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/features/arm-features/README.md
+++ b/sdk/features/arm-features/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for FeatureClient.
 
-> Please note, a newer package [@azure/arm-features](https://www.npmjs.com/package/@azure/arm-features) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-features with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/frontdoor/arm-frontdoor/README.md
+++ b/sdk/frontdoor/arm-frontdoor/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for FrontDoorManagementClient.
 
-> ⚠️ This package @azure/arm-frontdoor with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
+> ⚠️ This package @azure/arm-frontdoor with versions lower than 5.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 5.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/frontdoor/arm-frontdoor/README.md
+++ b/sdk/frontdoor/arm-frontdoor/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for FrontDoorManagementClient.
 
+> Please note, a newer package [@azure/arm-frontdoor](https://www.npmjs.com/package/@azure/arm-frontdoor) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge, and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/frontdoor/arm-frontdoor/README.md
+++ b/sdk/frontdoor/arm-frontdoor/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for FrontDoorManagementClient.
 
-> Please note, a newer package [@azure/arm-frontdoor](https://www.npmjs.com/package/@azure/arm-frontdoor) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-frontdoor with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/hanaonazure/arm-hanaonazure/README.md
+++ b/sdk/hanaonazure/arm-hanaonazure/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for HanaManagementClient.
 
+> Please note, a newer package [@azure/arm-hanaonazure](https://www.npmjs.com/package/@azure/arm-hanaonazure) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge, and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/hanaonazure/arm-hanaonazure/README.md
+++ b/sdk/hanaonazure/arm-hanaonazure/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for HanaManagementClient.
 
-> Please note, a newer package [@azure/arm-hanaonazure](https://www.npmjs.com/package/@azure/arm-hanaonazure) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-hanaonazure with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/hanaonazure/arm-hanaonazure/README.md
+++ b/sdk/hanaonazure/arm-hanaonazure/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for HanaManagementClient.
 
-> ⚠️ This package @azure/arm-hanaonazure with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
+> ⚠️ This package @azure/arm-hanaonazure with versions lower than 4.0.0-beta.1 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 4.0.0-beta.1 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/hdinsight/arm-hdinsight/README.md
+++ b/sdk/hdinsight/arm-hdinsight/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for HDInsightManagementClient.
 
-> Please note, a newer package [@azure/arm-hdinsight](https://www.npmjs.com/package/@azure/arm-hdinsight) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-hdinsight with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/hdinsight/arm-hdinsight/README.md
+++ b/sdk/hdinsight/arm-hdinsight/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for HDInsightManagementClient.
 
+> Please note, a newer package [@azure/arm-hdinsight](https://www.npmjs.com/package/@azure/arm-hdinsight) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
-- Latest versions of Safari, Chrome, Edge and Firefox.
+- Latest versions of Safari, Chrome, Edge, and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/hdinsight/arm-hdinsight/README.md
+++ b/sdk/hdinsight/arm-hdinsight/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for HDInsightManagementClient.
 
-> ⚠️ This package @azure/arm-hdinsight with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
+> ⚠️ This package @azure/arm-hdinsight with versions lower than 1.1.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 1.1.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/healthbot/arm-healthbot/README.md
+++ b/sdk/healthbot/arm-healthbot/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for HealthbotClient.
 
+> Please note, a newer package [@azure/arm-healthbot](https://www.npmjs.com/package/@azure/arm-healthbot) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge, and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/healthbot/arm-healthbot/README.md
+++ b/sdk/healthbot/arm-healthbot/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for HealthbotClient.
 
-> Please note, a newer package [@azure/arm-healthbot](https://www.npmjs.com/package/@azure/arm-healthbot) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-healthbot with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/healthcareapis/arm-healthcareapis/README.md
+++ b/sdk/healthcareapis/arm-healthcareapis/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for HealthcareApisManagementClient.
 
-> Please note, a newer package [@azure/arm-healthcareapis](https://www.npmjs.com/package/@azure/arm-healthcareapis) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-healthcareapis with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/healthcareapis/arm-healthcareapis/README.md
+++ b/sdk/healthcareapis/arm-healthcareapis/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for HealthcareApisManagementClient.
 
+> Please note, a newer package [@azure/arm-healthcareapis](https://www.npmjs.com/package/@azure/arm-healthcareapis) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge, and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/hybridcompute/arm-hybridcompute/README.md
+++ b/sdk/hybridcompute/arm-hybridcompute/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for HybridComputeManagementClient.
 
+> Please note, a newer package [@azure/arm-hybridcompute](https://www.npmjs.com/package/@azure/arm-hybridcompute) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge, and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/hybridcompute/arm-hybridcompute/README.md
+++ b/sdk/hybridcompute/arm-hybridcompute/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for HybridComputeManagementClient.
 
-> Please note, a newer package [@azure/arm-hybridcompute](https://www.npmjs.com/package/@azure/arm-hybridcompute) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-hybridcompute with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/hybridcompute/arm-hybridcompute/README.md
+++ b/sdk/hybridcompute/arm-hybridcompute/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for HybridComputeManagementClient.
 
-> ⚠️ This package @azure/arm-hybridcompute with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
+> ⚠️ This package @azure/arm-hybridcompute with versions lower than 3.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 3.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/hybridkubernetes/arm-hybridkubernetes/README.md
+++ b/sdk/hybridkubernetes/arm-hybridkubernetes/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for ConnectedKubernetesClient.
 
+> Please note, a newer package [@azure/arm-hybridkubernetes](https://www.npmjs.com/package/@azure/arm-hybridkubernetes) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
-- Latest versions of Safari, Chrome, Edge and Firefox.
+- Latest versions of Safari, Chrome, Edge, and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/hybridkubernetes/arm-hybridkubernetes/README.md
+++ b/sdk/hybridkubernetes/arm-hybridkubernetes/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for ConnectedKubernetesClient.
 
-> Please note, a newer package [@azure/arm-hybridkubernetes](https://www.npmjs.com/package/@azure/arm-hybridkubernetes) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-hybridkubernetes with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/iotcentral/arm-iotcentral/README.md
+++ b/sdk/iotcentral/arm-iotcentral/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for IotCentralClient.
 
+> Please note, a newer package [@azure/arm-iotcentral](https://www.npmjs.com/package/@azure/arm-iotcentral) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
-- Latest versions of Safari, Chrome, Edge and Firefox.
+- Latest versions of Safari, Chrome, Edge, and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/iotcentral/arm-iotcentral/README.md
+++ b/sdk/iotcentral/arm-iotcentral/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for IotCentralClient.
 
-> ⚠️ This package @azure/arm-iotcentral with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
+> ⚠️ This package @azure/arm-iotcentral with versions lower than 6.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 6.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/iotcentral/arm-iotcentral/README.md
+++ b/sdk/iotcentral/arm-iotcentral/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for IotCentralClient.
 
-> Please note, a newer package [@azure/arm-iotcentral](https://www.npmjs.com/package/@azure/arm-iotcentral) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-iotcentral with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/iothub/arm-iothub-profile-2020-09-01-hybrid/README.md
+++ b/sdk/iothub/arm-iothub-profile-2020-09-01-hybrid/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for IotHubClient.
 
-> Please note, a newer package [@azure/arm-iothub-profile-2020-09-01-hybrid](https://www.npmjs.com/package/@azure/arm-iothub-profile-2020-09-01-hybrid) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-iothub-profile-2020-09-01-hybrid with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/iothub/arm-iothub-profile-2020-09-01-hybrid/README.md
+++ b/sdk/iothub/arm-iothub-profile-2020-09-01-hybrid/README.md
@@ -2,11 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for IotHubClient.
 
+> Please note, a newer package [@azure/arm-iothub-profile-2020-09-01-hybrid](https://www.npmjs.com/package/@azure/arm-iothub-profile-2020-09-01-hybrid) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge, and Firefox.
 
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 ### Prerequisites
 
 You must have an [Azure subscription](https://azure.microsoft.com/free/).

--- a/sdk/iothub/arm-iothub/README.md
+++ b/sdk/iothub/arm-iothub/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for IotHubClient.
 
+> Please note, a newer package [@azure/arm-iothub](https://www.npmjs.com/package/@azure/arm-iothub) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge, and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/iothub/arm-iothub/README.md
+++ b/sdk/iothub/arm-iothub/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for IotHubClient.
 
-> Please note, a newer package [@azure/arm-iothub](https://www.npmjs.com/package/@azure/arm-iothub) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-iothub with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/iothub/arm-iothub/README.md
+++ b/sdk/iothub/arm-iothub/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for IotHubClient.
 
-> ⚠️ This package @azure/arm-iothub with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
+> ⚠️ This package @azure/arm-iothub with versions lower than 6.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 6.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/iotspaces/arm-iotspaces/README.md
+++ b/sdk/iotspaces/arm-iotspaces/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for IoTSpacesClient.
 
+> Please note, a newer package [@azure/arm-iotspaces](https://www.npmjs.com/package/@azure/arm-iotspaces) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge, and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/iotspaces/arm-iotspaces/README.md
+++ b/sdk/iotspaces/arm-iotspaces/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for IoTSpacesClient.
 
-> Please note, a newer package [@azure/arm-iotspaces](https://www.npmjs.com/package/@azure/arm-iotspaces) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-iotspaces with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/iotspaces/arm-iotspaces/README.md
+++ b/sdk/iotspaces/arm-iotspaces/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for IoTSpacesClient.
 
-> ⚠️ This package @azure/arm-iotspaces with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
+> ⚠️ This package @azure/arm-iotspaces with versions lower than 1.2.1 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 1.2.1 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/keyvault/arm-keyvault-profile-2019-03-01-hybrid/README.md
+++ b/sdk/keyvault/arm-keyvault-profile-2019-03-01-hybrid/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for KeyVaultManagementClient.
 
-> Please note, a newer package [@azure/arm-keyvault-profile-2019-03-01-hybrid](https://www.npmjs.com/package/@azure/arm-keyvault-profile-2019-03-01-hybrid) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-keyvault-profile-2019-03-01-hybrid with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/keyvault/arm-keyvault-profile-2019-03-01-hybrid/README.md
+++ b/sdk/keyvault/arm-keyvault-profile-2019-03-01-hybrid/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for KeyVaultManagementClient.
 
+> Please note, a newer package [@azure/arm-keyvault-profile-2019-03-01-hybrid](https://www.npmjs.com/package/@azure/arm-keyvault-profile-2019-03-01-hybrid) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge, and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/keyvault/arm-keyvault-profile-2020-09-01-hybrid/README.md
+++ b/sdk/keyvault/arm-keyvault-profile-2020-09-01-hybrid/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for KeyVaultManagementClient.
 
-> Please note, a newer package [@azure/arm-keyvault-profile-2020-09-01-hybrid](https://www.npmjs.com/package/@azure/arm-keyvault-profile-2020-09-01-hybrid) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-keyvault-profile-2020-09-01-hybrid with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/keyvault/arm-keyvault-profile-2020-09-01-hybrid/README.md
+++ b/sdk/keyvault/arm-keyvault-profile-2020-09-01-hybrid/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for KeyVaultManagementClient.
 
+> Please note, a newer package [@azure/arm-keyvault-profile-2020-09-01-hybrid](https://www.npmjs.com/package/@azure/arm-keyvault-profile-2020-09-01-hybrid) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge, and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/keyvault/arm-keyvault/README.md
+++ b/sdk/keyvault/arm-keyvault/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for KeyVaultManagementClient.
 
+> Please note, a newer package [@azure/arm-keyvault](https://www.npmjs.com/package/@azure/arm-keyvault) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge, and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/keyvault/arm-keyvault/README.md
+++ b/sdk/keyvault/arm-keyvault/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for KeyVaultManagementClient.
 
-> Please note, a newer package [@azure/arm-keyvault](https://www.npmjs.com/package/@azure/arm-keyvault) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-keyvault with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/kubernetesconfiguration/arm-kubernetesconfiguration/README.md
+++ b/sdk/kubernetesconfiguration/arm-kubernetesconfiguration/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for SourceControlConfigurationClient.
 
-> ⚠️ This package @azure/arm-kubernetesconfiguration with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
+> ⚠️ This package @azure/arm-kubernetesconfiguration with versions lower than 5.0.0-beta.1 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 5.0.0-beta.1 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/kubernetesconfiguration/arm-kubernetesconfiguration/README.md
+++ b/sdk/kubernetesconfiguration/arm-kubernetesconfiguration/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for SourceControlConfigurationClient.
 
-> Please note, a newer package [@azure/arm-kubernetesconfiguration](https://www.npmjs.com/package/@azure/arm-kubernetesconfiguration) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-kubernetesconfiguration with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/kubernetesconfiguration/arm-kubernetesconfiguration/README.md
+++ b/sdk/kubernetesconfiguration/arm-kubernetesconfiguration/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for SourceControlConfigurationClient.
 
+> Please note, a newer package [@azure/arm-kubernetesconfiguration](https://www.npmjs.com/package/@azure/arm-kubernetesconfiguration) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
-- Latest versions of Safari, Chrome, Edge and Firefox.
+- Latest versions of Safari, Chrome, Edge, and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/kusto/arm-kusto/README.md
+++ b/sdk/kusto/arm-kusto/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for KustoManagementClient.
 
-> ⚠️ This package @azure/arm-kusto with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
+> ⚠️ This package @azure/arm-kusto with versions lower than 7.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 7.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/kusto/arm-kusto/README.md
+++ b/sdk/kusto/arm-kusto/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for KustoManagementClient.
 
+> Please note, a newer package [@azure/arm-kusto](https://www.npmjs.com/package/@azure/arm-kusto) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
-- Latest versions of Safari, Chrome, Edge and Firefox.
+- Latest versions of Safari, Chrome, Edge, and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/kusto/arm-kusto/README.md
+++ b/sdk/kusto/arm-kusto/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for KustoManagementClient.
 
-> Please note, a newer package [@azure/arm-kusto](https://www.npmjs.com/package/@azure/arm-kusto) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-kusto with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/labservices/arm-labservices/README.md
+++ b/sdk/labservices/arm-labservices/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for LabServicesClient.
 
-> Please note, a newer package [@azure/arm-labservices](https://www.npmjs.com/package/@azure/arm-labservices) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-labservices with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/labservices/arm-labservices/README.md
+++ b/sdk/labservices/arm-labservices/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for LabServicesClient.
 
+> Please note, a newer package [@azure/arm-labservices](https://www.npmjs.com/package/@azure/arm-labservices) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
-- Latest versions of Safari, Chrome, Edge and Firefox.
+- Latest versions of Safari, Chrome, Edge, and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/labservices/arm-labservices/README.md
+++ b/sdk/labservices/arm-labservices/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for LabServicesClient.
 
-> ⚠️ This package @azure/arm-labservices with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
+> ⚠️ This package @azure/arm-labservices with versions lower than 3.0.0-beta.1 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 3.0.0-beta.1 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/links/arm-links/README.md
+++ b/sdk/links/arm-links/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for ManagementLinkClient.
 
-> Please note, a newer package [@azure/arm-links](https://www.npmjs.com/package/@azure/arm-links) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-links with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/links/arm-links/README.md
+++ b/sdk/links/arm-links/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for ManagementLinkClient.
 
+> Please note, a newer package [@azure/arm-links](https://www.npmjs.com/package/@azure/arm-links) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge, and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/locks/arm-locks-profile-2020-09-01-hybrid/README.md
+++ b/sdk/locks/arm-locks-profile-2020-09-01-hybrid/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for ManagementLockClient.
 
+> Please note, a newer package [@azure/arm-locks-profile-2020-09-01-hybrid](https://www.npmjs.com/package/@azure/arm-locks-profile-2020-09-01-hybrid) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge, and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/locks/arm-locks-profile-2020-09-01-hybrid/README.md
+++ b/sdk/locks/arm-locks-profile-2020-09-01-hybrid/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for ManagementLockClient.
 
-> Please note, a newer package [@azure/arm-locks-profile-2020-09-01-hybrid](https://www.npmjs.com/package/@azure/arm-locks-profile-2020-09-01-hybrid) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-locks-profile-2020-09-01-hybrid with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/locks/arm-locks-profile-hybrid-2019-03-01/README.md
+++ b/sdk/locks/arm-locks-profile-hybrid-2019-03-01/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for ManagementLockClient.
 
+> Please note, a newer package [@azure/arm-locks-profile-hybrid-2019-03-01](https://www.npmjs.com/package/@azure/arm-locks-profile-hybrid-2019-03-01) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge, and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/locks/arm-locks-profile-hybrid-2019-03-01/README.md
+++ b/sdk/locks/arm-locks-profile-hybrid-2019-03-01/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for ManagementLockClient.
 
-> Please note, a newer package [@azure/arm-locks-profile-hybrid-2019-03-01](https://www.npmjs.com/package/@azure/arm-locks-profile-hybrid-2019-03-01) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-locks-profile-hybrid-2019-03-01 with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/locks/arm-locks/README.md
+++ b/sdk/locks/arm-locks/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for ManagementLockClient.
 
-> Please note, a newer package [@azure/arm-locks](https://www.npmjs.com/package/@azure/arm-locks) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-locks with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/locks/arm-locks/README.md
+++ b/sdk/locks/arm-locks/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for ManagementLockClient.
 
+> Please note, a newer package [@azure/arm-locks](https://www.npmjs.com/package/@azure/arm-locks) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge, and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/logic/arm-logic/README.md
+++ b/sdk/logic/arm-logic/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for LogicManagementClient.
 
-> ⚠️ This package @azure/arm-logic with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
+> ⚠️ This package @azure/arm-logic with versions lower than 8.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 8.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/logic/arm-logic/README.md
+++ b/sdk/logic/arm-logic/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for LogicManagementClient.
 
-> Please note, a newer package [@azure/arm-logic](https://www.npmjs.com/package/@azure/arm-logic) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-logic with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/logic/arm-logic/README.md
+++ b/sdk/logic/arm-logic/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for LogicManagementClient.
 
+> Please note, a newer package [@azure/arm-logic](https://www.npmjs.com/package/@azure/arm-logic) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge, and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/machinelearning/arm-commitmentplans/README.md
+++ b/sdk/machinelearning/arm-commitmentplans/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for AzureMLCommitmentPlansManagementClient.
 
-> Please note, a newer package [@azure/arm-commitmentplans](https://www.npmjs.com/package/@azure/arm-commitmentplans) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-commitmentplans with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/machinelearning/arm-commitmentplans/README.md
+++ b/sdk/machinelearning/arm-commitmentplans/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for AzureMLCommitmentPlansManagementClient.
 
-> ⚠️ This package @azure/arm-commitmentplans with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
+> ⚠️ This package @azure/arm-commitmentplans with versions lower than 2.0.0-beta.1 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0-beta.1 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/machinelearning/arm-commitmentplans/README.md
+++ b/sdk/machinelearning/arm-commitmentplans/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for AzureMLCommitmentPlansManagementClient.
 
+> Please note, a newer package [@azure/arm-commitmentplans](https://www.npmjs.com/package/@azure/arm-commitmentplans) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge, and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/machinelearning/arm-webservices/README.md
+++ b/sdk/machinelearning/arm-webservices/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for AzureMLWebServicesManagementClient.
 
-> ⚠️ This package @azure/arm-webservices with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
+> ⚠️ This package @azure/arm-webservices with versions lower than 1.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 1.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/machinelearning/arm-webservices/README.md
+++ b/sdk/machinelearning/arm-webservices/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for AzureMLWebServicesManagementClient.
 
-> Please note, a newer package [@azure/arm-webservices](https://www.npmjs.com/package/@azure/arm-webservices) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-webservices with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/machinelearning/arm-webservices/README.md
+++ b/sdk/machinelearning/arm-webservices/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for AzureMLWebServicesManagementClient.
 
+> Please note, a newer package [@azure/arm-webservices](https://www.npmjs.com/package/@azure/arm-webservices) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge, and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/machinelearning/arm-workspaces/README.md
+++ b/sdk/machinelearning/arm-workspaces/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for MachineLearningWorkspacesManagementClient.
 
-> Please note, a newer package [@azure/arm-workspaces](https://www.npmjs.com/package/@azure/arm-workspaces) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-workspaces with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/machinelearning/arm-workspaces/README.md
+++ b/sdk/machinelearning/arm-workspaces/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for MachineLearningWorkspacesManagementClient.
 
+> Please note, a newer package [@azure/arm-workspaces](https://www.npmjs.com/package/@azure/arm-workspaces) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge, and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/machinelearning/arm-workspaces/README.md
+++ b/sdk/machinelearning/arm-workspaces/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for MachineLearningWorkspacesManagementClient.
 
-> ⚠️ This package @azure/arm-workspaces with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
+> ⚠️ This package @azure/arm-workspaces with versions lower than 1.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 1.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/machinelearningcompute/arm-machinelearningcompute/README.md
+++ b/sdk/machinelearningcompute/arm-machinelearningcompute/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for MachineLearningComputeManagementClient.
 
+> Please note, a newer package [@azure/arm-machinelearningcompute](https://www.npmjs.com/package/@azure/arm-machinelearningcompute) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge, and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/machinelearningcompute/arm-machinelearningcompute/README.md
+++ b/sdk/machinelearningcompute/arm-machinelearningcompute/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for MachineLearningComputeManagementClient.
 
-> ⚠️ This package @azure/arm-machinelearningcompute with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
+> ⚠️ This package @azure/arm-machinelearningcompute with versions lower than 3.0.0-beta.1 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 3.0.0-beta.1 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/machinelearningcompute/arm-machinelearningcompute/README.md
+++ b/sdk/machinelearningcompute/arm-machinelearningcompute/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for MachineLearningComputeManagementClient.
 
-> Please note, a newer package [@azure/arm-machinelearningcompute](https://www.npmjs.com/package/@azure/arm-machinelearningcompute) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-machinelearningcompute with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/machinelearningexperimentation/arm-machinelearningexperimentation/README.md
+++ b/sdk/machinelearningexperimentation/arm-machinelearningexperimentation/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for MLTeamAccountManagementClient.
 
-> ⚠️ This package @azure/arm-machinelearningexperimentation with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
+> ⚠️ This package @azure/arm-machinelearningexperimentation with versions lower than 2.0.0-beta.1 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0-beta.1 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/machinelearningexperimentation/arm-machinelearningexperimentation/README.md
+++ b/sdk/machinelearningexperimentation/arm-machinelearningexperimentation/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for MLTeamAccountManagementClient.
 
-> Please note, a newer package [@azure/arm-machinelearningexperimentation](https://www.npmjs.com/package/@azure/arm-machinelearningexperimentation) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-machinelearningexperimentation with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/machinelearningexperimentation/arm-machinelearningexperimentation/README.md
+++ b/sdk/machinelearningexperimentation/arm-machinelearningexperimentation/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for MLTeamAccountManagementClient.
 
+> Please note, a newer package [@azure/arm-machinelearningexperimentation](https://www.npmjs.com/package/@azure/arm-machinelearningexperimentation) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge, and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/machinelearningservices/arm-machinelearningservices/README.md
+++ b/sdk/machinelearningservices/arm-machinelearningservices/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for AzureMachineLearningWorkspaces.
 
-> ⚠️ This package @azure/arm-machinelearningservices with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
+> ⚠️ This package @azure/arm-machinelearningservices with versions lower than 5.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 5.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/machinelearningservices/arm-machinelearningservices/README.md
+++ b/sdk/machinelearningservices/arm-machinelearningservices/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for AzureMachineLearningWorkspaces.
 
-> Please note, a newer package [@azure/arm-machinelearningservices](https://www.npmjs.com/package/@azure/arm-machinelearningservices) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-machinelearningservices with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/machinelearningservices/arm-machinelearningservices/README.md
+++ b/sdk/machinelearningservices/arm-machinelearningservices/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for AzureMachineLearningWorkspaces.
 
+> Please note, a newer package [@azure/arm-machinelearningservices](https://www.npmjs.com/package/@azure/arm-machinelearningservices) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge, and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/managedapplications/arm-managedapplications/README.md
+++ b/sdk/managedapplications/arm-managedapplications/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for ManagedApplicationClient.
 
-> Please note, a newer package [@azure/arm-managedapplications](https://www.npmjs.com/package/@azure/arm-managedapplications) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-managedapplications with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/managedapplications/arm-managedapplications/README.md
+++ b/sdk/managedapplications/arm-managedapplications/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for ManagedApplicationClient.
 
+> Please note, a newer package [@azure/arm-managedapplications](https://www.npmjs.com/package/@azure/arm-managedapplications) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge, and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/managementgroups/arm-managementgroups/README.md
+++ b/sdk/managementgroups/arm-managementgroups/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for ManagementGroupsAPI.
 
-> Please note, a newer package [@azure/arm-managementgroups](https://www.npmjs.com/package/@azure/arm-managementgroups) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-managementgroups with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/managementgroups/arm-managementgroups/README.md
+++ b/sdk/managementgroups/arm-managementgroups/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for ManagementGroupsAPI.
 
+> Please note, a newer package [@azure/arm-managementgroups](https://www.npmjs.com/package/@azure/arm-managementgroups) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge, and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/managementpartner/arm-managementpartner/README.md
+++ b/sdk/managementpartner/arm-managementpartner/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for ACEProvisioningManagementPartnerAPI.
 
+> Please note, a newer package [@azure/arm-managementpartner](https://www.npmjs.com/package/@azure/arm-managementpartner) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge, and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/managementpartner/arm-managementpartner/README.md
+++ b/sdk/managementpartner/arm-managementpartner/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for ACEProvisioningManagementPartnerAPI.
 
-> Please note, a newer package [@azure/arm-managementpartner](https://www.npmjs.com/package/@azure/arm-managementpartner) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-managementpartner with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/maps/arm-maps/README.md
+++ b/sdk/maps/arm-maps/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for AzureMapsManagementClient.
 
-> ⚠️ This package @azure/arm-maps with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
+> ⚠️ This package @azure/arm-maps with versions lower than 3.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 3.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/maps/arm-maps/README.md
+++ b/sdk/maps/arm-maps/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for AzureMapsManagementClient.
 
+> Please note, a newer package [@azure/arm-maps](https://www.npmjs.com/package/@azure/arm-maps) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge, and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/maps/arm-maps/README.md
+++ b/sdk/maps/arm-maps/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for AzureMapsManagementClient.
 
-> Please note, a newer package [@azure/arm-maps](https://www.npmjs.com/package/@azure/arm-maps) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-maps with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/mariadb/arm-mariadb/README.md
+++ b/sdk/mariadb/arm-mariadb/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for MariaDBManagementClient.
 
+> Please note, a newer package [@azure/arm-mariadb](https://www.npmjs.com/package/@azure/arm-mariadb) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge, and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/mariadb/arm-mariadb/README.md
+++ b/sdk/mariadb/arm-mariadb/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for MariaDBManagementClient.
 
-> Please note, a newer package [@azure/arm-mariadb](https://www.npmjs.com/package/@azure/arm-mariadb) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-mariadb with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/marketplaceordering/arm-marketplaceordering/README.md
+++ b/sdk/marketplaceordering/arm-marketplaceordering/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for MarketplaceOrderingAgreements.
 
-> ⚠️ This package @azure/arm-marketplaceordering with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
+> ⚠️ This package @azure/arm-marketplaceordering with versions lower than 3.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 3.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/marketplaceordering/arm-marketplaceordering/README.md
+++ b/sdk/marketplaceordering/arm-marketplaceordering/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for MarketplaceOrderingAgreements.
 
-> Please note, a newer package [@azure/arm-marketplaceordering](https://www.npmjs.com/package/@azure/arm-marketplaceordering) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-marketplaceordering with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/marketplaceordering/arm-marketplaceordering/README.md
+++ b/sdk/marketplaceordering/arm-marketplaceordering/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for MarketplaceOrderingAgreements.
 
+> Please note, a newer package [@azure/arm-marketplaceordering](https://www.npmjs.com/package/@azure/arm-marketplaceordering) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge, and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/mediaservices/arm-mediaservices/README.md
+++ b/sdk/mediaservices/arm-mediaservices/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for AzureMediaServices.
 
-> Please note, a newer package [@azure/arm-mediaservices](https://www.npmjs.com/package/@azure/arm-mediaservices) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-mediaservices with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/mediaservices/arm-mediaservices/README.md
+++ b/sdk/mediaservices/arm-mediaservices/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for AzureMediaServices.
 
+> Please note, a newer package [@azure/arm-mediaservices](https://www.npmjs.com/package/@azure/arm-mediaservices) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
-- Latest versions of Safari, Chrome, Edge and Firefox.
+- Latest versions of Safari, Chrome, Edge, and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/mediaservices/arm-mediaservices/README.md
+++ b/sdk/mediaservices/arm-mediaservices/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for AzureMediaServices.
 
-> ⚠️ This package @azure/arm-mediaservices with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
+> ⚠️ This package @azure/arm-mediaservices with versions lower than 10.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 10.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/migrate/arm-migrate/README.md
+++ b/sdk/migrate/arm-migrate/README.md
@@ -2,11 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for AzureMigrate.
 
+> Please note, a newer package [@azure/arm-migrate](https://www.npmjs.com/package/@azure/arm-migrate) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge, and Firefox.
 
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 ### Prerequisites
 
 You must have an [Azure subscription](https://azure.microsoft.com/free/).

--- a/sdk/migrate/arm-migrate/README.md
+++ b/sdk/migrate/arm-migrate/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for AzureMigrate.
 
-> Please note, a newer package [@azure/arm-migrate](https://www.npmjs.com/package/@azure/arm-migrate) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-migrate with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/mixedreality/arm-mixedreality/README.md
+++ b/sdk/mixedreality/arm-mixedreality/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for MixedRealityClient.
 
+> Please note, a newer package [@azure/arm-mixedreality](https://www.npmjs.com/package/@azure/arm-mixedreality) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge, and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/mixedreality/arm-mixedreality/README.md
+++ b/sdk/mixedreality/arm-mixedreality/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for MixedRealityClient.
 
-> ⚠️ This package @azure/arm-mixedreality with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
+> ⚠️ This package @azure/arm-mixedreality with versions lower than 4.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 4.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/mixedreality/arm-mixedreality/README.md
+++ b/sdk/mixedreality/arm-mixedreality/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for MixedRealityClient.
 
-> Please note, a newer package [@azure/arm-mixedreality](https://www.npmjs.com/package/@azure/arm-mixedreality) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-mixedreality with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/monitor/arm-monitor-profile-2019-03-01-hybrid/README.md
+++ b/sdk/monitor/arm-monitor-profile-2019-03-01-hybrid/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for MonitorManagementClient.
 
-> Please note, a newer package [@azure/arm-monitor-profile-2019-03-01-hybrid](https://www.npmjs.com/package/@azure/arm-monitor-profile-2019-03-01-hybrid) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-monitor-profile-2019-03-01-hybrid with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/monitor/arm-monitor-profile-2019-03-01-hybrid/README.md
+++ b/sdk/monitor/arm-monitor-profile-2019-03-01-hybrid/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for MonitorManagementClient.
 
+> Please note, a newer package [@azure/arm-monitor-profile-2019-03-01-hybrid](https://www.npmjs.com/package/@azure/arm-monitor-profile-2019-03-01-hybrid) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge, and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/monitor/arm-monitor-profile-2020-09-01-hybrid/README.md
+++ b/sdk/monitor/arm-monitor-profile-2020-09-01-hybrid/README.md
@@ -2,11 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for MonitorManagementClient.
 
+> Please note, a newer package [@azure/arm-monitor-profile-2020-09-01-hybrid](https://www.npmjs.com/package/@azure/arm-monitor-profile-2020-09-01-hybrid) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge, and Firefox.
 
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 ### Prerequisites
 
 You must have an [Azure subscription](https://azure.microsoft.com/free/).

--- a/sdk/monitor/arm-monitor-profile-2020-09-01-hybrid/README.md
+++ b/sdk/monitor/arm-monitor-profile-2020-09-01-hybrid/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for MonitorManagementClient.
 
-> Please note, a newer package [@azure/arm-monitor-profile-2020-09-01-hybrid](https://www.npmjs.com/package/@azure/arm-monitor-profile-2020-09-01-hybrid) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-monitor-profile-2020-09-01-hybrid with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/monitor/arm-monitor/README.md
+++ b/sdk/monitor/arm-monitor/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for MonitorManagementClient.
 
-> ⚠️ This package @azure/arm-monitor with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
+> ⚠️ This package @azure/arm-monitor with versions lower than 7.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 7.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/monitor/arm-monitor/README.md
+++ b/sdk/monitor/arm-monitor/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for MonitorManagementClient.
 
+> Please note, a newer package [@azure/arm-monitor](https://www.npmjs.com/package/@azure/arm-monitor) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge, and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/monitor/arm-monitor/README.md
+++ b/sdk/monitor/arm-monitor/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for MonitorManagementClient.
 
-> Please note, a newer package [@azure/arm-monitor](https://www.npmjs.com/package/@azure/arm-monitor) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-monitor with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/msi/arm-msi/README.md
+++ b/sdk/msi/arm-msi/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for ManagedServiceIdentityClient.
 
-> Please note, a newer package [@azure/arm-msi](https://www.npmjs.com/package/@azure/arm-msi) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-msi with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/msi/arm-msi/README.md
+++ b/sdk/msi/arm-msi/README.md
@@ -2,11 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for ManagedServiceIdentityClient.
 
+> Please note, a newer package [@azure/arm-msi](https://www.npmjs.com/package/@azure/arm-msi) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge, and Firefox.
 
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 ### Prerequisites
 
 You must have an [Azure subscription](https://azure.microsoft.com/free/).

--- a/sdk/mysql/arm-mysql-flexible/README.md
+++ b/sdk/mysql/arm-mysql-flexible/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for MySQLManagementClient.
 
-> Please note, a newer package [@azure/arm-mysql-flexible](https://www.npmjs.com/package/@azure/arm-mysql-flexible) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-mysql-flexible with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/mysql/arm-mysql-flexible/README.md
+++ b/sdk/mysql/arm-mysql-flexible/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for MySQLManagementClient.
 
+> Please note, a newer package [@azure/arm-mysql-flexible](https://www.npmjs.com/package/@azure/arm-mysql-flexible) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
-- Latest versions of Safari, Chrome, Edge and Firefox.
+- Latest versions of Safari, Chrome, Edge, and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/mysql/arm-mysql-flexible/README.md
+++ b/sdk/mysql/arm-mysql-flexible/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for MySQLManagementClient.
 
-> ⚠️ This package @azure/arm-mysql-flexible with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
+> ⚠️ This package @azure/arm-mysql-flexible with versions lower than 1.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 1.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/mysql/arm-mysql/README.md
+++ b/sdk/mysql/arm-mysql/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for MySQLManagementClient.
 
-> ⚠️ This package @azure/arm-mysql with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
+> ⚠️ This package @azure/arm-mysql with versions lower than 5.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 5.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/mysql/arm-mysql/README.md
+++ b/sdk/mysql/arm-mysql/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for MySQLManagementClient.
 
+> Please note, a newer package [@azure/arm-mysql](https://www.npmjs.com/package/@azure/arm-mysql) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
-- Latest versions of Safari, Chrome, Edge and Firefox.
+- Latest versions of Safari, Chrome, Edge, and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/mysql/arm-mysql/README.md
+++ b/sdk/mysql/arm-mysql/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for MySQLManagementClient.
 
-> Please note, a newer package [@azure/arm-mysql](https://www.npmjs.com/package/@azure/arm-mysql) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-mysql with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/netapp/arm-netapp/README.md
+++ b/sdk/netapp/arm-netapp/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for AzureNetAppFilesManagementClient.
 
-> ⚠️ This package @azure/arm-netapp with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
+> ⚠️ This package @azure/arm-netapp with versions lower than 15.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 15.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/netapp/arm-netapp/README.md
+++ b/sdk/netapp/arm-netapp/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for AzureNetAppFilesManagementClient.
 
-> Please note, a newer package [@azure/arm-netapp](https://www.npmjs.com/package/@azure/arm-netapp) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-netapp with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/netapp/arm-netapp/README.md
+++ b/sdk/netapp/arm-netapp/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for AzureNetAppFilesManagementClient.
 
+> Please note, a newer package [@azure/arm-netapp](https://www.npmjs.com/package/@azure/arm-netapp) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
-- Latest versions of Safari, Chrome, Edge and Firefox.
+- Latest versions of Safari, Chrome, Edge, and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/network/arm-network-profile-2019-03-01-hybrid/README.md
+++ b/sdk/network/arm-network-profile-2019-03-01-hybrid/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for NetworkManagementClient.
 
-> Please note, a newer package [@azure/arm-network-profile-2019-03-01-hybrid](https://www.npmjs.com/package/@azure/arm-network-profile-2019-03-01-hybrid) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-network-profile-2019-03-01-hybrid with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/network/arm-network-profile-2019-03-01-hybrid/README.md
+++ b/sdk/network/arm-network-profile-2019-03-01-hybrid/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for NetworkManagementClient.
 
+> Please note, a newer package [@azure/arm-network-profile-2019-03-01-hybrid](https://www.npmjs.com/package/@azure/arm-network-profile-2019-03-01-hybrid) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge, and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/network/arm-network-profile-2020-09-01-hybrid/README.md
+++ b/sdk/network/arm-network-profile-2020-09-01-hybrid/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for NetworkManagementClient.
 
-> Please note, a newer package [@azure/arm-network-profile-2020-09-01-hybrid](https://www.npmjs.com/package/@azure/arm-network-profile-2020-09-01-hybrid) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-network-profile-2020-09-01-hybrid with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/network/arm-network-profile-2020-09-01-hybrid/README.md
+++ b/sdk/network/arm-network-profile-2020-09-01-hybrid/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for NetworkManagementClient.
 
+> Please note, a newer package [@azure/arm-network-profile-2020-09-01-hybrid](https://www.npmjs.com/package/@azure/arm-network-profile-2020-09-01-hybrid) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge, and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/network/arm-network/README.md
+++ b/sdk/network/arm-network/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for NetworkManagementClient.
 
-> ⚠️ This package @azure/arm-network with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
+> ⚠️ This package @azure/arm-network with versions lower than 26.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 26.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/network/arm-network/README.md
+++ b/sdk/network/arm-network/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for NetworkManagementClient.
 
-> Please note, a newer package [@azure/arm-network](https://www.npmjs.com/package/@azure/arm-network) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-network with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/network/arm-network/README.md
+++ b/sdk/network/arm-network/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for NetworkManagementClient.
 
+> Please note, a newer package [@azure/arm-network](https://www.npmjs.com/package/@azure/arm-network) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
-- Latest versions of Safari, Chrome, Edge and Firefox.
+- Latest versions of Safari, Chrome, Edge, and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/notificationhubs/arm-notificationhubs/README.md
+++ b/sdk/notificationhubs/arm-notificationhubs/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for NotificationHubsManagementClient.
 
+> Please note, a newer package [@azure/arm-notificationhubs](https://www.npmjs.com/package/@azure/arm-notificationhubs) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge, and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/notificationhubs/arm-notificationhubs/README.md
+++ b/sdk/notificationhubs/arm-notificationhubs/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for NotificationHubsManagementClient.
 
-> Please note, a newer package [@azure/arm-notificationhubs](https://www.npmjs.com/package/@azure/arm-notificationhubs) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-notificationhubs with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/operationalinsights/arm-operationalinsights/README.md
+++ b/sdk/operationalinsights/arm-operationalinsights/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for OperationalInsightsManagementClient.
 
-> Please note, a newer package [@azure/arm-operationalinsights](https://www.npmjs.com/package/@azure/arm-operationalinsights) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-operationalinsights with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/operationalinsights/arm-operationalinsights/README.md
+++ b/sdk/operationalinsights/arm-operationalinsights/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for OperationalInsightsManagementClient.
 
-> ⚠️ This package @azure/arm-operationalinsights with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
+> ⚠️ This package @azure/arm-operationalinsights with versions lower than 8.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 8.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/operationalinsights/arm-operationalinsights/README.md
+++ b/sdk/operationalinsights/arm-operationalinsights/README.md
@@ -2,11 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for OperationalInsightsManagementClient.
 
+> Please note, a newer package [@azure/arm-operationalinsights](https://www.npmjs.com/package/@azure/arm-operationalinsights) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge, and Firefox.
 
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 ### Prerequisites
 
 You must have an [Azure subscription](https://azure.microsoft.com/free/).

--- a/sdk/operationsmanagement/arm-operations/README.md
+++ b/sdk/operationsmanagement/arm-operations/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for OperationsManagementClient.
 
-> Please note, a newer package [@azure/arm-operations](https://www.npmjs.com/package/@azure/arm-operations) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-operations with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/operationsmanagement/arm-operations/README.md
+++ b/sdk/operationsmanagement/arm-operations/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for OperationsManagementClient.
 
-> ⚠️ This package @azure/arm-operations with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
+> ⚠️ This package @azure/arm-operations with versions lower than 4.0.0-beta.1 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 4.0.0-beta.1 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/operationsmanagement/arm-operations/README.md
+++ b/sdk/operationsmanagement/arm-operations/README.md
@@ -2,11 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for OperationsManagementClient.
 
+> Please note, a newer package [@azure/arm-operations](https://www.npmjs.com/package/@azure/arm-operations) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
-- Latest versions of Safari, Chrome, Edge and Firefox.
+- Latest versions of Safari, Chrome, Edge, and Firefox.
 
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 ### Prerequisites
 
 You must have an [Azure subscription](https://azure.microsoft.com/free/).

--- a/sdk/peering/arm-peering/README.md
+++ b/sdk/peering/arm-peering/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for PeeringManagementClient.
 
+> Please note, a newer package [@azure/arm-peering](https://www.npmjs.com/package/@azure/arm-peering) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge, and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/peering/arm-peering/README.md
+++ b/sdk/peering/arm-peering/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for PeeringManagementClient.
 
-> Please note, a newer package [@azure/arm-peering](https://www.npmjs.com/package/@azure/arm-peering) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-peering with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/policy/arm-policy-profile-2020-09-01-hybrid/README.md
+++ b/sdk/policy/arm-policy-profile-2020-09-01-hybrid/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for PolicyClient.
 
+> Please note, a newer package [@azure/arm-policy-profile-2020-09-01-hybrid](https://www.npmjs.com/package/@azure/arm-policy-profile-2020-09-01-hybrid) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge, and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/policy/arm-policy-profile-2020-09-01-hybrid/README.md
+++ b/sdk/policy/arm-policy-profile-2020-09-01-hybrid/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for PolicyClient.
 
-> Please note, a newer package [@azure/arm-policy-profile-2020-09-01-hybrid](https://www.npmjs.com/package/@azure/arm-policy-profile-2020-09-01-hybrid) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-policy-profile-2020-09-01-hybrid with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/policy/arm-policy-profile-hybrid-2019-03-01/README.md
+++ b/sdk/policy/arm-policy-profile-hybrid-2019-03-01/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for PolicyClient.
 
-> Please note, a newer package [@azure/arm-policy-profile-hybrid-2019-03-01](https://www.npmjs.com/package/@azure/arm-policy-profile-hybrid-2019-03-01) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-policy-profile-hybrid-2019-03-01 with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/policy/arm-policy-profile-hybrid-2019-03-01/README.md
+++ b/sdk/policy/arm-policy-profile-hybrid-2019-03-01/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for PolicyClient.
 
+> Please note, a newer package [@azure/arm-policy-profile-hybrid-2019-03-01](https://www.npmjs.com/package/@azure/arm-policy-profile-hybrid-2019-03-01) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge, and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/policy/arm-policy/README.md
+++ b/sdk/policy/arm-policy/README.md
@@ -2,11 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for PolicyClient.
 
+> Please note, a newer package [@azure/arm-policy](https://www.npmjs.com/package/@azure/arm-policy) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
-- Latest versions of Safari, Chrome, Edge and Firefox.
+- Latest versions of Safari, Chrome, Edge, and Firefox.
 
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 ### Prerequisites
 
 You must have an [Azure subscription](https://azure.microsoft.com/free/).

--- a/sdk/policy/arm-policy/README.md
+++ b/sdk/policy/arm-policy/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for PolicyClient.
 
-> Please note, a newer package [@azure/arm-policy](https://www.npmjs.com/package/@azure/arm-policy) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-policy with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/policy/arm-policy/README.md
+++ b/sdk/policy/arm-policy/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for PolicyClient.
 
-> ⚠️ This package @azure/arm-policy with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
+> ⚠️ This package @azure/arm-policy with versions lower than 5.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 5.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/policyinsights/arm-policyinsights/README.md
+++ b/sdk/policyinsights/arm-policyinsights/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for PolicyInsightsClient.
 
+> Please note, a newer package [@azure/arm-policyinsights](https://www.npmjs.com/package/@azure/arm-policyinsights) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge, and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/policyinsights/arm-policyinsights/README.md
+++ b/sdk/policyinsights/arm-policyinsights/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for PolicyInsightsClient.
 
-> Please note, a newer package [@azure/arm-policyinsights](https://www.npmjs.com/package/@azure/arm-policyinsights) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-policyinsights with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/policyinsights/arm-policyinsights/README.md
+++ b/sdk/policyinsights/arm-policyinsights/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for PolicyInsightsClient.
 
-> ⚠️ This package @azure/arm-policyinsights with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
+> ⚠️ This package @azure/arm-policyinsights with versions lower than 5.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 5.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/postgresql/arm-postgresql-flexible/README.md
+++ b/sdk/postgresql/arm-postgresql-flexible/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for PostgreSQLManagementClient.
 
-> ⚠️ This package @azure/arm-postgresql-flexible with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
+> ⚠️ This package @azure/arm-postgresql-flexible with versions lower than 5.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 5.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/postgresql/arm-postgresql-flexible/README.md
+++ b/sdk/postgresql/arm-postgresql-flexible/README.md
@@ -2,11 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for PostgreSQLManagementClient.
 
+> Please note, a newer package [@azure/arm-postgresql-flexible](https://www.npmjs.com/package/@azure/arm-postgresql-flexible) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
-- Latest versions of Safari, Chrome, Edge and Firefox.
+- Latest versions of Safari, Chrome, Edge, and Firefox.
 
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 ### Prerequisites
 
 You must have an [Azure subscription](https://azure.microsoft.com/free/).

--- a/sdk/postgresql/arm-postgresql-flexible/README.md
+++ b/sdk/postgresql/arm-postgresql-flexible/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for PostgreSQLManagementClient.
 
-> Please note, a newer package [@azure/arm-postgresql-flexible](https://www.npmjs.com/package/@azure/arm-postgresql-flexible) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-postgresql-flexible with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/postgresql/arm-postgresql/README.md
+++ b/sdk/postgresql/arm-postgresql/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for PostgreSQLManagementClient.
 
+> Please note, a newer package [@azure/arm-postgresql](https://www.npmjs.com/package/@azure/arm-postgresql) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
-- Latest versions of Safari, Chrome, Edge and Firefox.
+- Latest versions of Safari, Chrome, Edge, and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/postgresql/arm-postgresql/README.md
+++ b/sdk/postgresql/arm-postgresql/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for PostgreSQLManagementClient.
 
-> Please note, a newer package [@azure/arm-postgresql](https://www.npmjs.com/package/@azure/arm-postgresql) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-postgresql with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/postgresql/arm-postgresql/README.md
+++ b/sdk/postgresql/arm-postgresql/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for PostgreSQLManagementClient.
 
-> ⚠️ This package @azure/arm-postgresql with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
+> ⚠️ This package @azure/arm-postgresql with versions lower than 6.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 6.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/powerbidedicated/arm-powerbidedicated/README.md
+++ b/sdk/powerbidedicated/arm-powerbidedicated/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for PowerBIDedicatedManagementClient.
 
-> Please note, a newer package [@azure/arm-powerbidedicated](https://www.npmjs.com/package/@azure/arm-powerbidedicated) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-powerbidedicated with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/powerbidedicated/arm-powerbidedicated/README.md
+++ b/sdk/powerbidedicated/arm-powerbidedicated/README.md
@@ -2,11 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for PowerBIDedicatedManagementClient.
 
+> Please note, a newer package [@azure/arm-powerbidedicated](https://www.npmjs.com/package/@azure/arm-powerbidedicated) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge, and Firefox.
 
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 ### Prerequisites
 
 You must have an [Azure subscription](https://azure.microsoft.com/free/).

--- a/sdk/powerbidedicated/arm-powerbidedicated/README.md
+++ b/sdk/powerbidedicated/arm-powerbidedicated/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for PowerBIDedicatedManagementClient.
 
-> ⚠️ This package @azure/arm-powerbidedicated with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
+> ⚠️ This package @azure/arm-powerbidedicated with versions lower than 3.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 3.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/powerbiembedded/arm-powerbiembedded/README.md
+++ b/sdk/powerbiembedded/arm-powerbiembedded/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for PowerBIEmbeddedManagementClient.
 
-> Please note, a newer package [@azure/arm-powerbiembedded](https://www.npmjs.com/package/@azure/arm-powerbiembedded) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-powerbiembedded with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/powerbiembedded/arm-powerbiembedded/README.md
+++ b/sdk/powerbiembedded/arm-powerbiembedded/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for PowerBIEmbeddedManagementClient.
 
+> Please note, a newer package [@azure/arm-powerbiembedded](https://www.npmjs.com/package/@azure/arm-powerbiembedded) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge, and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/privatedns/arm-privatedns/README.md
+++ b/sdk/privatedns/arm-privatedns/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for PrivateDnsManagementClient.
 
-> Please note, a newer package [@azure/arm-privatedns](https://www.npmjs.com/package/@azure/arm-privatedns) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-privatedns with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/privatedns/arm-privatedns/README.md
+++ b/sdk/privatedns/arm-privatedns/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for PrivateDnsManagementClient.
 
+> Please note, a newer package [@azure/arm-privatedns](https://www.npmjs.com/package/@azure/arm-privatedns) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge, and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/privatedns/arm-privatedns/README.md
+++ b/sdk/privatedns/arm-privatedns/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for PrivateDnsManagementClient.
 
-> ⚠️ This package @azure/arm-privatedns with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
+> ⚠️ This package @azure/arm-privatedns with versions lower than 3.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 3.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/recoveryservices/arm-recoveryservices/README.md
+++ b/sdk/recoveryservices/arm-recoveryservices/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for RecoveryServicesClient.
 
+> Please note, a newer package [@azure/arm-recoveryservices](https://www.npmjs.com/package/@azure/arm-recoveryservices) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge, and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/recoveryservices/arm-recoveryservices/README.md
+++ b/sdk/recoveryservices/arm-recoveryservices/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for RecoveryServicesClient.
 
-> ⚠️ This package @azure/arm-recoveryservices with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
+> ⚠️ This package @azure/arm-recoveryservices with versions lower than 5.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 5.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/recoveryservices/arm-recoveryservices/README.md
+++ b/sdk/recoveryservices/arm-recoveryservices/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for RecoveryServicesClient.
 
-> Please note, a newer package [@azure/arm-recoveryservices](https://www.npmjs.com/package/@azure/arm-recoveryservices) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-recoveryservices with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/recoveryservicesbackup/arm-recoveryservicesbackup/README.md
+++ b/sdk/recoveryservicesbackup/arm-recoveryservicesbackup/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for RecoveryServicesBackupClient.
 
-> ⚠️ This package @azure/arm-recoveryservicesbackup with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
+> ⚠️ This package @azure/arm-recoveryservicesbackup with versions lower than 8.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 8.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/recoveryservicesbackup/arm-recoveryservicesbackup/README.md
+++ b/sdk/recoveryservicesbackup/arm-recoveryservicesbackup/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for RecoveryServicesBackupClient.
 
-> Please note, a newer package [@azure/arm-recoveryservicesbackup](https://www.npmjs.com/package/@azure/arm-recoveryservicesbackup) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-recoveryservicesbackup with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/recoveryservicesbackup/arm-recoveryservicesbackup/README.md
+++ b/sdk/recoveryservicesbackup/arm-recoveryservicesbackup/README.md
@@ -2,11 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for RecoveryServicesBackupClient.
 
+> Please note, a newer package [@azure/arm-recoveryservicesbackup](https://www.npmjs.com/package/@azure/arm-recoveryservicesbackup) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
-- Latest versions of Safari, Chrome, Edge and Firefox.
+- Latest versions of Safari, Chrome, Edge, and Firefox.
 
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 ### Prerequisites
 
 You must have an [Azure subscription](https://azure.microsoft.com/free/).

--- a/sdk/recoveryservicessiterecovery/arm-recoveryservices-siterecovery/README.md
+++ b/sdk/recoveryservicessiterecovery/arm-recoveryservices-siterecovery/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for SiteRecoveryManagementClient.
 
+> Please note, a newer package [@azure/arm-recoveryservices-siterecovery](https://www.npmjs.com/package/@azure/arm-recoveryservices-siterecovery) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge, and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/recoveryservicessiterecovery/arm-recoveryservices-siterecovery/README.md
+++ b/sdk/recoveryservicessiterecovery/arm-recoveryservices-siterecovery/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for SiteRecoveryManagementClient.
 
-> Please note, a newer package [@azure/arm-recoveryservices-siterecovery](https://www.npmjs.com/package/@azure/arm-recoveryservices-siterecovery) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-recoveryservices-siterecovery with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/recoveryservicessiterecovery/arm-recoveryservices-siterecovery/README.md
+++ b/sdk/recoveryservicessiterecovery/arm-recoveryservices-siterecovery/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for SiteRecoveryManagementClient.
 
-> ⚠️ This package @azure/arm-recoveryservices-siterecovery with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
+> ⚠️ This package @azure/arm-recoveryservices-siterecovery with versions lower than 4.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 4.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/redis/arm-rediscache/README.md
+++ b/sdk/redis/arm-rediscache/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for RedisManagementClient.
 
-> ⚠️ This package @azure/arm-rediscache with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
+> ⚠️ This package @azure/arm-rediscache with versions lower than 6.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 6.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/redis/arm-rediscache/README.md
+++ b/sdk/redis/arm-rediscache/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for RedisManagementClient.
 
-> Please note, a newer package [@azure/arm-rediscache](https://www.npmjs.com/package/@azure/arm-rediscache) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-rediscache with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/redis/arm-rediscache/README.md
+++ b/sdk/redis/arm-rediscache/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for RedisManagementClient.
 
+> Please note, a newer package [@azure/arm-rediscache](https://www.npmjs.com/package/@azure/arm-rediscache) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
-- Latest versions of Safari, Chrome, Edge and Firefox.
+- Latest versions of Safari, Chrome, Edge, and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/redisenterprise/arm-redisenterprisecache/README.md
+++ b/sdk/redisenterprise/arm-redisenterprisecache/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for RedisEnterpriseManagementClient.
 
+> Please note, a newer package [@azure/arm-redisenterprisecache](https://www.npmjs.com/package/@azure/arm-redisenterprisecache) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge, and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/redisenterprise/arm-redisenterprisecache/README.md
+++ b/sdk/redisenterprise/arm-redisenterprisecache/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for RedisEnterpriseManagementClient.
 
-> Please note, a newer package [@azure/arm-redisenterprisecache](https://www.npmjs.com/package/@azure/arm-redisenterprisecache) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-redisenterprisecache with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/relay/arm-relay/README.md
+++ b/sdk/relay/arm-relay/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for RelayManagementClient.
 
-> Please note, a newer package [@azure/arm-relay](https://www.npmjs.com/package/@azure/arm-relay) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-relay with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/relay/arm-relay/README.md
+++ b/sdk/relay/arm-relay/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for RelayManagementClient.
 
-> ⚠️ This package @azure/arm-relay with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
+> ⚠️ This package @azure/arm-relay with versions lower than 3.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 3.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/relay/arm-relay/README.md
+++ b/sdk/relay/arm-relay/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for RelayManagementClient.
 
+> Please note, a newer package [@azure/arm-relay](https://www.npmjs.com/package/@azure/arm-relay) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge, and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/reservations/arm-reservations/README.md
+++ b/sdk/reservations/arm-reservations/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for AzureReservationAPI.
 
-> ⚠️ This package @azure/arm-reservations with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
+> ⚠️ This package @azure/arm-reservations with versions lower than 7.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 7.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/reservations/arm-reservations/README.md
+++ b/sdk/reservations/arm-reservations/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for AzureReservationAPI.
 
+> Please note, a newer package [@azure/arm-reservations](https://www.npmjs.com/package/@azure/arm-reservations) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge, and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/reservations/arm-reservations/README.md
+++ b/sdk/reservations/arm-reservations/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for AzureReservationAPI.
 
-> Please note, a newer package [@azure/arm-reservations](https://www.npmjs.com/package/@azure/arm-reservations) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-reservations with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/resourcegraph/arm-resourcegraph/README.md
+++ b/sdk/resourcegraph/arm-resourcegraph/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for ResourceGraphClient.
 
+> Please note, a newer package [@azure/arm-resourcegraph](https://www.npmjs.com/package/@azure/arm-resourcegraph) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge, and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/resourcegraph/arm-resourcegraph/README.md
+++ b/sdk/resourcegraph/arm-resourcegraph/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for ResourceGraphClient.
 
-> Please note, a newer package [@azure/arm-resourcegraph](https://www.npmjs.com/package/@azure/arm-resourcegraph) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-resourcegraph with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/resourcegraph/arm-resourcegraph/README.md
+++ b/sdk/resourcegraph/arm-resourcegraph/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for ResourceGraphClient.
 
-> ⚠️ This package @azure/arm-resourcegraph with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
+> ⚠️ This package @azure/arm-resourcegraph with versions lower than 5.0.0-beta.1 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 5.0.0-beta.1 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/resourcehealth/arm-resourcehealth/README.md
+++ b/sdk/resourcehealth/arm-resourcehealth/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for MicrosoftResourceHealth.
 
+> Please note, a newer package [@azure/arm-resourcehealth](https://www.npmjs.com/package/@azure/arm-resourcehealth) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
-- Latest versions of Safari, Chrome, Edge and Firefox.
+- Latest versions of Safari, Chrome, Edge, and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/resourcehealth/arm-resourcehealth/README.md
+++ b/sdk/resourcehealth/arm-resourcehealth/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for MicrosoftResourceHealth.
 
-> Please note, a newer package [@azure/arm-resourcehealth](https://www.npmjs.com/package/@azure/arm-resourcehealth) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-resourcehealth with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/resourcehealth/arm-resourcehealth/README.md
+++ b/sdk/resourcehealth/arm-resourcehealth/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for MicrosoftResourceHealth.
 
-> ⚠️ This package @azure/arm-resourcehealth with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
+> ⚠️ This package @azure/arm-resourcehealth with versions lower than 3.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 3.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/resourcemover/arm-resourcemover/README.md
+++ b/sdk/resourcemover/arm-resourcemover/README.md
@@ -2,11 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for ResourceMoverServiceAPI.
 
+> Please note, a newer package [@azure/arm-resourcemover](https://www.npmjs.com/package/@azure/arm-resourcemover) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge, and Firefox.
 
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 ### Prerequisites
 
 You must have an [Azure subscription](https://azure.microsoft.com/free/).

--- a/sdk/resourcemover/arm-resourcemover/README.md
+++ b/sdk/resourcemover/arm-resourcemover/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for ResourceMoverServiceAPI.
 
-> Please note, a newer package [@azure/arm-resourcemover](https://www.npmjs.com/package/@azure/arm-resourcemover) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-resourcemover with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/resources-subscriptions/arm-resources-subscriptions/README.md
+++ b/sdk/resources-subscriptions/arm-resources-subscriptions/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for SubscriptionClient.
 
-> Please note, a newer package [@azure/arm-resources-subscriptions](https://www.npmjs.com/package/@azure/arm-resources-subscriptions) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-resources-subscriptions with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/resources-subscriptions/arm-resources-subscriptions/README.md
+++ b/sdk/resources-subscriptions/arm-resources-subscriptions/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for SubscriptionClient.
 
+> Please note, a newer package [@azure/arm-resources-subscriptions](https://www.npmjs.com/package/@azure/arm-resources-subscriptions) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
-- Latest versions of Safari, Chrome, Edge and Firefox.
+- Latest versions of Safari, Chrome, Edge, and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/resources/arm-resources-profile-2020-09-01-hybrid/README.md
+++ b/sdk/resources/arm-resources-profile-2020-09-01-hybrid/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for ResourceManagementClient.
 
+> Please note, a newer package [@azure/arm-resources-profile-2020-09-01-hybrid](https://www.npmjs.com/package/@azure/arm-resources-profile-2020-09-01-hybrid) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge, and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/resources/arm-resources-profile-2020-09-01-hybrid/README.md
+++ b/sdk/resources/arm-resources-profile-2020-09-01-hybrid/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for ResourceManagementClient.
 
-> Please note, a newer package [@azure/arm-resources-profile-2020-09-01-hybrid](https://www.npmjs.com/package/@azure/arm-resources-profile-2020-09-01-hybrid) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-resources-profile-2020-09-01-hybrid with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/resources/arm-resources-profile-hybrid-2019-03-01/README.md
+++ b/sdk/resources/arm-resources-profile-hybrid-2019-03-01/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for ResourceManagementClient.
 
+> Please note, a newer package [@azure/arm-resources-profile-hybrid-2019-03-01](https://www.npmjs.com/package/@azure/arm-resources-profile-hybrid-2019-03-01) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge, and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/resources/arm-resources-profile-hybrid-2019-03-01/README.md
+++ b/sdk/resources/arm-resources-profile-hybrid-2019-03-01/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for ResourceManagementClient.
 
-> Please note, a newer package [@azure/arm-resources-profile-hybrid-2019-03-01](https://www.npmjs.com/package/@azure/arm-resources-profile-hybrid-2019-03-01) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-resources-profile-hybrid-2019-03-01 with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/resources/arm-resources/README.md
+++ b/sdk/resources/arm-resources/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for ResourceManagementClient.
 
+> Please note, a newer package [@azure/arm-resources](https://www.npmjs.com/package/@azure/arm-resources) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge, and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/resources/arm-resources/README.md
+++ b/sdk/resources/arm-resources/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for ResourceManagementClient.
 
-> Please note, a newer package [@azure/arm-resources](https://www.npmjs.com/package/@azure/arm-resources) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-resources with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/resources/arm-resources/README.md
+++ b/sdk/resources/arm-resources/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for ResourceManagementClient.
 
-> ⚠️ This package @azure/arm-resources with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
+> ⚠️ This package @azure/arm-resources with versions lower than 5.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 5.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/search/arm-search/README.md
+++ b/sdk/search/arm-search/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for SearchManagementClient.
 
-> Please note, a newer package [@azure/arm-search](https://www.npmjs.com/package/@azure/arm-search) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-search with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/search/arm-search/README.md
+++ b/sdk/search/arm-search/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for SearchManagementClient.
 
-> ⚠️ This package @azure/arm-search with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
+> ⚠️ This package @azure/arm-search with versions lower than 3.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 3.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/search/arm-search/README.md
+++ b/sdk/search/arm-search/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for SearchManagementClient.
 
+> Please note, a newer package [@azure/arm-search](https://www.npmjs.com/package/@azure/arm-search) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
-- Latest versions of Safari, Chrome, Edge and Firefox.
+- Latest versions of Safari, Chrome, Edge, and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/security/arm-security/README.md
+++ b/sdk/security/arm-security/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for SecurityCenter.
 
+> Please note, a newer package [@azure/arm-security](https://www.npmjs.com/package/@azure/arm-security) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
-- Latest versions of Safari, Chrome, Edge and Firefox.
+- Latest versions of Safari, Chrome, Edge, and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/security/arm-security/README.md
+++ b/sdk/security/arm-security/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for SecurityCenter.
 
-> ⚠️ This package @azure/arm-security with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
+> ⚠️ This package @azure/arm-security with versions lower than 4.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 4.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/security/arm-security/README.md
+++ b/sdk/security/arm-security/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for SecurityCenter.
 
-> Please note, a newer package [@azure/arm-security](https://www.npmjs.com/package/@azure/arm-security) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-security with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/serialconsole/arm-serialconsole/README.md
+++ b/sdk/serialconsole/arm-serialconsole/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for MicrosoftSerialConsoleClient.
 
-> Please note, a newer package [@azure/arm-serialconsole](https://www.npmjs.com/package/@azure/arm-serialconsole) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-serialconsole with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/serialconsole/arm-serialconsole/README.md
+++ b/sdk/serialconsole/arm-serialconsole/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for MicrosoftSerialConsoleClient.
 
+> Please note, a newer package [@azure/arm-serialconsole](https://www.npmjs.com/package/@azure/arm-serialconsole) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge, and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/service-map/arm-servicemap/README.md
+++ b/sdk/service-map/arm-servicemap/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for ServicemapManagementClient.
 
-> Please note, a newer package [@azure/arm-servicemap](https://www.npmjs.com/package/@azure/arm-servicemap) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-servicemap with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/service-map/arm-servicemap/README.md
+++ b/sdk/service-map/arm-servicemap/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for ServicemapManagementClient.
 
+> Please note, a newer package [@azure/arm-servicemap](https://www.npmjs.com/package/@azure/arm-servicemap) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge, and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/service-map/arm-servicemap/README.md
+++ b/sdk/service-map/arm-servicemap/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for ServicemapManagementClient.
 
-> ⚠️ This package @azure/arm-servicemap with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
+> ⚠️ This package @azure/arm-servicemap with versions lower than 3.0.0-beta.1 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 3.0.0-beta.1 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/servicebus/arm-servicebus/README.md
+++ b/sdk/servicebus/arm-servicebus/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for ServiceBusManagementClient.
 
+> Please note, a newer package [@azure/arm-servicebus](https://www.npmjs.com/package/@azure/arm-servicebus) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge, and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/servicebus/arm-servicebus/README.md
+++ b/sdk/servicebus/arm-servicebus/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for ServiceBusManagementClient.
 
-> Please note, a newer package [@azure/arm-servicebus](https://www.npmjs.com/package/@azure/arm-servicebus) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-servicebus with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/servicefabric/arm-servicefabric/README.md
+++ b/sdk/servicefabric/arm-servicefabric/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for ServiceFabricManagementClient.
 
+> Please note, a newer package [@azure/arm-servicefabric](https://www.npmjs.com/package/@azure/arm-servicefabric) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge, and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/servicefabric/arm-servicefabric/README.md
+++ b/sdk/servicefabric/arm-servicefabric/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for ServiceFabricManagementClient.
 
-> Please note, a newer package [@azure/arm-servicefabric](https://www.npmjs.com/package/@azure/arm-servicefabric) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-servicefabric with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/servicefabricmesh/arm-servicefabricmesh/README.md
+++ b/sdk/servicefabricmesh/arm-servicefabricmesh/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for ServiceFabricMeshManagementClient.
 
+> Please note, a newer package [@azure/arm-servicefabricmesh](https://www.npmjs.com/package/@azure/arm-servicefabricmesh) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge, and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/servicefabricmesh/arm-servicefabricmesh/README.md
+++ b/sdk/servicefabricmesh/arm-servicefabricmesh/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for ServiceFabricMeshManagementClient.
 
-> ⚠️ This package @azure/arm-servicefabricmesh with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
+> ⚠️ This package @azure/arm-servicefabricmesh with versions lower than 3.0.0-beta.1 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 3.0.0-beta.1 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/servicefabricmesh/arm-servicefabricmesh/README.md
+++ b/sdk/servicefabricmesh/arm-servicefabricmesh/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for ServiceFabricMeshManagementClient.
 
-> Please note, a newer package [@azure/arm-servicefabricmesh](https://www.npmjs.com/package/@azure/arm-servicefabricmesh) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-servicefabricmesh with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/signalr/arm-signalr/README.md
+++ b/sdk/signalr/arm-signalr/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for SignalRManagementClient.
 
-> ⚠️ This package @azure/arm-signalr with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
+> ⚠️ This package @azure/arm-signalr with versions lower than 5.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 5.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/signalr/arm-signalr/README.md
+++ b/sdk/signalr/arm-signalr/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for SignalRManagementClient.
 
+> Please note, a newer package [@azure/arm-signalr](https://www.npmjs.com/package/@azure/arm-signalr) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
-- Latest versions of Safari, Chrome, Edge and Firefox.
+- Latest versions of Safari, Chrome, Edge, and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/signalr/arm-signalr/README.md
+++ b/sdk/signalr/arm-signalr/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for SignalRManagementClient.
 
-> Please note, a newer package [@azure/arm-signalr](https://www.npmjs.com/package/@azure/arm-signalr) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-signalr with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/sql/arm-sql/README.md
+++ b/sdk/sql/arm-sql/README.md
@@ -2,11 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for SqlManagementClient.
 
+> Please note, a newer package [@azure/arm-sql](https://www.npmjs.com/package/@azure/arm-sql) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
-- Latest versions of Safari, Chrome, Edge and Firefox.
+- Latest versions of Safari, Chrome, Edge, and Firefox.
 
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 ### Prerequisites
 
 You must have an [Azure subscription](https://azure.microsoft.com/free/).

--- a/sdk/sql/arm-sql/README.md
+++ b/sdk/sql/arm-sql/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for SqlManagementClient.
 
-> ⚠️ This package @azure/arm-sql with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
+> ⚠️ This package @azure/arm-sql with versions lower than 9.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 9.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/sql/arm-sql/README.md
+++ b/sdk/sql/arm-sql/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for SqlManagementClient.
 
-> Please note, a newer package [@azure/arm-sql](https://www.npmjs.com/package/@azure/arm-sql) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-sql with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/sqlvirtualmachine/arm-sqlvirtualmachine/README.md
+++ b/sdk/sqlvirtualmachine/arm-sqlvirtualmachine/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for SqlVirtualMachineManagementClient.
 
+> Please note, a newer package [@azure/arm-sqlvirtualmachine](https://www.npmjs.com/package/@azure/arm-sqlvirtualmachine) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge, and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/sqlvirtualmachine/arm-sqlvirtualmachine/README.md
+++ b/sdk/sqlvirtualmachine/arm-sqlvirtualmachine/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for SqlVirtualMachineManagementClient.
 
-> Please note, a newer package [@azure/arm-sqlvirtualmachine](https://www.npmjs.com/package/@azure/arm-sqlvirtualmachine) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-sqlvirtualmachine with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/sqlvirtualmachine/arm-sqlvirtualmachine/README.md
+++ b/sdk/sqlvirtualmachine/arm-sqlvirtualmachine/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for SqlVirtualMachineManagementClient.
 
-> ⚠️ This package @azure/arm-sqlvirtualmachine with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
+> ⚠️ This package @azure/arm-sqlvirtualmachine with versions lower than 5.0.0-beta.1 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 5.0.0-beta.1 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/storage/arm-storage-profile-2019-03-01-hybrid/README.md
+++ b/sdk/storage/arm-storage-profile-2019-03-01-hybrid/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for StorageManagementClient.
 
+> Please note, a newer package [@azure/arm-storage-profile-2019-03-01-hybrid](https://www.npmjs.com/package/@azure/arm-storage-profile-2019-03-01-hybrid) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge, and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/storage/arm-storage-profile-2019-03-01-hybrid/README.md
+++ b/sdk/storage/arm-storage-profile-2019-03-01-hybrid/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for StorageManagementClient.
 
-> Please note, a newer package [@azure/arm-storage-profile-2019-03-01-hybrid](https://www.npmjs.com/package/@azure/arm-storage-profile-2019-03-01-hybrid) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-storage-profile-2019-03-01-hybrid with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/storage/arm-storage-profile-2020-09-01-hybrid/README.md
+++ b/sdk/storage/arm-storage-profile-2020-09-01-hybrid/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for StorageManagementClient.
 
-> Please note, a newer package [@azure/arm-storage-profile-2020-09-01-hybrid](https://www.npmjs.com/package/@azure/arm-storage-profile-2020-09-01-hybrid) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-storage-profile-2020-09-01-hybrid with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/storage/arm-storage-profile-2020-09-01-hybrid/README.md
+++ b/sdk/storage/arm-storage-profile-2020-09-01-hybrid/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for StorageManagementClient.
 
+> Please note, a newer package [@azure/arm-storage-profile-2020-09-01-hybrid](https://www.npmjs.com/package/@azure/arm-storage-profile-2020-09-01-hybrid) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge, and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/storage/arm-storage/README.md
+++ b/sdk/storage/arm-storage/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for StorageManagementClient.
 
-> Please note, a newer package [@azure/arm-storage](https://www.npmjs.com/package/@azure/arm-storage) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-storage with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/storage/arm-storage/README.md
+++ b/sdk/storage/arm-storage/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for StorageManagementClient.
 
-> ⚠️ This package @azure/arm-storage with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
+> ⚠️ This package @azure/arm-storage with versions lower than 17.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 17.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/storage/arm-storage/README.md
+++ b/sdk/storage/arm-storage/README.md
@@ -2,11 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for StorageManagementClient.
 
+> Please note, a newer package [@azure/arm-storage](https://www.npmjs.com/package/@azure/arm-storage) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge, and Firefox.
 
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 ### Prerequisites
 
 You must have an [Azure subscription](https://azure.microsoft.com/free/).

--- a/sdk/storagecache/arm-storagecache/README.md
+++ b/sdk/storagecache/arm-storagecache/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for StorageCacheManagementClient.
 
-> ⚠️ This package @azure/arm-storagecache with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
+> ⚠️ This package @azure/arm-storagecache with versions lower than 5.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 5.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/storagecache/arm-storagecache/README.md
+++ b/sdk/storagecache/arm-storagecache/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for StorageCacheManagementClient.
 
+> Please note, a newer package [@azure/arm-storagecache](https://www.npmjs.com/package/@azure/arm-storagecache) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
-- Latest versions of Safari, Chrome, Edge and Firefox.
+- Latest versions of Safari, Chrome, Edge, and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/storagecache/arm-storagecache/README.md
+++ b/sdk/storagecache/arm-storagecache/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for StorageCacheManagementClient.
 
-> Please note, a newer package [@azure/arm-storagecache](https://www.npmjs.com/package/@azure/arm-storagecache) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-storagecache with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/storageimportexport/arm-storageimportexport/README.md
+++ b/sdk/storageimportexport/arm-storageimportexport/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for StorageImportExportManagementClient.
 
-> Please note, a newer package [@azure/arm-storageimportexport](https://www.npmjs.com/package/@azure/arm-storageimportexport) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-storageimportexport with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/storageimportexport/arm-storageimportexport/README.md
+++ b/sdk/storageimportexport/arm-storageimportexport/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for StorageImportExportManagementClient.
 
+> Please note, a newer package [@azure/arm-storageimportexport](https://www.npmjs.com/package/@azure/arm-storageimportexport) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge, and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/storagesync/arm-storagesync/README.md
+++ b/sdk/storagesync/arm-storagesync/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for StorageSyncManagementClient.
 
-> Please note, a newer package [@azure/arm-storagesync](https://www.npmjs.com/package/@azure/arm-storagesync) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-storagesync with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/storagesync/arm-storagesync/README.md
+++ b/sdk/storagesync/arm-storagesync/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for StorageSyncManagementClient.
 
-> ⚠️ This package @azure/arm-storagesync with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
+> ⚠️ This package @azure/arm-storagesync with versions lower than 9.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 9.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/storagesync/arm-storagesync/README.md
+++ b/sdk/storagesync/arm-storagesync/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for StorageSyncManagementClient.
 
+> Please note, a newer package [@azure/arm-storagesync](https://www.npmjs.com/package/@azure/arm-storagesync) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge, and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/storsimple1200series/arm-storsimple1200series/README.md
+++ b/sdk/storsimple1200series/arm-storsimple1200series/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for StorSimpleManagementClient.
 
-> Please note, a newer package [@azure/arm-storsimple1200series](https://www.npmjs.com/package/@azure/arm-storsimple1200series) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-storsimple1200series with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/storsimple1200series/arm-storsimple1200series/README.md
+++ b/sdk/storsimple1200series/arm-storsimple1200series/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for StorSimpleManagementClient.
 
+> Please note, a newer package [@azure/arm-storsimple1200series](https://www.npmjs.com/package/@azure/arm-storsimple1200series) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge, and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/storsimple8000series/arm-storsimple8000series/README.md
+++ b/sdk/storsimple8000series/arm-storsimple8000series/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for StorSimple8000SeriesManagementClient.
 
+> Please note, a newer package [@azure/arm-storsimple8000series](https://www.npmjs.com/package/@azure/arm-storsimple8000series) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge, and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/storsimple8000series/arm-storsimple8000series/README.md
+++ b/sdk/storsimple8000series/arm-storsimple8000series/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for StorSimple8000SeriesManagementClient.
 
-> Please note, a newer package [@azure/arm-storsimple8000series](https://www.npmjs.com/package/@azure/arm-storsimple8000series) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-storsimple8000series with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/streamanalytics/arm-streamanalytics/README.md
+++ b/sdk/streamanalytics/arm-streamanalytics/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for StreamAnalyticsManagementClient.
 
-> Please note, a newer package [@azure/arm-streamanalytics](https://www.npmjs.com/package/@azure/arm-streamanalytics) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-streamanalytics with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/streamanalytics/arm-streamanalytics/README.md
+++ b/sdk/streamanalytics/arm-streamanalytics/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for StreamAnalyticsManagementClient.
 
-> ⚠️ This package @azure/arm-streamanalytics with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
+> ⚠️ This package @azure/arm-streamanalytics with versions lower than 4.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 4.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/streamanalytics/arm-streamanalytics/README.md
+++ b/sdk/streamanalytics/arm-streamanalytics/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for StreamAnalyticsManagementClient.
 
+> Please note, a newer package [@azure/arm-streamanalytics](https://www.npmjs.com/package/@azure/arm-streamanalytics) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
-- Latest versions of Safari, Chrome, Edge and Firefox.
+- Latest versions of Safari, Chrome, Edge, and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/subscription/arm-subscriptions-profile-2020-09-01-hybrid/README.md
+++ b/sdk/subscription/arm-subscriptions-profile-2020-09-01-hybrid/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for SubscriptionClient.
 
+> Please note, a newer package [@azure/arm-subscriptions-profile-2020-09-01-hybrid](https://www.npmjs.com/package/@azure/arm-subscriptions-profile-2020-09-01-hybrid) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge, and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/subscription/arm-subscriptions-profile-2020-09-01-hybrid/README.md
+++ b/sdk/subscription/arm-subscriptions-profile-2020-09-01-hybrid/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for SubscriptionClient.
 
-> Please note, a newer package [@azure/arm-subscriptions-profile-2020-09-01-hybrid](https://www.npmjs.com/package/@azure/arm-subscriptions-profile-2020-09-01-hybrid) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-subscriptions-profile-2020-09-01-hybrid with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/subscription/arm-subscriptions-profile-hybrid-2019-03-01/README.md
+++ b/sdk/subscription/arm-subscriptions-profile-hybrid-2019-03-01/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for SubscriptionClient.
 
-> Please note, a newer package [@azure/arm-subscriptions-profile-hybrid-2019-03-01](https://www.npmjs.com/package/@azure/arm-subscriptions-profile-hybrid-2019-03-01) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-subscriptions-profile-hybrid-2019-03-01 with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/subscription/arm-subscriptions-profile-hybrid-2019-03-01/README.md
+++ b/sdk/subscription/arm-subscriptions-profile-hybrid-2019-03-01/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for SubscriptionClient.
 
+> Please note, a newer package [@azure/arm-subscriptions-profile-hybrid-2019-03-01](https://www.npmjs.com/package/@azure/arm-subscriptions-profile-hybrid-2019-03-01) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge, and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/subscription/arm-subscriptions/README.md
+++ b/sdk/subscription/arm-subscriptions/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for SubscriptionClient.
 
+> Please note, a newer package [@azure/arm-subscriptions](https://www.npmjs.com/package/@azure/arm-subscriptions) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge, and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/subscription/arm-subscriptions/README.md
+++ b/sdk/subscription/arm-subscriptions/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for SubscriptionClient.
 
-> ⚠️ This package @azure/arm-subscriptions with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
+> ⚠️ This package @azure/arm-subscriptions with versions lower than 5.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 5.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/subscription/arm-subscriptions/README.md
+++ b/sdk/subscription/arm-subscriptions/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for SubscriptionClient.
 
-> Please note, a newer package [@azure/arm-subscriptions](https://www.npmjs.com/package/@azure/arm-subscriptions) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-subscriptions with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/support/arm-support/README.md
+++ b/sdk/support/arm-support/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for MicrosoftSupport.
 
-> Please note, a newer package [@azure/arm-support](https://www.npmjs.com/package/@azure/arm-support) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-support with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/support/arm-support/README.md
+++ b/sdk/support/arm-support/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for MicrosoftSupport.
 
+> Please note, a newer package [@azure/arm-support](https://www.npmjs.com/package/@azure/arm-support) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge, and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/synapse/arm-synapse/README.md
+++ b/sdk/synapse/arm-synapse/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for SynapseManagementClient.
 
-> Please note, a newer package [@azure/arm-synapse](https://www.npmjs.com/package/@azure/arm-synapse) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-synapse with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/synapse/arm-synapse/README.md
+++ b/sdk/synapse/arm-synapse/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for SynapseManagementClient.
 
+> Please note, a newer package [@azure/arm-synapse](https://www.npmjs.com/package/@azure/arm-synapse) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
-- Latest versions of Safari, Chrome, Edge and Firefox.
+- Latest versions of Safari, Chrome, Edge, and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/synapse/arm-synapse/README.md
+++ b/sdk/synapse/arm-synapse/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for SynapseManagementClient.
 
-> ⚠️ This package @azure/arm-synapse with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
+> ⚠️ This package @azure/arm-synapse with versions lower than 8.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 8.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/templatespecs/arm-templatespecs/README.md
+++ b/sdk/templatespecs/arm-templatespecs/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for TemplateSpecsClient.
 
-> Please note, a newer package [@azure/arm-templatespecs](https://www.npmjs.com/package/@azure/arm-templatespecs) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-templatespecs with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/templatespecs/arm-templatespecs/README.md
+++ b/sdk/templatespecs/arm-templatespecs/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for TemplateSpecsClient.
 
+> Please note, a newer package [@azure/arm-templatespecs](https://www.npmjs.com/package/@azure/arm-templatespecs) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
-- Latest versions of Safari, Chrome, Edge and Firefox.
+- Latest versions of Safari, Chrome, Edge, and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/timeseriesinsights/arm-timeseriesinsights/README.md
+++ b/sdk/timeseriesinsights/arm-timeseriesinsights/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for TimeSeriesInsightsClient.
 
-> Please note, a newer package [@azure/arm-timeseriesinsights](https://www.npmjs.com/package/@azure/arm-timeseriesinsights) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-timeseriesinsights with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/timeseriesinsights/arm-timeseriesinsights/README.md
+++ b/sdk/timeseriesinsights/arm-timeseriesinsights/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for TimeSeriesInsightsClient.
 
+> Please note, a newer package [@azure/arm-timeseriesinsights](https://www.npmjs.com/package/@azure/arm-timeseriesinsights) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge, and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/trafficmanager/arm-trafficmanager/README.md
+++ b/sdk/trafficmanager/arm-trafficmanager/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for TrafficManagerManagementClient.
 
+> Please note, a newer package [@azure/arm-trafficmanager](https://www.npmjs.com/package/@azure/arm-trafficmanager) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge, and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/trafficmanager/arm-trafficmanager/README.md
+++ b/sdk/trafficmanager/arm-trafficmanager/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for TrafficManagerManagementClient.
 
-> Please note, a newer package [@azure/arm-trafficmanager](https://www.npmjs.com/package/@azure/arm-trafficmanager) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-trafficmanager with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/trafficmanager/arm-trafficmanager/README.md
+++ b/sdk/trafficmanager/arm-trafficmanager/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for TrafficManagerManagementClient.
 
-> ⚠️ This package @azure/arm-trafficmanager with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
+> ⚠️ This package @azure/arm-trafficmanager with versions lower than 6.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 6.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/visualstudio/arm-visualstudio/README.md
+++ b/sdk/visualstudio/arm-visualstudio/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for VisualStudioResourceProviderClient.
 
-> Please note, a newer package [@azure/arm-visualstudio](https://www.npmjs.com/package/@azure/arm-visualstudio) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-visualstudio with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/visualstudio/arm-visualstudio/README.md
+++ b/sdk/visualstudio/arm-visualstudio/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for VisualStudioResourceProviderClient.
 
+> Please note, a newer package [@azure/arm-visualstudio](https://www.npmjs.com/package/@azure/arm-visualstudio) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
-- Latest versions of Safari, Chrome, Edge and Firefox.
+- Latest versions of Safari, Chrome, Edge, and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 

--- a/sdk/visualstudio/arm-visualstudio/README.md
+++ b/sdk/visualstudio/arm-visualstudio/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for VisualStudioResourceProviderClient.
 
-> ⚠️ This package @azure/arm-visualstudio with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
+> ⚠️ This package @azure/arm-visualstudio with versions lower than 4.0.0-beta.1 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 4.0.0-beta.1 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/vmwarecloudsimple/arm-vmwarecloudsimple/README.md
+++ b/sdk/vmwarecloudsimple/arm-vmwarecloudsimple/README.md
@@ -2,7 +2,7 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for VMwareCloudSimpleClient.
 
-> Please note, a newer package [@azure/arm-vmwarecloudsimple](https://www.npmjs.com/package/@azure/arm-vmwarecloudsimple) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+> ⚠️ This package @azure/arm-vmwarecloudsimple with versions lower than 2.0.0 are going to be deprecated in March 2022, we strongly recommend you to upgrade your dependency on it to version 2.0.0 or above as soon as possible. The deprecate means, it starts the end of support for that library. You can continue to use the libraries indefinitely (as long as the service is running), but after 1 year, no further bug fixes or security fixes will be provided.
 
 ### Currently supported environments
 

--- a/sdk/vmwarecloudsimple/arm-vmwarecloudsimple/README.md
+++ b/sdk/vmwarecloudsimple/arm-vmwarecloudsimple/README.md
@@ -2,10 +2,14 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for VMwareCloudSimpleClient.
 
+> Please note, a newer package [@azure/arm-vmwarecloudsimple](https://www.npmjs.com/package/@azure/arm-vmwarecloudsimple) is available as of March 2022 While this package will continue to receive critical bug fixes and we strongly encourage you to upgrade.
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge, and Firefox.
+
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
 ### Prerequisites
 


### PR DESCRIPTION
This PR will remind track1 JS SDK users to upgrade the sdk version to track2, the reasons for doing so are:

- The sdk of track1 has stopped updating. If you want to get better technical support in the process of using the sdk, we recommend upgrading the sdk version