### PR TITLE
[core-tracing] - Export az.namespace key

### DIFF
--- a/sdk/core/core-tracing/review/core-tracing.api.md
+++ b/sdk/core/core-tracing/review/core-tracing.api.md
@@ -50,6 +50,9 @@ export type SpanStatusSuccess = {
 };
 
 // @public
+export const TRACING_CONTEXT_NAMESPACE_KEY: unique symbol;
+
+// @public
 export interface TracingClient {
     createRequestHeaders(tracingContext?: TracingContext): Record<string, string>;
     parseTraceparentHeader(traceparentHeader: string): TracingContext | undefined;

--- a/sdk/core/core-tracing/src/constants.ts
+++ b/sdk/core/core-tracing/src/constants.ts
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+/** @internal */
+export const TRACING_CONTEXT_SPAN_KEY = Symbol.for("@azure/core-tracing span");
+
+/**
+ * The key for the az.namespace entry in a {@link TracingContext}
+ */
+export const TRACING_CONTEXT_NAMESPACE_KEY = Symbol.for("@azure/core-tracing namespace");
+
+/** @internal */
+export const TRACING_CONTEXT_CLIENT_KEY = Symbol.for("@azure/core-tracing client");

--- a/sdk/core/core-tracing/src/index.ts
+++ b/sdk/core/core-tracing/src/index.ts
@@ -19,3 +19,4 @@ export {
 } from "./interfaces";
 export { useInstrumenter } from "./instrumenter";
 export { createTracingClient } from "./tracingClient";
+export { TRACING_CONTEXT_NAMESPACE_KEY } from "./constants";

--- a/sdk/core/core-tracing/src/tracingClient.ts
+++ b/sdk/core/core-tracing/src/tracingClient.ts
@@ -10,8 +10,8 @@ import {
   TracingSpan,
   TracingSpanOptions,
 } from "./interfaces";
+import { TRACING_CONTEXT_NAMESPACE_KEY } from "./constants";
 import { getInstrumenter } from "./instrumenter";
-import { knownContextKeys } from "./tracingContext";
 
 /**
  * Creates a new tracing client.
@@ -38,10 +38,10 @@ export function createTracingClient(options: TracingClientOptions): TracingClien
     });
     let tracingContext = startSpanResult.tracingContext;
     const span = startSpanResult.span;
-    if (!tracingContext.getValue(knownContextKeys.namespace)) {
-      tracingContext = tracingContext.setValue(knownContextKeys.namespace, namespace);
+    if (!tracingContext.getValue(TRACING_CONTEXT_NAMESPACE_KEY)) {
+      tracingContext = tracingContext.setValue(TRACING_CONTEXT_NAMESPACE_KEY, namespace);
     }
-    span.setAttribute("az.namespace", tracingContext.getValue(knownContextKeys.namespace));
+    span.setAttribute("az.namespace", tracingContext.getValue(TRACING_CONTEXT_NAMESPACE_KEY));
     const updatedOptions = {
       ...operationOptions,
       tracingOptions: {

--- a/sdk/core/core-tracing/src/tracingContext.ts
+++ b/sdk/core/core-tracing/src/tracingContext.ts
@@ -1,15 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+import {
+  TRACING_CONTEXT_CLIENT_KEY,
+  TRACING_CONTEXT_NAMESPACE_KEY,
+  TRACING_CONTEXT_SPAN_KEY,
+} from "./constants";
 import { TracingClient, TracingContext, TracingSpan } from "./interfaces";
-
-/** @internal */
-export const knownContextKeys = {
-  span: Symbol.for("@azure/core-tracing span"),
-  namespace: Symbol.for("@azure/core-tracing namespace"),
-  client: Symbol.for("@azure/core-tracing client"),
-  parentContext: Symbol.for("@azure/core-tracing parent context"),
-};
 
 /**
  * Creates a new {@link TracingContext} with the given options.
@@ -21,13 +18,13 @@ export const knownContextKeys = {
 export function createTracingContext(options: CreateTracingContextOptions = {}): TracingContext {
   let context: TracingContext = new TracingContextImpl(options.parentContext);
   if (options.span) {
-    context = context.setValue(knownContextKeys.span, options.span);
+    context = context.setValue(TRACING_CONTEXT_SPAN_KEY, options.span);
   }
   if (options.client) {
-    context = context.setValue(knownContextKeys.client, options.client);
+    context = context.setValue(TRACING_CONTEXT_CLIENT_KEY, options.client);
   }
   if (options.namespace) {
-    context = context.setValue(knownContextKeys.namespace, options.namespace);
+    context = context.setValue(TRACING_CONTEXT_NAMESPACE_KEY, options.namespace);
   }
   return context;
 }

--- a/sdk/core/core-tracing/test/instrumenter.spec.ts
+++ b/sdk/core/core-tracing/test/instrumenter.spec.ts
@@ -8,8 +8,9 @@ import {
   getInstrumenter,
   useInstrumenter,
 } from "../src/instrumenter";
-import { createTracingContext, knownContextKeys } from "../src/tracingContext";
+import { TRACING_CONTEXT_SPAN_KEY } from "../src/constants";
 import { assert } from "chai";
+import { createTracingContext } from "../src/tracingContext";
 
 describe("Instrumenter", () => {
   describe("NoOpInstrumenter", () => {
@@ -59,7 +60,7 @@ describe("Instrumenter", () => {
         assert.isEmpty(instrumenter.createRequestHeaders(createTracingContext()));
         assert.isEmpty(
           instrumenter.createRequestHeaders(
-            createTracingContext().setValue(knownContextKeys.span, createDefaultTracingSpan())
+            createTracingContext().setValue(TRACING_CONTEXT_SPAN_KEY, createDefaultTracingSpan())
           )
         );
       });

--- a/sdk/core/core-tracing/test/tracingClient.spec.ts
+++ b/sdk/core/core-tracing/test/tracingClient.spec.ts
@@ -7,9 +7,10 @@ import {
   createDefaultTracingSpan,
   useInstrumenter,
 } from "../src/instrumenter";
-import { createTracingContext, knownContextKeys } from "../src/tracingContext";
+import { TRACING_CONTEXT_NAMESPACE_KEY } from "../src";
 import { assert } from "chai";
 import { createTracingClient } from "../src/tracingClient";
+import { createTracingContext } from "../src/tracingContext";
 import sinon from "sinon";
 
 describe("TracingClient", () => {
@@ -68,18 +69,21 @@ describe("TracingClient", () => {
     it("sets namespace on context", () => {
       const { updatedOptions } = client.startSpan("test");
       assert.equal(
-        updatedOptions.tracingOptions?.tracingContext?.getValue(knownContextKeys.namespace),
+        updatedOptions.tracingOptions?.tracingContext?.getValue(TRACING_CONTEXT_NAMESPACE_KEY),
         expectedNamespace
       );
     });
 
     it("does not override existing namespace on context", () => {
-      context = createTracingContext().setValue(knownContextKeys.namespace, "Existing.Namespace");
+      context = createTracingContext().setValue(
+        TRACING_CONTEXT_NAMESPACE_KEY,
+        "Existing.Namespace"
+      );
       const { updatedOptions } = client.startSpan("test", {
         tracingOptions: { tracingContext: context },
       });
       assert.equal(
-        updatedOptions.tracingOptions?.tracingContext?.getValue(knownContextKeys.namespace),
+        updatedOptions.tracingOptions?.tracingContext?.getValue(TRACING_CONTEXT_NAMESPACE_KEY),
         "Existing.Namespace"
       );
     });

--- a/sdk/core/core-tracing/test/tracingContext.spec.ts
+++ b/sdk/core/core-tracing/test/tracingContext.spec.ts
@@ -1,7 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { TracingContextImpl, createTracingContext, knownContextKeys } from "../src/tracingContext";
+import {
+  TRACING_CONTEXT_CLIENT_KEY,
+  TRACING_CONTEXT_NAMESPACE_KEY,
+  TRACING_CONTEXT_SPAN_KEY,
+} from "../src/constants";
+import { TracingContextImpl, createTracingContext } from "../src/tracingContext";
 import { assert } from "chai";
 import { createDefaultTracingSpan } from "../src/instrumenter";
 import { createTracingClient } from "../src/tracingClient";
@@ -104,18 +109,18 @@ describe("TracingContext", () => {
         span,
         namespace,
       });
-      assert.strictEqual(newContext.getValue(knownContextKeys.client), client);
-      assert.strictEqual(newContext.getValue(knownContextKeys.namespace), namespace);
-      assert.strictEqual(newContext.getValue(knownContextKeys.span), span);
+      assert.strictEqual(newContext.getValue(TRACING_CONTEXT_CLIENT_KEY), client);
+      assert.strictEqual(newContext.getValue(TRACING_CONTEXT_NAMESPACE_KEY), namespace);
+      assert.strictEqual(newContext.getValue(TRACING_CONTEXT_SPAN_KEY), span);
     });
 
     it("can be initialized from an existing context", () => {
       const parentContext = createTracingContext().setValue(
-        knownContextKeys.namespace,
+        TRACING_CONTEXT_NAMESPACE_KEY,
         "test-namespace"
       );
       const newContext = createTracingContext({ parentContext: parentContext });
-      assert.equal(newContext.getValue(knownContextKeys.namespace), "test-namespace");
+      assert.equal(newContext.getValue(TRACING_CONTEXT_NAMESPACE_KEY), "test-namespace");
     });
   });
 });


### PR DESCRIPTION
### Packages impacted by this PR
@azure/core-tracing

### Describe the problem that is addressed by this PR
The latest set of changes introduced a new naming convention for our context
keys in the form of "@azure/core-tracing {name}". Historically for the
az.namespace attribute we used "az.namespace". Now that we changed it we
probably will end up changing in tracingPolicy as well. So, we should probably
export the constant to avoid duplication.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?
Alternatives:
- Copy/paste the string into tracingPolicy, which can be frustrating if they
ever drift
- Export the original KnownContextKeys object, but this felt more in-line with
what I used to do in constants file, just export a bunch of individual
constants.

### Are there test cases added in this PR? _(If not, why?)_
No, just updated existing ones.

### Checklists
- [x] Added impacted package name to the issue description.
- [ ] Added a changelog (if necessary).
