### PR TITLE
[eventhub] - Move tracing spec to internal

### DIFF
--- a/sdk/eventhub/event-hubs/test/internal/node/client.spec.ts
+++ b/sdk/eventhub/event-hubs/test/internal/node/client.spec.ts
@@ -1,0 +1,76 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import chai, { assert } from "chai";
+
+import { EventHubConsumerClient } from "../../../src/eventHubConsumerClient";
+import Sinon from "sinon";
+import { TokenCredential } from "@azure/core-auth";
+import { createMockServer } from "../../public/utils/mockService";
+import { getEnvVars } from "../../public/utils/testUtils";
+import { testWithServiceTypes } from "../../public/utils/testWithServiceTypes";
+import { tracingClient } from "../../../src/diagnostics/tracing";
+
+const should = chai.should();
+
+testWithServiceTypes((serviceVersion) => {
+  const env = getEnvVars();
+  if (serviceVersion === "mock") {
+    let service: ReturnType<typeof createMockServer>;
+
+    before("Starting mock service", () => {
+      service = createMockServer();
+      return service.start();
+    });
+
+    after("Stopping mock service", async () => {
+      await service?.stop();
+    });
+
+    let endpoint: string;
+    let credential: TokenCredential;
+    let client: EventHubConsumerClient;
+
+    afterEach(async () => {
+      // The client must always be closed, or MockHub will hang on shutdown.
+      await client?.close();
+    });
+
+    describe("tracing", () => {
+      it("getEventHubProperties() creates a span with a peer.address attribute as the FQNS", async () => {
+        client = new EventHubConsumerClient(
+          EventHubConsumerClient.defaultConsumerGroupName,
+          endpoint,
+          env.EVENTHUB_NAME,
+          credential
+        );
+        should.equal(client.fullyQualifiedNamespace, endpoint);
+
+        const withSpanStub = Sinon.spy(tracingClient, "withSpan");
+
+        // Ensure tracing is implemented correctly
+        await assert.supportsTracing(
+          (options) => client.getEventHubProperties(options),
+          ["ManagementClient.getEventHubProperties"]
+        );
+
+        // Additional validation that we created the correct initial span options
+        const expectedSpanOptions = {
+          spanAttributes: {
+            "peer.address": client.fullyQualifiedNamespace,
+            "message_bus.destination": client.eventHubName,
+          },
+        };
+
+        assert.isTrue(
+          withSpanStub.calledWith(
+            Sinon.match.any,
+            Sinon.match.any,
+            Sinon.match.any,
+            expectedSpanOptions
+          )
+        );
+      });
+    });
+  }
+});

--- a/sdk/eventhub/event-hubs/test/internal/node/client.spec.ts
+++ b/sdk/eventhub/event-hubs/test/internal/node/client.spec.ts
@@ -1,23 +1,22 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import chai, { assert } from "chai";
+import { EnvVarKeys, getEnvVars } from "../../public/utils/testUtils";
+import { EnvironmentCredential, TokenCredential } from "@azure/identity";
+import { EventHubConsumerClient, EventHubProducerClient } from "../../../src";
+import { assert, should as shouldFn } from "@azure/test-utils";
 
-import { EventHubConsumerClient } from "../../../src/eventHubConsumerClient";
 import Sinon from "sinon";
-import { TokenCredential } from "@azure/core-auth";
 import { createMockServer } from "../../public/utils/mockService";
-import { getEnvVars } from "../../public/utils/testUtils";
 import { testWithServiceTypes } from "../../public/utils/testWithServiceTypes";
 import { tracingClient } from "../../../src/diagnostics/tracing";
 
-const should = chai.should();
+const should = shouldFn();
 
 testWithServiceTypes((serviceVersion) => {
   const env = getEnvVars();
   if (serviceVersion === "mock") {
     let service: ReturnType<typeof createMockServer>;
-
     before("Starting mock service", () => {
       service = createMockServer();
       return service.start();
@@ -26,51 +25,82 @@ testWithServiceTypes((serviceVersion) => {
     after("Stopping mock service", async () => {
       await service?.stop();
     });
+  }
 
+  describe("Create clients using Azure Identity (Internal)", function (): void {
     let endpoint: string;
     let credential: TokenCredential;
-    let client: EventHubConsumerClient;
+    let client: EventHubConsumerClient | EventHubProducerClient;
 
     afterEach(async () => {
       // The client must always be closed, or MockHub will hang on shutdown.
       await client?.close();
     });
 
-    describe("tracing", () => {
-      it("getEventHubProperties() creates a span with a peer.address attribute as the FQNS", async () => {
-        client = new EventHubConsumerClient(
-          EventHubConsumerClient.defaultConsumerGroupName,
-          endpoint,
-          env.EVENTHUB_NAME,
-          credential
-        );
-        should.equal(client.fullyQualifiedNamespace, endpoint);
-
-        const withSpanStub = Sinon.spy(tracingClient, "withSpan");
-
-        // Ensure tracing is implemented correctly
-        await assert.supportsTracing(
-          (options) => client.getEventHubProperties(options),
-          ["ManagementClient.getEventHubProperties"]
-        );
-
-        // Additional validation that we created the correct initial span options
-        const expectedSpanOptions = {
-          spanAttributes: {
-            "peer.address": client.fullyQualifiedNamespace,
-            "message_bus.destination": client.eventHubName,
+    before("validate environment", function () {
+      should.exist(
+        env[EnvVarKeys.AZURE_CLIENT_ID],
+        "define AZURE_CLIENT_ID in your environment before running integration tests."
+      );
+      should.exist(
+        env[EnvVarKeys.AZURE_TENANT_ID],
+        "define AZURE_TENANT_ID in your environment before running integration tests."
+      );
+      should.exist(
+        env[EnvVarKeys.AZURE_CLIENT_SECRET],
+        "define AZURE_CLIENT_SECRET in your environment before running integration tests."
+      );
+      should.exist(
+        env[EnvVarKeys.EVENTHUB_CONNECTION_STRING],
+        "define EVENTHUB_CONNECTION_STRING in your environment before running integration tests."
+      );
+      // This is of the form <your-namespace>.servicebus.windows.net
+      endpoint = (env.EVENTHUB_CONNECTION_STRING.match("Endpoint=sb://(.*)/;") || "")[1];
+      if (serviceVersion === "mock") {
+        // Create a mock credential that implements the TokenCredential interface.
+        credential = {
+          getToken(_args) {
+            return Promise.resolve({ token: "token", expiresOnTimestamp: Date.now() + 360000 });
           },
         };
-
-        assert.isTrue(
-          withSpanStub.calledWith(
-            Sinon.match.any,
-            Sinon.match.any,
-            Sinon.match.any,
-            expectedSpanOptions
-          )
-        );
-      });
+      } else {
+        credential = new EnvironmentCredential();
+      }
     });
-  }
+
+    it("getEventHubProperties() creates a span with a peer.address attribute as the FQNS", async () => {
+      client = new EventHubConsumerClient(
+        EventHubConsumerClient.defaultConsumerGroupName,
+        endpoint,
+        env.EVENTHUB_NAME,
+        credential
+      );
+      should.equal(client.fullyQualifiedNamespace, endpoint);
+
+      const withSpanStub = Sinon.spy(tracingClient, "withSpan");
+
+      // Ensure tracing is implemented correctly
+      await assert.supportsTracing(
+        (options) => client.getEventHubProperties(options),
+        ["ManagementClient.getEventHubProperties"]
+      );
+
+      // Additional validation that we created the correct initial span options
+      const expectedSpanOptions = {
+        spanAttributes: {
+          "peer.address": client.fullyQualifiedNamespace,
+          "message_bus.destination": client.eventHubName,
+        },
+      };
+
+      assert.isTrue(
+        withSpanStub.calledWith(
+          Sinon.match.any,
+          Sinon.match.any,
+          Sinon.match.any,
+          expectedSpanOptions
+        )
+      );
+    });
+  });
 });

--- a/sdk/eventhub/event-hubs/test/public/node/client.spec.ts
+++ b/sdk/eventhub/event-hubs/test/public/node/client.spec.ts
@@ -9,7 +9,6 @@ import chaiString from "chai-string";
 import { createMockServer } from "../utils/mockService";
 import { testWithServiceTypes } from "../utils/testWithServiceTypes";
 import Sinon from "sinon";
-import { tracingClient } from "../../../src/diagnostics/tracing";
 
 chai.use(chaiString);
 const should = shouldFn();

--- a/sdk/eventhub/event-hubs/test/public/node/client.spec.ts
+++ b/sdk/eventhub/event-hubs/test/public/node/client.spec.ts
@@ -4,11 +4,10 @@
 import { EnvVarKeys, getEnvVars } from "../utils/testUtils";
 import { EnvironmentCredential, TokenCredential } from "@azure/identity";
 import { EventHubConsumerClient, EventHubProducerClient } from "../../../src";
-import { chai, assert, should as shouldFn } from "@azure/test-utils";
+import { chai, should as shouldFn } from "@azure/test-utils";
 import chaiString from "chai-string";
 import { createMockServer } from "../utils/mockService";
 import { testWithServiceTypes } from "../utils/testWithServiceTypes";
-import Sinon from "sinon";
 
 chai.use(chaiString);
 const should = shouldFn();
@@ -89,43 +88,6 @@ testWithServiceTypes((serviceVersion) => {
       // Extra check involving actual call to the service to ensure this works
       const hubInfo = await client.getEventHubProperties();
       should.equal(hubInfo.name, client.eventHubName);
-    });
-
-    describe("tracing", () => {
-      it("getEventHubProperties() creates a span with a peer.address attribute as the FQNS", async () => {
-        client = new EventHubConsumerClient(
-          EventHubConsumerClient.defaultConsumerGroupName,
-          endpoint,
-          env.EVENTHUB_NAME,
-          credential
-        );
-        should.equal(client.fullyQualifiedNamespace, endpoint);
-
-        const withSpanStub = Sinon.spy(tracingClient, "withSpan");
-
-        // Ensure tracing is implemented correctly
-        await assert.supportsTracing(
-          (options) => client.getEventHubProperties(options),
-          ["ManagementClient.getEventHubProperties"]
-        );
-
-        // Additional validation that we created the correct initial span options
-        const expectedSpanOptions = {
-          spanAttributes: {
-            "peer.address": client.fullyQualifiedNamespace,
-            "message_bus.destination": client.eventHubName,
-          },
-        };
-
-        assert.isTrue(
-          withSpanStub.calledWith(
-            Sinon.match.any,
-            Sinon.match.any,
-            Sinon.match.any,
-            expectedSpanOptions
-          )
-        );
-      });
     });
   });
 });


### PR DESCRIPTION
### Packages impacted by this PR
event-hubs

### Issues associated with this PR
Fixes #21226

### Describe the problem that is addressed by this PR
The tracing client test adds an internal reference; however, the test is still
not excluded during min/max due to the nesting of the tracing reference. That
will be fixed separately, but it also makes sense to make this an internal test
as it tests the internals of how we trace.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_
N/A

### Provide a list of related PRs _(if any)_


### Command used to generate this PR: _(Applicable only to SDK release request PRs)_


### Checklists
- [x] Added impacted package name to the issue description.
- [x] Does this PR need any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here.)_
- [x] Added a changelog (if necessary).
