### PR TITLE
[KeyVault] - Add release policy grammar links

### DIFF
--- a/sdk/keyvault/keyvault-keys/src/keysModels.ts
+++ b/sdk/keyvault/keyvault-keys/src/keysModels.ts
@@ -2,12 +2,14 @@
 // Licensed under the MIT license.
 
 import * as coreHttp from "@azure/core-http";
+
 import {
   DeletionRecoveryLevel,
+  JsonWebKeyOperation as KeyOperation,
   JsonWebKeyType as KeyType,
   KnownJsonWebKeyType as KnownKeyTypes,
-  JsonWebKeyOperation as KeyOperation,
 } from "./generated/models";
+
 import { KeyCurveName } from "./cryptographyClientModels";
 
 export { KeyType, KnownKeyTypes, KeyOperation };
@@ -285,7 +287,13 @@ export interface KeyReleasePolicy {
    */
   contentType?: string;
 
-  /** Blob encoding the policy rules under which the key can be released. */
+  /**
+   * The policy rules under which the key can be released. Encoded based on the {@link KeyReleasePolicy.contentType}.
+   *
+   * For more information regarding the release policy grammar for Azure Key Vault, please refer to:
+   * - https://aka.ms/policygrammarkeys for Azure Key Vault release policy grammar.
+   * - https://aka.ms/policygrammarmhsm for Azure Managed HSM release policy grammar.
+   */
   encodedPolicy?: Uint8Array;
 
   /** Marks a release policy as immutable. An immutable release policy cannot be changed or updated after marked immutable. */

--- a/sdk/keyvault/keyvault-keys/src/keysModels.ts
+++ b/sdk/keyvault/keyvault-keys/src/keysModels.ts
@@ -296,7 +296,7 @@ export interface KeyReleasePolicy {
    */
   encodedPolicy?: Uint8Array;
 
-  /** Marks a release policy as immutable. An immutable release policy cannot be changed or updated after marked immutable. */
+  /** Marks a release policy as immutable. An immutable release policy cannot be changed or updated after being marked immutable. */
   immutable?: boolean;
 }
 


### PR DESCRIPTION
### Packages impacted by this PR
@azure/keyvault-keys

### Issues associated with this PR
#18400

### Describe the problem that is addressed by this PR
The service team would like to document the release policy grammar, and as such
has asked us to link to their documentation. While the documentation is not live
yet, I did get the content folks to point it to a valid url so that we can
include it in our doc-comments now.

### Checklists
- [x] Added impacted package name to the issue description.
- [x] Does this PR need any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here.)_
- [x] Added a changelog (if necessary).
