### PR TITLE
Adding Support for DedicatedGatewayRequestOptions and MaxIntegratedCacheStaleness

### DIFF
--- a/sdk/cosmosdb/cosmos/src/common/constants.ts
+++ b/sdk/cosmosdb/cosmos/src/common/constants.ts
@@ -160,6 +160,10 @@ export const Constants = {
 
     // Cache Refresh header
     ForceRefresh: "x-ms-force-refresh",
+
+    // Dedicated Gateway Header
+    DedicatedGatewayCacheStaleness: "x-ms-dedicatedgateway-max-age",
+    
   },
 
   // GlobalDB related constants

--- a/sdk/cosmosdb/cosmos/src/request/RequestOptions.ts
+++ b/sdk/cosmosdb/cosmos/src/request/RequestOptions.ts
@@ -44,4 +44,6 @@ export interface RequestOptions extends SharedOptions {
   urlConnection?: string;
   /** Disable automatic id generation (will cause creates to fail if id isn't on the definition) */
   disableAutomaticIdGeneration?: boolean;
+  /** Allows a lower bound to be set on the lifespan of a response from the cache for each request. */
+  maxIntegratedCacheStaleness?: string;
 }

--- a/sdk/cosmosdb/cosmos/src/request/request.ts
+++ b/sdk/cosmosdb/cosmos/src/request/request.ts
@@ -187,6 +187,9 @@ export async function getHeaders({
   if (options.disableRUPerMinuteUsage) {
     headers[Constants.HttpHeaders.DisableRUPerMinuteUsage] = true;
   }
+  if (options.maxIntegratedCacheStaleness) {
+    headers[Constants.HttpHeaders.DedicatedGatewayCacheStaleness] = options.maxIntegratedCacheStaleness
+  }
   if (
     clientOptions.key ||
     clientOptions.resourceTokens ||


### PR DESCRIPTION
- Currently, the integrated cache (with the dedicated gateway) has a default expiration time for each of the entries in the cache (CacheEntryExpirationTime) of 5 minutes. Any response served from cache is guaranteed to be no staler than this CacheEntryExpirationTime. In the existing design, CacheEntryExpirationTime cannot be configured by customers.

- For customers to have more control over how stale each of their requests could be, we plan to introduce a new “RequestOption” called “MaxIntegratedCacheStaleness”. This option will allow the customer to set a lower bound on the lifespan of the response from the cache for each request. If the lifetime of the response stored in the cache is greater than the value indicated by “MaxIntegratedCacheStaleness”, that item will not be served from the cache and the request will go to the backend.

- Similar PRs: https://github.com/Azure/azure-sdk-for-python/pull/22946 / https://github.com/Azure/azure-sdk-for-java/pull/20971

- Related Docs: https://docs.microsoft.com/en-us/azure/cosmos-db/dedicated-gateway / https://docs.microsoft.com/en-us/azure/cosmos-db/integrated-cache