### PR TITLE
Added a missing space in Azure Communication READMEs

### DIFF
--- a/sdk/communication/communication-identity/README.md
+++ b/sdk/communication/communication-identity/README.md
@@ -7,7 +7,7 @@ The identity library is used for managing users and tokens for Azure Communicati
 ### Prerequisites
 
 - An [Azure subscription][azure_sub].
-- An existing Communication Services resource. If you need to create the resource, you can use the [Azure Portal][azure_portal], the[Azure PowerShell][azure_powershell], or the [Azure CLI][azure_cli].
+- An existing Communication Services resource. If you need to create the resource, you can use the [Azure Portal][azure_portal], the [Azure PowerShell][azure_powershell], or the [Azure CLI][azure_cli].
 
 ### Installing
 

--- a/sdk/communication/communication-network-traversal/README.md
+++ b/sdk/communication/communication-network-traversal/README.md
@@ -9,7 +9,7 @@ It will provide TURN credentials to a user.
 ### Prerequisites
 
 - An [Azure subscription][azure_sub].
-- An existing Communication Services resource. If you need to create the resource, you can use the [Azure Portal][azure_portal], the[Azure PowerShell][azure_powershell], or the [Azure CLI][azure_cli].
+- An existing Communication Services resource. If you need to create the resource, you can use the [Azure Portal][azure_portal], the [Azure PowerShell][azure_powershell], or the [Azure CLI][azure_cli].
 
 ### Installing
 

--- a/sdk/communication/communication-phone-numbers/README.md
+++ b/sdk/communication/communication-phone-numbers/README.md
@@ -9,7 +9,7 @@ Purchased phone numbers can come with many capabilities, depending on the countr
 ### Prerequisites
 
 - An [Azure subscription][azure_sub].
-- An existing Communication Services resource. If you need to create the resource, you can use the [Azure Portal][azure_portal], the[Azure PowerShell][azure_powershell], or the [Azure CLI][azure_cli].
+- An existing Communication Services resource. If you need to create the resource, you can use the [Azure Portal][azure_portal], the [Azure PowerShell][azure_powershell], or the [Azure CLI][azure_cli].
 
 ### Installing
 

--- a/sdk/communication/communication-short-codes/README.md
+++ b/sdk/communication/communication-short-codes/README.md
@@ -7,7 +7,7 @@ The phone numbers library provides capabilities for short codes administration.
 ### Prerequisites
 
 - An [Azure subscription][azure_sub].
-- An existing Communication Services resource. If you need to create the resource, you can use the [Azure Portal][azure_portal], the[Azure PowerShell][azure_powershell], or the [Azure CLI][azure_cli].
+- An existing Communication Services resource. If you need to create the resource, you can use the [Azure Portal][azure_portal], the [Azure PowerShell][azure_powershell], or the [Azure CLI][azure_cli].
 
 ### Installing
 


### PR DESCRIPTION
- just a typo

**Impacted packages:**

- @azure/communication-identity
- @azure/communication-network-traversal
- @azure/communication-phone-numbers
- @azure-tools/communication-short-codes