### PR TITLE
[Recorder] Add return types to test/utils methods

### DIFF
--- a/sdk/test-utils/recorder/test/utils/utils.ts
+++ b/sdk/test-utils/recorder/test/utils/utils.ts
@@ -1,4 +1,4 @@
-import { createPipelineRequest, HttpMethods } from "@azure/core-rest-pipeline";
+import { createPipelineRequest, HttpMethods, PipelineResponse } from "@azure/core-rest-pipeline";
 import { expect } from "chai";
 import { env } from "../../src";
 import { isLiveMode, TestMode } from "../../src/utils/utils";
@@ -14,7 +14,7 @@ export const setTestMode = (mode: TestMode): TestMode => {
  * Returns the test server url
  * Acts as the endpoint [ Works as a substitute to the actual Azure Services ]
  */
-export function getTestServerUrl() {
+export function getTestServerUrl(): string {
   // utils/server.ts creates a localhost server at port 8080
   // - In "live" mode, we are hitting directly the localhost endpoint
   // - In "record" and "playback" modes, we need to hit the localhost of the host network
@@ -39,7 +39,7 @@ export async function makeRequestAndVerifyResponse(
     method: HttpMethods;
   },
   expectedResponse: { [key: string]: unknown } | undefined
-) {
+): Promise<PipelineResponse> {
   const req = createPipelineRequest({
     url: request.url ?? getTestServerUrl() + request.path,
     body: request.body,


### PR DESCRIPTION
Fixes #20511 '

Aims to fix this error.
```
test/utils/utils.ts(32,23): error TS2742: The inferred type of 'makeRequestAndVerifyResponse' cannot be named without a reference to '../../../../../common/temp/node_modules/.pnpm/@azure+core-rest-pipeline@1.5.0/node_modules/@azure/core-rest-pipeline/core-rest-pipeline.shims'. This is likely not portable. A type annotation is necessary.

```