### PR TITLE
[engsys] exclude .env and launch.json files when `rush reset-workspace`

### DIFF
--- a/common/config/rush/command-line.json
+++ b/common/config/rush/command-line.json
@@ -185,7 +185,7 @@
       "name": "reset-workspace",
       "summary": "Reset your workspace - !!DANGER!! unlink dependencies, purge downloaded node_modules, and remove all untracked files and directories",
       "safeForSimultaneousRushProcesses": true,
-      "shellCommand": "rush unlink && echo \"\nStarting \\\"git clean\\\"\" && git clean -dfx -e *.env && rush purge"
+      "shellCommand": "rush unlink && echo \"\nStarting \\\"git clean\\\"\" && git clean -dfx -e *.env -e launch.json && rush purge"
     },
     {
       "commandKind": "global",

--- a/common/config/rush/command-line.json
+++ b/common/config/rush/command-line.json
@@ -185,7 +185,7 @@
       "name": "reset-workspace",
       "summary": "Reset your workspace - !!DANGER!! unlink dependencies, purge downloaded node_modules, and remove all untracked files and directories",
       "safeForSimultaneousRushProcesses": true,
-      "shellCommand": "rush unlink && echo \"\nStarting \\\"git clean\\\"\" && git clean -dfx && rush purge"
+      "shellCommand": "rush unlink && echo \"\nStarting \\\"git clean\\\"\" && git clean -dfx -e *.env && rush purge"
     },
     {
       "commandKind": "global",


### PR DESCRIPTION
as they are useful for local development. We don't like to lose them without
realizing that `rush reset-workspace` would remove them.  If we want we can
always run `git clean -dfx` directly.
