### PR TITLE
[engsys] update rush and pnpm versions

### DIFF
--- a/rush.json
+++ b/rush.json
@@ -14,7 +14,7 @@
    * path segment in the "$schema" field for all your Rush config files.  This will ensure
    * correct error-underlining and tab-completion for editors such as VS Code.
    */
-  "rushVersion": "5.61.2",
+  "rushVersion": "5.63.0",
   /**
    * The next field selects which package manager should be installed and determines its version.
    * Rush installs its own local copy of the package manager to ensure that your build process
@@ -23,7 +23,7 @@
    * Specify one of: "pnpmVersion", "npmVersion", or "yarnVersion".  See the Rush documentation
    * for details about these alternatives.
    */
-  "pnpmVersion": "6.19.1",
+  "pnpmVersion": "6.32.3",
   // "npmVersion": "4.5.0",
   // "yarnVersion": "1.9.4",
   /**

--- a/sdk/core/core-http/package.json
+++ b/sdk/core/core-http/package.json
@@ -143,7 +143,6 @@
     "@types/tough-cookie": "^4.0.0",
     "@types/uuid": "^8.0.0",
     "@types/xml2js": "^0.4.3",
-    "babel-runtime": "^6.26.0",
     "chai": "^4.2.0",
     "cross-env": "^7.0.2",
     "downlevel-dts": "^0.8.0",


### PR DESCRIPTION
and remove unused `babel-runtime` dependency from core-http to address `lodash`
dependabot alert

https://github.com/Azure/azure-sdk-for-js/security/dependabot/2

