### PR TITLE
[Schema Registry] Include name and groupName in SchemaProperties

### DIFF
--- a/sdk/schemaregistry/schema-registry-avro/test/public/utils/mockedRegistryClient.ts
+++ b/sdk/schemaregistry/schema-registry-avro/test/public/utils/mockedRegistryClient.ts
@@ -73,6 +73,8 @@ function createMockedTestRegistry(): SchemaRegistry {
         properties: {
           id: newId(),
           format: schema.format,
+          groupName: schema.groupName,
+          name: schema.name,
         },
       };
       mapByContent.set(result.definition, result);

--- a/sdk/schemaregistry/schema-registry/CHANGELOG.md
+++ b/sdk/schemaregistry/schema-registry/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Release History
 
-## 1.0.2 (Unreleased)
+## 1.1.0 (Unreleased)
 
 ### Features Added
+
 - Added support for distributed tracing using OpenTelemetry - please refer to the [@azure/opentelemetry-instrumentation-azure-sdk](https://www.npmjs.com/package/@azure/opentelemetry-instrumentation-azure-sdk) package for instructions.
 
 ### Breaking Changes
@@ -10,6 +11,8 @@
 ### Bugs Fixed
 
 ### Other Changes
+
+- `SchemaProperties` now includes `name` and `groupName` for the schema name and its group respectively.
 
 ## 1.0.1 (2021-11-17)
 

--- a/sdk/schemaregistry/schema-registry/package.json
+++ b/sdk/schemaregistry/schema-registry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/schema-registry",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "Schema Registry Library with typescript type definitions for node.js and browser.",
   "sdk-type": "client",
   "main": "dist/index.js",

--- a/sdk/schemaregistry/schema-registry/review/schema-registry.api.md
+++ b/sdk/schemaregistry/schema-registry/review/schema-registry.api.md
@@ -37,7 +37,9 @@ export interface SchemaDescription {
 // @public
 export interface SchemaProperties {
     format: string;
+    groupName: string;
     id: string;
+    name: string;
 }
 
 // @public

--- a/sdk/schemaregistry/schema-registry/src/constants.ts
+++ b/sdk/schemaregistry/schema-registry/src/constants.ts
@@ -9,4 +9,4 @@ export const DEFAULT_SCOPE = "https://eventhubs.azure.net/.default";
 /**
  * @internal
  */
-export const SDK_VERSION = "1.0.2";
+export const SDK_VERSION = "1.1.0";

--- a/sdk/schemaregistry/schema-registry/src/conversions.ts
+++ b/sdk/schemaregistry/schema-registry/src/conversions.ts
@@ -32,6 +32,8 @@ export async function convertSchemaResponse(response: GeneratedSchemaResponse): 
     properties: {
       id: response.schemaId!,
       format: mapContentTypeToFormat(response.contentType!),
+      groupName: response.schemaGroupName!,
+      name: response.schemaName!,
     },
   };
 }
@@ -50,6 +52,8 @@ export function convertSchemaIdResponse(
       // is not modeled by the generated client.
       id: response.schemaId!,
       format: schemaFormat,
+      groupName: response.schemaGroupName!,
+      name: response.schemaName!,
     };
   };
 }

--- a/sdk/schemaregistry/schema-registry/src/generated/generatedSchemaRegistryClient.ts
+++ b/sdk/schemaregistry/schema-registry/src/generated/generatedSchemaRegistryClient.ts
@@ -6,12 +6,15 @@
  * Changes may cause incorrect behavior and will be lost if the code is regenerated.
  */
 
+import * as coreClient from "@azure/core-client";
 import { SchemaGroupsOperationsImpl, SchemaImpl } from "./operations";
 import { SchemaGroupsOperations, Schema } from "./operationsInterfaces";
-import { GeneratedSchemaRegistryClientContext } from "./generatedSchemaRegistryClientContext";
 import { GeneratedSchemaRegistryClientOptionalParams } from "./models";
 
-export class GeneratedSchemaRegistryClient extends GeneratedSchemaRegistryClientContext {
+export class GeneratedSchemaRegistryClient extends coreClient.ServiceClient {
+  endpoint: string;
+  apiVersion: string;
+
   /**
    * Initializes a new instance of the GeneratedSchemaRegistryClient class.
    * @param endpoint The Schema Registry service endpoint, for example
@@ -22,7 +25,38 @@ export class GeneratedSchemaRegistryClient extends GeneratedSchemaRegistryClient
     endpoint: string,
     options?: GeneratedSchemaRegistryClientOptionalParams
   ) {
-    super(endpoint, options);
+    if (endpoint === undefined) {
+      throw new Error("'endpoint' cannot be null");
+    }
+
+    // Initializing default values for options
+    if (!options) {
+      options = {};
+    }
+    const defaults: GeneratedSchemaRegistryClientOptionalParams = {
+      requestContentType: "application/json; charset=utf-8"
+    };
+
+    const packageDetails = `azsdk-js-schema-registry/1.1.0`;
+    const userAgentPrefix =
+      options.userAgentOptions && options.userAgentOptions.userAgentPrefix
+        ? `${options.userAgentOptions.userAgentPrefix} ${packageDetails}`
+        : `${packageDetails}`;
+
+    const optionsWithDefaults = {
+      ...defaults,
+      ...options,
+      userAgentOptions: {
+        userAgentPrefix
+      },
+      baseUri: options.endpoint ?? options.baseUri ?? "https://{endpoint}"
+    };
+    super(optionsWithDefaults);
+    // Parameter assignments
+    this.endpoint = endpoint;
+
+    // Assigning values to Constant parameters
+    this.apiVersion = options.apiVersion || "2021-10";
     this.schemaGroupsOperations = new SchemaGroupsOperationsImpl(this);
     this.schema = new SchemaImpl(this);
   }

--- a/sdk/schemaregistry/schema-registry/src/generated/index.ts
+++ b/sdk/schemaregistry/schema-registry/src/generated/index.ts
@@ -8,5 +8,4 @@
 
 export * from "./models";
 export { GeneratedSchemaRegistryClient } from "./generatedSchemaRegistryClient";
-export { GeneratedSchemaRegistryClientContext } from "./generatedSchemaRegistryClientContext";
 export * from "./operationsInterfaces";

--- a/sdk/schemaregistry/schema-registry/src/generated/operations/schema.ts
+++ b/sdk/schemaregistry/schema-registry/src/generated/operations/schema.ts
@@ -11,7 +11,7 @@ import * as coreClient from "@azure/core-client";
 import * as coreRestPipeline from "@azure/core-rest-pipeline";
 import * as Mappers from "../models/mappers";
 import * as Parameters from "../models/parameters";
-import { GeneratedSchemaRegistryClientContext } from "../generatedSchemaRegistryClientContext";
+import { GeneratedSchemaRegistryClient } from "../generatedSchemaRegistryClient";
 import {
   SchemaGetByIdOptionalParams,
   SchemaGetByIdResponse,
@@ -25,13 +25,13 @@ import {
 
 /** Class containing Schema operations. */
 export class SchemaImpl implements Schema {
-  private readonly client: GeneratedSchemaRegistryClientContext;
+  private readonly client: GeneratedSchemaRegistryClient;
 
   /**
    * Initialize a new instance of the class Schema class.
    * @param client Reference to the service client
    */
-  constructor(client: GeneratedSchemaRegistryClientContext) {
+  constructor(client: GeneratedSchemaRegistryClient) {
     this.client = client;
   }
 

--- a/sdk/schemaregistry/schema-registry/src/generated/operations/schemaGroupsOperations.ts
+++ b/sdk/schemaregistry/schema-registry/src/generated/operations/schemaGroupsOperations.ts
@@ -10,7 +10,7 @@ import { SchemaGroupsOperations } from "../operationsInterfaces";
 import * as coreClient from "@azure/core-client";
 import * as Mappers from "../models/mappers";
 import * as Parameters from "../models/parameters";
-import { GeneratedSchemaRegistryClientContext } from "../generatedSchemaRegistryClientContext";
+import { GeneratedSchemaRegistryClient } from "../generatedSchemaRegistryClient";
 import {
   SchemaGroupsListOptionalParams,
   SchemaGroupsListResponse
@@ -18,13 +18,13 @@ import {
 
 /** Class containing SchemaGroupsOperations operations. */
 export class SchemaGroupsOperationsImpl implements SchemaGroupsOperations {
-  private readonly client: GeneratedSchemaRegistryClientContext;
+  private readonly client: GeneratedSchemaRegistryClient;
 
   /**
    * Initialize a new instance of the class SchemaGroupsOperations class.
    * @param client Reference to the service client
    */
-  constructor(client: GeneratedSchemaRegistryClientContext) {
+  constructor(client: GeneratedSchemaRegistryClient) {
     this.client = client;
   }
 

--- a/sdk/schemaregistry/schema-registry/src/models.ts
+++ b/sdk/schemaregistry/schema-registry/src/models.ts
@@ -15,6 +15,12 @@ export interface SchemaProperties {
    * Currently only 'avro' is supported, but this is subject to change.
    */
   format: string;
+
+  /** Schema group under which schema is or should be registered. */
+  groupName: string;
+
+  /** Name of schema.*/
+  name: string;
 }
 
 /**

--- a/sdk/schemaregistry/schema-registry/swagger/README.md
+++ b/sdk/schemaregistry/schema-registry/swagger/README.md
@@ -10,7 +10,7 @@ https://github.com/Azure/azure-rest-api-specs/pull/10220 is merged.
 ```yaml
 v3: true
 package-name: "@azure/schema-registry"
-package-version: 1.0.2
+package-version: 1.1.0
 title: GeneratedSchemaRegistryClient
 description: Generated Schema Registry Client
 generate-metadata: false

--- a/sdk/schemaregistry/schema-registry/test/public/schemaRegistry.spec.ts
+++ b/sdk/schemaregistry/schema-registry/test/public/schemaRegistry.spec.ts
@@ -35,6 +35,8 @@ function assertIsValidSchemaProperties(
 ): asserts schemaProperties {
   assert.isNotEmpty(schemaProperties.id);
   assert.equal(schemaProperties.format, expectedSerializationType);
+  assert.isNotEmpty(schemaProperties.groupName);
+  assert.isNotEmpty(schemaProperties.name);
 }
 
 function assertIsValidSchema(schema: Schema, expectedSerializationType = "Avro"): asserts schema {


### PR DESCRIPTION
### Packages impacted by this PR
@azure/schema-registry

### Issues associated with this PR
Fixes https://github.com/Azure/azure-sdk-for-js/issues/21294

### Describe the problem that is addressed by this PR
These properties can help customers register updated versions of schemas based on previously registered ones because `name` and `groupName` are required by `registerSchema`.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?
N/A

### Are there test cases added in this PR? _(If not, why?)_
N/A

### Provide a list of related PRs _(if any)_
N/A

### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [x] Added a changelog (if necessary)
