### PR TITLE
[Identity] Add vscode workaround into the troubleshooting guide

### DIFF
--- a/sdk/identity/identity/TROUBLESHOOTING.md
+++ b/sdk/identity/identity/TROUBLESHOOTING.md
@@ -276,6 +276,8 @@ curl 'http://169.254.169.254/metadata/identity/oauth2/token?resource=https://man
 
 ## Troubleshoot Visual Studio Code authentication issues
 
+> It's a [known issue](https://github.com/Azure/azure-sdk-for-js/issues/20500) that `VisualStudioCodeCredential` doesn't work with [Azure Account extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.azure-account) versions newer than **0.9.11**. If you're using Azure Account extension version 0.10.0 or later, downgrading to **version 0.9.11** will resolve this issue. A long-term fix to this problem is in progress.
+  
 ### CredentialUnavailableError
 
 | Error Message |Description| Mitigation |


### PR DESCRIPTION
Doing the same that Xiang Yan did here: https://github.com/Azure/azure-sdk-for-net/pull/27800