### PR TITLE
[test-util] - Ensure the global instrumenter is cleared between tests

### DIFF
--- a/sdk/test-utils/test-utils/src/tracing/chaiAzureTrace.ts
+++ b/sdk/test-utils/test-utils/src/tracing/chaiAzureTrace.ts
@@ -2,11 +2,14 @@
 // Licensed under the MIT license.
 
 import { OperationTracingOptions, useInstrumenter } from "@azure/core-tracing";
-import { assert } from "chai";
+import { SpanGraph, SpanGraphNode } from "./spanGraphModel";
+
 import { MockInstrumenter } from "./mockInstrumenter";
 import { MockTracingSpan } from "./mockTracingSpan";
-import { SpanGraph, SpanGraphNode } from "./spanGraphModel";
+import { assert } from "chai";
+
 const instrumenter = new MockInstrumenter();
+
 /**
  * The supports Tracing function does the verification of whether the core-tracing is supported correctly with the client method
  * This function verifies the root span, if all the correct spans are called as expected and if they are closed.
@@ -25,7 +28,6 @@ export async function supportsTracing<
   thisArg?: ThisParameterType<Callback>
 ) {
   useInstrumenter(instrumenter);
-  instrumenter.enable();
   instrumenter.reset();
   try {
     const startSpanOptions = {
@@ -61,7 +63,9 @@ export async function supportsTracing<
       `All spans should have been closed, but found ${openSpans.map((s) => s.name)} open spans.`
     );
   } finally {
-    instrumenter.disable();
+    // By resetting the instrumenter to undefined, we force the next call to instantiate the
+    // no-op instrumenter and prevent test pollution.
+    useInstrumenter(<any>undefined);
   }
 }
 

--- a/sdk/test-utils/test-utils/src/tracing/mockInstrumenter.ts
+++ b/sdk/test-utils/test-utils/src/tracing/mockInstrumenter.ts
@@ -8,6 +8,7 @@ import {
   TracingSpan,
 } from "@azure/core-tracing";
 import { MockContext, spanKey } from "./mockContext";
+
 import { MockTracingSpan } from "./mockTracingSpan";
 
 /**
@@ -17,7 +18,7 @@ export class MockInstrumenter implements Instrumenter {
   private isEnabled: boolean;
 
   constructor() {
-    this.isEnabled = false;
+    this.isEnabled = true;
   }
 
   /**


### PR DESCRIPTION
### Packages impacted by this PR
@azure/test-util 

### Issues associated with this PR
Resolves #20802

### Describe the problem that is addressed by this PR
Since the instrumenter that is set for tests is global, it can pollute other tests depending on the order in which they are
run. This manifested in what is an otherwise completely unrelated error in event-hubs

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?
We can update the core-tracing API to allow undefined as a value for `useInstrumenter` but I hesitated to do that
since it would otherwise not be needed by anyone

### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [ ] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
