### PR TITLE
[Schema Registry Avro] drop MessageData postfix in method names

### DIFF
--- a/sdk/schemaregistry/schema-registry-avro/CHANGELOG.md
+++ b/sdk/schemaregistry/schema-registry-avro/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Features Added
 
 ### Breaking Changes
+- The `encodeMessageData` method has been renamed to `serialize`
+- The `decodeMessageData` method has been renamed to `deserialize`
 
 ### Bugs Fixed
 

--- a/sdk/schemaregistry/schema-registry-avro/README.md
+++ b/sdk/schemaregistry/schema-registry-avro/README.md
@@ -99,10 +99,10 @@ const schema = JSON.stringify({
 const value = { score: 42 };
 
 // Serialize value to a message
-const message = await serializer.serializeMessageData(value, schema);
+const message = await serializer.serialize(value, schema);
 
 // Deserialize a message to value
-const deserializedValue = await serializer.deserializeMessageData(message);
+const deserializedValue = await serializer.deserialize(message);
 ```
 
 ## Troubleshooting

--- a/sdk/schemaregistry/schema-registry-avro/review/schema-registry-avro.api.md
+++ b/sdk/schemaregistry/schema-registry-avro/review/schema-registry-avro.api.md
@@ -9,8 +9,8 @@ import { SchemaRegistry } from '@azure/schema-registry';
 // @public
 export class AvroSerializer<MessageT = MessageWithMetadata> {
     constructor(client: SchemaRegistry, options?: AvroSerializerOptions<MessageT>);
-    deserializeMessageData(message: MessageT, options?: DeserializeMessageDataOptions): Promise<unknown>;
-    serializeMessageData(value: unknown, schema: string): Promise<MessageT>;
+    deserialize(message: MessageT, options?: DeserializeOptions): Promise<unknown>;
+    serialize(value: unknown, schema: string): Promise<MessageT>;
 }
 
 // @public
@@ -21,7 +21,7 @@ export interface AvroSerializerOptions<MessageT> {
 }
 
 // @public
-export interface DeserializeMessageDataOptions {
+export interface DeserializeOptions {
     schema?: string;
 }
 

--- a/sdk/schemaregistry/schema-registry-avro/samples-dev/schemaRegistryAvroSample.ts
+++ b/sdk/schemaregistry/schema-registry-avro/samples-dev/schemaRegistryAvroSample.ts
@@ -61,7 +61,7 @@ export async function main() {
   );
 
   // Register the schema. This would generally have been done somewhere else.
-  // You can also skip this step and let `serializeMessageData` automatically register
+  // You can also skip this step and let `serialize` automatically register
   // schemas using autoRegisterSchemas=true, but that is NOT recommended in production.
   await client.registerSchema(schemaDescription);
 
@@ -70,12 +70,12 @@ export async function main() {
 
   // serialize an object that matches the schema and put it in a message
   const value: User = { firstName: "Jane", lastName: "Doe" };
-  const message = await serializer.serializeMessageData(value, schema);
+  const message = await serializer.serialize(value, schema);
   console.log("Created message:");
   console.log(JSON.stringify(message));
 
   // deserialize the message back to an object
-  const deserializedObject = await serializer.deserializeMessageData(message);
+  const deserializedObject = await serializer.deserialize(message);
   console.log("Deserialized object:");
   console.log(JSON.stringify(deserializedObject as User));
 }

--- a/sdk/schemaregistry/schema-registry-avro/samples-dev/withEventHubsBufferedProducerClient.ts
+++ b/sdk/schemaregistry/schema-registry-avro/samples-dev/withEventHubsBufferedProducerClient.ts
@@ -69,7 +69,7 @@ export async function main() {
   );
 
   // Register the schema. This would generally have been done somewhere else.
-  // You can also skip this step and let `serializeMessageData` automatically register
+  // You can also skip this step and let `serialize` automatically register
   // schemas using autoRegisterSchemas=true, but that is NOT recommended in production.
   await schemaRegistryClient.registerSchema(schemaDescription);
 
@@ -88,7 +88,7 @@ export async function main() {
 
   // serialize an object that matches the schema
   const value: User = { firstName: "Jane", lastName: "Doe" };
-  const message = await serializer.serializeMessageData(value, schema);
+  const message = await serializer.serialize(value, schema);
   console.log("Created message:");
   console.log(message);
 

--- a/sdk/schemaregistry/schema-registry-avro/samples-dev/withEventHubsConsumerClient.ts
+++ b/sdk/schemaregistry/schema-registry-avro/samples-dev/withEventHubsConsumerClient.ts
@@ -69,7 +69,7 @@ export async function main() {
   );
 
   // Register the schema. This would generally have been done somewhere else.
-  // You can also skip this step and let `serializeMessageData` automatically register
+  // You can also skip this step and let `serialize` automatically register
   // schemas using autoRegisterSchemas=true, but that is NOT recommended in production.
   await schemaRegistryClient.registerSchema(schemaDescription);
 
@@ -104,7 +104,7 @@ export async function main() {
           if (event.contentType !== undefined && event.body) {
             const contentTypeParts = event.contentType.split("+");
             if (contentTypeParts[0] === "avro/binary") {
-              const deserializedEvent = await serializer.deserializeMessageData(event);
+              const deserializedEvent = await serializer.deserialize(event);
               console.log(`Deserialized message: '${JSON.stringify(deserializedEvent)}'`);
             }
           }

--- a/sdk/schemaregistry/schema-registry-avro/samples-dev/withEventHubsProducerClient.ts
+++ b/sdk/schemaregistry/schema-registry-avro/samples-dev/withEventHubsProducerClient.ts
@@ -68,7 +68,7 @@ export async function main() {
   );
 
   // Register the schema. This would generally have been done somewhere else.
-  // You can also skip this step and let `serializeMessageData` automatically register
+  // You can also skip this step and let `serialize` automatically register
   // schemas using autoRegisterSchemas=true, but that is NOT recommended in production.
   await schemaRegistryClient.registerSchema(schemaDescription);
 
@@ -85,7 +85,7 @@ export async function main() {
 
   // serialize an object that matches the schema
   const value: User = { firstName: "Joe", lastName: "Doe" };
-  const message = await serializer.serializeMessageData(value, schema);
+  const message = await serializer.serialize(value, schema);
   console.log("Created message:");
   console.log(message);
 

--- a/sdk/schemaregistry/schema-registry-avro/src/avroSerializer.ts
+++ b/sdk/schemaregistry/schema-registry-avro/src/avroSerializer.ts
@@ -4,7 +4,7 @@
 import * as avro from "avsc";
 import {
   AvroSerializerOptions,
-  DeserializeMessageDataOptions,
+  DeserializeOptions,
   MessageAdapter,
   MessageWithMetadata,
 } from "./models";
@@ -65,12 +65,12 @@ export class AvroSerializer<MessageT = MessageWithMetadata> {
    * serializes the value parameter according to the input schema and creates a message
    * with the serialized data.
    *
-   * @param value - The value to serializeMessageData.
+   * @param value - The value to serialize.
    * @param schema - The Avro schema to use.
    * @returns A new message with the serialized value. The structure of message is
    * constrolled by the message factory option.
    */
-  async serializeMessageData(value: unknown, schema: string): Promise<MessageT> {
+  async serialize(value: unknown, schema: string): Promise<MessageT> {
     const entry = await this.getSchemaByDefinition(schema);
     const buffer = entry.serializer.toBuffer(value);
     const payload = new Uint8Array(
@@ -103,10 +103,7 @@ export class AvroSerializer<MessageT = MessageWithMetadata> {
    * @param options - Decoding options.
    * @returns The deserialized value.
    */
-  async deserializeMessageData(
-    message: MessageT,
-    options: DeserializeMessageDataOptions = {}
-  ): Promise<unknown> {
+  async deserialize(message: MessageT, options: DeserializeOptions = {}): Promise<unknown> {
     const { schema: readerSchema } = options;
     const { body, contentType } = convertMessage(message, this.messageAdapter);
     const buffer = Buffer.from(body);

--- a/sdk/schemaregistry/schema-registry-avro/src/models.ts
+++ b/sdk/schemaregistry/schema-registry-avro/src/models.ts
@@ -35,7 +35,7 @@ export interface MessageAdapter<MessageT> {
  */
 export interface AvroSerializerOptions<MessageT> {
   /**
-   * When true, register new schemas passed to serializeMessageData. Otherwise, and by
+   * When true, register new schemas passed to serialize. Otherwise, and by
    * default, fail if schema has not already been registered.
    *
    * Automatic schema registration is NOT recommended for production scenarios.
@@ -43,7 +43,7 @@ export interface AvroSerializerOptions<MessageT> {
   autoRegisterSchemas?: boolean;
   /**
    * The group name to be used when registering/looking up a schema. Must be specified
-   * if `serializeMessageData` will be called.
+   * if `serialize` will be called.
    */
   groupName?: string;
   /**
@@ -53,9 +53,9 @@ export interface AvroSerializerOptions<MessageT> {
 }
 
 /**
- * The options to the deserializeMessageData method.
+ * The options to the deserialize method.
  */
-export interface DeserializeMessageDataOptions {
+export interface DeserializeOptions {
   /**
    * The schema to be used for deserializing.
    */

--- a/sdk/schemaregistry/schema-registry-avro/test/withMessagingClients.spec.ts
+++ b/sdk/schemaregistry/schema-registry-avro/test/withMessagingClients.spec.ts
@@ -70,10 +70,10 @@ describe("With messaging clients", function () {
           height: 13.5,
           randb: Buffer.from("\u00FF"),
         };
-        const message = await serializer.serializeMessageData(value, schema);
+        const message = await serializer.serialize(value, schema);
         await testInfo.client.send(message);
         const receivedMessage = await testInfo.client.receive();
-        const deserializedValue = await serializer.deserializeMessageData(receivedMessage);
+        const deserializedValue = await serializer.deserialize(receivedMessage);
         assert.deepStrictEqual(deserializedValue, value);
       });
 
@@ -98,10 +98,10 @@ describe("With messaging clients", function () {
           ],
         });
         const value = { name: "Ben", favorite_number: 7, favorite_color: "red" };
-        const message = await serializer.serializeMessageData(value, writerSchema);
+        const message = await serializer.serialize(value, writerSchema);
         await testInfo.client.send(message);
         const receivedMessage = await testInfo.client.receive();
-        const deserializedValue = await serializer.deserializeMessageData(receivedMessage, {
+        const deserializedValue = await serializer.deserialize(receivedMessage, {
           schema: readerSchema,
         });
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -131,10 +131,10 @@ describe("With messaging clients", function () {
           ],
         });
         const value = { name: "Ben", favorite_number: 7, favorite_color: "red" };
-        const message = await serializer.serializeMessageData(value, writerSchema);
+        const message = await serializer.serialize(value, writerSchema);
         await testInfo.client.send(message);
         const receivedMessage = await testInfo.client.receive();
-        const deserializedValue = await serializer.deserializeMessageData(receivedMessage, {
+        const deserializedValue = await serializer.deserialize(receivedMessage, {
           schema: readerSchema,
         });
         assert.deepStrictEqual(deserializedValue, { ...value, favorite_city: "Redmond" });


### PR DESCRIPTION
### Packages impacted by this PR
@azure/schema-registry-avro

### Issues associated with this PR
Fixes https://github.com/Azure/azure-sdk-for-js/issues/20814

### Describe the problem that is addressed by this PR
`serializeMessageData` is too long and can be simplified to `serialize`.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?
N/A

### Are there test cases added in this PR? _(If not, why?)_
N/A

### Provide a list of related PRs _(if any)_
N/A

### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [x] Added a changelog (if necessary)
