### PR TITLE
Do not overwrite existing labels on auto generated dependency upgrade…

### DIFF
--- a/eng/scripts/check-external-dependency.ps1
+++ b/eng/scripts/check-external-dependency.ps1
@@ -58,7 +58,6 @@ function Set-GitHubIssue($Package) {
   if ($issue) {
     if ($issue.body -ne $issueDesc) {
       # Copy over current lables to avoid removing manually tagged labels
-      Write-Host "Labels: $($issue.labels)"
       foreach($lbl in $issue.labels)
       {
         $labels += ",$($lbl.name)"
@@ -101,7 +100,7 @@ Write-Host "Running rush update"
 $rushUpdateOutput = node common/scripts/install-run-rush.js update --full
 write-host $rushUpdateOutput
 foreach ($line in $rushUpdateOutput) {
-  if ($line -match $dependencyRegex -and !$matches['pkg'].StartsWith("@azure") -and $matches['pkg'].StartsWith('mocha')) {
+  if ($line -match $dependencyRegex -and !$matches['pkg'].StartsWith("@azure")) {
     $p = New-Object PSObject -Property @{
       Name         = $matches['pkg']  
       OldVersion   = [AzureEngSemanticVersion]::ParseVersionString($matches['version'])

--- a/eng/scripts/check-external-dependency.ps1
+++ b/eng/scripts/check-external-dependency.ps1
@@ -57,8 +57,15 @@ function Set-GitHubIssue($Package) {
   $issue = Get-GithubIssue -IssueTitle $issueTitle
   if ($issue) {
     if ($issue.body -ne $issueDesc) {
+      # Copy over current lables to avoid removing manually tagged labels
+      Write-Host "Labels: $($issue.labels)"
+      foreach($lbl in $issue.labels)
+      {
+        $labels += ",$($lbl.name)"
+      }
+      Write-Host "Updating existing issue  $($issue.number). Labels: $($labels)"
       $oldIssue = Update-GitHubIssue -RepoOwner $RepoOwner -RepoName $RepoName -AuthToken $AuthToken -IssueNumber $issue.number -Body $issueDesc -Labels $labels
-      Write-Host "Updated existing issue $($oldIssue.number)"      
+      Write-Host "Updated existing issue $($oldIssue.number)"
     }
     else {
       Write-Host "Found existing issue for package $($Package.Name)"
@@ -94,10 +101,10 @@ Write-Host "Running rush update"
 $rushUpdateOutput = node common/scripts/install-run-rush.js update --full
 write-host $rushUpdateOutput
 foreach ($line in $rushUpdateOutput) {
-  if ($line -match $dependencyRegex -and !$matches['pkg'].StartsWith("@azure")) { 
+  if ($line -match $dependencyRegex -and !$matches['pkg'].StartsWith("@azure") -and $matches['pkg'].StartsWith('mocha')) {
     $p = New-Object PSObject -Property @{
       Name         = $matches['pkg']  
-      OldVersion   = [AzureEngSemanticVersion]::ParseVersionString($matches['version'])        
+      OldVersion   = [AzureEngSemanticVersion]::ParseVersionString($matches['version'])
       NewVersion   = [AzureEngSemanticVersion]::ParseVersionString($matches['newVersion'])
       IsDeprecated = ($matches['deprecated'] -eq "deprecated")
     }

--- a/eng/scripts/check-external-dependency.ps1
+++ b/eng/scripts/check-external-dependency.ps1
@@ -57,7 +57,7 @@ function Set-GitHubIssue($Package) {
   $issue = Get-GithubIssue -IssueTitle $issueTitle
   if ($issue) {
     if ($issue.body -ne $issueDesc) {
-      # Copy over current lables to avoid removing manually tagged labels
+      # Copy over current labels to avoid removing manually tagged labels
       foreach($lbl in $issue.labels)
       {
         $labels += ",$($lbl.name)"


### PR DESCRIPTION
Automation task to detect and file issue to upgrade dependencies is overwriting labels if issue already exists for that package but with older version details.