### PR TITLE
Replace `getRequiredEnvVar` function with `assertEnvironmentVariable` helper from new recorder

### DIFF
--- a/sdk/monitor/monitor-query/test/public/logsQueryClient.spec.ts
+++ b/sdk/monitor/monitor-query/test/public/logsQueryClient.spec.ts
@@ -25,7 +25,7 @@ describe("LogsQueryClient live tests", function () {
     loggerForTest.verbose(`Recorder: starting...`);
     recorder = new Recorder(this.currentTest);
     const recordedClient: RecorderAndLogsClient = await createRecorderAndLogsClient(recorder);
-    monitorWorkspaceId = getMonitorWorkspaceId(this);
+    monitorWorkspaceId = getMonitorWorkspaceId();
     logsClient = recordedClient.client;
   });
   afterEach(async function () {
@@ -470,7 +470,7 @@ describe("LogsQueryClient live tests - server timeout", function () {
     });
     logsClient = recordedClient.client;
     recorder = recordedClient.recorder;
-    monitorWorkspaceId = getMonitorWorkspaceId(this);
+    monitorWorkspaceId = getMonitorWorkspaceId();
   });
   afterEach(async function () {
     loggerForTest.verbose("Recorder: stopping");

--- a/sdk/monitor/monitor-query/test/public/metricsQueryClient.spec.ts
+++ b/sdk/monitor/monitor-query/test/public/metricsQueryClient.spec.ts
@@ -22,7 +22,7 @@ describe("MetricsClient live tests", function () {
     loggerForTest.verbose(`Recorder: starting...`);
     recorder = new Recorder(this.currentTest);
     const recordedClient: RecorderAndMetricsClient = await createRecorderAndMetricsClient(recorder);
-    ({ resourceId } = getMetricsArmResourceId(this));
+    ({ resourceId } = getMetricsArmResourceId());
     metricsQueryClient = recordedClient.client;
   });
 

--- a/sdk/monitor/monitor-query/test/public/shared/testShared.ts
+++ b/sdk/monitor/monitor-query/test/public/shared/testShared.ts
@@ -1,9 +1,13 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 import { createTestCredential } from "@azure-tools/test-credential";
-import { env, Recorder, RecorderStartOptions } from "@azure-tools/test-recorder";
+import {
+  env,
+  Recorder,
+  RecorderStartOptions,
+  assertEnvironmentVariable,
+} from "@azure-tools/test-recorder";
 import * as assert from "assert";
-import { Context } from "mocha";
 import { createClientLogger } from "@azure/logger";
 import { LogsTable, LogsQueryClient, MetricsQueryClient } from "../../../src";
 import { ExponentialRetryPolicyOptions } from "@azure/core-rest-pipeline";
@@ -70,21 +74,20 @@ export async function createRecorderAndLogsClient(
   };
 }
 
-export function getMonitorWorkspaceId(mochaContext: Pick<Context, "skip">): string {
-  return getRequiredEnvVar(mochaContext, "MONITOR_WORKSPACE_ID");
+export function getMonitorWorkspaceId(): string {
+  return assertEnvironmentVariable("MONITOR_WORKSPACE_ID");
 }
 
-export function getMetricsArmResourceId(mochaContext: Pick<Context, "skip">): {
+export function getMetricsArmResourceId(): {
   resourceId: string;
 } {
   return {
-    resourceId: getRequiredEnvVar(mochaContext, "METRICS_RESOURCE_ID"),
+    resourceId: assertEnvironmentVariable("METRICS_RESOURCE_ID"),
   };
 }
 
-export function getAppInsightsConnectionString(mochaContext: Pick<Context, "skip">): string {
-  let appInsightsConnectionString = getRequiredEnvVar(
-    mochaContext,
+export function getAppInsightsConnectionString(): string {
+  let appInsightsConnectionString = assertEnvironmentVariable(
     "MQ_APPLICATIONINSIGHTS_CONNECTION_STRING"
   );
 
@@ -96,21 +99,6 @@ export function getAppInsightsConnectionString(mochaContext: Pick<Context, "skip
   );
 
   return appInsightsConnectionString;
-}
-
-function getRequiredEnvVar(mochaContext: Pick<Context, "skip">, variableName: string): string {
-  const envVar = env[variableName];
-
-  if (!envVar) {
-    console.log(
-      `TODO: live tests skipped until test-resources + data population is set up (missing ${variableName} env var).`
-    );
-    mochaContext.skip();
-
-    throw new Error(`Missing ${variableName} env var`);
-  }
-
-  return envVar ?? "";
 }
 
 export function printLogQueryTables(tables: LogsTable[]): void {


### PR DESCRIPTION
### Packages impacted by this PR
`@azure/monitor-query`

### Issues associated with this PR

- https://github.com/Azure/azure-sdk-for-js/issues/21005

### Describe the problem that is addressed by this PR
This PR introduces a small change. The function `getRequiredEnvVar()` is no longer necessary since the new recorder provides a helper method [`assertEnvironmentVariable()`](https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/test-utils/recorder/src/utils/utils.ts#L355-L362) that behaves in the same way.

### Provide a list of related PRs _(if any)_
This change was originally proposed in https://github.com/Azure/azure-sdk-for-js/pull/20178#discussion_r804952261

### Checklists
- [X] Added impacted package name to the issue description
- [X] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [X] Added a changelog (if necessary)
