### PR TITLE
[Farmbeats] Fix broken browser test

### DIFF
--- a/sdk/agrifood/agrifood-farming-rest/package.json
+++ b/sdk/agrifood/agrifood-farming-rest/package.json
@@ -82,7 +82,7 @@
   "sideEffects": false,
   "autoPublish": false,
   "dependencies": {
-    "@azure-rest/core-client": "1.0.0-beta.7",
+    "@azure-rest/core-client": "1.0.0-beta.9",
     "@azure/core-auth": "^1.3.0",
     "@azure/core-lro": "^2.2.4",
     "@azure/core-paging": "^1.2.2",
@@ -94,6 +94,7 @@
     "@azure/dev-tool": "^1.0.0",
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
     "@azure/identity": "^2.0.1",
+    "@azure/test-utils": "^1.0.0",
     "@azure-tools/test-recorder": "^1.0.0",
     "@microsoft/api-extractor": "^7.18.11",
     "@types/chai": "^4.1.6",

--- a/sdk/agrifood/agrifood-farming-rest/test/public/utils/recordedClient.ts
+++ b/sdk/agrifood/agrifood-farming-rest/test/public/utils/recordedClient.ts
@@ -3,14 +3,21 @@
 
 /// <reference lib="esnext.asynciterable" />
 
-import { Context } from "mocha";
-
-import { env, Recorder, record, RecorderEnvironmentSetup } from "@azure-tools/test-recorder";
-import FarmBeats, { FarmBeatsRestClient } from "../../../src";
-import { ClientSecretCredential } from "@azure/identity";
-
 import "./env";
+
+import FarmBeats, { FarmBeatsRestClient } from "../../../src";
+import {
+  Recorder,
+  RecorderEnvironmentSetup,
+  env,
+  isLiveMode,
+  record,
+} from "@azure-tools/test-recorder";
+import { createXhrHttpClient, isNode } from "@azure/test-utils";
+
 import { ClientOptions } from "@azure-rest/core-client";
+import { ClientSecretCredential } from "@azure/identity";
+import { Context } from "mocha";
 
 const replaceableVariables: { [k: string]: string } = {
   FARMBEATS_ENDPOINT: "https://endpoint",
@@ -37,12 +44,15 @@ export const environmentSetup: RecorderEnvironmentSetup = {
 };
 
 export function createClient(options?: ClientOptions): FarmBeatsRestClient {
+  const httpClient = isNode || isLiveMode() ? undefined : createXhrHttpClient();
   const credential = new ClientSecretCredential(
     env.AZURE_TENANT_ID,
     env.AZURE_CLIENT_ID,
-    env.AZURE_CLIENT_SECRET
+    env.AZURE_CLIENT_SECRET,
+    { httpClient }
   );
-  return FarmBeats(env.FARMBEATS_ENDPOINT, credential, options);
+  
+  return FarmBeats(env.FARMBEATS_ENDPOINT, credential, { ...options, httpClient });
 }
 
 /**

--- a/sdk/agrifood/agrifood-farming-rest/test/public/utils/recordedClient.ts
+++ b/sdk/agrifood/agrifood-farming-rest/test/public/utils/recordedClient.ts
@@ -51,7 +51,7 @@ export function createClient(options?: ClientOptions): FarmBeatsRestClient {
     env.AZURE_CLIENT_SECRET,
     { httpClient }
   );
-  
+
   return FarmBeats(env.FARMBEATS_ENDPOINT, credential, { ...options, httpClient });
 }
 


### PR DESCRIPTION
### Packages impacted by this PR
@azure-rest/agrifood-farming

### Issues associated with this PR
N/A

### Describe the problem that is addressed by this PR
Agrifood farming hasn't been migrated to the new recorder and it is failing in CI.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?
To mitigate the failure we need to pass the xhrhttpclient

https://github.com/Azure/azure-sdk-for-js/issues/20592 Tracks the migration

### Are there test cases added in this PR? _(If not, why?)_
Current test cases verify fix
