### PR TITLE
[Tables] Fix issue handling empty nextRowKey

### DIFF
--- a/sdk/tables/data-tables/CHANGELOG.md
+++ b/sdk/tables/data-tables/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Bugs Fixed
 
+- Fix issue when the Service returns an empty nextRowKey. [#20916](https://github.com/Azure/azure-sdk-for-js/pull/20916).
 - Fix issue with `getStatistics()` operation consistently failing and added test. [#20398](https://github.com/Azure/azure-sdk-for-js/pull/20398)
 
 ### Other Changes

--- a/sdk/tables/data-tables/src/utils/continuationToken.ts
+++ b/sdk/tables/data-tables/src/utils/continuationToken.ts
@@ -5,26 +5,26 @@ import { base64Decode, base64Encode } from "./bufferSerializer";
 
 export interface ContinuationToken {
   nextPartitionKey: string;
-  nextRowKey: string;
+  nextRowKey?: string;
 }
 
 /**
  * Encodes the nextPartitionKey and nextRowKey into a single continuation token
  */
 export function encodeContinuationToken(
-  nextPartitionKey: string = "",
-  nextRowKey: string = ""
+  nextPartitionKey?: string,
+  nextRowKey?: string
 ): string | undefined {
-  if (!nextPartitionKey && !nextRowKey) {
+  if (!nextPartitionKey) {
     return undefined;
   }
 
-  const continuationToken = JSON.stringify({
+  const continuationToken: { nextPartitionKey: string; nextRowKey?: string } = {
     nextPartitionKey,
-    nextRowKey,
-  });
+    ...{ nextRowKey },
+  };
 
-  return base64Encode(continuationToken);
+  return base64Encode(JSON.stringify(continuationToken));
 }
 
 /**

--- a/sdk/tables/data-tables/src/utils/continuationToken.ts
+++ b/sdk/tables/data-tables/src/utils/continuationToken.ts
@@ -19,7 +19,7 @@ export function encodeContinuationToken(
     return undefined;
   }
 
-  const continuationToken: { nextPartitionKey: string; nextRowKey?: string } = {
+  const continuationToken = {
     nextPartitionKey,
     ...{ nextRowKey },
   };

--- a/sdk/tables/data-tables/src/utils/continuationToken.ts
+++ b/sdk/tables/data-tables/src/utils/continuationToken.ts
@@ -21,7 +21,8 @@ export function encodeContinuationToken(
 
   const continuationToken = {
     nextPartitionKey,
-    ...{ nextRowKey },
+    // Only add nextRowKey if the value is not null, undefined or empty string.
+    ...(nextRowKey && { nextRowKey }),
   };
 
   return base64Encode(JSON.stringify(continuationToken));

--- a/sdk/tables/data-tables/src/utils/continuationToken.ts
+++ b/sdk/tables/data-tables/src/utils/continuationToken.ts
@@ -3,7 +3,7 @@
 
 import { base64Decode, base64Encode } from "./bufferSerializer";
 
-export interface ContinuationToken {
+interface ContinuationToken {
   nextPartitionKey: string;
   nextRowKey?: string;
 }

--- a/sdk/tables/data-tables/test/internal/continuationToken.spec.ts
+++ b/sdk/tables/data-tables/test/internal/continuationToken.spec.ts
@@ -34,9 +34,4 @@ describe("continuation token utils", () => {
     const decoded = decodeContinuationToken("eyJuZXh0UGFydGl0aW9uS2V5IjoiZm9vIn0=");
     assert.deepEqual(decoded, { nextPartitionKey: "foo" } as any);
   });
-
-  it("should return undefined if nextPartitionKey and nextRowKey are empty", () => {
-    const encoded = encodeContinuationToken();
-    assert.equal(encoded, undefined);
-  });
 });

--- a/sdk/tables/data-tables/test/internal/continuationToken.spec.ts
+++ b/sdk/tables/data-tables/test/internal/continuationToken.spec.ts
@@ -1,11 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { assert } from "chai";
 import {
   decodeContinuationToken,
   encodeContinuationToken,
 } from "../../src/utils/continuationToken";
+
+import { assert } from "chai";
 
 describe("continuation token utils", () => {
   it("should encode nextPartitionKey and nextRowKey", () => {

--- a/sdk/tables/data-tables/test/internal/continuationToken.spec.ts
+++ b/sdk/tables/data-tables/test/internal/continuationToken.spec.ts
@@ -1,0 +1,42 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { assert } from "chai";
+import {
+  decodeContinuationToken,
+  encodeContinuationToken,
+} from "../../src/utils/continuationToken";
+
+describe("continuation token utils", () => {
+  it("should encode nextPartitionKey and nextRowKey", () => {
+    const encoded = encodeContinuationToken("foo", "bar");
+    assert.equal(encoded, "eyJuZXh0UGFydGl0aW9uS2V5IjoiZm9vIiwibmV4dFJvd0tleSI6ImJhciJ9");
+  });
+
+  it("should encode nextPartitionKey and undefined nextRowKey", () => {
+    const encoded = encodeContinuationToken("foo");
+    assert.equal(encoded, "eyJuZXh0UGFydGl0aW9uS2V5IjoiZm9vIn0=");
+  });
+
+  it("should return undefined if nextPartitionKey and nextRowKey are empty", () => {
+    const encoded = encodeContinuationToken();
+    assert.equal(encoded, undefined);
+  });
+
+  it("should decode nextPartitionKey and nextRowKey", () => {
+    const decoded = decodeContinuationToken(
+      "eyJuZXh0UGFydGl0aW9uS2V5IjoiZm9vIiwibmV4dFJvd0tleSI6ImJhciJ9"
+    );
+    assert.deepEqual(decoded, { nextPartitionKey: "foo", nextRowKey: "bar" });
+  });
+
+  it("should decode nextPartitionKey and undefined nextRowKey", () => {
+    const decoded = decodeContinuationToken("eyJuZXh0UGFydGl0aW9uS2V5IjoiZm9vIn0=");
+    assert.deepEqual(decoded, { nextPartitionKey: "foo" } as any);
+  });
+
+  it("should return undefined if nextPartitionKey and nextRowKey are empty", () => {
+    const encoded = encodeContinuationToken();
+    assert.equal(encoded, undefined);
+  });
+});

--- a/sdk/tables/data-tables/test/internal/continuationToken.spec.ts
+++ b/sdk/tables/data-tables/test/internal/continuationToken.spec.ts
@@ -14,6 +14,11 @@ describe("continuation token utils", () => {
     assert.equal(encoded, "eyJuZXh0UGFydGl0aW9uS2V5IjoiZm9vIiwibmV4dFJvd0tleSI6ImJhciJ9");
   });
 
+  it("should not encode nextRowKey if it is empty string", () => {
+    const encoded = encodeContinuationToken("foo", "");
+    assert.deepEqual(decodeContinuationToken(encoded!), { nextPartitionKey: "foo" });
+  });
+
   it("should encode nextPartitionKey and undefined nextRowKey", () => {
     const encoded = encodeContinuationToken("foo");
     assert.equal(encoded, "eyJuZXh0UGFydGl0aW9uS2V5IjoiZm9vIn0=");


### PR DESCRIPTION
### Packages impacted by this PR
@azure/data-tables

### Issues associated with this PR
#20913 

### Describe the problem that is addressed by this PR
When querying entities from a table, the service may respond with a `nextPartitionKey` and no or empty `nextRowKey`. Currently, the library assumes that `nextRowKey` will always be present. When an empty `nextRowKey` is sent to the service, we get a 400 error.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?
Do not try to use `nextRowKey` if the service didn't send it or sent it empty

### Are there test cases added in this PR? _(If not, why?)_
Yes added Unit Tests

### Checklists
- [ ] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
