### PR TITLE
[Identity] Fixed bug on 2.0.3

### DIFF
--- a/sdk/identity/identity/CHANGELOG.md
+++ b/sdk/identity/identity/CHANGELOG.md
@@ -1,14 +1,10 @@
 # Release History
 
-## 2.0.4 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
+## 2.0.4 (2022-02-18)
 
 ### Bugs Fixed
 
-### Other Changes
+- 2.0.3 contains a regression: Passing a client Id besides the options argument on the `ManagedIdentityCredential` would discard the options argument. We have fixed it and we have added tests.
 
 ## 2.0.3 (2022-02-16)
 

--- a/sdk/identity/identity/CHANGELOG.md
+++ b/sdk/identity/identity/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bugs Fixed
 
-- 2.0.3 contains a regression: Passing a client Id besides the options argument on the `ManagedIdentityCredential` would discard the options argument. We have fixed it and we have added tests.
+- Fixed a regression in version 2.0.3 in which providing an options bag, but _not_ a client ID, to the `ManagedIdentityCredential` constructor would discard the `options` parameter.
 
 ## 2.0.3 (2022-02-16)
 

--- a/sdk/identity/identity/src/credentials/managedIdentityCredential/index.ts
+++ b/sdk/identity/identity/src/credentials/managedIdentityCredential/index.ts
@@ -62,7 +62,7 @@ export class ManagedIdentityCredential implements TokenCredential {
       _options = options;
     } else {
       // options only constructor
-      _options = options;
+      _options = clientIdOrOptions;
     }
     this.identityClient = new IdentityClient(_options);
     this.isAvailableIdentityClient = new IdentityClient({

--- a/sdk/identity/identity/test/internal/node/managedIdentityCredential.spec.ts
+++ b/sdk/identity/identity/test/internal/node/managedIdentityCredential.spec.ts
@@ -299,6 +299,34 @@ describe("ManagedIdentityCredential", function () {
     );
   });
 
+  it("IMDS MSI accepts a custom set of retries, even when client Id is passed through the first parameter", async function () {
+    const { error } = await testContext.sendCredentialRequests({
+      scopes: ["scopes"],
+      credential: new ManagedIdentityCredential("errclient", {
+        retryOptions: {
+          maxRetries: 4,
+        },
+      }),
+      insecureResponses: [
+        // Any response on the ping request is fine, since it means that the endpoint is indeed there.
+        createResponse(503, {}, { "Retry-After": "2" }),
+        // After the ping, we try to get a token from the IMDS endpoint.
+        createResponse(503, {}, { "Retry-After": "2" }),
+        createResponse(503, {}, { "Retry-After": "2" }),
+        createResponse(503, {}, { "Retry-After": "2" }),
+        createResponse(503, {}, { "Retry-After": "2" }),
+        // This is the extra one
+        createResponse(503, {}, { "Retry-After": "2" }),
+      ],
+    });
+
+    assert.ok(error?.message);
+    assert.equal(
+      error?.message.split("\n")[0],
+      "ManagedIdentityCredential authentication failed. Status code: 503"
+    );
+  });
+
   it("IMDS MSI skips verification if the AZURE_POD_IDENTITY_AUTHORITY_HOST environment variable is available", async function () {
     process.env.AZURE_POD_IDENTITY_AUTHORITY_HOST = "token URL";
 


### PR DESCRIPTION
Fixed a regression in version 2.0.3 in which providing an options bag, but _not_ a client ID, to the `ManagedIdentityCredential` constructor would discard the `options` parameter.