### PR TITLE
[ServiceBus] Respect user request to close receiver when disconnected

### DIFF
--- a/sdk/servicebus/service-bus/CHANGELOG.md
+++ b/sdk/servicebus/service-bus/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Fix an issue where we don't respect user request to close the receiver when the connection is disconnected. [PR #20427](https://github.com/Azure/azure-sdk-for-js/pull/20427)
+
 ### Other Changes
 
 ## 7.5.0 (2022-02-14)

--- a/sdk/servicebus/service-bus/CHANGELOG.md
+++ b/sdk/servicebus/service-bus/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Bugs Fixed
 
-- Fix an issue where we don't respect user request to close the receiver when the connection is disconnected. [PR #20427](https://github.com/Azure/azure-sdk-for-js/pull/20427)
+- Fix an issue where we don't respect user request to close the receiver if the connection is disconnected when using the `subscribe()` method. [PR #20427](https://github.com/Azure/azure-sdk-for-js/pull/20427)
 
 ### Other Changes
 

--- a/sdk/servicebus/service-bus/src/core/streamingReceiver.ts
+++ b/sdk/servicebus/service-bus/src/core/streamingReceiver.ts
@@ -576,16 +576,16 @@ export class StreamingReceiver extends MessageReceiver {
    * @param catchAndReportError - A function and reports an error but does not throw it.
    */
   private async _initAndAddCreditOperation(caller: "detach" | "subscribe"): Promise<void> {
-    throwErrorIfConnectionClosed(this._context);
-
-    await this._messageHandlers().preInitialize();
-
     if (this._receiverHelper.isSuspended()) {
       // user has suspended us while we were initializing
       // the connection. Abort this attempt - if they attempt
       // resubscribe we'll just reinitialize.
       throw new AbortError("Receiver was suspended during initialization.");
     }
+
+    throwErrorIfConnectionClosed(this._context);
+
+    await this._messageHandlers().preInitialize();
 
     await this._init(
       this._createReceiverOptions(caller === "detach", this._getHandlers()),

--- a/sdk/servicebus/service-bus/src/receivers/receiverCommon.ts
+++ b/sdk/servicebus/service-bus/src/receivers/receiverCommon.ts
@@ -321,10 +321,15 @@ export async function retryForever<T>(
   if (!config.retryOptions) {
     config.retryOptions = {};
   }
-  if (!config.retryOptions.retryDelayInMs || config.retryOptions.retryDelayInMs < 0) {
+  // eslint-disable-next-line eqeqeq
+  if (config.retryOptions.retryDelayInMs == undefined || config.retryOptions.retryDelayInMs < 0) {
     config.retryOptions.retryDelayInMs = Constants.defaultDelayBetweenOperationRetriesInMs;
   }
-  if (!config.retryOptions.maxRetryDelayInMs || config.retryOptions.maxRetryDelayInMs < 0) {
+  if (
+    // eslint-disable-next-line eqeqeq
+    config.retryOptions.maxRetryDelayInMs == undefined ||
+    config.retryOptions.maxRetryDelayInMs < 0
+  ) {
     config.retryOptions.maxRetryDelayInMs = Constants.defaultMaxDelayForExponentialRetryInMs;
   }
   if (!config.retryOptions.mode) {


### PR DESCRIPTION
When receiving messages in a stream using `receiver.subscribe()`, 
Under certain situation when the underlying connection is closed, we don't respect user request to close the receiver, but keep retrying to recover.

The problem is that we check the connection status and throw an error if it is closed in
`_initAndAddCreditOperation`.  We restart retry cycle because of the error in the
`retryForEver()` function with the same operation, trying to re-establish the connection, then throw the same error again.
User calling `close()` wouldn't help because the place we
check for suspended state then throw `AbortError` is after we check the
connection and throw error.

This PR adds the checking of whether user has suspended the receiver before checking of connection so we
could throw `AbortError` to end the retry cycles.  The check after `preInitialize()` invocation is still needed
as user could suspend us in the `preInitialize()` handler.

I also fix another issue of not respecting 0 values in user specified retry options.

### Packages impacted by this PR

@azure/service-bus

### Issues associated with this PR

#20388 

### Are there test cases added in this PR? _(If not, why?)_
The issue has test coverage.

### Checklists
- [x] Added impacted package name to the issue description
- [x] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [x] Added a changelog (if necessary)
