### PR TITLE
[core-rest-pipeline] Fixed bugs introduced on 1.4.0, and added tests

### DIFF
--- a/sdk/core/core-rest-pipeline/CHANGELOG.md
+++ b/sdk/core/core-rest-pipeline/CHANGELOG.md
@@ -11,6 +11,8 @@
 ### Bugs Fixed
 
 - [Bug #20778](https://github.com/Azure/azure-sdk-for-js/pull/20778) Customers can provide abort signals in the options bags for the client libraries but they were not being checked when requests were being retried. The issue is fixed in [#20781](https://github.com/Azure/azure-sdk-for-js/pull/20781).
+- Fixed a bug introduced on 1.4.0 that prevented the retry policies from throwing errors after all the retry steps are exhausted.
+- Fixed a bug introduced on 1.4.0 that prevented the exponential retry policy to retry when the server answered with some expected errors.
 
 ### Other Changes
 

--- a/sdk/core/core-rest-pipeline/CHANGELOG.md
+++ b/sdk/core/core-rest-pipeline/CHANGELOG.md
@@ -17,6 +17,7 @@
 ### Other Changes
 
 - Changed the default number of retries from 10 to 3.
+- The retry policies now throw errors (if encountered) at the time they stop retrying, rather than merely returning the response.
 
 ## 1.6.0 (2022-03-03)
 

--- a/sdk/core/core-rest-pipeline/src/policies/retryPolicy.ts
+++ b/sdk/core/core-rest-pipeline/src/policies/retryPolicy.ts
@@ -59,10 +59,15 @@ export function retryPolicy(
           logger.info(`Retry ${retryCount}: Received a response from request`, request.requestId);
         } catch (e) {
           logger.error(`Retry ${retryCount}: Received an error from request`, request.requestId);
+
+          // RestErrors are valid targets for the retry strategies.
+          // If none of the retry strategies can work with them, they will be thrown later in this policy.
+          // If the received error is not a RestError, it is immediately thrown.
           responseError = e as RestError;
           if (!e || responseError.name !== "RestError") {
             throw e;
           }
+
           response = responseError.response;
         }
 

--- a/sdk/core/core-rest-pipeline/src/policies/retryPolicy.ts
+++ b/sdk/core/core-rest-pipeline/src/policies/retryPolicy.ts
@@ -81,10 +81,13 @@ export function retryPolicy(
           logger.info(
             `Retry ${retryCount}: Maximum retries reached. Returning the last received response, or throwing the last received error.`
           );
-          if (response !== undefined) {
+          if (responseError) {
+            throw responseError;
+          } else if (response) {
             return response;
+          } else {
+            throw new Error("Maximum retries reached with no response or error to throw");
           }
-          throw responseError;
         }
 
         logger.info(`Retry ${retryCount}: Processing ${strategies.length} retry strategies.`);

--- a/sdk/core/core-rest-pipeline/src/policies/retryPolicy.ts
+++ b/sdk/core/core-rest-pipeline/src/policies/retryPolicy.ts
@@ -126,6 +126,10 @@ export function retryPolicy(
           }
         }
 
+        if (responseError) {
+          logger.info(`Throwing the last received error.`);
+          throw responseError;
+        }
         if (response) {
           logger.info(`Returning the last received response.`);
           return response;

--- a/sdk/core/core-rest-pipeline/src/policies/retryPolicy.ts
+++ b/sdk/core/core-rest-pipeline/src/policies/retryPolicy.ts
@@ -132,11 +132,15 @@ export function retryPolicy(
         }
 
         if (responseError) {
-          logger.info(`Throwing the last received error.`);
+          logger.info(
+            `None of the retry strategies could work with the received error. Throwing it.`
+          );
           throw responseError;
         }
         if (response) {
-          logger.info(`Returning the last received response.`);
+          logger.info(
+            `None of the retry strategies could work with the received response. Returning it.`
+          );
           return response;
         }
 

--- a/sdk/core/core-rest-pipeline/src/retryStrategies/exponentialRetryStrategy.ts
+++ b/sdk/core/core-rest-pipeline/src/retryStrategies/exponentialRetryStrategy.ts
@@ -61,7 +61,7 @@ export function exponentialRetryStrategy(
         return { skipStrategy: true };
       }
 
-      if (responseError && !matchedSystemError) {
+      if (responseError && !matchedSystemError && !isExponential) {
         return { errorToThrow: responseError };
       }
 

--- a/sdk/core/core-rest-pipeline/test/defaultRetryPolicy.spec.ts
+++ b/sdk/core/core-rest-pipeline/test/defaultRetryPolicy.spec.ts
@@ -68,16 +68,7 @@ describe("defaultRetryPolicy", function () {
     const next = sinon.stub<Parameters<SendRequest>, ReturnType<SendRequest>>();
     next.rejects(testError);
 
-    const clock = sinon.useFakeTimers();
-
-    let catchCalled = false;
-    const promise = policy.sendRequest(request, next);
-    promise.catch((e) => {
-      catchCalled = true;
-      assert.strictEqual(e, testError);
-    });
-    await clock.runAllAsync();
+    await assert.isRejected(policy.sendRequest(request, next), /Test Error/);
     assert.strictEqual(next.callCount, 1);
-    assert.isTrue(catchCalled);
   });
 });

--- a/sdk/core/core-rest-pipeline/test/exponentialRetryPolicy.spec.ts
+++ b/sdk/core/core-rest-pipeline/test/exponentialRetryPolicy.spec.ts
@@ -33,17 +33,8 @@ describe("exponentialRetryPolicy", function () {
     const next = sinon.stub<Parameters<SendRequest>, ReturnType<SendRequest>>();
     next.rejects(testError);
 
-    const clock = sinon.useFakeTimers();
-
-    let catchCalled = false;
-    const promise = policy.sendRequest(request, next);
-    promise.catch((e) => {
-      catchCalled = true;
-      assert.strictEqual(e, testError);
-    });
-    await clock.runAllAsync();
+    await assert.isRejected(policy.sendRequest(request, next), /Test Error/);
     assert.strictEqual(next.callCount, 1);
-    assert.isTrue(catchCalled);
   });
 
   it("It should retry with a 503 response", async () => {
@@ -63,14 +54,9 @@ describe("exponentialRetryPolicy", function () {
 
     const clock = sinon.useFakeTimers();
 
-    let catchCalled = false;
     const promise = policy.sendRequest(request, next);
-    promise.catch((e) => {
-      catchCalled = true;
-      assert.strictEqual(e, testError);
-    });
     await clock.runAllAsync();
+    await promise;
     assert.strictEqual(next.callCount, DEFAULT_RETRY_POLICY_COUNT + 1);
-    assert.isFalse(catchCalled);
   });
 });

--- a/sdk/core/core-rest-pipeline/test/exponentialRetryPolicy.spec.ts
+++ b/sdk/core/core-rest-pipeline/test/exponentialRetryPolicy.spec.ts
@@ -1,0 +1,76 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { assert } from "chai";
+import * as sinon from "sinon";
+import {
+  RestError,
+  SendRequest,
+  createPipelineRequest,
+  PipelineResponse,
+  createHttpHeaders,
+  exponentialRetryPolicy,
+} from "../src";
+import { DEFAULT_RETRY_POLICY_COUNT } from "../src/constants";
+
+describe("exponentialRetryPolicy", function () {
+  afterEach(function () {
+    sinon.restore();
+  });
+
+  it("It should throw immediately if we get a 416 response", async () => {
+    const request = createPipelineRequest({
+      url: "https://bing.com",
+    });
+    const response: PipelineResponse = {
+      headers: createHttpHeaders({}),
+      request,
+      status: 416,
+    };
+    const testError = new RestError("Test Error!", { statusCode: 416, response });
+
+    const policy = exponentialRetryPolicy();
+    const next = sinon.stub<Parameters<SendRequest>, ReturnType<SendRequest>>();
+    next.rejects(testError);
+
+    const clock = sinon.useFakeTimers();
+
+    let catchCalled = false;
+    const promise = policy.sendRequest(request, next);
+    promise.catch((e) => {
+      catchCalled = true;
+      assert.strictEqual(e, testError);
+    });
+    await clock.runAllAsync();
+    assert.strictEqual(next.callCount, 1);
+    assert.isTrue(catchCalled);
+  });
+
+  it("It should retry with a 503 response", async () => {
+    const request = createPipelineRequest({
+      url: "https://bing.com",
+    });
+    const response: PipelineResponse = {
+      headers: createHttpHeaders({}),
+      request,
+      status: 503,
+    };
+    const testError = new RestError("Test Error!", { statusCode: 503, response });
+
+    const policy = exponentialRetryPolicy();
+    const next = sinon.stub<Parameters<SendRequest>, ReturnType<SendRequest>>();
+    next.rejects(testError);
+
+    const clock = sinon.useFakeTimers();
+
+    let catchCalled = false;
+    const promise = policy.sendRequest(request, next);
+    promise.catch((e) => {
+      catchCalled = true;
+      assert.strictEqual(e, testError);
+    });
+    await clock.runAllAsync();
+    assert.strictEqual(next.callCount, DEFAULT_RETRY_POLICY_COUNT + 1);
+    assert.isFalse(catchCalled);
+  });
+});

--- a/sdk/core/core-rest-pipeline/test/exponentialRetryPolicy.spec.ts
+++ b/sdk/core/core-rest-pipeline/test/exponentialRetryPolicy.spec.ts
@@ -54,7 +54,7 @@ describe("exponentialRetryPolicy", function () {
 
     const clock = sinon.useFakeTimers();
 
-    const promise = policy.sendRequest(request, next);
+    const promise = assert.isRejected(policy.sendRequest(request, next), /Test Error/);
     await clock.runAllAsync();
     await promise;
     assert.strictEqual(next.callCount, DEFAULT_RETRY_POLICY_COUNT + 1);

--- a/sdk/core/core-rest-pipeline/test/retryPolicy.spec.ts
+++ b/sdk/core/core-rest-pipeline/test/retryPolicy.spec.ts
@@ -371,7 +371,7 @@ describe("retryPolicy", function () {
       [
         "Retry 0: Attempting to send request [Request Id]",
         "Retry 0: Processing 1 retry strategies.",
-        "Throwing the last received error.",
+        "None of the retry strategies could work with the received error. Throwing it.",
       ]
     );
 

--- a/sdk/core/core-rest-pipeline/test/retryPolicy.spec.ts
+++ b/sdk/core/core-rest-pipeline/test/retryPolicy.spec.ts
@@ -363,7 +363,7 @@ describe("retryPolicy", function () {
     });
     await clock.runAllAsync();
     // should be one more than the default retry count
-    assert.strictEqual(next.callCount, DEFAULT_RETRY_POLICY_COUNT + 1);
+    assert.strictEqual(next.callCount, 1);
     assert.isTrue(catchCalled);
 
     assert.deepEqual(
@@ -371,34 +371,17 @@ describe("retryPolicy", function () {
       [
         "Retry 0: Attempting to send request [Request Id]",
         "Retry 0: Processing 1 retry strategies.",
-        "Retry 1: Attempting to send request [Request Id]",
-        "Retry 1: Processing 1 retry strategies.",
-        "Retry 2: Attempting to send request [Request Id]",
-        "Retry 2: Processing 1 retry strategies.",
-        "Retry 3: Attempting to send request [Request Id]",
-        "Retry 3: Maximum retries reached. Returning the last received response, or throwing the last received error.",
+        "Throwing the last received error.",
       ]
     );
 
     assert.deepEqual(
       policyLogger.params.error.map((x) => x.replace(/ request .*/g, " request [Request Id]")),
-      [
-        "Retry 0: Received an error from request [Request Id]",
-        "Retry 1: Received an error from request [Request Id]",
-        "Retry 2: Received an error from request [Request Id]",
-        "Retry 3: Received an error from request [Request Id]",
-      ]
+      ["Retry 0: Received an error from request [Request Id]"]
     );
 
     assert.deepEqual(strategyLogger.params, {
-      info: [
-        "Retry 0: Processing retry strategy testRetryStrategy.",
-        "Retry 0: Skipped.",
-        "Retry 1: Processing retry strategy testRetryStrategy.",
-        "Retry 1: Skipped.",
-        "Retry 2: Processing retry strategy testRetryStrategy.",
-        "Retry 2: Skipped.",
-      ],
+      info: ["Retry 0: Processing retry strategy testRetryStrategy.", "Retry 0: Skipped."],
       error: [],
     });
   });


### PR DESCRIPTION
~This PR confirms that the retry policies by default do not retry on a RestError with status code 416.~

After meeting with @sarangan12 , we were able to narrow down the problem. It wasn’t that the retry policies were not throwing as soon as an error was received, but that the retry policies where not throwing after all the retry steps were exhausted.

Through the autorrest.Typescript tests, we’ve also found that the `exponentialRetryPolicy` was skipping retries if some expected errors were received.

I’ve added tests to confirm these fixes.