### PR TITLE
[Schema Registry Avro] Fix live tests

### DIFF
--- a/sdk/schemaregistry/schema-registry-avro/test/utils/assertSerializationError.ts
+++ b/sdk/schemaregistry/schema-registry-avro/test/utils/assertSerializationError.ts
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { assert } from "@azure/test-utils";
 import { AvroSerializationError } from "../../src/models";
+import { assert } from "@azure/test-utils";
 
 export async function assertSerializationError<T>(
   p: Promise<T>,

--- a/sdk/schemaregistry/schema-registry-avro/test/utils/mockedRegistryClient.ts
+++ b/sdk/schemaregistry/schema-registry-avro/test/utils/mockedRegistryClient.ts
@@ -64,6 +64,10 @@ function createMockedTestRegistry(): SchemaRegistry {
   ): Promise<SchemaProperties> {
     let result = mapByContent.get(schema.definition);
     if (!result) {
+      const format = schema.format.toLowerCase();
+      if (format !== "avro") {
+        throw new Error(`Invalid schema type for PUT request. '${format}' is not supported`);
+      }
       result = {
         definition: schema.definition,
         properties: {


### PR DESCRIPTION
### Packages impacted by this PR
@azure/schema-registry-avro

### Issues associated with this PR
Fixes https://github.com/Azure/azure-sdk-for-js/issues/21046

### Describe the problem that is addressed by this PR
Live test failed in https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1459741&view=results because the test suite attempts to register more than 25 schemas, the maximum number of allowed schemas in the standard-tier resource.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?
This PR fixes the issue by skipping a test that registers the bulk of the schemas in live mode.

### Are there test cases added in this PR? _(If not, why?)_
N/A

### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
