### PR TITLE
[Schema Registry Avro] Simplfy MessageAdapter

### DIFF
--- a/sdk/eventhub/event-hubs/CHANGELOG.md
+++ b/sdk/eventhub/event-hubs/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Breaking Changes
 - `MessageWithMetadata` has been renamed to `MessageContent`.
 - `MessageContent`'s `body` has been renamed to `data`.
+- `MessageAdapter`'s `consumeMessage` and `produceMessage` have been renamed to `consume` and `produce`.
 
 ### Bugs Fixed
 

--- a/sdk/eventhub/event-hubs/review/event-hubs.api.md
+++ b/sdk/eventhub/event-hubs/review/event-hubs.api.md
@@ -234,8 +234,8 @@ export const logger: AzureLogger;
 
 // @public
 export interface MessageAdapter<MessageT> {
-    consumeMessage: (message: MessageT) => MessageContent;
-    produceMessage: (MessageContent: MessageContent) => MessageT;
+    consume: (message: MessageT) => MessageContent;
+    produce: (MessageContent: MessageContent) => MessageT;
 }
 
 // @public

--- a/sdk/eventhub/event-hubs/src/eventDataAdapter.ts
+++ b/sdk/eventhub/event-hubs/src/eventDataAdapter.ts
@@ -33,11 +33,11 @@ export interface MessageAdapter<MessageT> {
   /**
    * defines how to create a message from a payload and a content type
    */
-  produceMessage: (MessageContent: MessageContent) => MessageT;
+  produce: (MessageContent: MessageContent) => MessageT;
   /**
    * defines how to access the payload and the content type of a message
    */
-  consumeMessage: (message: MessageT) => MessageContent;
+  consume: (message: MessageT) => MessageContent;
 }
 
 // This type should always be equivalent to Omit<Omit<EventData, "body">, "contentType">
@@ -79,14 +79,14 @@ export function createEventDataAdapter(
   params: EventDataAdapterParameters = {}
 ): MessageAdapter<EventData> {
   return {
-    produceMessage: ({ data: body, contentType }: MessageContent) => {
+    produce: ({ data: body, contentType }: MessageContent) => {
       return {
         ...params,
         body,
         contentType,
       };
     },
-    consumeMessage: (message: EventData): MessageContent => {
+    consume: (message: EventData): MessageContent => {
       const { body, contentType } = message;
       if (body === undefined) {
         throw new Error("Expected the data field to be defined");

--- a/sdk/schemaregistry/schema-registry-avro/CHANGELOG.md
+++ b/sdk/schemaregistry/schema-registry-avro/CHANGELOG.md
@@ -5,10 +5,11 @@
 ### Features Added
 
 ### Breaking Changes
-- The `encodeMessageData` method has been renamed to `serialize`
-- The `decodeMessageData` method has been renamed to `deserialize`
-- The `MessageWithMetadata` interface has been renamed to `MessageContent`
-- `MessageContent`'s `body` has been renamed to `data`
+- The `encodeMessageData` method has been renamed to `serialize`.
+- The `decodeMessageData` method has been renamed to `deserialize`.
+- The `MessageWithMetadata` interface has been renamed to `MessageContent`.
+- `MessageContent`'s `body` has been renamed to `data`.
+- `MessageAdapter`'s `consumeMessage` and `produceMessage` have been renamed to `consume` and `produce`.
 
 ### Bugs Fixed
 

--- a/sdk/schemaregistry/schema-registry-avro/review/schema-registry-avro.api.md
+++ b/sdk/schemaregistry/schema-registry-avro/review/schema-registry-avro.api.md
@@ -27,8 +27,8 @@ export interface DeserializeOptions {
 
 // @public
 export interface MessageAdapter<MessageT> {
-    consumeMessage: (message: MessageT) => MessageContent;
-    produceMessage: (messageContent: MessageContent) => MessageT;
+    consume: (message: MessageT) => MessageContent;
+    produce: (messageContent: MessageContent) => MessageT;
 }
 
 // @public

--- a/sdk/schemaregistry/schema-registry-avro/src/avroSerializer.ts
+++ b/sdk/schemaregistry/schema-registry-avro/src/avroSerializer.ts
@@ -80,7 +80,7 @@ export class AvroSerializer<MessageT = MessageContent> {
     );
     const contentType = `${avroMimeType}+${entry.id}`;
     return this.messageAdapter
-      ? this.messageAdapter.produceMessage({
+      ? this.messageAdapter.produce({
           contentType,
           data,
         })
@@ -229,7 +229,7 @@ function convertMessage<MessageT>(
   message: MessageT,
   adapter?: MessageAdapter<MessageT>
 ): MessageContent {
-  const messageConsumer = adapter?.consumeMessage;
+  const messageConsumer = adapter?.consume;
   if (messageConsumer) {
     const { data, contentType } = messageConsumer(message);
     return convertPayload(data, contentType);

--- a/sdk/schemaregistry/schema-registry-avro/src/models.ts
+++ b/sdk/schemaregistry/schema-registry-avro/src/models.ts
@@ -23,11 +23,11 @@ export interface MessageAdapter<MessageT> {
   /**
    * defines how to create a message from a payload and a content type
    */
-  produceMessage: (messageContent: MessageContent) => MessageT;
+  produce: (messageContent: MessageContent) => MessageT;
   /**
    * defines how to access the payload and the content type of a message
    */
-  consumeMessage: (message: MessageT) => MessageContent;
+  consume: (message: MessageT) => MessageContent;
 }
 
 /**

--- a/sdk/schemaregistry/schema-registry-avro/test/messageAdapter.spec.ts
+++ b/sdk/schemaregistry/schema-registry-avro/test/messageAdapter.spec.ts
@@ -1,14 +1,19 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { EventData, EventDataAdapterParameters, createEventDataAdapter } from "@azure/event-hubs";
+import {
+  MessageAdapter as EHMessageAdapter,
+  EventData,
+  EventDataAdapterParameters,
+  createEventDataAdapter,
+} from "@azure/event-hubs";
 import { AssertEqualKeys } from "./utils/utils";
 import { MessageAdapter } from "../src/models";
 import { assert } from "chai";
 import { matrix } from "@azure/test-utils";
 
 function isMessageAdapter<MessageT>(obj: any): obj is MessageAdapter<MessageT> {
-  return typeof obj.produceMessage === "function" && typeof obj.consumeMessage === "function";
+  return typeof obj.produce === "function" && typeof obj.consume === "function";
 }
 
 /**
@@ -31,6 +36,15 @@ describe("Message Adapters", function () {
     adapterFactory: createEventDataAdapter(),
     adapterFactoryName: createEventDataAdapter.name,
   };
+  describe("MessageAdapter types are identical", function () {
+    it("Event Hubs", function () {
+      const areEqual: AssertEqualKeys<MessageAdapter<unknown>, EHMessageAdapter<unknown>> = true;
+      assert.isTrue(
+        areEqual,
+        "MessageAdapter should have the same shape as @azure/event-hubs's MessageAdapter."
+      );
+    });
+  });
   describe("Input types for message adapter factories are sound", function () {
     it("EventDataAdapterParameters", function () {
       const areEqual: AssertEqualKeys<
@@ -52,7 +66,7 @@ describe("Message Adapters", function () {
       it("consumeMessage rejects undefined data", async () => {
         assert.throws(
           () =>
-            adapter.consumeMessage({
+            adapter.consume({
               body: undefined,
               contentType: "",
             }),
@@ -62,7 +76,7 @@ describe("Message Adapters", function () {
       it("consumeMessage rejects messages with no contentType", async () => {
         assert.throws(
           () =>
-            adapter.consumeMessage({
+            adapter.consume({
               body: dummyUint8Array,
             }),
           /Expected the contentType field to be defined/

--- a/sdk/schemaregistry/schema-registry-avro/test/messageContent.spec.ts
+++ b/sdk/schemaregistry/schema-registry-avro/test/messageContent.spec.ts
@@ -6,7 +6,7 @@ import { MessageContent as EHMessageContent } from "@azure/event-hubs";
 import { MessageContent } from "../src/models";
 import { assert } from "chai";
 
-describe("MessageContent types are identically the same", function () {
+describe("MessageContent types are identical", function () {
   it("Event Hubs", function () {
     const areEqual: AssertEqualKeys<MessageContent, EHMessageContent> = true;
     assert.isTrue(


### PR DESCRIPTION
### Packages impacted by this PR
@azure/schema-registry-avro. @azure/event-hubs

### Issues associated with this PR
Fixes https://github.com/Azure/azure-sdk-for-js/issues/20880

### Describe the problem that is addressed by this PR
The word "Message" in the method names is redundant since it is already part of the type and part of the field name an object of this interface will be passed to

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?
N/A

### Are there test cases added in this PR? _(If not, why?)_
yes

### Provide a list of related PRs _(if any)_
N/A

### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [x] Added a changelog (if necessary)
