### PR TITLE
[samples] - Fix web-workers sample

### DIFF
--- a/samples/web-workers/README.md
+++ b/samples/web-workers/README.md
@@ -30,7 +30,7 @@ To avoid complexity in this sample, we will be using a [SAS Connection String][s
 
 To quickly create the needed resources in Azure and to receive the necessary environment variables for them, you can deploy our sample template by clicking:
 
-[![](http://azuredeploy.net/deploybutton.png)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-sdk-for-js%2Fmaster%2Fsamples%2Fweb-workers%2arm-template.json)
+[![](http://azuredeploy.net/deploybutton.png)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-sdk-for-js%2Fmain%2Fsamples%2Fweb-workers%2Farm-template.json)
 
 Once the deployment completes, head over to the "outputs" tab and copy the outputs to a local file - you'll need them in the next step.
 

--- a/samples/web-workers/ts/package.json
+++ b/samples/web-workers/ts/package.json
@@ -20,7 +20,7 @@
     "last 1 Chrome versions"
   ],
   "dependencies": {
-    "@azure/storage-blob": "^12.5.0",
-    "jsdom": "^16.5.0"
+    "@azure/storage-blob": "^12.9.0",
+    "jsdom": "^19.0.0"
   }
 }


### PR DESCRIPTION
### Packages impacted by this PR
N/A

### Issues associated with this PR
Fixes #20934

### Describe the problem that is addressed by this PR
A customer reported a few issues:
- At some point when updating our arm-template path we lost a character for
url-encoded / - instead of %2F we only had %2... combined with the followed
character "a" this would end up as the * character instead of the intended
".../a..." character.
- It seems that a recent change in browsers to remove SharedArrayBuffer (see
https://developer.chrome.com/blog/enabling-shared-array-buffer/) has broken
JSDOM's dependencies and by extension JSDOM. This has been fixed upstream. 
For good measure, I just bumped both dependencies.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_
No, these are just samples

### Provide a list of related PRs _(if any)_


### Command used to generate this PR: _(Applicable only to SDK release request PRs)_


### Checklists
- [ ] Added impacted package name to the issue description.
- [ ] Does this PR need any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here.)_
- [ ] Added a changelog (if necessary).
