### PR TITLE
[EventHubs][Test] work around issue with fresh hubs and start positions

### DIFF
--- a/sdk/eventhub/event-hubs/test/public/eventData.spec.ts
+++ b/sdk/eventhub/event-hubs/test/public/eventData.spec.ts
@@ -110,6 +110,15 @@ testWithServiceTypes((serviceVersion) => {
     }
 
     describe("round-tripping AMQP encoding/decoding", () => {
+      beforeEach(
+        "work around initial state issue by filling partitions with at least one message",
+        async () => {
+          for (let i = 1; i < 100; i++) {
+            const filer = { body: "b", messageId: v4() };
+            await producerClient.sendBatch([filer]);
+          }
+        }
+      );
       it(`props`, async () => {
         const startingPositions = await getStartingPositionsForTests(consumerClient);
         const testEvent = getSampleEventData();


### PR DESCRIPTION
While we continue investigating why using a filter of
`amqp.annotation.x-opt-sequence-number > '-1'` doesn't work on freshly-created
hub whose starting sequence numbers are all `-1`, this change would allow the
test to pass.
