### PR TITLE
[core-http] Address some issues for react-native

### DIFF
--- a/sdk/core/core-http/CHANGELOG.md
+++ b/sdk/core/core-http/CHANGELOG.md
@@ -8,8 +8,8 @@
 
 ### Bugs Fixed
 
-- Fix an issue where React-Native is loading the wrong file. Adding a `react-native` mapping to point to the ESM entrypoint file.
-- delay creating XML parser/builder objects so that packages not requiring XML functionality but running on platforms lacking XML support can still load this package.
+- Fix an issue where React-Native is loading the wrong file. Adding a `react-native` mapping to point to the ESM entrypoint file. [PR #21118](https://github.com/Azure/azure-sdk-for-js/pull/21118)
+- delay creating XML parser/builder objects so that packages not requiring XML functionality but running on platforms lacking XML support can still load this package. [PR #21118](https://github.com/Azure/azure-sdk-for-js/pull/21118)
 
 ### Other Changes
 

--- a/sdk/core/core-http/CHANGELOG.md
+++ b/sdk/core/core-http/CHANGELOG.md
@@ -8,6 +8,9 @@
 
 ### Bugs Fixed
 
+- Fix an issue where React-Native is loading the wrong file. Adding a `react-native` mapping to point to the ESM entrypoint file.
+- delay creating XML parser/builder objects so that packages not requiring XML functionality but running on platforms lacking XML support can still load this package.
+
 ### Other Changes
 
 ## 2.2.4 (2022-02-03)

--- a/sdk/core/core-http/package.json
+++ b/sdk/core/core-http/package.json
@@ -56,6 +56,9 @@
     "./dist-esm/src/util/inspect.js": "./dist-esm/src/util/inspect.browser.js",
     "./dist-esm/src/util/url.js": "./dist-esm/src/util/url.browser.js"
   },
+  "react-native": {
+    "./dist/index.js": "./dist-esm/src/coreHttp.js"
+  },
   "license": "MIT",
   "homepage": "https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/core/core-http/README.md",
   "repository": "github:Azure/azure-sdk-for-js",


### PR DESCRIPTION
- Add the mapping for react-native to ESM entrypoint
- Delay creating XML objects so packages not requiring XML functionality would not fail at module loading time.


### Packages impacted by this PR
@azure/core-http

### Issues associated with this PR
#20806 
