### PR TITLE
[EventGrid] Update for March Release

### DIFF
--- a/sdk/eventgrid/eventgrid/CHANGELOG.md
+++ b/sdk/eventgrid/eventgrid/CHANGELOG.md
@@ -1,14 +1,10 @@
 # Release History
 
-## 4.7.1 (Unreleased)
+## 4.8.0 (2022-03-08)
 
 ### Features Added
 
-### Breaking Changes
-
-### Bugs Fixed
-
-### Other Changes
+- Added new value `IdentityUnsupported` to `MediaJobErrorCode` and `Account` to `MediaJobErrorCategory` for `Microsoft.Media` events.
 
 ## 4.7.0 (2022-02-08)
 

--- a/sdk/eventgrid/eventgrid/package.json
+++ b/sdk/eventgrid/eventgrid/package.json
@@ -3,7 +3,7 @@
   "sdk-type": "client",
   "author": "Microsoft Corporation",
   "description": "An isomorphic client library for the Azure Event Grid service.",
-  "version": "4.7.1",
+  "version": "4.8.0",
   "keywords": [
     "node",
     "azure",

--- a/sdk/eventgrid/eventgrid/review/eventgrid.api.md
+++ b/sdk/eventgrid/eventgrid/review/eventgrid.api.md
@@ -838,10 +838,10 @@ export interface MediaJobError {
 }
 
 // @public
-export type MediaJobErrorCategory = "Service" | "Download" | "Upload" | "Configuration" | "Content";
+export type MediaJobErrorCategory = "Service" | "Download" | "Upload" | "Configuration" | "Content" | "Account";
 
 // @public
-export type MediaJobErrorCode = "ServiceError" | "ServiceTransientError" | "DownloadNotAccessible" | "DownloadTransientError" | "UploadNotAccessible" | "UploadTransientError" | "ConfigurationUnsupported" | "ContentMalformed" | "ContentUnsupported";
+export type MediaJobErrorCode = "ServiceError" | "ServiceTransientError" | "DownloadNotAccessible" | "DownloadTransientError" | "UploadNotAccessible" | "UploadTransientError" | "ConfigurationUnsupported" | "ContentMalformed" | "ContentUnsupported" | "IdentityUnsupported";
 
 // @public
 export interface MediaJobErrorDetail {

--- a/sdk/eventgrid/eventgrid/src/generated/generatedClient.ts
+++ b/sdk/eventgrid/eventgrid/src/generated/generatedClient.ts
@@ -101,7 +101,7 @@ const publishCloudEventEventsOperationSpec: coreClient.OperationSpec = {
   requestBody: Parameters.events1,
   queryParameters: [Parameters.apiVersion],
   urlParameters: [Parameters.topicHostname],
-  headerParameters: [Parameters.contentType1],
+  headerParameters: [Parameters.contentType1, Parameters.aegChannelName],
   mediaType: "json",
   serializer
 };

--- a/sdk/eventgrid/eventgrid/src/generated/generatedClientContext.ts
+++ b/sdk/eventgrid/eventgrid/src/generated/generatedClientContext.ts
@@ -26,7 +26,7 @@ export class GeneratedClientContext extends coreClient.ServiceClient {
       requestContentType: "application/json; charset=utf-8"
     };
 
-    const packageDetails = `azsdk-js-eventgrid/4.7.1`;
+    const packageDetails = `azsdk-js-eventgrid/4.8.0`;
     const userAgentPrefix =
       options.userAgentOptions && options.userAgentOptions.userAgentPrefix
         ? `${options.userAgentOptions.userAgentPrefix} ${packageDetails}`

--- a/sdk/eventgrid/eventgrid/src/generated/models/index.ts
+++ b/sdk/eventgrid/eventgrid/src/generated/models/index.ts
@@ -2717,14 +2717,16 @@ export type MediaJobErrorCode =
   | "UploadTransientError"
   | "ConfigurationUnsupported"
   | "ContentMalformed"
-  | "ContentUnsupported";
+  | "ContentUnsupported"
+  | "IdentityUnsupported";
 /** Defines values for MediaJobErrorCategory. */
 export type MediaJobErrorCategory =
   | "Service"
   | "Download"
   | "Upload"
   | "Configuration"
-  | "Content";
+  | "Content"
+  | "Account";
 /** Defines values for MediaJobRetry. */
 export type MediaJobRetry = "DoNotRetry" | "MayRetry";
 
@@ -2734,7 +2736,10 @@ export interface GeneratedClientPublishEventsOptionalParams
 
 /** Optional parameters. */
 export interface GeneratedClientPublishCloudEventEventsOptionalParams
-  extends coreClient.OperationOptions {}
+  extends coreClient.OperationOptions {
+  /** Required only when publishing to partner namespaces with partner topic routing mode ChannelNameHeader. */
+  aegChannelName?: string;
+}
 
 /** Optional parameters. */
 export interface GeneratedClientPublishCustomEventEventsOptionalParams

--- a/sdk/eventgrid/eventgrid/src/generated/models/mappers.ts
+++ b/sdk/eventgrid/eventgrid/src/generated/models/mappers.ts
@@ -2734,7 +2734,8 @@ export const MediaJobError: coreClient.CompositeMapper = {
             "UploadTransientError",
             "ConfigurationUnsupported",
             "ContentMalformed",
-            "ContentUnsupported"
+            "ContentUnsupported",
+            "IdentityUnsupported"
           ]
         }
       },
@@ -2757,7 +2758,8 @@ export const MediaJobError: coreClient.CompositeMapper = {
             "Download",
             "Upload",
             "Configuration",
-            "Content"
+            "Content",
+            "Account"
           ]
         }
       },

--- a/sdk/eventgrid/eventgrid/src/generated/models/parameters.ts
+++ b/sdk/eventgrid/eventgrid/src/generated/models/parameters.ts
@@ -94,6 +94,16 @@ export const events1: OperationParameter = {
   }
 };
 
+export const aegChannelName: OperationParameter = {
+  parameterPath: ["options", "aegChannelName"],
+  mapper: {
+    serializedName: "aeg-channel-name",
+    type: {
+      name: "String"
+    }
+  }
+};
+
 export const events2: OperationParameter = {
   parameterPath: "events",
   mapper: {

--- a/sdk/eventgrid/eventgrid/swagger/README.md
+++ b/sdk/eventgrid/eventgrid/swagger/README.md
@@ -5,9 +5,9 @@
 ## Configuration
 
 ```yaml
-require: "https://github.com/Azure/azure-rest-api-specs/blob/03da592cccfa0e52ccd6ecc53d232afda8a38c95/specification/eventgrid/data-plane/readme.md"
+require: "https://github.com/Azure/azure-rest-api-specs/blob/6b29b8552671eded065f51ee1b291582ab8cc149/specification/eventgrid/data-plane/readme.md"
 package-name: "@azure/eventgrid"
-package-version: "4.7.1"
+package-version: "4.8.0"
 title: GeneratedClient
 description: EventGrid Client
 generate-metadata: false


### PR DESCRIPTION
This change updates our Swagger API reference and re-runs the code
generation. There are no new events this sprint, however a new value
was added to an enum used by some `Microsoft.Media` events.

As part of the update, we pulled in changes around a new
`aeg-channel-name` header which was added to support a new Event Grid
feature. It is currently unexposed, but we expect to add support in
the April release.