### PR TITLE
[Schema Registry Avro] Add AvroSerializationError

### DIFF
--- a/sdk/schemaregistry/schema-registry-avro/CHANGELOG.md
+++ b/sdk/schemaregistry/schema-registry-avro/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.0.0 (Unreleased)
 
 ### Features Added
+- A new error type, `AvroSerializationError`, is added and is thrown in all error cases except for service calls.
 
 ### Breaking Changes
 

--- a/sdk/schemaregistry/schema-registry-avro/README.md
+++ b/sdk/schemaregistry/schema-registry-avro/README.md
@@ -107,6 +107,8 @@ const deserializedValue = await serializer.deserializeMessageData(message);
 
 ## Troubleshooting
 
+The Avro serializer communicates with the [Schema Registry][schema_registry] service as needed to register or query schemas and those service calls could throw a [RestError][resterror]. Furthermore, errors of type `AvroSerializationError` will be thrown when serialization or deserialization fails. The `innerError` property will contain the underlying error that was thrown from the Avro implementation library.
+
 ### Logging
 
 Enabling logging may help uncover useful information about failures. In order to
@@ -160,3 +162,5 @@ learn more about how to build and test the code.
 [azure_portal]: https://portal.azure.com
 [azure_identity]: https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/identity/identity
 [defaultazurecredential]: https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/identity/identity#defaultazurecredential
+[resterror]: https://docs.microsoft.com/javascript/api/@azure/core-rest-pipeline/resterror?view=azure-node-latest
+[schema_registry]: https://docs.microsoft.com/javascript/api/overview/azure/schema-registry-readme?view=azure-node-latest

--- a/sdk/schemaregistry/schema-registry-avro/review/schema-registry-avro.api.md
+++ b/sdk/schemaregistry/schema-registry-avro/review/schema-registry-avro.api.md
@@ -7,6 +7,12 @@
 import { SchemaRegistry } from '@azure/schema-registry';
 
 // @public
+export class AvroSerializationError extends Error {
+    constructor(message: string, innerError?: unknown);
+    innerError?: unknown;
+}
+
+// @public
 export class AvroSerializer<MessageT = MessageWithMetadata> {
     constructor(client: SchemaRegistry, options?: AvroSerializerOptions<MessageT>);
     deserializeMessageData(message: MessageT, options?: DeserializeMessageDataOptions): Promise<unknown>;

--- a/sdk/schemaregistry/schema-registry-avro/src/avroSerializer.ts
+++ b/sdk/schemaregistry/schema-registry-avro/src/avroSerializer.ts
@@ -3,6 +3,7 @@
 
 import * as avro from "avsc";
 import {
+  AvroSerializationError,
   AvroSerializerOptions,
   DeserializeMessageDataOptions,
   MessageAdapter,
@@ -72,7 +73,10 @@ export class AvroSerializer<MessageT = MessageWithMetadata> {
    */
   async serializeMessageData(value: unknown, schema: string): Promise<MessageT> {
     const entry = await this.getSchemaByDefinition(schema);
-    const buffer = entry.serializer.toBuffer(value);
+    const buffer = wrapException(
+      () => entry.serializer.toBuffer(value),
+      "Avro serialization failed. See innerException for more details."
+    );
     const payload = new Uint8Array(
       buffer.buffer,
       buffer.byteOffset,
@@ -114,10 +118,19 @@ export class AvroSerializer<MessageT = MessageWithMetadata> {
     const writerSchemaSerializer = await this.getSchemaById(writerSchemaId);
     if (readerSchema) {
       const readerSchemaSerializer = getSerializerForSchema(readerSchema);
-      const resolver = readerSchemaSerializer.createResolver(writerSchemaSerializer);
-      return readerSchemaSerializer.fromBuffer(buffer, resolver, true);
+      const resolver = wrapException(
+        () => readerSchemaSerializer.createResolver(writerSchemaSerializer),
+        `Avro reader schema is incompatible with the writer schema (schema ID: (${writerSchemaId})):\n\n\treader schema: ${readerSchema}\n\nSee innerException for more details.`
+      );
+      return wrapException(
+        () => readerSchemaSerializer.fromBuffer(buffer, resolver, true),
+        `Avro deserialization with reader schema failed: \n\treader schema: ${readerSchema}\nSee innerException for more details.`
+      );
     } else {
-      return writerSchemaSerializer.fromBuffer(buffer);
+      return wrapException(
+        () => writerSchemaSerializer.fromBuffer(buffer),
+        `Avro deserialization failed with schema ID (${writerSchemaId}). See innerException for more details.`
+      );
     }
   }
 
@@ -129,11 +142,11 @@ export class AvroSerializer<MessageT = MessageWithMetadata> {
 
     const schemaResponse = await this.registry.getSchema(schemaId);
     if (!schemaResponse) {
-      throw new Error(`Schema with ID '${schemaId}' not found.`);
+      throw new AvroSerializationError(`Schema with ID '${schemaId}' not found.`);
     }
 
     if (!schemaResponse.properties.format.match(/^avro$/i)) {
-      throw new Error(
+      throw new AvroSerializationError(
         `Schema with ID '${schemaResponse.properties.id}' has format '${schemaResponse.properties.format}', not 'avro'.`
       );
     }
@@ -150,11 +163,11 @@ export class AvroSerializer<MessageT = MessageWithMetadata> {
 
     const avroType = getSerializerForSchema(schema);
     if (!avroType.name) {
-      throw new Error("Schema must have a name.");
+      throw new AvroSerializationError("Schema must have a name.");
     }
 
     if (!this.schemaGroup) {
-      throw new Error(
+      throw new AvroSerializationError(
         "Schema group must have been specified in the constructor options when the client was created in order to serialize."
       );
     }
@@ -174,7 +187,7 @@ export class AvroSerializer<MessageT = MessageWithMetadata> {
         id = (await this.registry.getSchemaProperties(description)).id;
       } catch (e) {
         if (e.statusCode === 404) {
-          throw new Error(
+          throw new AvroSerializationError(
             `Schema '${description.name}' not found in registry group '${description.groupName}', or not found to have matching definition.`
           );
         } else {
@@ -200,10 +213,12 @@ export class AvroSerializer<MessageT = MessageWithMetadata> {
 function getSchemaId(contentType: string): string {
   const contentTypeParts = contentType.split("+");
   if (contentTypeParts.length !== 2) {
-    throw new Error("Content type was not in the expected format of MIME type + schema ID");
+    throw new AvroSerializationError(
+      "Content type was not in the expected format of MIME type + schema ID"
+    );
   }
   if (contentTypeParts[0] !== avroMimeType) {
-    throw new Error(
+    throw new AvroSerializationError(
       `Received content of type ${contentTypeParts[0]} but an avro serializer may only be used on content that is of '${avroMimeType}' type`
     );
   }
@@ -239,7 +254,7 @@ function convertMessage<MessageT>(
   } else if (isMessageWithMetadata(message)) {
     return convertPayload(message.body, message.contentType);
   } else {
-    throw new Error(
+    throw new AvroSerializationError(
       `Expected either a message adapter to be provided to the serializer or the input message to have body and contentType fields`
     );
   }
@@ -272,5 +287,18 @@ function tryReadingPreambleFormat(buffer: Buffer): MessageWithMetadata {
 }
 
 function getSerializerForSchema(schema: string): AVSCSerializer {
-  return avro.Type.forSchema(JSON.parse(schema), { omitRecordMethods: true });
+  return wrapException(
+    () => avro.Type.forSchema(JSON.parse(schema), { omitRecordMethods: true }),
+    `Parsing Avro schema failed:\n\n\t${schema}\n\nSee innerException for more details.`
+  );
+}
+
+function wrapException<T>(f: () => T, message: string): T {
+  let result: T;
+  try {
+    result = f();
+  } catch (innerException) {
+    throw new AvroSerializationError(message, innerException);
+  }
+  return result;
 }

--- a/sdk/schemaregistry/schema-registry-avro/src/avroSerializer.ts
+++ b/sdk/schemaregistry/schema-registry-avro/src/avroSerializer.ts
@@ -75,7 +75,7 @@ export class AvroSerializer<MessageT = MessageWithMetadata> {
     const entry = await this.getSchemaByDefinition(schema);
     const buffer = wrapException(
       () => entry.serializer.toBuffer(value),
-      "Avro serialization failed. See innerException for more details."
+      "Avro serialization failed. See innerError for more details."
     );
     const payload = new Uint8Array(
       buffer.buffer,
@@ -120,16 +120,16 @@ export class AvroSerializer<MessageT = MessageWithMetadata> {
       const readerSchemaSerializer = getSerializerForSchema(readerSchema);
       const resolver = wrapException(
         () => readerSchemaSerializer.createResolver(writerSchemaSerializer),
-        `Avro reader schema is incompatible with the writer schema (schema ID: (${writerSchemaId})):\n\n\treader schema: ${readerSchema}\n\nSee innerException for more details.`
+        `Avro reader schema is incompatible with the writer schema (schema ID: (${writerSchemaId})):\n\n\treader schema: ${readerSchema}\n\nSee innerError for more details.`
       );
       return wrapException(
         () => readerSchemaSerializer.fromBuffer(buffer, resolver, true),
-        `Avro deserialization with reader schema failed: \n\treader schema: ${readerSchema}\nSee innerException for more details.`
+        `Avro deserialization with reader schema failed: \n\treader schema: ${readerSchema}\nSee innerError for more details.`
       );
     } else {
       return wrapException(
         () => writerSchemaSerializer.fromBuffer(buffer),
-        `Avro deserialization failed with schema ID (${writerSchemaId}). See innerException for more details.`
+        `Avro deserialization failed with schema ID (${writerSchemaId}). See innerError for more details.`
       );
     }
   }
@@ -289,7 +289,7 @@ function tryReadingPreambleFormat(buffer: Buffer): MessageWithMetadata {
 function getSerializerForSchema(schema: string): AVSCSerializer {
   return wrapException(
     () => avro.Type.forSchema(JSON.parse(schema), { omitRecordMethods: true }),
-    `Parsing Avro schema failed:\n\n\t${schema}\n\nSee innerException for more details.`
+    `Parsing Avro schema failed:\n\n\t${schema}\n\nSee innerError for more details.`
   );
 }
 
@@ -297,8 +297,8 @@ function wrapException<T>(f: () => T, message: string): T {
   let result: T;
   try {
     result = f();
-  } catch (innerException) {
-    throw new AvroSerializationError(message, innerException);
+  } catch (innerError) {
+    throw new AvroSerializationError(message, innerError);
   }
   return result;
 }

--- a/sdk/schemaregistry/schema-registry-avro/src/avroSerializer.ts
+++ b/sdk/schemaregistry/schema-registry-avro/src/avroSerializer.ts
@@ -70,6 +70,8 @@ export class AvroSerializer<MessageT = MessageWithMetadata> {
    * @param schema - The Avro schema to use.
    * @returns A new message with the serialized value. The structure of message is
    * constrolled by the message factory option.
+   * @throws {@link AvroSerializationError}
+   * Thrown if the schema can not be parsed or the value does not match the schema.
    */
   async serializeMessageData(value: unknown, schema: string): Promise<MessageT> {
     const entry = await this.getSchemaByDefinition(schema);
@@ -106,6 +108,8 @@ export class AvroSerializer<MessageT = MessageWithMetadata> {
    * @param message - The message with the payload to be deserialized.
    * @param options - Decoding options.
    * @returns The deserialized value.
+   * @throws {@link AvroSerializationError}
+   * Thrown if the deserialization failed, e.g. because reader and writer schemas are incompatible.
    */
   async deserializeMessageData(
     message: MessageT,

--- a/sdk/schemaregistry/schema-registry-avro/src/models.ts
+++ b/sdk/schemaregistry/schema-registry-avro/src/models.ts
@@ -67,7 +67,7 @@ export interface DeserializeMessageDataOptions {
  */
 export class AvroSerializationError extends Error {
   /**
-   * The inner exception that was thrown by the Avro implementation.
+   * The inner error that was thrown by the Avro implementation library.
    */
   public innerError?: unknown;
 

--- a/sdk/schemaregistry/schema-registry-avro/src/models.ts
+++ b/sdk/schemaregistry/schema-registry-avro/src/models.ts
@@ -61,3 +61,21 @@ export interface DeserializeMessageDataOptions {
    */
   schema?: string;
 }
+
+/**
+ * A custom error type for failed Avro serialization/deserialization.
+ */
+export class AvroSerializationError extends Error {
+  /**
+   * The inner exception that was thrown by the Avro implementation.
+   */
+  public innerError?: unknown;
+
+  constructor(message: string, innerError?: unknown) {
+    super(message);
+    this.innerError = innerError;
+    this.name = "AvroSerializationError";
+
+    Object.setPrototypeOf(this, AvroSerializationError.prototype);
+  }
+}

--- a/sdk/schemaregistry/schema-registry-avro/test/errors.spec.ts
+++ b/sdk/schemaregistry/schema-registry-avro/test/errors.spec.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 import { assert, use as chaiUse } from "chai";
+import { AvroSerializationError } from "../src/models";
 import { AvroSerializer } from "../src/avroSerializer";
 import { Context } from "mocha";
 import { SchemaRegistry } from "@azure/schema-registry";
@@ -13,6 +14,30 @@ import { testGroup } from "./utils/dummies";
 import { v4 as uuid } from "uuid";
 
 chaiUse(chaiPromises);
+
+async function assertError<T>(
+  p: Promise<T>,
+  expectations: {
+    innerMessage?: RegExp;
+    message?: RegExp;
+  } = {}
+): Promise<void> {
+  const { innerMessage, message } = expectations;
+  try {
+    await p;
+  } catch (e) {
+    assert.instanceOf(e, AvroSerializationError);
+    const error = e as AvroSerializationError;
+    if (message) {
+      assert.match(error.message, message);
+    }
+    if (innerMessage) {
+      assert.isDefined(error.innerError, "innerError is not found");
+      const innerError = error.innerError as Error;
+      assert.match(innerError.message, innerMessage);
+    }
+  }
+}
 
 describe("Error scenarios", function () {
   let serializer: AvroSerializer;
@@ -121,28 +146,32 @@ describe("Error scenarios", function () {
         },
         JSON.stringify(writerSchema)
       );
-      assert.isRejected(
+      await assertError(
         serializer.deserializeMessageData(message, {
           schema: JSON.stringify(incompatibleReaderSchema),
         }),
-        /no matching field for default-less validation.AvroUser.age/
+        {
+          innerMessage: /no matching field for default-less validation.AvroUser.age/,
+        }
       );
     });
     it("null schema", async function () {
-      await assert.isRejected(
+      await assertError(
         /**
          * The type checking will prevent this from happening but I am including
          * it for completeness.
          */
         serializer.serializeMessageData(null, null as any),
-        /invalid type: null/
+        {
+          innerMessage: /invalid type: null/,
+        }
       );
     });
     it("schema without a name", async function () {
       /**
        * The serializer expects a record schema as the top-level schema
        */
-      await assert.isRejected(
+      await assertError(
         serializer.serializeMessageData(
           null,
           JSON.stringify({
@@ -150,11 +179,13 @@ describe("Error scenarios", function () {
             items: "int",
           })
         ),
-        /Schema must have a name/
+        {
+          message: /Schema must have a name/,
+        }
       );
     });
     it("enum schema without symbols", async function () {
-      await assert.isRejected(
+      await assertError(
         serializer.serializeMessageData(
           null,
           JSON.stringify({
@@ -170,11 +201,13 @@ describe("Error scenarios", function () {
             ],
           })
         ),
-        /invalid enum symbols: undefined/
+        {
+          innerMessage: /invalid enum symbols: undefined/,
+        }
       );
     });
     it("fixed schema without size", async function () {
-      await assert.isRejected(
+      await assertError(
         serializer.serializeMessageData(
           null,
           JSON.stringify({
@@ -190,11 +223,13 @@ describe("Error scenarios", function () {
             ],
           })
         ),
-        /invalid fixed size/
+        {
+          innerMessage: /invalid fixed size/,
+        }
       );
     });
     it("array schema without items", async function () {
-      await assert.isRejected(
+      await assertError(
         serializer.serializeMessageData(
           null,
           JSON.stringify({
@@ -210,11 +245,13 @@ describe("Error scenarios", function () {
             ],
           })
         ),
-        /missing array items: {"type":"array"}/
+        {
+          innerMessage: /missing array items: {"type":"array"}/,
+        }
       );
     });
     it("map schema without values", async function () {
-      await assert.isRejected(
+      await assertError(
         serializer.serializeMessageData(
           null,
           JSON.stringify({
@@ -230,11 +267,13 @@ describe("Error scenarios", function () {
             ],
           })
         ),
-        /missing map values: {"type":"map"}/
+        {
+          innerMessage: /missing map values: {"type":"map"}/,
+        }
       );
     });
     it("record schema without fields", async function () {
-      await assert.isRejected(
+      await assertError(
         serializer.serializeMessageData(
           null,
           JSON.stringify({
@@ -242,7 +281,9 @@ describe("Error scenarios", function () {
             name: "foo",
           })
         ),
-        /non-array record fields: undefined/
+        {
+          innerMessage: /non-array record fields: undefined/,
+        }
       );
     });
   });
@@ -260,7 +301,7 @@ describe("Error scenarios", function () {
           groupName: testGroup,
         },
       });
-      await assert.isRejected(
+      await assertError(
         customSerializer.serializeMessageData(
           {
             field: 1,
@@ -277,11 +318,13 @@ describe("Error scenarios", function () {
             ],
           })
         ),
-        /invalid "null": 1/
+        {
+          innerMessage: /invalid "null": 1/,
+        }
       );
     });
     it("null", async function () {
-      await assert.isRejected(
+      await assertError(
         serializer.serializeMessageData(
           {
             field: 1,
@@ -298,11 +341,13 @@ describe("Error scenarios", function () {
             ],
           })
         ),
-        /invalid "null": 1/
+        {
+          innerMessage: /invalid "null": 1/,
+        }
       );
     });
     it("boolean", async function () {
-      await assert.isRejected(
+      await assertError(
         serializer.serializeMessageData(
           {
             field: 1,
@@ -319,11 +364,13 @@ describe("Error scenarios", function () {
             ],
           })
         ),
-        /invalid "boolean": 1/
+        {
+          innerMessage: /invalid "boolean": 1/,
+        }
       );
     });
     it("int", async function () {
-      await assert.isRejected(
+      await assertError(
         serializer.serializeMessageData(
           {
             field: null,
@@ -340,11 +387,13 @@ describe("Error scenarios", function () {
             ],
           })
         ),
-        /invalid "int": null/
+        {
+          innerMessage: /invalid "int": null/,
+        }
       );
     });
     it("long", async function () {
-      await assert.isRejected(
+      await assertError(
         serializer.serializeMessageData(
           {
             field: 9007199254740991,
@@ -361,11 +410,13 @@ describe("Error scenarios", function () {
             ],
           })
         ),
-        /invalid "long": 9007199254740991/
+        {
+          innerMessage: /invalid "long": 9007199254740991/,
+        }
       );
     });
     it("float", async function () {
-      await assert.isRejected(
+      await assertError(
         serializer.serializeMessageData(
           {
             field: "",
@@ -382,11 +433,13 @@ describe("Error scenarios", function () {
             ],
           })
         ),
-        /invalid "float": ""/
+        {
+          innerMessage: /invalid "float": ""/,
+        }
       );
     });
     it("double", async function () {
-      await assert.isRejected(
+      await assertError(
         serializer.serializeMessageData(
           {
             field: "",
@@ -403,11 +456,13 @@ describe("Error scenarios", function () {
             ],
           })
         ),
-        /invalid "double": ""/
+        {
+          innerMessage: /invalid "double": ""/,
+        }
       );
     });
     it("string", async function () {
-      await assert.isRejected(
+      await assertError(
         serializer.serializeMessageData(
           {
             field: 1,
@@ -424,11 +479,13 @@ describe("Error scenarios", function () {
             ],
           })
         ),
-        /invalid "string": 1/
+        {
+          innerMessage: /invalid "string": 1/,
+        }
       );
     });
     it("bytes", async function () {
-      await assert.isRejected(
+      await assertError(
         serializer.serializeMessageData(
           {
             field: 1,
@@ -445,11 +502,13 @@ describe("Error scenarios", function () {
             ],
           })
         ),
-        /invalid "bytes": 1/
+        {
+          innerMessage: /invalid "bytes": 1/,
+        }
       );
     });
     it("union", async function () {
-      await assert.isRejected(
+      await assertError(
         serializer.serializeMessageData(
           {
             field: 1,
@@ -466,11 +525,13 @@ describe("Error scenarios", function () {
             ],
           })
         ),
-        /invalid \["null","string"\]: 1/
+        {
+          innerMessage: /invalid \["null","string"\]: 1/,
+        }
       );
     });
     it("enum", async function () {
-      await assert.isRejected(
+      await assertError(
         serializer.serializeMessageData(
           {
             field: "x",
@@ -491,11 +552,14 @@ describe("Error scenarios", function () {
             ],
           })
         ),
-        /invalid {"name":"validation.foo","type":"enum","symbols":\["A","B"\]}: "x"/
+        {
+          innerMessage:
+            /invalid {"name":"validation.foo","type":"enum","symbols":\["A","B"\]}: "x"/,
+        }
       );
     });
     it("fixed", async function () {
-      await assert.isRejected(
+      await assertError(
         serializer.serializeMessageData(
           {
             field: "x",
@@ -516,11 +580,13 @@ describe("Error scenarios", function () {
             ],
           })
         ),
-        /invalid {"name":"validation.foo","type":"fixed","size":16}: "x"/
+        {
+          innerMessage: /invalid {"name":"validation.foo","type":"fixed","size":16}: "x"/,
+        }
       );
     });
     it("map", async function () {
-      await assert.isRejected(
+      await assertError(
         serializer.serializeMessageData(
           {
             field: "x",
@@ -544,11 +610,13 @@ describe("Error scenarios", function () {
             ],
           })
         ),
-        /invalid {"type":"map","values":"long"}: "x"/
+        {
+          innerMessage: /invalid {"type":"map","values":"long"}: "x"/,
+        }
       );
     });
     it("array", async function () {
-      await assert.isRejected(
+      await assertError(
         serializer.serializeMessageData(
           {
             field: "x",
@@ -572,11 +640,13 @@ describe("Error scenarios", function () {
             ],
           })
         ),
-        /invalid {"type":"array","items":"long"}: "x"/
+        {
+          innerMessage: /invalid {"type":"array","items":"long"}: "x"/,
+        }
       );
     });
     it("record", async function () {
-      await assert.isRejected(
+      await assertError(
         serializer.serializeMessageData(
           "x",
           JSON.stringify({
@@ -591,7 +661,9 @@ describe("Error scenarios", function () {
             ],
           })
         ),
-        /invalid "int": undefined/
+        {
+          innerMessage: /invalid "int": undefined/,
+        }
       );
     });
   });
@@ -620,12 +692,13 @@ describe("Error scenarios", function () {
       );
       assert.deepEqual(serializedValue.body, Uint8Array.from([2, 2, 120]));
       serializedValue.body = Buffer.from([2, 2]);
-      await assert.isRejected(
-        serializer.deserializeMessageData(serializedValue),
-        /truncated buffer/
-      );
+      await assertError(serializer.deserializeMessageData(serializedValue), {
+        innerMessage: /truncated buffer/,
+      });
       serializedValue.body = Buffer.from([2, 2, 120, 5]);
-      await assert.isRejected(serializer.deserializeMessageData(serializedValue), /trailing data/);
+      await assertError(serializer.deserializeMessageData(serializedValue), {
+        innerMessage: /trailing data/,
+      });
     });
     it("long", async function () {
       const serializedValue = await serializer.serializeMessageData(
@@ -649,10 +722,9 @@ describe("Error scenarios", function () {
         Uint8Array.from([252, 255, 255, 255, 255, 255, 255, 31])
       );
       serializedValue.body = Uint8Array.from([252, 255, 255, 255, 255, 255, 255, 32]);
-      await assert.isRejected(
-        serializer.deserializeMessageData(serializedValue),
-        /potential precision loss/
-      );
+      await assertError(serializer.deserializeMessageData(serializedValue), {
+        innerMessage: /potential precision loss/,
+      });
     });
     it("union", async function () {
       const serializedValue = await serializer.serializeMessageData(
@@ -673,10 +745,9 @@ describe("Error scenarios", function () {
       );
       assert.deepEqual(serializedValue.body, Uint8Array.from([2, 2, 120]));
       serializedValue.body = Uint8Array.from([5, 2, 120]);
-      await assert.isRejected(
-        serializer.deserializeMessageData(serializedValue),
-        /invalid union index: -3/
-      );
+      await assertError(serializer.deserializeMessageData(serializedValue), {
+        innerMessage: /invalid union index: -3/,
+      });
     });
     it("enum", async function () {
       const serializedValue = await serializer.serializeMessageData(
@@ -701,10 +772,9 @@ describe("Error scenarios", function () {
       );
       assert.deepEqual(serializedValue.body, Uint8Array.from([0]));
       serializedValue.body = Uint8Array.from([10]);
-      await assert.isRejected(
-        serializer.deserializeMessageData(serializedValue),
-        /invalid validation.foo enum index: 5/
-      );
+      await assertError(serializer.deserializeMessageData(serializedValue), {
+        innerMessage: /invalid validation.foo enum index: 5/,
+      });
     });
   });
 });

--- a/sdk/schemaregistry/schema-registry-avro/test/errors.spec.ts
+++ b/sdk/schemaregistry/schema-registry-avro/test/errors.spec.ts
@@ -2,7 +2,6 @@
 // Licensed under the MIT license.
 
 import { assert, use as chaiUse } from "chai";
-import { AvroSerializationError } from "../src/models";
 import { AvroSerializer } from "../src/avroSerializer";
 import { Context } from "mocha";
 import { SchemaRegistry } from "@azure/schema-registry";
@@ -12,33 +11,9 @@ import { createTestSerializer } from "./utils/mockedSerializer";
 import { isLive } from "./utils/isLive";
 import { testGroup } from "./utils/dummies";
 import { v4 as uuid } from "uuid";
+import { assertSerializationError } from "./utils/assertSerializationError";
 
 chaiUse(chaiPromises);
-
-async function assertSerializationError<T>(
-  p: Promise<T>,
-  expectations: {
-    innerMessage?: RegExp;
-    message?: RegExp;
-  } = {}
-): Promise<void> {
-  const { innerMessage, message } = expectations;
-  try {
-    await p;
-    assert.fail(`Expected promise to error, but resolved successfully`);
-  } catch (e) {
-    assert.instanceOf(e, AvroSerializationError);
-    const error = e as AvroSerializationError;
-    if (message) {
-      assert.match(error.message, message);
-    }
-    if (innerMessage) {
-      assert.isDefined(error.innerError, "innerError is not found");
-      const innerError = error.innerError as Error;
-      assert.match(innerError.message, innerMessage);
-    }
-  }
-}
 
 describe("Error scenarios", function () {
   let serializer: AvroSerializer;

--- a/sdk/schemaregistry/schema-registry-avro/test/errors.spec.ts
+++ b/sdk/schemaregistry/schema-registry-avro/test/errors.spec.ts
@@ -15,7 +15,7 @@ import { v4 as uuid } from "uuid";
 
 chaiUse(chaiPromises);
 
-async function assertError<T>(
+async function assertSerializationError<T>(
   p: Promise<T>,
   expectations: {
     innerMessage?: RegExp;
@@ -25,6 +25,7 @@ async function assertError<T>(
   const { innerMessage, message } = expectations;
   try {
     await p;
+    assert.fail(`Expected promise to error, but resolved successfully`);
   } catch (e) {
     assert.instanceOf(e, AvroSerializationError);
     const error = e as AvroSerializationError;
@@ -146,7 +147,7 @@ describe("Error scenarios", function () {
         },
         JSON.stringify(writerSchema)
       );
-      await assertError(
+      await assertSerializationError(
         serializer.deserializeMessageData(message, {
           schema: JSON.stringify(incompatibleReaderSchema),
         }),
@@ -156,7 +157,7 @@ describe("Error scenarios", function () {
       );
     });
     it("null schema", async function () {
-      await assertError(
+      await assertSerializationError(
         /**
          * The type checking will prevent this from happening but I am including
          * it for completeness.
@@ -171,7 +172,7 @@ describe("Error scenarios", function () {
       /**
        * The serializer expects a record schema as the top-level schema
        */
-      await assertError(
+      await assertSerializationError(
         serializer.serializeMessageData(
           null,
           JSON.stringify({
@@ -185,7 +186,7 @@ describe("Error scenarios", function () {
       );
     });
     it("enum schema without symbols", async function () {
-      await assertError(
+      await assertSerializationError(
         serializer.serializeMessageData(
           null,
           JSON.stringify({
@@ -207,7 +208,7 @@ describe("Error scenarios", function () {
       );
     });
     it("fixed schema without size", async function () {
-      await assertError(
+      await assertSerializationError(
         serializer.serializeMessageData(
           null,
           JSON.stringify({
@@ -229,7 +230,7 @@ describe("Error scenarios", function () {
       );
     });
     it("array schema without items", async function () {
-      await assertError(
+      await assertSerializationError(
         serializer.serializeMessageData(
           null,
           JSON.stringify({
@@ -251,7 +252,7 @@ describe("Error scenarios", function () {
       );
     });
     it("map schema without values", async function () {
-      await assertError(
+      await assertSerializationError(
         serializer.serializeMessageData(
           null,
           JSON.stringify({
@@ -273,7 +274,7 @@ describe("Error scenarios", function () {
       );
     });
     it("record schema without fields", async function () {
-      await assertError(
+      await assertSerializationError(
         serializer.serializeMessageData(
           null,
           JSON.stringify({
@@ -301,7 +302,7 @@ describe("Error scenarios", function () {
           groupName: testGroup,
         },
       });
-      await assertError(
+      await assertSerializationError(
         customSerializer.serializeMessageData(
           {
             field: 1,
@@ -324,7 +325,7 @@ describe("Error scenarios", function () {
       );
     });
     it("null", async function () {
-      await assertError(
+      await assertSerializationError(
         serializer.serializeMessageData(
           {
             field: 1,
@@ -347,7 +348,7 @@ describe("Error scenarios", function () {
       );
     });
     it("boolean", async function () {
-      await assertError(
+      await assertSerializationError(
         serializer.serializeMessageData(
           {
             field: 1,
@@ -370,7 +371,7 @@ describe("Error scenarios", function () {
       );
     });
     it("int", async function () {
-      await assertError(
+      await assertSerializationError(
         serializer.serializeMessageData(
           {
             field: null,
@@ -393,7 +394,7 @@ describe("Error scenarios", function () {
       );
     });
     it("long", async function () {
-      await assertError(
+      await assertSerializationError(
         serializer.serializeMessageData(
           {
             field: 9007199254740991,
@@ -416,7 +417,7 @@ describe("Error scenarios", function () {
       );
     });
     it("float", async function () {
-      await assertError(
+      await assertSerializationError(
         serializer.serializeMessageData(
           {
             field: "",
@@ -439,7 +440,7 @@ describe("Error scenarios", function () {
       );
     });
     it("double", async function () {
-      await assertError(
+      await assertSerializationError(
         serializer.serializeMessageData(
           {
             field: "",
@@ -462,7 +463,7 @@ describe("Error scenarios", function () {
       );
     });
     it("string", async function () {
-      await assertError(
+      await assertSerializationError(
         serializer.serializeMessageData(
           {
             field: 1,
@@ -485,7 +486,7 @@ describe("Error scenarios", function () {
       );
     });
     it("bytes", async function () {
-      await assertError(
+      await assertSerializationError(
         serializer.serializeMessageData(
           {
             field: 1,
@@ -508,7 +509,7 @@ describe("Error scenarios", function () {
       );
     });
     it("union", async function () {
-      await assertError(
+      await assertSerializationError(
         serializer.serializeMessageData(
           {
             field: 1,
@@ -531,7 +532,7 @@ describe("Error scenarios", function () {
       );
     });
     it("enum", async function () {
-      await assertError(
+      await assertSerializationError(
         serializer.serializeMessageData(
           {
             field: "x",
@@ -559,7 +560,7 @@ describe("Error scenarios", function () {
       );
     });
     it("fixed", async function () {
-      await assertError(
+      await assertSerializationError(
         serializer.serializeMessageData(
           {
             field: "x",
@@ -586,7 +587,7 @@ describe("Error scenarios", function () {
       );
     });
     it("map", async function () {
-      await assertError(
+      await assertSerializationError(
         serializer.serializeMessageData(
           {
             field: "x",
@@ -616,7 +617,7 @@ describe("Error scenarios", function () {
       );
     });
     it("array", async function () {
-      await assertError(
+      await assertSerializationError(
         serializer.serializeMessageData(
           {
             field: "x",
@@ -646,7 +647,7 @@ describe("Error scenarios", function () {
       );
     });
     it("record", async function () {
-      await assertError(
+      await assertSerializationError(
         serializer.serializeMessageData(
           "x",
           JSON.stringify({
@@ -692,11 +693,11 @@ describe("Error scenarios", function () {
       );
       assert.deepEqual(serializedValue.body, Uint8Array.from([2, 2, 120]));
       serializedValue.body = Buffer.from([2, 2]);
-      await assertError(serializer.deserializeMessageData(serializedValue), {
+      await assertSerializationError(serializer.deserializeMessageData(serializedValue), {
         innerMessage: /truncated buffer/,
       });
       serializedValue.body = Buffer.from([2, 2, 120, 5]);
-      await assertError(serializer.deserializeMessageData(serializedValue), {
+      await assertSerializationError(serializer.deserializeMessageData(serializedValue), {
         innerMessage: /trailing data/,
       });
     });
@@ -722,7 +723,7 @@ describe("Error scenarios", function () {
         Uint8Array.from([252, 255, 255, 255, 255, 255, 255, 31])
       );
       serializedValue.body = Uint8Array.from([252, 255, 255, 255, 255, 255, 255, 32]);
-      await assertError(serializer.deserializeMessageData(serializedValue), {
+      await assertSerializationError(serializer.deserializeMessageData(serializedValue), {
         innerMessage: /potential precision loss/,
       });
     });
@@ -745,7 +746,7 @@ describe("Error scenarios", function () {
       );
       assert.deepEqual(serializedValue.body, Uint8Array.from([2, 2, 120]));
       serializedValue.body = Uint8Array.from([5, 2, 120]);
-      await assertError(serializer.deserializeMessageData(serializedValue), {
+      await assertSerializationError(serializer.deserializeMessageData(serializedValue), {
         innerMessage: /invalid union index: -3/,
       });
     });
@@ -772,7 +773,7 @@ describe("Error scenarios", function () {
       );
       assert.deepEqual(serializedValue.body, Uint8Array.from([0]));
       serializedValue.body = Uint8Array.from([10]);
-      await assertError(serializer.deserializeMessageData(serializedValue), {
+      await assertSerializationError(serializer.deserializeMessageData(serializedValue), {
         innerMessage: /invalid validation.foo enum index: 5/,
       });
     });

--- a/sdk/schemaregistry/schema-registry-avro/test/utils/assertSerializationError.ts
+++ b/sdk/schemaregistry/schema-registry-avro/test/utils/assertSerializationError.ts
@@ -1,0 +1,30 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { assert } from "@azure/test-utils";
+import { AvroSerializationError } from "../../src/models";
+
+export async function assertSerializationError<T>(
+  p: Promise<T>,
+  expectations: {
+    innerMessage?: RegExp;
+    message?: RegExp;
+  } = {}
+): Promise<void> {
+  const { innerMessage, message } = expectations;
+  try {
+    await p;
+    assert.fail(`Expected promise to error, but resolved successfully`);
+  } catch (e) {
+    assert.instanceOf(e, AvroSerializationError);
+    const error = e as AvroSerializationError;
+    if (message) {
+      assert.match(error.message, message);
+    }
+    if (innerMessage) {
+      assert.isDefined(error.innerError, "innerError is not found");
+      const innerError = error.innerError as Error;
+      assert.match(innerError.message, innerMessage);
+    }
+  }
+}

--- a/sdk/schemaregistry/schema-registry-avro/test/withMessagingClients.spec.ts
+++ b/sdk/schemaregistry/schema-registry-avro/test/withMessagingClients.spec.ts
@@ -25,6 +25,7 @@ import { createTestSerializer } from "./utils/mockedSerializer";
 import { env } from "./utils/env";
 import { matrix } from "@azure/test-utils";
 import { testGroup } from "./utils/dummies";
+import { assertSerializationError } from "./utils/assertSerializationError";
 
 /**
  * An interface to group different bits needed by the tests for each messaging service
@@ -283,7 +284,9 @@ describe("With messaging clients", function () {
           writerSchema,
           readerSchema,
           processMessage: async (p: Promise<unknown>) =>
-            assert.isRejected(p, /no matching field for default-less/),
+            assertSerializationError(p, {
+              innerMessage: /no matching field for default-less/,
+            }),
         });
       });
     });


### PR DESCRIPTION
### Packages impacted by this PR
@azure/schema-registry-avro

### Issues associated with this PR
Fixes https://github.com/Azure/azure-sdk-for-js/issues/20072

### Describe the problem that is addressed by this PR
@azure/schema-registry-avro depends on avsc, a third party package for Avro encoding, and it throws exceptions in certain cases. If in the future we decide to switch away from avsc to some other library, @azure/schema-registry-avro will be throwing new and different exceptions.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?

- Wrapping avsc exceptions in @azure/schema-registry-avro exceptions so that the customer experience stays consistent regardless of which Avro library to use. One question remain: should one exception suffice or should fine-grained exceptions provided?

### Are there test cases added in this PR? _(If not, why?)_
Yes

### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [x] Added a changelog (if necessary)
