### PR TITLE
[phone number sdk] Adds environment variable AZURE_USERAGENT_OVERRIDE that overrides HTTP header x-ms-useragent during tests

### DIFF
--- a/sdk/communication/communication-phone-numbers/CHANGELOG.md
+++ b/sdk/communication/communication-phone-numbers/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Features Added
 
+- Added environment variable `AZURE_USERAGENT_OVERRIDE` that overrides the HTTP header `x-ms-useragent` during tests
+
 ### Breaking Changes
 
 ### Bugs Fixed

--- a/sdk/communication/communication-phone-numbers/karma.conf.js
+++ b/sdk/communication/communication-phone-numbers/karma.conf.js
@@ -71,6 +71,7 @@ module.exports = function (config) {
       "COMMUNICATION_SKIP_INT_PHONENUMBERS_TESTS",
       "SKIP_UPDATE_CAPABILITIES_LIVE_TESTS",
       "AZURE_TEST_AGENT",
+      "AZURE_USERAGENT_OVERRIDE",
       ...getPhoneNumberPoolEnvVars(),
     ],
 

--- a/sdk/communication/communication-phone-numbers/test/public/utils/msUserAgentPolicy.ts
+++ b/sdk/communication/communication-phone-numbers/test/public/utils/msUserAgentPolicy.ts
@@ -14,7 +14,7 @@ export function createMSUserAgentPolicy(): PipelinePolicy {
     name: "msUserAgentPolicy",
     async sendRequest(request: PipelineRequest, next: SendRequest): Promise<PipelineResponse> {
       const useragent = env.AZURE_USERAGENT_OVERRIDE;
-      if (useragent){
+      if (useragent) {
         request.headers.set("x-ms-useragent", useragent);
       }
 

--- a/sdk/communication/communication-phone-numbers/test/public/utils/msUserAgentPolicy.ts
+++ b/sdk/communication/communication-phone-numbers/test/public/utils/msUserAgentPolicy.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
 import {
   PipelinePolicy,
   PipelineRequest,
@@ -10,12 +13,12 @@ export function createMSUserAgentPolicy(): PipelinePolicy {
   return {
     name: "msUserAgentPolicy",
     async sendRequest(request: PipelineRequest, next: SendRequest): Promise<PipelineResponse> {
-      let useragent = env.AZURE_USERAGENT_OVERRIDE;
+      const useragent = env.AZURE_USERAGENT_OVERRIDE;
       if (useragent){
         request.headers.set("x-ms-useragent", useragent);
       }
 
-      return await next(request);
+      return next(request);
     },
   };
 }

--- a/sdk/communication/communication-phone-numbers/test/public/utils/msUserAgentPolicy.ts
+++ b/sdk/communication/communication-phone-numbers/test/public/utils/msUserAgentPolicy.ts
@@ -1,0 +1,21 @@
+import {
+  PipelinePolicy,
+  PipelineRequest,
+  PipelineResponse,
+  SendRequest,
+} from "@azure/core-rest-pipeline";
+import { env } from "@azure-tools/test-recorder";
+
+export function createMSUserAgentPolicy(): PipelinePolicy {
+  return {
+    name: "msUserAgentPolicy",
+    async sendRequest(request: PipelineRequest, next: SendRequest): Promise<PipelineResponse> {
+      let useragent = env.AZURE_USERAGENT_OVERRIDE;
+      if (useragent){
+        request.headers.set("x-ms-useragent", useragent);
+      }
+
+      return await next(request);
+    },
+  };
+}

--- a/sdk/communication/communication-phone-numbers/test/public/utils/recordedClient.ts
+++ b/sdk/communication/communication-phone-numbers/test/public/utils/recordedClient.ts
@@ -16,6 +16,8 @@ import { PhoneNumbersClient } from "../../../src";
 import { parseConnectionString } from "@azure/communication-common";
 import { ClientSecretCredential, DefaultAzureCredential, TokenCredential } from "@azure/identity";
 import { createXhrHttpClient, isNode } from "@azure/test-utils";
+import { AdditionalPolicyConfig } from "@azure/core-client";
+import { createMSUserAgentPolicy } from "./msUserAgentPolicy";
 
 if (isNode) {
   dotenv.config();
@@ -51,6 +53,13 @@ export const environmentSetup: RecorderEnvironmentSetup = {
   queryParametersToSkip: [],
 };
 
+const additionalPolicies: AdditionalPolicyConfig[] = [
+  {
+    policy: createMSUserAgentPolicy(),
+    position: "perRetry"
+  }
+];
+
 export function createRecordedClient(context: Context): RecordedClient<PhoneNumbersClient> {
   const recorder = record(context, environmentSetup);
 
@@ -58,6 +67,7 @@ export function createRecordedClient(context: Context): RecordedClient<PhoneNumb
   return {
     client: new PhoneNumbersClient(env.COMMUNICATION_LIVETEST_STATIC_CONNECTION_STRING, {
       httpClient,
+      additionalPolicies,
     }),
     recorder,
   };
@@ -101,11 +111,12 @@ export function createRecordedClientWithToken(
       { httpClient }
     );
   }
-
+  
   // casting is a workaround to enable min-max testing
   return {
     client: new PhoneNumbersClient(endpoint, credential, {
       httpClient,
+      additionalPolicies,
     }),
     recorder,
   };

--- a/sdk/communication/communication-phone-numbers/test/public/utils/recordedClient.ts
+++ b/sdk/communication/communication-phone-numbers/test/public/utils/recordedClient.ts
@@ -40,6 +40,7 @@ const replaceableVariables: { [k: string]: string } = {
   AZURE_TENANT_ID: "SomeTenantId",
   AZURE_PHONE_NUMBER: "+14155550100",
   COMMUNICATION_SKIP_INT_PHONENUMBERS_TESTS: "false",
+  AZURE_USERAGENT_OVERRIDE: "fake-useragent",
 };
 
 export const environmentSetup: RecorderEnvironmentSetup = {

--- a/sdk/communication/communication-phone-numbers/test/public/utils/recordedClient.ts
+++ b/sdk/communication/communication-phone-numbers/test/public/utils/recordedClient.ts
@@ -56,8 +56,8 @@ export const environmentSetup: RecorderEnvironmentSetup = {
 const additionalPolicies: AdditionalPolicyConfig[] = [
   {
     policy: createMSUserAgentPolicy(),
-    position: "perRetry"
-  }
+    position: "perRetry",
+  },
 ];
 
 export function createRecordedClient(context: Context): RecordedClient<PhoneNumbersClient> {
@@ -111,7 +111,7 @@ export function createRecordedClientWithToken(
       { httpClient }
     );
   }
-  
+
   // casting is a workaround to enable min-max testing
   return {
     client: new PhoneNumbersClient(endpoint, credential, {


### PR DESCRIPTION
This change is needed to fix the test pipeline


### Packages impacted by this PR
communication-phone-numbers

### Issues associated with this PR


### Describe the problem that is addressed by this PR
Adds a way to mark request as test traffic

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?
--

### Are there test cases added in this PR? _(If not, why?)_
No new test cases, this updates only unit test code

### Provide a list of related PRs _(if any)_
--

### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_
--
### Checklists
- [x] Added impacted package name to the issue description
- [x] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [x] Added a changelog (if necessary)
