### PR TITLE
Checkout all CI onboarding info

### DIFF
--- a/eng/pipelines/docindex.yml
+++ b/eng/pipelines/docindex.yml
@@ -18,9 +18,7 @@ jobs:
         parameters:
           SkipDefaultCheckout: true
           Paths:
-            - ci-configs/packages-latest.json
-            - ci-configs/packages-preview.json
-            - ci-configs/packages-legacy.json
+            - ci-configs/
             - metadata/
             - docs-ref-mapping/
           Repositories:


### PR DESCRIPTION
We're seeing an error when attempting to merge: 

https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1401686&view=logs&j=dc056dfc-c0cf-5958-c8c4-8da4f91a3739&t=fd4e3270-b8e3-5fbf-e599-e8f3c9d442f6

```
git add -A
The following paths and/or pathspecs matched paths that exist
outside of your sparse-checkout definition, so will not be
updated in the index:
ci-configs/packages-latest.json.log
hint: If you intend to update such entries, try one of the following:
hint: * Use the --sparse option.
hint: * Disable or modify the sparsity rules.
hint: Disable this message with "git config advice.updateSparsePath false"
Write-Error: /home/vsts/work/_temp/431f548d-6670-48ee-889f-e8e402ec4c27.ps1:2
Line |
   2 |  . '/home/vsts/work/1/s/eng/common/scripts/git-branch-push.ps1' -PRBra …
     |  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     | Unable to git add LASTEXITCODE=1, see command output above.

```

In this case the sparse checkout includes only the specified json files and not other files. If we attempt to check in changes to these files which were not checked out `git-branch-push.ps1` will skip committing the changes when it gets a nonzero exit code from `git add -A` ... This results in the changes not making into the target branch. (Issue opened here: https://github.com/Azure/azure-sdk-tools/issues/2839)