### PR TITLE
[Tables] Fix getStatistics operation

### DIFF
--- a/sdk/tables/data-tables/CHANGELOG.md
+++ b/sdk/tables/data-tables/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Fix issue with `getStatistics()` operation consistently failing and added test. [#20398](https://github.com/Azure/azure-sdk-for-js/pull/20398)
+
 ### Other Changes
 
 ## 13.0.1 (2022-01-12)

--- a/sdk/tables/data-tables/recordings/browsers/tableserviceclient_statistics/recording_should_getstatistics.json
+++ b/sdk/tables/data-tables/recordings/browsers/tableserviceclient_statistics/recording_should_getstatistics.json
@@ -1,0 +1,40 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://fakeaccountname-secondary.table.core.windows.net/?st=2021-08-03T08:52:15Z\u0026spr=https\u0026sig=fakesigval\u0026restype=service\u0026comp=stats",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Accept-Encoding": "gzip, deflate, br",
+        "Accept-Language": "en-US",
+        "Referer": "http://localhost:9876/",
+        "sec-ch-ua": "",
+        "sec-ch-ua-mobile": "?0",
+        "sec-ch-ua-platform": "",
+        "Sec-Fetch-Dest": "empty",
+        "Sec-Fetch-Mode": "cors",
+        "Sec-Fetch-Site": "same-site",
+        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/93.0.4577.0 Safari/537.36",
+        "x-ms-client-request-id": "daf85fb6-9736-4caf-8df8-cf1affc2c740",
+        "x-ms-useragent": "azsdk-js-data-tables/13.0.2 core-rest-pipeline/1.5.1 OS/Linuxx86_64",
+        "x-ms-version": "2019-02-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Type": "application/xml",
+        "Date": "Tue, 15 Feb 2022 21:39:23 GMT",
+        "Server": [
+          "Windows-Azure-Table/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Transfer-Encoding": "chunked",
+        "x-ms-client-request-id": "daf85fb6-9736-4caf-8df8-cf1affc2c740",
+        "x-ms-request-id": "17d2cc60-7002-005f-55b4-22142e000000",
+        "x-ms-version": "2019-02-02"
+      },
+      "ResponseBody": "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CStorageServiceStats\u003E\u003CGeoReplication\u003E\u003CStatus\u003Elive\u003C/Status\u003E\u003CLastSyncTime\u003ETue, 15 Feb 2022 21:35:13 GMT\u003C/LastSyncTime\u003E\u003C/GeoReplication\u003E\u003C/StorageServiceStats\u003E"
+    }
+  ],
+  "Variables": {}
+}

--- a/sdk/tables/data-tables/recordings/node/tableserviceclient_statistics/recording_should_getstatistics.json
+++ b/sdk/tables/data-tables/recordings/node/tableserviceclient_statistics/recording_should_getstatistics.json
@@ -1,0 +1,31 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://fakeaccountname-secondary.table.core.windows.net/?st=2021-08-03T08:52:15Z\u0026spr=https\u0026sig=fakesigval\u0026restype=service\u0026comp=stats",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Accept-Encoding": "gzip,deflate",
+        "User-Agent": "azsdk-js-data-tables/13.0.2 core-rest-pipeline/1.5.1 Node/v12.22.9 OS/(x64-Linux-5.4.0-1067-azure)",
+        "x-ms-client-request-id": "a9f80d16-4d59-4dbc-80b5-76bb0456af08",
+        "x-ms-version": "2019-02-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Type": "application/xml",
+        "Date": "Tue, 15 Feb 2022 21:46:40 GMT",
+        "Server": [
+          "Windows-Azure-Table/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Transfer-Encoding": "chunked",
+        "x-ms-client-request-id": "a9f80d16-4d59-4dbc-80b5-76bb0456af08",
+        "x-ms-request-id": "b12d2e24-6002-00b7-50b5-228db8000000",
+        "x-ms-version": "2019-02-02"
+      },
+      "ResponseBody": "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CStorageServiceStats\u003E\u003CGeoReplication\u003E\u003CStatus\u003Elive\u003C/Status\u003E\u003CLastSyncTime\u003ETue, 15 Feb 2022 21:43:21 GMT\u003C/LastSyncTime\u003E\u003C/GeoReplication\u003E\u003C/StorageServiceStats\u003E"
+    }
+  ],
+  "Variables": {}
+}

--- a/sdk/tables/data-tables/src/TableServiceClient.ts
+++ b/sdk/tables/data-tables/src/TableServiceClient.ts
@@ -188,7 +188,7 @@ export class TableServiceClient {
     this.pipeline = client.pipeline;
     this.table = client.table;
     this.service = client.service;
-    
+
     const secondaryUrl = getSecondaryUrlFromPrimarystri(this.url);
     this.secondaryServiceOperations = new GeneratedClient(secondaryUrl, {
       ...internalPipelineOptions,

--- a/sdk/tables/data-tables/src/TableServiceClient.ts
+++ b/sdk/tables/data-tables/src/TableServiceClient.ts
@@ -26,11 +26,11 @@ import {
   isTokenCredential,
 } from "@azure/core-auth";
 import { STORAGE_SCOPE, TablesLoggingAllowedHeaderNames } from "./utils/constants";
+import { Service, Table } from "./generated";
 import {
-  SecondaryLocationHeaderName,
+  injectSecondaryEndpointHeader,
   tablesSecondaryEndpointPolicy,
 } from "./secondaryEndpointPolicy";
-import { Service, Table } from "./generated";
 import { parseXML, stringifyXML } from "@azure/core-xml";
 
 import { GeneratedClient } from "./generated/generatedClient";
@@ -199,11 +199,12 @@ export class TableServiceClient {
    */
   public async getStatistics(options: OperationOptions = {}): Promise<GetStatisticsResponse> {
     const { span, updatedOptions } = createSpan("TableServiceClient-getStatistics", options);
+    if (updatedOptions.requestOptions?.customHeaders) {
+      updatedOptions.requestOptions?.customHeaders;
+    }
+
     try {
-      return await this.service.getStatistics({
-        ...updatedOptions,
-        requestOptions: { customHeaders: { [SecondaryLocationHeaderName]: "true" } },
-      });
+      return await this.service.getStatistics(injectSecondaryEndpointHeader(updatedOptions));
     } catch (e) {
       span.setStatus({ code: SpanStatusCode.ERROR, message: e.message });
       throw e;

--- a/sdk/tables/data-tables/src/TableServiceClient.ts
+++ b/sdk/tables/data-tables/src/TableServiceClient.ts
@@ -199,10 +199,6 @@ export class TableServiceClient {
    */
   public async getStatistics(options: OperationOptions = {}): Promise<GetStatisticsResponse> {
     const { span, updatedOptions } = createSpan("TableServiceClient-getStatistics", options);
-    if (updatedOptions.requestOptions?.customHeaders) {
-      updatedOptions.requestOptions?.customHeaders;
-    }
-
     try {
       return await this.service.getStatistics(injectSecondaryEndpointHeader(updatedOptions));
     } catch (e) {

--- a/sdk/tables/data-tables/src/secondaryEndpointPolicy.ts
+++ b/sdk/tables/data-tables/src/secondaryEndpointPolicy.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+import { OperationOptions } from "@azure/core-client";
 import { PipelinePolicy } from "@azure/core-rest-pipeline";
 
 /**
@@ -28,6 +29,30 @@ export const tablesSecondaryEndpointPolicy: PipelinePolicy = {
     return next(req);
   },
 };
+
+/**
+ * Utilility function that injects the SecondaryEndpointHeader into an operation options
+ */
+export function injectSecondaryEndpointHeader(options: OperationOptions): OperationOptions {
+  const requestOptions = options.requestOptions;
+  const headerToInject = { [SecondaryLocationHeaderName]: "true" };
+  if (!requestOptions) {
+    return {
+      ...options,
+      requestOptions: { customHeaders: headerToInject },
+    };
+  }
+
+  if (!requestOptions.customHeaders) {
+    return {
+      ...options,
+      requestOptions: { ...requestOptions, customHeaders: headerToInject },
+    };
+  } else {
+    requestOptions.customHeaders = { ...requestOptions.customHeaders, ...headerToInject };
+    return { ...options, requestOptions };
+  }
+}
 
 /**
  * Utility function that calculates the secondary URL for a table instance given the primary URL.

--- a/sdk/tables/data-tables/src/secondaryEndpointPolicy.ts
+++ b/sdk/tables/data-tables/src/secondaryEndpointPolicy.ts
@@ -34,24 +34,17 @@ export const tablesSecondaryEndpointPolicy: PipelinePolicy = {
  * Utilility function that injects the SecondaryEndpointHeader into an operation options
  */
 export function injectSecondaryEndpointHeader(options: OperationOptions): OperationOptions {
-  const requestOptions = options.requestOptions;
   const headerToInject = { [SecondaryLocationHeaderName]: "true" };
-  if (!requestOptions) {
-    return {
-      ...options,
-      requestOptions: { customHeaders: headerToInject },
-    };
-  }
-
-  if (!requestOptions.customHeaders) {
-    return {
-      ...options,
-      requestOptions: { ...requestOptions, customHeaders: headerToInject },
-    };
-  } else {
-    requestOptions.customHeaders = { ...requestOptions.customHeaders, ...headerToInject };
-    return { ...options, requestOptions };
-  }
+  return {
+    ...options,
+    requestOptions: {
+      ...options.requestOptions,
+      customHeaders: {
+        ...options.requestOptions?.customHeaders,
+        ...headerToInject,
+      },
+    },
+  };
 }
 
 /**

--- a/sdk/tables/data-tables/src/secondaryEndpointPolicy.ts
+++ b/sdk/tables/data-tables/src/secondaryEndpointPolicy.ts
@@ -4,17 +4,24 @@
 import { PipelinePolicy } from "@azure/core-rest-pipeline";
 
 /**
- * The programmatic identifier of the tablesNamedKeyCredentialPolicy.
+ * The programmatic identifier of the tablesSecondaryEndpointPolicy.
  */
 export const tablesSecondaryEndpointPolicyName = "tablesSecondaryEndpointPolicy";
 export const SecondaryLocationHeaderName = "tables-secondary-endpoint";
 const SecondaryLocationAccountSuffix = "-secondary";
 
+/**
+ * Policy that would replace the Primary Endpoint with the secondary endpoint
+ * when the `tables-secondary-endpoint` is set in the request
+ */
 export const tablesSecondaryEndpointPolicy: PipelinePolicy = {
   name: tablesSecondaryEndpointPolicyName,
   sendRequest: async (req, next) => {
+    // Only replace the URL if the SecondaryLocationHeader is set
     if (req.headers.get(SecondaryLocationHeaderName)) {
+      // Since the header is for internal use only, clean it up.
       req.headers.delete(SecondaryLocationHeaderName);
+      // Calculate and update the secondary url
       req.url = getSecondaryUrlFromPrimary(req.url);
     }
 

--- a/sdk/tables/data-tables/src/secondaryEndpointPolicy.ts
+++ b/sdk/tables/data-tables/src/secondaryEndpointPolicy.ts
@@ -31,7 +31,7 @@ export const tablesSecondaryEndpointPolicy: PipelinePolicy = {
 };
 
 /**
- * Utilility function that injects the SecondaryEndpointHeader into an operation options
+ * Utility function that injects the SecondaryEndpointHeader into an operation options
  */
 export function injectSecondaryEndpointHeader(options: OperationOptions): OperationOptions {
   const headerToInject = { [SecondaryLocationHeaderName]: "true" };

--- a/sdk/tables/data-tables/src/secondaryEndpointPolicy.ts
+++ b/sdk/tables/data-tables/src/secondaryEndpointPolicy.ts
@@ -1,0 +1,37 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { PipelinePolicy } from "@azure/core-rest-pipeline";
+
+/**
+ * The programmatic identifier of the tablesNamedKeyCredentialPolicy.
+ */
+export const tablesSecondaryEndpointPolicyName = "tablesSecondaryEndpointPolicy";
+export const SecondaryLocationHeaderName = "tables-secondary-endpoint";
+const SecondaryLocationAccountSuffix = "-secondary";
+
+export const tablesSecondaryEndpointPolicy: PipelinePolicy = {
+  name: tablesSecondaryEndpointPolicyName,
+  sendRequest: async (req, next) => {
+    if (req.headers.get(SecondaryLocationHeaderName)) {
+      req.headers.delete(SecondaryLocationHeaderName);
+      req.url = getSecondaryUrlFromPrimary(req.url);
+    }
+
+    return next(req);
+  },
+};
+
+/**
+ * Utility function that calculates the secondary URL for a table instance given the primary URL.
+ */
+function getSecondaryUrlFromPrimary(primaryUrl: string): string {
+  const parsedPrimaryUrl = new URL(primaryUrl);
+  const host = parsedPrimaryUrl.hostname.split(".");
+  if (host.length > 1) {
+    host[0] = `${host[0]}${SecondaryLocationAccountSuffix}`;
+  }
+  parsedPrimaryUrl.hostname = host.join(".");
+
+  return parsedPrimaryUrl.toString();
+}

--- a/sdk/tables/data-tables/src/utils/connectionString.ts
+++ b/sdk/tables/data-tables/src/utils/connectionString.ts
@@ -10,8 +10,6 @@ import { URL } from "./url";
 const DevelopmentConnectionString =
   "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;TableEndpoint=http://127.0.0.1:10002/devstoreaccount1";
 
-const SecondaryLocationAccountSuffix = "-secondary";
-
 /**
  * This function parses a connection string into a set of
  * parameters to pass to be passed to TableClientService,
@@ -165,18 +163,4 @@ function getAccountNameFromUrl(url: string): string {
   }
 
   return accountName;
-}
-
-/**
- * Utility function that calculates the secondary URL for a table instance given the primary URL.
- */
-export function getSecondaryUrlFromPrimarystri(primaryUrl: string): string {
-  const parsedPrimaryUrl = new URL(primaryUrl);
-  const host = parsedPrimaryUrl.hostname.split(".");
-  if (host.length > 1) {
-    host[0] = `${host[0]}${SecondaryLocationAccountSuffix}`;
-  }
-  parsedPrimaryUrl.hostname = host.join(".");
-
-  return parsedPrimaryUrl.toString();
 }

--- a/sdk/tables/data-tables/src/utils/connectionString.ts
+++ b/sdk/tables/data-tables/src/utils/connectionString.ts
@@ -3,11 +3,14 @@
 
 import { ClientParamsFromConnectionString, ConnectionString } from "./internalModels";
 import { fromAccountConnectionString, getAccountConnectionString } from "./accountConnectionString";
+
 import { TableServiceClientOptions } from "../models";
 import { URL } from "./url";
 
 const DevelopmentConnectionString =
   "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;TableEndpoint=http://127.0.0.1:10002/devstoreaccount1";
+
+const SecondaryLocationAccountSuffix = "-secondary";
 
 /**
  * This function parses a connection string into a set of
@@ -162,4 +165,18 @@ function getAccountNameFromUrl(url: string): string {
   }
 
   return accountName;
+}
+
+/**
+ * Utility function that calculates the secondary URL for a table instance given the primary URL.
+ */
+export function getSecondaryUrlFromPrimarystri(primaryUrl: string) {
+  const parsedPrimaryUrl = new URL(primaryUrl);
+  const host = parsedPrimaryUrl.hostname.split(".");
+  if (host.length > 1) {
+    host[0] = `${host[0]}${SecondaryLocationAccountSuffix}`;
+  }
+  parsedPrimaryUrl.hostname = host.join(".");
+
+  return parsedPrimaryUrl.toString();
 }

--- a/sdk/tables/data-tables/src/utils/connectionString.ts
+++ b/sdk/tables/data-tables/src/utils/connectionString.ts
@@ -170,7 +170,7 @@ function getAccountNameFromUrl(url: string): string {
 /**
  * Utility function that calculates the secondary URL for a table instance given the primary URL.
  */
-export function getSecondaryUrlFromPrimarystri(primaryUrl: string) {
+export function getSecondaryUrlFromPrimarystri(primaryUrl: string): string {
   const parsedPrimaryUrl = new URL(primaryUrl);
   const host = parsedPrimaryUrl.hostname.split(".");
   if (host.length > 1) {

--- a/sdk/tables/data-tables/test/internal/secondaryEndpointPolicy.spec.ts
+++ b/sdk/tables/data-tables/test/internal/secondaryEndpointPolicy.spec.ts
@@ -1,0 +1,40 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { assert } from "chai";
+import { createHttpHeaders } from "@azure/core-rest-pipeline";
+import { tablesSecondaryEndpointPolicy } from "../../src/secondaryEndpointPolicy";
+
+describe("tablesSecondaryEndpointPolicy", () => {
+  it("should send the request to the secondary endpoint ", async () => {
+    const primaryURL = "https://testaccount.table.core.windows.net/";
+    const expectedSecondary = "https://testaccount-secondary.table.core.windows.net/";
+
+    await tablesSecondaryEndpointPolicy.sendRequest(
+      {
+        url: primaryURL,
+        headers: createHttpHeaders({ "tables-secondary-endpoint": "true" }),
+      } as any,
+      async (req) => {
+        assert.equal(req.url, expectedSecondary);
+        assert.isUndefined(req.headers.get("tables-secondary-endpoint"));
+        return { status: 200 } as any;
+      }
+    );
+  });
+
+  it("should send the request to the primary endpoint when the header is not set", async () => {
+    const primaryURL = "https://testaccount.table.core.windows.net/";
+
+    await tablesSecondaryEndpointPolicy.sendRequest(
+      {
+        url: primaryURL,
+        headers: createHttpHeaders(),
+      } as any,
+      async (req) => {
+        assert.equal(req.url, primaryURL);
+        return {} as any;
+      }
+    );
+  });
+});

--- a/sdk/tables/data-tables/test/internal/utils.spec.ts
+++ b/sdk/tables/data-tables/test/internal/utils.spec.ts
@@ -2,27 +2,14 @@
 // Licensed under the MIT license.
 
 import { base64Decode, base64Encode } from "../../src/utils/bufferSerializer";
-import {
-  extractConnectionStringParts,
-  getSecondaryUrlFromPrimarystri,
-} from "../../src/utils/connectionString";
 
 import { ConnectionString } from "../../src/utils/internalModels";
 import { Context } from "mocha";
 import { assert } from "chai";
+import { extractConnectionStringParts } from "../../src/utils/connectionString";
 import { isNode } from "@azure/test-utils";
 
 describe("Utility Helpers", () => {
-  describe("SecondaryUrl", () => {
-    it("should build secondary URL", () => {
-      const primaryURL = "https://testaccount.table.core.windows.net/";
-      const expectedSecondary = "https://testaccount-secondary.table.core.windows.net/";
-
-      const result = getSecondaryUrlFromPrimarystri(primaryURL);
-      assert.equal(result, expectedSecondary);
-    });
-  });
-
   describe("extractConnectionStringParts", () => {
     describe("Account Connection String", () => {
       beforeEach(function (this: Context) {

--- a/sdk/tables/data-tables/test/internal/utils.spec.ts
+++ b/sdk/tables/data-tables/test/internal/utils.spec.ts
@@ -2,13 +2,27 @@
 // Licensed under the MIT license.
 
 import { base64Decode, base64Encode } from "../../src/utils/bufferSerializer";
+import {
+  extractConnectionStringParts,
+  getSecondaryUrlFromPrimarystri,
+} from "../../src/utils/connectionString";
+
 import { ConnectionString } from "../../src/utils/internalModels";
 import { Context } from "mocha";
 import { assert } from "chai";
-import { extractConnectionStringParts } from "../../src/utils/connectionString";
 import { isNode } from "@azure/test-utils";
 
 describe("Utility Helpers", () => {
+  describe("SecondaryUrl", () => {
+    it("should build secondary URL", () => {
+      const primaryURL = "https://testaccount.table.core.windows.net/";
+      const expectedSecondary = "https://testaccount-secondary.table.core.windows.net/";
+
+      const result = getSecondaryUrlFromPrimarystri(primaryURL);
+      assert.equal(result, expectedSecondary);
+    });
+  });
+
   describe("extractConnectionStringParts", () => {
     describe("Account Connection String", () => {
       beforeEach(function (this: Context) {

--- a/sdk/tables/data-tables/test/public/tableserviceclient.spec.ts
+++ b/sdk/tables/data-tables/test/public/tableserviceclient.spec.ts
@@ -140,4 +140,11 @@ describe(`TableServiceClient`, () => {
       assert.deepEqual(result, lastPage);
     });
   });
+
+  describe("Statistics", () => {
+    it("should getStatistics", async () => {
+      const result = await client.getStatistics();
+      assert.deepEqual(result.geoReplication?.status, "live");
+    });
+  });
 });

--- a/sdk/tables/data-tables/test/public/utils/recordedClient.ts
+++ b/sdk/tables/data-tables/test/public/utils/recordedClient.ts
@@ -139,6 +139,7 @@ export async function createTableServiceClient(
 
   if (recorder) {
     await recorder.start(recorderOptions);
+    await recorder.setMatcher("HeaderlessMatcher");
     options = recorder.configureClientOptions({ allowInsecureConnection: true });
   }
 


### PR DESCRIPTION
### Packages impacted by this PR
`@azure/data-tables`

### Issues associated with this PR
#13085

### Describe the problem that is addressed by this PR
`getStatistics()` operation fails consistently. The problem is that this operation needs to target the secondary URL when geo-replication is enabled for the table service instance. This secondary URL can be calculated by appending a `-secondary` suffix to the account name in the primary URL.

### What are the possible designs available to address the problem? If there is more than one possible design, why was the one in this PR chosen?
We need to create an additional ServiceClient that targets the secondary endpoint to execute this operation

### Are there test cases added in this PR? _(If not, why?)_
Yes, an integration and a unit test were added.

### Checklists
- [ x] Added impacted package name to the issue description
- [x] Added a changelog (if necessary)
