### PR TITLE
[Communication] - phone-numbers - Azure Core V2 migration cleanup

### DIFF
--- a/sdk/communication/communication-phone-numbers/package.json
+++ b/sdk/communication/communication-phone-numbers/package.json
@@ -65,7 +65,7 @@
     "@azure/core-auth": "^1.3.0",
     "@azure/core-client": "^1.3.0",
     "@azure/core-rest-pipeline": "^1.3.0",
-    "@azure/core-lro": "^2.2.0",
+    "@azure/core-lro": "^2.2.4",
     "@azure/core-paging": "^1.1.1",
     "@azure/core-tracing": "1.0.0-preview.13",
     "@azure/logger": "^1.0.0",

--- a/sdk/communication/communication-phone-numbers/src/generated/src/phoneNumbersClientContext.ts
+++ b/sdk/communication/communication-phone-numbers/src/generated/src/phoneNumbersClientContext.ts
@@ -32,7 +32,7 @@ export class PhoneNumbersClientContext extends coreClient.ServiceClient {
       requestContentType: "application/json; charset=utf-8"
     };
 
-    const packageDetails = `azsdk-js-azure-communication-phone-numbers/1.2.0-beta.2`;
+    const packageDetails = `azsdk-js-communication-phone-numbers/1.2.0-beta.2`;
     const userAgentPrefix =
       options.userAgentOptions && options.userAgentOptions.userAgentPrefix
         ? `${options.userAgentOptions.userAgentPrefix} ${packageDetails}`

--- a/sdk/communication/communication-phone-numbers/src/phoneNumbersClient.ts
+++ b/sdk/communication/communication-phone-numbers/src/phoneNumbersClient.ts
@@ -32,10 +32,7 @@ import {
   BeginSearchAvailablePhoneNumbersOptions,
   BeginUpdatePhoneNumberCapabilitiesOptions,
 } from "./lroModels";
-import {
-  createPhoneNumbersPagingPolicy,
-  phoneNumbersLroPolicy,
-} from "./utils/customPipelinePolicies";
+import { createPhoneNumbersPagingPolicy } from "./utils/customPipelinePolicies";
 import { CommonClientOptions } from "@azure/core-client";
 
 /**
@@ -106,10 +103,9 @@ export class PhoneNumbersClient {
     const authPolicy = createCommunicationAuthPolicy(credential);
     this.client.pipeline.addPolicy(authPolicy);
 
-    // These policies are temporary workarounds to address compatibility issues with Azure Core V2.
+    // This policy is temporary workarounds to address compatibility issues with Azure Core V2.
     const phoneNumbersPagingPolicy = createPhoneNumbersPagingPolicy(url);
     this.client.pipeline.addPolicy(phoneNumbersPagingPolicy);
-    this.client.pipeline.addPolicy(phoneNumbersLroPolicy);
   }
 
   /**

--- a/sdk/communication/communication-phone-numbers/src/utils/customPipelinePolicies.ts
+++ b/sdk/communication/communication-phone-numbers/src/utils/customPipelinePolicies.ts
@@ -34,27 +34,3 @@ export function createPhoneNumbersPagingPolicy(host: string): PipelinePolicy {
     },
   };
 }
-
-/**
- * A `PipelinePolicy` that adds the `azure-asyncoperation` header to the request with the
- * same value as the `operation-location` header, if it exists.
- *
- * This is used because the phone-numbers API uses LROs with status monitors, but
- * the Core V2 LRO implementation only supports this pattern if the legacy
- * `azure-asyncoperation` header is present.
- *
- * For more information on the LRO guidelines, refer to: https://github.com/microsoft/api-guidelines/blob/vNext/azure/Guidelines.md#long-running-operations-with-status-monitor
- */
-export const phoneNumbersLroPolicy: PipelinePolicy = {
-  name: "phoneNumbersLroPolicy",
-  async sendRequest(request: PipelineRequest, next: SendRequest): Promise<PipelineResponse> {
-    const response = await next(request);
-
-    const operationLocation = response.headers?.get("operation-location");
-    if (operationLocation) {
-      response.headers.set("azure-asyncoperation", operationLocation);
-    }
-
-    return response;
-  },
-};

--- a/sdk/communication/communication-phone-numbers/swagger/README.md
+++ b/sdk/communication/communication-phone-numbers/swagger/README.md
@@ -5,7 +5,7 @@
 ## Configuration
 
 ```yaml
-package-name: azure-communication-phone-numbers
+package-name: "@azure/communication-phone-numbers"
 description: Phone number configuration client
 package-version: 1.2.0-beta.2
 generate-metadata: false
@@ -23,7 +23,6 @@ azure-arm: false
 skip-enum-validation: true
 title: Phone Numbers Client
 v3: true
-use-core-v2: true
 ```
 
 ## Customizations

--- a/sdk/communication/communication-phone-numbers/test/internal/customPipelinePolicies.spec.ts
+++ b/sdk/communication/communication-phone-numbers/test/internal/customPipelinePolicies.spec.ts
@@ -3,16 +3,12 @@
 
 import { FullOperationResponse } from "@azure/core-client";
 import {
-  HttpHeaders,
   PipelineRequest,
   PipelineResponse,
   createHttpHeaders,
 } from "@azure/core-rest-pipeline";
 import { assert } from "chai";
-import {
-  createPhoneNumbersPagingPolicy,
-  phoneNumbersLroPolicy,
-} from "../../src/utils/customPipelinePolicies";
+import { createPhoneNumbersPagingPolicy } from "../../src/utils/customPipelinePolicies";
 
 describe("phoneNumbersPagingPolicy", function () {
   const endpoint = "https://contoso.spool.azure.local";
@@ -77,41 +73,5 @@ describe("phoneNumbersPagingPolicy", function () {
       response.parsedBody.nextLink,
       "https://contoso.spool.azure.local/phoneNumbers?top=100&skip=100"
     );
-  });
-});
-
-describe("phoneNumbersLroPolicy", function () {
-  const request: PipelineRequest = {
-    url: "https://contoso.spool.azure.local/availablePhoneNumbers/countries/{countryCode}/:search",
-    method: "POST",
-    headers: createHttpHeaders(),
-    timeout: 0,
-    withCredentials: false,
-    requestId: "any-id",
-  };
-
-  async function createMockResponse(headers: HttpHeaders) {
-    return Promise.resolve({ headers }) as unknown as PipelineResponse;
-  }
-
-  it("sets azure-asyncoperation header", async function () {
-    const headers = createHttpHeaders();
-    headers.set("operation-location", "/phoneNumbers/operations/search_12345");
-    const response = await phoneNumbersLroPolicy.sendRequest(request, (_request) =>
-      createMockResponse(headers)
-    );
-    assert.exists(response.headers.get("azure-asyncoperation"));
-    assert.equal(
-      response.headers.get("azure-asyncoperation"),
-      "/phoneNumbers/operations/search_12345"
-    );
-  });
-
-  it("does not mutate headers without operation-location", async function () {
-    const response = await phoneNumbersLroPolicy.sendRequest(request, (_request) =>
-      createMockResponse(createHttpHeaders())
-    );
-    assert.isUndefined(response.headers.get("azure-asyncoperation"));
-    assert.deepEqual(response.headers, createHttpHeaders());
   });
 });

--- a/sdk/communication/communication-phone-numbers/test/internal/customPipelinePolicies.spec.ts
+++ b/sdk/communication/communication-phone-numbers/test/internal/customPipelinePolicies.spec.ts
@@ -2,11 +2,7 @@
 // Licensed under the MIT license.
 
 import { FullOperationResponse } from "@azure/core-client";
-import {
-  PipelineRequest,
-  PipelineResponse,
-  createHttpHeaders,
-} from "@azure/core-rest-pipeline";
+import { PipelineRequest, PipelineResponse, createHttpHeaders } from "@azure/core-rest-pipeline";
 import { assert } from "chai";
 import { createPhoneNumbersPagingPolicy } from "../../src/utils/customPipelinePolicies";
 

--- a/sdk/communication/communication-phone-numbers/test/internal/headers.spec.ts
+++ b/sdk/communication/communication-phone-numbers/test/internal/headers.spec.ts
@@ -44,7 +44,7 @@ describe("PhoneNumbersClient - headers", function () {
     const userAgentHeader = isNode ? "user-agent" : "x-ms-useragent";
     assert.match(
       request.headers.get(userAgentHeader) as string,
-      new RegExp(`azsdk-js-azure-communication-phone-numbers/${SDK_VERSION}`, "g")
+      new RegExp(`azsdk-js-communication-phone-numbers/${SDK_VERSION}`, "g")
     );
   });
 
@@ -112,7 +112,7 @@ describe("PhoneNumbersClient - headers", function () {
     assert.match(
       request.headers.get(userAgentHeader) as string,
       new RegExp(
-        `phonenumbersclient-headers-test azsdk-js-azure-communication-phone-numbers/${SDK_VERSION}`,
+        `phonenumbersclient-headers-test azsdk-js-communication-phone-numbers/${SDK_VERSION}`,
         "g"
       )
     );

--- a/sdk/communication/communication-phone-numbers/test/internal/phoneNumbersClientPolicies.spec.ts
+++ b/sdk/communication/communication-phone-numbers/test/internal/phoneNumbersClientPolicies.spec.ts
@@ -3,11 +3,9 @@
 
 import { AzureKeyCredential } from "@azure/core-auth";
 import { assert } from "chai";
-import { SearchAvailablePhoneNumbersRequest } from "../../src/models";
 import { PhoneNumbersClient } from "../../src/phoneNumbersClient";
 import {
   mockListPhoneNumbersHttpClient,
-  mockSearchHttpClient,
 } from "../public/utils/mockHttpClients";
 
 describe("PhoneNumbersClient - custom policies ", function () {
@@ -15,34 +13,6 @@ describe("PhoneNumbersClient - custom policies ", function () {
   const accessKey = "banana";
   let client: PhoneNumbersClient;
 
-  it("applies the phoneNumbersLroPolicy", async function () {
-    client = new PhoneNumbersClient(endpoint, new AzureKeyCredential(accessKey), {
-      httpClient: mockSearchHttpClient,
-    });
-
-    const searchRequest: SearchAvailablePhoneNumbersRequest = {
-      countryCode: "US",
-      phoneNumberType: "tollFree",
-      assignmentType: "application",
-      capabilities: {
-        sms: "none",
-        calling: "outbound",
-      },
-    };
-
-    const poller = await client.beginSearchAvailablePhoneNumbers(searchRequest, {
-      onResponse: (_response) => {
-        assert.isDefined(_response.headers.get("azure-asyncoperation"));
-        assert.equal(
-          _response.headers.get("azure-asyncopearation"),
-          _response.headers.get("opearation-location")
-        );
-      },
-    });
-
-    // It is only required to poll once to check if the initial request contains the header
-    await poller.poll();
-  });
 
   it("applies the phoneNumbersPagingPolicy", async function () {
     client = new PhoneNumbersClient(endpoint, new AzureKeyCredential(accessKey), {

--- a/sdk/communication/communication-phone-numbers/test/internal/phoneNumbersClientPolicies.spec.ts
+++ b/sdk/communication/communication-phone-numbers/test/internal/phoneNumbersClientPolicies.spec.ts
@@ -4,15 +4,12 @@
 import { AzureKeyCredential } from "@azure/core-auth";
 import { assert } from "chai";
 import { PhoneNumbersClient } from "../../src/phoneNumbersClient";
-import {
-  mockListPhoneNumbersHttpClient,
-} from "../public/utils/mockHttpClients";
+import { mockListPhoneNumbersHttpClient } from "../public/utils/mockHttpClients";
 
 describe("PhoneNumbersClient - custom policies ", function () {
   const endpoint = "https://contoso.spool.azure.local";
   const accessKey = "banana";
   let client: PhoneNumbersClient;
-
 
   it("applies the phoneNumbersPagingPolicy", async function () {
     client = new PhoneNumbersClient(endpoint, new AzureKeyCredential(accessKey), {

--- a/sdk/communication/communication-phone-numbers/test/public/utils/mockHttpClients.ts
+++ b/sdk/communication/communication-phone-numbers/test/public/utils/mockHttpClients.ts
@@ -6,7 +6,6 @@ import {
   HttpHeaders,
   PipelineRequest,
   PipelineResponse,
-  createHttpHeaders,
 } from "@azure/core-rest-pipeline";
 import { PurchasedPhoneNumber } from "../../../src";
 import { PurchasedPhoneNumbers } from "../../../src/generated/src/models";
@@ -47,26 +46,6 @@ export const getPhoneNumberHttpClient: HttpClient = createMockHttpClient<Purchas
       billingFrequency: "monthly",
     },
   }
-);
-
-function createMockSearchResponseHeaders(): HttpHeaders {
-  const headers = createHttpHeaders();
-  headers.set(
-    "Operation-Location",
-    "/phoneNumbers/operations/search_378ddf60-81be-452a-ba4f-613198ea6c28"
-  );
-  headers.set(
-    "Location",
-    "/availablePhoneNumbers/searchResults/378ddf60-81be-452a-ba4f-613198ea6c28"
-  );
-  headers.set("operation-id", "search_378ddf60-81be-452a-ba4f-613198ea6c28");
-  headers.set("search-id", "378ddf60-81be-452a-ba4f-613198ea6c28");
-  return headers;
-}
-export const mockSearchHttpClient = createMockHttpClient(
-  202,
-  null,
-  createMockSearchResponseHeaders()
 );
 
 export const mockListPhoneNumbersHttpClient = createMockHttpClient<PurchasedPhoneNumbers>(200, {


### PR DESCRIPTION
### Packages impacted by this PR
- `@azure/communication-phone-numbers`

### Issues associated with this PR
- https://github.com/Azure/azure-sdk-for-js/issues/20647

### Describe the problem that is addressed by this PR
Address pending feedback from https://github.com/Azure/azure-sdk-for-js/pull/20633. More specifically:
- Update the `@azure/core-lro` dependency to version 2.2.4 in order to remove LRO workaround
- Update `package-name` in autorest configuration file, so the user agent of the client is properly generated
- Remove redundant `use-core-v2` property in autorest configuration file

### Provide a list of related PRs _(if any)_
- https://github.com/Azure/azure-sdk-for-js/pull/20633
- https://github.com/Azure/azure-sdk-for-js/pull/20656

### Checklists
- [ ] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
