### PR TITLE
[Schema Registry Avro] Fix nightly test

### DIFF
--- a/sdk/schemaregistry/schema-registry-avro/test/public/errors.spec.ts
+++ b/sdk/schemaregistry/schema-registry-avro/test/public/errors.spec.ts
@@ -451,6 +451,7 @@ describe("Error scenarios", function () {
         ),
         {
           innerMessage: /invalid "null": 1/,
+          schemaId: true,
         }
       );
       assert.isTrue(ran, `Expected a service call to register the schema but non was sent!`);


### PR DESCRIPTION
### Packages impacted by this PR
@schema-registry-avro

### Issues associated with this PR
Fixes https://github.com/Azure/azure-sdk-for-js/issues/21175

### Describe the problem that is addressed by this PR
The test checks if there was a request sent to register a schema even if the serialization of the input value failed. This request should return a schema ID for the registered schema but the test was expecting the schema ID to be undefined.

Successful run with this PR: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1480429&view=results. Note that the failure in min/max testing is expected because of a recent breaking change in Event Hubs that was not released yet (will be released this week).

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?
N/A

### Are there test cases added in this PR? _(If not, why?)_
N/A

### Provide a list of related PRs _(if any)_
N/A

### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
