### PR TITLE
Remove nguerrera from schema-registry owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -133,7 +133,7 @@
 /sdk/textanalytics/ @deyaaeldeen @witemple-msft
 
 # PRLabel: %Schema Registry
-/sdk/schemaregistry/ @deyaaeldeen @nguerrera
+/sdk/schemaregistry/ @deyaaeldeen
 
 # PRLabel: %Cognitive - Form Recognizer
 /sdk/formrecognizer/ @witemple-msft @HarshaNalluru @jeremymeng


### PR DESCRIPTION
I'm removing myself from being designated in CODEONWERS as owning schema registry. The library has evolved quite a bit since I started it and I have not been able to keep up with all the changes. I will be more than happy to answer any questions that trace back to my original design or implementation or really any question at all, but I don't think I'm being useful enough to be a reviewer of every PR anymore.

### Packages impacted by this PR
None

### Issues associated with this PR
N/A

### Describe the problem that is addressed by this PR
I have not worked on this library in a long time and no longer feel comfortable being desingated as a code owner.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?
N/A

### Are there test cases added in this PR? _(If not, why?)_
N/A

### Provide a list of related PRs _(if any)_
N/A

### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_
N/A

### Checklists
- [ ] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)

N/A