### PR TITLE
[@azure/core-http-compat] Rename ExtendedOptions to ExtendedClientOptions

### DIFF
--- a/sdk/core/ci.yml
+++ b/sdk/core/ci.yml
@@ -66,3 +66,5 @@ extends:
         safeName: azurecoreutil
       - name: azure-logger
         safeName: azurelogger
+      - name: azure-core-http-compat
+        safeName: azurecorehttpcompat

--- a/sdk/core/core-http-compat/README.md
+++ b/sdk/core/core-http-compat/README.md
@@ -4,35 +4,6 @@ This library provides classes and interfaces to be used by Azure client librarie
 
 ## Usage
 
-### ExtendedServiceClientOptions
-
-With `@azure/core-http` library, the `options` parameter to the generated client will look like:
-
-```
-export interface SearchClientOptionalParams extends coreHttp.ServiceClientOptions {
-  /** Overrides client endpoint. */
-  endpoint?: string;
-}
-```
-
-With the `@azure/core-client` & `@azure/core-rest-pipeline` libraries, the `options` parameter to the generated client will look like:
-
-```
-export interface SearchClientOptionalParams extends coreClient.ServiceClientOptions {
-  /** Overrides client endpoint. */
-  endpoint?: string;
-}
-```
-
-With the Core HTTP Compatibility library, the `options` parameter to the generated client will look like:
-
-```
-export interface SearchClientOptionalParams extends coreHttpCompat.ExtendedServiceClientOptions {
-  /** Overrides client endpoint. */
-  endpoint?: string;
-}
-```
-
 ### ExtendedCommonClientOptions
 
 With `@azure/core-http` library, the `options` parameter to the custom client will look like:

--- a/sdk/core/core-http-compat/review/core-http-compat.api.md
+++ b/sdk/core/core-http-compat/review/core-http-compat.api.md
@@ -12,13 +12,13 @@ import { ServiceClientOptions } from '@azure/core-client';
 export const disbaleKeepAlivePolicyName = "DisableKeepAlivePolicy";
 
 // @public
-export type ExtendedCommonClientOptions = CommonClientOptions & ExtendedOptions;
-
-// @public
-export interface ExtendedOptions {
+export interface ExtendedClientOptions {
     keepAliveOptions?: KeepAliveOptions;
     redirectOptions?: RedirectOptions;
 }
+
+// @public
+export type ExtendedCommonClientOptions = CommonClientOptions & ExtendedClientOptions;
 
 // @public
 export class ExtendedServiceClient extends ServiceClient {
@@ -26,7 +26,7 @@ export class ExtendedServiceClient extends ServiceClient {
 }
 
 // @public
-export type ExtendedServiceClientOptions = ServiceClientOptions & ExtendedOptions;
+export type ExtendedServiceClientOptions = ServiceClientOptions & ExtendedClientOptions;
 
 // @public
 export interface KeepAliveOptions {

--- a/sdk/core/core-http-compat/src/extendedClient.ts
+++ b/sdk/core/core-http-compat/src/extendedClient.ts
@@ -12,7 +12,7 @@ import { CommonClientOptions } from "@azure/core-client";
 /**
  * Options specific to Shim Clients.
  */
-export interface ExtendedOptions {
+export interface ExtendedClientOptions {
   /**
    * Options to disable keep alive.
    */
@@ -26,12 +26,12 @@ export interface ExtendedOptions {
 /**
  * Options that shim clients are expected to expose.
  */
-export type ExtendedServiceClientOptions = ServiceClientOptions & ExtendedOptions;
+export type ExtendedServiceClientOptions = ServiceClientOptions & ExtendedClientOptions;
 
 /**
  * The common set of options that custom shim clients are expected to expose.
  */
-export type ExtendedCommonClientOptions = CommonClientOptions & ExtendedOptions;
+export type ExtendedCommonClientOptions = CommonClientOptions & ExtendedClientOptions;
 
 /**
  * Client to provide compatability between core V1 & V2.

--- a/sdk/core/core-http-compat/src/index.ts
+++ b/sdk/core/core-http-compat/src/index.ts
@@ -10,7 +10,7 @@ export {
   ExtendedServiceClient,
   ExtendedServiceClientOptions,
   ExtendedCommonClientOptions,
-  ExtendedOptions,
+  ExtendedClientOptions,
 } from "./extendedClient";
 export { KeepAliveOptions } from "./policies/keepAliveOptions";
 export { RedirectOptions } from "./policies/redirectOptions";


### PR DESCRIPTION
### Packages impacted by this PR
@azure/core-http-compat

### Issues associated with this PR
N/A

### Describe the problem that is addressed by this PR
The Initial Version of the @azure/core-http-compat SDK was done in https://github.com/Azure/azure-sdk-for-js/pull/20034. Two of the comments ([1](https://github.com/Azure/azure-sdk-for-js/pull/20034/files#r808546641) & [2](https://github.com/Azure/azure-sdk-for-js/pull/20034/files#r808530377)) were missed in that PR. They are:
1. Remove one section on generated client in the Readme file
2. Change `ExtendedOptions` to `ExtendedClientOptions`

Also updated the `ci.yml` file to include the new package.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?
There is no special design concern. It is simple name change.

### Are there test cases added in this PR? _(If not, why?)_
Not necessary. Existing test cases are sufficient.

### Provide a list of related PRs _(if any)_
https://github.com/Azure/azure-sdk-for-js/pull/20034.

### Checklists
- [X] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
