### PR TITLE
[Identity] ManagedIdentityCredential MSI order

### DIFF
--- a/sdk/identity/identity/src/credentials/managedIdentityCredential/index.ts
+++ b/sdk/identity/identity/src/credentials/managedIdentityCredential/index.ts
@@ -127,11 +127,11 @@ export class ManagedIdentityCredential implements TokenCredential {
     }
 
     const MSIs = [
+      arcMsi,
       fabricMsi,
       appServiceMsi2019,
       appServiceMsi2017,
       cloudShellMsi,
-      arcMsi,
       tokenExchangeMsi(),
       imdsMsi,
     ];


### PR DESCRIPTION
The order of MSIs that all languages should align to is:

1. Arc.    
2. Fabric.    
3. App Service 2019.                                                                                                            
4. App Service 2017.                                                           
5. Cloud Shell.                                                                               
6. Pod Identity v2.                                                            
7. IMDS / Pod Identity v1.  

For us, that only means moving the Arc MSI to be the first.

Feedback appreciated.