### PR TITLE
[EventHubs] fix sample issue when running in build pipeline

### DIFF
--- a/sdk/eventhub/event-hubs/samples-dev/sendBufferedEvents.ts
+++ b/sdk/eventhub/event-hubs/samples-dev/sendBufferedEvents.ts
@@ -16,6 +16,7 @@ import * as dotenv from "dotenv";
 dotenv.config();
 
 const connectionString = process.env["EVENTHUB_CONNECTION_STRING"] || "";
+const eventHubName = process.env["EVENTHUB_NAME"] || "";
 
 async function handleError(ctx: OnSendEventsErrorContext): Promise<void> {
   console.log(`The following error occurred:`);
@@ -36,7 +37,7 @@ export async function main(): Promise<void> {
    * Create a buffered client that batches the enqueued events and sends it either
    * after 750ms or after batching 1000 events, whichever occurs first.
    */
-  const client = new EventHubBufferedProducerClient(connectionString, {
+  const client = new EventHubBufferedProducerClient(connectionString, eventHubName, {
     /** An error handler must be provided */
     onSendEventsErrorHandler: handleError,
 


### PR DESCRIPTION
The value provided to EVENTHUB_CONNECTION_STRING in the live test pipeline
doesn't contain the event hub name so it's failing with error:

> TypeError: Either provide "eventHubName" or the "connectionString": "***", must contain "EntityPath=<your-event-hub-name>".

This PR passes event hub name too to the client constructor in the same way as
some other tests do.

Fixes #20369 
