### PR TITLE
Support the skipUrlEncoding option at query parameter

### DIFF
--- a/sdk/core/core-client-rest/src/urlHelpers.ts
+++ b/sdk/core/core-client-rest/src/urlHelpers.ts
@@ -18,39 +18,13 @@ export function buildRequestUrl(
   pathParameters: string[],
   options: RequestParameters = {}
 ): string {
-  let path = routePath;
-
-  if (path.startsWith("https://") || path.startsWith("http://")) {
-    return path;
+  if (routePath.startsWith("https://") || routePath.startsWith("http://")) {
+    return routePath;
   }
-
   baseUrl = buildBaseUrl(baseUrl, options);
-
-  for (const pathParam of pathParameters) {
-    let value = pathParam;
-    if (!options.skipUrlEncoding) {
-      value = encodeURIComponent(pathParam);
-    }
-
-    path = path.replace(/{([^/]+)}/, value);
-  }
-
-  const url = new URL(`${baseUrl}/${path}`);
-
-  if (options.queryParameters) {
-    const queryParams = options.queryParameters;
-    for (const key of Object.keys(queryParams)) {
-      const param = queryParams[key] as any;
-      if (param === undefined || param === null) {
-        continue;
-      }
-      if (!param.toString || typeof param.toString !== "function") {
-        throw new Error(`Query parameters must be able to be represented as string, ${key} can't`);
-      }
-      const value = param.toISOString !== undefined ? param.toISOString() : param.toString();
-      url.searchParams.append(key, value);
-    }
-  }
+  routePath = buildRoutePath(routePath, pathParameters, options);
+  const requestUrl = appendQueryParams(`${baseUrl}/${routePath}`, options);
+  const url = new URL(requestUrl);
 
   return (
     url
@@ -58,6 +32,40 @@ export function buildRequestUrl(
       // Remove double forward slashes
       .replace(/([^:]\/)\/+/g, "$1")
   );
+}
+
+function appendQueryParams(
+  url: string,
+  options: RequestParameters = {}
+) {
+  if (!options.queryParameters) {
+    return url;
+  }
+  const parsedUrl = new URL(url);
+  const queryParams = options.queryParameters;
+  for (const key of Object.keys(queryParams)) {
+    const param = queryParams[key] as any;
+    if (param === undefined || param === null) {
+      continue;
+    }
+    if (!param.toString || typeof param.toString !== "function") {
+      throw new Error(`Query parameters must be able to be represented as string, ${key} can't`);
+    }
+    const value = param.toISOString !== undefined ? param.toISOString() : param.toString();
+    parsedUrl.searchParams.append(key, value);
+  }
+
+  const searchPieces: string[] = [];
+  for (let [name, value] of parsedUrl.searchParams) {
+    // QUIRK: encode only values by default
+    if (!options.skipUrlEncoding) {
+      value = encodeURIComponent(value);
+    }
+    searchPieces.push(`${name}=${value}`);
+  }
+  // QUIRK: we have to set search manually as searchParams will encode comma when it shouldn't.
+  parsedUrl.search = searchPieces.length ? `?${searchPieces.join("&")}` : "";
+  return parsedUrl.toString();
 }
 
 export function buildBaseUrl(baseUrl: string, options: RequestParameters): string {
@@ -79,6 +87,20 @@ export function buildBaseUrl(baseUrl: string, options: RequestParameters): strin
     baseUrl = replaceAll(baseUrl, `{${key}}`, value) ?? "";
   }
   return baseUrl;
+}
+
+function buildRoutePath(routePath: string,
+  pathParameters: string[],
+  options: RequestParameters = {}) {
+  for (const pathParam of pathParameters) {
+    let value = pathParam;
+    if (!options.skipUrlEncoding) {
+      value = encodeURIComponent(pathParam);
+    }
+
+    routePath = routePath.replace(/{([^/]+)}/, value);
+  }
+  return routePath;
 }
 
 /**

--- a/sdk/core/core-client-rest/src/urlHelpers.ts
+++ b/sdk/core/core-client-rest/src/urlHelpers.ts
@@ -41,7 +41,7 @@ function appendQueryParams(
   if (!options.queryParameters) {
     return url;
   }
-  const parsedUrl = new URL(url);
+  let parsedUrl = new URL(url);
   const queryParams = options.queryParameters;
   for (const key of Object.keys(queryParams)) {
     const param = queryParams[key] as any;
@@ -55,17 +55,24 @@ function appendQueryParams(
     parsedUrl.searchParams.append(key, value);
   }
 
+  if (options.skipUrlEncoding) {
+    parsedUrl = skipQueryParameterEncoding(parsedUrl);
+  }
+  return parsedUrl.toString();
+}
+
+function skipQueryParameterEncoding(url: URL) {
+  if (!url) {
+    return url;
+  }
   const searchPieces: string[] = [];
-  for (let [name, value] of parsedUrl.searchParams) {
-    // QUIRK: encode only values by default
-    if (!options.skipUrlEncoding) {
-      value = encodeURIComponent(value);
-    }
+  for (let [name, value] of url.searchParams) {
+    // QUIRK: searchParams.get will NOT encode the values
     searchPieces.push(`${name}=${value}`);
   }
   // QUIRK: we have to set search manually as searchParams will encode comma when it shouldn't.
-  parsedUrl.search = searchPieces.length ? `?${searchPieces.join("&")}` : "";
-  return parsedUrl.toString();
+  url.search = searchPieces.length ? `?${searchPieces.join("&")}` : "";
+  return url;
 }
 
 export function buildBaseUrl(baseUrl: string, options: RequestParameters): string {

--- a/sdk/core/core-client-rest/src/urlHelpers.ts
+++ b/sdk/core/core-client-rest/src/urlHelpers.ts
@@ -34,10 +34,7 @@ export function buildRequestUrl(
   );
 }
 
-function appendQueryParams(
-  url: string,
-  options: RequestParameters = {}
-) {
+function appendQueryParams(url: string, options: RequestParameters = {}) {
   if (!options.queryParameters) {
     return url;
   }
@@ -96,9 +93,11 @@ export function buildBaseUrl(baseUrl: string, options: RequestParameters): strin
   return baseUrl;
 }
 
-function buildRoutePath(routePath: string,
+function buildRoutePath(
+  routePath: string,
   pathParameters: string[],
-  options: RequestParameters = {}) {
+  options: RequestParameters = {}
+) {
   for (const pathParam of pathParameters) {
     let value = pathParam;
     if (!options.skipUrlEncoding) {

--- a/sdk/core/core-client-rest/src/urlHelpers.ts
+++ b/sdk/core/core-client-rest/src/urlHelpers.ts
@@ -64,7 +64,7 @@ function skipQueryParameterEncoding(url: URL) {
   }
   const searchPieces: string[] = [];
   for (let [name, value] of url.searchParams) {
-    // QUIRK: searchParams.get will NOT encode the values
+    // QUIRK: searchParams.get retrieves the values decoded
     searchPieces.push(`${name}=${value}`);
   }
   // QUIRK: we have to set search manually as searchParams will encode comma when it shouldn't.

--- a/sdk/core/core-client-rest/test/urlHelpers.spec.ts
+++ b/sdk/core/core-client-rest/test/urlHelpers.spec.ts
@@ -44,6 +44,15 @@ describe("urlHelpers", () => {
     assert.equal(result, `https://example.org/foo/one?foo=1&bar=two&$maxpagesize=1&$skip=$_20`);
   });
 
+  it("should skip encoding if the client already encoded the parameters", () => {
+    const result = buildRequestUrl(mockBaseUrl, "/foo/{id}", ["one"], {
+      queryParameters: { foo: "%24encoded%20value" }, // the value is already encoded so we could enable the setting skipUrlEncoding
+      skipUrlEncoding: true,
+    });
+
+    assert.equal(result, `https://example.org/foo/one?foo=%24encoded%20value`);
+  });
+
   it("should enable encoding for values in query parameter", () => {
     const result = buildRequestUrl(mockBaseUrl, "/foo/{id}", ["one"], {
       queryParameters: { foo: "1", bar: "two", $maxpagesize: 1, $skip: "$_20" },

--- a/sdk/core/core-client-rest/test/urlHelpers.spec.ts
+++ b/sdk/core/core-client-rest/test/urlHelpers.spec.ts
@@ -32,7 +32,7 @@ describe("urlHelpers", () => {
       queryParameters: { foo: "1", bar: "two", $maxpagesize: 1, $skip: 2 },
     });
 
-    assert.equal(result, `https://example.org/foo/one?foo=1&bar=two&$maxpagesize=1&$skip=2`);
+    assert.equal(result, `https://example.org/foo/one?foo=1&bar=two&%24maxpagesize=1&%24skip=2`);
   });
 
   it("should skip encoding for values in query parameter", () => {
@@ -50,7 +50,7 @@ describe("urlHelpers", () => {
       skipUrlEncoding: false
     });
 
-    assert.equal(result, `https://example.org/foo/one?foo=1&bar=two&$maxpagesize=1&$skip=%24_20`);
+    assert.equal(result, `https://example.org/foo/one?foo=1&bar=two&%24maxpagesize=1&%24skip=%24_20`);
   });
 
   it("should append date query parameter as ISO string", () => {
@@ -90,7 +90,7 @@ describe("urlHelpers", () => {
       },
     });
 
-    assert.equal(result, `https://example.org/foo?existing=hey&arrayQuery=ArrayQuery1%2Cbegin!*%27()%3B%3A%40%20%26%3D%2B%24%2C%2F%3F%23%5B%5Dend%2C%2C`);
+    assert.equal(result, `https://example.org/foo?existing=hey&arrayQuery=ArrayQuery1%2Cbegin%21*%27%28%29%3B%3A%40+%26%3D%2B%24%2C%2F%3F%23%5B%5Dend%2C%2C`);
     result = buildRequestUrl(mockBaseUrl, "/foo?existing=hey", [], {
       queryParameters: {
         arrayQuery: []
@@ -113,7 +113,7 @@ describe("urlHelpers", () => {
     const result = buildRequestUrl(mockBaseUrl, "/foo", [], {
       queryParameters: { foo: " aaaa", bar: "b= " },
     });
-    assert.equal(result, `https://example.org/foo?foo=%20aaaa&bar=b%3D%20`);
+    assert.equal(result, `https://example.org/foo?foo=+aaaa&bar=b%3D+`);
   });
 
   it("should encode url when skip encoding path parameter", () => {

--- a/sdk/core/core-client-rest/test/urlHelpers.spec.ts
+++ b/sdk/core/core-client-rest/test/urlHelpers.spec.ts
@@ -38,7 +38,7 @@ describe("urlHelpers", () => {
   it("should skip encoding for values in query parameter", () => {
     const result = buildRequestUrl(mockBaseUrl, "/foo/{id}", ["one"], {
       queryParameters: { foo: "1", bar: "two", $maxpagesize: 1, $skip: "$_20" },
-      skipUrlEncoding: true
+      skipUrlEncoding: true,
     });
 
     assert.equal(result, `https://example.org/foo/one?foo=1&bar=two&$maxpagesize=1&$skip=$_20`);
@@ -47,10 +47,13 @@ describe("urlHelpers", () => {
   it("should enable encoding for values in query parameter", () => {
     const result = buildRequestUrl(mockBaseUrl, "/foo/{id}", ["one"], {
       queryParameters: { foo: "1", bar: "two", $maxpagesize: 1, $skip: "$_20" },
-      skipUrlEncoding: false
+      skipUrlEncoding: false,
     });
 
-    assert.equal(result, `https://example.org/foo/one?foo=1&bar=two&%24maxpagesize=1&%24skip=%24_20`);
+    assert.equal(
+      result,
+      `https://example.org/foo/one?foo=1&bar=two&%24maxpagesize=1&%24skip=%24_20`
+    );
   });
 
   it("should append date query parameter as ISO string", () => {
@@ -78,22 +81,20 @@ describe("urlHelpers", () => {
   });
 
   it("should build url with array queries", () => {
-    const testArray = [
-      "ArrayQuery1",
-      "begin!*'();:@ &=+$,/?#[]end",
-      null as any,
-      ""
-    ] as string[];
+    const testArray = ["ArrayQuery1", "begin!*'();:@ &=+$,/?#[]end", null as any, ""] as string[];
     let result = buildRequestUrl(mockBaseUrl, "/foo?existing=hey", [], {
       queryParameters: {
-        arrayQuery: testArray
+        arrayQuery: testArray,
       },
     });
 
-    assert.equal(result, `https://example.org/foo?existing=hey&arrayQuery=ArrayQuery1%2Cbegin%21*%27%28%29%3B%3A%40+%26%3D%2B%24%2C%2F%3F%23%5B%5Dend%2C%2C`);
+    assert.equal(
+      result,
+      `https://example.org/foo?existing=hey&arrayQuery=ArrayQuery1%2Cbegin%21*%27%28%29%3B%3A%40+%26%3D%2B%24%2C%2F%3F%23%5B%5Dend%2C%2C`
+    );
     result = buildRequestUrl(mockBaseUrl, "/foo?existing=hey", [], {
       queryParameters: {
-        arrayQuery: []
+        arrayQuery: [],
       },
     });
     assert.equal(result, `https://example.org/foo?existing=hey&arrayQuery=`);


### PR DESCRIPTION
### Background
During Metrics Advisor exmperienment, we found that the nextLink functionality is not working well if we encoded the query keys in URL. You could try it by [this call](https://endpoint.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds?dataFeedName=js-test-&%24maxpagesize=1). So I fix this by

1. Only encode the query values and keep the keys as themselves
2. Support the skipUrlEncoding option at query value level


All integration cases in autorest.typescript repo has passed.

### Detailed
#20987 