### PR TITLE
Remove baseline file on credscan

### DIFF
--- a/eng/pipelines/templates/jobs/ci.yml
+++ b/eng/pipelines/templates/jobs/ci.yml
@@ -75,7 +75,6 @@ jobs:
       - template: /eng/common/pipelines/templates/steps/credscan.yml
         parameters:
           ServiceDirectory: ${{ parameters.ServiceDirectory }}
-          BaselineFilePath: $(Build.SourcesDirectory)\eng\js.gdnbaselines
 
   - ${{ if ne(parameters.RunUnitTests, false) }}:
       - template: /eng/common/pipelines/templates/jobs/archetype-sdk-tests-generate.yml


### PR DESCRIPTION
### Packages impacted by this PR


### Issues associated with this PR


### Describe the problem that is addressed by this PR
Js removes its baseline recently which failed the analysis step.
Failed pipeline: https://dev.azure.com/azure-sdk/public/_build/results?buildId=1420643&view=logs&j=90227089-9f51-5ecc-566c-84e1f2918394&t=7da0f684-6369-5290-bb0b-5d27f59dde66
Remove the baseline file on credscan

Testing pipeline: https://dev.azure.com/azure-sdk/public/_build/results?buildId=1421187&view=logs&j=bc67675d-56bf-581f-e0a2-208848ba68ca&t=7eee3a58-6120-518b-7fcb-7e943712aa81

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [ ] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
