### PR TITLE
[Recorder] Do not depend on test-utils

### DIFF
--- a/sdk/test-utils/recorder/package.json
+++ b/sdk/test-utils/recorder/package.json
@@ -67,7 +67,6 @@
   "dependencies": {
     "@azure/core-http": "^2.0.0",
     "@azure/core-rest-pipeline": "^1.1.0",
-    "@azure/test-utils": "^1.0.0",
     "@azure/core-auth": "^1.3.2"
   },
   "devDependencies": {

--- a/sdk/test-utils/recorder/package.json
+++ b/sdk/test-utils/recorder/package.json
@@ -67,7 +67,8 @@
   "dependencies": {
     "@azure/core-http": "^2.0.0",
     "@azure/core-rest-pipeline": "^1.1.0",
-    "@azure/core-auth": "^1.3.2"
+    "@azure/core-auth": "^1.3.2",
+    "@azure/core-util": "^1.0.0-beta.1"
   },
   "devDependencies": {
     "@azure/core-client": "^1.0.0",

--- a/sdk/test-utils/recorder/src/utils/sessionFilePath.ts
+++ b/sdk/test-utils/recorder/src/utils/sessionFilePath.ts
@@ -1,11 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { isNode } from "@azure/test-utils";
 import { env } from "./env";
 import { generateTestRecordingFilePath } from "./filePathGenerator";
 import { relativeRecordingsPath } from "./relativePathCalculator";
-import { RecorderError } from "./utils";
+import { isNode, RecorderError } from "./utils";
 
 export function sessionFilePath(testContext: Mocha.Test): string {
   const recordingsFolder = !isNode ? env.RECORDINGS_RELATIVE_PATH : relativeRecordingsPath(); // sdk/service/project/recordings

--- a/sdk/test-utils/recorder/src/utils/sessionFilePath.ts
+++ b/sdk/test-utils/recorder/src/utils/sessionFilePath.ts
@@ -1,10 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+import { isNode } from "@azure/core-util";
 import { env } from "./env";
 import { generateTestRecordingFilePath } from "./filePathGenerator";
 import { relativeRecordingsPath } from "./relativePathCalculator";
-import { isNode, RecorderError } from "./utils";
+import { RecorderError } from "./utils";
 
 export function sessionFilePath(testContext: Mocha.Test): string {
   const recordingsFolder = !isNode ? env.RECORDINGS_RELATIVE_PATH : relativeRecordingsPath(); // sdk/service/project/recordings

--- a/sdk/test-utils/recorder/src/utils/utils.ts
+++ b/sdk/test-utils/recorder/src/utils/utils.ts
@@ -360,12 +360,3 @@ export function assertEnvironmentVariable(variable: string): string {
   if (!value) throw new Error(`${variable} is not defined`);
   return value;
 }
-
-/**
- * A constant that indicates whether the environment is node.js or browser based.
- */
-export const isNode =
-  typeof process !== "undefined" &&
-  !!process.version &&
-  !!process.versions &&
-  !!process.versions.node;

--- a/sdk/test-utils/recorder/src/utils/utils.ts
+++ b/sdk/test-utils/recorder/src/utils/utils.ts
@@ -360,3 +360,12 @@ export function assertEnvironmentVariable(variable: string): string {
   if (!value) throw new Error(`${variable} is not defined`);
   return value;
 }
+
+/**
+ * A constant that indicates whether the environment is node.js or browser based.
+ */
+export const isNode =
+  typeof process !== "undefined" &&
+  !!process.version &&
+  !!process.versions &&
+  !!process.versions.node;


### PR DESCRIPTION
`@azure-tools/test-recorder` 2.0 couldn't be published because it depended on `test-utils` which is not public.
The only import is `isNode`, redeclaring and removing the test-utils dependency to go ahead with the release smoothly instead of waiting for `@azure/test-utils` release.


Edit: Getting it from core-utils instead, as suggested by @joheredi 