### PR TITLE
[EventGrid] Use `^1.5.0` for `@azure/core-client`

### DIFF
--- a/sdk/eventgrid/eventgrid/package.json
+++ b/sdk/eventgrid/eventgrid/package.json
@@ -88,7 +88,7 @@
   "autoPublish": false,
   "dependencies": {
     "@azure/core-auth": "^1.3.0",
-    "@azure/core-client": "^1.5.1",
+    "@azure/core-client": "^1.5.0",
     "@azure/core-rest-pipeline": "^1.1.0",
     "@azure/core-tracing": "1.0.0-preview.13",
     "@azure/logger": "^1.0.0",


### PR DESCRIPTION
In #20273 we moved our `@azure/core-client` reference to `^1.5.1` in
order to pick up some new features we needed for use with the new
recorder. The version of this package has not shipped yet and we'd
like to release EventGrid this release cycle.

Talking with Jose, there's nothing we should need right now newer than
1.5.0, so we'll move our constraint back to that version.