### PR TITLE
[core-rest-pipeline] add XhrHttpClient back for React-Native support

### DIFF
--- a/sdk/core/core-rest-pipeline/CHANGELOG.md
+++ b/sdk/core/core-rest-pipeline/CHANGELOG.md
@@ -1,10 +1,11 @@
 # Release History
 
-## 1.8.0 (Unreleased)
+## 1.9.0 (Unreleased)
 
 ### Features Added
 
 - Support resettable streams in the form of `() => NodeJS.ReadableStream` for NodeJS and `() => ReadableStream` for browser. [#21013](https://github.com/Azure/azure-sdk-for-js/pull/21013)
+- Add a React-Native mapping for default HTTP Client to the old `XhrHttpClient` because the Fetch API implementation in React-Native runtime is missing streaming support.
 
 ### Breaking Changes
 

--- a/sdk/core/core-rest-pipeline/CHANGELOG.md
+++ b/sdk/core/core-rest-pipeline/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.9.0 (Unreleased)
+## 1.8.0 (Unreleased)
 
 ### Features Added
 

--- a/sdk/core/core-rest-pipeline/package.json
+++ b/sdk/core/core-rest-pipeline/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/core-rest-pipeline",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "description": "Isomorphic client library for making HTTP requests in node.js and browser.",
   "sdk-type": "client",
   "main": "dist/index.js",
@@ -16,6 +16,7 @@
   },
   "react-native": {
     "./dist/index.js": "./dist-esm/src/index.js",
+    "./dist-esm/src/defaultHttpClient.js": "./dist-esm/src/defaultHttpClient.native.js",
     "./dist-esm/src/util/userAgentPlatform.js": "./dist-esm/src/util/userAgentPlatform.native.js"
   },
   "types": "core-rest-pipeline.shims.d.ts",

--- a/sdk/core/core-rest-pipeline/package.json
+++ b/sdk/core/core-rest-pipeline/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/core-rest-pipeline",
-  "version": "1.9.0",
+  "version": "1.8.0",
   "description": "Isomorphic client library for making HTTP requests in node.js and browser.",
   "sdk-type": "client",
   "main": "dist/index.js",

--- a/sdk/core/core-rest-pipeline/src/constants.ts
+++ b/sdk/core/core-rest-pipeline/src/constants.ts
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-export const SDK_VERSION: string = "1.9.0";
+export const SDK_VERSION: string = "1.8.0";
 
 export const DEFAULT_RETRY_POLICY_COUNT = 3;

--- a/sdk/core/core-rest-pipeline/src/constants.ts
+++ b/sdk/core/core-rest-pipeline/src/constants.ts
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-export const SDK_VERSION: string = "1.8.0";
+export const SDK_VERSION: string = "1.9.0";
 
 export const DEFAULT_RETRY_POLICY_COUNT = 3;

--- a/sdk/core/core-rest-pipeline/src/defaultHttpClient.native.ts
+++ b/sdk/core/core-rest-pipeline/src/defaultHttpClient.native.ts
@@ -1,0 +1,12 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { HttpClient } from "./interfaces";
+import { createXhrHttpClient } from "./xhrHttpClient";
+
+/**
+ * Create the correct HttpClient for the current environment.
+ */
+export function createDefaultHttpClient(): HttpClient {
+  return createXhrHttpClient();
+}

--- a/sdk/core/core-rest-pipeline/src/xhrHttpClient.ts
+++ b/sdk/core/core-rest-pipeline/src/xhrHttpClient.ts
@@ -1,0 +1,210 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { AbortError } from "@azure/abort-controller";
+import {
+  HttpClient,
+  PipelineRequest,
+  PipelineResponse,
+  TransferProgressEvent,
+  HttpHeaders,
+} from "./interfaces";
+import { createHttpHeaders } from "./httpHeaders";
+import { RestError } from "./restError";
+
+function isReadableStream(body: any): body is NodeJS.ReadableStream {
+  return body && typeof body.pipe === "function";
+}
+
+/**
+ * A HttpClient implementation that uses XMLHttpRequest to send HTTP requests.
+ * @internal
+ */
+class XhrHttpClient implements HttpClient {
+  /**
+   * Makes a request over an underlying transport layer and returns the response.
+   * @param request - The request to be made.
+   */
+  public async sendRequest(request: PipelineRequest): Promise<PipelineResponse> {
+    const url = new URL(request.url);
+    const isInsecure = url.protocol !== "https:";
+
+    if (isInsecure && !request.allowInsecureConnection) {
+      throw new Error(`Cannot connect to ${request.url} while allowInsecureConnection is false.`);
+    }
+
+    const xhr = new XMLHttpRequest();
+
+    if (request.proxySettings) {
+      throw new Error("HTTP proxy is not supported in browser environment");
+    }
+
+    const abortSignal = request.abortSignal;
+    if (abortSignal) {
+      if (abortSignal.aborted) {
+        throw new AbortError("The operation was aborted.");
+      }
+
+      const listener = (): void => {
+        xhr.abort();
+      };
+      abortSignal.addEventListener("abort", listener);
+      xhr.addEventListener("readystatechange", () => {
+        if (xhr.readyState === XMLHttpRequest.DONE) {
+          abortSignal.removeEventListener("abort", listener);
+        }
+      });
+    }
+
+    addProgressListener(xhr.upload, request.onUploadProgress);
+    addProgressListener(xhr, request.onDownloadProgress);
+
+    xhr.open(request.method, request.url);
+    xhr.timeout = request.timeout;
+    xhr.withCredentials = request.withCredentials;
+    for (const [name, value] of request.headers) {
+      xhr.setRequestHeader(name, value);
+    }
+
+    xhr.responseType = request.streamResponseStatusCodes?.size ? "blob" : "text";
+
+    const body = typeof request.body === "function" ? request.body() : request.body;
+    if (isReadableStream(body)) {
+      throw new Error("Node streams are not supported in browser environment.");
+    }
+
+    xhr.send(body === undefined ? null : body);
+
+    if (xhr.responseType === "blob") {
+      return new Promise((resolve, reject) => {
+        handleBlobResponse(xhr, request, resolve, reject);
+        rejectOnTerminalEvent(request, xhr, reject);
+      });
+    } else {
+      return new Promise(function (resolve, reject) {
+        xhr.addEventListener("load", () =>
+          resolve({
+            request,
+            status: xhr.status,
+            headers: parseHeaders(xhr),
+            bodyAsText: xhr.responseText,
+          })
+        );
+        rejectOnTerminalEvent(request, xhr, reject);
+      });
+    }
+  }
+}
+
+function handleBlobResponse(
+  xhr: XMLHttpRequest,
+  request: PipelineRequest,
+  res: (value: PipelineResponse | PromiseLike<PipelineResponse>) => void,
+  rej: (reason?: any) => void
+): void {
+  xhr.addEventListener("readystatechange", () => {
+    // Resolve as soon as headers are loaded
+    if (xhr.readyState === XMLHttpRequest.HEADERS_RECEIVED) {
+      if (
+        // Value of POSITIVE_INFINITY in streamResponseStatusCodes is considered as any status code
+        request.streamResponseStatusCodes?.has(Number.POSITIVE_INFINITY) ||
+        request.streamResponseStatusCodes?.has(xhr.status)
+      ) {
+        const blobBody = new Promise<Blob>((resolve, reject) => {
+          xhr.addEventListener("load", () => {
+            resolve(xhr.response);
+          });
+          rejectOnTerminalEvent(request, xhr, reject);
+        });
+        res({
+          request,
+          status: xhr.status,
+          headers: parseHeaders(xhr),
+          blobBody,
+        });
+      } else {
+        xhr.addEventListener("load", () => {
+          // xhr.response is of Blob type if the request is sent with xhr.responseType === "blob"
+          // but the status code is not one of the stream response status codes,
+          // so treat it as text and convert from Blob to text
+          if (xhr.response) {
+            xhr.response
+              .text()
+              .then((text: string) => {
+                res({
+                  request: request,
+                  status: xhr.status,
+                  headers: parseHeaders(xhr),
+                  bodyAsText: text,
+                });
+                return;
+              })
+              .catch((e: any) => {
+                rej(e);
+              });
+          } else {
+            res({
+              request,
+              status: xhr.status,
+              headers: parseHeaders(xhr),
+            });
+          }
+        });
+      }
+    }
+  });
+}
+
+function addProgressListener(
+  xhr: XMLHttpRequestEventTarget,
+  listener?: (progress: TransferProgressEvent) => void
+): void {
+  if (listener) {
+    xhr.addEventListener("progress", (rawEvent) =>
+      listener({
+        loadedBytes: rawEvent.loaded,
+      })
+    );
+  }
+}
+
+function parseHeaders(xhr: XMLHttpRequest): HttpHeaders {
+  const responseHeaders = createHttpHeaders();
+  const headerLines = xhr
+    .getAllResponseHeaders()
+    .trim()
+    .split(/[\r\n]+/);
+  for (const line of headerLines) {
+    const index = line.indexOf(":");
+    const headerName = line.slice(0, index);
+    const headerValue = line.slice(index + 2);
+    responseHeaders.set(headerName, headerValue);
+  }
+  return responseHeaders;
+}
+
+function rejectOnTerminalEvent(
+  request: PipelineRequest,
+  xhr: XMLHttpRequest,
+  reject: (err: any) => void
+): void {
+  xhr.addEventListener("error", () =>
+    reject(
+      new RestError(`Failed to send request to ${request.url}`, {
+        code: RestError.REQUEST_SEND_ERROR,
+        request,
+      })
+    )
+  );
+  const abortError = new AbortError("The operation was aborted.");
+  xhr.addEventListener("abort", () => reject(abortError));
+  xhr.addEventListener("timeout", () => reject(abortError));
+}
+
+/**
+ * Create a new HttpClient instance for the browser environment.
+ * @internal
+ */
+export function createXhrHttpClient(): HttpClient {
+  return new XhrHttpClient();
+}


### PR DESCRIPTION
### Packages impacted by this PR
@azure/core-rest-pipeline

### Issues associated with this PR
#20787 

### Describe the problem that is addressed by this PR

After we switch browser HTTP client to based on Fetch api, React-Native scenario is broken because streaming is not supported in React-Native's Fetch implementation. We get empty `bodyAsText` back from the response body.  This PR adds the old `XhrHttpClient` back just for React-Native using the `react-native` mapping in package.json.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?

We could use Fetch polyfill for React-Native out there: `react-native-fetch-api`, but it involves a bunch of additional polyfills, and requires passing a non-standard option to the Fetch api. https://www.npmjs.com/package/react-native-fetch-api
