### PR TITLE
[Tables] Fix query filter in listTables by page

### DIFF
--- a/sdk/tables/data-tables/recordings/browsers/tableserviceclient_listtables/recording_should_list_by_page_with_filter.json
+++ b/sdk/tables/data-tables/recordings/browsers/tableserviceclient_listtables/recording_should_list_by_page_with_filter.json
@@ -1,0 +1,50 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://fakeaccountname.table.core.windows.net/Tables?st=2021-08-03T08:52:15Z\u0026spr=https\u0026sig=fakesigval\u0026$filter=TableName%20eq%20%27ListTableTestbrowser1%27",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json;odata=minimalmetadata",
+        "Accept-Encoding": "gzip, deflate, br",
+        "Accept-Language": "en-US",
+        "dataserviceversion": "3.0",
+        "Referer": "http://localhost:9876/",
+        "sec-ch-ua": "",
+        "sec-ch-ua-mobile": "?0",
+        "sec-ch-ua-platform": "",
+        "Sec-Fetch-Dest": "empty",
+        "Sec-Fetch-Mode": "cors",
+        "Sec-Fetch-Site": "same-site",
+        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/100.0.4889.0 Safari/537.36",
+        "x-ms-client-request-id": "a22391c3-a12b-46d5-94b4-54b0cdc97309",
+        "x-ms-useragent": "azsdk-js-data-tables/13.1.0 core-rest-pipeline/1.8.1 OS/Linuxx86_64",
+        "x-ms-version": "2019-02-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Type": "application/json; odata=minimalmetadata; streaming=true; charset=utf-8",
+        "Date": "Sat, 02 Apr 2022 17:42:38 GMT",
+        "Server": [
+          "Windows-Azure-Table/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "a22391c3-a12b-46d5-94b4-54b0cdc97309",
+        "x-ms-request-id": "28273786-5002-00b5-39b9-46fcd6000000",
+        "x-ms-version": "2019-02-02"
+      },
+      "ResponseBody": {
+        "odata.metadata": "https://fakeaccountname.table.core.windows.net/$metadata#Tables",
+        "value": [
+          {
+            "TableName": "ListTableTestbrowser1"
+          }
+        ]
+      }
+    }
+  ],
+  "Variables": {}
+}

--- a/sdk/tables/data-tables/recordings/browsers/tableserviceclient_listtables/recording_should_list_with_filter.json
+++ b/sdk/tables/data-tables/recordings/browsers/tableserviceclient_listtables/recording_should_list_with_filter.json
@@ -1,0 +1,50 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://fakeaccountname.table.core.windows.net/Tables?st=2021-08-03T08:52:15Z\u0026spr=https\u0026sig=fakesigval\u0026$filter=TableName%20eq%20%27ListTableTestbrowser1%27",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json;odata=minimalmetadata",
+        "Accept-Encoding": "gzip, deflate, br",
+        "Accept-Language": "en-US",
+        "dataserviceversion": "3.0",
+        "Referer": "http://localhost:9876/",
+        "sec-ch-ua": "",
+        "sec-ch-ua-mobile": "?0",
+        "sec-ch-ua-platform": "",
+        "Sec-Fetch-Dest": "empty",
+        "Sec-Fetch-Mode": "cors",
+        "Sec-Fetch-Site": "same-site",
+        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/100.0.4889.0 Safari/537.36",
+        "x-ms-client-request-id": "a63fb8de-1309-4687-8276-068e51e3249b",
+        "x-ms-useragent": "azsdk-js-data-tables/13.1.0 core-rest-pipeline/1.8.1 OS/Linuxx86_64",
+        "x-ms-version": "2019-02-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Type": "application/json; odata=minimalmetadata; streaming=true; charset=utf-8",
+        "Date": "Sat, 02 Apr 2022 17:42:38 GMT",
+        "Server": [
+          "Windows-Azure-Table/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "a63fb8de-1309-4687-8276-068e51e3249b",
+        "x-ms-request-id": "28273723-5002-00b5-5bb9-46fcd6000000",
+        "x-ms-version": "2019-02-02"
+      },
+      "ResponseBody": {
+        "odata.metadata": "https://fakeaccountname.table.core.windows.net/$metadata#Tables",
+        "value": [
+          {
+            "TableName": "ListTableTestbrowser1"
+          }
+        ]
+      }
+    }
+  ],
+  "Variables": {}
+}

--- a/sdk/tables/data-tables/recordings/node/tableserviceclient_listtables/recording_should_list_by_page_with_filter.json
+++ b/sdk/tables/data-tables/recordings/node/tableserviceclient_listtables/recording_should_list_by_page_with_filter.json
@@ -1,0 +1,41 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://fakeaccountname.table.core.windows.net/Tables?st=2021-08-03T08:52:15Z\u0026spr=https\u0026sig=fakesigval\u0026$filter=TableName%20eq%20%27ListTableTestnode1%27",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json;odata=minimalmetadata",
+        "Accept-Encoding": "gzip,deflate",
+        "DataServiceVersion": "3.0",
+        "User-Agent": "azsdk-js-data-tables/13.1.0 core-rest-pipeline/1.8.1 Node/v14.17.5 OS/(x64-Linux-5.10.102.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "3a1cdbab-5311-40b7-b867-b19ab922b789",
+        "x-ms-version": "2019-02-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Type": "application/json; odata=minimalmetadata; streaming=true; charset=utf-8",
+        "Date": "Sat, 02 Apr 2022 17:42:24 GMT",
+        "Server": [
+          "Windows-Azure-Table/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "3a1cdbab-5311-40b7-b867-b19ab922b789",
+        "x-ms-request-id": "211c3124-8002-005c-65b9-469ab2000000",
+        "x-ms-version": "2019-02-02"
+      },
+      "ResponseBody": {
+        "odata.metadata": "https://fakeaccountname.table.core.windows.net/$metadata#Tables",
+        "value": [
+          {
+            "TableName": "ListTableTestnode1"
+          }
+        ]
+      }
+    }
+  ],
+  "Variables": {}
+}

--- a/sdk/tables/data-tables/recordings/node/tableserviceclient_listtables/recording_should_list_with_filter.json
+++ b/sdk/tables/data-tables/recordings/node/tableserviceclient_listtables/recording_should_list_with_filter.json
@@ -1,0 +1,41 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://fakeaccountname.table.core.windows.net/Tables?st=2021-08-03T08:52:15Z\u0026spr=https\u0026sig=fakesigval\u0026$filter=TableName%20eq%20%27ListTableTestnode1%27",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json;odata=minimalmetadata",
+        "Accept-Encoding": "gzip,deflate",
+        "DataServiceVersion": "3.0",
+        "User-Agent": "azsdk-js-data-tables/13.1.0 core-rest-pipeline/1.8.1 Node/v14.17.5 OS/(x64-Linux-5.10.102.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "3cd086e2-3aa9-4c80-800f-3b96e12fe257",
+        "x-ms-version": "2019-02-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Type": "application/json; odata=minimalmetadata; streaming=true; charset=utf-8",
+        "Date": "Sat, 02 Apr 2022 17:42:23 GMT",
+        "Server": [
+          "Windows-Azure-Table/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "3cd086e2-3aa9-4c80-800f-3b96e12fe257",
+        "x-ms-request-id": "211c308c-8002-005c-5db9-469ab2000000",
+        "x-ms-version": "2019-02-02"
+      },
+      "ResponseBody": {
+        "odata.metadata": "https://fakeaccountname.table.core.windows.net/$metadata#Tables",
+        "value": [
+          {
+            "TableName": "ListTableTestnode1"
+          }
+        ]
+      }
+    }
+  ],
+  "Variables": {}
+}

--- a/sdk/tables/data-tables/src/TableServiceClient.ts
+++ b/sdk/tables/data-tables/src/TableServiceClient.ts
@@ -290,7 +290,7 @@ export class TableServiceClient {
       byPage: (settings) => {
         const pageOptions: InternalListTablesOptions = {
           ...options,
-          queryOptions: { top: settings?.maxPageSize },
+          queryOptions: { ...options?.queryOptions, top: settings?.maxPageSize },
         };
 
         if (settings?.continuationToken) {

--- a/sdk/tables/data-tables/test/public/tableserviceclient.spec.ts
+++ b/sdk/tables/data-tables/test/public/tableserviceclient.spec.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 
 import { Recorder, isPlaybackMode } from "@azure-tools/test-recorder";
-import { TableItem, TableItemResultPage, TableServiceClient } from "../../src";
+import { TableItem, TableItemResultPage, TableServiceClient, odata } from "../../src";
 
 import { Context } from "mocha";
 import { FullOperationResponse } from "@azure/core-client";
@@ -92,6 +92,19 @@ describe(`TableServiceClient`, () => {
       }
     });
 
+    it("should list with filter", async () => {
+      const tableName = `ListTableTest${suffix}1`;
+      const tables = client.listTables({
+        queryOptions: { filter: odata`TableName eq ${tableName}` },
+      });
+      const all: TableItem[] = [];
+      for await (const table of tables) {
+        all.push(table);
+      }
+
+      assert.lengthOf(all, 1);
+    });
+
     it("should list by page", async function () {
       let all: TableItem[] = [];
       const maxPageSize = 5;
@@ -109,6 +122,20 @@ describe(`TableServiceClient`, () => {
           `Couldn't find table ListTableTest${suffix}${i}`
         );
       }
+    });
+
+    it("should list by page with filter", async function () {
+      let all: TableItem[] = [];
+      const tableName = `ListTableTest${suffix}1`;
+      const tables = client.listTables({
+        queryOptions: { filter: odata`TableName eq ${tableName}` },
+      });
+
+      for await (const page of tables.byPage()) {
+        all = [...all, ...page];
+      }
+
+      assert.lengthOf(all, 1);
     });
 
     it("should list a specific page with continuationToken", async function () {


### PR DESCRIPTION
### Packages impacted by this PR
@azure/data-tables

### Issues associated with this PR
#21156 

### Describe the problem that is addressed by this PR

When querying tables using a filter, `byPage` ignores the query filter passed by users in the `listTables` call.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?

Pass the query filter to the page call, the same way we do this in `listEntities`.

### Are there test cases added in this PR? _(If not, why?)_
Yes added 2 test cases

### Provide a list of related PRs _(if any)_
N/A

### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_
N/A

### Checklists
- [x] Added impacted package name to the issue description
- [x] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [x] Added a changelog (if necessary)
