### PR TITLE
[Communication] - phone-numbers - Implement phone number pool for live testing

### DIFF
--- a/sdk/communication/communication-phone-numbers/karma.conf.js
+++ b/sdk/communication/communication-phone-numbers/karma.conf.js
@@ -69,7 +69,7 @@ module.exports = function (config) {
       "AZURE_CLIENT_SECRET",
       "AZURE_TENANT_ID",
       "COMMUNICATION_SKIP_INT_PHONENUMBERS_TESTS",
-      "INCLUDE_UPDATE_CAPABILITIES_LIVE_TESTS",
+      "SKIP_UPDATE_CAPABILITIES_LIVE_TESTS",
       "AZURE_TEST_AGENT",
       ...getPhoneNumberPoolEnvVars(),
     ],

--- a/sdk/communication/communication-phone-numbers/karma.conf.js
+++ b/sdk/communication/communication-phone-numbers/karma.conf.js
@@ -69,6 +69,7 @@ module.exports = function (config) {
       "AZURE_CLIENT_SECRET",
       "AZURE_TENANT_ID",
       "COMMUNICATION_SKIP_INT_PHONENUMBERS_TESTS",
+      "INCLUDE_UPDATE_CAPABILITIES_LIVE_TESTS",
       "AZURE_TEST_AGENT",
       ...getPhoneNumberPoolEnvVars()
     ],

--- a/sdk/communication/communication-phone-numbers/karma.conf.js
+++ b/sdk/communication/communication-phone-numbers/karma.conf.js
@@ -11,7 +11,7 @@ const {
 // Get all variables containing the available phone numbers per test agent.
 // E.g. -> AZURE_PHONE_NUMBER_windows_2019_node12
 const getPhoneNumberPoolEnvVars = () => {
-  return Object.keys(process.env).filter(key => key.startsWith("AZURE_PHONE_NUMBER_"));
+  return Object.keys(process.env).filter((key) => key.startsWith("AZURE_PHONE_NUMBER_"));
 };
 
 module.exports = function (config) {
@@ -71,7 +71,7 @@ module.exports = function (config) {
       "COMMUNICATION_SKIP_INT_PHONENUMBERS_TESTS",
       "INCLUDE_UPDATE_CAPABILITIES_LIVE_TESTS",
       "AZURE_TEST_AGENT",
-      ...getPhoneNumberPoolEnvVars()
+      ...getPhoneNumberPoolEnvVars(),
     ],
 
     // test results reporter to use

--- a/sdk/communication/communication-phone-numbers/karma.conf.js
+++ b/sdk/communication/communication-phone-numbers/karma.conf.js
@@ -8,6 +8,12 @@ const {
   isRecordMode,
 } = require("@azure-tools/test-recorder");
 
+// Get all variables containing the available phone numbers per test agent.
+// E.g. -> AZURE_PHONE_NUMBER_windows_2019_node12
+const getPhoneNumberPoolEnvVars = () => {
+  return Object.keys(process.env).filter(key => key.startsWith("AZURE_PHONE_NUMBER_"));
+};
+
 module.exports = function (config) {
   config.set({
     // base path that will be used to resolve all patterns (eg. files, exclude)
@@ -63,6 +69,8 @@ module.exports = function (config) {
       "AZURE_CLIENT_SECRET",
       "AZURE_TENANT_ID",
       "COMMUNICATION_SKIP_INT_PHONENUMBERS_TESTS",
+      "AZURE_TEST_AGENT",
+      ...getPhoneNumberPoolEnvVars()
     ],
 
     // test results reporter to use

--- a/sdk/communication/communication-phone-numbers/phone-numbers-livetest-matrix.json
+++ b/sdk/communication/communication-phone-numbers/phone-numbers-livetest-matrix.json
@@ -7,18 +7,18 @@
       "windows-2019": {
         "OSVmImage": "MMS2019",
         "Pool": "azsdk-pool-mms-win-2019-general",
-        "INCLUDE_UPDATE_CAPABILITIES_LIVE_TESTS": "false"
+        "SKIP_UPDATE_CAPABILITIES_LIVE_TESTS": "true"
       },
       "ubuntu-20.04": {
         "OSVmImage": "MMSUbuntu20.04",
         "Pool": "azsdk-pool-mms-ubuntu-2004-general",
         "AZURE_TEST_AGENT": "ubuntu_2004_node14",
-        "INCLUDE_UPDATE_CAPABILITIES_LIVE_TESTS": "true"
+        "SKIP_UPDATE_CAPABILITIES_LIVE_TESTS": "false"
       },
       "macOS-10.15": {
         "OSVmImage": "macOS-10.15",
         "Pool": "Azure Pipelines",
-        "INCLUDE_UPDATE_CAPABILITIES_LIVE_TESTS": "false"
+        "SKIP_UPDATE_CAPABILITIES_LIVE_TESTS": "true"
       }
     },
     "NodeTestVersion": ["12.x", "14.x", "16.x", "17.x"],
@@ -39,18 +39,18 @@
           "TestResultsFiles": "**/test-results.xml",
           "PublishCodeCoverage": "true",
           "AZURE_TEST_AGENT": "windows_2019_node12",
-          "INCLUDE_UPDATE_CAPABILITIES_LIVE_TESTS": "true"
+          "SKIP_UPDATE_CAPABILITIES_LIVE_TESTS": "false"
         },
         "sample": {
           "TestType": "sample",
           "TestResultsFiles": "**/test-results.xml",
-          "INCLUDE_UPDATE_CAPABILITIES_LIVE_TESTS": "false"
+          "SKIP_UPDATE_CAPABILITIES_LIVE_TESTS": "true"
         },
         "browser": {
           "TestType": "browser",
           "TestResultsFiles": "**/test-results.browser.xml",
           "AZURE_TEST_AGENT": "windows_2019_browser",
-          "INCLUDE_UPDATE_CAPABILITIES_LIVE_TESTS": "true"
+          "SKIP_UPDATE_CAPABILITIES_LIVE_TESTS": "false"
         }
       },
       "NodeTestVersion": "12.x"
@@ -66,7 +66,7 @@
       "NodeTestVersion": "12.x",
       "DependencyVersion": ["max", "min"],
       "TestResultsFiles": "**/test-results.xml",
-      "INCLUDE_UPDATE_CAPABILITIES_LIVE_TESTS": "false"
+      "SKIP_UPDATE_CAPABILITIES_LIVE_TESTS": "true"
     }
   ]
 }

--- a/sdk/communication/communication-phone-numbers/phone-numbers-livetest-matrix.json
+++ b/sdk/communication/communication-phone-numbers/phone-numbers-livetest-matrix.json
@@ -1,0 +1,80 @@
+{
+    "displayNames": {
+        "**/test-results.xml": ""
+    },
+    "matrix": {
+        "Agent": {
+            "windows-2019": {
+                "OSVmImage": "MMS2019",
+                "Pool": "azsdk-pool-mms-win-2019-general",
+                "INCLUDE_UPDATE_CAPABILITIES_LIVE_TESTS": "false"
+            },
+            "ubuntu-20.04": {
+                "OSVmImage": "MMSUbuntu20.04",
+                "Pool": "azsdk-pool-mms-ubuntu-2004-general",
+                "AZURE_TEST_AGENT": "ubuntu_2004_node14",
+                "INCLUDE_UPDATE_CAPABILITIES_LIVE_TESTS": "true"
+            },
+            "macOS-10.15": {
+                "OSVmImage": "macOS-10.15",
+                "Pool": "Azure Pipelines",
+                "INCLUDE_UPDATE_CAPABILITIES_LIVE_TESTS": "false"
+            }
+        },
+        "NodeTestVersion": [
+            "12.x",
+            "14.x",
+            "16.x",
+            "17.x"
+        ],
+        "TestType": "node",
+        "TestResultsFiles": "**/test-results.xml"
+    },
+    "include": [
+        {
+            "Agent": {
+                "windows-2019": {
+                    "OSVmImage": "MMS2019",
+                    "Pool": "azsdk-pool-mms-win-2019-general"
+                }
+            },
+            "Scenario": {
+                "coverage": {
+                    "TestType": "node",
+                    "TestResultsFiles": "**/test-results.xml",
+                    "PublishCodeCoverage": "true",
+                    "AZURE_TEST_AGENT": "windows_2019_node12",
+                    "INCLUDE_UPDATE_CAPABILITIES_LIVE_TESTS": "true"
+                },
+                "sample": {
+                    "TestType": "sample",
+                    "TestResultsFiles": "**/test-results.xml",
+                    "INCLUDE_UPDATE_CAPABILITIES_LIVE_TESTS": "false"
+                },
+                "browser": {
+                    "TestType": "browser",
+                    "TestResultsFiles": "**/test-results.browser.xml",
+                    "AZURE_TEST_AGENT": "windows_2019_browser",
+                    "INCLUDE_UPDATE_CAPABILITIES_LIVE_TESTS": "true"
+                }
+            },
+            "NodeTestVersion": "12.x"
+        },
+        {
+            "Agent": {
+                "ubuntu-20.04": {
+                    "OSVmImage": "MMSUbuntu20.04",
+                    "Pool": "azsdk-pool-mms-ubuntu-2004-general"
+                }
+            },
+            "TestType": "node",
+            "NodeTestVersion": "12.x",
+            "DependencyVersion": [
+                "max",
+                "min"
+            ],
+            "TestResultsFiles": "**/test-results.xml",
+            "INCLUDE_UPDATE_CAPABILITIES_LIVE_TESTS": "false"
+        }
+    ]
+}

--- a/sdk/communication/communication-phone-numbers/phone-numbers-livetest-matrix.json
+++ b/sdk/communication/communication-phone-numbers/phone-numbers-livetest-matrix.json
@@ -1,80 +1,72 @@
 {
-    "displayNames": {
-        "**/test-results.xml": ""
+  "displayNames": {
+    "**/test-results.xml": ""
+  },
+  "matrix": {
+    "Agent": {
+      "windows-2019": {
+        "OSVmImage": "MMS2019",
+        "Pool": "azsdk-pool-mms-win-2019-general",
+        "INCLUDE_UPDATE_CAPABILITIES_LIVE_TESTS": "false"
+      },
+      "ubuntu-20.04": {
+        "OSVmImage": "MMSUbuntu20.04",
+        "Pool": "azsdk-pool-mms-ubuntu-2004-general",
+        "AZURE_TEST_AGENT": "ubuntu_2004_node14",
+        "INCLUDE_UPDATE_CAPABILITIES_LIVE_TESTS": "true"
+      },
+      "macOS-10.15": {
+        "OSVmImage": "macOS-10.15",
+        "Pool": "Azure Pipelines",
+        "INCLUDE_UPDATE_CAPABILITIES_LIVE_TESTS": "false"
+      }
     },
-    "matrix": {
-        "Agent": {
-            "windows-2019": {
-                "OSVmImage": "MMS2019",
-                "Pool": "azsdk-pool-mms-win-2019-general",
-                "INCLUDE_UPDATE_CAPABILITIES_LIVE_TESTS": "false"
-            },
-            "ubuntu-20.04": {
-                "OSVmImage": "MMSUbuntu20.04",
-                "Pool": "azsdk-pool-mms-ubuntu-2004-general",
-                "AZURE_TEST_AGENT": "ubuntu_2004_node14",
-                "INCLUDE_UPDATE_CAPABILITIES_LIVE_TESTS": "true"
-            },
-            "macOS-10.15": {
-                "OSVmImage": "macOS-10.15",
-                "Pool": "Azure Pipelines",
-                "INCLUDE_UPDATE_CAPABILITIES_LIVE_TESTS": "false"
-            }
-        },
-        "NodeTestVersion": [
-            "12.x",
-            "14.x",
-            "16.x",
-            "17.x"
-        ],
-        "TestType": "node",
-        "TestResultsFiles": "**/test-results.xml"
-    },
-    "include": [
-        {
-            "Agent": {
-                "windows-2019": {
-                    "OSVmImage": "MMS2019",
-                    "Pool": "azsdk-pool-mms-win-2019-general"
-                }
-            },
-            "Scenario": {
-                "coverage": {
-                    "TestType": "node",
-                    "TestResultsFiles": "**/test-results.xml",
-                    "PublishCodeCoverage": "true",
-                    "AZURE_TEST_AGENT": "windows_2019_node12",
-                    "INCLUDE_UPDATE_CAPABILITIES_LIVE_TESTS": "true"
-                },
-                "sample": {
-                    "TestType": "sample",
-                    "TestResultsFiles": "**/test-results.xml",
-                    "INCLUDE_UPDATE_CAPABILITIES_LIVE_TESTS": "false"
-                },
-                "browser": {
-                    "TestType": "browser",
-                    "TestResultsFiles": "**/test-results.browser.xml",
-                    "AZURE_TEST_AGENT": "windows_2019_browser",
-                    "INCLUDE_UPDATE_CAPABILITIES_LIVE_TESTS": "true"
-                }
-            },
-            "NodeTestVersion": "12.x"
-        },
-        {
-            "Agent": {
-                "ubuntu-20.04": {
-                    "OSVmImage": "MMSUbuntu20.04",
-                    "Pool": "azsdk-pool-mms-ubuntu-2004-general"
-                }
-            },
-            "TestType": "node",
-            "NodeTestVersion": "12.x",
-            "DependencyVersion": [
-                "max",
-                "min"
-            ],
-            "TestResultsFiles": "**/test-results.xml",
-            "INCLUDE_UPDATE_CAPABILITIES_LIVE_TESTS": "false"
+    "NodeTestVersion": ["12.x", "14.x", "16.x", "17.x"],
+    "TestType": "node",
+    "TestResultsFiles": "**/test-results.xml"
+  },
+  "include": [
+    {
+      "Agent": {
+        "windows-2019": {
+          "OSVmImage": "MMS2019",
+          "Pool": "azsdk-pool-mms-win-2019-general"
         }
-    ]
+      },
+      "Scenario": {
+        "coverage": {
+          "TestType": "node",
+          "TestResultsFiles": "**/test-results.xml",
+          "PublishCodeCoverage": "true",
+          "AZURE_TEST_AGENT": "windows_2019_node12",
+          "INCLUDE_UPDATE_CAPABILITIES_LIVE_TESTS": "true"
+        },
+        "sample": {
+          "TestType": "sample",
+          "TestResultsFiles": "**/test-results.xml",
+          "INCLUDE_UPDATE_CAPABILITIES_LIVE_TESTS": "false"
+        },
+        "browser": {
+          "TestType": "browser",
+          "TestResultsFiles": "**/test-results.browser.xml",
+          "AZURE_TEST_AGENT": "windows_2019_browser",
+          "INCLUDE_UPDATE_CAPABILITIES_LIVE_TESTS": "true"
+        }
+      },
+      "NodeTestVersion": "12.x"
+    },
+    {
+      "Agent": {
+        "ubuntu-20.04": {
+          "OSVmImage": "MMSUbuntu20.04",
+          "Pool": "azsdk-pool-mms-ubuntu-2004-general"
+        }
+      },
+      "TestType": "node",
+      "NodeTestVersion": "12.x",
+      "DependencyVersion": ["max", "min"],
+      "TestResultsFiles": "**/test-results.xml",
+      "INCLUDE_UPDATE_CAPABILITIES_LIVE_TESTS": "false"
+    }
+  ]
 }

--- a/sdk/communication/communication-phone-numbers/test/public/get.spec.ts
+++ b/sdk/communication/communication-phone-numbers/test/public/get.spec.ts
@@ -2,11 +2,12 @@
 // Licensed under the MIT license.
 
 import { matrix } from "@azure/test-utils";
-import { Recorder, env, isPlaybackMode } from "@azure-tools/test-recorder";
+import { Recorder } from "@azure-tools/test-recorder";
 import { assert } from "chai";
 import { Context } from "mocha";
 import { PhoneNumbersClient } from "../../src";
 import { createRecordedClient, createRecordedClientWithToken } from "./utils/recordedClient";
+import { getPhoneNumber } from "./utils/testPhoneNumber";
 
 matrix([[true, false]], async function (useAad) {
   describe(`PhoneNumbersClient - get phone number${useAad ? " [AAD]" : ""}`, function () {
@@ -26,7 +27,7 @@ matrix([[true, false]], async function (useAad) {
     });
 
     it("can get a purchased phone number", async function (this: Context) {
-      const purchasedPhoneNumber = isPlaybackMode() ? "+14155550100" : env.AZURE_PHONE_NUMBER;
+      const purchasedPhoneNumber = getPhoneNumber();
       const { phoneNumber } = await client.getPurchasedPhoneNumber(purchasedPhoneNumber);
 
       assert.strictEqual(purchasedPhoneNumber, phoneNumber);

--- a/sdk/communication/communication-phone-numbers/test/public/lro.update.spec.ts
+++ b/sdk/communication/communication-phone-numbers/test/public/lro.update.spec.ts
@@ -7,10 +7,11 @@ import { assert } from "chai";
 import { Context } from "mocha";
 import { PhoneNumbersClient, PhoneNumberCapabilitiesRequest } from "../../src";
 import { createRecordedClient, createRecordedClientWithToken } from "./utils/recordedClient";
+import { getPhoneNumber } from "./utils/testPhoneNumber";
 
 matrix([[true, false]], async function (useAad) {
   describe(`PhoneNumbersClient - lro - update${useAad ? " [AAD]" : ""}`, function () {
-    const purchasedPhoneNumber = isPlaybackMode() ? "+14155550100" : env.AZURE_PHONE_NUMBER;
+    const purchasedPhoneNumber = getPhoneNumber();
     const update: PhoneNumberCapabilitiesRequest = { calling: "none", sms: "outbound" };
     let recorder: Recorder;
     let client: PhoneNumbersClient;
@@ -43,12 +44,10 @@ matrix([[true, false]], async function (useAad) {
         update
       );
 
-      // TODO: this validation is flakey because multiple tests attempt to update the same number
-      // re-enable when we make each lang run it's own number
-      // const phoneNumber = await updatePoller.pollUntilDone();
+      const phoneNumber = await updatePoller.pollUntilDone();
       await updatePoller.pollUntilDone();
       assert.ok(updatePoller.getOperationState().isCompleted);
-      // assert.deepEqual(phoneNumber.capabilities, update);
+      assert.deepEqual(phoneNumber.capabilities, update);
     }).timeout(120000);
 
     it("update throws when phone number isn't owned", async function () {

--- a/sdk/communication/communication-phone-numbers/test/public/lro.update.spec.ts
+++ b/sdk/communication/communication-phone-numbers/test/public/lro.update.spec.ts
@@ -5,7 +5,7 @@ import { matrix } from "@azure/test-utils";
 import { Recorder, env, isPlaybackMode } from "@azure-tools/test-recorder";
 import { assert } from "chai";
 import { Context } from "mocha";
-import { PhoneNumbersClient, PhoneNumberCapabilitiesRequest } from "../../src";
+import { PhoneNumberCapabilitiesRequest, PhoneNumbersClient } from "../../src";
 import { createRecordedClient, createRecordedClientWithToken } from "./utils/recordedClient";
 import { getPhoneNumber } from "./utils/testPhoneNumber";
 

--- a/sdk/communication/communication-phone-numbers/test/public/lro.update.spec.ts
+++ b/sdk/communication/communication-phone-numbers/test/public/lro.update.spec.ts
@@ -18,10 +18,10 @@ matrix([[true, false]], async function (useAad) {
 
     before(function (this: Context) {
       const skipPhoneNumbersTests = env.COMMUNICATION_SKIP_INT_PHONENUMBERS_TESTS === "true";
-      const includeUpdateCapabilitiesLiveTests =
-        isPlaybackMode() || env.INCLUDE_UPDATE_CAPABILITIES_LIVE_TESTS === "true";
+      const skipUpdateCapabilitiesLiveTests =
+        isPlaybackMode() || env.SKIP_UPDATE_CAPABILITIES_LIVE_TESTS === "true";
 
-      if (skipPhoneNumbersTests || !includeUpdateCapabilitiesLiveTests) {
+      if (skipPhoneNumbersTests || skipUpdateCapabilitiesLiveTests) {
         this.skip();
       }
     });

--- a/sdk/communication/communication-phone-numbers/test/public/lro.update.spec.ts
+++ b/sdk/communication/communication-phone-numbers/test/public/lro.update.spec.ts
@@ -18,10 +18,10 @@ matrix([[true, false]], async function (useAad) {
 
     before(function (this: Context) {
       const skipPhoneNumbersTests = env.COMMUNICATION_SKIP_INT_PHONENUMBERS_TESTS === "true";
-      const includePhoneNumberLiveTests =
-        isPlaybackMode() || env.INCLUDE_PHONENUMBER_LIVE_TESTS === "true";
+      const includeUpdateCapabilitiesLiveTests =
+        isPlaybackMode() || env.INCLUDE_UPDATE_CAPABILITIES_LIVE_TESTS === "true";
 
-      if (skipPhoneNumbersTests || !includePhoneNumberLiveTests) {
+      if (skipPhoneNumbersTests || !includeUpdateCapabilitiesLiveTests) {
         this.skip();
       }
     });

--- a/sdk/communication/communication-phone-numbers/test/public/utils/recordedClient.ts
+++ b/sdk/communication/communication-phone-numbers/test/public/utils/recordedClient.ts
@@ -5,19 +5,19 @@ import { Context } from "mocha";
 import * as dotenv from "dotenv";
 
 import {
-  env,
   Recorder,
-  record,
   RecorderEnvironmentSetup,
+  env,
   isPlaybackMode,
+  record,
 } from "@azure-tools/test-recorder";
 import {
   DefaultHttpClient,
   HttpClient,
   HttpOperationResponse,
-  isNode,
   TokenCredential,
   WebResourceLike,
+  isNode,
 } from "@azure/core-http";
 import { PhoneNumbersClient, PhoneNumbersClientOptions } from "../../../src";
 import { parseConnectionString } from "@azure/communication-common";

--- a/sdk/communication/communication-phone-numbers/test/public/utils/recordedClient.ts
+++ b/sdk/communication/communication-phone-numbers/test/public/utils/recordedClient.ts
@@ -35,7 +35,7 @@ export interface RecordedClient<T> {
 const replaceableVariables: { [k: string]: string } = {
   COMMUNICATION_LIVETEST_STATIC_CONNECTION_STRING: "endpoint=https://endpoint/;accesskey=banana",
   INCLUDE_PHONENUMBER_LIVE_TESTS: "false",
-  INCLUDE_UPDATE_CAPABILITIES_LIVE_TESTS: "false",
+  SKIP_UPDATE_CAPABILITIES_LIVE_TESTS: "false",
   COMMUNICATION_ENDPOINT: "https://endpoint/",
   AZURE_CLIENT_ID: "SomeClientId",
   AZURE_CLIENT_SECRET: "azure_client_secret",

--- a/sdk/communication/communication-phone-numbers/test/public/utils/recordedClient.ts
+++ b/sdk/communication/communication-phone-numbers/test/public/utils/recordedClient.ts
@@ -35,6 +35,7 @@ export interface RecordedClient<T> {
 const replaceableVariables: { [k: string]: string } = {
   COMMUNICATION_LIVETEST_STATIC_CONNECTION_STRING: "endpoint=https://endpoint/;accesskey=banana",
   INCLUDE_PHONENUMBER_LIVE_TESTS: "false",
+  INCLUDE_UPDATE_CAPABILITIES_LIVE_TESTS: "false",
   COMMUNICATION_ENDPOINT: "https://endpoint/",
   AZURE_CLIENT_ID: "SomeClientId",
   AZURE_CLIENT_SECRET: "azure_client_secret",

--- a/sdk/communication/communication-phone-numbers/test/public/utils/testPhoneNumber.ts
+++ b/sdk/communication/communication-phone-numbers/test/public/utils/testPhoneNumber.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
 import { env, isPlaybackMode } from "@azure-tools/test-recorder";
 
 const DEFAULT_PHONE_NUMBER = "+14155550100";

--- a/sdk/communication/communication-phone-numbers/test/public/utils/testPhoneNumber.ts
+++ b/sdk/communication/communication-phone-numbers/test/public/utils/testPhoneNumber.ts
@@ -4,7 +4,6 @@
 import { env, isPlaybackMode } from "@azure-tools/test-recorder";
 
 const DEFAULT_PHONE_NUMBER = "+14155550100";
-const testAgent = () => env.AZURE_TEST_AGENT;
 const testAgentPhoneNumber = () => env[`AZURE_PHONE_NUMBER_${env.AZURE_TEST_AGENT}`];
 const defaultTestPhoneNumber = () => env.AZURE_PHONE_NUMBER;
 
@@ -13,5 +12,11 @@ export function getPhoneNumber(): string {
 }
 
 function getPhoneNumberFromEnvironment(): string {
-  return testAgent() ? testAgentPhoneNumber() : defaultTestPhoneNumber();
+  if (env.SKIP_UPDATE_CAPABILITIES_LIVE_TESTS === "true") {
+    return defaultTestPhoneNumber();
+  }
+
+  // If either the AZURE_TEST_AGENT or the AZURE_PHONE_NUMBER_<AZURE_TEST_AGENT> are missing,
+  // this will return `undefined` and, in turn, tests will fail because of this.
+  return testAgentPhoneNumber();
 }

--- a/sdk/communication/communication-phone-numbers/test/public/utils/testPhoneNumber.ts
+++ b/sdk/communication/communication-phone-numbers/test/public/utils/testPhoneNumber.ts
@@ -1,0 +1,14 @@
+import { env, isPlaybackMode } from "@azure-tools/test-recorder";
+
+const DEFAULT_PHONE_NUMBER = "+14155550100";
+const testAgent = () => env.AZURE_TEST_AGENT;
+const testAgentPhoneNumber = () => env[`AZURE_PHONE_NUMBER_${env.AZURE_TEST_AGENT}`];
+const defaultTestPhoneNumber = () => env.AZURE_PHONE_NUMBER;
+
+export function getPhoneNumber(): string {
+  return isPlaybackMode() ? DEFAULT_PHONE_NUMBER : getPhoneNumberFromEnvironment();
+}
+
+function getPhoneNumberFromEnvironment(): string {
+  return testAgent() ? testAgentPhoneNumber() : defaultTestPhoneNumber();
+}

--- a/sdk/communication/communication-phone-numbers/tests.yml
+++ b/sdk/communication/communication-phone-numbers/tests.yml
@@ -18,7 +18,7 @@ stages:
           MatrixFilters:
             - TestType=^(?!(browser|sample)).*
           MatrixReplace:
-            - INCLUDE_UPDATE_CAPABILITIES_LIVE_TESTS=true/false
+            - SKIP_UPDATE_CAPABILITIES_LIVE_TESTS=false/true
       Clouds: Public,Int
       MatrixConfigs:
         - Name: PhoneNumbers_js_livetest_matrix

--- a/sdk/communication/communication-phone-numbers/tests.yml
+++ b/sdk/communication/communication-phone-numbers/tests.yml
@@ -17,5 +17,12 @@ stages:
             - $(sub-config-communication-int-test-resources-js)
           MatrixFilters:
             - TestType=^(?!(browser|sample)).*
+          MatrixReplace:
+            - INCLUDE_UPDATE_CAPABILITIES_LIVE_TESTS=true/false
       Clouds: Public,Int
+      MatrixConfigs:
+        - Name: PhoneNumbers_js_livetest_matrix
+          Path: sdk/communication/communication-phone-numbers/phone-numbers-livetest-matrix.json
+          Selection: sparse
+          GenerateVMJobs: true
 


### PR DESCRIPTION
This implements a simple pool of available phone numbers to use in live test pipelines. This solves an issue with the update capabilities live tests caused when multiple tests attempt to modify the state of a phone number simultaneously. 

In order to make use of this, the following environment variables need to be passed:
- `AZURE_TEST_AGENT` specifies the OS and runtime configuration for the job. It should contain the OS, the OS version and the framework/runtime version separated by underscores; e.g. `windows_2019_node12`.
- `AZURE_PHONE_NUMBER_<AZURE_TEST_AGENT>`, where _`<AZURE_TEST_AGENT>`_ corresponds to the value of the variable described prior; e.g. `AZURE_PHONE_NUMBER_windows_2019_node12`.

Additionally, by setting the `SKIP_UPDATE_CAPABILITIES_LIVE_TESTS` variable to `true`, update capabilities tests can be skipped altoghether. This is useful because the amount of phone numbers available for testing (currently limited to 3) is smaller than the number of test jobs running in parallel.

**NOTE: If either the `AZURE_TEST_AGENT` or `AZURE_PHONE_NUMBER_<AZURE_TEST_AGENT>` are not present when running live tests and `SKIP_UPDATE_CAPABILITIES_LIVE_TESTS=false`, then the test run will fail. In any other scenario, the `AZURE_PHONE_NUMBER` will be used.**

This PR is a follow-up to #20216.