### PR TITLE
[Identity] Skipping test in live mode

### DIFF
--- a/sdk/identity/identity/test/internal/node/clientSecretCredential.spec.ts
+++ b/sdk/identity/identity/test/internal/node/clientSecretCredential.spec.ts
@@ -94,9 +94,9 @@ describe("ClientSecretCredential (internal)", function () {
 
   it("Authenticates with tenantId on getToken", async function (this: Context) {
     // The live environment isn't ready for this test
-    // if (isLiveMode()) {
-    //   this.skip();
-    // }
+    if (isLiveMode()) {
+      this.skip();
+    }
     const credential = new ClientSecretCredential(
       env.AZURE_TENANT_ID!,
       env.AZURE_CLIENT_ID!,


### PR DESCRIPTION
We have an issue that’s already tracking similar cases in which sending `tenantId` on getToken on live tests is failing in live mode: https://github.com/Azure/azure-sdk-for-js/issues/21055

This test should’ve been skipped before, but somehow it got through. Skipping now.
