### PR TITLE
[Test] Reduce some live tests time out limits

### DIFF
--- a/sdk/appconfiguration/app-configuration/tests.yml
+++ b/sdk/appconfiguration/app-configuration/tests.yml
@@ -5,7 +5,6 @@ stages:
     parameters:
       PackageName: "@azure/app-configuration"
       ServiceDirectory: appconfiguration
-      TimeoutInMinutes: 200
       SupportedClouds: 'Public,UsGov,China'
       EnvVars:
         AZURE_CLIENT_ID: $(aad-azure-sdk-test-client-id)

--- a/sdk/eventhub/event-hubs/package.json
+++ b/sdk/eventhub/event-hubs/package.json
@@ -60,7 +60,7 @@
     "format": "prettier --write --config ../../../.prettierrc.json --ignore-path ../../../.prettierignore \"src/**/*.ts\" \"test/**/*.ts\" \"samples-dev/**/*.ts\" \"*.{js,json}\"",
     "generate-certs": "node ./scripts/generateCerts.js",
     "integration-test:browser": "cross-env TEST_TARGET=live DISABLE_MULTI_VERSION_TESTING=true karma start --single-run",
-    "integration-test:node": "cross-env TEST_TARGET=live DISABLE_MULTI_VERSION_TESTING=true nyc mocha -r esm --require source-map-support/register --reporter ../../../common/tools/mocha-multi-reporter.js --timeout 1200000 --full-trace \"dist-esm/test/internal/*.spec.js\" \"dist-esm/test/public/*.spec.js\" \"dist-esm/test/public/**/*.spec.js\" \"dist-esm/test/internal/**/*.spec.js\"",
+    "integration-test:node": "cross-env TEST_TARGET=live DISABLE_MULTI_VERSION_TESTING=true nyc mocha -r esm --require source-map-support/register --reporter ../../../common/tools/mocha-multi-reporter.js --timeout 600000 --full-trace \"dist-esm/test/internal/*.spec.js\" \"dist-esm/test/public/*.spec.js\" \"dist-esm/test/public/**/*.spec.js\" \"dist-esm/test/internal/**/*.spec.js\"",
     "integration-test": "npm run integration-test:node && npm run integration-test:browser",
     "lint:fix": "eslint package.json api-extractor.json src test --ext .ts --fix --fix-type [problem,suggestion]",
     "lint": "eslint package.json api-extractor.json src test --ext .ts",

--- a/sdk/servicebus/service-bus/package.json
+++ b/sdk/servicebus/service-bus/package.json
@@ -60,7 +60,7 @@
     "extract-api": "tsc -p . && api-extractor run --local",
     "format": "prettier --write --config ../../../.prettierrc.json --ignore-path ../../../.prettierignore \"samples/**/*.{ts,js}\" \"src/**/*.ts\" \"test/**/*.ts\" \"samples-dev/**/*.ts\" \"*.{js,json}\"",
     "integration-test:browser": "karma start --single-run",
-    "integration-test:node": "nyc mocha -r esm --require source-map-support/register --reporter ../../../common/tools/mocha-multi-reporter.js --timeout 1200000 --full-trace \"dist-esm/test/internal/**/*.spec.js\" \"dist-esm/test/public/**/*.spec.js\"",
+    "integration-test:node": "nyc mocha -r esm --require source-map-support/register --reporter ../../../common/tools/mocha-multi-reporter.js --timeout 600000 --full-trace \"dist-esm/test/internal/**/*.spec.js\" \"dist-esm/test/public/**/*.spec.js\"",
     "integration-test": "npm run integration-test:node && npm run integration-test:browser",
     "lint:fix": "eslint package.json api-extractor.json src test --ext .ts --fix --fix-type [problem,suggestion]",
     "lint": "eslint package.json api-extractor.json src test --ext .ts",

--- a/sdk/servicebus/service-bus/tests.yml
+++ b/sdk/servicebus/service-bus/tests.yml
@@ -5,7 +5,7 @@ stages:
     parameters:
       PackageName: "@azure/service-bus"
       ServiceDirectory: servicebus
-      TimeoutInMinutes: 180
+      TimeoutInMinutes: 90
       Clouds: 'Public,Canary'
       SupportedClouds: 'Public,UsGov,China'
       EnvVars:


### PR DESCRIPTION
- Service Bus and Event Hubs live tests used to take much longer time to run but we have
improved significantly since then.

- AppConfig live tests usually finish under 30 minutes.