### PR TITLE
Remove URL/Browser.URL polyfills

### DIFF
--- a/sdk/containerregistry/container-registry/package.json
+++ b/sdk/containerregistry/container-registry/package.json
@@ -6,7 +6,6 @@
   "main": "dist/index.js",
   "module": "dist-esm/src/index.js",
   "browser": {
-    "./dist-esm/src/utils/url.js": "./dist-esm/src/utils/url.browser.js",
     "./dist-esm/src/utils/base64.js": "./dist-esm/src/utils/base64.browser.js",
     "./dist-esm/test/utils/isNode.js": "./dist-esm/src/test/isNode.browser.js"
   },

--- a/sdk/containerregistry/container-registry/src/registryArtifact.ts
+++ b/sdk/containerregistry/container-registry/src/registryArtifact.ts
@@ -14,7 +14,6 @@ import {
   ArtifactTagOrder,
   TagPageResponse,
 } from "./models";
-import { URL } from "./utils/url";
 import { createSpan } from "./tracing";
 import { GeneratedClient } from "./generated";
 import { extractNextLink, isDigest } from "./utils/helpers";

--- a/sdk/containerregistry/container-registry/src/utils/url.browser.ts
+++ b/sdk/containerregistry/container-registry/src/utils/url.browser.ts
@@ -1,7 +1,0 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT license.
-
-const url = URL;
-const urlSearchParams = URLSearchParams;
-
-export { url as URL, urlSearchParams as URLSearchParams };

--- a/sdk/containerregistry/container-registry/src/utils/url.ts
+++ b/sdk/containerregistry/container-registry/src/utils/url.ts
@@ -1,4 +1,0 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT license.
-
-export { URL, URLSearchParams } from "url";

--- a/sdk/core/core-client-rest/package.json
+++ b/sdk/core/core-client-rest/package.json
@@ -5,9 +5,6 @@
   "sdk-type": "client",
   "main": "dist/index.js",
   "module": "dist-esm/src/index.js",
-  "browser": {
-    "./dist-esm/src/url.js": "./dist-esm/src/url.browser.js"
-  },
   "types": "types/latest/core-client-rest.d.ts",
   "scripts": {
     "audit": "node ../../../common/scripts/rush-audit.js && rimraf node_modules package-lock.json && npm i --package-lock-only 2>&1 && npm audit",

--- a/sdk/core/core-client-rest/src/apiVersionPolicy.ts
+++ b/sdk/core/core-client-rest/src/apiVersionPolicy.ts
@@ -3,7 +3,6 @@
 
 import { PipelinePolicy } from "@azure/core-rest-pipeline";
 import { ClientOptions } from "./common";
-import { URL } from "./url";
 
 export const apiVersionPolicyName = "ApiVersionPolicy";
 

--- a/sdk/core/core-client-rest/src/url.browser.ts
+++ b/sdk/core/core-client-rest/src/url.browser.ts
@@ -1,7 +1,0 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT license.
-
-const url = URL;
-const urlSearchParams = URLSearchParams;
-
-export { url as URL, urlSearchParams as URLSearchParams };

--- a/sdk/core/core-client-rest/src/url.ts
+++ b/sdk/core/core-client-rest/src/url.ts
@@ -1,4 +1,0 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT license.
-
-export { URL, URLSearchParams } from "url";

--- a/sdk/core/core-client-rest/src/urlHelpers.ts
+++ b/sdk/core/core-client-rest/src/urlHelpers.ts
@@ -2,7 +2,6 @@
 // Licensed under the MIT license.
 
 import { RequestParameters } from "./common";
-import { URL } from "./url";
 
 /**
  * Builds the request url, filling in query and path parameters

--- a/sdk/core/core-http/package.json
+++ b/sdk/core/core-http/package.json
@@ -53,8 +53,7 @@
     "./dist-esm/src/util/base64.js": "./dist-esm/src/util/base64.browser.js",
     "./dist-esm/src/util/xml.js": "./dist-esm/src/util/xml.browser.js",
     "./dist-esm/src/defaultHttpClient.js": "./dist-esm/src/defaultHttpClient.browser.js",
-    "./dist-esm/src/util/inspect.js": "./dist-esm/src/util/inspect.browser.js",
-    "./dist-esm/src/util/url.js": "./dist-esm/src/util/url.browser.js"
+    "./dist-esm/src/util/inspect.js": "./dist-esm/src/util/inspect.browser.js"
   },
   "react-native": {
     "./dist/index.js": "./dist-esm/src/coreHttp.js"

--- a/sdk/core/core-http/src/serviceClient.ts
+++ b/sdk/core/core-http/src/serviceClient.ts
@@ -47,7 +47,6 @@ import { OperationArguments } from "./operationArguments";
 import { OperationResponse } from "./operationResponse";
 import { QueryCollectionFormat } from "./queryCollectionFormat";
 import { ServiceClientCredentials } from "./credentials/serviceClientCredentials";
-import { URL } from "./url";
 import { URLBuilder } from "./url";
 import { bearerTokenAuthenticationPolicy } from "./policies/bearerTokenAuthenticationPolicy";
 import { disableResponseDecompressionPolicy } from "./policies/disableResponseDecompressionPolicy";

--- a/sdk/core/core-http/src/url.ts
+++ b/sdk/core/core-http/src/url.ts
@@ -3,8 +3,6 @@
 
 import { replaceAll } from "./util/utils";
 
-export { URL } from "./util/url";
-
 type URLQueryParseState = "ParameterName" | "ParameterValue";
 
 /**

--- a/sdk/core/core-http/src/util/url.browser.ts
+++ b/sdk/core/core-http/src/util/url.browser.ts
@@ -1,6 +1,0 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT license.
-
-const url = URL;
-
-export { url as URL };

--- a/sdk/core/core-http/src/util/url.ts
+++ b/sdk/core/core-http/src/util/url.ts
@@ -1,4 +1,0 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT license.
-
-export { URL } from "url";

--- a/sdk/core/core-rest-pipeline/package.json
+++ b/sdk/core/core-rest-pipeline/package.json
@@ -11,7 +11,6 @@
     "./dist-esm/src/policies/formDataPolicy.js": "./dist-esm/src/policies/formDataPolicy.browser.js",
     "./dist-esm/src/policies/proxyPolicy.js": "./dist-esm/src/policies/proxyPolicy.browser.js",
     "./dist-esm/src/util/inspect.js": "./dist-esm/src/util/inspect.browser.js",
-    "./dist-esm/src/util/url.js": "./dist-esm/src/util/url.browser.js",
     "./dist-esm/src/util/userAgentPlatform.js": "./dist-esm/src/util/userAgentPlatform.browser.js"
   },
   "react-native": {

--- a/sdk/core/core-rest-pipeline/src/nodeHttpClient.ts
+++ b/sdk/core/core-rest-pipeline/src/nodeHttpClient.ts
@@ -16,7 +16,6 @@ import {
 } from "./interfaces";
 import { createHttpHeaders } from "./httpHeaders";
 import { RestError } from "./restError";
-import { URL } from "./util/url";
 import { IncomingMessage } from "http";
 import { logger } from "./log";
 

--- a/sdk/core/core-rest-pipeline/src/policies/proxyPolicy.ts
+++ b/sdk/core/core-rest-pipeline/src/policies/proxyPolicy.ts
@@ -13,7 +13,6 @@ import {
   SendRequest,
 } from "../interfaces";
 import { PipelinePolicy } from "../pipeline";
-import { URL } from "../util/url";
 
 const HTTPS_PROXY = "HTTPS_PROXY";
 const HTTP_PROXY = "HTTP_PROXY";

--- a/sdk/core/core-rest-pipeline/src/policies/redirectPolicy.ts
+++ b/sdk/core/core-rest-pipeline/src/policies/redirectPolicy.ts
@@ -3,7 +3,6 @@
 
 import { PipelineRequest, PipelineResponse, SendRequest } from "../interfaces";
 import { PipelinePolicy } from "../pipeline";
-import { URL } from "../util/url";
 
 /**
  * The programmatic identifier of the redirectPolicy.

--- a/sdk/core/core-rest-pipeline/src/util/sanitizer.ts
+++ b/sdk/core/core-rest-pipeline/src/util/sanitizer.ts
@@ -2,7 +2,6 @@
 // Licensed under the MIT license.
 
 import { UnknownObject, isObject } from "./helpers";
-import { URL } from "./url";
 
 /**
  * @internal

--- a/sdk/core/core-rest-pipeline/src/util/url.browser.ts
+++ b/sdk/core/core-rest-pipeline/src/util/url.browser.ts
@@ -1,7 +1,0 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT license.
-
-const url = URL;
-const urlSearchParams = URLSearchParams;
-
-export { url as URL, urlSearchParams as URLSearchParams };

--- a/sdk/core/core-rest-pipeline/src/util/url.ts
+++ b/sdk/core/core-rest-pipeline/src/util/url.ts
@@ -1,4 +1,0 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT license.
-
-export { URL, URLSearchParams } from "url";

--- a/sdk/cosmosdb/cosmos/package.json
+++ b/sdk/cosmosdb/cosmos/package.json
@@ -22,8 +22,7 @@
     "./dist-esm/src/request/defaultAgent.js": "./dist-esm/src/request/defaultAgent.browser.js",
     "./dist-esm/src/utils/atob.js": "./dist-esm/src/utils/atob.browser.js",
     "./dist-esm/src/utils/digest.js": "./dist-esm/src/utils/digest.browser.js",
-    "./dist-esm/src/utils/hmac.js": "./dist-esm/src/utils/hmac.browser.js",
-    "./dist-esm/src/utils/url.js": "./dist-esm/src/utils/url.browser.js"
+    "./dist-esm/src/utils/hmac.js": "./dist-esm/src/utils/hmac.browser.js"
   },
   "files": [
     "changelog.md",

--- a/sdk/digitaltwins/dtdl-parser/package.json
+++ b/sdk/digitaltwins/dtdl-parser/package.json
@@ -6,7 +6,6 @@
   "main": "dist/index.js",
   "module": "dist-esm/src/index.js",
   "browser": {
-    "./dist-esm/src/utils/url.js": "./dist-esm/src/utils/url.browser.js",
     "./dist-esm/src/utils/getFilenames.js": "./dist-esm/src/utils/getFilenames.browser.js",
     "./dist-esm/src/utils/getTestcase.js": "./dist-esm/src/utils/getTestcase.browser.js"
   },

--- a/sdk/digitaltwins/dtdl-parser/src/parser/supplementalTypeInfoImpl.ts
+++ b/sdk/digitaltwins/dtdl-parser/src/parser/supplementalTypeInfoImpl.ts
@@ -20,7 +20,6 @@ import { ParsedObjectPropertyInfo } from "./internal";
 import { EntityKinds } from "./internal";
 import { Model } from "./internal";
 import { ExtensionKind } from "./internal";
-import { URL } from "../utils/url";
 /**
  * Class that provides information about a type is not materialized as a TS class.
  **/

--- a/sdk/digitaltwins/dtdl-parser/src/utils/url.browser.ts
+++ b/sdk/digitaltwins/dtdl-parser/src/utils/url.browser.ts
@@ -1,7 +1,0 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT license.
-/// <reference lib="dom" />
-
-const url = URL;
-
-export { url as URL };

--- a/sdk/digitaltwins/dtdl-parser/src/utils/url.ts
+++ b/sdk/digitaltwins/dtdl-parser/src/utils/url.ts
@@ -1,4 +1,0 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT license.
-
-export { URL } from "url";

--- a/sdk/iot/iot-modelsrepository/package.json
+++ b/sdk/iot/iot-modelsrepository/package.json
@@ -7,7 +7,6 @@
   "module": "dist-esm/src/index.js",
   "browser": {
     "./dist-esm/src/print.js": "./dist-esm/src/print.browser.js",
-    "./dist-esm/src/utils/url.js": "./dist-esm/src/utils/url.browser.js",
     "./dist-esm/src/utils/path.js": "./dist-esm/src/utils/path.browser.js",
     "./dist-esm/src/fetcherFilesystem.js": "./dist-esm/src/utils/fetcherFilesystem.browser.js"
   },

--- a/sdk/iot/iot-modelsrepository/src/modelsRepositoryClient.ts
+++ b/sdk/iot/iot-modelsrepository/src/modelsRepositoryClient.ts
@@ -11,7 +11,6 @@ import {
 } from "./utils/constants";
 import { createClientPipeline, InternalClientPipelineOptions } from "@azure/core-client";
 import { Fetcher } from "./fetcherAbstract";
-import { URL } from "./utils/url";
 import { isLocalPath, normalize } from "./utils/path";
 import { FilesystemFetcher } from "./fetcherFilesystem";
 import { dependencyResolutionType } from "./dependencyResolutionType";

--- a/sdk/iot/iot-modelsrepository/src/utils/url.browser.ts
+++ b/sdk/iot/iot-modelsrepository/src/utils/url.browser.ts
@@ -1,6 +1,0 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT license.
-
-const url = URL;
-
-export { url as URL };

--- a/sdk/iot/iot-modelsrepository/src/utils/url.ts
+++ b/sdk/iot/iot-modelsrepository/src/utils/url.ts
@@ -1,4 +1,0 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT license.
-
-export { URL } from "url";

--- a/sdk/tables/data-tables/package.json
+++ b/sdk/tables/data-tables/package.json
@@ -8,7 +8,6 @@
   "browser": {
     "./dist-esm/src/tablesNamedCredentialPolicy.js": "./dist-esm/src/tablesNamedCredentialPolicy.browser.js",
     "./dist-esm/src/utils/accountConnectionString.js": "./dist-esm/src/utils/accountConnectionString.browser.js",
-    "./dist-esm/src/utils/url.js": "./dist-esm/src/utils/url.browser.js",
     "./dist-esm/src/utils/computeHMACSHA256.js": "./dist-esm/src/utils/computeHMACSHA256.browser.js",
     "./dist-esm/src/utils/bufferSerializer.js": "./dist-esm/src/utils/bufferSerializer.browser.js",
     "./dist-esm/src/utils/transactionHeaders.js": "./dist-esm/src/utils/transactionHeaders.browser.js",

--- a/sdk/tables/data-tables/src/TablePolicies.ts
+++ b/sdk/tables/data-tables/src/TablePolicies.ts
@@ -14,7 +14,6 @@ import {
   createHttpHeaders,
   createPipelineRequest,
 } from "@azure/core-rest-pipeline";
-import { URL } from "./utils/url";
 import { getChangeSetBoundary } from "./utils/transactionHelpers";
 
 export const transactionRequestAssemblePolicyName = "transactionRequestAssemblePolicy";

--- a/sdk/tables/data-tables/src/tablesNamedCredentialPolicy.ts
+++ b/sdk/tables/data-tables/src/tablesNamedCredentialPolicy.ts
@@ -9,7 +9,6 @@ import {
 } from "@azure/core-rest-pipeline";
 import { HeaderConstants } from "./utils/constants";
 import { NamedKeyCredential } from "@azure/core-auth";
-import { URL } from "./utils/url";
 import { computeHMACSHA256 } from "./utils/computeHMACSHA256";
 
 /**

--- a/sdk/tables/data-tables/src/tablesSASTokenPolicy.ts
+++ b/sdk/tables/data-tables/src/tablesSASTokenPolicy.ts
@@ -7,7 +7,6 @@ import {
   PipelineResponse,
   SendRequest,
 } from "@azure/core-rest-pipeline";
-import { URL, URLSearchParams } from "./utils/url";
 import { SASCredential } from "@azure/core-auth";
 
 /**

--- a/sdk/tables/data-tables/src/utils/connectionString.ts
+++ b/sdk/tables/data-tables/src/utils/connectionString.ts
@@ -5,7 +5,6 @@ import { ClientParamsFromConnectionString, ConnectionString } from "./internalMo
 import { fromAccountConnectionString, getAccountConnectionString } from "./accountConnectionString";
 
 import { TableServiceClientOptions } from "../models";
-import { URL } from "./url";
 
 const DevelopmentConnectionString =
   "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;TableEndpoint=http://127.0.0.1:10002/devstoreaccount1";

--- a/sdk/tables/data-tables/src/utils/isCosmosEndpoint.ts
+++ b/sdk/tables/data-tables/src/utils/isCosmosEndpoint.ts
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { URL } from "./url";
-
 export function isCosmosEndpoint(url: string): boolean {
   const parsedURL = new URL(url);
   if (parsedURL.hostname.indexOf(".table.cosmosdb.") !== -1) {

--- a/sdk/tables/data-tables/src/utils/url.browser.ts
+++ b/sdk/tables/data-tables/src/utils/url.browser.ts
@@ -1,7 +1,0 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT license.
-
-const url = URL;
-const urlSearchParams = URLSearchParams;
-
-export { url as URL, urlSearchParams as URLSearchParams };

--- a/sdk/tables/data-tables/src/utils/url.ts
+++ b/sdk/tables/data-tables/src/utils/url.ts
@@ -1,4 +1,0 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT license.
-
-export { URL, URLSearchParams } from "url";

--- a/sdk/web-pubsub/web-pubsub/package.json
+++ b/sdk/web-pubsub/web-pubsub/package.json
@@ -52,9 +52,6 @@
       }
     ]
   },
-  "browser": {
-    "./dist-esm/src/util/url.js": "./dist-esm/src/util/url.browser.js"
-  },
   "repository": "github:Azure/azure-sdk-for-js",
   "keywords": [
     "azure",

--- a/sdk/web-pubsub/web-pubsub/src/parseConnectionString.ts
+++ b/sdk/web-pubsub/web-pubsub/src/parseConnectionString.ts
@@ -2,7 +2,6 @@
 // Licensed under the MIT license.
 
 import { AzureKeyCredential } from "@azure/core-auth";
-import { URL } from "./util/url";
 
 interface ParsedConnectionString {
   credential: AzureKeyCredential;

--- a/sdk/web-pubsub/web-pubsub/src/util/url.browser.ts
+++ b/sdk/web-pubsub/web-pubsub/src/util/url.browser.ts
@@ -1,6 +1,0 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT license.
-
-const url = URL;
-
-export { url as URL };

--- a/sdk/web-pubsub/web-pubsub/src/util/url.ts
+++ b/sdk/web-pubsub/web-pubsub/src/util/url.ts
@@ -1,4 +1,0 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT license.
-
-export { URL } from "url";


### PR DESCRIPTION
### Packages impacted by this PR

The following packages are affected by this change to remove the `url.js` and `url.browser.js` polyfills.

- core-http
- core-rest-pipeline
- core-client-rest
- iot-modelsrepository
- web-pubsub
- dtdl-parser
- container-registry
- cosmos
- data-tables

### Issues associated with this PR

- #20445

### Describe the problem that is addressed by this PR

This PR removes the `url.js` and `url.browser.js` files now that the LTS Node.js has full support for the `URL` class.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?

First was to remove the affected `url.js` and `url.browser.js` files and all references to the `url` module in the files.  The second is to remove the references in the `package.json` files.

### Are there test cases added in this PR? _(If not, why?)_

No, not necessary now that the URL class is being removed, it should no longer be under test.

### Provide a list of related PRs _(if any)_

- #20445

### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [ ] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
