### PR TITLE
[Identity] Maximum retries to 3

### DIFF
--- a/sdk/identity/identity/CHANGELOG.md
+++ b/sdk/identity/identity/CHANGELOG.md
@@ -22,9 +22,9 @@
 
 ### Bugs Fixed
 
+- `ManagedIdentityCredential` no won't retry when it tries to ping the IMDS endpoint.
 - Now we are specifying the maximum number of retries to 3 to ensure that maximum retries won't change without notice.
-  - While at some point in the past the default retries on our core pipeliens were 3, today the `@azure/core-rest-pipeline` retry strategies attempt up to 10 requests before giving up. This is causing some of the Identity requests to take minutes before resolving.
-  - We have also added tests to ensure that our retries do not go above 3 in the future.
+
 ### Other Changes
 
 ## 2.0.2 (2022-02-03)

--- a/sdk/identity/identity/CHANGELOG.md
+++ b/sdk/identity/identity/CHANGELOG.md
@@ -22,6 +22,9 @@
 
 ### Bugs Fixed
 
+- Now we are specifying the maximum number of retries to 3 to ensure that maximum retries won't change without notice.
+  - While at some point in the past the default retries on our core pipeliens were 3, today the `@azure/core-rest-pipeline` retry strategies attempt up to 10 requests before giving up. This is causing some of the Identity requests to take minutes before resolving.
+  - We have also added tests to ensure that our retries do not go above 3 in the future.
 ### Other Changes
 
 ## 2.0.2 (2022-02-03)

--- a/sdk/identity/identity/CHANGELOG.md
+++ b/sdk/identity/identity/CHANGELOG.md
@@ -22,7 +22,7 @@
 
 ### Bugs Fixed
 
-- `ManagedIdentityCredential` no won't retry when it tries to ping the IMDS endpoint.
+- `ManagedIdentityCredential` now won't retry when it tries to ping the IMDS endpoint.
 - Now we are specifying the maximum number of retries to 3 to ensure that maximum retries won't change without notice.
 
 ### Other Changes

--- a/sdk/identity/identity/src/client/identityClient.ts
+++ b/sdk/identity/identity/src/client/identityClient.ts
@@ -94,6 +94,9 @@ export class IdentityClient extends ServiceClient implements INetworkModule {
       userAgentOptions: {
         userAgentPrefix,
       },
+      retryOptions: {
+        maxRetries: 3,
+      },
       baseUri,
     });
 

--- a/sdk/identity/identity/src/client/identityClient.ts
+++ b/sdk/identity/identity/src/client/identityClient.ts
@@ -90,12 +90,12 @@ export class IdentityClient extends ServiceClient implements INetworkModule {
 
     super({
       requestContentType: "application/json; charset=utf-8",
+      retryOptions: {
+        maxRetries: 3,
+      },
       ...options,
       userAgentOptions: {
         userAgentPrefix,
-      },
-      retryOptions: {
-        maxRetries: 3,
       },
       baseUri,
     });

--- a/sdk/identity/identity/src/errors.ts
+++ b/sdk/identity/identity/src/errors.ts
@@ -138,7 +138,7 @@ export class AuthenticationError extends Error {
     }
 
     super(
-      `${errorResponse.error}(status code ${statusCode}).\nMore details:\n${errorResponse.errorDescription}`
+      `${errorResponse.error} Status code: ${statusCode}\nMore details:\n${errorResponse.errorDescription}`
     );
     this.statusCode = statusCode;
     this.errorResponse = errorResponse;

--- a/sdk/identity/identity/test/internal/node/managedIdentityCredential.spec.ts
+++ b/sdk/identity/identity/test/internal/node/managedIdentityCredential.spec.ts
@@ -224,12 +224,9 @@ describe("ManagedIdentityCredential", function () {
       scopes: ["scopes"],
       credential: new ManagedIdentityCredential("errclient"),
       insecureResponses: [
-        createResponse(503, {}, { "Retry-After": "2" }),
-        createResponse(503, {}, { "Retry-After": "2" }),
-        createResponse(503, {}, { "Retry-After": "2" }),
-        // The ThrottlingRetryPolicy of core-http will retry up to 3 times, an extra retry would make this fail (meaning a 503 response would be considered the result)
-        // createResponse(503, {}, { "Retry-After": "2" }),
-        createResponse(200),
+        // Any response on the ping request is fine, since it means that the endpoint is indeed there.
+        createResponse(503),
+        // After the ping, we try to get a token from the IMDS endpoint.
         createResponse(503, {}, { "Retry-After": "2" }),
         createResponse(503, {}, { "Retry-After": "2" }),
         createResponse(503, {}, { "Retry-After": "2" }),
@@ -245,12 +242,9 @@ describe("ManagedIdentityCredential", function () {
       scopes: ["scopes"],
       credential: new ManagedIdentityCredential("errclient"),
       insecureResponses: [
+        // Any response on the ping request is fine, since it means that the endpoint is indeed there.
         createResponse(500, {}),
-        createResponse(500, {}),
-        createResponse(500, {}),
-        // The ThrottlingRetryPolicy of core-http will retry up to 3 times, an extra retry would make this fail (meaning a 503 response would be considered the result)
-        // createResponse(503, {}, { "Retry-After": "2" }),
-        createResponse(200),
+        // After the ping, we try to get a token from the IMDS endpoint.
         createResponse(500, {}),
         createResponse(500, {}),
         createResponse(500, {}),
@@ -266,12 +260,9 @@ describe("ManagedIdentityCredential", function () {
       scopes: ["scopes"],
       credential: new ManagedIdentityCredential("errclient"),
       insecureResponses: [
-        // Ping failed. We consider any response a valid ping, so we continue afterwards.
+        // Any response on the ping request is fine, since it means that the endpoint is indeed there.
         createResponse(503, {}, { "Retry-After": "2" }),
-        createResponse(503, {}, { "Retry-After": "2" }),
-        createResponse(503, {}, { "Retry-After": "2" }),
-        createResponse(503, {}, { "Retry-After": "2" }),
-        // Non-ping failed
+        // After the ping, we try to get a token from the IMDS endpoint.
         createResponse(503, {}, { "Retry-After": "2" }),
         createResponse(503, {}, { "Retry-After": "2" }),
         createResponse(503, {}, { "Retry-After": "2" }),
@@ -291,12 +282,9 @@ describe("ManagedIdentityCredential", function () {
       scopes: ["scopes"],
       credential: new ManagedIdentityCredential("errclient"),
       insecureResponses: [
-        // Ping failed. We consider any response a valid ping, so we continue afterwards.
+        // Any response on the ping request is fine, since it means that the endpoint is indeed there.
         createResponse(500, {}),
-        createResponse(500, {}),
-        createResponse(500, {}),
-        createResponse(500, {}),
-        // Non-ping failed
+        // After the ping, we try to get a token from the IMDS endpoint.
         createResponse(500, {}),
         createResponse(500, {}),
         createResponse(500, {}),


### PR DESCRIPTION
A customer recently reported that the ManagedIdentityCredential takes 5 minutes to retrieve any result in some environments: https://github.com/Azure/azure-sdk-for-js/issues/20308 — in this specific case, the endpoint is answering with a 5XX error, making our pipelines retry with exponential backoff up to 10 times.

As part of the recent change to unify the retry policies, our core retries now go up to 10 attempts by default: https://github.com/Azure/azure-sdk-for-js/pull/19078 — before this change, the maximum number of retries were inconsistent. In some cases, they were 3, in other cases 10. The unification has caused Identity to take too long to make some requests.

Ultimately, Identity should not delegate its max number of retries to the default values, so in this PR I’m specifying the maximum number of retries for all Identity pipelines to 3, which will ensure that this expected behavior will not change later inadvertently.

I had tests that I expected would have asserted this behavior, but these tests returned earlier than the maximum number of retries, hiding the behavioral change. Therefore, I have added two new tests that will fail if the maximum number of retries in the Identity pipelines change in the future.

I want to release this fix as part of 2.0.3.

---

After going through this PR, we also noticed that the ping request should have zero retries. To achieve that, now the `ManagedIdentityCredential` has a new separate `isAvailableIdentityClient` that has zero retries, that is used on the `isAvailable` calls to see which MSI is available.