### PR TITLE
[Form Recognizer] Fix integration-test:node command to run all tests in all OSes

### DIFF
--- a/sdk/formrecognizer/ai-form-recognizer/package.json
+++ b/sdk/formrecognizer/ai-form-recognizer/package.json
@@ -64,7 +64,7 @@
     "extract-api": "tsc -p . && api-extractor run --local",
     "format": "prettier --write --config ../../../.prettierrc.json --ignore-path ../../../.prettierignore \"src/**/*.ts\" \"test/**/*.ts\" \"samples-dev/**/*.ts\" \"*.{js,json}\"",
     "integration-test:browser": "dev-tool run test:browser",
-    "integration-test:node": "dev-tool run test:node-ts-input -- --timeout 1200000 --exclude 'test/**/browser/*.spec.ts' \"test/**/*.spec.ts\"",
+    "integration-test:node": "dev-tool run test:node-js-input -- --timeout 1200000 --exclude 'dist-esm/**/browser/*.spec.js' \"dist-esm/test/**/*.spec.js\" \"dist-esm/test/**/node/*.spec.js\"",
     "integration-test": "npm run integration-test:node && npm run integration-test:browser",
     "lint:fix": "eslint package.json api-extractor.json src test --ext .ts --fix --fix-type [problem,suggestion]",
     "lint": "eslint package.json api-extractor.json src test --ext .ts",


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-sdk-for-js/issues/20525

Updates the test command from
> "dev-tool run test:node-ts-input -- --timeout 1200000 --exclude 'test/**/browser/*.spec.ts' \"test/\*\*/\*.spec.ts\""

to
> "dev-tool run test:node-js-input -- --timeout 1200000 --exclude 'dist-esm/**/browser/*.spec.js' \"dist-esm/test/\*\*/\*.spec.js\" \"dist-esm/test/\*\*/node/\*.spec.js\""

Updating the command achieves the following.
- To have all the tests run in all the OSes (Ubuntu and Mac were running only 20 tests instead of 80 tests that were run in Windows.)
- To be consistent with other packages w.r.t to code coverage generation