### PR TITLE
Use a commit hash url when referencing the spec file

### DIFF
--- a/sdk/communication/communication-short-codes/swagger/README.md
+++ b/sdk/communication/communication-short-codes/swagger/README.md
@@ -12,7 +12,7 @@ generate-metadata: false
 license-header: MICROSOFT_MIT_NO_VERSION
 output-folder: ../src/generated
 tag: package-shortcode-2021-10-25-preview
-require: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/main/specification/communication/data-plane/ShortCodes/readme.md
+require: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/ca0335b44b4eca2c5b5673ee2c58a87e524b669f/specification/communication/data-plane/ShortCodes/readme.md
 model-date-time-as-string: false
 optional-response-headers: true
 payload-flattening-threshold: 10


### PR DESCRIPTION
### Packages impacted by this PR
- @azure-tools/communication-short-codes

### Issues associated with this PR
-- 

### Describe the problem that is addressed by this PR
The autorest file wasn't referencing the spec file by a commit hash.
The spec file will be removed (see https://github.com/Azure/azure-rest-api-specs/pull/18559) and it will break the builds for this repo. Please be aware that this package is not meant to be used by customers yet. **It is still a private preview release**.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?
--

### Are there test cases added in this PR? _(If not, why?)_
--

### Provide a list of related PRs _(if any)_
- https://github.com/Azure/azure-rest-api-specs/pull/18559
  - This is the pull request for removing the spec file
- https://github.com/Azure/azure-sdk-for-js/pull/18429
  - This is the initial pull request that makes it clear that this package is for internal use only

### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_
--

### Checklists
- [x] Added impacted package name to the issue description
- [x] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [x] Added a changelog (if necessary)
