### PR TITLE
[storage/blob,file-datalake] Fix browser mappings for BufferScheduler.js

### DIFF
--- a/sdk/storage/storage-blob/CHANGELOG.md
+++ b/sdk/storage/storage-blob/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Fix incorrect browser mapping path for BufferScheduler.js
+
 ### Other Changes
 
 ## 12.9.0 (2022-03-11)

--- a/sdk/storage/storage-blob/package.json
+++ b/sdk/storage/storage-blob/package.json
@@ -14,7 +14,7 @@
     "./dist-esm/storage-blob/src/BatchUtils.js": "./dist-esm/storage-blob/src/BatchUtils.browser.js",
     "./dist-esm/storage-blob/src/BlobDownloadResponse.js": "./dist-esm/storage-blob/src/BlobDownloadResponse.browser.js",
     "./dist-esm/storage-blob/src/BlobQueryResponse.js": "./dist-esm/storage-blob/src/BlobQueryResponse.browser.js",
-    "./dist-esm/storage-blob/src/utils/BufferScheduler.js": "./dist-esm/storage-blob/src/utils/BufferScheduler.browser.js",
+    "./dist-esm/storage-common/src/BufferScheduler.js": "./dist-esm/storage-common/src/BufferScheduler.browser.js",
     "./dist-esm/storage-common/src/index.js": "./dist-esm/storage-common/src/index.browser.js",
     "fs": false,
     "os": false,

--- a/sdk/storage/storage-file-datalake/CHANGELOG.md
+++ b/sdk/storage/storage-file-datalake/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Add missing browser mapping for `./dist-esm/storage-common/src/BufferScheduler.js`
+
 ### Other Changes
 
 ## 12.8.0 (2022-03-11)

--- a/sdk/storage/storage-file-datalake/package.json
+++ b/sdk/storage/storage-file-datalake/package.json
@@ -20,6 +20,7 @@
     "./dist-esm/storage-file-datalake/src/utils/utils.node.js": "./dist-esm/storage-file-datalake/src/utils/utils.browser.js",
     "./dist-esm/storage-file-datalake/test/utils/index.js": "./dist-esm/storage-file-datalake/test/utils/index.browser.js",
     "./dist-esm/storage-common/src/index.js": "./dist-esm/storage-common/src/index.browser.js",
+    "./dist-esm/storage-common/src/BufferScheduler.js": "./dist-esm/storage-common/src/BufferScheduler.browser.js",
     "fs": false,
     "os": false,
     "process": false


### PR DESCRIPTION
The browser mapping for BufferSchedule.js was not updated/not added during refactoring in #11005.  This PR fixes the issue by updating the mapping paths for blob and adding the mapping for file-datalake.