### PR TITLE
[engsys] improve smoke test runner 

### DIFF
--- a/common/smoke-test/run.js
+++ b/common/smoke-test/run.js
@@ -5,13 +5,12 @@ async function main() {
   // Read manifest
   const manifest = require("./run-manifest.json");
 
-  let exitCode = 0;
   const samplesToExecute = [];
   const failures = [];
 
   // Bring all samples and includes into memory
   for (const entry of manifest) {
-    // filter out `arm-` for now
+    // TODO: do we want to run management samples as well? filter out `arm-` for now
     if (entry.Name.startsWith("arm-")) {
       continue;
     }
@@ -45,7 +44,6 @@ async function main() {
     const result = await executeSample(sample);
 
     if (!result.success) {
-      exitCode++;
       failures.push({
         sample,
         result,
@@ -62,17 +60,18 @@ async function main() {
       console.log(`Exception: ${failure.result.exception}`);
       console.log(failure);
     }
+    process.exit(1);
   }
 
   // TODO: Don't do it this way if possible?
-  process.exit(exitCode);
+  process.exit();
 }
 
 async function executeSample(sample) {
   const { name, sampleFile, directory } = sample;
   console.log("============== SMOKE TESTS ==============");
-  console.log(`Sample Name: ${name}`);
-  console.log(`Sample File: ${sampleFile}`);
+  console.log(`  Sample Name: ${name}`);
+  console.log(`  Sample File: ${sampleFile}`);
 
   const currentDir = process.cwd();
 
@@ -83,7 +82,7 @@ async function executeSample(sample) {
     const entryPoint = require(`${directory}/${sampleFile}`).main;
     await entryPoint();
   } catch (exception) {
-    console.log("FAILURE");
+    console.log("  FAILURE");
     return {
       success: false,
       exception,

--- a/common/smoke-test/run.js
+++ b/common/smoke-test/run.js
@@ -10,10 +10,6 @@ async function main() {
 
   // Bring all samples and includes into memory
   for (const entry of manifest) {
-    // TODO: do we want to run management samples as well? filter out `arm-` for now
-    if (entry.Name.startsWith("arm-")) {
-      continue;
-    }
     console.log(`Gathering samples for ${entry.Name}...`);
 
     // Read configuration from package.json's //sampleConfiguration field

--- a/common/smoke-test/run.js
+++ b/common/smoke-test/run.js
@@ -6,12 +6,16 @@ async function main() {
   const manifest = require("./run-manifest.json");
 
   let exitCode = 0;
-  let samplesToExecute = [];
-  let failures = [];
+  const samplesToExecute = [];
+  const failures = [];
 
   // Bring all samples and includes into memory
-  for (let entry of manifest) {
-    console.log(`Importing samples for ${entry.Name}...`);
+  for (const entry of manifest) {
+    // filter out `arm-` for now
+    if (entry.Name.startsWith("arm-")) {
+      continue;
+    }
+    console.log(`Gathering samples for ${entry.Name}...`);
 
     // Read configuration from package.json's //sampleConfiguration field
     const packageJson = require(`${entry.PackageDirectory}/package.json`);
@@ -22,37 +26,36 @@ async function main() {
     }
 
     const skipFiles = smokeTestConfig.skip || [];
-    const jsFiles = fs.readdirSync(entry.SamplesDirectory)
+    const jsFiles = fs
+      .readdirSync(entry.SamplesDirectory)
       .filter((name) => name.endsWith(".js"))
       .filter((name) => !skipFiles.includes(name));
 
-    for (let targetSample of jsFiles) {
-      const sampleModule = require(`${entry.SamplesDirectory}/${targetSample}`);
+    for (const targetSample of jsFiles) {
       samplesToExecute.push({
-        entrypoint: sampleModule.main,
         name: entry.Name,
         sampleFile: targetSample,
-        directory: entry.SamplesDirectory
+        directory: entry.SamplesDirectory,
       });
     }
   }
 
   // Run all samples
-  for (let sample of samplesToExecute) {
-    let result = await executeSample(sample);
+  for (const sample of samplesToExecute) {
+    const result = await executeSample(sample);
 
     if (!result.success) {
-      exitCode = 1;
+      exitCode++;
       failures.push({
         sample,
-        result
+        result,
       });
     }
   }
 
   if (failures.length > 0) {
     console.log("SMOKE TEST FAILURES");
-    for (let failure of failures) {
+    for (const failure of failures) {
       console.error(
         `Test Failed - Package: ${failure.sample.name} - Sample File:${failure.sample.sampleFile}`
       );
@@ -66,27 +69,24 @@ async function main() {
 }
 
 async function executeSample(sample) {
+  const { name, sampleFile, directory } = sample;
   console.log("============== SMOKE TESTS ==============");
-  console.log(`Sample Name: ${sample.name}`);
-  console.log(`Sample File: ${sample.sampleFile}`);
+  console.log(`Sample Name: ${name}`);
+  console.log(`Sample File: ${sampleFile}`);
 
-  let result = {
-    success: true
-  };
-
-  let currentDir = process.cwd();
+  const currentDir = process.cwd();
 
   try {
     // Set the process directory to the sample's directory because some samples
     // use file paths relative to the sample's directory.
-    process.chdir(sample.directory);
-
-    await sample.entrypoint();
+    process.chdir(directory);
+    const entryPoint = require(`${directory}/${sampleFile}`).main;
+    await entryPoint();
   } catch (exception) {
     console.log("FAILURE");
-    result = {
+    return {
       success: false,
-      exception
+      exception,
     };
   } finally {
     // Reset the working directory to the root directory after execution
@@ -95,7 +95,7 @@ async function executeSample(sample) {
 
   console.log("=========================================");
 
-  return result;
+  return { success: true };
 }
 
 // If command line parameter `--devops-logging` is set, then have console.error

--- a/sdk/eventgrid/eventgrid/samples-dev/consumeEventsFromServiceBusQueue.ts
+++ b/sdk/eventgrid/eventgrid/samples-dev/consumeEventsFromServiceBusQueue.ts
@@ -63,9 +63,9 @@ async function main() {
   // Stop processing events and exit.
   await closer.close();
   await receiver.close();
-  process.exit();
 }
 
 main().catch((err) => {
   console.error("The sample encountered an error:", err);
+  process.exit(1);
 });

--- a/sdk/eventgrid/eventgrid/samples/v4/javascript/consumeEventsFromServiceBusQueue.js
+++ b/sdk/eventgrid/eventgrid/samples/v4/javascript/consumeEventsFromServiceBusQueue.js
@@ -62,9 +62,9 @@ async function main() {
   // Stop processing events and exit.
   await closer.close();
   await receiver.close();
-  process.exit();
 }
 
 main().catch((err) => {
   console.error("The sample encountered an error:", err);
+  process.exit(1);
 });

--- a/sdk/eventgrid/eventgrid/samples/v4/typescript/src/consumeEventsFromServiceBusQueue.ts
+++ b/sdk/eventgrid/eventgrid/samples/v4/typescript/src/consumeEventsFromServiceBusQueue.ts
@@ -62,9 +62,9 @@ async function main() {
   // Stop processing events and exit.
   await closer.close();
   await receiver.close();
-  process.exit();
 }
 
 main().catch((err) => {
   console.error("The sample encountered an error:", err);
+  process.exit(1);
 });


### PR DESCRIPTION
- previously the runner loads sample modules in `main()` without any error handling so any error would cause
`main()` to exit thus skip the rest of samples. This PR delays sample loading to when they
are executed so errors in loading modules can be caught and reported.

- the `consumeEventsFromServiceBusQueue` sample is calling `process.exit()` upon
completion, causing the runner to exit because it currently runs tests in-proc.
Update the test to exit with code 1 when failing.

### Packages impacted by this PR
None
