### PR TITLE
Trigger template instead of core for eng/common

### DIFF
--- a/sdk/core/ci.yml
+++ b/sdk/core/ci.yml
@@ -14,6 +14,7 @@ trigger:
       - rush.json
     exclude:
       - common/smoke-test/
+      - eng/common/
 
 pr:
   branches:
@@ -30,6 +31,7 @@ pr:
       - rush.json
     exclude:
       - common/smoke-test/
+      - eng/common/
 
 extends:
   template: ../../eng/pipelines/templates/stages/archetype-sdk-client.yml

--- a/sdk/template/ci.yml
+++ b/sdk/template/ci.yml
@@ -8,7 +8,9 @@ trigger:
       - hotfix/*
   paths:
     include:
-      - sdk/template/
+      - sdk/template/      
+      # eng/common code changes trigger template pipeline for basic checking.
+      - eng/common
 
 pr:
   branches:
@@ -20,6 +22,8 @@ pr:
   paths:
     include:
       - sdk/template/
+      # eng/common code changes trigger template pipeline for basic checking.
+      - eng/common
 
 extends:
   template: ../../eng/pipelines/templates/stages/archetype-sdk-client.yml

--- a/sdk/template/ci.yml
+++ b/sdk/template/ci.yml
@@ -10,7 +10,7 @@ trigger:
     include:
       - sdk/template/      
       # eng/common code changes trigger template pipeline for basic checking.
-      - eng/common
+      - eng/common/
 
 pr:
   branches:
@@ -23,7 +23,7 @@ pr:
     include:
       - sdk/template/
       # eng/common code changes trigger template pipeline for basic checking.
-      - eng/common
+      - eng/common/
 
 extends:
   template: ../../eng/pipelines/templates/stages/archetype-sdk-client.yml


### PR DESCRIPTION
### Packages impacted by this PR


### Issues associated with this PR


### Describe the problem that is addressed by this PR
**Current workflow for eng work:**
For work under `eng/common` like PR: https://github.com/Azure/azure-sdk-tools/pull/2861.

It will trigger 9 PRs like below:
<img width="842" alt="image" src="https://user-images.githubusercontent.com/48036328/158711136-401f0b2e-ff1a-4398-be0c-fd4a8922ce41.png">

For PR to lang repo, they trigger core pipeline for testing the changes. Like sync PR here: https://github.com/Azure/azure-sdk-for-js/pull/20837

Java has switched to template already and run for a while. The PR is to align with Java trigger branch and path.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [ ] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
