### PR TITLE
[Core] Release 1.3.0 core-http-compat

### DIFF
--- a/sdk/core/core-http-compat/CHANGELOG.md
+++ b/sdk/core/core-http-compat/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.3.0 (#Unreleased)
+## 1.3.0 (2022-04-08)
 
 ### Features Added
 


### PR DESCRIPTION
Changelog updates to release the `@azure/core-http-compat` 1.3.0 so that `@azure/app-configuration`  can be released with the core-v2 changes.