### PR TITLE
[core-rest-pipeline] Remove authorization header on redirected requests

### DIFF
--- a/sdk/core/core-rest-pipeline/CHANGELOG.md
+++ b/sdk/core/core-rest-pipeline/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Updated `redirectPolicy` to remove the `Authorization` header from redirected requests. [#21026](https://github.com/Azure/azure-sdk-for-js/pull/21026)
+
 ### Other Changes
 
 ## 1.7.0 (2022-03-21)

--- a/sdk/core/core-rest-pipeline/src/policies/redirectPolicy.ts
+++ b/sdk/core/core-rest-pipeline/src/policies/redirectPolicy.ts
@@ -70,6 +70,8 @@ async function handleRedirect(
       delete request.body;
     }
 
+    request.headers.delete("Authorization");
+
     const res = await next(request);
     return handleRedirect(next, res, maxRetries, currentRetries + 1);
   }


### PR DESCRIPTION
## Packages impacted by this PR

- `@azure/core-rest-pipeline`

## Issues associated with this PR

- Resolves #20957

## Describe the problem that is addressed by this PR

When following a redirect, our redirection policy sends the Authorization header from the original request again in the redirected request. This is a potential security risk, and can also cause issues when the resource at the end of the redirect does not support the authorization method initially provided (as I encountered with ACR in #20957).

This PR causes the redirection policy to remove the header before the request is redirected. This approach is in-line with .NET and Python, which were both already removing this header.

## Are there test cases added in this PR? _(If not, why?)_

Yes, added a test case to make sure the header gets removed.

## Checklists
- [x] Added impacted package name to the issue description
- [ ] Added a changelog (if necessary)
