### PR TITLE
Update aggregate pipeline to use common variables

### DIFF
--- a/eng/pipelines/aggregate-reports.yml
+++ b/eng/pipelines/aggregate-reports.yml
@@ -9,8 +9,7 @@ pr:
       - eng/pipelines/aggregate-reports.yml
 
 pool:
-  name: azsdk-pool-mms-ubuntu-2004-general
-  vmImage: MMSUbuntu20.04
+  vmImage: 'windows-2019'
 
 stages:
   - stage: AggregateReports

--- a/eng/pipelines/aggregate-reports.yml
+++ b/eng/pipelines/aggregate-reports.yml
@@ -20,7 +20,7 @@ stages:
       - job: GenerateReports
         timeoutInMinutes: 120
         variables:
-          - template: ../variables/globals.yml        
+          - template: /eng/pipelines/templates/variables/globals.yml        
         steps:
           - template: /eng/pipelines/templates/steps/common.yml
 

--- a/eng/pipelines/aggregate-reports.yml
+++ b/eng/pipelines/aggregate-reports.yml
@@ -30,6 +30,10 @@ stages:
               pwsh: true
             displayName: Spell check public API
 
+          - template: /eng/pipelines/templates/steps/use-node-version.yml
+            parameters:
+              NodeVersion: 10.x
+
           - template: ../common/pipelines/templates/steps/verify-links.yml
             parameters:
               Directory: ""

--- a/eng/pipelines/aggregate-reports.yml
+++ b/eng/pipelines/aggregate-reports.yml
@@ -9,7 +9,8 @@ pr:
       - eng/pipelines/aggregate-reports.yml
 
 pool:
-  vmImage: 'windows-2019'
+  name: azsdk-pool-mms-ubuntu-2004-general
+  vmImage: MMSUbuntu20.04
 
 stages:
   - stage: AggregateReports
@@ -18,10 +19,10 @@ stages:
     jobs:
       - job: GenerateReports
         timeoutInMinutes: 120
+        variables:
+          - template: ../variables/globals.yml        
         steps:
-          - template: /eng/pipelines/templates/steps/use-node-version.yml
-            parameters:
-              NodeVersion: 16.x
+          - template: /eng/pipelines/templates/steps/common.yml
 
           - task: PowerShell@2
             inputs:
@@ -29,10 +30,6 @@ stages:
               filePath: eng/scripts/spell-check-public-api.ps1
               pwsh: true
             displayName: Spell check public API
-
-          - template: /eng/pipelines/templates/steps/use-node-version.yml
-            parameters:
-              NodeVersion: 10.x
 
           - template: ../common/pipelines/templates/steps/verify-links.yml
             parameters:


### PR DESCRIPTION
Aggregate pipeline should use common variables to get default node version to be used by the pipeline.