### PR TITLE
[Schema Registry Avro] Add perf test for deserialize

### DIFF
--- a/sdk/schemaregistry/perf-tests/schema-registry-avro/README.md
+++ b/sdk/schemaregistry/perf-tests/schema-registry-avro/README.md
@@ -7,5 +7,8 @@
 3. Create an Event Hubs account and populate the `.env` file with the relevant credentials.
 4. Run the tests as follows
 
-   - detect language
+   - serialize
      - `npm run perf-test:node -- SerializeTest --warmup 1 --iterations 10 --parallel 100 --duration 15 --items-count 1000`
+
+   - deserialize
+     - `npm run perf-test:node -- DeserializeTest --warmup 1 --iterations 10 --parallel 100 --duration 15 --items-count 1000`

--- a/sdk/schemaregistry/perf-tests/schema-registry-avro/test/deserialize.spec.ts
+++ b/sdk/schemaregistry/perf-tests/schema-registry-avro/test/deserialize.spec.ts
@@ -1,0 +1,42 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { AvroSerializerTest } from "./avroSerializerTest.spec";
+import { PerfOptionDictionary } from "@azure/test-utils-perf";
+import { MessageContent } from "@azure/schema-registry-avro";
+
+interface SerializePerfTestOptions {
+  "items-count": number;
+}
+
+export class DeserializeTest extends AvroSerializerTest<SerializePerfTestOptions> {
+  options: PerfOptionDictionary<SerializePerfTestOptions> = {
+    "items-count": {
+      required: false,
+      description: "Number of array items",
+      shortName: "n",
+      longName: "items-count",
+      defaultValue: 1000,
+    },
+  };
+  serialized: MessageContent | undefined;
+
+  constructor() {
+    super();
+    this.options = this.parsedOptions;
+  }
+
+  async setup(): Promise<void> {
+    this.serialized = await this.serializer.serialize(
+      {
+        name: "test",
+        favoriteNumbers: [...Array(this.options["items-count"].value).keys()],
+      },
+      AvroSerializerTest.schema
+    );
+  }
+
+  async run(): Promise<void> {
+    await this.serializer.deserialize(this.serialized!);
+  }
+}

--- a/sdk/schemaregistry/perf-tests/schema-registry-avro/test/deserialize.spec.ts
+++ b/sdk/schemaregistry/perf-tests/schema-registry-avro/test/deserialize.spec.ts
@@ -19,7 +19,7 @@ export class DeserializeTest extends AvroSerializerTest<SerializePerfTestOptions
       defaultValue: 1000,
     },
   };
-  serialized: MessageContent | undefined;
+  private serialized: MessageContent | undefined;
 
   constructor() {
     super();

--- a/sdk/schemaregistry/perf-tests/schema-registry-avro/test/index.spec.ts
+++ b/sdk/schemaregistry/perf-tests/schema-registry-avro/test/index.spec.ts
@@ -3,12 +3,13 @@
 
 import { PerfProgram, selectPerfTest } from "@azure/test-utils-perf";
 import { SerializeTest } from "./serialize.spec";
+import { DeserializeTest } from "./deserialize.spec";
 
 import dotenv from "dotenv";
 dotenv.config();
 
 console.log("=== Starting the perf test ===");
 
-const perfProgram = new PerfProgram(selectPerfTest([SerializeTest]));
+const perfProgram = new PerfProgram(selectPerfTest([SerializeTest, DeserializeTest]));
 
 perfProgram.run();


### PR DESCRIPTION
### Packages impacted by this PR
@azure/schema-registry-avro

### Issues associated with this PR
Related to https://github.com/Azure/azure-sdk-for-js/issues/16983

### Describe the problem that is addressed by this PR
Missing performance test for deserialize

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?
N/A

### Are there test cases added in this PR? _(If not, why?)_
N/A

### Provide a list of related PRs _(if any)_
N/A

### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
