### PR TITLE
[Schema Registry Avro] Add an error scenario

### DIFF
--- a/sdk/schemaregistry/schema-registry-avro/test/avroSerializer.spec.ts
+++ b/sdk/schemaregistry/schema-registry-avro/test/avroSerializer.spec.ts
@@ -13,11 +13,10 @@ import { createTestRegistry } from "./utils/mockedRegistryClient";
 
 chaiUse(chaiPromises);
 
-const noAutoRegisterOptions: CreateTestSerializerOptions<any> = {
-  serializerOptions: { autoRegisterSchemas: false, groupName: testGroup },
-};
-
 describe("AvroSerializer", function () {
+  const noAutoRegisterOptions: CreateTestSerializerOptions<any> = {
+    serializerOptions: { autoRegisterSchemas: false, groupName: testGroup },
+  };
   it("rejects invalid format", async () => {
     const serializer = await createTestSerializer();
     await assert.isRejected(
@@ -242,7 +241,7 @@ describe("AvroSerializer", function () {
      * The standard tier resource supports registering up to 25 schemas per a schema group.
      */
     const maxSchemaCount = 25;
-    const maxCacheEntriesCount = Math.floor(maxSchemaCount / 2 - 1);
+    const maxCacheEntriesCount = Math.floor(maxSchemaCount / 2 - 5);
     (serializer["cacheById"] as any).max = maxCacheEntriesCount;
     (serializer["cacheBySchemaDefinition"] as any).max = maxCacheEntriesCount;
     const itersCount = 2 * maxCacheEntriesCount;

--- a/sdk/schemaregistry/schema-registry-avro/test/utils/dummies.ts
+++ b/sdk/schemaregistry/schema-registry-avro/test/utils/dummies.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 import * as avro from "avsc/";
+import { env } from "./env";
 
 export const testSchemaObject: avro.schema.RecordType = {
   type: "record",
@@ -19,7 +20,7 @@ export const testSchemaObject: avro.schema.RecordType = {
   ],
 };
 
-export const testGroup = "azsdk_js_test_group";
+export const testGroup = env.SCHEMA_REGISTRY_GROUP || "azsdk_js_test_group";
 
 export const testSchemaIds = [
   "{773E17BE-793E-40B0-98F1-0A6EA3C11895}",


### PR DESCRIPTION
### Packages impacted by this PR
@azure/schema-registry-avro

### Issues associated with this PR
Fixes https://github.com/Azure/azure-sdk-for-js/issues/20839

### Describe the problem that is addressed by this PR
One of the tests is currently failing because the CI resource only allows up to 25 unique schemas per a schema group but that number is exhausted by another test that checks whether the growth of the serializer's internal cache is bounded. This PR reduces the number of schemas registered in the latter so there is enough room for subsequent tests to register their own schemas.

Furthermore, an additional test is added that checks an error case when deserializing with incompatible schema.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?
N/A

### Are there test cases added in this PR? _(If not, why?)_
Yes. Also see a successful nightly run in https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1439397&view=results

### Provide a list of related PRs _(if any)_
N/A

### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
