### PR TITLE
[Digital Twins] Use "@azure-tools/test-credential";

### DIFF
--- a/sdk/digitaltwins/digital-twins-core/package.json
+++ b/sdk/digitaltwins/digital-twins-core/package.json
@@ -74,6 +74,7 @@
     "@azure/dev-tool": "^1.0.0",
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
     "@azure/identity": "^2.0.1",
+    "@azure-tools/test-credential": "^1.0.0",
     "@azure-tools/test-recorder": "^1.0.0",
     "@microsoft/api-extractor": "^7.18.11",
     "@types/chai": "^4.1.6",

--- a/sdk/digitaltwins/digital-twins-core/test/utils/testAuthentication.ts
+++ b/sdk/digitaltwins/digital-twins-core/test/utils/testAuthentication.ts
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { ClientSecretCredential } from "@azure/identity";
 import { DigitalTwinsClient } from "../../src";
 import { env, record, RecorderEnvironmentSetup } from "@azure-tools/test-recorder";
 import { uniqueString } from "./recorderUtils";
 import TestClient from "./testClient";
+import { createTestCredential } from "@azure-tools/test-credential";
 
 export async function authenticate(that: Mocha.Context): Promise<any> {
   const keySuffix = uniqueString();
@@ -25,11 +25,7 @@ export async function authenticate(that: Mocha.Context): Promise<any> {
     queryParametersToSkip: [],
   };
   const recorder = record(that, recorderEnvSetup);
-  const credential = new ClientSecretCredential(
-    env.AZURE_TENANT_ID,
-    env.AZURE_CLIENT_ID,
-    env.AZURE_CLIENT_SECRET
-  );
+  const credential = createTestCredential();
   const AZURE_DIGITALTWINS_URL = env.AZURE_DIGITALTWINS_URL;
   const client = new DigitalTwinsClient(AZURE_DIGITALTWINS_URL, credential);
   const testClient = new TestClient(client);


### PR DESCRIPTION
### Packages impacted by this PR
Tests in digital-twins-core

### Issues associated with this PR
https://github.com/Azure/azure-sdk-for-js/issues/20493
Unblocks https://github.com/Azure/azure-sdk-for-js/pull/20300

### Describe the problem that is addressed by this PR
Fixes https://github.com/Azure/azure-sdk-for-js/issues/20493

Requests from the AAD browser tests are hitting the live service in playback mode instead of using the recordings.
My best guess on the cause of the problem is that something has changed at the msal level which kicked in a tenant-id validation and failed for the "12345678-1234-1234-1234-123456789012" fake tenant-id.
Haven't investigated deeper on what is causing the failure, instead using the test-credential which would bypass the AAD traffic in playback mode.
