### PR TITLE
[KeyVault] - Fix user-agent tests in KeyVault Admin

### DIFF
--- a/sdk/keyvault/keyvault-admin/package.json
+++ b/sdk/keyvault/keyvault-admin/package.json
@@ -74,7 +74,7 @@
     "constantPaths": [
       {
         "path": "src/generated/keyVaultClientContext.ts",
-        "prefix": "packageVersion"
+        "prefix": "packageDetails"
       },
       {
         "path": "src/constants.ts",

--- a/sdk/keyvault/keyvault-admin/src/generated/keyVaultClientContext.ts
+++ b/sdk/keyvault/keyvault-admin/src/generated/keyVaultClientContext.ts
@@ -9,8 +9,6 @@
 import * as coreClient from "@azure/core-client";
 import { ApiVersion73, KeyVaultClientOptionalParams } from "./models";
 
-export const packageVersion = "4.3.0-beta.1";
-
 export class KeyVaultClientContext extends coreClient.ServiceClient {
   apiVersion: ApiVersion73;
 
@@ -35,7 +33,7 @@ export class KeyVaultClientContext extends coreClient.ServiceClient {
       requestContentType: "application/json; charset=utf-8"
     };
 
-    const packageDetails = `azsdk-js-keyvault-admin/4.2.0`;
+    const packageDetails = `azsdk-js-keyvault-admin/4.3.0-beta.1`;
     const userAgentPrefix =
       options.userAgentOptions && options.userAgentOptions.userAgentPrefix
         ? `${options.userAgentOptions.userAgentPrefix} ${packageDetails}`

--- a/sdk/keyvault/keyvault-admin/src/tracing.ts
+++ b/sdk/keyvault/keyvault-admin/src/tracing.ts
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { createTracingClient } from "@azure/core-tracing";
 import { SDK_VERSION } from "./constants";
+import { createTracingClient } from "@azure/core-tracing";
 
 export const tracingClient = createTracingClient({
   namespace: "Microsoft.KeyVault",

--- a/sdk/keyvault/keyvault-admin/test/internal/userAgent.spec.ts
+++ b/sdk/keyvault/keyvault-admin/test/internal/userAgent.spec.ts
@@ -9,43 +9,35 @@ import fs from "fs";
 import { isNode } from "@azure/core-util";
 import path from "path";
 
-describe("Key Vault Admin's user agent (only in Node, because of fs)", function () {
-  beforeEach(function () {
-    if (!isNode) {
-      this.skip();
-    }
-  });
-
-  it("SDK_VERSION and packageVersion should match", async function () {
+describe("Key Vault Admin's user agent", function () {
+  it("SDK_VERSION and user-agent should match", async function () {
     let userAgent: string | undefined;
     const client = new KeyVaultAccessControlClient(
       "https://myvault.vault.azure.net",
       {} as TokenCredential,
       {
-        additionalPolicies: [
-          {
-            policy: {
-              name: "fetchUserAgent",
-              sendRequest: (request, next) => {
-                userAgent = request.headers.get("user-agent");
-                return next(request);
-              },
-            },
-            position: "perCall",
+        httpClient: {
+          sendRequest: async (request) => {
+            userAgent = request.headers.get("user-agent");
+            throw new Error("only a test");
           },
-        ],
+        },
       }
     );
+
     try {
       await client.getRoleAssignment("/", "");
     } catch {
       // no-op, we don't care about the response, only the user-agent header
     }
-    assert.exists(userAgent);
+    assert.exists(userAgent, "Expected a User-Agent header to be sent");
     assert.include(userAgent!, `azsdk-js-keyvault-admin/${SDK_VERSION}`);
   });
 
   it("the version should also match with the one available in the package.json  (only in Node, because of fs)", async function () {
+    if (!isNode) {
+      this.skip();
+    }
     let version: string;
     try {
       const fileContents = JSON.parse(

--- a/sdk/keyvault/keyvault-certificates/src/generated/keyVaultClientContext.ts
+++ b/sdk/keyvault/keyvault-certificates/src/generated/keyVaultClientContext.ts
@@ -10,7 +10,7 @@ import * as coreHttp from "@azure/core-http";
 import { ApiVersion73, KeyVaultClientOptionalParams } from "./models";
 
 const packageName = "@azure/keyvault-certificates";
-export const packageVersion = "4.5.0-beta.1";
+const packageVersion = "4.5.0-beta.1";
 
 /** @internal */
 export class KeyVaultClientContext extends coreHttp.ServiceClient {

--- a/sdk/keyvault/keyvault-certificates/test/internal/userAgent.spec.ts
+++ b/sdk/keyvault/keyvault-certificates/test/internal/userAgent.spec.ts
@@ -4,14 +4,36 @@
 import { assert } from "@azure/test-utils";
 import { Context } from "mocha";
 import { SDK_VERSION } from "../../src/constants";
-import { packageVersion } from "../../src/generated/keyVaultClientContext";
 import { isNode } from "@azure/core-http";
 import path from "path";
 import fs from "fs";
+import { CertificateClient } from "../../src";
+import { ClientSecretCredential } from "@azure/identity";
+import { env } from "@azure-tools/test-recorder";
 
 describe("Certificates client's user agent (only in Node, because of fs)", () => {
-  it("SDK_VERSION and packageVersion should match", async function () {
-    assert.equal(SDK_VERSION, packageVersion);
+  it("SDK_VERSION and user-agent should match", async function () {
+    let userAgent: string | undefined;
+    const client = new CertificateClient(
+      "https://myvault.vault.azure.net",
+      new ClientSecretCredential(env.AZURE_TENANT_ID, env.AZURE_CLIENT_ID, env.AZURE_CLIENT_SECRET),
+      {
+        httpClient: {
+          sendRequest: async (request) => {
+            userAgent = request.headers.get("user-agent") ?? request.headers.get("x-ms-useragent");
+            throw new Error("only a test");
+          },
+        },
+      }
+    );
+
+    try {
+      await client.getCertificate("foo");
+    } catch {
+      // no-op, we don't care about the response, only the user-agent header
+    }
+    assert.exists(userAgent, "Expected a User-Agent header to be sent");
+    assert.include(userAgent!, `azsdk-js-keyvault-certificates/${SDK_VERSION}`);
   });
 
   it("the version should also match with the one available in the package.json  (only in Node, because of fs)", async function (this: Context) {
@@ -34,6 +56,6 @@ describe("Certificates client's user agent (only in Node, because of fs)", () =>
       );
       version = fileContents.version;
     }
-    assert.equal(version, packageVersion);
+    assert.equal(version, SDK_VERSION);
   });
 });

--- a/sdk/keyvault/keyvault-certificates/test/internal/userAgent.spec.ts
+++ b/sdk/keyvault/keyvault-certificates/test/internal/userAgent.spec.ts
@@ -1,15 +1,15 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { assert } from "@azure/test-utils";
-import { Context } from "mocha";
-import { SDK_VERSION } from "../../src/constants";
-import { isNode } from "@azure/core-http";
-import path from "path";
-import fs from "fs";
 import { CertificateClient } from "../../src";
 import { ClientSecretCredential } from "@azure/identity";
+import { Context } from "mocha";
+import { SDK_VERSION } from "../../src/constants";
+import { assert } from "@azure/test-utils";
 import { env } from "@azure-tools/test-recorder";
+import fs from "fs";
+import { isNode } from "@azure/core-http";
+import path from "path";
 
 describe("Certificates client's user agent (only in Node, because of fs)", () => {
   it("SDK_VERSION and user-agent should match", async function () {

--- a/sdk/keyvault/keyvault-keys/src/generated/keyVaultClientContext.ts
+++ b/sdk/keyvault/keyvault-keys/src/generated/keyVaultClientContext.ts
@@ -10,7 +10,7 @@ import * as coreHttp from "@azure/core-http";
 import { ApiVersion73, KeyVaultClientOptionalParams } from "./models";
 
 const packageName = "@azure/keyvault-keys";
-export const packageVersion = "4.5.0-beta.1";
+const packageVersion = "4.5.0-beta.1";
 
 export class KeyVaultClientContext extends coreHttp.ServiceClient {
   apiVersion: ApiVersion73;

--- a/sdk/keyvault/keyvault-keys/test/internal/userAgent.spec.ts
+++ b/sdk/keyvault/keyvault-keys/test/internal/userAgent.spec.ts
@@ -1,23 +1,45 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { assert } from "@azure/test-utils";
-import { Context } from "mocha";
-import { SDK_VERSION } from "../../src/constants";
-import { packageVersion } from "../../src/generated/keyVaultClientContext";
 import { isNode } from "@azure/core-http";
-import path from "path";
-import fs from "fs";
 
-describe("Keys client's user agent (only in Node, because of fs)", () => {
-  it("SDK_VERSION and packageVersion should match", async function () {
-    assert.equal(SDK_VERSION, packageVersion);
+import { Context } from "mocha";
+import { KeyClient } from "../../src";
+import { SDK_VERSION } from "../../src/constants";
+import { assert } from "@azure/test-utils";
+import fs from "fs";
+import path from "path";
+import { env } from "@azure-tools/test-recorder";
+import { ClientSecretCredential } from "@azure/identity";
+
+describe("Keys client's user agent", () => {
+  it("SDK_VERSION and user-agent should match", async function () {
+    let userAgent: string | undefined;
+    const client = new KeyClient(
+      "https://myvault.vault.azure.net",
+      new ClientSecretCredential(env.AZURE_TENANT_ID, env.AZURE_CLIENT_ID, env.AZURE_CLIENT_SECRET),
+      {
+        httpClient: {
+          sendRequest: async (request) => {
+            userAgent = request.headers.get("user-agent") ?? request.headers.get("x-ms-useragent");
+            throw new Error("only a test");
+          },
+        },
+      }
+    );
+
+    try {
+      await client.getKey("foo");
+    } catch {
+      // no-op, we don't care about the response, only the user-agent header
+    }
+    assert.exists(userAgent, "Expected a User-Agent header to be sent");
+    assert.include(userAgent!, `azsdk-js-keyvault-keys/${SDK_VERSION}`);
   });
 
   it("the version should also match with the one available in the package.json  (only in Node, because of fs)", async function (this: Context) {
     if (!isNode) {
       this.skip();
-      return;
     }
     let version: string;
     try {
@@ -34,6 +56,6 @@ describe("Keys client's user agent (only in Node, because of fs)", () => {
       );
       version = fileContents.version;
     }
-    assert.equal(version, packageVersion);
+    assert.equal(version, SDK_VERSION);
   });
 });

--- a/sdk/keyvault/keyvault-secrets/src/generated/keyVaultClientContext.ts
+++ b/sdk/keyvault/keyvault-secrets/src/generated/keyVaultClientContext.ts
@@ -10,7 +10,7 @@ import * as coreHttp from "@azure/core-http";
 import { ApiVersion73, KeyVaultClientOptionalParams } from "./models";
 
 const packageName = "@azure/keyvault-secrets";
-export const packageVersion = "4.5.0-beta.1";
+const packageVersion = "4.5.0-beta.1";
 
 /** @internal */
 export class KeyVaultClientContext extends coreHttp.ServiceClient {

--- a/sdk/keyvault/keyvault-secrets/test/internal/userAgent.spec.ts
+++ b/sdk/keyvault/keyvault-secrets/test/internal/userAgent.spec.ts
@@ -1,23 +1,44 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { assert } from "@azure/test-utils";
+import { ClientSecretCredential } from "@azure/identity";
 import { Context } from "mocha";
 import { SDK_VERSION } from "../../src/constants";
-import { packageVersion } from "../../src/generated/keyVaultClientContext";
+import { SecretClient } from "../../src";
+import { assert } from "@azure/test-utils";
+import { env } from "@azure-tools/test-recorder";
+import fs from "fs";
 import { isNode } from "@azure/core-http";
 import path from "path";
-import fs from "fs";
 
 describe("Secrets client's user agent (only in Node, because of fs)", () => {
-  it("SDK_VERSION and packageVersion should match", async function () {
-    assert.equal(SDK_VERSION, packageVersion);
+  it("SDK_VERSION and user-agent should match", async function () {
+    let userAgent: string | undefined;
+    const client = new SecretClient(
+      "https://myvault.vault.azure.net",
+      new ClientSecretCredential(env.AZURE_TENANT_ID, env.AZURE_CLIENT_ID, env.AZURE_CLIENT_SECRET),
+      {
+        httpClient: {
+          sendRequest: async (request) => {
+            userAgent = request.headers.get("user-agent") ?? request.headers.get("x-ms-useragent");
+            throw new Error("only a test");
+          },
+        },
+      }
+    );
+
+    try {
+      await client.getSecret("foo");
+    } catch {
+      // no-op, we don't care about the response, only the user-agent header
+    }
+    assert.exists(userAgent, "Expected a User-Agent header to be sent");
+    assert.include(userAgent!, `azsdk-js-keyvault-secrets/${SDK_VERSION}`);
   });
 
   it("the version should also match with the one available in the package.json  (only in Node, because of fs)", async function (this: Context) {
     if (!isNode) {
       this.skip();
-      return;
     }
     let version: string;
     try {
@@ -34,6 +55,6 @@ describe("Secrets client's user agent (only in Node, because of fs)", () => {
       );
       version = fileContents.version;
     }
-    assert.equal(version, packageVersion);
+    assert.equal(version, SDK_VERSION);
   });
 });


### PR DESCRIPTION
### Packages impacted by this PR
@azure/keyvault-admin 

### Issues associated with this PR
Resolves #21188

### Describe the problem that is addressed by this PR
`KeyVaultClientContext` is a generated file that in core v1 included a
non-exported constant `packageVersion`. Because we have a test that depends on
that constant we always have to update the file to re-export it (as the
generated code does not export it).

Even worse, in coreV2 that constant is not even generated anymore, so the test
is outdated.

This PR fixes all of these issues by examining what we _actually_ care about,
which is that our user-agent includes the correct package version.

This way anyone can regenerate the code at any time without getting weird build
errors.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_


### Command used to generate this PR: _(Applicable only to SDK release request PRs)_


### Checklists
- [x] Added impacted package name to the issue description.
- [x] Does this PR need any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here.)_
- [x] Added a changelog (if necessary).
