### PR TITLE
[abort-controller] - Fix broken link

### DIFF
--- a/sdk/core/abort-controller/README.md
+++ b/sdk/core/abort-controller/README.md
@@ -8,9 +8,9 @@ in an Azure SDK that accept a parameter of type `AbortSignalLike`.
 
 Key links:
 
- - [Source code](https://github.com/Azure/azure-sdk-for-js/edit/master/sdk/core/abort-controller)
- - [Package (npm)](https://www.npmjs.com/package/@azure/abort-controller)
- - [API Reference Documentation](https://docs.microsoft.com/javascript/api/overview/azure/abort-controller-readme)
+- [Source code](https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/core/abort-controller)
+- [Package (npm)](https://www.npmjs.com/package/@azure/abort-controller)
+- [API Reference Documentation](https://docs.microsoft.com/javascript/api/overview/azure/abort-controller-readme)
 
 ## Getting started
 


### PR DESCRIPTION
Link verification check is failing for the link in this PR. Not sure why it
started failing now but the link certainly isn't valid.
