### PR TITLE
[Tests] fix build failures by upgrading identity dev dependency version

### DIFF
--- a/sdk/containerregistry/container-registry/package.json
+++ b/sdk/containerregistry/container-registry/package.json
@@ -85,7 +85,7 @@
   "devDependencies": {
     "@azure/dev-tool": "^1.0.0",
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
-    "@azure/identity": "^2.0.1",
+    "@azure/identity": "^2.1.0-beta.2",
     "@azure/test-utils": "^1.0.0",
     "@azure-tools/test-credential": "^1.0.0",
     "@azure-tools/test-recorder": "^2.0.0",

--- a/sdk/containerregistry/perf-tests/container-registry/package.json
+++ b/sdk/containerregistry/perf-tests/container-registry/package.json
@@ -7,7 +7,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@azure/container-registry": "1.0.0-beta.4",
+    "@azure/container-registry": "^1.0.0",
     "@azure/test-utils-perf": "^1.0.0",
     "dotenv": "^8.2.0"
   },

--- a/sdk/keyvault/keyvault-certificates/package.json
+++ b/sdk/keyvault/keyvault-certificates/package.json
@@ -116,7 +116,7 @@
   "devDependencies": {
     "@azure/dev-tool": "^1.0.0",
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
-    "@azure/identity": "^2.0.1",
+    "@azure/identity": "^2.1.0-beta.2",
     "@azure/keyvault-secrets": "^4.2.0",
     "@azure/test-utils": "^1.0.0",
     "@azure-tools/test-recorder": "^1.0.0",

--- a/sdk/keyvault/keyvault-certificates/test/public/utils/testAuthentication.ts
+++ b/sdk/keyvault/keyvault-certificates/test/public/utils/testAuthentication.ts
@@ -4,7 +4,7 @@
 import { ClientSecretCredential } from "@azure/identity";
 import { CertificateClient } from "../../../src";
 import { uniqueString } from "./recorderUtils";
-import { env, record, RecorderEnvironmentSetup } from "@azure-tools/test-recorder";
+import { env, isLiveMode, record, RecorderEnvironmentSetup } from "@azure-tools/test-recorder";
 import { getServiceVersion } from "./common";
 import TestClient from "./testClient";
 import { Context } from "mocha";
@@ -36,7 +36,7 @@ export async function authenticate(
     queryParametersToSkip: [],
   };
   const recorder = record(that, recorderEnvSetup);
-  const identityHttpClient = isNode ? undefined : createXhrHttpClient();
+  const identityHttpClient = isNode || isLiveMode() ? undefined : createXhrHttpClient();
   const credential = new ClientSecretCredential(
     env.AZURE_TENANT_ID,
     env.AZURE_CLIENT_ID,

--- a/sdk/keyvault/keyvault-keys/package.json
+++ b/sdk/keyvault/keyvault-keys/package.json
@@ -114,7 +114,7 @@
   "devDependencies": {
     "@azure/dev-tool": "^1.0.0",
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
-    "@azure/identity": "^2.0.1",
+    "@azure/identity": "^2.1.0-beta.2",
     "@azure/test-utils": "^1.0.0",
     "@azure-tools/test-recorder": "^1.0.0",
     "@microsoft/api-extractor": "^7.18.11",

--- a/sdk/keyvault/keyvault-keys/test/public/utils/testAuthentication.ts
+++ b/sdk/keyvault/keyvault-keys/test/public/utils/testAuthentication.ts
@@ -3,7 +3,7 @@
 
 import { ClientSecretCredential } from "@azure/identity";
 import { KeyClient } from "../../../src";
-import { env, record, RecorderEnvironmentSetup } from "@azure-tools/test-recorder";
+import { env, isLiveMode, record, RecorderEnvironmentSetup } from "@azure-tools/test-recorder";
 import { uniqueString } from "./recorderUtils";
 import TestClient from "./testClient";
 import { Context } from "mocha";
@@ -46,7 +46,7 @@ export async function authenticate(that: Context, version: string): Promise<any>
     queryParametersToSkip: [],
   };
   const recorder = record(that, recorderEnvSetup);
-  const identityHttpClient = isNode ? undefined : createXhrHttpClient();
+  const identityHttpClient = isNode || isLiveMode() ? undefined : createXhrHttpClient();
   const credential = new ClientSecretCredential(
     env.AZURE_TENANT_ID,
     env.AZURE_CLIENT_ID,

--- a/sdk/keyvault/keyvault-secrets/package.json
+++ b/sdk/keyvault/keyvault-secrets/package.json
@@ -112,7 +112,7 @@
   "devDependencies": {
     "@azure/dev-tool": "^1.0.0",
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
-    "@azure/identity": "^2.0.1",
+    "@azure/identity": "^2.1.0-beta.2",
     "@azure/test-utils": "^1.0.0",
     "@azure-tools/test-recorder": "^1.0.0",
     "@microsoft/api-extractor": "^7.18.11",

--- a/sdk/keyvault/keyvault-secrets/test/public/utils/testAuthentication.ts
+++ b/sdk/keyvault/keyvault-secrets/test/public/utils/testAuthentication.ts
@@ -3,7 +3,7 @@
 
 import { ClientSecretCredential } from "@azure/identity";
 import { SecretClient } from "../../../src";
-import { env, record, RecorderEnvironmentSetup } from "@azure-tools/test-recorder";
+import { env, isLiveMode, record, RecorderEnvironmentSetup } from "@azure-tools/test-recorder";
 import { uniqueString } from "./recorderUtils";
 import TestClient from "./testClient";
 import { Context } from "mocha";
@@ -32,7 +32,7 @@ export async function authenticate(
     queryParametersToSkip: [],
   };
   const recorder = record(that, recorderEnvSetup);
-  const identityHttpClient = isNode ? undefined : createXhrHttpClient();
+  const identityHttpClient = isNode || isLiveMode() ? undefined : createXhrHttpClient();
   const credential = new ClientSecretCredential(
     env.AZURE_TENANT_ID,
     env.AZURE_CLIENT_ID,

--- a/sdk/test-utils/test-credential/package.json
+++ b/sdk/test-utils/test-credential/package.json
@@ -55,7 +55,7 @@
   "dependencies": {
     "@azure/core-auth": "^1.3.2",
     "@azure-tools/test-recorder": "^1.0.0",
-    "@azure/identity": "^2.0.1"
+    "@azure/identity": "^2.1.0-beta.2"
   },
   "devDependencies": {
     "@azure/dev-tool": "^1.0.0",


### PR DESCRIPTION
Identity released version v2.0.4 is not pulling down core-rest-pipeline v1.8.0
because the latter is not released yet, so identity credentials find the new
request body type unexpected.  This RP updates the identity dev dependency
version to v2.1.0-beta.2 which is in the repo and references the new
core-rest-pipeline version in the repo.

while fixing container registry I also move its perf tests to depend on
latest version of container registry instead of a pinned beta version at the time
when the tests were created.
