### PR TITLE
[GitHub Automation] Communication Owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -40,14 +40,29 @@
 # PRLabel: %Batch
 /sdk/batch/ @dpwatrous @paterasMSFT @zfengms @deyaaeldeen
 
-# PRLabel: %Communication
+# PRLabel: %Communication - Identity
 /sdk/communication/communication-identity/ @Azure/acs-identity-sdk @petrsvihlik @AikoBB @maximrytych-ms @martinbarnas-ms
+
+# PRLabel: %Communication - Chat
 /sdk/communication/communication-chat/ @LuChen-Microsoft
+
+# PRLabel: %Communication - Phone Numbers
 /sdk/communication/communication-phone-numbers/ @miguhern @whisper6284 @lucasrsant @RoyHerrod @danielav7
+
+# PRLabel: %Communication - Network Traversal
 /sdk/communication/communication-network-traversal/ @AriZavala2
+
+# PRLabel: %Communication - SMS
 /sdk/communication/communication-sms/ @arifibrahim4 @RoyHerrod
+
+# PRLabel: %Communication - Short Codes
 /sdk/communication/communication-short-codes/ @danielav7 @AlonsoMondal @ericasp16
+
+# PRLabel: %Communication - Common
 /sdk/communication/communication-common/ @Azure/acs-identity-sdk @petrsvihlik @AikoBB @maximrytych-ms @martinbarnas-ms
+
+# PRLabel: %Communication
+/sdk/communication/communication/ @Azure/acs-identity-sdk @petrsvihlik @AikoBB @maximrytych-ms @martinbarnas-ms
 
 # PRLabel: %Container Registry
 /sdk/containerregistry/ @jeremymeng


### PR DESCRIPTION
# Summary 

The focus of these changes is to add rules for the Communication sub-areas to apply unique labels to better integrate with the team's tooling.