### PR TITLE
[core-rest-pipeline] - Upgrade to core-tracing@1.0.0

### DIFF
--- a/sdk/core/core-rest-pipeline/package.json
+++ b/sdk/core/core-rest-pipeline/package.json
@@ -87,7 +87,7 @@
   "dependencies": {
     "@azure/abort-controller": "^1.0.0",
     "@azure/core-auth": "^1.3.0",
-    "@azure/core-tracing": "1.0.0-preview.13",
+    "@azure/core-tracing": "^1.0.0",
     "@azure/logger": "^1.0.0",
     "form-data": "^4.0.0",
     "tslib": "^2.2.0",

--- a/sdk/core/core-rest-pipeline/src/policies/tracingPolicy.ts
+++ b/sdk/core/core-rest-pipeline/src/policies/tracingPolicy.ts
@@ -45,18 +45,14 @@ export function tracingPolicy(options: TracingPolicyOptions = {}): PipelinePolic
   return {
     name: tracingPolicyName,
     async sendRequest(request: PipelineRequest, next: SendRequest): Promise<PipelineResponse> {
-      if (!request.tracingOptions?.tracingContext) {
-        return next(request);
-      }
-
       const { span, tracingContext } = tryCreateSpan(request, userAgent);
 
-      if (!span || !tracingContext) {
+      if (!span) {
         return next(request);
       }
 
       try {
-        const response = await tracingClient.withContext(tracingContext, () => next(request));
+        const response = await tracingClient.withContext(tracingContext!, next, request);
         tryProcessResponse(span, response);
         return response;
       } catch (err) {

--- a/sdk/eventhub/event-hubs/package.json
+++ b/sdk/eventhub/event-hubs/package.json
@@ -110,7 +110,7 @@
     "@azure/core-amqp": "^3.1.0",
     "@azure/core-asynciterator-polyfill": "^1.0.0",
     "@azure/core-auth": "^1.3.0",
-    "@azure/core-tracing": "1.0.0-preview.14",
+    "@azure/core-tracing": "^1.0.0",
     "@azure/logger": "^1.0.0",
     "buffer": "^6.0.0",
     "is-buffer": "^2.0.3",

--- a/sdk/formrecognizer/ai-form-recognizer/package.json
+++ b/sdk/formrecognizer/ai-form-recognizer/package.json
@@ -86,7 +86,7 @@
     "@azure/core-paging": "^1.1.1",
     "@azure/core-rest-pipeline": "^1.1.0",
     "@azure/core-client": "^1.0.0",
-    "@azure/core-tracing": "1.0.0-preview.14",
+    "@azure/core-tracing": "^1.0.0",
     "@azure/logger": "^1.0.0",
     "tslib": "^2.2.0"
   },

--- a/sdk/instrumentation/opentelemetry-instrumentation-azure-sdk/package.json
+++ b/sdk/instrumentation/opentelemetry-instrumentation-azure-sdk/package.json
@@ -78,7 +78,7 @@
   "sideEffects": false,
   "prettier": "@azure/eslint-plugin-azure-sdk/prettier.json",
   "dependencies": {
-    "@azure/core-tracing": "1.0.0-preview.14",
+    "@azure/core-tracing": "^1.0.0",
     "@azure/logger": "^1.0.0",
     "@opentelemetry/api": "~1.0.3",
     "@opentelemetry/core": "~1.0.1",

--- a/sdk/tables/data-tables/package.json
+++ b/sdk/tables/data-tables/package.json
@@ -81,7 +81,7 @@
     "@azure/core-paging": "^1.1.1",
     "@azure/core-xml": "^1.0.0",
     "@azure/logger": "^1.0.0",
-    "@azure/core-tracing": "1.0.0-preview.14",
+    "@azure/core-tracing": "^1.0.0",
     "tslib": "^2.2.0",
     "uuid": "^8.3.0"
   },

--- a/sdk/template/template/package.json
+++ b/sdk/template/template/package.json
@@ -84,7 +84,7 @@
     "@azure/core-auth": "^1.3.0",
     "@azure/core-client": "^1.4.0",
     "@azure/core-rest-pipeline": "^1.4.0",
-    "@azure/core-tracing": "1.0.0-preview.14",
+    "@azure/core-tracing": "^1.0.0",
     "@azure/logger": "^1.0.0",
     "tslib": "^2.2.0"
   },

--- a/sdk/test-utils/test-utils/package.json
+++ b/sdk/test-utils/test-utils/package.json
@@ -59,7 +59,7 @@
     "@azure-tools/test-recorder": "^1.0.0",
     "@azure/abort-controller": "^1.0.0",
     "@azure/core-rest-pipeline": "^1.1.0",
-    "@azure/core-tracing": "1.0.0-preview.14",
+    "@azure/core-tracing": "^1.0.0",
     "@opentelemetry/api": "^1.0.3",
     "@types/chai": "^4.1.6",
     "@types/chai-as-promised": "^7.1.4",


### PR DESCRIPTION
### Packages impacted by this PR
@azure/core-rest-pipeline
@azure/event-hubs
@azure/data-tables

### Issues associated with this PR
I don't even know anymore... TODO :)

### Describe the problem that is addressed by this PR
With @azure/core-tracing going 1.0.0 this milestone, it's time to migrate over.
There are two libraries we already moved over to the latest APIs, so this is a
no-op version change for them. 

For @azure/core-rest-pipeline I went ahead and upgraded it to
@azure/core-tracing@^1.0.0 and made all the necessary changes.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_
Yup!

### Provide a list of related PRs _(if any)_
TODO

### Checklists
- [x] Added impacted package name to the issue description.
- [ ] Does this PR need any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here.)_
- [ ] Added a changelog (if necessary).
