### PR TITLE
[tables] Add NamedKeyCredential to exports for easier consumption

### DIFF
--- a/sdk/tables/data-tables/CHANGELOG.md
+++ b/sdk/tables/data-tables/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Updated our `@azure/core-tracing` dependency to the latest version (1.0.0)
   - Notable changes include Removal of `@opentelemetry/api` as a transitive dependency and ensuring that the active context is properly propagated.
   - Customers who would like to continue using OpenTelemetry driven tracing should visit our [OpenTelemetry Instrumentation](https://www.npmjs.com/package/@azure/opentelemetry-instrumentation-azure-sdk) package for instructions.
+- Export NamedKeyCredential [#20935](https://github.com/Azure/azure-sdk-for-js/pull/20935). (A community contribution, courtesy of _[dhensby](https://github.com/dhensby))_
 
 ## 13.0.1 (2022-01-12)
 

--- a/sdk/tables/data-tables/review/data-tables.api.md
+++ b/sdk/tables/data-tables/review/data-tables.api.md
@@ -160,6 +160,8 @@ export interface Metrics {
     version?: string;
 }
 
+export { NamedKeyCredential }
+
 // @public
 export function odata(strings: TemplateStringsArray, ...values: unknown[]): string;
 

--- a/sdk/tables/data-tables/src/index.ts
+++ b/sdk/tables/data-tables/src/index.ts
@@ -9,5 +9,5 @@ export { TableServiceClient } from "./TableServiceClient";
 export { TableTransaction } from "./TableTransaction";
 export { TableClient } from "./TableClient";
 export { odata } from "./odata";
-export { AzureNamedKeyCredential, AzureSASCredential } from "@azure/core-auth";
+export { AzureNamedKeyCredential, AzureSASCredential, NamedKeyCredential } from "@azure/core-auth";
 export { RestError } from "@azure/core-rest-pipeline";


### PR DESCRIPTION
### Packages impacted by this PR

`@azure/data-tables`

### Issues associated with this PR

n/a

### Describe the problem that is addressed by this PR

As a consumer of the typings, one may want to define a parameter that is compatible with the underlying TableClient, eg:

```ts
function createClient(accountName: string, tableName: string, credential?: NamedKeyCredential);
```

At the moment this isn't possible without importing the `NamedKeyCredential` directly from `@azure/core-auth` which means having to explicitly declare this dependency in a project.


### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?

In line with other exports, exporting dependant types helps keep the API more clearly defined and makes the load on consumers lighter by having to not know about implicit dependencies.

### Are there test cases added in this PR? _(If not, why?)_

yes


### Provide a list of related PRs _(if any)_

n/a

### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [x] Added impacted package name to the issue description
- [ ] ~Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_~
- [x] Added a changelog (if necessary)
