### PR TITLE
Support releasing util packages like test recorder using unified pipe…

### DIFF
--- a/eng/pipelines/templates/stages/archetype-js-release.yml
+++ b/eng/pipelines/templates/stages/archetype-js-release.yml
@@ -289,7 +289,7 @@ stages:
                 arguments: '-pathToArtifacts $(Package.Archive) -accessLevel "public" -tag "dev" -registry "$(Registry)" -npmToken "$(NpmToken)"'
 
     - job: PublishDocsToNightlyBranch
-      condition: or(eq(variables['SetDevVersion'], 'true'), and(eq(variables['Build.Reason'],'Schedule'), eq(variables['System.TeamProject'], 'internal')))
+      condition: or(eq(variables['SetDevVersion'], 'true'), and(eq(variables['Build.Reason'],'Schedule'), eq(variables['System.TeamProject'], 'internal'),  ne(variables['Skip.PublishDocs'], 'true')))
       dependsOn: PublishPackages
       pool:
         name: azsdk-pool-mms-ubuntu-2004-general

--- a/eng/pipelines/templates/steps/build.yml
+++ b/eng/pipelines/templates/steps/build.yml
@@ -85,7 +85,7 @@ steps:
         New-Item -Type Directory -Name $artifactName -Path $(Build.ArtifactStagingDirectory) > $null
         Copy-Item sdk/${{parameters.ServiceDirectory}}/**/$artifactName-[0-9]*.[0-9]*.[0-9]*.tgz $(Build.ArtifactStagingDirectory)/$artifactName
         Copy-Item sdk/${{parameters.ServiceDirectory}}/**/browser/$artifactName-[0-9]*.[0-9]*.[0-9]*.zip $(Build.ArtifactStagingDirectory)/$artifactName
-        if ($${{ parameters.IncludeRelease }} -eq $true)
+        if ($${{ parameters.IncludeRelease }} -eq $true -and $artifact.skipPublishDocMs -ne $true)
         {
           New-Item -Type Directory -Name documentation -Path $(Build.ArtifactStagingDirectory)/$artifactName > $null
           Copy-Item $(Build.SourcesDirectory)/docGen/$artifactName.zip $(Build.ArtifactStagingDirectory)/$artifactName/documentation

--- a/sdk/test-utils/ci.yml
+++ b/sdk/test-utils/ci.yml
@@ -28,9 +28,17 @@ extends:
     Artifacts:
       - name: azure-tools-test-recorder
         safeName: azuretoolstestrecorder
+        skipPublishDocMs: true
+        skipPublishDocGithubIo: true
       - name: azure-test-utils-perf
         safeName: azuretestutilsperf
+        skipPublishDocMs: true
+        skipPublishDocGithubIo: true
       - name: azure-tools-test-credential
         safeName: azuretoolstestcredential
+        skipPublishDocMs: true
+        skipPublishDocGithubIo: true
       - name: azure-test-utils
         safeName: azuretestutils
+        skipPublishDocMs: true
+        skipPublishDocGithubIo: true

--- a/sdk/test-utils/ci.yml
+++ b/sdk/test-utils/ci.yml
@@ -25,7 +25,6 @@ extends:
   template: ../../eng/pipelines/templates/stages/archetype-sdk-client.yml
   parameters:
     ServiceDirectory: test-utils
-    IncludeRelease: false
     Artifacts:
       - name: azure-tools-test-recorder
         safeName: azuretoolstestrecorder

--- a/sdk/test-utils/ci.yml
+++ b/sdk/test-utils/ci.yml
@@ -21,6 +21,8 @@ pr:
     include:
       - sdk/test-utils/
 
+variables:
+   Skip.PublishDocs: true
 extends:
   template: ../../eng/pipelines/templates/stages/archetype-sdk-client.yml
   parameters:
@@ -30,15 +32,19 @@ extends:
         safeName: azuretoolstestrecorder
         skipPublishDocMs: true
         skipPublishDocGithubIo: true
+        skipPublishDevFeed: true
       - name: azure-test-utils-perf
         safeName: azuretestutilsperf
         skipPublishDocMs: true
         skipPublishDocGithubIo: true
+        skipPublishDevFeed: true
       - name: azure-tools-test-credential
         safeName: azuretoolstestcredential
         skipPublishDocMs: true
         skipPublishDocGithubIo: true
+        skipPublishDevFeed: true
       - name: azure-test-utils
         safeName: azuretestutils
         skipPublishDocMs: true
         skipPublishDocGithubIo: true
+        skipPublishDevFeed: true


### PR DESCRIPTION
Release stage was disable for JS util packages in test-util services. This PR is to enable release stage in unified pipeline for test-utils to publish the package to npm.