### PR TITLE
[CODEOWNERS] Remove @mikeharder from pnpm-lock.yaml

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1439,7 +1439,7 @@ sdk/dnsresolver/ci.mgmt.yml @qiaozha @dw511214992 @MaryGao
 ###########
 /.vscode/ @mikeharder @praveenkuttappan @deyaaeldeen
 /common/ @mikeharder @praveenkuttappan @witemple-msft @deyaaeldeen
-/common/config/rush/pnpm-lock.yaml @praveenkuttappan @witemple-msft @deyaaeldeen
+/common/config/rush/pnpm-lock.yaml @praveenkuttappan @witemple-msft @deyaaeldeen @jeremymeng
 /common/smoke-test @mikeharder @praveenkuttappan @witemple-msft @deyaaeldeen @benbp
 
 /rush.json @mikeharder @praveenkuttappan

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1439,6 +1439,7 @@ sdk/dnsresolver/ci.mgmt.yml @qiaozha @dw511214992 @MaryGao
 ###########
 /.vscode/ @mikeharder @praveenkuttappan @deyaaeldeen
 /common/ @mikeharder @praveenkuttappan @witemple-msft @deyaaeldeen
+/common/config/rush/pnpm-lock.yaml @praveenkuttappan @witemple-msft @deyaaeldeen
 /common/smoke-test @mikeharder @praveenkuttappan @witemple-msft @deyaaeldeen @benbp
 
 /rush.json @mikeharder @praveenkuttappan


### PR DESCRIPTION
Excluding myself from owning /common/config/rush/pnpm-lock.yaml, but still owning everything else under /common/.