### PR TITLE
[KeyVault] - Fix recorded browser tests

### DIFF
--- a/sdk/keyvault/keyvault-certificates/test/public/utils/testAuthentication.ts
+++ b/sdk/keyvault/keyvault-certificates/test/public/utils/testAuthentication.ts
@@ -8,7 +8,7 @@ import { env, record, RecorderEnvironmentSetup } from "@azure-tools/test-recorde
 import { getServiceVersion } from "./common";
 import TestClient from "./testClient";
 import { Context } from "mocha";
-import { createXhrHttpClient } from "@azure/test-utils";
+import { createXhrHttpClient, isNode } from "@azure/test-utils";
 
 export async function authenticate(
   that: Context,
@@ -36,13 +36,14 @@ export async function authenticate(
     queryParametersToSkip: [],
   };
   const recorder = record(that, recorderEnvSetup);
+  const identityHttpClient = isNode ? undefined : createXhrHttpClient();
   const credential = new ClientSecretCredential(
     env.AZURE_TENANT_ID,
     env.AZURE_CLIENT_ID,
     env.AZURE_CLIENT_SECRET,
     {
       authorityHost: env.AZURE_AUTHORITY_HOST,
-      httpClient: createXhrHttpClient(),
+      httpClient: identityHttpClient,
     }
   );
 

--- a/sdk/keyvault/keyvault-certificates/test/public/utils/testAuthentication.ts
+++ b/sdk/keyvault/keyvault-certificates/test/public/utils/testAuthentication.ts
@@ -8,6 +8,7 @@ import { env, record, RecorderEnvironmentSetup } from "@azure-tools/test-recorde
 import { getServiceVersion } from "./common";
 import TestClient from "./testClient";
 import { Context } from "mocha";
+import { createXhrHttpClient } from "@azure/test-utils";
 
 export async function authenticate(
   that: Context,
@@ -41,6 +42,7 @@ export async function authenticate(
     env.AZURE_CLIENT_SECRET,
     {
       authorityHost: env.AZURE_AUTHORITY_HOST,
+      httpClient: createXhrHttpClient(),
     }
   );
 

--- a/sdk/keyvault/keyvault-keys/test/public/utils/testAuthentication.ts
+++ b/sdk/keyvault/keyvault-keys/test/public/utils/testAuthentication.ts
@@ -8,6 +8,7 @@ import { uniqueString } from "./recorderUtils";
 import TestClient from "./testClient";
 import { Context } from "mocha";
 import { fromBase64url, toBase64url } from "./base64url";
+import { createXhrHttpClient } from "@azure/test-utils";
 
 const replaceableVariables = {
   AZURE_CLIENT_ID: "azure_client_id",
@@ -51,6 +52,7 @@ export async function authenticate(that: Context, version: string): Promise<any>
     env.AZURE_CLIENT_SECRET,
     {
       authorityHost: env.AZURE_AUTHORITY_HOST,
+      httpClient: createXhrHttpClient(),
     }
   );
 

--- a/sdk/keyvault/keyvault-keys/test/public/utils/testAuthentication.ts
+++ b/sdk/keyvault/keyvault-keys/test/public/utils/testAuthentication.ts
@@ -8,7 +8,7 @@ import { uniqueString } from "./recorderUtils";
 import TestClient from "./testClient";
 import { Context } from "mocha";
 import { fromBase64url, toBase64url } from "./base64url";
-import { createXhrHttpClient } from "@azure/test-utils";
+import { createXhrHttpClient, isNode } from "@azure/test-utils";
 
 const replaceableVariables = {
   AZURE_CLIENT_ID: "azure_client_id",
@@ -46,13 +46,14 @@ export async function authenticate(that: Context, version: string): Promise<any>
     queryParametersToSkip: [],
   };
   const recorder = record(that, recorderEnvSetup);
+  const identityHttpClient = isNode ? undefined : createXhrHttpClient();
   const credential = new ClientSecretCredential(
     env.AZURE_TENANT_ID,
     env.AZURE_CLIENT_ID,
     env.AZURE_CLIENT_SECRET,
     {
       authorityHost: env.AZURE_AUTHORITY_HOST,
-      httpClient: createXhrHttpClient(),
+      httpClient: identityHttpClient,
     }
   );
 

--- a/sdk/keyvault/keyvault-secrets/test/public/utils/testAuthentication.ts
+++ b/sdk/keyvault/keyvault-secrets/test/public/utils/testAuthentication.ts
@@ -8,7 +8,7 @@ import { uniqueString } from "./recorderUtils";
 import TestClient from "./testClient";
 import { Context } from "mocha";
 import { getServiceVersion } from "./common";
-import { createXhrHttpClient } from "@azure/test-utils";
+import { createXhrHttpClient, isNode } from "@azure/test-utils";
 
 export async function authenticate(
   that: Context,
@@ -32,13 +32,14 @@ export async function authenticate(
     queryParametersToSkip: [],
   };
   const recorder = record(that, recorderEnvSetup);
+  const identityHttpClient = isNode ? undefined : createXhrHttpClient();
   const credential = new ClientSecretCredential(
     env.AZURE_TENANT_ID,
     env.AZURE_CLIENT_ID,
     env.AZURE_CLIENT_SECRET,
     {
       authorityHost: env.AZURE_AUTHORITY_HOST,
-      httpClient: createXhrHttpClient(),
+      httpClient: identityHttpClient,
     }
   );
 

--- a/sdk/keyvault/keyvault-secrets/test/public/utils/testAuthentication.ts
+++ b/sdk/keyvault/keyvault-secrets/test/public/utils/testAuthentication.ts
@@ -8,6 +8,7 @@ import { uniqueString } from "./recorderUtils";
 import TestClient from "./testClient";
 import { Context } from "mocha";
 import { getServiceVersion } from "./common";
+import { createXhrHttpClient } from "@azure/test-utils";
 
 export async function authenticate(
   that: Context,
@@ -37,6 +38,7 @@ export async function authenticate(
     env.AZURE_CLIENT_SECRET,
     {
       authorityHost: env.AZURE_AUTHORITY_HOST,
+      httpClient: createXhrHttpClient(),
     }
   );
 


### PR DESCRIPTION
### Packages impacted by this PR
@azure/keyvault-keys
@azure/keyvault-certificates
@azure/keyvault-secrets

Note: @azure/keyvault-admin is _not_ impacted because it has no browser test.


### Describe the problem that is addressed by this PR
I noticed that our recorded browser tests were failing in the browser. My good
friend `git bisect` pointed to 9afbe3fc46b63516e88b508911b2b2d4517dd42b as the
commit that introduced this issue.

Digging into it, it looks like this is unique to KeyVault in that it is _still_
on coreV1 but uses Identity which is on coreV2. Not sure about other client
libraries, it looks like they were fixed in the PR itself.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?
Really we just need to migrate KV to coreV2 and the new recorder... but this
will unblock the tests for now


### Provide a list of related PRs _(if any)_
https://github.com/Azure/azure-sdk-for-js/pull/20201

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
