### PR TITLE
[storage internal avro] Fix ESLint errors

### DIFF
--- a/sdk/storage/storage-internal-avro/package.json
+++ b/sdk/storage/storage-internal-avro/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@azure/storage-internal-avro",
+  "sdk-type": "client",
   "sideEffects": false,
   "private": true,
   "author": "Microsoft Corporation",
@@ -51,7 +52,7 @@
     "integration-test:node": "nyc mocha -r esm --require source-map-support/register --reporter ../../../common/tools/mocha-multi-reporter.js --full-trace -t 300000  \"dist-esm/storage-internal-avro/test/*.spec.js\" \"dist-esm/storage-internal-avro/test/node/*.spec.js\"",
     "integration-test": "npm run integration-test:node && npm run integration-test:browser",
     "lint:fix": "eslint package.json api-extractor.json src test --ext .ts --fix",
-    "lint": "eslint package.json api-extractor.json src test --ext .ts -f html -o storage-internal-avro-lintReport.html || exit 0",
+    "lint": "eslint package.json api-extractor.json src test --ext .ts",
     "pack": "npm pack 2>&1",
     "test:browser": "npm run clean && npm run build:test && npm run unit-test:browser",
     "test:node": "npm run clean && npm run build:test && npm run unit-test:node",

--- a/sdk/storage/storage-internal-avro/src/AvroParser.ts
+++ b/sdk/storage/storage-internal-avro/src/AvroParser.ts
@@ -1,9 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+// TODO: Do a review of the Object usage and non-interfaces
+/* eslint-disable @typescript-eslint/ban-types, @azure/azure-sdk/ts-use-interface-parameters */
+
+import { AbortSignalLike } from "@azure/abort-controller";
 import { AvroReadable } from "./AvroReadable";
 import { KeyValuePair } from "./utils/utils.common";
-import { AbortSignalLike } from "@azure/abort-controller";
 
 /**
  * Options to configure the AvroParser read methods.
@@ -31,7 +34,7 @@ export class AvroParser {
     options: AvroParserReadOptions = {}
   ): Promise<Uint8Array> {
     const bytes = await stream.read(length, { abortSignal: options.abortSignal });
-    if (bytes.length != length) {
+    if (bytes.length !== length) {
       throw new Error("Hit stream end.");
     }
     return bytes;
@@ -71,6 +74,7 @@ export class AvroParser {
 
     if (haveMoreByte) {
       // Switch to float arithmetic
+      // eslint-disable-next-line no-self-assign
       zigZagEncoded = zigZagEncoded;
       significanceInFloat = 268435456; // 2 ** 28.
       do {
@@ -112,9 +116,9 @@ export class AvroParser {
     options: AvroParserReadOptions = {}
   ): Promise<boolean> {
     const b = await AvroParser.readByte(stream, options);
-    if (b == 1) {
+    if (b === 1) {
       return true;
-    } else if (b == 0) {
+    } else if (b === 0) {
       return false;
     } else {
       throw new Error("Byte was not a boolean.");
@@ -148,7 +152,7 @@ export class AvroParser {
       throw new Error("Bytes size was negative.");
     }
 
-    return await stream.read(size, { abortSignal: options.abortSignal });
+    return stream.read(size, { abortSignal: options.abortSignal });
   }
 
   public static async readString(
@@ -156,14 +160,6 @@ export class AvroParser {
     options: AvroParserReadOptions = {}
   ): Promise<string> {
     const u8arr = await AvroParser.readBytes(stream, options);
-
-    // polyfill TextDecoder to be backward compatible with older
-    // nodejs that doesn't expose TextDecoder as a global variable
-    if (typeof TextDecoder === "undefined" && typeof require !== "undefined") {
-      (global as any).TextDecoder = require("util").TextDecoder;
-    }
-
-    // FUTURE: need TextDecoder polyfill for IE
     const utf8decoder = new TextDecoder();
     return utf8decoder.decode(u8arr);
   }
@@ -184,11 +180,11 @@ export class AvroParser {
     readItemMethod: (s: AvroReadable, options?: AvroParserReadOptions) => Promise<T>,
     options: AvroParserReadOptions = {}
   ): Promise<Record<string, T>> {
-    const readPairMethod = async (
-      stream: AvroReadable,
-      options: AvroParserReadOptions = {}
+    const readPairMethod = (
+      s: AvroReadable,
+      opts: AvroParserReadOptions = {}
     ): Promise<KeyValuePair<T>> => {
-      return await AvroParser.readMapPair(stream, readItemMethod, options);
+      return AvroParser.readMapPair(s, readItemMethod, opts);
     };
 
     const pairs: KeyValuePair<T>[] = await AvroParser.readArray(stream, readPairMethod, options);
@@ -208,7 +204,7 @@ export class AvroParser {
     const items: T[] = [];
     for (
       let count = await AvroParser.readLong(stream, options);
-      count != 0;
+      count !== 0;
       count = await AvroParser.readLong(stream, options)
     ) {
       if (count < 0) {
@@ -250,6 +246,17 @@ interface ObjectSchema {
   size?: number;
 }
 
+enum AvroPrimitive {
+  NULL = "null",
+  BOOLEAN = "boolean",
+  INT = "int",
+  LONG = "long",
+  FLOAT = "float",
+  DOUBLE = "double",
+  BYTES = "bytes",
+  STRING = "string",
+}
+
 export abstract class AvroType {
   /**
    * Reads an object from the stream.
@@ -257,7 +264,7 @@ export abstract class AvroType {
   public abstract read(
     stream: AvroReadable,
     options?: AvroParserReadOptions
-  ): Promise<Object | null>;
+  ): Promise<Object | null>; // eslint-disable-line @typescript-eslint/ban-types
 
   /**
    * Determines the AvroType from the Avro Schema.
@@ -297,7 +304,9 @@ export abstract class AvroType {
     // Primitives can be defined as strings or objects
     try {
       return AvroType.fromStringSchema(type);
-    } catch (err) {}
+    } catch (err) {
+      // eslint-disable-line no-empty
+    }
 
     switch (type) {
       case AvroComplex.RECORD:
@@ -308,6 +317,7 @@ export abstract class AvroType {
           throw new Error(`Required attribute 'name' doesn't exist on schema: ${schema}`);
         }
 
+        // eslint-disable-next-line no-case-declarations
         const fields: Record<string, AvroType> = {};
         if (!schema.fields) {
           throw new Error(`Required attribute 'fields' doesn't exist on schema: ${schema}`);
@@ -337,17 +347,6 @@ export abstract class AvroType {
   }
 }
 
-enum AvroPrimitive {
-  NULL = "null",
-  BOOLEAN = "boolean",
-  INT = "int",
-  LONG = "long",
-  FLOAT = "float",
-  DOUBLE = "double",
-  BYTES = "bytes",
-  STRING = "string",
-}
-
 class AvroPrimitiveType extends AvroType {
   private _primitive: AvroPrimitive;
 
@@ -356,27 +355,27 @@ class AvroPrimitiveType extends AvroType {
     this._primitive = primitive;
   }
 
-  public async read(
+  public read(
     stream: AvroReadable,
     options: AvroParserReadOptions = {}
   ): Promise<Object | null> {
     switch (this._primitive) {
       case AvroPrimitive.NULL:
-        return await AvroParser.readNull();
+        return AvroParser.readNull();
       case AvroPrimitive.BOOLEAN:
-        return await AvroParser.readBoolean(stream, options);
+        return AvroParser.readBoolean(stream, options);
       case AvroPrimitive.INT:
-        return await AvroParser.readInt(stream, options);
+        return AvroParser.readInt(stream, options);
       case AvroPrimitive.LONG:
-        return await AvroParser.readLong(stream, options);
+        return AvroParser.readLong(stream, options);
       case AvroPrimitive.FLOAT:
-        return await AvroParser.readFloat(stream, options);
+        return AvroParser.readFloat(stream, options);
       case AvroPrimitive.DOUBLE:
-        return await AvroParser.readDouble(stream, options);
+        return AvroParser.readDouble(stream, options);
       case AvroPrimitive.BYTES:
-        return await AvroParser.readBytes(stream, options);
+        return AvroParser.readBytes(stream, options);
       case AvroPrimitive.STRING:
-        return await AvroParser.readString(stream, options);
+        return AvroParser.readString(stream, options);
       default:
         throw new Error("Unknown Avro Primitive");
     }
@@ -408,9 +407,9 @@ class AvroUnionType extends AvroType {
   public async read(
     stream: AvroReadable,
     options: AvroParserReadOptions = {}
-  ): Promise<Object | null> {
+  ): Promise<Object | null> { // eslint-disable-line @typescript-eslint/ban-types
     const typeIndex = await AvroParser.readInt(stream, options);
-    return await this._types[typeIndex].read(stream, options);
+    return this._types[typeIndex].read(stream, options);
   }
 }
 
@@ -422,14 +421,14 @@ class AvroMapType extends AvroType {
     this._itemType = itemType;
   }
 
-  public async read(stream: AvroReadable, options: AvroParserReadOptions = {}): Promise<Object> {
-    const readItemMethod = async (
+  public read(stream: AvroReadable, options: AvroParserReadOptions = {}): Promise<Object> {
+    const readItemMethod = (
       s: AvroReadable,
-      options?: AvroParserReadOptions
-    ): Promise<Object | null> => {
-      return await this._itemType.read(s, options);
+      opts?: AvroParserReadOptions
+    ): Promise<Object | null> => { 
+      return this._itemType.read(s, opts);
     };
-    return await AvroParser.readMap(stream, readItemMethod, options);
+    return AvroParser.readMap(stream, readItemMethod, options);
   }
 }
 
@@ -447,7 +446,7 @@ class AvroRecordType extends AvroType {
     const record: Record<string, Object | null> = {};
     record["$schema"] = this._name;
     for (const key in this._fields) {
-      if (this._fields.hasOwnProperty(key)) {
+      if (Object.prototype.hasOwnProperty.call(this._fields, key)) {
         record[key] = await this._fields[key].read(stream, options);
       }
     }

--- a/sdk/storage/storage-internal-avro/src/AvroReadableFromBlob.ts
+++ b/sdk/storage/storage-internal-avro/src/AvroReadableFromBlob.ts
@@ -28,17 +28,18 @@ export class AvroReadableFromBlob extends AvroReadable {
 
     const fileReader = new FileReader();
     return new Promise<Uint8Array>((resolve, reject) => {
-      const cleanUp = () => {
+
+      function cleanUp(): void {
         if (options.abortSignal) {
           options.abortSignal!.removeEventListener("abort", abortHandler);
         }
-      };
+      }
 
-      const abortHandler = () => {
+      function abortHandler(): void {
         fileReader.abort();
         cleanUp();
         reject(ABORT_ERROR);
-      };
+      }
 
       if (options.abortSignal) {
         options.abortSignal.addEventListener("abort", abortHandler);

--- a/sdk/storage/storage-internal-avro/src/AvroReadableFromStream.ts
+++ b/sdk/storage/storage-internal-avro/src/AvroReadableFromStream.ts
@@ -50,7 +50,8 @@ export class AvroReadableFromStream extends AvroReadable {
     } else {
       // register callback to wait for enough data to read
       return new Promise((resolve, reject) => {
-        const cleanUp = () => {
+        /* eslint-disable @typescript-eslint/no-use-before-define */
+        const cleanUp: () => void = () => {
           this._readable.removeListener("readable", readableCallback);
           this._readable.removeListener("error", rejectCallback);
           this._readable.removeListener("end", rejectCallback);
@@ -61,22 +62,22 @@ export class AvroReadableFromStream extends AvroReadable {
           }
         };
 
-        const readableCallback = () => {
-          const chunk = this._readable.read(size);
-          if (chunk) {
-            this._position += chunk.length;
+        const readableCallback: () => void = () => {
+          const callbackChunk = this._readable.read(size);
+          if (callbackChunk) {
+            this._position += callbackChunk.length;
             cleanUp();
-            // chunk.length maybe less than desired size if the stream ends.
-            resolve(this.toUint8Array(chunk));
+            // callbackChunk.length maybe less than desired size if the stream ends.
+            resolve(this.toUint8Array(callbackChunk));
           }
         };
 
-        const rejectCallback = () => {
+        const rejectCallback: () => void = () => {
           cleanUp();
           reject();
         };
 
-        const abortHandler = () => {
+        const abortHandler: () => void = () => {
           cleanUp();
           reject(ABORT_ERROR);
         };
@@ -88,6 +89,7 @@ export class AvroReadableFromStream extends AvroReadable {
         if (options.abortSignal) {
           options.abortSignal!.addEventListener("abort", abortHandler);
         }
+        /* eslint-enable @typescript-eslint/no-use-before-define */
       });
     }
   }

--- a/sdk/storage/storage-internal-avro/src/AvroReader.ts
+++ b/sdk/storage/storage-internal-avro/src/AvroReader.ts
@@ -1,17 +1,20 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { AvroReadable } from "./AvroReadable";
-import {
-  AVRO_SYNC_MARKER_SIZE,
-  AVRO_INIT_BYTES,
-  AVRO_CODEC_KEY,
-  AVRO_SCHEMA_KEY,
-} from "./AvroConstants";
-import { arraysEqual } from "./utils/utils.common";
-import { AvroType, AvroParser } from "./AvroParser";
+// TODO: Do a review of non-interfaces
+/* eslint-disable @azure/azure-sdk/ts-use-interface-parameters */
+
 import "@azure/core-paging";
+import {
+  AVRO_CODEC_KEY,
+  AVRO_INIT_BYTES,
+  AVRO_SCHEMA_KEY,
+  AVRO_SYNC_MARKER_SIZE,
+} from "./AvroConstants";
+import { AvroParser, AvroType } from "./AvroParser";
 import { AbortSignalLike } from "@azure/abort-controller";
+import { AvroReadable } from "./AvroReadable";
+import { arraysEqual } from "./utils/utils.common";
 
 /**
  * Options to configure the {@link AvroReader.parseObjects} operation.
@@ -77,7 +80,7 @@ export class AvroReader {
     this._initialBlockOffset = currentBlockOffset || 0;
   }
 
-  private async initialize(options: AvroParseOptions = {}) {
+  private async initialize(options: AvroParseOptions = {}): Promise<void> {
     const header = await AvroParser.readFixedBytes(this._headerStream, AVRO_INIT_BYTES.length, {
       abortSignal: options.abortSignal,
     });
@@ -93,7 +96,7 @@ export class AvroReader {
 
     // Validate codec
     const codec = this._metadata![AVRO_CODEC_KEY];
-    if (!(codec == undefined || codec == "null")) {
+    if (!(codec === undefined || codec === null || codec === "null")) {
       throw new Error("Codecs are not supported");
     }
 
@@ -106,7 +109,7 @@ export class AvroReader {
     const schema = JSON.parse(this._metadata![AVRO_SCHEMA_KEY]);
     this._itemType = AvroType.fromSchema(schema);
 
-    if (this._blockOffset == 0) {
+    if (this._blockOffset === 0) {
       this._blockOffset = this._initialBlockOffset + this._dataStream.position;
     }
 
@@ -144,7 +147,7 @@ export class AvroReader {
       this._itemsRemainingInBlock!--;
       this._objectIndex!++;
 
-      if (this._itemsRemainingInBlock == 0) {
+      if (this._itemsRemainingInBlock === 0) {
         const marker = await AvroParser.readFixedBytes(this._dataStream, AVRO_SYNC_MARKER_SIZE, {
           abortSignal: options.abortSignal,
         });

--- a/sdk/storage/storage-internal-avro/src/utils/utils.common.ts
+++ b/sdk/storage/storage-internal-avro/src/utils/utils.common.ts
@@ -8,8 +8,9 @@ export interface KeyValuePair<T> {
 
 export function arraysEqual(a: Uint8Array, b: Uint8Array): boolean {
   if (a === b) return true;
+  // eslint-disable-next-line eqeqeq
   if (a == null || b == null) return false;
-  if (a.length != b.length) return false;
+  if (a.length !== b.length) return false;
 
   for (let i = 0; i < a.length; ++i) {
     if (a[i] !== b[i]) return false;

--- a/sdk/storage/storage-internal-avro/test/browser/avroreadable.spec.ts
+++ b/sdk/storage/storage-internal-avro/test/browser/avroreadable.spec.ts
@@ -1,10 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { assert } from "chai";
 import { AvroReadableFromBlob } from "../../src/index.browser";
 import { arraysEqual } from "../../src/utils/utils.common";
-// import { AbortController } from "@azure/abort-controller";
+import { assert } from "chai";
 
 describe("AvroReadableFromBlob", () => {
   const size = 1024;

--- a/sdk/storage/storage-internal-avro/test/node/avroreadable.spec.ts
+++ b/sdk/storage/storage-internal-avro/test/node/avroreadable.spec.ts
@@ -2,10 +2,10 @@
 // Licensed under the MIT license.
 
 import * as fs from "fs";
-import { assert } from "chai";
-import { AvroReadableFromStream } from "../../src";
 import { AbortController } from "@azure/abort-controller";
+import { AvroReadableFromStream } from "../../src";
 import { Readable } from "stream";
+import { assert } from "chai";
 
 describe("AvroReadableFromStream", () => {
   it("read pass end should throw", async () => {

--- a/sdk/storage/storage-internal-avro/test/node/avroreader.spec.ts
+++ b/sdk/storage/storage-internal-avro/test/node/avroreader.spec.ts
@@ -2,11 +2,11 @@
 // Licensed under the MIT license.
 
 import * as fs from "fs";
-import { assert } from "chai";
-import { AvroReader, AvroReadableFromStream } from "../../src";
-import { arraysEqual } from "../../src/utils/utils.common";
+import { AvroReadableFromStream, AvroReader } from "../../src";
 import { AbortController } from "@azure/abort-controller";
 import { Readable } from "stream";
+import { arraysEqual } from "../../src/utils/utils.common";
+import { assert } from "chai";
 
 type Action = (o: Record<string, any> | null) => void;
 class TestCase {
@@ -19,10 +19,7 @@ class TestCase {
 }
 
 describe("AvroReader", () => {
-  if (typeof TextEncoder === "undefined" && typeof require !== "undefined") {
-    (global as any).TextEncoder = require("util").TextEncoder;
-  }
-
+  
   it("test with local avro files", async () => {
     const testCases: TestCase[] = [
       new TestCase("test_null_0.avro", (o) => assert.strictEqual(null, o)), // null


### PR DESCRIPTION
### Packages impacted by this PR

- storage-internal-avro

### Issues associated with this PR

- #17945

### Describe the problem that is addressed by this PR

Fixes the ESLint errors associated with the `storage-internal-avro` package.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?

This fixes many of the minor ESLint issues facing `storage-internal-avro`, however, there are some that are ignored.  

Some exceptions made:
- `no-self-assign`
- `no-empty`
- `no-case-declarations`
-` qeqeq`
- `@typescript-eslint/ban-types`
- `@azure/azure-sdk/ts-use-interface-parameters`
- `@typescript-eslint/no-use-before-define`

The `@typescript-eslint/ban-types` should be revisited by the owning team as they are using `Object` which its usage should be monitored.  An exception was made for `@typescript-eslint/no-use-before-define` as some callbacks were interwoven in their dependencies.

### Are there test cases added in this PR? _(If not, why?)_

Not applicable as fixing ESLint errors

### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [ ] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
