### PR TITLE
[keyvault] - KnownKeyUsageTypes should not be a const enum

### DIFF
--- a/sdk/keyvault/keyvault-certificates/review/keyvault-certificates.api.md
+++ b/sdk/keyvault/keyvault-certificates/review/keyvault-certificates.api.md
@@ -383,7 +383,7 @@ export enum KnownDeletionRecoveryLevels {
 }
 
 // @public
-export const enum KnownKeyUsageTypes {
+export enum KnownKeyUsageTypes {
     CRLSign = "cRLSign",
     DataEncipherment = "dataEncipherment",
     DecipherOnly = "decipherOnly",

--- a/sdk/keyvault/keyvault-certificates/src/certificatesModels.ts
+++ b/sdk/keyvault/keyvault-certificates/src/certificatesModels.ts
@@ -864,7 +864,7 @@ export enum KnownCertificateKeyTypes {
 }
 
 /** Known values of {@link KeyUsageType} that the service accepts. */
-export const enum KnownKeyUsageTypes {
+export enum KnownKeyUsageTypes {
   /**
    * DigitalSignature Usage Type.
    */


### PR DESCRIPTION
### Packages impacted by this PR
@azure/keyvault-certificates

### Issues associated with this PR
N/A  - architect review

### Describe the problem that is addressed by this PR
@xirzec noticed that in our effort to move away from `const enum` I forgot one 😄 

This PR fixes that by making it a non-const enum

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [ ] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
