### PR TITLE
lock file regression revert

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -619,9 +619,9 @@ packages:
       '@azure/core-asynciterator-polyfill': 1.0.2
       '@azure/core-auth': 1.3.2
       '@azure/core-client': 1.5.0
-      '@azure/core-lro': 2.2.3
+      '@azure/core-lro': 2.2.4
       '@azure/core-paging': 1.2.1
-      '@azure/core-rest-pipeline': 1.6.0
+      '@azure/core-rest-pipeline': 1.8.0
       '@azure/core-tracing': 1.0.0-preview.12
       '@azure/logger': 1.0.3
       tslib: 2.3.1
@@ -651,7 +651,7 @@ packages:
       '@azure/core-auth': 1.3.2
       '@azure/core-client': 1.5.0
       '@azure/core-paging': 1.2.1
-      '@azure/core-rest-pipeline': 1.6.0
+      '@azure/core-rest-pipeline': 1.8.0
       tslib: 2.3.1
     transitivePeerDependencies:
       - supports-color
@@ -704,21 +704,6 @@ packages:
       - encoding
     dev: false
 
-  /@azure/container-registry/1.0.0-beta.4:
-    resolution: {integrity: sha512-QXKm9kRvQl8pgky0NVU4Xbyq8A0QHvzrndqFr2cKScUpO6fCLuqMv/O7HFAVr/KyfHFTlL+23a4R3npnRjGyGA==}
-    engines: {node: '>=12.0.0'}
-    dependencies:
-      '@azure/core-auth': 1.3.2
-      '@azure/core-client': 1.5.0
-      '@azure/core-paging': 1.2.1
-      '@azure/core-rest-pipeline': 1.6.0
-      '@azure/core-tracing': 1.0.0-preview.13
-      '@azure/logger': 1.0.3
-      tslib: 2.3.1
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
   /@azure/core-amqp/3.1.0:
     resolution: {integrity: sha512-TyI0WFNrVb0EkRg36UwdcqR/7n9YpcEw64O4xVrgzMAlXIciVZpabl05C/Q0iUvLkItmez2XSVDduncjr02oGw==}
     engines: {node: '>=12.0.0'}
@@ -757,21 +742,10 @@ packages:
       '@azure/abort-controller': 1.0.4
       '@azure/core-asynciterator-polyfill': 1.0.2
       '@azure/core-auth': 1.3.2
-      '@azure/core-rest-pipeline': 1.6.0
+      '@azure/core-rest-pipeline': 1.8.0
       '@azure/core-tracing': 1.0.0-preview.13
       '@azure/logger': 1.0.3
       tslib: 2.3.1
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  /@azure/core-http-compat/1.2.0:
-    resolution: {integrity: sha512-kfs0KOjHkIQ4aE8PN7OXdFn44rCMaPlXxYFy27UqL8GPj4YO2Ap0HPlw/ZDx6IZFnsqp5wfKmgz+JDUptFpw0w==}
-    engines: {node: '>=12.0.0'}
-    dependencies:
-      '@azure/abort-controller': 1.0.4
-      '@azure/core-client': 1.5.0
-      '@azure/core-rest-pipeline': 1.6.0
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -858,8 +832,8 @@ packages:
       - encoding
     dev: false
 
-  /@azure/core-lro/2.2.3:
-    resolution: {integrity: sha512-UMdlR9NsqDCLTba3EUbRjfMF4gDmWvld196JmUjbz9WWhJ2XT00OR5MXeWiR+vmGT+ETiO4hHFCi2/eGO5YVtg==}
+  /@azure/core-lro/2.2.4:
+    resolution: {integrity: sha512-e1I2v2CZM0mQo8+RSix0x091Av493e4bnT22ds2fcQGslTHzM2oTbswkB65nP4iEpCxBrFxOSDPKExmTmjCVtQ==}
     engines: {node: '>=12.0.0'}
     dependencies:
       '@azure/abort-controller': 1.0.4
@@ -876,8 +850,8 @@ packages:
       tslib: 2.3.1
     dev: false
 
-  /@azure/core-rest-pipeline/1.6.0:
-    resolution: {integrity: sha512-9Euoat1TPR97Q1l5aylxhDyKbtp2hv15AoFeOwC5frQAFNJegtDDf6BUBr7OiAggzjGAYidxkyhL0T6Yu05XWQ==}
+  /@azure/core-rest-pipeline/1.8.0:
+    resolution: {integrity: sha512-o8eZr96erQpiq8EZhZU/SyN6ncOfZ6bexwN2nMm9WpDmZGvaq907kopADt8XvNhbEF7kRA1l901Pg8mXjWp3UQ==}
     engines: {node: '>=12.0.0'}
     dependencies:
       '@azure/abort-controller': 1.0.4
@@ -927,13 +901,6 @@ packages:
       tslib: 2.3.1
     dev: false
 
-  /@azure/core-tracing/1.0.0-preview.14:
-    resolution: {integrity: sha512-FFIzVoQ+kcvyxJi+OJdiM+Ec3dNdNnWTpErdppbPCU7XRqBjWn+LARc/5j4feEDkKh1nPq6Cb82MI6ExH3GR6A==}
-    engines: {node: '>=12.0.0'}
-    dependencies:
-      tslib: 2.3.1
-    dev: false
-
   /@azure/core-tracing/1.0.0-preview.9:
     resolution: {integrity: sha512-zczolCLJ5QG42AEPQ+Qg9SRYNUyB+yZ5dzof4YEc+dyWczO9G2sBqbAjLB7IqrsdHN2apkiB2oXeDKCsq48jug==}
     engines: {node: '>=8.0.0'}
@@ -954,7 +921,7 @@ packages:
     resolution: {integrity: sha512-oWWQUWfllD3RO8Ixnsw5RjAUWPitjRI+LXSM0KFmgkSjl0R6RTQzXU2SEMsgAENkD5nzyI4yPpTRJcN2svM6ug==}
     engines: {node: '>=12.0.0'}
     dependencies:
-      fast-xml-parser: 4.0.5
+      fast-xml-parser: 4.0.7
       tslib: 2.3.1
     dev: false
 
@@ -965,7 +932,7 @@ packages:
       '@azure/core-auth': 1.3.2
       '@azure/core-client': 1.5.0
       '@azure/core-paging': 1.2.1
-      '@azure/core-rest-pipeline': 1.6.0
+      '@azure/core-rest-pipeline': 1.8.0
       '@azure/core-tracing': 1.0.0-preview.13
       '@azure/core-xml': 1.2.0
       '@azure/logger': 1.0.3
@@ -994,17 +961,17 @@ packages:
       uuid: 8.3.2
     dev: false
 
-  /@azure/identity/1.2.5_debug@4.3.3:
+  /@azure/identity/1.2.5_debug@4.3.4:
     resolution: {integrity: sha512-Q71Buur3RMcg6lCnisLL8Im562DBw+ybzgm+YQj/FbAaI8ZNu/zl/5z1fE4k3Q9LSIzYrz6HLRzlhdSBXpydlQ==}
     engines: {node: '>=8.0.0'}
     dependencies:
       '@azure/core-http': 1.2.6
       '@azure/core-tracing': 1.0.0-preview.9
       '@azure/logger': 1.0.3
-      '@azure/msal-node': 1.0.0-beta.6_debug@4.3.3
+      '@azure/msal-node': 1.0.0-beta.6_debug@4.3.4
       '@opentelemetry/api': 0.10.2
       '@types/stoppable': 1.1.1
-      axios: 0.21.4_debug@4.3.3
+      axios: 0.21.4_debug@4.3.4
       events: 3.3.0
       jws: 4.0.0
       msal: 1.4.16
@@ -1028,13 +995,13 @@ packages:
       '@azure/abort-controller': 1.0.4
       '@azure/core-auth': 1.3.2
       '@azure/core-client': 1.5.0
-      '@azure/core-rest-pipeline': 1.6.0
+      '@azure/core-rest-pipeline': 1.8.0
       '@azure/core-tracing': 1.0.0-preview.13
       '@azure/core-util': 1.0.0-beta.1
       '@azure/logger': 1.0.3
-      '@azure/msal-browser': 2.22.0
+      '@azure/msal-browser': 2.22.1
       '@azure/msal-common': 4.5.1
-      '@azure/msal-node': 1.6.0
+      '@azure/msal-node': 1.7.0
       events: 3.3.0
       jws: 4.0.0
       open: 8.4.0
@@ -1046,20 +1013,20 @@ packages:
       - supports-color
     dev: false
 
-  /@azure/identity/2.0.4_debug@4.3.3:
+  /@azure/identity/2.0.4_debug@4.3.4:
     resolution: {integrity: sha512-ZgFubAsmo7dji63NLPaot6O7pmDfceAUPY57uphSCr0hmRj+Cakqb4SUz5SohCHFtscrhcmejRU903Fowz6iXg==}
     engines: {node: '>=12.0.0'}
     dependencies:
       '@azure/abort-controller': 1.0.4
       '@azure/core-auth': 1.3.2
       '@azure/core-client': 1.5.0
-      '@azure/core-rest-pipeline': 1.6.0
+      '@azure/core-rest-pipeline': 1.8.0
       '@azure/core-tracing': 1.0.0-preview.13
       '@azure/core-util': 1.0.0-beta.1
       '@azure/logger': 1.0.3
-      '@azure/msal-browser': 2.22.0
+      '@azure/msal-browser': 2.22.1
       '@azure/msal-common': 4.5.1
-      '@azure/msal-node': 1.6.0_debug@4.3.3
+      '@azure/msal-node': 1.7.0_debug@4.3.4
       events: 3.3.0
       jws: 4.0.0
       open: 8.4.0
@@ -1071,13 +1038,13 @@ packages:
       - supports-color
     dev: false
 
-  /@azure/keyvault-certificates/4.3.0:
-    resolution: {integrity: sha512-wCceKxgorRupYqx8jmWkyCiBmEfOo3VXONYp4eyDhXt/MfaYf0YF5O829Ft6EFQLf6D9CQMc2maZgCMOajaeOA==}
+  /@azure/keyvault-certificates/4.4.0:
+    resolution: {integrity: sha512-42RSptwsDTfMYREnlYZgj85wMj5SyVhtsP2wQePq/k1s7MUKlX3dygCLkkVVJ6rpi1ivQZItwQ/grYu4Zek7TQ==}
     engines: {node: '>=12.0.0'}
     dependencies:
       '@azure/abort-controller': 1.0.4
       '@azure/core-http': 2.2.4
-      '@azure/core-lro': 2.2.3
+      '@azure/core-lro': 2.2.4
       '@azure/core-paging': 1.2.1
       '@azure/core-tracing': 1.0.0-preview.13
       '@azure/logger': 1.0.3
@@ -1101,13 +1068,13 @@ packages:
       - encoding
     dev: false
 
-  /@azure/keyvault-keys/4.3.0:
-    resolution: {integrity: sha512-OEosl0/rE/mKD5Ji9KaQN7UH+yQnV5MS0MRhGqQIiJrG+qAvAla0MYudJzv3XvBlplpGk0+MVgyL9H3KX/UAwQ==}
-    engines: {node: '>=8.0.0'}
+  /@azure/keyvault-keys/4.4.0:
+    resolution: {integrity: sha512-W9sPZebXYa3aar7BGIA+fAsq/sy1nf2TZAETbkv7DRawzVLrWv8QoVVceqNHjy3cigT4HNxXjaPYCI49ez5CUA==}
+    engines: {node: '>=12.0.0'}
     dependencies:
       '@azure/abort-controller': 1.0.4
       '@azure/core-http': 2.2.4
-      '@azure/core-lro': 2.2.3
+      '@azure/core-lro': 2.2.4
       '@azure/core-paging': 1.2.1
       '@azure/core-tracing': 1.0.0-preview.13
       '@azure/logger': 1.0.3
@@ -1122,7 +1089,7 @@ packages:
     dependencies:
       '@azure/abort-controller': 1.0.4
       '@azure/core-http': 2.2.4
-      '@azure/core-lro': 2.2.3
+      '@azure/core-lro': 2.2.4
       '@azure/core-paging': 1.2.1
       '@azure/core-tracing': 1.0.0-preview.13
       '@azure/logger': 1.0.3
@@ -1175,8 +1142,8 @@ packages:
       - encoding
     dev: false
 
-  /@azure/msal-browser/2.22.0:
-    resolution: {integrity: sha512-ZpnbnzjYGRGHjWDPOLjSp47CQvhK927+W9avtLoNNCMudqs2dBfwj76lnJwObDE7TAKmCUueTiieglBiPb1mgQ==}
+  /@azure/msal-browser/2.22.1:
+    resolution: {integrity: sha512-VYvdSHnOen1CDok01OhfQ2qNxsrY10WAKe6c2reIuwqqDDOkWwq1IDkieGHpDRjj4kGdPZ/dle4d7SlvNi9EJQ==}
     engines: {node: '>=0.8.0'}
     dependencies:
       '@azure/msal-common': 6.1.0
@@ -1188,7 +1155,7 @@ packages:
     resolution: {integrity: sha512-/i5dXM+QAtO+6atYd5oHGBAx48EGSISkXNXViheliOQe+SIFMDo3gSq3lL54W0suOSAsVPws3XnTaIHlla0PIQ==}
     engines: {node: '>=0.8.0'}
     dependencies:
-      debug: 4.3.3
+      debug: 4.3.4
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -1197,7 +1164,7 @@ packages:
     resolution: {integrity: sha512-oVc4soy5MEZOp9NvCDqBk57mtiUTJXQQ8Z8S/4UiRQP8RG8snuCFQUs9xxdIfvl2FWIvgiBz+SMByyjTaRX42Q==}
     engines: {node: '>=0.8.0'}
     dependencies:
-      debug: 4.3.3
+      debug: 4.3.4
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -1206,7 +1173,7 @@ packages:
     resolution: {integrity: sha512-IGjAHttOgKDPQr0Qxx1NjABR635ZNuN7LHjxI0Y7SEA2thcaRGTccy+oaXTFabM/rZLt4F2VrPKUX4BnR9hW9g==}
     engines: {node: '>=0.8.0'}
     dependencies:
-      debug: 4.3.3
+      debug: 4.3.4
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -1224,11 +1191,11 @@ packages:
       - supports-color
     dev: false
 
-  /@azure/msal-node/1.0.0-beta.6_debug@4.3.3:
+  /@azure/msal-node/1.0.0-beta.6_debug@4.3.4:
     resolution: {integrity: sha512-ZQI11Uz1j0HJohb9JZLRD8z0moVcPks1AFW4Q/Gcl67+QvH4aKEJti7fjCcipEEZYb/qzLSO8U6IZgPYytsiJQ==}
     dependencies:
       '@azure/msal-common': 4.5.1
-      axios: 0.21.4_debug@4.3.3
+      axios: 0.21.4_debug@4.3.4
       jsonwebtoken: 8.5.1
       uuid: 8.3.2
     transitivePeerDependencies:
@@ -1236,8 +1203,8 @@ packages:
       - supports-color
     dev: false
 
-  /@azure/msal-node/1.6.0:
-    resolution: {integrity: sha512-RCPXVWsjqYZh7NB1pAJLn4ypHlLBulOjw5nKPLsJiaJJIXnN8kc6SMkK3S9/80DZCEBstvoRMz6zF50QZJUeOQ==}
+  /@azure/msal-node/1.7.0:
+    resolution: {integrity: sha512-qDkW+Z4b0SGkkYrM1x+0s5WJ3z96vgiNZ20iwpmtCUHVfSrDiGFB8s8REKVaz7JZJi2L1s0vQRbUahly8EoGnw==}
     engines: {node: 10 || 12 || 14 || 16}
     dependencies:
       '@azure/msal-common': 6.1.0
@@ -1250,12 +1217,12 @@ packages:
       - supports-color
     dev: false
 
-  /@azure/msal-node/1.6.0_debug@4.3.3:
-    resolution: {integrity: sha512-RCPXVWsjqYZh7NB1pAJLn4ypHlLBulOjw5nKPLsJiaJJIXnN8kc6SMkK3S9/80DZCEBstvoRMz6zF50QZJUeOQ==}
+  /@azure/msal-node/1.7.0_debug@4.3.4:
+    resolution: {integrity: sha512-qDkW+Z4b0SGkkYrM1x+0s5WJ3z96vgiNZ20iwpmtCUHVfSrDiGFB8s8REKVaz7JZJi2L1s0vQRbUahly8EoGnw==}
     engines: {node: 10 || 12 || 14 || 16}
     dependencies:
       '@azure/msal-common': 6.1.0
-      axios: 0.21.4_debug@4.3.3
+      axios: 0.21.4_debug@4.3.4
       https-proxy-agent: 5.0.0
       jsonwebtoken: 8.5.1
       uuid: 8.3.2
@@ -1271,7 +1238,7 @@ packages:
       '@azure/core-auth': 1.3.2
       '@azure/core-client': 1.5.0
       '@azure/core-paging': 1.2.1
-      '@azure/core-rest-pipeline': 1.6.0
+      '@azure/core-rest-pipeline': 1.8.0
       '@azure/core-tracing': 1.0.0-preview.13
       '@azure/logger': 1.0.3
       events: 3.3.0
@@ -1305,36 +1272,6 @@ packages:
       - encoding
     dev: false
 
-  /@azure/storage-blob/12.8.0:
-    resolution: {integrity: sha512-c8+Wz19xauW0bGkTCoqZH4dYfbtBniPiGiRQOn1ca6G5jsjr4azwaTk9gwjVY8r3vY2Taf95eivLzipfIfiS4A==}
-    engines: {node: '>=12.0.0'}
-    dependencies:
-      '@azure/abort-controller': 1.0.4
-      '@azure/core-http': 2.2.4
-      '@azure/core-lro': 2.2.3
-      '@azure/core-paging': 1.2.1
-      '@azure/core-tracing': 1.0.0-preview.13
-      '@azure/logger': 1.0.3
-      events: 3.3.0
-      tslib: 2.3.1
-    transitivePeerDependencies:
-      - encoding
-    dev: false
-
-  /@azure/storage-queue/12.7.0:
-    resolution: {integrity: sha512-yS27do9Dn3ohaOHWIwZfyu+I3gG0QJWNCl+qTLmsyWxBz5KO3O+clQ+NYo9tvovPBkBftf3kY2K705AeH0o0SQ==}
-    engines: {node: '>=12.0.0'}
-    dependencies:
-      '@azure/abort-controller': 1.0.4
-      '@azure/core-http': 2.2.4
-      '@azure/core-paging': 1.2.1
-      '@azure/core-tracing': 1.0.0-preview.13
-      '@azure/logger': 1.0.3
-      tslib: 2.3.1
-    transitivePeerDependencies:
-      - encoding
-    dev: false
-
   /@babel/code-frame/7.12.11:
     resolution: {integrity: sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==}
     dependencies:
@@ -1348,36 +1285,36 @@ packages:
       '@babel/highlight': 7.16.10
     dev: false
 
-  /@babel/compat-data/7.17.0:
-    resolution: {integrity: sha512-392byTlpGWXMv4FbyWw3sAZ/FrW/DrwqLGXpy0mbyNe9Taqv1mg9yON5/o0cnr8XYCkFTZbC1eV+c+LAROgrng==}
+  /@babel/compat-data/7.17.7:
+    resolution: {integrity: sha512-p8pdE6j0a29TNGebNm7NzYZWB3xVZJBZ7XGs42uAKzQo8VQ3F0By/cQCtUEABwIqw5zo6WA4NbmxsfzADzMKnQ==}
     engines: {node: '>=6.9.0'}
     dev: false
 
-  /@babel/core/7.17.5:
-    resolution: {integrity: sha512-/BBMw4EvjmyquN5O+t5eh0+YqB3XXJkYD2cjKpYtWOfFy4lQ4UozNSmxAcWT8r2XtZs0ewG+zrfsqeR15i1ajA==}
+  /@babel/core/7.17.8:
+    resolution: {integrity: sha512-OdQDV/7cRBtJHLSOBqqbYNkOcydOgnX59TZx4puf41fzcVtN3e/4yqY8lMQsK+5X2lJtAdmA+6OHqsj1hBJ4IQ==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@ampproject/remapping': 2.1.2
       '@babel/code-frame': 7.16.7
-      '@babel/generator': 7.17.3
-      '@babel/helper-compilation-targets': 7.16.7_@babel+core@7.17.5
-      '@babel/helper-module-transforms': 7.17.6
-      '@babel/helpers': 7.17.2
-      '@babel/parser': 7.17.3
+      '@babel/generator': 7.17.7
+      '@babel/helper-compilation-targets': 7.17.7_@babel+core@7.17.8
+      '@babel/helper-module-transforms': 7.17.7
+      '@babel/helpers': 7.17.8
+      '@babel/parser': 7.17.8
       '@babel/template': 7.16.7
       '@babel/traverse': 7.17.3
       '@babel/types': 7.17.0
       convert-source-map: 1.8.0
-      debug: 4.3.3
+      debug: 4.3.4
       gensync: 1.0.0-beta.2
-      json5: 2.2.0
+      json5: 2.2.1
       semver: 6.3.0
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /@babel/generator/7.17.3:
-    resolution: {integrity: sha512-+R6Dctil/MgUsZsZAkYgK+ADNSZzJRRy0TvY65T71z/CR854xHQ1EweBYXdfT+HNeN7w0cSJJEzgxZMv40pxsg==}
+  /@babel/generator/7.17.7:
+    resolution: {integrity: sha512-oLcVCTeIFadUoArDTwpluncplrYBmTCCZZgXCbgNGvOBBiSDDK3eWO4b/+eOTli5tKv1lg+a5/NAXg+nTcei1w==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/types': 7.17.0
@@ -1385,16 +1322,16 @@ packages:
       source-map: 0.5.7
     dev: false
 
-  /@babel/helper-compilation-targets/7.16.7_@babel+core@7.17.5:
-    resolution: {integrity: sha512-mGojBwIWcwGD6rfqgRXVlVYmPAv7eOpIemUG3dGnDdCY4Pae70ROij3XmfrH6Fa1h1aiDylpglbZyktfzyo/hA==}
+  /@babel/helper-compilation-targets/7.17.7_@babel+core@7.17.8:
+    resolution: {integrity: sha512-UFzlz2jjd8kroj0hmCFV5zr+tQPi1dpC2cRsDV/3IEW8bJfCPrPpmcSN6ZS8RqIq4LXcmpipCQFPddyFA5Yc7w==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/compat-data': 7.17.0
-      '@babel/core': 7.17.5
+      '@babel/compat-data': 7.17.7
+      '@babel/core': 7.17.8
       '@babel/helper-validator-option': 7.16.7
-      browserslist: 4.20.0
+      browserslist: 4.20.2
       semver: 6.3.0
     dev: false
 
@@ -1435,13 +1372,13 @@ packages:
       '@babel/types': 7.17.0
     dev: false
 
-  /@babel/helper-module-transforms/7.17.6:
-    resolution: {integrity: sha512-2ULmRdqoOMpdvkbT8jONrZML/XALfzxlb052bldftkicAUy8AxSCkD5trDPQcwHNmolcl7wP6ehNqMlyUw6AaA==}
+  /@babel/helper-module-transforms/7.17.7:
+    resolution: {integrity: sha512-VmZD99F3gNTYB7fJRDTi+u6l/zxY0BE6OIxPSU7a50s6ZUQkHwSDmV92FfM+oCG0pZRVojGYhkR8I0OGeCVREw==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/helper-environment-visitor': 7.16.7
       '@babel/helper-module-imports': 7.16.7
-      '@babel/helper-simple-access': 7.16.7
+      '@babel/helper-simple-access': 7.17.7
       '@babel/helper-split-export-declaration': 7.16.7
       '@babel/helper-validator-identifier': 7.16.7
       '@babel/template': 7.16.7
@@ -1451,8 +1388,8 @@ packages:
       - supports-color
     dev: false
 
-  /@babel/helper-simple-access/7.16.7:
-    resolution: {integrity: sha512-ZIzHVyoeLMvXMN/vok/a4LWRy8G2v205mNP0XOuf9XRLyX5/u9CnVulUtDgUTama3lT+bf/UqucuZjqiGuTS1g==}
+  /@babel/helper-simple-access/7.17.7:
+    resolution: {integrity: sha512-txyMCGroZ96i+Pxr3Je3lzEJjqwaRC9buMUgtomcrLe5Nd0+fk1h0LLA+ixUF5OW7AhHuQ7Es1WcQJZmZsz2XA==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/types': 7.17.0
@@ -1475,8 +1412,8 @@ packages:
     engines: {node: '>=6.9.0'}
     dev: false
 
-  /@babel/helpers/7.17.2:
-    resolution: {integrity: sha512-0Qu7RLR1dILozr/6M0xgj+DFPmi6Bnulgm9M8BVa9ZCWxDqlSnqt3cf8IDPB5m45sVXUZ0kuQAgUrdSFFH79fQ==}
+  /@babel/helpers/7.17.8:
+    resolution: {integrity: sha512-QcL86FGxpfSJwGtAvv4iG93UL6bmqBdmoVY0CMCU2g+oD2ezQse3PT5Pa+jiD6LJndBQi0EDlpzOWNlLuhz5gw==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/template': 7.16.7
@@ -1495,14 +1432,14 @@ packages:
       js-tokens: 4.0.0
     dev: false
 
-  /@babel/parser/7.17.3:
-    resolution: {integrity: sha512-7yJPvPV+ESz2IUTPbOL+YkIGyCqOyNIzdguKQuJGnH7bg1WTIifuM21YqokFt/THWh1AkCRn9IgoykTRCBVpzA==}
+  /@babel/parser/7.17.8:
+    resolution: {integrity: sha512-BoHhDJrJXqcg+ZL16Xv39H9n+AqJ4pcDrQBGZN+wHxIysrLZ3/ECwCBUch/1zUNhnsXULcONU3Ei5Hmkfk6kiQ==}
     engines: {node: '>=6.0.0'}
     hasBin: true
     dev: false
 
-  /@babel/runtime/7.17.2:
-    resolution: {integrity: sha512-hzeyJyMA1YGdJTuWU0e/j4wKXrU4OMFvY2MSlaI9B7VQb0r5cxTE3EAIS2Q7Tn2RIcDkRvTA/v2JsAEhxe99uw==}
+  /@babel/runtime/7.17.8:
+    resolution: {integrity: sha512-dQpEpK0O9o6lj6oPu0gRDbbnk+4LeHlNcBpspf6Olzt3GIX4P1lWF1gS+pHLDFlaJvbR6q7jCfQ08zA4QJBnmA==}
     engines: {node: '>=6.9.0'}
     dependencies:
       regenerator-runtime: 0.13.9
@@ -1513,7 +1450,7 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/code-frame': 7.16.7
-      '@babel/parser': 7.17.3
+      '@babel/parser': 7.17.8
       '@babel/types': 7.17.0
     dev: false
 
@@ -1522,14 +1459,14 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/code-frame': 7.16.7
-      '@babel/generator': 7.17.3
+      '@babel/generator': 7.17.7
       '@babel/helper-environment-visitor': 7.16.7
       '@babel/helper-function-name': 7.16.7
       '@babel/helper-hoist-variables': 7.16.7
       '@babel/helper-split-export-declaration': 7.16.7
-      '@babel/parser': 7.17.3
+      '@babel/parser': 7.17.8
       '@babel/types': 7.17.0
-      debug: 4.3.3
+      debug: 4.3.4
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -1565,9 +1502,9 @@ packages:
     engines: {node: ^10.12.0 || >=12.0.0}
     dependencies:
       ajv: 6.12.6
-      debug: 4.3.3
+      debug: 4.3.4
       espree: 7.3.1
-      globals: 13.12.1
+      globals: 13.13.0
       ignore: 4.0.6
       import-fresh: 3.3.0
       js-yaml: 3.14.1
@@ -1582,7 +1519,7 @@ packages:
     engines: {node: '>=10.10.0'}
     dependencies:
       '@humanwhocodes/object-schema': 1.2.1
-      debug: 4.3.3
+      debug: 4.3.4
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -1624,12 +1561,12 @@ packages:
       '@jridgewell/sourcemap-codec': 1.4.11
     dev: false
 
-  /@microsoft/api-extractor-model/7.15.3:
-    resolution: {integrity: sha512-NkSjolmSI7NGvbdz0Y7kjQfdpD+j9E5CwXTxEyjDqxd10MI7GXV8DnAsQ57GFJcgHKgTjf2aUnYfMJ9w3aMicw==}
+  /@microsoft/api-extractor-model/7.16.0:
+    resolution: {integrity: sha512-0FOrbNIny8mzBrzQnSIkEjAXk0JMSnPmWYxt3ZDTPVg9S8xIPzB6lfgTg9+Mimu0RKCpGKBpd+v2WcR5vGzyUQ==}
     dependencies:
       '@microsoft/tsdoc': 0.13.2
       '@microsoft/tsdoc-config': 0.15.2
-      '@rushstack/node-core-library': 3.45.0
+      '@rushstack/node-core-library': 3.45.1
     dev: false
 
   /@microsoft/api-extractor-model/7.7.10:
@@ -1639,16 +1576,16 @@ packages:
       '@rushstack/node-core-library': 3.19.6
     dev: false
 
-  /@microsoft/api-extractor/7.19.4:
-    resolution: {integrity: sha512-iehC6YA3DGJvxTUaK7HUtQmP6hAQU07+Q/OR8TG4dVR6KpqCi9UPEVk8AgCvQkiK+6FbVEFQTx0qLuYk4EeuHg==}
+  /@microsoft/api-extractor/7.20.0:
+    resolution: {integrity: sha512-WKAu5JpkRXWKL3AyxmFXuwNNPpBlsAefwZIDl8M5mhEqRji4w+gexb0pku3Waa0flm3vm0Cwpm+kGYYJ4/gzAA==}
     hasBin: true
     dependencies:
-      '@microsoft/api-extractor-model': 7.15.3
+      '@microsoft/api-extractor-model': 7.16.0
       '@microsoft/tsdoc': 0.13.2
       '@microsoft/tsdoc-config': 0.15.2
-      '@rushstack/node-core-library': 3.45.0
-      '@rushstack/rig-package': 0.3.7
-      '@rushstack/ts-command-line': 4.10.6
+      '@rushstack/node-core-library': 3.45.1
+      '@rushstack/rig-package': 0.3.8
+      '@rushstack/ts-command-line': 4.10.7
       colors: 1.2.5
       lodash: 4.17.21
       resolve: 1.17.0
@@ -1994,47 +1931,47 @@ packages:
       rollup: 1.32.1
     dev: false
 
-  /@rollup/plugin-commonjs/21.0.1_rollup@2.70.0:
+  /@rollup/plugin-commonjs/21.0.1_rollup@2.70.1:
     resolution: {integrity: sha512-EA+g22lbNJ8p5kuZJUYyhhDK7WgJckW5g4pNN7n4mAFUM96VuwUnNT3xr2Db2iCZPI1pJPbGyfT5mS9T1dHfMg==}
     engines: {node: '>= 8.0.0'}
     peerDependencies:
       rollup: ^2.38.3
     dependencies:
-      '@rollup/pluginutils': 3.1.0_rollup@2.70.0
+      '@rollup/pluginutils': 3.1.0_rollup@2.70.1
       commondir: 1.0.1
       estree-walker: 2.0.2
       glob: 7.2.0
       is-reference: 1.2.1
       magic-string: 0.25.9
       resolve: 1.22.0
-      rollup: 2.70.0
+      rollup: 2.70.1
     dev: false
 
-  /@rollup/plugin-commonjs/21.0.2_rollup@2.70.0:
-    resolution: {integrity: sha512-d/OmjaLVO4j/aQX69bwpWPpbvI3TJkQuxoAk7BH8ew1PyoMBLTOuvJTjzG8oEoW7drIIqB0KCJtfFLu/2GClWg==}
+  /@rollup/plugin-commonjs/21.0.3_rollup@2.70.1:
+    resolution: {integrity: sha512-ThGfwyvcLc6cfP/MWxA5ACF+LZCvsuhUq7V5134Az1oQWsiC7lNpLT4mJI86WQunK7BYmpUiHmMk2Op6OAHs0g==}
     engines: {node: '>= 8.0.0'}
     peerDependencies:
       rollup: ^2.38.3
     dependencies:
-      '@rollup/pluginutils': 3.1.0_rollup@2.70.0
+      '@rollup/pluginutils': 3.1.0_rollup@2.70.1
       commondir: 1.0.1
       estree-walker: 2.0.2
       glob: 7.2.0
       is-reference: 1.2.1
       magic-string: 0.25.9
       resolve: 1.22.0
-      rollup: 2.70.0
+      rollup: 2.70.1
     dev: false
 
-  /@rollup/plugin-inject/4.0.4_rollup@2.70.0:
+  /@rollup/plugin-inject/4.0.4_rollup@2.70.1:
     resolution: {integrity: sha512-4pbcU4J/nS+zuHk+c+OL3WtmEQhqxlZ9uqfjQMQDOHOPld7PsCd8k5LWs8h5wjwJN7MgnAn768F2sDxEP4eNFQ==}
     peerDependencies:
       rollup: ^1.20.0 || ^2.0.0
     dependencies:
-      '@rollup/pluginutils': 3.1.0_rollup@2.70.0
+      '@rollup/pluginutils': 3.1.0_rollup@2.70.1
       estree-walker: 2.0.2
       magic-string: 0.25.9
-      rollup: 2.70.0
+      rollup: 2.70.1
     dev: false
 
   /@rollup/plugin-json/4.1.0_rollup@1.32.1:
@@ -2046,13 +1983,13 @@ packages:
       rollup: 1.32.1
     dev: false
 
-  /@rollup/plugin-json/4.1.0_rollup@2.70.0:
+  /@rollup/plugin-json/4.1.0_rollup@2.70.1:
     resolution: {integrity: sha512-yfLbTdNS6amI/2OpmbiBoW12vngr5NW2jCJVZSBEz+H5KfUJZ2M7sDjk0U6GOOdCWFVScShte29o9NezJ53TPw==}
     peerDependencies:
       rollup: ^1.20.0 || ^2.0.0
     dependencies:
-      '@rollup/pluginutils': 3.1.0_rollup@2.70.0
-      rollup: 2.70.0
+      '@rollup/pluginutils': 3.1.0_rollup@2.70.1
+      rollup: 2.70.1
     dev: false
 
   /@rollup/plugin-multi-entry/3.0.1_rollup@1.32.1:
@@ -2064,39 +2001,39 @@ packages:
       rollup: 1.32.1
     dev: false
 
-  /@rollup/plugin-multi-entry/3.0.1_rollup@2.70.0:
+  /@rollup/plugin-multi-entry/3.0.1_rollup@2.70.1:
     resolution: {integrity: sha512-Gcp9E8y68Kx+Jo8zy/ZpiiAkb0W01cSqnxOz6h9bPR7MU3gaoTEdRf7xXYplwli1SBFEswXX588ESj+50Brfxw==}
     peerDependencies:
       rollup: ^1.20.0 || ^2.0.0
     dependencies:
       matched: 1.0.2
-      rollup: 2.70.0
+      rollup: 2.70.1
     dev: false
 
-  /@rollup/plugin-multi-entry/4.1.0_rollup@2.70.0:
+  /@rollup/plugin-multi-entry/4.1.0_rollup@2.70.1:
     resolution: {integrity: sha512-nellK5pr50W0JA2+bDJbG8F79GBP802J40YRoC0wyfpTAeAn5mJ4eaFiB/MN+YoX9hgb/6RJoZl9leDjZnUFKw==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       rollup: ^1.20.0 || ^2.0.0
     dependencies:
-      '@rollup/plugin-virtual': 2.1.0_rollup@2.70.0
+      '@rollup/plugin-virtual': 2.1.0_rollup@2.70.1
       matched: 5.0.1
-      rollup: 2.70.0
+      rollup: 2.70.1
     dev: false
 
-  /@rollup/plugin-node-resolve/13.1.3_rollup@2.70.0:
+  /@rollup/plugin-node-resolve/13.1.3_rollup@2.70.1:
     resolution: {integrity: sha512-BdxNk+LtmElRo5d06MGY4zoepyrXX1tkzX2hrnPEZ53k78GuOMWLqmJDGIIOPwVRIFZrLQOo+Yr6KtCuLIA0AQ==}
     engines: {node: '>= 10.0.0'}
     peerDependencies:
       rollup: ^2.42.0
     dependencies:
-      '@rollup/pluginutils': 3.1.0_rollup@2.70.0
+      '@rollup/pluginutils': 3.1.0_rollup@2.70.1
       '@types/resolve': 1.17.1
       builtin-modules: 3.2.0
       deepmerge: 4.2.2
       is-module: 1.0.0
       resolve: 1.22.0
-      rollup: 2.70.0
+      rollup: 2.70.1
     dev: false
 
   /@rollup/plugin-node-resolve/8.4.0_rollup@1.32.1:
@@ -2115,39 +2052,39 @@ packages:
       rollup: 1.32.1
     dev: false
 
-  /@rollup/plugin-node-resolve/8.4.0_rollup@2.70.0:
+  /@rollup/plugin-node-resolve/8.4.0_rollup@2.70.1:
     resolution: {integrity: sha512-LFqKdRLn0ShtQyf6SBYO69bGE1upV6wUhBX0vFOUnLAyzx5cwp8svA0eHUnu8+YU57XOkrMtfG63QOpQx25pHQ==}
     engines: {node: '>= 8.0.0'}
     peerDependencies:
       rollup: ^1.20.0||^2.0.0
     dependencies:
-      '@rollup/pluginutils': 3.1.0_rollup@2.70.0
+      '@rollup/pluginutils': 3.1.0_rollup@2.70.1
       '@types/resolve': 1.17.1
       builtin-modules: 3.2.0
       deep-freeze: 0.0.1
       deepmerge: 4.2.2
       is-module: 1.0.0
       resolve: 1.22.0
-      rollup: 2.70.0
+      rollup: 2.70.1
     dev: false
 
-  /@rollup/plugin-replace/2.4.2_rollup@2.70.0:
+  /@rollup/plugin-replace/2.4.2_rollup@2.70.1:
     resolution: {integrity: sha512-IGcu+cydlUMZ5En85jxHH4qj2hta/11BHq95iHEyb2sbgiN0eCdzvUcHw5gt9pBL5lTi4JDYJ1acCoMGpTvEZg==}
     peerDependencies:
       rollup: ^1.20.0 || ^2.0.0
     dependencies:
-      '@rollup/pluginutils': 3.1.0_rollup@2.70.0
+      '@rollup/pluginutils': 3.1.0_rollup@2.70.1
       magic-string: 0.25.9
-      rollup: 2.70.0
+      rollup: 2.70.1
     dev: false
 
-  /@rollup/plugin-virtual/2.1.0_rollup@2.70.0:
+  /@rollup/plugin-virtual/2.1.0_rollup@2.70.1:
     resolution: {integrity: sha512-CPPAtlKT53HFqC8jFHb/V5WErpU8Hrq2TyCR0A7kPQMlF2wNUf0o1xuAc+Qxj8NCZM0Z3Yvl+FbUXfJjVWqDwA==}
     engines: {node: '>=8.0.0'}
     peerDependencies:
       rollup: ^1.20.0||^2.0.0
     dependencies:
-      rollup: 2.70.0
+      rollup: 2.70.1
     dev: false
 
   /@rollup/pluginutils/3.1.0_rollup@1.32.1:
@@ -2162,7 +2099,7 @@ packages:
       rollup: 1.32.1
     dev: false
 
-  /@rollup/pluginutils/3.1.0_rollup@2.70.0:
+  /@rollup/pluginutils/3.1.0_rollup@2.70.1:
     resolution: {integrity: sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==}
     engines: {node: '>= 8.0.0'}
     peerDependencies:
@@ -2171,7 +2108,7 @@ packages:
       '@types/estree': 0.0.39
       estree-walker: 1.0.1
       picomatch: 2.3.1
-      rollup: 2.70.0
+      rollup: 2.70.1
     dev: false
 
   /@rushstack/node-core-library/3.19.6:
@@ -2186,8 +2123,8 @@ packages:
       z-schema: 3.18.4
     dev: false
 
-  /@rushstack/node-core-library/3.45.0:
-    resolution: {integrity: sha512-YMuIJl19vQT1+g/OU9mLY6T5ZBT9uDlmeXExDQACpGuxTJW+LHNbk/lRX+eCApQI2eLBlaL4U68r3kZlqwbdmw==}
+  /@rushstack/node-core-library/3.45.1:
+    resolution: {integrity: sha512-BwdssTNe007DNjDBxJgInHg8ePytIPyT0La7ZZSQZF9+rSkT42AygXPGvbGsyFfEntjr4X37zZSJI7yGzL16cQ==}
     dependencies:
       '@types/node': 12.20.24
       colors: 1.2.5
@@ -2200,15 +2137,15 @@ packages:
       z-schema: 5.0.2
     dev: false
 
-  /@rushstack/rig-package/0.3.7:
-    resolution: {integrity: sha512-pzMsTSeTC8IiZ6EJLr53gGMvhT4oLWH+hxD7907cHyWuIUlEXFtu/2pK25vUQT13nKp5DJCWxXyYoGRk/h6rtA==}
+  /@rushstack/rig-package/0.3.8:
+    resolution: {integrity: sha512-MDWg1xovea99PWloSiYMjFcCLsrdjFtYt6aOyHNs5ojn5mxrzR6U9F83hvbQjTWnKPMvZtr0vcek+4n+OQOp3Q==}
     dependencies:
       resolve: 1.17.0
       strip-json-comments: 3.1.1
     dev: false
 
-  /@rushstack/ts-command-line/4.10.6:
-    resolution: {integrity: sha512-Y3GkUag39sTIlukDg9mUp8MCHrrlJ27POrBNRQGc/uF+VVgX8M7zMzHch5zP6O1QVquWgD7Engdpn2piPYaS/g==}
+  /@rushstack/ts-command-line/4.10.7:
+    resolution: {integrity: sha512-CjS+DfNXUSO5Ab2wD1GBGtUTnB02OglRWGqfaTcac9Jn45V5MeUOsq/wA8wEeS5Y/3TZ2P1k+IWdVDiuOFP9Og==}
     dependencies:
       '@types/argparse': 1.0.38
       argparse: 1.0.10
@@ -2304,7 +2241,7 @@ packages:
     resolution: {integrity: sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==}
     dependencies:
       '@types/connect': 3.4.35
-      '@types/node': 17.0.21
+      '@types/node': 17.0.23
     dev: false
 
   /@types/chai-as-promised/7.1.5:
@@ -2330,14 +2267,14 @@ packages:
   /@types/concurrently/6.4.0:
     resolution: {integrity: sha512-CYU1eyFHsIa2IZIsb8gfUOdiewfnZcyM2Hg1Zaq95xnmB0Ix/bTRM8SttqZ2Cjy6JGPZLttHjZewVsDg1yvnJg==}
     dependencies:
-      '@types/node': 17.0.21
+      '@types/node': 17.0.23
       chalk: 4.1.2
     dev: false
 
   /@types/connect/3.4.35:
     resolution: {integrity: sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==}
     dependencies:
-      '@types/node': 17.0.21
+      '@types/node': 17.0.23
     dev: false
 
   /@types/cookie/0.4.1:
@@ -2358,7 +2295,7 @@ packages:
     resolution: {integrity: sha512-pESyhSbUOskqrGcaN+bCXIQDyT5zTaRWfj5ZjjSlMatgGjIn3QQPfocAu4WSabUR7CGyLZ2CQaZyISOEX7/saw==}
     dependencies:
       '@types/estree': 0.0.51
-      '@types/json-schema': 7.0.9
+      '@types/json-schema': 7.0.11
     dev: false
 
   /@types/estree/0.0.39:
@@ -2372,7 +2309,7 @@ packages:
   /@types/express-serve-static-core/4.17.28:
     resolution: {integrity: sha512-P1BJAEAW3E2DJUlkgq4tOL3RyMunoWXqbSCygWo5ZIWTjUgN1YnaXWW4VWl/oc8vs/XoYibEGBKP0uZyF4AHig==}
     dependencies:
-      '@types/node': 17.0.21
+      '@types/node': 17.0.23
       '@types/qs': 6.9.7
       '@types/range-parser': 1.2.4
     dev: false
@@ -2389,30 +2326,30 @@ packages:
   /@types/fs-extra/8.1.2:
     resolution: {integrity: sha512-SvSrYXfWSc7R4eqnOzbQF4TZmfpNSM9FrSWLU3EUnWBuyZqNBOrv1B1JA3byUDPUl9z4Ab3jeZG2eDdySlgNMg==}
     dependencies:
-      '@types/node': 17.0.21
+      '@types/node': 17.0.23
     dev: false
 
   /@types/fs-extra/9.0.13:
     resolution: {integrity: sha512-nEnwB++1u5lVDM2UI4c1+5R+FYaKfaAzS4OococimjVm3nQw3TuzH5UNsocrcTBbhnerblyHj4A49qXbIiZdpA==}
     dependencies:
-      '@types/node': 17.0.21
+      '@types/node': 17.0.23
     dev: false
 
   /@types/glob/7.2.0:
     resolution: {integrity: sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==}
     dependencies:
       '@types/minimatch': 3.0.5
-      '@types/node': 17.0.21
+      '@types/node': 17.0.23
     dev: false
 
   /@types/is-buffer/2.0.0:
     resolution: {integrity: sha512-0f7N/e3BAz32qDYvgB4d2cqv1DqUwvGxHkXsrucICn8la1Vb6Yl6Eg8mPScGwUiqHJeE7diXlzaK+QMA9m4Gxw==}
     dependencies:
-      '@types/node': 17.0.21
+      '@types/node': 17.0.23
     dev: false
 
-  /@types/json-schema/7.0.9:
-    resolution: {integrity: sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==}
+  /@types/json-schema/7.0.11:
+    resolution: {integrity: sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==}
     dev: false
 
   /@types/json5/0.0.29:
@@ -2422,21 +2359,21 @@ packages:
   /@types/jsonwebtoken/8.5.8:
     resolution: {integrity: sha512-zm6xBQpFDIDM6o9r6HSgDeIcLy82TKWctCXEPbJJcXb5AKmi5BNNdLXneixK4lplX3PqIVcwLBCGE/kAGnlD4A==}
     dependencies:
-      '@types/node': 17.0.21
+      '@types/node': 17.0.23
     dev: false
 
   /@types/jws/3.2.4:
     resolution: {integrity: sha512-aqtH4dPw1wUjFZaeMD1ak/pf8iXlu/odFe+trJrvw0g1sTh93i+SCykg0Ek8C6B7rVK3oBORbfZAsKO7P10etg==}
     dependencies:
-      '@types/node': 17.0.21
+      '@types/node': 17.0.23
     dev: false
 
   /@types/long/4.0.1:
     resolution: {integrity: sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w==}
     dev: false
 
-  /@types/lru-cache/7.4.0:
-    resolution: {integrity: sha512-jZ/Tb2/3vXw4VYd9AImFC/n6XT3WywZNAxwY8Ox9eM87M9ta9G7KzCx4aKo2Zllvr02k40eY328cjOO3WuK5Kw==}
+  /@types/lru-cache/7.6.1:
+    resolution: {integrity: sha512-69x+Dhrm2aShFkTqUuPgUXbKYwvq4FH/DVeeQH7MBfTjbKjPX51NGLERxVV1vf33N71dzLvXCko4OLqRvsq53Q==}
     dev: false
 
   /@types/md5/2.3.2:
@@ -2472,13 +2409,13 @@ packages:
   /@types/mock-fs/4.13.1:
     resolution: {integrity: sha512-m6nFAJ3lBSnqbvDZioawRvpLXSaPyn52Srf7OfzjubYbYX8MTUdIgDxQl0wEapm4m/pNYSd9TXocpQ0TvZFlYA==}
     dependencies:
-      '@types/node': 17.0.21
+      '@types/node': 17.0.23
     dev: false
 
   /@types/mock-require/2.0.1:
     resolution: {integrity: sha512-O7U5DVGboY/Crueb5/huUCIRjKtRVRaLmRDbZJBlDQgJn966z3aiFDN+6AtYviu2ExwMkl34LjT/IiC0OPtKuQ==}
     dependencies:
-      '@types/node': 17.0.21
+      '@types/node': 17.0.23
     dev: false
 
   /@types/ms/0.7.31:
@@ -2492,7 +2429,7 @@ packages:
   /@types/node-fetch/2.6.1:
     resolution: {integrity: sha512-oMqjURCaxoSIsHSr1E47QHzbmzNR5rK8McHuNb11BOM9cHcIK3Avy0s/b2JlXHoQGTYS3NsvWzV1M0iK7l0wbA==}
     dependencies:
-      '@types/node': 17.0.21
+      '@types/node': 17.0.23
       form-data: 3.0.1
     dev: false
 
@@ -2504,12 +2441,12 @@ packages:
     resolution: {integrity: sha512-yxDeaQIAJlMav7fH5AQqPH1u8YIuhYJXYBzxaQ4PifsU0GDO38MSdmEDeRlIxrKbC6NbEaaEHDanWb+y30U8SQ==}
     dev: false
 
-  /@types/node/12.20.46:
-    resolution: {integrity: sha512-cPjLXj8d6anFPzFvOPxS3fvly3Shm5nTfl6g8X5smexixbuGUf7hfr21J5tX9JW+UPStp/5P5R8qrKL5IyVJ+A==}
+  /@types/node/12.20.47:
+    resolution: {integrity: sha512-BzcaRsnFuznzOItW1WpQrDHM7plAa7GIDMZ6b5pnMbkqEtM/6WCOhvZar39oeMQP79gwvFUWjjptE7/KGcNqFg==}
     dev: false
 
-  /@types/node/17.0.21:
-    resolution: {integrity: sha512-DBZCJbhII3r90XbQxI8Y9IjjiiOGlZ0Hr32omXIZvwwZ7p4DMMXGrKXVyPfuoBOri9XNtL0UK69jYIBIsRX3QQ==}
+  /@types/node/17.0.23:
+    resolution: {integrity: sha512-UxDxWn7dl97rKVeVS61vErvw086aCYhDLyvRQZ5Rk65rZKepaFdm53GeqXaKBuOhED4e9uWq34IC3TdSdJJ2Gw==}
     dev: false
 
   /@types/prettier/2.4.4:
@@ -2531,7 +2468,7 @@ packages:
   /@types/resolve/1.17.1:
     resolution: {integrity: sha512-yy7HuzQhj0dhGpD8RLXSZWEkLsV9ibvxvi6EiJ3bkqLAO1RGo0WbkWQiwpRlSFymTJRz0d3k5LM3kkx8ArDbLw==}
     dependencies:
-      '@types/node': 17.0.21
+      '@types/node': 17.0.23
     dev: false
 
   /@types/semaphore/1.1.1:
@@ -2542,29 +2479,29 @@ packages:
     resolution: {integrity: sha512-nCkHGI4w7ZgAdNkrEu0bv+4xNV/XDqW+DydknebMOQwkpDGx8G+HTlj7R7ABI8i8nKxVw0wtKPi1D+lPOkh4YQ==}
     dependencies:
       '@types/mime': 1.3.2
-      '@types/node': 17.0.21
+      '@types/node': 17.0.23
     dev: false
 
   /@types/sinon/10.0.11:
     resolution: {integrity: sha512-dmZsHlBsKUtBpHriNjlK0ndlvEh8dcb9uV9Afsbt89QIyydpC7NcR+nWlAhASfy3GHnxTl4FX/aKE7XZUt/B4g==}
     dependencies:
-      '@types/sinonjs__fake-timers': 8.1.1
+      '@types/sinonjs__fake-timers': 8.1.2
     dev: false
 
   /@types/sinon/9.0.11:
     resolution: {integrity: sha512-PwP4UY33SeeVKodNE37ZlOsR9cReypbMJOhZ7BVE0lB+Hix3efCOxiJWiE5Ia+yL9Cn2Ch72EjFTRze8RZsNtg==}
     dependencies:
-      '@types/sinonjs__fake-timers': 8.1.1
+      '@types/sinonjs__fake-timers': 8.1.2
     dev: false
 
-  /@types/sinonjs__fake-timers/8.1.1:
-    resolution: {integrity: sha512-0kSuKjAS0TrGLJ0M/+8MaFkGsQhZpB6pxOmvS3K8FYI72K//YmdfoW9X2qPsAKh1mkwxGD5zib9s1FIFed6E8g==}
+  /@types/sinonjs__fake-timers/8.1.2:
+    resolution: {integrity: sha512-9GcLXF0/v3t80caGs5p2rRfkB+a8VBGLJZVih6CNFkx8IZ994wiKKLSRs9nuFwk1HevWs/1mnUmkApGrSGsShA==}
     dev: false
 
   /@types/stoppable/1.1.1:
     resolution: {integrity: sha512-b8N+fCADRIYYrGZOcmOR8ZNBOqhktWTB/bMUl5LvGtT201QKJZOOH5UsFyI3qtteM6ZAJbJqZoBcLqqxKIwjhw==}
     dependencies:
-      '@types/node': 17.0.21
+      '@types/node': 17.0.23
     dev: false
 
   /@types/tough-cookie/4.0.1:
@@ -2574,13 +2511,13 @@ packages:
   /@types/tunnel/0.0.1:
     resolution: {integrity: sha512-AOqu6bQu5MSWwYvehMXLukFHnupHrpZ8nvgae5Ggie9UwzDR1CCwoXgSSWNZJuyOlCdfdsWMA5F2LlmvyoTv8A==}
     dependencies:
-      '@types/node': 17.0.21
+      '@types/node': 17.0.23
     dev: false
 
   /@types/tunnel/0.0.3:
     resolution: {integrity: sha512-sOUTGn6h1SfQ+gbgqC364jLFBw2lnFqkgF3q0WovEHRLMrVD1sd5aufqi/aJObLekJO+Aq5z646U4Oxy6shXMA==}
     dependencies:
-      '@types/node': 17.0.21
+      '@types/node': 17.0.23
     dev: false
 
   /@types/underscore/1.11.4:
@@ -2598,26 +2535,26 @@ packages:
   /@types/ws/7.4.7:
     resolution: {integrity: sha512-JQbbmxZTZehdc2iszGKs5oC3NFnjeay7mtAWrdt7qNtAVK0g19muApzAy4bm9byz79xa2ZnO/BOBC2R8RC5Lww==}
     dependencies:
-      '@types/node': 17.0.21
+      '@types/node': 17.0.23
     dev: false
 
-  /@types/ws/8.5.2:
-    resolution: {integrity: sha512-VXI82ykONr5tacHEojnErTQk+KQSoYbW1NB6iz6wUwrNd+BqfkfggQNoNdCqhJSzbNumShPERbM+Pc5zpfhlbw==}
+  /@types/ws/8.5.3:
+    resolution: {integrity: sha512-6YOoWjruKj1uLf3INHH7D3qTXwFfEsg1kf3c0uDdSBJwfa/llkwIjrAGV7j7mVgGNbzTQ3HiHKKDXl6bJPD97w==}
     dependencies:
-      '@types/node': 17.0.21
+      '@types/node': 17.0.23
     dev: false
 
   /@types/xml2js/0.4.9:
     resolution: {integrity: sha512-CHiCKIihl1pychwR2RNX5mAYmJDACgFVCMT5OArMaO3erzwXVcBqPcusr+Vl8yeeXukxZqtF8mZioqX+mpjjdw==}
     dependencies:
-      '@types/node': 17.0.21
+      '@types/node': 17.0.23
     dev: false
 
   /@types/yauzl/2.9.2:
     resolution: {integrity: sha512-8uALY5LTvSuHgloDVUvWP3pIauILm+8/0pDMokuDYIoNsOkSwd5AiHBTSEJjKTDcZr5z8UpgOWZkxBF4iJftoA==}
     requiresBuild: true
     dependencies:
-      '@types/node': 17.0.21
+      '@types/node': 17.0.23
     dev: false
     optional: true
 
@@ -2635,7 +2572,7 @@ packages:
       '@typescript-eslint/experimental-utils': 4.19.0_eslint@7.32.0+typescript@4.2.4
       '@typescript-eslint/parser': 4.19.0_eslint@7.32.0+typescript@4.2.4
       '@typescript-eslint/scope-manager': 4.19.0
-      debug: 4.3.3
+      debug: 4.3.4
       eslint: 7.32.0
       functional-red-black-tree: 1.0.1
       lodash: 4.17.21
@@ -2653,7 +2590,7 @@ packages:
     peerDependencies:
       eslint: '*'
     dependencies:
-      '@types/json-schema': 7.0.9
+      '@types/json-schema': 7.0.11
       '@typescript-eslint/scope-manager': 4.19.0
       '@typescript-eslint/types': 4.19.0
       '@typescript-eslint/typescript-estree': 4.19.0_typescript@4.2.4
@@ -2678,7 +2615,7 @@ packages:
       '@typescript-eslint/scope-manager': 4.19.0
       '@typescript-eslint/types': 4.19.0
       '@typescript-eslint/typescript-estree': 4.19.0_typescript@4.2.4
-      debug: 4.3.3
+      debug: 4.3.4
       eslint: 7.32.0
       typescript: 4.2.4
     transitivePeerDependencies:
@@ -2709,7 +2646,7 @@ packages:
     dependencies:
       '@typescript-eslint/types': 4.19.0
       '@typescript-eslint/visitor-keys': 4.19.0
-      debug: 4.3.3
+      debug: 4.3.4
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.3.5
@@ -2738,7 +2675,7 @@ packages:
     resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
     engines: {node: '>= 0.6'}
     dependencies:
-      mime-types: 2.1.34
+      mime-types: 2.1.35
       negotiator: 0.6.3
     dev: false
 
@@ -2771,7 +2708,7 @@ packages:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
     engines: {node: '>= 6.0.0'}
     dependencies:
-      debug: 4.3.3
+      debug: 4.3.4
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -2793,8 +2730,8 @@ packages:
       uri-js: 4.4.1
     dev: false
 
-  /ajv/8.10.0:
-    resolution: {integrity: sha512-bzqAEZOjkrUMl2afH8dknrq5KEk2SrwdBROR+vH1EKVQTqaUbJVPdc/gEdggTMM0Se+s+Ja4ju4TlNcStKl2Hw==}
+  /ajv/8.11.0:
+    resolution: {integrity: sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==}
     dependencies:
       fast-deep-equal: 3.1.3
       json-schema-traverse: 1.0.0
@@ -2817,13 +2754,13 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: false
 
-  /ansi-regex/3.0.0:
-    resolution: {integrity: sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=}
+  /ansi-regex/3.0.1:
+    resolution: {integrity: sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw==}
     engines: {node: '>=4'}
     dev: false
 
-  /ansi-regex/4.1.0:
-    resolution: {integrity: sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==}
+  /ansi-regex/4.1.1:
+    resolution: {integrity: sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==}
     engines: {node: '>=6'}
     dev: false
 
@@ -2908,7 +2845,7 @@ packages:
     dependencies:
       call-bind: 1.0.2
       define-properties: 1.1.3
-      es-abstract: 1.19.1
+      es-abstract: 1.19.2
       get-intrinsic: 1.1.1
       is-string: 1.0.7
     dev: false
@@ -2924,7 +2861,7 @@ packages:
     dependencies:
       call-bind: 1.0.2
       define-properties: 1.1.3
-      es-abstract: 1.19.1
+      es-abstract: 1.19.2
     dev: false
 
   /asap/2.0.6:
@@ -2974,8 +2911,8 @@ packages:
     engines: {node: '>= 0.4'}
     dev: false
 
-  /avsc/5.7.3:
-    resolution: {integrity: sha512-uUbetCWczQHbsKyX1C99XpQHBM8SWfovvaZhPIj23/1uV7SQf0WeRZbiLpw0JZm+LHTChfNgrLfDJOVoU2kU+A==}
+  /avsc/5.7.4:
+    resolution: {integrity: sha512-z4oo33lmnvvNRqfUe3YjDGGpqu/L2+wXBIhMtwq6oqZ+exOUAkQYM6zd2VWKF7AIlajOF8ZZuPFfryTG9iLC/w==}
     engines: {node: '>=0.11'}
     dev: false
 
@@ -2987,10 +2924,10 @@ packages:
       - debug
     dev: false
 
-  /axios/0.21.4_debug@4.3.3:
+  /axios/0.21.4_debug@4.3.4:
     resolution: {integrity: sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==}
     dependencies:
-      follow-redirects: 1.14.9_debug@4.3.3
+      follow-redirects: 1.14.9_debug@4.3.4
     transitivePeerDependencies:
       - debug
     dev: false
@@ -3001,7 +2938,7 @@ packages:
     dependencies:
       async: 2.6.3
       azure-iot-common: 1.12.13
-      debug: 4.3.3
+      debug: 4.3.4
       lodash.merge: 4.6.2
       machina: 4.0.2
       rhea: 1.0.24
@@ -3015,7 +2952,7 @@ packages:
     resolution: {integrity: sha512-s29mPg+Wj17bVaKMM8im4+sWeXYSs4ern5Eelqs3qKU8dc4REWQ43Ln2t6J/A1MqZ/UxAPgXrVhHk1DCN8NQGQ==}
     engines: {node: '>= 12.0.0'}
     dependencies:
-      debug: 4.3.3
+      debug: 4.3.4
       getos: 3.2.1
     transitivePeerDependencies:
       - supports-color
@@ -3026,7 +2963,7 @@ packages:
     engines: {node: '>= 12.0.0'}
     dependencies:
       azure-iot-common: 1.12.13
-      debug: 4.3.3
+      debug: 4.3.4
       uuid: 8.3.2
     transitivePeerDependencies:
       - supports-color
@@ -3037,13 +2974,13 @@ packages:
     engines: {node: '>= 12.0.0'}
     dependencies:
       '@azure/core-http': 1.2.3
-      '@azure/identity': 1.2.5_debug@4.3.3
+      '@azure/identity': 1.2.5_debug@4.3.4
       '@azure/ms-rest-js': 2.6.1
       async: 2.6.3
       azure-iot-amqp-base: 2.4.13
       azure-iot-common: 1.12.13
       azure-iot-http-base: 1.11.13
-      debug: 4.3.3
+      debug: 4.3.4
       lodash: 4.17.21
       machina: 4.0.2
       rhea: 1.0.24
@@ -3051,13 +2988,6 @@ packages:
     transitivePeerDependencies:
       - encoding
       - supports-color
-    dev: false
-
-  /babel-runtime/6.26.0:
-    resolution: {integrity: sha1-llxwWGaOgrVde/4E/yM3vItWR/4=}
-    dependencies:
-      core-js: 2.6.12
-      regenerator-runtime: 0.11.1
     dev: false
 
   /backbone/1.4.1:
@@ -3126,13 +3056,13 @@ packages:
     resolution: {integrity: sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==}
     dev: false
 
-  /browserslist/4.20.0:
-    resolution: {integrity: sha512-bnpOoa+DownbciXj0jVGENf8VYQnE2LNWomhYuCsMmmx9Jd9lwq0WXODuwpSsp8AVdKM2/HorrzxAfbKvWTByQ==}
+  /browserslist/4.20.2:
+    resolution: {integrity: sha512-CQOBCqp/9pDvDbx3xfMi+86pr4KXIf2FDkTTdeuYw8OxS9t898LA1Khq57gtufFILXpfgsSx5woNgsBgvGjpsA==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
     dependencies:
-      caniuse-lite: 1.0.30001313
-      electron-to-chromium: 1.4.76
+      caniuse-lite: 1.0.30001323
+      electron-to-chromium: 1.4.103
       escalade: 3.1.1
       node-releases: 2.0.2
       picocolors: 1.0.0
@@ -3216,8 +3146,8 @@ packages:
     engines: {node: '>=6'}
     dev: false
 
-  /caniuse-lite/1.0.30001313:
-    resolution: {integrity: sha512-rI1UN0koZUiKINjysQDuRi2VeSCce3bYJNmDcj3PIKREiAmjakugBul1QSkg/fPrlULYl6oWfGg3PbgOSY9X4Q==}
+  /caniuse-lite/1.0.30001323:
+    resolution: {integrity: sha512-e4BF2RlCVELKx8+RmklSEIVub1TWrmdhvA5kEUueummz1XyySW0DVk+3x9HyhU9MuWTa2BhqLgEuEmUwASAdCA==}
     dev: false
 
   /chai-as-promised/7.1.1_chai@4.3.6:
@@ -3482,12 +3412,6 @@ packages:
       yargs: 16.2.0
     dev: false
 
-  /core-js/2.6.12:
-    resolution: {integrity: sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==}
-    deprecated: core-js@<3.4 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Please, upgrade your dependencies to the actual version of core-js.
-    requiresBuild: true
-    dev: false
-
   /core-js/3.21.1:
     resolution: {integrity: sha512-FRq5b/VMrWlrmCzwRrpDYNxyHP9BcAZC+xHJaqTgIE5091ZV1NTmyh0sGOg5XqpnHvR0svdy0sv1gWA1zmhxig==}
     requiresBuild: true
@@ -3511,7 +3435,7 @@ packages:
     dependencies:
       graceful-fs: 4.2.9
       make-dir: 2.1.0
-      nested-error-stacks: 2.1.0
+      nested-error-stacks: 2.1.1
       pify: 4.0.1
       safe-buffer: 5.2.1
     dev: false
@@ -3580,13 +3504,13 @@ packages:
     engines: {node: '>=0.11'}
     dev: false
 
-  /date-format/4.0.4:
-    resolution: {integrity: sha512-/jyf4rhB17ge328HJuJjAcmRtCsGd+NDeAtahRBTaK6vSPR6MO5HlrAit3Nn7dVjaa6sowW0WXt8yQtLyZQFRg==}
+  /date-format/4.0.6:
+    resolution: {integrity: sha512-B9vvg5rHuQ8cbUXE/RMWMyX2YA5TecT3jKF5fLtGNlzPlU7zblSPmAm2OImDbWL+LDOQ6pUm+4LOFz+ywS41Zw==}
     engines: {node: '>=4.0'}
     dev: false
 
-  /dayjs/1.10.8:
-    resolution: {integrity: sha512-wbNwDfBHHur9UOzNUjeKUOJ0fCb0a52Wx0xInmQ7Y8FstyajiV1NmK1e00cxsr9YrE9r7yAChE0VvpuY5Rnlow==}
+  /dayjs/1.11.0:
+    resolution: {integrity: sha512-JLC809s6Y948/FuCZPm5IX8rRhQwOiyMb2TfVVQEixG7P8Lm/gt5S7yoQZmC8x1UehI9Pb7sksEt4xx14m+7Ug==}
     dev: false
 
   /debug/2.6.9:
@@ -3608,8 +3532,8 @@ packages:
       ms: 2.1.3
     dev: false
 
-  /debug/4.3.3:
-    resolution: {integrity: sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==}
+  /debug/4.3.4:
+    resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
     engines: {node: '>=6.0'}
     peerDependencies:
       supports-color: '*'
@@ -3809,8 +3733,8 @@ packages:
     resolution: {integrity: sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=}
     dev: false
 
-  /electron-to-chromium/1.4.76:
-    resolution: {integrity: sha512-3Vftv7cenJtQb+k00McEBZ2vVmZ/x+HEF7pcZONZIkOsESqAqVuACmBxMv0JhzX7u0YltU0vSqRqgBSTAhFUjA==}
+  /electron-to-chromium/1.4.103:
+    resolution: {integrity: sha512-c/uKWR1Z/W30Wy/sx3dkZoj4BijbXX85QKWu9jJfjho3LBAXNEGAEW3oWiGb+dotA6C6BzCTxL2/aLes7jlUeg==}
     dev: false
 
   /emoji-regex/7.0.3:
@@ -3845,12 +3769,12 @@ packages:
     dependencies:
       '@types/cookie': 0.4.1
       '@types/cors': 2.8.12
-      '@types/node': 17.0.21
+      '@types/node': 17.0.23
       accepts: 1.3.8
       base64id: 2.0.0
       cookie: 0.4.2
       cors: 2.8.5
-      debug: 4.3.3
+      debug: 4.3.4
       engine.io-parser: 5.0.3
       ws: 8.2.3
     transitivePeerDependencies:
@@ -3876,8 +3800,8 @@ packages:
       is-arrayish: 0.2.1
     dev: false
 
-  /es-abstract/1.19.1:
-    resolution: {integrity: sha512-2vJ6tjA/UfqLm2MPs7jxVybLoB8i1t1Jd9R3kISld20sIxPcTbLuggQOUxeWeAvIUkduv/CfMjuh4WmiXr2v9w==}
+  /es-abstract/1.19.2:
+    resolution: {integrity: sha512-gfSBJoZdlL2xRiOCy0g8gLMryhoe1TlimjzU99L/31Z8QEGIhVQI+EWwt5lT+AuU9SnorVupXFqqOGqGfsyO6w==}
     engines: {node: '>= 0.4'}
     dependencies:
       call-bind: 1.0.2
@@ -3992,7 +3916,7 @@ packages:
       minimatch: 3.1.2
       object.values: 1.1.5
       resolve: 1.22.0
-      tsconfig-paths: 3.13.0
+      tsconfig-paths: 3.14.1
     dev: false
 
   /eslint-plugin-markdown/2.2.1_eslint@7.32.0:
@@ -4079,7 +4003,7 @@ packages:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.3
-      debug: 4.3.3
+      debug: 4.3.4
       doctrine: 3.0.0
       enquirer: 2.3.6
       escape-string-regexp: 4.0.0
@@ -4093,7 +4017,7 @@ packages:
       file-entry-cache: 6.0.1
       functional-red-black-tree: 1.0.1
       glob-parent: 5.1.2
-      globals: 13.12.1
+      globals: 13.13.0
       ignore: 4.0.6
       import-fresh: 3.3.0
       imurmurhash: 0.1.4
@@ -4284,7 +4208,7 @@ packages:
     engines: {node: '>= 10.17.0'}
     hasBin: true
     dependencies:
-      debug: 4.3.3
+      debug: 4.3.4
       get-stream: 5.2.0
       yauzl: 2.10.0
     optionalDependencies:
@@ -4305,7 +4229,7 @@ packages:
       '@nodelib/fs.walk': 1.2.8
       glob-parent: 5.1.2
       merge2: 1.4.1
-      micromatch: 4.0.4
+      micromatch: 4.0.5
     dev: false
 
   /fast-json-stable-stringify/2.1.0:
@@ -4316,8 +4240,8 @@ packages:
     resolution: {integrity: sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=}
     dev: false
 
-  /fast-xml-parser/4.0.5:
-    resolution: {integrity: sha512-B3eG9unGn4SqG6Fdwhc4eaIFBSN/0CdqUKG1nzjLuojhMyq4qMxNShzng0QjOW3swE3MhERMf70u7C/XnzmshA==}
+  /fast-xml-parser/4.0.7:
+    resolution: {integrity: sha512-dMtibyus3kC7nbxj1CpVtysLzO13UOAZEFAb5vpQg3T4O6qvetmSePpXKFx5KPNCHKoGwjtgjfF5DOyn7s1ylQ==}
     hasBin: true
     dependencies:
       strnum: 1.0.5
@@ -4348,10 +4272,10 @@ packages:
       node-fetch:
         optional: true
     dependencies:
-      '@babel/core': 7.17.5
-      '@babel/runtime': 7.17.2
+      '@babel/core': 7.17.8
+      '@babel/runtime': 7.17.8
       core-js: 3.21.1
-      debug: 4.3.3
+      debug: 4.3.4
       glob-to-regexp: 0.4.1
       is-subset: 0.1.1
       lodash.isequal: 4.5.0
@@ -4463,7 +4387,7 @@ packages:
         optional: true
     dev: false
 
-  /follow-redirects/1.14.9_debug@4.3.3:
+  /follow-redirects/1.14.9_debug@4.3.4:
     resolution: {integrity: sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w==}
     engines: {node: '>=4.0'}
     peerDependencies:
@@ -4472,7 +4396,7 @@ packages:
       debug:
         optional: true
     dependencies:
-      debug: 4.3.3
+      debug: 4.3.4
     dev: false
 
   /foreach/2.0.5:
@@ -4500,7 +4424,7 @@ packages:
     dependencies:
       asynckit: 0.4.0
       combined-stream: 1.0.8
-      mime-types: 2.1.34
+      mime-types: 2.1.35
     dev: false
 
   /form-data/3.0.1:
@@ -4509,7 +4433,7 @@ packages:
     dependencies:
       asynckit: 0.4.0
       combined-stream: 1.0.8
-      mime-types: 2.1.34
+      mime-types: 2.1.35
     dev: false
 
   /form-data/4.0.0:
@@ -4518,7 +4442,7 @@ packages:
     dependencies:
       asynckit: 0.4.0
       combined-stream: 1.0.8
-      mime-types: 2.1.34
+      mime-types: 2.1.35
     dev: false
 
   /forwarded/0.2.0:
@@ -4734,8 +4658,8 @@ packages:
     engines: {node: '>=4'}
     dev: false
 
-  /globals/13.12.1:
-    resolution: {integrity: sha512-317dFlgY2pdJZ9rspXDks7073GpDmXdfbM3vYYp0HAMKGDh1FfWPleI2ljVNLQX5M5lXcAslTcPTrOrMEFOjyw==}
+  /globals/13.13.0:
+    resolution: {integrity: sha512-EQ7Q18AJlPwp3vUDL4mKA0KXrXyNIQyWon6T6XQiBQF0XHvRsiCSrWmmeATpUzdJN2HhWZU6Pdl0a9zdep5p6A==}
     engines: {node: '>=8'}
     dependencies:
       type-fest: 0.20.2
@@ -4771,12 +4695,12 @@ packages:
     engines: {node: '>=0.4.7'}
     hasBin: true
     dependencies:
-      minimist: 1.2.5
+      minimist: 1.2.6
       neo-async: 2.6.2
       source-map: 0.6.1
       wordwrap: 1.0.0
     optionalDependencies:
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     dev: false
 
   /has-bigints/1.0.1:
@@ -4881,7 +4805,7 @@ packages:
     dependencies:
       '@tootallnate/once': 1.1.2
       agent-base: 6.0.2
-      debug: 4.3.3
+      debug: 4.3.4
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -4897,12 +4821,12 @@ packages:
       - debug
     dev: false
 
-  /http-proxy/1.18.1_debug@4.3.3:
+  /http-proxy/1.18.1_debug@4.3.4:
     resolution: {integrity: sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==}
     engines: {node: '>=8.0.0'}
     dependencies:
       eventemitter3: 4.0.7
-      follow-redirects: 1.14.9_debug@4.3.3
+      follow-redirects: 1.14.9_debug@4.3.4
       requires-port: 1.0.0
     transitivePeerDependencies:
       - debug
@@ -4913,7 +4837,7 @@ packages:
     engines: {node: '>= 6'}
     dependencies:
       agent-base: 6.0.2
-      debug: 4.3.3
+      debug: 4.3.4
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -5217,7 +5141,7 @@ packages:
     dependencies:
       available-typed-arrays: 1.0.5
       call-bind: 1.0.2
-      es-abstract: 1.19.1
+      es-abstract: 1.19.2
       foreach: 2.0.5
       has-tostringtag: 1.0.0
     dev: false
@@ -5257,8 +5181,8 @@ packages:
     resolution: {integrity: sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=}
     dev: false
 
-  /isbinaryfile/4.0.8:
-    resolution: {integrity: sha512-53h6XFniq77YdW+spoRrebh0mnmTxRPTlcuIArO57lmMdq4uBKFKaeTjnb92oYWrSn/LVL+LT+Hap2tFQj8V+w==}
+  /isbinaryfile/4.0.10:
+    resolution: {integrity: sha512-iHrqe5shvBUcFbmZq9zOQHBoeOhZJu6RQGrDpBgenUm/Am+F3JM2MgQj+rK3Z601fzrL5gLZWtAPH2OBaSVcyw==}
     engines: {node: '>= 8.0.0'}
     dev: false
 
@@ -5294,8 +5218,8 @@ packages:
     resolution: {integrity: sha512-5nnIN4vo5xQZHdXno/YDXJ0G+I3dAm4XgzfSVTPLQpj/zAV2dV6Juy0yaf10/zrJOJeHoN3fraFe+XRq2bFVZA==}
     engines: {node: '>=6'}
     dependencies:
-      '@babel/generator': 7.17.3
-      '@babel/parser': 7.17.3
+      '@babel/generator': 7.17.7
+      '@babel/parser': 7.17.8
       '@babel/template': 7.16.7
       '@babel/traverse': 7.17.3
       '@babel/types': 7.17.0
@@ -5309,7 +5233,7 @@ packages:
     resolution: {integrity: sha512-BXgQl9kf4WTCPCCpmFGoJkz/+uhvm7h7PFKUYxh7qarQd3ER33vHG//qaE8eN25l07YqZPpHXU9I09l/RD5aGQ==}
     engines: {node: '>=8'}
     dependencies:
-      '@babel/core': 7.17.5
+      '@babel/core': 7.17.8
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.0
       semver: 6.3.0
@@ -5321,8 +5245,8 @@ packages:
     resolution: {integrity: sha512-czwUz525rkOFDJxfKK6mYfIs9zBKILyrZQxjz3ABhjQXhbhFsSbo1HW/BFcsDnfJYJWA6thRR5/TUY2qs5W99Q==}
     engines: {node: '>=8'}
     dependencies:
-      '@babel/core': 7.17.5
-      '@babel/parser': 7.17.3
+      '@babel/core': 7.17.8
+      '@babel/parser': 7.17.8
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.0
       semver: 6.3.0
@@ -5365,7 +5289,7 @@ packages:
     resolution: {integrity: sha512-R47KzMtDJH6X4/YW9XTx+jrLnZnscW4VpNN+1PViSYTejLVPWv7oov+Duf8YQSPyVRUvueQqz1TcsC6mooZTXw==}
     engines: {node: '>=6'}
     dependencies:
-      debug: 4.3.3
+      debug: 4.3.4
       istanbul-lib-coverage: 2.0.5
       make-dir: 2.1.0
       rimraf: 2.7.1
@@ -5378,7 +5302,7 @@ packages:
     resolution: {integrity: sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==}
     engines: {node: '>=10'}
     dependencies:
-      debug: 4.3.3
+      debug: 4.3.4
       istanbul-lib-coverage: 3.2.0
       source-map: 0.6.1
     transitivePeerDependencies:
@@ -5474,15 +5398,13 @@ packages:
     resolution: {integrity: sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==}
     hasBin: true
     dependencies:
-      minimist: 1.2.5
+      minimist: 1.2.6
     dev: false
 
-  /json5/2.2.0:
-    resolution: {integrity: sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==}
+  /json5/2.2.1:
+    resolution: {integrity: sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==}
     engines: {node: '>=6'}
     hasBin: true
-    dependencies:
-      minimist: 1.2.5
     dev: false
 
   /jsonfile/4.0.0:
@@ -5515,8 +5437,8 @@ packages:
       semver: 5.7.1
     dev: false
 
-  /jsrsasign/10.5.8:
-    resolution: {integrity: sha512-ewFUGPZJujIR9j84Q5LEzPTG4D1qQZ4CjJrgHfMEAAiArkC3xfdgNP0ZAXXxXbb+K8Phw15soOIJ8bX3+usEdQ==}
+  /jsrsasign/10.5.14:
+    resolution: {integrity: sha512-W49L90gR5E8lOMfZJzhq/JHM2Am6slJWsaI/aiyDZurK1CQly9/FN9ZCvM5ez8Svbw5+CwVEH25iIARLoh4Viw==}
     dev: false
 
   /jssha/3.2.0:
@@ -5575,8 +5497,8 @@ packages:
       karma: 6.3.17
     dev: false
 
-  /karma-chrome-launcher/3.1.0:
-    resolution: {integrity: sha512-3dPs/n7vgz1rxxtynpzZTvb9y/GIaW8xjAwcIGttLbycqoFtI7yo1NGnQi6oFTherRE+GIhCAHZC4vEqWGhNvg==}
+  /karma-chrome-launcher/3.1.1:
+    resolution: {integrity: sha512-hsIglcq1vtboGPAN+DGCISCFOxW+ZVnIqhDQcCMqqCp+4dmJ0Qpq5QAjkbA0X2L9Mi6OBkHi2Srrbmm7pUKkzQ==}
     dependencies:
       which: 1.3.1
     dev: false
@@ -5635,7 +5557,7 @@ packages:
   /karma-json-to-file-reporter/1.0.1:
     resolution: {integrity: sha512-kNCi+0UrXAeTJMpMsHkHNbfmlErsYT+/haNakJIhsE/gtj3Jx7zWRg7BTc1HHSbH5KeVXVRJr3/KLB/NHWY7Hg==}
     dependencies:
-      json5: 2.2.0
+      json5: 2.2.1
     dev: false
 
   /karma-junit-reporter/2.0.1_karma@6.3.17:
@@ -5663,7 +5585,7 @@ packages:
   /karma-mocha/2.0.1:
     resolution: {integrity: sha512-Tzd5HBjm8his2OA4bouAsATYEpZrp9vC7z5E5j4C5Of5Rrs1jY67RAwXNcVmd/Bnk1wgvQRou0zGVLey44G4tQ==}
     dependencies:
-      minimist: 1.2.5
+      minimist: 1.2.6
     dev: false
 
   /karma-source-map-support/1.4.0:
@@ -5693,12 +5615,12 @@ packages:
       glob: 7.2.0
       graceful-fs: 4.2.9
       http-proxy: 1.18.1
-      isbinaryfile: 4.0.8
+      isbinaryfile: 4.0.10
       lodash: 4.17.21
-      log4js: 6.4.2
+      log4js: 6.4.4
       mime: 2.6.0
       minimatch: 3.1.2
-      mkdirp: 0.5.5
+      mkdirp: 0.5.6
       qjobs: 1.2.0
       range-parser: 1.2.1
       rimraf: 3.0.2
@@ -5714,7 +5636,7 @@ packages:
       - utf-8-validate
     dev: false
 
-  /karma/6.3.17_debug@4.3.3:
+  /karma/6.3.17_debug@4.3.4:
     resolution: {integrity: sha512-2TfjHwrRExC8yHoWlPBULyaLwAFmXmxQrcuFImt/JsAsSZu1uOWTZ1ZsWjqQtWpHLiatJOHL5jFjXSJIgCd01g==}
     engines: {node: '>= 10'}
     hasBin: true
@@ -5728,13 +5650,13 @@ packages:
       dom-serialize: 2.2.1
       glob: 7.2.0
       graceful-fs: 4.2.9
-      http-proxy: 1.18.1_debug@4.3.3
-      isbinaryfile: 4.0.8
+      http-proxy: 1.18.1_debug@4.3.4
+      isbinaryfile: 4.0.10
       lodash: 4.17.21
-      log4js: 6.4.2
+      log4js: 6.4.4
       mime: 2.6.0
       minimatch: 3.1.2
-      mkdirp: 0.5.5
+      mkdirp: 0.5.6
       qjobs: 1.2.0
       range-parser: 1.2.1
       rimraf: 3.0.2
@@ -5869,15 +5791,15 @@ packages:
       chalk: 2.4.2
     dev: false
 
-  /log4js/6.4.2:
-    resolution: {integrity: sha512-k80cggS2sZQLBwllpT1p06GtfvzMmSdUCkW96f0Hj83rKGJDAu2vZjt9B9ag2vx8Zz1IXzxoLgqvRJCdMKybGg==}
+  /log4js/6.4.4:
+    resolution: {integrity: sha512-ncaWPsuw9Vl1CKA406hVnJLGQKy1OHx6buk8J4rE2lVW+NW5Y82G5/DIloO7NkqLOUtNPEANaWC1kZYVjXssPw==}
     engines: {node: '>=8.0'}
     dependencies:
-      date-format: 4.0.4
-      debug: 4.3.3
+      date-format: 4.0.6
+      debug: 4.3.4
       flatted: 3.2.5
       rfdc: 1.3.0
-      streamroller: 3.0.4
+      streamroller: 3.0.6
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -5906,8 +5828,8 @@ packages:
       yallist: 4.0.0
     dev: false
 
-  /lru-cache/7.4.2:
-    resolution: {integrity: sha512-Xs3+hFPDSKQmL05Gs6NhvAADol1u9TmLoNoE03ZjszX6a5iYIO3rPUM4jIjoBUJeTaWEBMozjjmV70gvdRfIdw==}
+  /lru-cache/7.7.3:
+    resolution: {integrity: sha512-WY9wjJNQt9+PZilnLbuFKM+SwDull9+6IAguOrarOMoOHTcJ9GnXSO11+Gw6c7xtDkBkthR57OZMtZKYr+1CEw==}
     engines: {node: '>=12'}
     dev: false
 
@@ -6034,30 +5956,30 @@ packages:
   /micromark/2.11.4:
     resolution: {integrity: sha512-+WoovN/ppKolQOFIAajxi7Lu9kInbPxFuTBVEavFcL8eAfVstoc5MocPmqBeAdBOJV00uaVjegzH4+MA0DN/uA==}
     dependencies:
-      debug: 4.3.3
+      debug: 4.3.4
       parse-entities: 2.0.0
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /micromatch/4.0.4:
-    resolution: {integrity: sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==}
+  /micromatch/4.0.5:
+    resolution: {integrity: sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==}
     engines: {node: '>=8.6'}
     dependencies:
       braces: 3.0.2
       picomatch: 2.3.1
     dev: false
 
-  /mime-db/1.51.0:
-    resolution: {integrity: sha512-5y8A56jg7XVQx2mbv1lu49NR4dokRnhZYTtL+KGfaa27uq4pSTXkwQkFJl4pkRMyNFz/EtYDSkiiEHx3F7UN6g==}
+  /mime-db/1.52.0:
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
     engines: {node: '>= 0.6'}
     dev: false
 
-  /mime-types/2.1.34:
-    resolution: {integrity: sha512-6cP692WwGIs9XXdOO4++N+7qjqv0rqxxVvJ3VHPh/Sc9mVZcQP+ZGhkKiTvWMQRr2tbHkJP/Yn7Y0npb3ZBs4A==}
+  /mime-types/2.1.35:
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
     dependencies:
-      mime-db: 1.51.0
+      mime-db: 1.52.0
     dev: false
 
   /mime/1.6.0:
@@ -6105,8 +6027,8 @@ packages:
       brace-expansion: 1.1.11
     dev: false
 
-  /minimist/1.2.5:
-    resolution: {integrity: sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==}
+  /minimist/1.2.6:
+    resolution: {integrity: sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==}
     dev: false
 
   /mkdirp-classic/0.5.3:
@@ -6117,7 +6039,14 @@ packages:
     resolution: {integrity: sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==}
     hasBin: true
     dependencies:
-      minimist: 1.2.5
+      minimist: 1.2.6
+    dev: false
+
+  /mkdirp/0.5.6:
+    resolution: {integrity: sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==}
+    hasBin: true
+    dependencies:
+      minimist: 1.2.6
     dev: false
 
   /mkdirp/1.0.4:
@@ -6133,7 +6062,7 @@ packages:
     dependencies:
       debug: 2.6.9
       md5: 2.3.0
-      mkdirp: 0.5.5
+      mkdirp: 0.5.6
       mocha: 7.2.0
       strip-ansi: 4.0.0
       xml: 1.0.1
@@ -6146,7 +6075,7 @@ packages:
     dependencies:
       debug: 2.6.9
       md5: 2.3.0
-      mkdirp: 0.5.5
+      mkdirp: 0.5.6
       mocha: 7.2.0
       strip-ansi: 6.0.1
       xml: 1.0.1
@@ -6231,8 +6160,8 @@ packages:
     resolution: {integrity: sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ==}
     dev: false
 
-  /nanoid/3.3.1:
-    resolution: {integrity: sha512-n6Vs/3KGyxPQd6uO0eH4Bv0ojGSUvuLlIHtC3Y0kEO23YRge8H9x1GCzLn28YX0H66pMkxuaeESFq4tKISKwdw==}
+  /nanoid/3.3.2:
+    resolution: {integrity: sha512-CuHBogktKwpm5g2sRgv83jEy2ijFzBwMoYA60orPDR7ynsLijJDqgsi4RDGj3OJpy3Ieb+LYwiRmIOGyytgITA==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
     dev: false
@@ -6254,8 +6183,8 @@ packages:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
     dev: false
 
-  /nested-error-stacks/2.1.0:
-    resolution: {integrity: sha512-AO81vsIO1k1sM4Zrd6Hu7regmJN1NSiAja10gc4bX3F0wd+9rQmcuHQaHVQCYIEC8iFXnE+mavh23GOt7wBgug==}
+  /nested-error-stacks/2.1.1:
+    resolution: {integrity: sha512-9iN1ka/9zmX1ZvLV9ewJYEk9h7RyRRtqdK0woXcqohu8EWIerfPUjYJPg0ULy0UqP7cslmdGc8xKDJcojlKiaw==}
     dev: false
 
   /nice-try/1.0.5:
@@ -6286,7 +6215,7 @@ packages:
     resolution: {integrity: sha512-QNb/j8kbFnKCiyqi9C5DD0jH/FubFGj5rt9NQFONXwQm3IPB0CULECg/eS3AU1KgZb/6SwUa4/DTRKhVxkGABw==}
     engines: {node: '>= 10.13'}
     dependencies:
-      debug: 4.3.3
+      debug: 4.3.4
       json-stringify-safe: 5.0.1
       lodash: 4.17.21
       propagate: 2.0.1
@@ -6521,7 +6450,7 @@ packages:
     dependencies:
       call-bind: 1.0.2
       define-properties: 1.1.3
-      es-abstract: 1.19.1
+      es-abstract: 1.19.2
     dev: false
 
   /object.values/1.1.5:
@@ -6530,7 +6459,7 @@ packages:
     dependencies:
       call-bind: 1.0.2
       define-properties: 1.1.3
-      es-abstract: 1.19.1
+      es-abstract: 1.19.2
     dev: false
 
   /on-finished/2.3.0:
@@ -6817,7 +6746,7 @@ packages:
       detect-libc: 2.0.1
       expand-template: 2.0.3
       github-from-package: 0.0.0
-      minimist: 1.2.5
+      minimist: 1.2.6
       mkdirp-classic: 0.5.3
       napi-build-utils: 1.0.2
       node-abi: 3.8.0
@@ -6848,6 +6777,12 @@ packages:
 
   /prettier/2.5.1:
     resolution: {integrity: sha512-vBZcPRUR5MZJwoyi3ZoyQlc1rXeEck8KgeC9AwwOn+exuxLxq5toTRDTSaVrXHxelDMHy9zlicw8u66yxoSUFg==}
+    engines: {node: '>=10.13.0'}
+    hasBin: true
+    dev: false
+
+  /prettier/2.6.1:
+    resolution: {integrity: sha512-8UVbTBYGwN37Bs9LERmxCPjdvPxlEowx2urIL6urHzdb3SDq4B/Z6xLFCblrSnE4iKWcS6ziJ3aOYrc1kz/E2A==}
     engines: {node: '>=10.13.0'}
     hasBin: true
     dev: false
@@ -6924,13 +6859,13 @@ packages:
     engines: {node: '>=6'}
     dev: false
 
-  /puppeteer/13.5.1:
-    resolution: {integrity: sha512-wWxO//vMiqxlvuzHMAJ0pRJeDHvDtM7DQpW1GKdStz2nZo2G42kOXBDgkmQ+zqjwMCFofKGesBeeKxIkX9BO+w==}
+  /puppeteer/13.5.2:
+    resolution: {integrity: sha512-DJAyXODBikZ3xPs8C35CtExEw78LZR9RyelGDAs0tX1dERv3OfW7qpQ9VPBgsfz+hG2HiMTO/Tyf7BuMVWsrxg==}
     engines: {node: '>=10.18.1'}
     requiresBuild: true
     dependencies:
       cross-fetch: 3.1.5
-      debug: 4.3.3
+      debug: 4.3.4
       devtools-protocol: 0.0.969999
       extract-zip: 2.0.1
       https-proxy-agent: 5.0.0
@@ -7008,7 +6943,7 @@ packages:
     dependencies:
       deep-extend: 0.6.0
       ini: 1.3.8
-      minimist: 1.2.5
+      minimist: 1.2.6
       strip-json-comments: 2.0.1
     dev: false
 
@@ -7080,10 +7015,6 @@ packages:
       resolve: 1.22.0
     dev: false
 
-  /regenerator-runtime/0.11.1:
-    resolution: {integrity: sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==}
-    dev: false
-
   /regenerator-runtime/0.13.9:
     resolution: {integrity: sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==}
     dev: false
@@ -7117,7 +7048,7 @@ packages:
   /require-in-the-middle/5.1.0:
     resolution: {integrity: sha512-M2rLKVupQfJ5lf9OvqFGIT+9iVLnTmjgbOmpil12hiSQNn5zJTKGPoIisETNjfK+09vP3rpm1zJajmErpr2sEQ==}
     dependencies:
-      debug: 4.3.3
+      debug: 4.3.4
       module-details-from-path: 1.0.3
       resolve: 1.22.0
     transitivePeerDependencies:
@@ -7241,13 +7172,13 @@ packages:
       resolve: 1.22.0
     dev: false
 
-  /rollup-plugin-polyfill-node/0.8.0_rollup@2.70.0:
+  /rollup-plugin-polyfill-node/0.8.0_rollup@2.70.1:
     resolution: {integrity: sha512-C4UeKedOmOBkB3FgR+z/v9kzRwV1Q/H8xWs1u1+CNe4XOV6hINfOrcO+TredKxYvopCmr+WKUSNsFUnD1RLHgQ==}
     peerDependencies:
       rollup: ^1.20.0 || ^2.0.0
     dependencies:
-      '@rollup/plugin-inject': 4.0.4_rollup@2.70.0
-      rollup: 2.70.0
+      '@rollup/plugin-inject': 4.0.4_rollup@2.70.1
+      rollup: 2.70.1
     dev: false
 
   /rollup-plugin-shim/1.0.0:
@@ -7265,18 +7196,18 @@ packages:
       source-map-resolve: 0.5.3
     dev: false
 
-  /rollup-plugin-sourcemaps/0.4.2_rollup@2.70.0:
+  /rollup-plugin-sourcemaps/0.4.2_rollup@2.70.1:
     resolution: {integrity: sha1-YhJaqUCHqt97g+9N+vYptHMTXoc=}
     engines: {node: '>=4.5.0', npm: '>=2.15.9'}
     peerDependencies:
       rollup: '>=0.31.2'
     dependencies:
-      rollup: 2.70.0
+      rollup: 2.70.1
       rollup-pluginutils: 2.8.2
       source-map-resolve: 0.5.3
     dev: false
 
-  /rollup-plugin-sourcemaps/0.6.3_7b21584653753493578248d33259a4c9:
+  /rollup-plugin-sourcemaps/0.6.3_0b8c6e9127356138a5eb10cf645561b8:
     resolution: {integrity: sha512-paFu+nT1xvuO1tPFYXGe+XnQvg4Hjqv/eIhG8i5EspfYYPBKL57X7iVbfv55aNVASg3dzWvES9dmWsL2KhfByw==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
@@ -7286,13 +7217,13 @@ packages:
       '@types/node':
         optional: true
     dependencies:
-      '@rollup/pluginutils': 3.1.0_rollup@2.70.0
-      '@types/node': 12.20.46
-      rollup: 2.70.0
+      '@rollup/pluginutils': 3.1.0_rollup@2.70.1
+      '@types/node': 12.20.47
+      rollup: 2.70.1
       source-map-resolve: 0.6.0
     dev: false
 
-  /rollup-plugin-sourcemaps/0.6.3_rollup@2.70.0:
+  /rollup-plugin-sourcemaps/0.6.3_rollup@2.70.1:
     resolution: {integrity: sha512-paFu+nT1xvuO1tPFYXGe+XnQvg4Hjqv/eIhG8i5EspfYYPBKL57X7iVbfv55aNVASg3dzWvES9dmWsL2KhfByw==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
@@ -7302,50 +7233,50 @@ packages:
       '@types/node':
         optional: true
     dependencies:
-      '@rollup/pluginutils': 3.1.0_rollup@2.70.0
-      rollup: 2.70.0
+      '@rollup/pluginutils': 3.1.0_rollup@2.70.1
+      rollup: 2.70.1
       source-map-resolve: 0.6.0
     dev: false
 
-  /rollup-plugin-terser/5.3.1_rollup@2.70.0:
+  /rollup-plugin-terser/5.3.1_rollup@2.70.1:
     resolution: {integrity: sha512-1pkwkervMJQGFYvM9nscrUoncPwiKR/K+bHdjv6PFgRo3cgPHoRT83y2Aa3GvINj4539S15t/tpFPb775TDs6w==}
     peerDependencies:
       rollup: '>=0.66.0 <3'
     dependencies:
       '@babel/code-frame': 7.16.7
       jest-worker: 24.9.0
-      rollup: 2.70.0
+      rollup: 2.70.1
       rollup-pluginutils: 2.8.2
       serialize-javascript: 4.0.0
       terser: 4.8.0
     dev: false
 
-  /rollup-plugin-visualizer/4.2.2_rollup@2.70.0:
+  /rollup-plugin-visualizer/4.2.2_rollup@2.70.1:
     resolution: {integrity: sha512-10/TsugsaQL5rdynl0lrklBngTtkRBESZdxUJy+3fN+xKqNdg5cr7JQU1OoPx4p5mhQ+nspa6EvX3qc8SsBvnA==}
     engines: {node: '>=10'}
     hasBin: true
     peerDependencies:
       rollup: '>=1.20.0'
     dependencies:
-      nanoid: 3.3.1
+      nanoid: 3.3.2
       open: 7.4.2
-      rollup: 2.70.0
+      rollup: 2.70.1
       source-map: 0.7.3
       yargs: 16.2.0
     dev: false
 
-  /rollup-plugin-visualizer/5.6.0_rollup@2.70.0:
+  /rollup-plugin-visualizer/5.6.0_rollup@2.70.1:
     resolution: {integrity: sha512-CKcc8GTUZjC+LsMytU8ocRr/cGZIfMR7+mdy4YnlyetlmIl/dM8BMnOEpD4JPIGt+ZVW7Db9ZtSsbgyeBH3uTA==}
     engines: {node: '>=12'}
     hasBin: true
     peerDependencies:
       rollup: ^2.0.0
     dependencies:
-      nanoid: 3.3.1
+      nanoid: 3.3.2
       open: 8.4.0
-      rollup: 2.70.0
+      rollup: 2.70.1
       source-map: 0.7.3
-      yargs: 17.3.1
+      yargs: 17.4.0
     dev: false
 
   /rollup-pluginutils/2.8.2:
@@ -7359,12 +7290,12 @@ packages:
     hasBin: true
     dependencies:
       '@types/estree': 0.0.51
-      '@types/node': 17.0.21
+      '@types/node': 17.0.23
       acorn: 7.4.1
     dev: false
 
-  /rollup/2.70.0:
-    resolution: {integrity: sha512-iEzYw+syFxQ0X9RefVwhr8BA2TNJsTaX8L8dhyeyMECDbmiba+8UQzcu+xZdji0+JQ+s7kouQnw+9Oz5M19XKA==}
+  /rollup/2.70.1:
+    resolution: {integrity: sha512-CRYsI5EuzLbXdxC6RnYhOuRdtz4bhejPMSWjsFLfVM/7w/85n2szZv6yExqUXsBdz5KT8eoubeyDUDjhLHEslA==}
     engines: {node: '>=10.0.0'}
     hasBin: true
     optionalDependencies:
@@ -7518,7 +7449,7 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
     dependencies:
-      minimist: 1.2.5
+      minimist: 1.2.6
       shelljs: 0.8.5
     dev: false
 
@@ -7592,7 +7523,7 @@ packages:
     dependencies:
       '@types/component-emitter': 1.2.11
       component-emitter: 1.3.0
-      debug: 4.3.3
+      debug: 4.3.4
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -7603,7 +7534,7 @@ packages:
     dependencies:
       accepts: 1.3.8
       base64id: 2.0.0
-      debug: 4.3.3
+      debug: 4.3.4
       engine.io: 6.1.3
       socket.io-adapter: 2.3.3
       socket.io-parser: 4.0.4
@@ -7671,7 +7602,7 @@ packages:
     resolution: {integrity: sha512-IgB8md0QW/+tWqcavuFgKYR/qIRvJkRLPJDFaoXtLLUaVcCDK0+HeFTkmQHj3eprcYhc+gOl0aEA1w7qZlYezw==}
     dependencies:
       foreground-child: 1.5.6
-      mkdirp: 0.5.5
+      mkdirp: 0.5.6
       os-homedir: 1.0.2
       rimraf: 2.7.1
       signal-exit: 3.0.7
@@ -7726,12 +7657,12 @@ packages:
     engines: {node: '>=4', npm: '>=6'}
     dev: false
 
-  /streamroller/3.0.4:
-    resolution: {integrity: sha512-GI9NzeD+D88UFuIlJkKNDH/IsuR+qIN7Qh8EsmhoRZr9bQoehTraRgwtLUkZbpcAw+hLPfHOypmppz8YyGK68w==}
+  /streamroller/3.0.6:
+    resolution: {integrity: sha512-Qz32plKq/MZywYyhEatxyYc8vs994Gz0Hu2MSYXXLD233UyPeIeRBZARIIGwFer4Mdb8r3Y2UqKkgyDghM6QCg==}
     engines: {node: '>=8.0'}
     dependencies:
-      date-format: 4.0.4
-      debug: 4.3.3
+      date-format: 4.0.6
+      debug: 4.3.4
       fs-extra: 10.0.1
     transitivePeerDependencies:
       - supports-color
@@ -7783,7 +7714,7 @@ packages:
     dependencies:
       call-bind: 1.0.2
       define-properties: 1.1.3
-      es-abstract: 1.19.1
+      es-abstract: 1.19.2
     dev: false
 
   /string.prototype.trimend/1.0.4:
@@ -7827,14 +7758,14 @@ packages:
     resolution: {integrity: sha1-qEeQIusaw2iocTibY1JixQXuNo8=}
     engines: {node: '>=4'}
     dependencies:
-      ansi-regex: 3.0.0
+      ansi-regex: 3.0.1
     dev: false
 
   /strip-ansi/5.2.0:
     resolution: {integrity: sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==}
     engines: {node: '>=6'}
     dependencies:
-      ansi-regex: 4.1.0
+      ansi-regex: 4.1.1
     dev: false
 
   /strip-ansi/6.0.1:
@@ -7922,7 +7853,7 @@ packages:
     resolution: {integrity: sha512-s/fitrbVeEyHKFa7mFdkuQMWlH1Wgw/yEXMt5xACT4ZpzWFluehAxRtUUQKPuWhaLAWhFcVx6w3oC8VKaUfPGA==}
     engines: {node: '>=10.0.0'}
     dependencies:
-      ajv: 8.10.0
+      ajv: 8.11.0
       lodash.truncate: 4.4.2
       slice-ansi: 4.0.0
       string-width: 4.2.3
@@ -8054,7 +7985,7 @@ packages:
     hasBin: true
     dev: false
 
-  /ts-node/10.7.0_33a8d453f89e9f3bb66aee69722d1299:
+  /ts-node/10.7.0_b23b0a2d2a25417b088e86bfb6fd069e:
     resolution: {integrity: sha512-TbIGS4xgJoX2i3do417KSaep1uRAW/Lu+WAL2doDHC0D6ummjirVOXU5/7aiZotbQ5p1Zp9tP7U6cYhA0O7M8A==}
     hasBin: true
     peerDependencies:
@@ -8073,38 +8004,7 @@ packages:
       '@tsconfig/node12': 1.0.9
       '@tsconfig/node14': 1.0.1
       '@tsconfig/node16': 1.0.2
-      '@types/node': 12.20.46
-      acorn: 8.7.0
-      acorn-walk: 8.2.0
-      arg: 4.1.3
-      create-require: 1.1.1
-      diff: 4.0.2
-      make-error: 1.3.6
-      typescript: 4.4.4
-      v8-compile-cache-lib: 3.0.0
-      yn: 3.1.1
-    dev: false
-
-  /ts-node/10.7.0_be7399ac25415134b30a5f1c20a06532:
-    resolution: {integrity: sha512-TbIGS4xgJoX2i3do417KSaep1uRAW/Lu+WAL2doDHC0D6ummjirVOXU5/7aiZotbQ5p1Zp9tP7U6cYhA0O7M8A==}
-    hasBin: true
-    peerDependencies:
-      '@swc/core': '>=1.2.50'
-      '@swc/wasm': '>=1.2.50'
-      '@types/node': '*'
-      typescript: '>=2.7'
-    peerDependenciesMeta:
-      '@swc/core':
-        optional: true
-      '@swc/wasm':
-        optional: true
-    dependencies:
-      '@cspotcode/source-map-support': 0.7.0
-      '@tsconfig/node10': 1.0.8
-      '@tsconfig/node12': 1.0.9
-      '@tsconfig/node14': 1.0.1
-      '@tsconfig/node16': 1.0.2
-      '@types/node': 12.20.46
+      '@types/node': 12.20.47
       acorn: 8.7.0
       acorn-walk: 8.2.0
       arg: 4.1.3
@@ -8112,6 +8012,37 @@ packages:
       diff: 4.0.2
       make-error: 1.3.6
       typescript: 4.2.4
+      v8-compile-cache-lib: 3.0.0
+      yn: 3.1.1
+    dev: false
+
+  /ts-node/10.7.0_c7b7062e0b9347939444ea76e6e422c3:
+    resolution: {integrity: sha512-TbIGS4xgJoX2i3do417KSaep1uRAW/Lu+WAL2doDHC0D6ummjirVOXU5/7aiZotbQ5p1Zp9tP7U6cYhA0O7M8A==}
+    hasBin: true
+    peerDependencies:
+      '@swc/core': '>=1.2.50'
+      '@swc/wasm': '>=1.2.50'
+      '@types/node': '*'
+      typescript: '>=2.7'
+    peerDependenciesMeta:
+      '@swc/core':
+        optional: true
+      '@swc/wasm':
+        optional: true
+    dependencies:
+      '@cspotcode/source-map-support': 0.7.0
+      '@tsconfig/node10': 1.0.8
+      '@tsconfig/node12': 1.0.9
+      '@tsconfig/node14': 1.0.1
+      '@tsconfig/node16': 1.0.2
+      '@types/node': 12.20.47
+      acorn: 8.7.0
+      acorn-walk: 8.2.0
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.2
+      make-error: 1.3.6
+      typescript: 4.4.4
       v8-compile-cache-lib: 3.0.0
       yn: 3.1.1
     dev: false
@@ -8147,12 +8078,12 @@ packages:
       yn: 3.1.1
     dev: false
 
-  /tsconfig-paths/3.13.0:
-    resolution: {integrity: sha512-nWuffZppoaYK0vQ1SQmkSsQzJoHA4s6uzdb2waRpD806x9yfq153AdVsWz4je2qZcW+pENrMQXbGQ3sMCkXuhw==}
+  /tsconfig-paths/3.14.1:
+    resolution: {integrity: sha512-fxDhWnFSLt3VuTwtvJt5fpwxBHg5AdKWMsgcPOOIilyjymcYVZoCQF8fvFRezCNfblEXmi+PcM1eYHeOAgXCOQ==}
     dependencies:
       '@types/json5': 0.0.29
       json5: 1.0.1
-      minimist: 1.2.5
+      minimist: 1.2.6
       strip-bom: 3.0.0
     dev: false
 
@@ -8212,7 +8143,7 @@ packages:
     engines: {node: '>= 0.6'}
     dependencies:
       media-typer: 0.3.0
-      mime-types: 2.1.34
+      mime-types: 2.1.35
     dev: false
 
   /typedarray-to-buffer/3.1.5:
@@ -8283,8 +8214,8 @@ packages:
     resolution: {integrity: sha512-qLK/Xe9E2uzmYI3qLeOmI0tEOt+TBBQyUIAh4aAgU05FVYzeZrKUdkAZfBNVGRaHVgV0TDkdEngJSw/SyQchkQ==}
     dev: false
 
-  /uglify-js/3.15.2:
-    resolution: {integrity: sha512-peeoTk3hSwYdoc9nrdiEJk+gx1ALCtTjdYuKSXMTDqq7n1W7dHPqWDdSi+BPL0ni2YMeHD7hKUSdbj3TZauY2A==}
+  /uglify-js/3.15.3:
+    resolution: {integrity: sha512-6iCVm2omGJbsu3JWac+p6kUiOpg3wFO2f8lIXjfEb8RrmLjzog1wTPMmwKB7swfzzqxj9YM+sGUM++u1qN4qJg==}
     engines: {node: '>=0.8.0'}
     hasBin: true
     dev: false
@@ -8466,7 +8397,7 @@ packages:
     dependencies:
       available-typed-arrays: 1.0.5
       call-bind: 1.0.2
-      es-abstract: 1.19.1
+      es-abstract: 1.19.2
       foreach: 2.0.5
       has-tostringtag: 1.0.0
       is-typed-array: 1.1.8
@@ -8723,8 +8654,8 @@ packages:
       yargs-parser: 20.2.9
     dev: false
 
-  /yargs/17.3.1:
-    resolution: {integrity: sha512-WUANQeVgjLbNsEmGk20f+nlHgOqzRFpiGWVaBrYGYIGANIIu3lWjoyi0fNlFmJkvfhCZ6BXINe7/W2O2bV4iaA==}
+  /yargs/17.4.0:
+    resolution: {integrity: sha512-WJudfrk81yWFSOkZYpAZx4Nt7V4xp7S/uJkX0CnxovMCt1wCE8LNftPpNuF9X/u9gN5nsD7ycYtRcDf2pL3UiA==}
     engines: {node: '>=12'}
     dependencies:
       cliui: 7.0.4
@@ -8776,16 +8707,16 @@ packages:
     name: '@rush-temp/abort-controller'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.19.4
+      '@microsoft/api-extractor': 7.20.0
       '@types/chai': 4.3.0
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.46
+      '@types/node': 12.20.47
       chai: 4.3.6
       cross-env: 7.0.3
       downlevel-dts: 0.8.0
       eslint: 7.32.0
       karma: 6.3.17
-      karma-chrome-launcher: 3.1.0
+      karma-chrome-launcher: 3.1.1
       karma-coverage: 2.2.0
       karma-edge-launcher: 0.4.2_karma@6.3.17
       karma-env-preprocessor: 0.1.1
@@ -8798,9 +8729,9 @@ packages:
       mocha: 7.2.0
       mocha-junit-reporter: 2.0.2_mocha@7.2.0
       nyc: 15.1.0
-      prettier: 2.5.1
+      prettier: 2.6.1
       rimraf: 3.0.2
-      ts-node: 10.7.0_be7399ac25415134b30a5f1c20a06532
+      ts-node: 10.7.0_b23b0a2d2a25417b088e86bfb6fd069e
       tslib: 2.3.1
       typescript: 4.2.4
     transitivePeerDependencies:
@@ -8819,16 +8750,16 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
+      '@microsoft/api-extractor': 7.20.0
       '@types/chai': 4.3.0
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.46
+      '@types/node': 12.20.47
       chai: 4.3.6
       cross-env: 7.0.3
       dotenv: 8.6.0
       eslint: 7.32.0
       karma: 6.3.17
-      karma-chrome-launcher: 3.1.0
+      karma-chrome-launcher: 3.1.1
       karma-coverage: 2.2.0
       karma-edge-launcher: 0.4.2_karma@6.3.17
       karma-env-preprocessor: 0.1.1
@@ -8845,7 +8776,7 @@ packages:
       mocha: 7.2.0
       mocha-junit-reporter: 2.0.2_mocha@7.2.0
       nyc: 15.1.0
-      prettier: 2.5.1
+      prettier: 2.6.1
       rimraf: 3.0.2
       source-map-support: 0.5.21
       tslib: 2.3.1
@@ -8866,10 +8797,10 @@ packages:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/core-tracing': 1.0.0-preview.13
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
+      '@microsoft/api-extractor': 7.20.0
       '@types/chai': 4.3.0
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.46
+      '@types/node': 12.20.47
       chai: 4.3.6
       cross-env: 7.0.3
       csv-parse: 5.0.4
@@ -8877,7 +8808,7 @@ packages:
       eslint: 7.32.0
       inherits: 2.0.4
       karma: 6.3.17
-      karma-chrome-launcher: 3.1.0
+      karma-chrome-launcher: 3.1.1
       karma-coverage: 2.2.0
       karma-edge-launcher: 0.4.2_karma@6.3.17
       karma-env-preprocessor: 0.1.1
@@ -8890,7 +8821,7 @@ packages:
       mocha: 7.2.0
       mocha-junit-reporter: 2.0.2_mocha@7.2.0
       nyc: 15.1.0
-      prettier: 2.5.1
+      prettier: 2.6.1
       rimraf: 3.0.2
       tslib: 2.3.1
       typescript: 4.2.4
@@ -8909,16 +8840,16 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
+      '@microsoft/api-extractor': 7.20.0
       '@types/chai': 4.3.0
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.46
+      '@types/node': 12.20.47
       chai: 4.3.6
       cross-env: 7.0.3
       dotenv: 8.6.0
       eslint: 7.32.0
       karma: 6.3.17
-      karma-chrome-launcher: 3.1.0
+      karma-chrome-launcher: 3.1.1
       karma-coverage: 2.2.0
       karma-edge-launcher: 0.4.2_karma@6.3.17
       karma-env-preprocessor: 0.1.1
@@ -8951,12 +8882,11 @@ packages:
     name: '@rush-temp/ai-form-recognizer'
     version: 0.0.0
     dependencies:
-      '@azure/core-tracing': 1.0.0-preview.14
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
+      '@microsoft/api-extractor': 7.20.0
       '@types/chai': 4.3.0
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.46
+      '@types/node': 12.20.47
       '@types/sinon': 9.0.11
       chai: 4.3.6
       chai-as-promised: 7.1.1_chai@4.3.6
@@ -8964,7 +8894,7 @@ packages:
       dotenv: 8.6.0
       eslint: 7.32.0
       karma: 6.3.17
-      karma-chrome-launcher: 3.1.0
+      karma-chrome-launcher: 3.1.1
       karma-coverage: 2.2.0
       karma-edge-launcher: 0.4.2_karma@6.3.17
       karma-env-preprocessor: 0.1.1
@@ -8977,7 +8907,7 @@ packages:
       mocha: 7.2.0
       mocha-junit-reporter: 2.0.2_mocha@7.2.0
       nyc: 15.1.0
-      prettier: 2.5.1
+      prettier: 2.6.1
       rimraf: 3.0.2
       sinon: 9.2.4
       source-map-support: 0.5.21
@@ -8998,10 +8928,10 @@ packages:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/core-tracing': 1.0.0-preview.13
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
+      '@microsoft/api-extractor': 7.20.0
       '@types/chai': 4.3.0
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.46
+      '@types/node': 12.20.47
       '@types/sinon': 9.0.11
       chai: 4.3.6
       chai-as-promised: 7.1.1_chai@4.3.6
@@ -9009,7 +8939,7 @@ packages:
       dotenv: 8.6.0
       eslint: 7.32.0
       karma: 6.3.17
-      karma-chrome-launcher: 3.1.0
+      karma-chrome-launcher: 3.1.1
       karma-coverage: 2.2.0
       karma-edge-launcher: 0.4.2_karma@6.3.17
       karma-env-preprocessor: 0.1.1
@@ -9024,11 +8954,11 @@ packages:
       mocha: 7.2.0
       mocha-junit-reporter: 2.0.2_mocha@7.2.0
       nyc: 15.1.0
-      prettier: 2.5.1
+      prettier: 2.6.1
       rimraf: 3.0.2
       sinon: 9.2.4
       source-map-support: 0.5.21
-      ts-node: 10.7.0_be7399ac25415134b30a5f1c20a06532
+      ts-node: 10.7.0_b23b0a2d2a25417b088e86bfb6fd069e
       tslib: 2.3.1
       typescript: 4.2.4
     transitivePeerDependencies:
@@ -9048,11 +8978,11 @@ packages:
     dependencies:
       '@azure/core-tracing': 1.0.0-preview.13
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
+      '@microsoft/api-extractor': 7.20.0
       '@types/chai': 4.3.0
       '@types/chai-as-promised': 7.1.5
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.46
+      '@types/node': 12.20.47
       '@types/sinon': 9.0.11
       chai: 4.3.6
       chai-as-promised: 7.1.1_chai@4.3.6
@@ -9060,7 +8990,7 @@ packages:
       dotenv: 8.6.0
       eslint: 7.32.0
       karma: 6.3.17
-      karma-chrome-launcher: 3.1.0
+      karma-chrome-launcher: 3.1.1
       karma-coverage: 2.2.0
       karma-edge-launcher: 0.4.2_karma@6.3.17
       karma-env-preprocessor: 0.1.1
@@ -9074,11 +9004,11 @@ packages:
       mocha: 7.2.0
       mocha-junit-reporter: 2.0.2_mocha@7.2.0
       nyc: 15.1.0
-      prettier: 2.5.1
+      prettier: 2.6.1
       rimraf: 3.0.2
       sinon: 9.2.4
       source-map-support: 0.5.21
-      ts-node: 10.7.0_be7399ac25415134b30a5f1c20a06532
+      ts-node: 10.7.0_b23b0a2d2a25417b088e86bfb6fd069e
       tslib: 2.3.1
       typescript: 4.2.4
     transitivePeerDependencies:
@@ -9096,20 +9026,19 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
-      '@azure/core-http-compat': 1.2.0
       '@azure/core-tracing': 1.0.0-preview.13
       '@azure/identity': 2.0.4
       '@azure/keyvault-secrets': 4.4.0
-      '@microsoft/api-extractor': 7.19.4
-      '@rollup/plugin-commonjs': 21.0.2_rollup@2.70.0
-      '@rollup/plugin-inject': 4.0.4_rollup@2.70.0
-      '@rollup/plugin-json': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-multi-entry': 3.0.1_rollup@2.70.0
-      '@rollup/plugin-node-resolve': 8.4.0_rollup@2.70.0
-      '@rollup/plugin-replace': 2.4.2_rollup@2.70.0
+      '@microsoft/api-extractor': 7.20.0
+      '@rollup/plugin-commonjs': 21.0.3_rollup@2.70.1
+      '@rollup/plugin-inject': 4.0.4_rollup@2.70.1
+      '@rollup/plugin-json': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-multi-entry': 3.0.1_rollup@2.70.1
+      '@rollup/plugin-node-resolve': 8.4.0_rollup@2.70.1
+      '@rollup/plugin-replace': 2.4.2_rollup@2.70.1
       '@types/chai': 4.3.0
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.46
+      '@types/node': 12.20.47
       '@types/sinon': 9.0.11
       '@types/uuid': 8.3.4
       chai: 4.3.6
@@ -9118,7 +9047,7 @@ packages:
       eslint: 7.32.0
       esm: 3.2.25
       karma: 6.3.17
-      karma-chrome-launcher: 3.1.0
+      karma-chrome-launcher: 3.1.1
       karma-coverage: 2.2.0
       karma-edge-launcher: 0.4.2_karma@6.3.17
       karma-env-preprocessor: 0.1.1
@@ -9132,17 +9061,17 @@ packages:
       mocha-junit-reporter: 2.0.2_mocha@7.2.0
       nock: 12.0.3
       nyc: 15.1.0
-      prettier: 2.5.1
+      prettier: 2.6.1
       rimraf: 3.0.2
-      rollup: 2.70.0
+      rollup: 2.70.1
       rollup-plugin-shim: 1.0.0
-      rollup-plugin-sourcemaps: 0.4.2_rollup@2.70.0
-      rollup-plugin-terser: 5.3.1_rollup@2.70.0
+      rollup-plugin-sourcemaps: 0.4.2_rollup@2.70.1
+      rollup-plugin-terser: 5.3.1_rollup@2.70.1
       sinon: 9.2.4
-      ts-node: 10.7.0_be7399ac25415134b30a5f1c20a06532
+      ts-node: 10.7.0_b23b0a2d2a25417b088e86bfb6fd069e
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
       uuid: 8.3.2
     transitivePeerDependencies:
       - '@swc/core'
@@ -9161,20 +9090,20 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
-      '@rollup/plugin-commonjs': 21.0.2_rollup@2.70.0
-      '@rollup/plugin-json': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-multi-entry': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-node-resolve': 13.1.3_rollup@2.70.0
+      '@microsoft/api-extractor': 7.20.0
+      '@rollup/plugin-commonjs': 21.0.3_rollup@2.70.1
+      '@rollup/plugin-json': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-multi-entry': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-node-resolve': 13.1.3_rollup@2.70.1
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
-      rollup: 2.70.0
-      rollup-plugin-sourcemaps: 0.6.3_rollup@2.70.0
+      rollup: 2.70.1
+      rollup-plugin-sourcemaps: 0.6.3_rollup@2.70.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - '@types/node'
       - debug
@@ -9189,20 +9118,20 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
-      '@rollup/plugin-commonjs': 21.0.2_rollup@2.70.0
-      '@rollup/plugin-json': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-multi-entry': 3.0.1_rollup@2.70.0
-      '@rollup/plugin-node-resolve': 8.4.0_rollup@2.70.0
+      '@microsoft/api-extractor': 7.20.0
+      '@rollup/plugin-commonjs': 21.0.3_rollup@2.70.1
+      '@rollup/plugin-json': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-multi-entry': 3.0.1_rollup@2.70.1
+      '@rollup/plugin-node-resolve': 8.4.0_rollup@2.70.1
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
-      rollup: 2.70.0
-      rollup-plugin-sourcemaps: 0.4.2_rollup@2.70.0
+      rollup: 2.70.1
+      rollup-plugin-sourcemaps: 0.4.2_rollup@2.70.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - debug
       - encoding
@@ -9216,20 +9145,20 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
-      '@rollup/plugin-commonjs': 21.0.2_rollup@2.70.0
-      '@rollup/plugin-json': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-multi-entry': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-node-resolve': 13.1.3_rollup@2.70.0
+      '@microsoft/api-extractor': 7.20.0
+      '@rollup/plugin-commonjs': 21.0.3_rollup@2.70.1
+      '@rollup/plugin-json': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-multi-entry': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-node-resolve': 13.1.3_rollup@2.70.1
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
-      rollup: 2.70.0
-      rollup-plugin-sourcemaps: 0.6.3_rollup@2.70.0
+      rollup: 2.70.1
+      rollup-plugin-sourcemaps: 0.6.3_rollup@2.70.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - '@types/node'
       - debug
@@ -9244,20 +9173,20 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
-      '@rollup/plugin-commonjs': 21.0.2_rollup@2.70.0
-      '@rollup/plugin-json': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-multi-entry': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-node-resolve': 13.1.3_rollup@2.70.0
+      '@microsoft/api-extractor': 7.20.0
+      '@rollup/plugin-commonjs': 21.0.3_rollup@2.70.1
+      '@rollup/plugin-json': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-multi-entry': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-node-resolve': 13.1.3_rollup@2.70.1
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
-      rollup: 2.70.0
-      rollup-plugin-sourcemaps: 0.6.3_rollup@2.70.0
+      rollup: 2.70.1
+      rollup-plugin-sourcemaps: 0.6.3_rollup@2.70.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - '@types/node'
       - debug
@@ -9272,20 +9201,20 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
-      '@rollup/plugin-commonjs': 21.0.2_rollup@2.70.0
-      '@rollup/plugin-json': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-multi-entry': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-node-resolve': 13.1.3_rollup@2.70.0
+      '@microsoft/api-extractor': 7.20.0
+      '@rollup/plugin-commonjs': 21.0.3_rollup@2.70.1
+      '@rollup/plugin-json': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-multi-entry': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-node-resolve': 13.1.3_rollup@2.70.1
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
-      rollup: 2.70.0
-      rollup-plugin-sourcemaps: 0.6.3_rollup@2.70.0
+      rollup: 2.70.1
+      rollup-plugin-sourcemaps: 0.6.3_rollup@2.70.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - '@types/node'
       - debug
@@ -9300,20 +9229,20 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
-      '@rollup/plugin-commonjs': 21.0.2_rollup@2.70.0
-      '@rollup/plugin-json': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-multi-entry': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-node-resolve': 13.1.3_rollup@2.70.0
+      '@microsoft/api-extractor': 7.20.0
+      '@rollup/plugin-commonjs': 21.0.3_rollup@2.70.1
+      '@rollup/plugin-json': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-multi-entry': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-node-resolve': 13.1.3_rollup@2.70.1
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
-      rollup: 2.70.0
-      rollup-plugin-sourcemaps: 0.6.3_rollup@2.70.0
+      rollup: 2.70.1
+      rollup-plugin-sourcemaps: 0.6.3_rollup@2.70.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - '@types/node'
       - debug
@@ -9328,20 +9257,20 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
-      '@rollup/plugin-commonjs': 21.0.2_rollup@2.70.0
-      '@rollup/plugin-json': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-multi-entry': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-node-resolve': 13.1.3_rollup@2.70.0
+      '@microsoft/api-extractor': 7.20.0
+      '@rollup/plugin-commonjs': 21.0.3_rollup@2.70.1
+      '@rollup/plugin-json': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-multi-entry': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-node-resolve': 13.1.3_rollup@2.70.1
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
-      rollup: 2.70.0
-      rollup-plugin-sourcemaps: 0.6.3_rollup@2.70.0
+      rollup: 2.70.1
+      rollup-plugin-sourcemaps: 0.6.3_rollup@2.70.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - '@types/node'
       - debug
@@ -9356,20 +9285,20 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
-      '@rollup/plugin-commonjs': 21.0.2_rollup@2.70.0
-      '@rollup/plugin-json': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-multi-entry': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-node-resolve': 13.1.3_rollup@2.70.0
+      '@microsoft/api-extractor': 7.20.0
+      '@rollup/plugin-commonjs': 21.0.3_rollup@2.70.1
+      '@rollup/plugin-json': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-multi-entry': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-node-resolve': 13.1.3_rollup@2.70.1
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
-      rollup: 2.70.0
-      rollup-plugin-sourcemaps: 0.6.3_rollup@2.70.0
+      rollup: 2.70.1
+      rollup-plugin-sourcemaps: 0.6.3_rollup@2.70.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - '@types/node'
       - debug
@@ -9384,20 +9313,20 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
-      '@rollup/plugin-commonjs': 21.0.2_rollup@2.70.0
-      '@rollup/plugin-json': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-multi-entry': 3.0.1_rollup@2.70.0
-      '@rollup/plugin-node-resolve': 8.4.0_rollup@2.70.0
+      '@microsoft/api-extractor': 7.20.0
+      '@rollup/plugin-commonjs': 21.0.3_rollup@2.70.1
+      '@rollup/plugin-json': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-multi-entry': 3.0.1_rollup@2.70.1
+      '@rollup/plugin-node-resolve': 8.4.0_rollup@2.70.1
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
-      rollup: 2.70.0
-      rollup-plugin-sourcemaps: 0.4.2_rollup@2.70.0
+      rollup: 2.70.1
+      rollup-plugin-sourcemaps: 0.4.2_rollup@2.70.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - debug
       - encoding
@@ -9411,7 +9340,7 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
+      '@microsoft/api-extractor': 7.20.0
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-json': 4.1.0_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
@@ -9424,7 +9353,7 @@ packages:
       rollup-plugin-sourcemaps: 0.4.2_rollup@1.32.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - debug
       - encoding
@@ -9438,20 +9367,20 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
-      '@rollup/plugin-commonjs': 21.0.2_rollup@2.70.0
-      '@rollup/plugin-json': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-multi-entry': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-node-resolve': 13.1.3_rollup@2.70.0
+      '@microsoft/api-extractor': 7.20.0
+      '@rollup/plugin-commonjs': 21.0.3_rollup@2.70.1
+      '@rollup/plugin-json': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-multi-entry': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-node-resolve': 13.1.3_rollup@2.70.1
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
-      rollup: 2.70.0
-      rollup-plugin-sourcemaps: 0.6.3_rollup@2.70.0
+      rollup: 2.70.1
+      rollup-plugin-sourcemaps: 0.6.3_rollup@2.70.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - '@types/node'
       - debug
@@ -9464,17 +9393,17 @@ packages:
     name: '@rush-temp/arm-authorization'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.19.4
-      '@rollup/plugin-commonjs': 21.0.2_rollup@2.70.0
-      '@rollup/plugin-json': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-multi-entry': 3.0.1_rollup@2.70.0
-      '@rollup/plugin-node-resolve': 8.4.0_rollup@2.70.0
+      '@microsoft/api-extractor': 7.20.0
+      '@rollup/plugin-commonjs': 21.0.3_rollup@2.70.1
+      '@rollup/plugin-json': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-multi-entry': 3.0.1_rollup@2.70.1
+      '@rollup/plugin-node-resolve': 8.4.0_rollup@2.70.1
       mkdirp: 1.0.4
-      rollup: 2.70.0
-      rollup-plugin-sourcemaps: 0.4.2_rollup@2.70.0
+      rollup: 2.70.1
+      rollup-plugin-sourcemaps: 0.4.2_rollup@2.70.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     dev: false
 
   file:projects/arm-avs.tgz:
@@ -9484,7 +9413,7 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
+      '@microsoft/api-extractor': 7.20.0
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-json': 4.1.0_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
@@ -9497,7 +9426,7 @@ packages:
       rollup-plugin-sourcemaps: 0.4.2_rollup@1.32.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - debug
       - encoding
@@ -9511,7 +9440,7 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
+      '@microsoft/api-extractor': 7.20.0
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-json': 4.1.0_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
@@ -9524,7 +9453,7 @@ packages:
       rollup-plugin-sourcemaps: 0.4.2_rollup@1.32.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - debug
       - encoding
@@ -9538,20 +9467,20 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
-      '@rollup/plugin-commonjs': 21.0.2_rollup@2.70.0
-      '@rollup/plugin-json': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-multi-entry': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-node-resolve': 13.1.3_rollup@2.70.0
+      '@microsoft/api-extractor': 7.20.0
+      '@rollup/plugin-commonjs': 21.0.3_rollup@2.70.1
+      '@rollup/plugin-json': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-multi-entry': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-node-resolve': 13.1.3_rollup@2.70.1
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
-      rollup: 2.70.0
-      rollup-plugin-sourcemaps: 0.6.3_rollup@2.70.0
+      rollup: 2.70.1
+      rollup-plugin-sourcemaps: 0.6.3_rollup@2.70.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - '@types/node'
       - debug
@@ -9566,20 +9495,20 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
-      '@rollup/plugin-commonjs': 21.0.2_rollup@2.70.0
-      '@rollup/plugin-json': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-multi-entry': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-node-resolve': 13.1.3_rollup@2.70.0
+      '@microsoft/api-extractor': 7.20.0
+      '@rollup/plugin-commonjs': 21.0.3_rollup@2.70.1
+      '@rollup/plugin-json': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-multi-entry': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-node-resolve': 13.1.3_rollup@2.70.1
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
-      rollup: 2.70.0
-      rollup-plugin-sourcemaps: 0.6.3_rollup@2.70.0
+      rollup: 2.70.1
+      rollup-plugin-sourcemaps: 0.6.3_rollup@2.70.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - '@types/node'
       - debug
@@ -9594,7 +9523,7 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
+      '@microsoft/api-extractor': 7.20.0
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-json': 4.1.0_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
@@ -9607,7 +9536,7 @@ packages:
       rollup-plugin-sourcemaps: 0.4.2_rollup@1.32.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - debug
       - encoding
@@ -9621,20 +9550,20 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
-      '@rollup/plugin-commonjs': 21.0.2_rollup@2.70.0
-      '@rollup/plugin-json': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-multi-entry': 3.0.1_rollup@2.70.0
-      '@rollup/plugin-node-resolve': 8.4.0_rollup@2.70.0
+      '@microsoft/api-extractor': 7.20.0
+      '@rollup/plugin-commonjs': 21.0.3_rollup@2.70.1
+      '@rollup/plugin-json': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-multi-entry': 3.0.1_rollup@2.70.1
+      '@rollup/plugin-node-resolve': 8.4.0_rollup@2.70.1
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
-      rollup: 2.70.0
-      rollup-plugin-sourcemaps: 0.4.2_rollup@2.70.0
+      rollup: 2.70.1
+      rollup-plugin-sourcemaps: 0.4.2_rollup@2.70.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - debug
       - encoding
@@ -9648,20 +9577,20 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
-      '@rollup/plugin-commonjs': 21.0.2_rollup@2.70.0
-      '@rollup/plugin-json': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-multi-entry': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-node-resolve': 13.1.3_rollup@2.70.0
+      '@microsoft/api-extractor': 7.20.0
+      '@rollup/plugin-commonjs': 21.0.3_rollup@2.70.1
+      '@rollup/plugin-json': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-multi-entry': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-node-resolve': 13.1.3_rollup@2.70.1
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
-      rollup: 2.70.0
-      rollup-plugin-sourcemaps: 0.6.3_rollup@2.70.0
+      rollup: 2.70.1
+      rollup-plugin-sourcemaps: 0.6.3_rollup@2.70.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - '@types/node'
       - debug
@@ -9676,7 +9605,7 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
+      '@microsoft/api-extractor': 7.20.0
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-json': 4.1.0_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
@@ -9689,7 +9618,7 @@ packages:
       rollup-plugin-sourcemaps: 0.4.2_rollup@1.32.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - debug
       - encoding
@@ -9703,20 +9632,20 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
-      '@rollup/plugin-commonjs': 21.0.2_rollup@2.70.0
-      '@rollup/plugin-json': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-multi-entry': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-node-resolve': 13.1.3_rollup@2.70.0
+      '@microsoft/api-extractor': 7.20.0
+      '@rollup/plugin-commonjs': 21.0.3_rollup@2.70.1
+      '@rollup/plugin-json': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-multi-entry': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-node-resolve': 13.1.3_rollup@2.70.1
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
-      rollup: 2.70.0
-      rollup-plugin-sourcemaps: 0.6.3_rollup@2.70.0
+      rollup: 2.70.1
+      rollup-plugin-sourcemaps: 0.6.3_rollup@2.70.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - '@types/node'
       - debug
@@ -9731,20 +9660,20 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
-      '@rollup/plugin-commonjs': 21.0.2_rollup@2.70.0
-      '@rollup/plugin-json': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-multi-entry': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-node-resolve': 13.1.3_rollup@2.70.0
+      '@microsoft/api-extractor': 7.20.0
+      '@rollup/plugin-commonjs': 21.0.3_rollup@2.70.1
+      '@rollup/plugin-json': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-multi-entry': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-node-resolve': 13.1.3_rollup@2.70.1
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
-      rollup: 2.70.0
-      rollup-plugin-sourcemaps: 0.6.3_rollup@2.70.0
+      rollup: 2.70.1
+      rollup-plugin-sourcemaps: 0.6.3_rollup@2.70.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - '@types/node'
       - debug
@@ -9759,7 +9688,7 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
+      '@microsoft/api-extractor': 7.20.0
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-json': 4.1.0_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
@@ -9772,7 +9701,7 @@ packages:
       rollup-plugin-sourcemaps: 0.4.2_rollup@1.32.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - debug
       - encoding
@@ -9786,7 +9715,7 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
+      '@microsoft/api-extractor': 7.20.0
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-json': 4.1.0_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
@@ -9799,7 +9728,7 @@ packages:
       rollup-plugin-sourcemaps: 0.4.2_rollup@1.32.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - debug
       - encoding
@@ -9813,7 +9742,7 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
+      '@microsoft/api-extractor': 7.20.0
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-json': 4.1.0_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
@@ -9826,7 +9755,7 @@ packages:
       rollup-plugin-sourcemaps: 0.4.2_rollup@1.32.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - debug
       - encoding
@@ -9840,20 +9769,20 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
-      '@rollup/plugin-commonjs': 21.0.2_rollup@2.70.0
-      '@rollup/plugin-json': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-multi-entry': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-node-resolve': 13.1.3_rollup@2.70.0
+      '@microsoft/api-extractor': 7.20.0
+      '@rollup/plugin-commonjs': 21.0.3_rollup@2.70.1
+      '@rollup/plugin-json': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-multi-entry': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-node-resolve': 13.1.3_rollup@2.70.1
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
-      rollup: 2.70.0
-      rollup-plugin-sourcemaps: 0.6.3_rollup@2.70.0
+      rollup: 2.70.1
+      rollup-plugin-sourcemaps: 0.6.3_rollup@2.70.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - '@types/node'
       - debug
@@ -9868,20 +9797,20 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
-      '@rollup/plugin-commonjs': 21.0.2_rollup@2.70.0
-      '@rollup/plugin-json': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-multi-entry': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-node-resolve': 13.1.3_rollup@2.70.0
+      '@microsoft/api-extractor': 7.20.0
+      '@rollup/plugin-commonjs': 21.0.3_rollup@2.70.1
+      '@rollup/plugin-json': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-multi-entry': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-node-resolve': 13.1.3_rollup@2.70.1
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
-      rollup: 2.70.0
-      rollup-plugin-sourcemaps: 0.6.3_rollup@2.70.0
+      rollup: 2.70.1
+      rollup-plugin-sourcemaps: 0.6.3_rollup@2.70.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - '@types/node'
       - debug
@@ -9896,7 +9825,7 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
+      '@microsoft/api-extractor': 7.20.0
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-json': 4.1.0_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
@@ -9909,7 +9838,7 @@ packages:
       rollup-plugin-sourcemaps: 0.4.2_rollup@1.32.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - debug
       - encoding
@@ -9923,20 +9852,20 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
-      '@rollup/plugin-commonjs': 21.0.2_rollup@2.70.0
-      '@rollup/plugin-json': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-multi-entry': 3.0.1_rollup@2.70.0
-      '@rollup/plugin-node-resolve': 8.4.0_rollup@2.70.0
+      '@microsoft/api-extractor': 7.20.0
+      '@rollup/plugin-commonjs': 21.0.3_rollup@2.70.1
+      '@rollup/plugin-json': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-multi-entry': 3.0.1_rollup@2.70.1
+      '@rollup/plugin-node-resolve': 8.4.0_rollup@2.70.1
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
-      rollup: 2.70.0
-      rollup-plugin-sourcemaps: 0.4.2_rollup@2.70.0
+      rollup: 2.70.1
+      rollup-plugin-sourcemaps: 0.4.2_rollup@2.70.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - debug
       - encoding
@@ -9950,20 +9879,20 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
-      '@rollup/plugin-commonjs': 21.0.2_rollup@2.70.0
-      '@rollup/plugin-json': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-multi-entry': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-node-resolve': 13.1.3_rollup@2.70.0
+      '@microsoft/api-extractor': 7.20.0
+      '@rollup/plugin-commonjs': 21.0.3_rollup@2.70.1
+      '@rollup/plugin-json': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-multi-entry': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-node-resolve': 13.1.3_rollup@2.70.1
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
-      rollup: 2.70.0
-      rollup-plugin-sourcemaps: 0.6.3_rollup@2.70.0
+      rollup: 2.70.1
+      rollup-plugin-sourcemaps: 0.6.3_rollup@2.70.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - '@types/node'
       - debug
@@ -9978,20 +9907,20 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
-      '@rollup/plugin-commonjs': 21.0.2_rollup@2.70.0
-      '@rollup/plugin-json': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-multi-entry': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-node-resolve': 13.1.3_rollup@2.70.0
+      '@microsoft/api-extractor': 7.20.0
+      '@rollup/plugin-commonjs': 21.0.3_rollup@2.70.1
+      '@rollup/plugin-json': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-multi-entry': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-node-resolve': 13.1.3_rollup@2.70.1
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
-      rollup: 2.70.0
-      rollup-plugin-sourcemaps: 0.6.3_rollup@2.70.0
+      rollup: 2.70.1
+      rollup-plugin-sourcemaps: 0.6.3_rollup@2.70.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - '@types/node'
       - debug
@@ -10006,20 +9935,20 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
-      '@rollup/plugin-commonjs': 21.0.2_rollup@2.70.0
-      '@rollup/plugin-json': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-multi-entry': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-node-resolve': 13.1.3_rollup@2.70.0
+      '@microsoft/api-extractor': 7.20.0
+      '@rollup/plugin-commonjs': 21.0.3_rollup@2.70.1
+      '@rollup/plugin-json': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-multi-entry': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-node-resolve': 13.1.3_rollup@2.70.1
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
-      rollup: 2.70.0
-      rollup-plugin-sourcemaps: 0.6.3_rollup@2.70.0
+      rollup: 2.70.1
+      rollup-plugin-sourcemaps: 0.6.3_rollup@2.70.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - '@types/node'
       - debug
@@ -10034,20 +9963,20 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
-      '@rollup/plugin-commonjs': 21.0.2_rollup@2.70.0
-      '@rollup/plugin-json': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-multi-entry': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-node-resolve': 13.1.3_rollup@2.70.0
+      '@microsoft/api-extractor': 7.20.0
+      '@rollup/plugin-commonjs': 21.0.3_rollup@2.70.1
+      '@rollup/plugin-json': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-multi-entry': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-node-resolve': 13.1.3_rollup@2.70.1
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
-      rollup: 2.70.0
-      rollup-plugin-sourcemaps: 0.6.3_rollup@2.70.0
+      rollup: 2.70.1
+      rollup-plugin-sourcemaps: 0.6.3_rollup@2.70.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - '@types/node'
       - debug
@@ -10062,7 +9991,7 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
+      '@microsoft/api-extractor': 7.20.0
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-json': 4.1.0_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
@@ -10075,7 +10004,7 @@ packages:
       rollup-plugin-sourcemaps: 0.4.2_rollup@1.32.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - debug
       - encoding
@@ -10089,7 +10018,7 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
+      '@microsoft/api-extractor': 7.20.0
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-json': 4.1.0_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
@@ -10102,7 +10031,7 @@ packages:
       rollup-plugin-sourcemaps: 0.4.2_rollup@1.32.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - debug
       - encoding
@@ -10116,20 +10045,20 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
-      '@rollup/plugin-commonjs': 21.0.2_rollup@2.70.0
-      '@rollup/plugin-json': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-multi-entry': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-node-resolve': 13.1.3_rollup@2.70.0
+      '@microsoft/api-extractor': 7.20.0
+      '@rollup/plugin-commonjs': 21.0.3_rollup@2.70.1
+      '@rollup/plugin-json': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-multi-entry': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-node-resolve': 13.1.3_rollup@2.70.1
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
-      rollup: 2.70.0
-      rollup-plugin-sourcemaps: 0.6.3_rollup@2.70.0
+      rollup: 2.70.1
+      rollup-plugin-sourcemaps: 0.6.3_rollup@2.70.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - '@types/node'
       - debug
@@ -10144,7 +10073,7 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
+      '@microsoft/api-extractor': 7.20.0
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-json': 4.1.0_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
@@ -10157,7 +10086,7 @@ packages:
       rollup-plugin-sourcemaps: 0.4.2_rollup@1.32.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - debug
       - encoding
@@ -10171,20 +10100,20 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
-      '@rollup/plugin-commonjs': 21.0.2_rollup@2.70.0
-      '@rollup/plugin-json': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-multi-entry': 3.0.1_rollup@2.70.0
-      '@rollup/plugin-node-resolve': 8.4.0_rollup@2.70.0
+      '@microsoft/api-extractor': 7.20.0
+      '@rollup/plugin-commonjs': 21.0.3_rollup@2.70.1
+      '@rollup/plugin-json': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-multi-entry': 3.0.1_rollup@2.70.1
+      '@rollup/plugin-node-resolve': 8.4.0_rollup@2.70.1
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
-      rollup: 2.70.0
-      rollup-plugin-sourcemaps: 0.4.2_rollup@2.70.0
+      rollup: 2.70.1
+      rollup-plugin-sourcemaps: 0.4.2_rollup@2.70.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - debug
       - encoding
@@ -10198,7 +10127,7 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
+      '@microsoft/api-extractor': 7.20.0
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-json': 4.1.0_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
@@ -10211,7 +10140,7 @@ packages:
       rollup-plugin-sourcemaps: 0.4.2_rollup@1.32.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - debug
       - encoding
@@ -10225,7 +10154,7 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
+      '@microsoft/api-extractor': 7.20.0
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-json': 4.1.0_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
@@ -10238,7 +10167,7 @@ packages:
       rollup-plugin-sourcemaps: 0.4.2_rollup@1.32.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - debug
       - encoding
@@ -10252,20 +10181,20 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
-      '@rollup/plugin-commonjs': 21.0.2_rollup@2.70.0
-      '@rollup/plugin-json': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-multi-entry': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-node-resolve': 13.1.3_rollup@2.70.0
+      '@microsoft/api-extractor': 7.20.0
+      '@rollup/plugin-commonjs': 21.0.3_rollup@2.70.1
+      '@rollup/plugin-json': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-multi-entry': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-node-resolve': 13.1.3_rollup@2.70.1
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
-      rollup: 2.70.0
-      rollup-plugin-sourcemaps: 0.6.3_rollup@2.70.0
+      rollup: 2.70.1
+      rollup-plugin-sourcemaps: 0.6.3_rollup@2.70.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - '@types/node'
       - debug
@@ -10280,20 +10209,20 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
-      '@rollup/plugin-commonjs': 21.0.2_rollup@2.70.0
-      '@rollup/plugin-json': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-multi-entry': 3.0.1_rollup@2.70.0
-      '@rollup/plugin-node-resolve': 8.4.0_rollup@2.70.0
+      '@microsoft/api-extractor': 7.20.0
+      '@rollup/plugin-commonjs': 21.0.3_rollup@2.70.1
+      '@rollup/plugin-json': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-multi-entry': 3.0.1_rollup@2.70.1
+      '@rollup/plugin-node-resolve': 8.4.0_rollup@2.70.1
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
-      rollup: 2.70.0
-      rollup-plugin-sourcemaps: 0.4.2_rollup@2.70.0
+      rollup: 2.70.1
+      rollup-plugin-sourcemaps: 0.4.2_rollup@2.70.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - debug
       - encoding
@@ -10307,7 +10236,7 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
+      '@microsoft/api-extractor': 7.20.0
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-json': 4.1.0_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
@@ -10320,7 +10249,7 @@ packages:
       rollup-plugin-sourcemaps: 0.4.2_rollup@1.32.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - debug
       - encoding
@@ -10334,7 +10263,7 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
+      '@microsoft/api-extractor': 7.20.0
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-json': 4.1.0_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
@@ -10347,7 +10276,7 @@ packages:
       rollup-plugin-sourcemaps: 0.4.2_rollup@1.32.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - debug
       - encoding
@@ -10361,20 +10290,20 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
-      '@rollup/plugin-commonjs': 21.0.2_rollup@2.70.0
-      '@rollup/plugin-json': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-multi-entry': 3.0.1_rollup@2.70.0
-      '@rollup/plugin-node-resolve': 8.4.0_rollup@2.70.0
+      '@microsoft/api-extractor': 7.20.0
+      '@rollup/plugin-commonjs': 21.0.3_rollup@2.70.1
+      '@rollup/plugin-json': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-multi-entry': 3.0.1_rollup@2.70.1
+      '@rollup/plugin-node-resolve': 8.4.0_rollup@2.70.1
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
-      rollup: 2.70.0
-      rollup-plugin-sourcemaps: 0.4.2_rollup@2.70.0
+      rollup: 2.70.1
+      rollup-plugin-sourcemaps: 0.4.2_rollup@2.70.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - debug
       - encoding
@@ -10388,7 +10317,7 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
+      '@microsoft/api-extractor': 7.20.0
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-json': 4.1.0_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
@@ -10401,7 +10330,7 @@ packages:
       rollup-plugin-sourcemaps: 0.4.2_rollup@1.32.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - debug
       - encoding
@@ -10415,7 +10344,7 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
+      '@microsoft/api-extractor': 7.20.0
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-json': 4.1.0_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
@@ -10428,7 +10357,7 @@ packages:
       rollup-plugin-sourcemaps: 0.4.2_rollup@1.32.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - debug
       - encoding
@@ -10442,20 +10371,20 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
-      '@rollup/plugin-commonjs': 21.0.2_rollup@2.70.0
-      '@rollup/plugin-json': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-multi-entry': 3.0.1_rollup@2.70.0
-      '@rollup/plugin-node-resolve': 8.4.0_rollup@2.70.0
+      '@microsoft/api-extractor': 7.20.0
+      '@rollup/plugin-commonjs': 21.0.3_rollup@2.70.1
+      '@rollup/plugin-json': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-multi-entry': 3.0.1_rollup@2.70.1
+      '@rollup/plugin-node-resolve': 8.4.0_rollup@2.70.1
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
-      rollup: 2.70.0
-      rollup-plugin-sourcemaps: 0.4.2_rollup@2.70.0
+      rollup: 2.70.1
+      rollup-plugin-sourcemaps: 0.4.2_rollup@2.70.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - debug
       - encoding
@@ -10469,20 +10398,20 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
-      '@rollup/plugin-commonjs': 21.0.2_rollup@2.70.0
-      '@rollup/plugin-json': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-multi-entry': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-node-resolve': 13.1.3_rollup@2.70.0
+      '@microsoft/api-extractor': 7.20.0
+      '@rollup/plugin-commonjs': 21.0.3_rollup@2.70.1
+      '@rollup/plugin-json': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-multi-entry': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-node-resolve': 13.1.3_rollup@2.70.1
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
-      rollup: 2.70.0
-      rollup-plugin-sourcemaps: 0.6.3_rollup@2.70.0
+      rollup: 2.70.1
+      rollup-plugin-sourcemaps: 0.6.3_rollup@2.70.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - '@types/node'
       - debug
@@ -10497,20 +10426,20 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
-      '@rollup/plugin-commonjs': 21.0.2_rollup@2.70.0
-      '@rollup/plugin-json': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-multi-entry': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-node-resolve': 13.1.3_rollup@2.70.0
+      '@microsoft/api-extractor': 7.20.0
+      '@rollup/plugin-commonjs': 21.0.3_rollup@2.70.1
+      '@rollup/plugin-json': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-multi-entry': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-node-resolve': 13.1.3_rollup@2.70.1
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
-      rollup: 2.70.0
-      rollup-plugin-sourcemaps: 0.6.3_rollup@2.70.0
+      rollup: 2.70.1
+      rollup-plugin-sourcemaps: 0.6.3_rollup@2.70.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - '@types/node'
       - debug
@@ -10525,7 +10454,7 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
+      '@microsoft/api-extractor': 7.20.0
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-json': 4.1.0_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
@@ -10538,7 +10467,7 @@ packages:
       rollup-plugin-sourcemaps: 0.4.2_rollup@1.32.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - debug
       - encoding
@@ -10552,20 +10481,20 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
-      '@rollup/plugin-commonjs': 21.0.2_rollup@2.70.0
-      '@rollup/plugin-json': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-multi-entry': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-node-resolve': 13.1.3_rollup@2.70.0
+      '@microsoft/api-extractor': 7.20.0
+      '@rollup/plugin-commonjs': 21.0.3_rollup@2.70.1
+      '@rollup/plugin-json': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-multi-entry': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-node-resolve': 13.1.3_rollup@2.70.1
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
-      rollup: 2.70.0
-      rollup-plugin-sourcemaps: 0.6.3_rollup@2.70.0
+      rollup: 2.70.1
+      rollup-plugin-sourcemaps: 0.6.3_rollup@2.70.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - '@types/node'
       - debug
@@ -10580,7 +10509,7 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
+      '@microsoft/api-extractor': 7.20.0
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-json': 4.1.0_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
@@ -10593,7 +10522,7 @@ packages:
       rollup-plugin-sourcemaps: 0.4.2_rollup@1.32.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - debug
       - encoding
@@ -10607,20 +10536,20 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
-      '@rollup/plugin-commonjs': 21.0.2_rollup@2.70.0
-      '@rollup/plugin-json': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-multi-entry': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-node-resolve': 13.1.3_rollup@2.70.0
+      '@microsoft/api-extractor': 7.20.0
+      '@rollup/plugin-commonjs': 21.0.3_rollup@2.70.1
+      '@rollup/plugin-json': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-multi-entry': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-node-resolve': 13.1.3_rollup@2.70.1
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
-      rollup: 2.70.0
-      rollup-plugin-sourcemaps: 0.6.3_rollup@2.70.0
+      rollup: 2.70.1
+      rollup-plugin-sourcemaps: 0.6.3_rollup@2.70.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - '@types/node'
       - debug
@@ -10635,20 +10564,20 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
-      '@rollup/plugin-commonjs': 21.0.2_rollup@2.70.0
-      '@rollup/plugin-json': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-multi-entry': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-node-resolve': 13.1.3_rollup@2.70.0
+      '@microsoft/api-extractor': 7.20.0
+      '@rollup/plugin-commonjs': 21.0.3_rollup@2.70.1
+      '@rollup/plugin-json': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-multi-entry': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-node-resolve': 13.1.3_rollup@2.70.1
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
-      rollup: 2.70.0
-      rollup-plugin-sourcemaps: 0.6.3_rollup@2.70.0
+      rollup: 2.70.1
+      rollup-plugin-sourcemaps: 0.6.3_rollup@2.70.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - '@types/node'
       - debug
@@ -10663,20 +10592,20 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
-      '@rollup/plugin-commonjs': 21.0.2_rollup@2.70.0
-      '@rollup/plugin-json': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-multi-entry': 3.0.1_rollup@2.70.0
-      '@rollup/plugin-node-resolve': 8.4.0_rollup@2.70.0
+      '@microsoft/api-extractor': 7.20.0
+      '@rollup/plugin-commonjs': 21.0.3_rollup@2.70.1
+      '@rollup/plugin-json': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-multi-entry': 3.0.1_rollup@2.70.1
+      '@rollup/plugin-node-resolve': 8.4.0_rollup@2.70.1
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
-      rollup: 2.70.0
-      rollup-plugin-sourcemaps: 0.4.2_rollup@2.70.0
+      rollup: 2.70.1
+      rollup-plugin-sourcemaps: 0.4.2_rollup@2.70.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - debug
       - encoding
@@ -10690,19 +10619,19 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
-      '@rollup/plugin-commonjs': 21.0.2_rollup@2.70.0
-      '@rollup/plugin-json': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-multi-entry': 3.0.1_rollup@2.70.0
-      '@rollup/plugin-node-resolve': 8.4.0_rollup@2.70.0
+      '@microsoft/api-extractor': 7.20.0
+      '@rollup/plugin-commonjs': 21.0.3_rollup@2.70.1
+      '@rollup/plugin-json': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-multi-entry': 3.0.1_rollup@2.70.1
+      '@rollup/plugin-node-resolve': 8.4.0_rollup@2.70.1
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
-      rollup: 2.70.0
-      rollup-plugin-sourcemaps: 0.4.2_rollup@2.70.0
+      rollup: 2.70.1
+      rollup-plugin-sourcemaps: 0.4.2_rollup@2.70.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - debug
       - encoding
@@ -10716,20 +10645,20 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
-      '@rollup/plugin-commonjs': 21.0.2_rollup@2.70.0
-      '@rollup/plugin-json': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-multi-entry': 3.0.1_rollup@2.70.0
-      '@rollup/plugin-node-resolve': 8.4.0_rollup@2.70.0
+      '@microsoft/api-extractor': 7.20.0
+      '@rollup/plugin-commonjs': 21.0.3_rollup@2.70.1
+      '@rollup/plugin-json': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-multi-entry': 3.0.1_rollup@2.70.1
+      '@rollup/plugin-node-resolve': 8.4.0_rollup@2.70.1
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
-      rollup: 2.70.0
-      rollup-plugin-sourcemaps: 0.4.2_rollup@2.70.0
+      rollup: 2.70.1
+      rollup-plugin-sourcemaps: 0.4.2_rollup@2.70.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - debug
       - encoding
@@ -10743,7 +10672,7 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
+      '@microsoft/api-extractor': 7.20.0
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-json': 4.1.0_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
@@ -10756,7 +10685,7 @@ packages:
       rollup-plugin-sourcemaps: 0.4.2_rollup@1.32.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - debug
       - encoding
@@ -10770,7 +10699,7 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
+      '@microsoft/api-extractor': 7.20.0
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-json': 4.1.0_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
@@ -10783,7 +10712,7 @@ packages:
       rollup-plugin-sourcemaps: 0.4.2_rollup@1.32.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - debug
       - encoding
@@ -10797,20 +10726,20 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
-      '@rollup/plugin-commonjs': 21.0.2_rollup@2.70.0
-      '@rollup/plugin-json': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-multi-entry': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-node-resolve': 13.1.3_rollup@2.70.0
+      '@microsoft/api-extractor': 7.20.0
+      '@rollup/plugin-commonjs': 21.0.3_rollup@2.70.1
+      '@rollup/plugin-json': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-multi-entry': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-node-resolve': 13.1.3_rollup@2.70.1
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
-      rollup: 2.70.0
-      rollup-plugin-sourcemaps: 0.6.3_rollup@2.70.0
+      rollup: 2.70.1
+      rollup-plugin-sourcemaps: 0.6.3_rollup@2.70.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - '@types/node'
       - debug
@@ -10825,7 +10754,7 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
+      '@microsoft/api-extractor': 7.20.0
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-json': 4.1.0_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
@@ -10838,7 +10767,7 @@ packages:
       rollup-plugin-sourcemaps: 0.4.2_rollup@1.32.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - debug
       - encoding
@@ -10852,7 +10781,7 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
+      '@microsoft/api-extractor': 7.20.0
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-json': 4.1.0_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
@@ -10865,7 +10794,7 @@ packages:
       rollup-plugin-sourcemaps: 0.4.2_rollup@1.32.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - debug
       - encoding
@@ -10879,20 +10808,20 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
-      '@rollup/plugin-commonjs': 21.0.2_rollup@2.70.0
-      '@rollup/plugin-json': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-multi-entry': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-node-resolve': 13.1.3_rollup@2.70.0
+      '@microsoft/api-extractor': 7.20.0
+      '@rollup/plugin-commonjs': 21.0.3_rollup@2.70.1
+      '@rollup/plugin-json': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-multi-entry': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-node-resolve': 13.1.3_rollup@2.70.1
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
-      rollup: 2.70.0
-      rollup-plugin-sourcemaps: 0.6.3_rollup@2.70.0
+      rollup: 2.70.1
+      rollup-plugin-sourcemaps: 0.6.3_rollup@2.70.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - '@types/node'
       - debug
@@ -10907,7 +10836,7 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
+      '@microsoft/api-extractor': 7.20.0
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-json': 4.1.0_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
@@ -10920,7 +10849,7 @@ packages:
       rollup-plugin-sourcemaps: 0.4.2_rollup@1.32.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - debug
       - encoding
@@ -10934,7 +10863,7 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
+      '@microsoft/api-extractor': 7.20.0
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-json': 4.1.0_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
@@ -10947,7 +10876,7 @@ packages:
       rollup-plugin-sourcemaps: 0.4.2_rollup@1.32.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - debug
       - encoding
@@ -10962,12 +10891,12 @@ packages:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/arm-msi': 2.0.0
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
+      '@microsoft/api-extractor': 7.20.0
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-json': 4.1.0_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
       '@rollup/plugin-node-resolve': 8.4.0_rollup@1.32.1
-      '@types/node': 12.20.46
+      '@types/node': 12.20.47
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
@@ -10976,7 +10905,7 @@ packages:
       rollup-plugin-sourcemaps: 0.4.2_rollup@1.32.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - debug
       - encoding
@@ -10990,7 +10919,7 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
+      '@microsoft/api-extractor': 7.20.0
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-json': 4.1.0_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
@@ -11003,7 +10932,7 @@ packages:
       rollup-plugin-sourcemaps: 0.4.2_rollup@1.32.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - debug
       - encoding
@@ -11017,20 +10946,20 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
-      '@rollup/plugin-commonjs': 21.0.2_rollup@2.70.0
-      '@rollup/plugin-json': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-multi-entry': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-node-resolve': 13.1.3_rollup@2.70.0
+      '@microsoft/api-extractor': 7.20.0
+      '@rollup/plugin-commonjs': 21.0.3_rollup@2.70.1
+      '@rollup/plugin-json': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-multi-entry': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-node-resolve': 13.1.3_rollup@2.70.1
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
-      rollup: 2.70.0
-      rollup-plugin-sourcemaps: 0.6.3_rollup@2.70.0
+      rollup: 2.70.1
+      rollup-plugin-sourcemaps: 0.6.3_rollup@2.70.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - '@types/node'
       - debug
@@ -11045,7 +10974,7 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
+      '@microsoft/api-extractor': 7.20.0
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-json': 4.1.0_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
@@ -11058,7 +10987,7 @@ packages:
       rollup-plugin-sourcemaps: 0.4.2_rollup@1.32.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - debug
       - encoding
@@ -11072,20 +11001,20 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
-      '@rollup/plugin-commonjs': 21.0.2_rollup@2.70.0
-      '@rollup/plugin-json': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-multi-entry': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-node-resolve': 13.1.3_rollup@2.70.0
+      '@microsoft/api-extractor': 7.20.0
+      '@rollup/plugin-commonjs': 21.0.3_rollup@2.70.1
+      '@rollup/plugin-json': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-multi-entry': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-node-resolve': 13.1.3_rollup@2.70.1
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
-      rollup: 2.70.0
-      rollup-plugin-sourcemaps: 0.6.3_rollup@2.70.0
+      rollup: 2.70.1
+      rollup-plugin-sourcemaps: 0.6.3_rollup@2.70.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - '@types/node'
       - debug
@@ -11100,20 +11029,20 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
-      '@rollup/plugin-commonjs': 21.0.2_rollup@2.70.0
-      '@rollup/plugin-json': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-multi-entry': 3.0.1_rollup@2.70.0
-      '@rollup/plugin-node-resolve': 8.4.0_rollup@2.70.0
+      '@microsoft/api-extractor': 7.20.0
+      '@rollup/plugin-commonjs': 21.0.3_rollup@2.70.1
+      '@rollup/plugin-json': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-multi-entry': 3.0.1_rollup@2.70.1
+      '@rollup/plugin-node-resolve': 8.4.0_rollup@2.70.1
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
-      rollup: 2.70.0
-      rollup-plugin-sourcemaps: 0.4.2_rollup@2.70.0
+      rollup: 2.70.1
+      rollup-plugin-sourcemaps: 0.4.2_rollup@2.70.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - debug
       - encoding
@@ -11127,20 +11056,20 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
-      '@rollup/plugin-commonjs': 21.0.2_rollup@2.70.0
-      '@rollup/plugin-json': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-multi-entry': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-node-resolve': 13.1.3_rollup@2.70.0
+      '@microsoft/api-extractor': 7.20.0
+      '@rollup/plugin-commonjs': 21.0.3_rollup@2.70.1
+      '@rollup/plugin-json': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-multi-entry': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-node-resolve': 13.1.3_rollup@2.70.1
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
-      rollup: 2.70.0
-      rollup-plugin-sourcemaps: 0.6.3_rollup@2.70.0
+      rollup: 2.70.1
+      rollup-plugin-sourcemaps: 0.6.3_rollup@2.70.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - '@types/node'
       - debug
@@ -11155,20 +11084,20 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
-      '@rollup/plugin-commonjs': 21.0.2_rollup@2.70.0
-      '@rollup/plugin-json': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-multi-entry': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-node-resolve': 13.1.3_rollup@2.70.0
+      '@microsoft/api-extractor': 7.20.0
+      '@rollup/plugin-commonjs': 21.0.3_rollup@2.70.1
+      '@rollup/plugin-json': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-multi-entry': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-node-resolve': 13.1.3_rollup@2.70.1
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
-      rollup: 2.70.0
-      rollup-plugin-sourcemaps: 0.6.3_rollup@2.70.0
+      rollup: 2.70.1
+      rollup-plugin-sourcemaps: 0.6.3_rollup@2.70.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - '@types/node'
       - debug
@@ -11183,7 +11112,7 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
+      '@microsoft/api-extractor': 7.20.0
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-json': 4.1.0_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
@@ -11196,7 +11125,7 @@ packages:
       rollup-plugin-sourcemaps: 0.4.2_rollup@1.32.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - debug
       - encoding
@@ -11210,20 +11139,20 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
-      '@rollup/plugin-commonjs': 21.0.2_rollup@2.70.0
-      '@rollup/plugin-json': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-multi-entry': 3.0.1_rollup@2.70.0
-      '@rollup/plugin-node-resolve': 8.4.0_rollup@2.70.0
+      '@microsoft/api-extractor': 7.20.0
+      '@rollup/plugin-commonjs': 21.0.3_rollup@2.70.1
+      '@rollup/plugin-json': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-multi-entry': 3.0.1_rollup@2.70.1
+      '@rollup/plugin-node-resolve': 8.4.0_rollup@2.70.1
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
-      rollup: 2.70.0
-      rollup-plugin-sourcemaps: 0.4.2_rollup@2.70.0
+      rollup: 2.70.1
+      rollup-plugin-sourcemaps: 0.4.2_rollup@2.70.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - debug
       - encoding
@@ -11237,7 +11166,7 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
+      '@microsoft/api-extractor': 7.20.0
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-json': 4.1.0_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
@@ -11250,7 +11179,7 @@ packages:
       rollup-plugin-sourcemaps: 0.4.2_rollup@1.32.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - debug
       - encoding
@@ -11264,20 +11193,20 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
-      '@rollup/plugin-commonjs': 21.0.2_rollup@2.70.0
-      '@rollup/plugin-json': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-multi-entry': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-node-resolve': 13.1.3_rollup@2.70.0
+      '@microsoft/api-extractor': 7.20.0
+      '@rollup/plugin-commonjs': 21.0.3_rollup@2.70.1
+      '@rollup/plugin-json': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-multi-entry': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-node-resolve': 13.1.3_rollup@2.70.1
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
-      rollup: 2.70.0
-      rollup-plugin-sourcemaps: 0.6.3_rollup@2.70.0
+      rollup: 2.70.1
+      rollup-plugin-sourcemaps: 0.6.3_rollup@2.70.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - '@types/node'
       - debug
@@ -11292,20 +11221,20 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
-      '@rollup/plugin-commonjs': 21.0.2_rollup@2.70.0
-      '@rollup/plugin-json': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-multi-entry': 3.0.1_rollup@2.70.0
-      '@rollup/plugin-node-resolve': 8.4.0_rollup@2.70.0
+      '@microsoft/api-extractor': 7.20.0
+      '@rollup/plugin-commonjs': 21.0.3_rollup@2.70.1
+      '@rollup/plugin-json': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-multi-entry': 3.0.1_rollup@2.70.1
+      '@rollup/plugin-node-resolve': 8.4.0_rollup@2.70.1
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
-      rollup: 2.70.0
-      rollup-plugin-sourcemaps: 0.4.2_rollup@2.70.0
+      rollup: 2.70.1
+      rollup-plugin-sourcemaps: 0.4.2_rollup@2.70.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - debug
       - encoding
@@ -11319,20 +11248,20 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
-      '@rollup/plugin-commonjs': 21.0.2_rollup@2.70.0
-      '@rollup/plugin-json': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-multi-entry': 3.0.1_rollup@2.70.0
-      '@rollup/plugin-node-resolve': 8.4.0_rollup@2.70.0
+      '@microsoft/api-extractor': 7.20.0
+      '@rollup/plugin-commonjs': 21.0.3_rollup@2.70.1
+      '@rollup/plugin-json': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-multi-entry': 3.0.1_rollup@2.70.1
+      '@rollup/plugin-node-resolve': 8.4.0_rollup@2.70.1
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
-      rollup: 2.70.0
-      rollup-plugin-sourcemaps: 0.4.2_rollup@2.70.0
+      rollup: 2.70.1
+      rollup-plugin-sourcemaps: 0.4.2_rollup@2.70.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - debug
       - encoding
@@ -11346,7 +11275,7 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
+      '@microsoft/api-extractor': 7.20.0
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-json': 4.1.0_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
@@ -11359,7 +11288,7 @@ packages:
       rollup-plugin-sourcemaps: 0.4.2_rollup@1.32.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - debug
       - encoding
@@ -11373,7 +11302,7 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
+      '@microsoft/api-extractor': 7.20.0
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-json': 4.1.0_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
@@ -11386,7 +11315,7 @@ packages:
       rollup-plugin-sourcemaps: 0.4.2_rollup@1.32.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - debug
       - encoding
@@ -11400,7 +11329,7 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
+      '@microsoft/api-extractor': 7.20.0
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-json': 4.1.0_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
@@ -11413,7 +11342,7 @@ packages:
       rollup-plugin-sourcemaps: 0.4.2_rollup@1.32.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - debug
       - encoding
@@ -11427,20 +11356,20 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
-      '@rollup/plugin-commonjs': 21.0.2_rollup@2.70.0
-      '@rollup/plugin-json': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-multi-entry': 3.0.1_rollup@2.70.0
-      '@rollup/plugin-node-resolve': 8.4.0_rollup@2.70.0
+      '@microsoft/api-extractor': 7.20.0
+      '@rollup/plugin-commonjs': 21.0.3_rollup@2.70.1
+      '@rollup/plugin-json': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-multi-entry': 3.0.1_rollup@2.70.1
+      '@rollup/plugin-node-resolve': 8.4.0_rollup@2.70.1
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
-      rollup: 2.70.0
-      rollup-plugin-sourcemaps: 0.4.2_rollup@2.70.0
+      rollup: 2.70.1
+      rollup-plugin-sourcemaps: 0.4.2_rollup@2.70.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - debug
       - encoding
@@ -11454,20 +11383,20 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
-      '@rollup/plugin-commonjs': 21.0.2_rollup@2.70.0
-      '@rollup/plugin-json': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-multi-entry': 3.0.1_rollup@2.70.0
-      '@rollup/plugin-node-resolve': 8.4.0_rollup@2.70.0
+      '@microsoft/api-extractor': 7.20.0
+      '@rollup/plugin-commonjs': 21.0.3_rollup@2.70.1
+      '@rollup/plugin-json': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-multi-entry': 3.0.1_rollup@2.70.1
+      '@rollup/plugin-node-resolve': 8.4.0_rollup@2.70.1
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
-      rollup: 2.70.0
-      rollup-plugin-sourcemaps: 0.4.2_rollup@2.70.0
+      rollup: 2.70.1
+      rollup-plugin-sourcemaps: 0.4.2_rollup@2.70.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - debug
       - encoding
@@ -11481,7 +11410,7 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
+      '@microsoft/api-extractor': 7.20.0
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-json': 4.1.0_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
@@ -11494,7 +11423,7 @@ packages:
       rollup-plugin-sourcemaps: 0.4.2_rollup@1.32.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - debug
       - encoding
@@ -11508,7 +11437,7 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
+      '@microsoft/api-extractor': 7.20.0
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-json': 4.1.0_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
@@ -11521,7 +11450,7 @@ packages:
       rollup-plugin-sourcemaps: 0.4.2_rollup@1.32.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - debug
       - encoding
@@ -11535,7 +11464,7 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
+      '@microsoft/api-extractor': 7.20.0
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-json': 4.1.0_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
@@ -11548,7 +11477,7 @@ packages:
       rollup-plugin-sourcemaps: 0.4.2_rollup@1.32.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - debug
       - encoding
@@ -11562,7 +11491,7 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
+      '@microsoft/api-extractor': 7.20.0
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-json': 4.1.0_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
@@ -11575,7 +11504,7 @@ packages:
       rollup-plugin-sourcemaps: 0.4.2_rollup@1.32.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - debug
       - encoding
@@ -11589,20 +11518,20 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
-      '@rollup/plugin-commonjs': 21.0.2_rollup@2.70.0
-      '@rollup/plugin-json': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-multi-entry': 3.0.1_rollup@2.70.0
-      '@rollup/plugin-node-resolve': 8.4.0_rollup@2.70.0
+      '@microsoft/api-extractor': 7.20.0
+      '@rollup/plugin-commonjs': 21.0.3_rollup@2.70.1
+      '@rollup/plugin-json': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-multi-entry': 3.0.1_rollup@2.70.1
+      '@rollup/plugin-node-resolve': 8.4.0_rollup@2.70.1
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
-      rollup: 2.70.0
-      rollup-plugin-sourcemaps: 0.4.2_rollup@2.70.0
+      rollup: 2.70.1
+      rollup-plugin-sourcemaps: 0.4.2_rollup@2.70.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - debug
       - encoding
@@ -11616,7 +11545,7 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
+      '@microsoft/api-extractor': 7.20.0
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-json': 4.1.0_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
@@ -11629,7 +11558,7 @@ packages:
       rollup-plugin-sourcemaps: 0.4.2_rollup@1.32.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - debug
       - encoding
@@ -11643,7 +11572,7 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
+      '@microsoft/api-extractor': 7.20.0
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-json': 4.1.0_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
@@ -11656,7 +11585,7 @@ packages:
       rollup-plugin-sourcemaps: 0.4.2_rollup@1.32.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - debug
       - encoding
@@ -11670,20 +11599,20 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
-      '@rollup/plugin-commonjs': 21.0.2_rollup@2.70.0
-      '@rollup/plugin-json': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-multi-entry': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-node-resolve': 13.1.3_rollup@2.70.0
+      '@microsoft/api-extractor': 7.20.0
+      '@rollup/plugin-commonjs': 21.0.3_rollup@2.70.1
+      '@rollup/plugin-json': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-multi-entry': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-node-resolve': 13.1.3_rollup@2.70.1
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
-      rollup: 2.70.0
-      rollup-plugin-sourcemaps: 0.6.3_rollup@2.70.0
+      rollup: 2.70.1
+      rollup-plugin-sourcemaps: 0.6.3_rollup@2.70.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - '@types/node'
       - debug
@@ -11698,20 +11627,20 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
-      '@rollup/plugin-commonjs': 21.0.2_rollup@2.70.0
-      '@rollup/plugin-json': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-multi-entry': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-node-resolve': 13.1.3_rollup@2.70.0
+      '@microsoft/api-extractor': 7.20.0
+      '@rollup/plugin-commonjs': 21.0.3_rollup@2.70.1
+      '@rollup/plugin-json': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-multi-entry': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-node-resolve': 13.1.3_rollup@2.70.1
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
-      rollup: 2.70.0
-      rollup-plugin-sourcemaps: 0.6.3_rollup@2.70.0
+      rollup: 2.70.1
+      rollup-plugin-sourcemaps: 0.6.3_rollup@2.70.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - '@types/node'
       - debug
@@ -11726,7 +11655,7 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
+      '@microsoft/api-extractor': 7.20.0
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-json': 4.1.0_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
@@ -11739,7 +11668,7 @@ packages:
       rollup-plugin-sourcemaps: 0.4.2_rollup@1.32.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - debug
       - encoding
@@ -11753,20 +11682,20 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
-      '@rollup/plugin-commonjs': 21.0.2_rollup@2.70.0
-      '@rollup/plugin-json': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-multi-entry': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-node-resolve': 13.1.3_rollup@2.70.0
+      '@microsoft/api-extractor': 7.20.0
+      '@rollup/plugin-commonjs': 21.0.3_rollup@2.70.1
+      '@rollup/plugin-json': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-multi-entry': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-node-resolve': 13.1.3_rollup@2.70.1
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
-      rollup: 2.70.0
-      rollup-plugin-sourcemaps: 0.6.3_rollup@2.70.0
+      rollup: 2.70.1
+      rollup-plugin-sourcemaps: 0.6.3_rollup@2.70.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - '@types/node'
       - debug
@@ -11781,20 +11710,20 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
-      '@rollup/plugin-commonjs': 21.0.2_rollup@2.70.0
-      '@rollup/plugin-json': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-multi-entry': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-node-resolve': 13.1.3_rollup@2.70.0
+      '@microsoft/api-extractor': 7.20.0
+      '@rollup/plugin-commonjs': 21.0.3_rollup@2.70.1
+      '@rollup/plugin-json': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-multi-entry': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-node-resolve': 13.1.3_rollup@2.70.1
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
-      rollup: 2.70.0
-      rollup-plugin-sourcemaps: 0.6.3_rollup@2.70.0
+      rollup: 2.70.1
+      rollup-plugin-sourcemaps: 0.6.3_rollup@2.70.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - '@types/node'
       - debug
@@ -11809,20 +11738,20 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
-      '@rollup/plugin-commonjs': 21.0.2_rollup@2.70.0
-      '@rollup/plugin-json': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-multi-entry': 3.0.1_rollup@2.70.0
-      '@rollup/plugin-node-resolve': 8.4.0_rollup@2.70.0
+      '@microsoft/api-extractor': 7.20.0
+      '@rollup/plugin-commonjs': 21.0.3_rollup@2.70.1
+      '@rollup/plugin-json': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-multi-entry': 3.0.1_rollup@2.70.1
+      '@rollup/plugin-node-resolve': 8.4.0_rollup@2.70.1
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
-      rollup: 2.70.0
-      rollup-plugin-sourcemaps: 0.4.2_rollup@2.70.0
+      rollup: 2.70.1
+      rollup-plugin-sourcemaps: 0.4.2_rollup@2.70.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - debug
       - encoding
@@ -11836,20 +11765,20 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
-      '@rollup/plugin-commonjs': 21.0.2_rollup@2.70.0
-      '@rollup/plugin-json': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-multi-entry': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-node-resolve': 13.1.3_rollup@2.70.0
+      '@microsoft/api-extractor': 7.20.0
+      '@rollup/plugin-commonjs': 21.0.3_rollup@2.70.1
+      '@rollup/plugin-json': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-multi-entry': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-node-resolve': 13.1.3_rollup@2.70.1
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
-      rollup: 2.70.0
-      rollup-plugin-sourcemaps: 0.6.3_rollup@2.70.0
+      rollup: 2.70.1
+      rollup-plugin-sourcemaps: 0.6.3_rollup@2.70.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - '@types/node'
       - debug
@@ -11864,20 +11793,20 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
-      '@rollup/plugin-commonjs': 21.0.2_rollup@2.70.0
-      '@rollup/plugin-json': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-multi-entry': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-node-resolve': 13.1.3_rollup@2.70.0
+      '@microsoft/api-extractor': 7.20.0
+      '@rollup/plugin-commonjs': 21.0.3_rollup@2.70.1
+      '@rollup/plugin-json': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-multi-entry': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-node-resolve': 13.1.3_rollup@2.70.1
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
-      rollup: 2.70.0
-      rollup-plugin-sourcemaps: 0.6.3_rollup@2.70.0
+      rollup: 2.70.1
+      rollup-plugin-sourcemaps: 0.6.3_rollup@2.70.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - '@types/node'
       - debug
@@ -11892,20 +11821,20 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
-      '@rollup/plugin-commonjs': 21.0.2_rollup@2.70.0
-      '@rollup/plugin-json': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-multi-entry': 3.0.1_rollup@2.70.0
-      '@rollup/plugin-node-resolve': 8.4.0_rollup@2.70.0
+      '@microsoft/api-extractor': 7.20.0
+      '@rollup/plugin-commonjs': 21.0.3_rollup@2.70.1
+      '@rollup/plugin-json': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-multi-entry': 3.0.1_rollup@2.70.1
+      '@rollup/plugin-node-resolve': 8.4.0_rollup@2.70.1
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
-      rollup: 2.70.0
-      rollup-plugin-sourcemaps: 0.4.2_rollup@2.70.0
+      rollup: 2.70.1
+      rollup-plugin-sourcemaps: 0.4.2_rollup@2.70.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - debug
       - encoding
@@ -11919,20 +11848,20 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
-      '@rollup/plugin-commonjs': 21.0.2_rollup@2.70.0
-      '@rollup/plugin-json': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-multi-entry': 3.0.1_rollup@2.70.0
-      '@rollup/plugin-node-resolve': 8.4.0_rollup@2.70.0
+      '@microsoft/api-extractor': 7.20.0
+      '@rollup/plugin-commonjs': 21.0.3_rollup@2.70.1
+      '@rollup/plugin-json': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-multi-entry': 3.0.1_rollup@2.70.1
+      '@rollup/plugin-node-resolve': 8.4.0_rollup@2.70.1
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
-      rollup: 2.70.0
-      rollup-plugin-sourcemaps: 0.4.2_rollup@2.70.0
+      rollup: 2.70.1
+      rollup-plugin-sourcemaps: 0.4.2_rollup@2.70.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - debug
       - encoding
@@ -11946,7 +11875,7 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
+      '@microsoft/api-extractor': 7.20.0
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-json': 4.1.0_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
@@ -11959,7 +11888,7 @@ packages:
       rollup-plugin-sourcemaps: 0.4.2_rollup@1.32.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - debug
       - encoding
@@ -11973,20 +11902,20 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
-      '@rollup/plugin-commonjs': 21.0.2_rollup@2.70.0
-      '@rollup/plugin-json': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-multi-entry': 3.0.1_rollup@2.70.0
-      '@rollup/plugin-node-resolve': 8.4.0_rollup@2.70.0
+      '@microsoft/api-extractor': 7.20.0
+      '@rollup/plugin-commonjs': 21.0.3_rollup@2.70.1
+      '@rollup/plugin-json': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-multi-entry': 3.0.1_rollup@2.70.1
+      '@rollup/plugin-node-resolve': 8.4.0_rollup@2.70.1
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
-      rollup: 2.70.0
-      rollup-plugin-sourcemaps: 0.4.2_rollup@2.70.0
+      rollup: 2.70.1
+      rollup-plugin-sourcemaps: 0.4.2_rollup@2.70.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - debug
       - encoding
@@ -12000,20 +11929,20 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
-      '@rollup/plugin-commonjs': 21.0.2_rollup@2.70.0
-      '@rollup/plugin-json': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-multi-entry': 3.0.1_rollup@2.70.0
-      '@rollup/plugin-node-resolve': 8.4.0_rollup@2.70.0
+      '@microsoft/api-extractor': 7.20.0
+      '@rollup/plugin-commonjs': 21.0.3_rollup@2.70.1
+      '@rollup/plugin-json': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-multi-entry': 3.0.1_rollup@2.70.1
+      '@rollup/plugin-node-resolve': 8.4.0_rollup@2.70.1
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
-      rollup: 2.70.0
-      rollup-plugin-sourcemaps: 0.4.2_rollup@2.70.0
+      rollup: 2.70.1
+      rollup-plugin-sourcemaps: 0.4.2_rollup@2.70.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - debug
       - encoding
@@ -12027,20 +11956,20 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
-      '@rollup/plugin-commonjs': 21.0.2_rollup@2.70.0
-      '@rollup/plugin-json': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-multi-entry': 3.0.1_rollup@2.70.0
-      '@rollup/plugin-node-resolve': 8.4.0_rollup@2.70.0
+      '@microsoft/api-extractor': 7.20.0
+      '@rollup/plugin-commonjs': 21.0.3_rollup@2.70.1
+      '@rollup/plugin-json': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-multi-entry': 3.0.1_rollup@2.70.1
+      '@rollup/plugin-node-resolve': 8.4.0_rollup@2.70.1
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
-      rollup: 2.70.0
-      rollup-plugin-sourcemaps: 0.4.2_rollup@2.70.0
+      rollup: 2.70.1
+      rollup-plugin-sourcemaps: 0.4.2_rollup@2.70.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - debug
       - encoding
@@ -12054,7 +11983,7 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
+      '@microsoft/api-extractor': 7.20.0
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-json': 4.1.0_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
@@ -12067,7 +11996,7 @@ packages:
       rollup-plugin-sourcemaps: 0.4.2_rollup@1.32.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - debug
       - encoding
@@ -12081,20 +12010,20 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
-      '@rollup/plugin-commonjs': 21.0.2_rollup@2.70.0
-      '@rollup/plugin-json': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-multi-entry': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-node-resolve': 13.1.3_rollup@2.70.0
+      '@microsoft/api-extractor': 7.20.0
+      '@rollup/plugin-commonjs': 21.0.3_rollup@2.70.1
+      '@rollup/plugin-json': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-multi-entry': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-node-resolve': 13.1.3_rollup@2.70.1
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
-      rollup: 2.70.0
-      rollup-plugin-sourcemaps: 0.6.3_rollup@2.70.0
+      rollup: 2.70.1
+      rollup-plugin-sourcemaps: 0.6.3_rollup@2.70.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - '@types/node'
       - debug
@@ -12109,20 +12038,20 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
-      '@rollup/plugin-commonjs': 21.0.2_rollup@2.70.0
-      '@rollup/plugin-json': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-multi-entry': 3.0.1_rollup@2.70.0
-      '@rollup/plugin-node-resolve': 8.4.0_rollup@2.70.0
+      '@microsoft/api-extractor': 7.20.0
+      '@rollup/plugin-commonjs': 21.0.3_rollup@2.70.1
+      '@rollup/plugin-json': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-multi-entry': 3.0.1_rollup@2.70.1
+      '@rollup/plugin-node-resolve': 8.4.0_rollup@2.70.1
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
-      rollup: 2.70.0
-      rollup-plugin-sourcemaps: 0.4.2_rollup@2.70.0
+      rollup: 2.70.1
+      rollup-plugin-sourcemaps: 0.4.2_rollup@2.70.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - debug
       - encoding
@@ -12136,20 +12065,20 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
-      '@rollup/plugin-commonjs': 21.0.2_rollup@2.70.0
-      '@rollup/plugin-json': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-multi-entry': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-node-resolve': 13.1.3_rollup@2.70.0
+      '@microsoft/api-extractor': 7.20.0
+      '@rollup/plugin-commonjs': 21.0.3_rollup@2.70.1
+      '@rollup/plugin-json': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-multi-entry': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-node-resolve': 13.1.3_rollup@2.70.1
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
-      rollup: 2.70.0
-      rollup-plugin-sourcemaps: 0.6.3_rollup@2.70.0
+      rollup: 2.70.1
+      rollup-plugin-sourcemaps: 0.6.3_rollup@2.70.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - '@types/node'
       - debug
@@ -12164,20 +12093,20 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
-      '@rollup/plugin-commonjs': 21.0.2_rollup@2.70.0
-      '@rollup/plugin-json': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-multi-entry': 3.0.1_rollup@2.70.0
-      '@rollup/plugin-node-resolve': 8.4.0_rollup@2.70.0
+      '@microsoft/api-extractor': 7.20.0
+      '@rollup/plugin-commonjs': 21.0.3_rollup@2.70.1
+      '@rollup/plugin-json': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-multi-entry': 3.0.1_rollup@2.70.1
+      '@rollup/plugin-node-resolve': 8.4.0_rollup@2.70.1
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
-      rollup: 2.70.0
-      rollup-plugin-sourcemaps: 0.4.2_rollup@2.70.0
+      rollup: 2.70.1
+      rollup-plugin-sourcemaps: 0.4.2_rollup@2.70.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - debug
       - encoding
@@ -12191,7 +12120,7 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
+      '@microsoft/api-extractor': 7.20.0
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-json': 4.1.0_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
@@ -12204,7 +12133,7 @@ packages:
       rollup-plugin-sourcemaps: 0.4.2_rollup@1.32.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - debug
       - encoding
@@ -12218,20 +12147,20 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
-      '@rollup/plugin-commonjs': 21.0.2_rollup@2.70.0
-      '@rollup/plugin-json': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-multi-entry': 3.0.1_rollup@2.70.0
-      '@rollup/plugin-node-resolve': 8.4.0_rollup@2.70.0
+      '@microsoft/api-extractor': 7.20.0
+      '@rollup/plugin-commonjs': 21.0.3_rollup@2.70.1
+      '@rollup/plugin-json': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-multi-entry': 3.0.1_rollup@2.70.1
+      '@rollup/plugin-node-resolve': 8.4.0_rollup@2.70.1
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
-      rollup: 2.70.0
-      rollup-plugin-sourcemaps: 0.4.2_rollup@2.70.0
+      rollup: 2.70.1
+      rollup-plugin-sourcemaps: 0.4.2_rollup@2.70.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - debug
       - encoding
@@ -12245,7 +12174,7 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
+      '@microsoft/api-extractor': 7.20.0
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-json': 4.1.0_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
@@ -12258,7 +12187,7 @@ packages:
       rollup-plugin-sourcemaps: 0.4.2_rollup@1.32.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - debug
       - encoding
@@ -12272,7 +12201,7 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
+      '@microsoft/api-extractor': 7.20.0
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-json': 4.1.0_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
@@ -12285,7 +12214,7 @@ packages:
       rollup-plugin-sourcemaps: 0.4.2_rollup@1.32.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - debug
       - encoding
@@ -12299,7 +12228,7 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
+      '@microsoft/api-extractor': 7.20.0
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-json': 4.1.0_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
@@ -12312,7 +12241,7 @@ packages:
       rollup-plugin-sourcemaps: 0.4.2_rollup@1.32.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - debug
       - encoding
@@ -12326,20 +12255,20 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
-      '@rollup/plugin-commonjs': 21.0.2_rollup@2.70.0
-      '@rollup/plugin-json': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-multi-entry': 3.0.1_rollup@2.70.0
-      '@rollup/plugin-node-resolve': 8.4.0_rollup@2.70.0
+      '@microsoft/api-extractor': 7.20.0
+      '@rollup/plugin-commonjs': 21.0.3_rollup@2.70.1
+      '@rollup/plugin-json': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-multi-entry': 3.0.1_rollup@2.70.1
+      '@rollup/plugin-node-resolve': 8.4.0_rollup@2.70.1
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
-      rollup: 2.70.0
-      rollup-plugin-sourcemaps: 0.4.2_rollup@2.70.0
+      rollup: 2.70.1
+      rollup-plugin-sourcemaps: 0.4.2_rollup@2.70.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - debug
       - encoding
@@ -12353,20 +12282,20 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
-      '@rollup/plugin-commonjs': 21.0.2_rollup@2.70.0
-      '@rollup/plugin-json': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-multi-entry': 3.0.1_rollup@2.70.0
-      '@rollup/plugin-node-resolve': 8.4.0_rollup@2.70.0
+      '@microsoft/api-extractor': 7.20.0
+      '@rollup/plugin-commonjs': 21.0.3_rollup@2.70.1
+      '@rollup/plugin-json': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-multi-entry': 3.0.1_rollup@2.70.1
+      '@rollup/plugin-node-resolve': 8.4.0_rollup@2.70.1
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
-      rollup: 2.70.0
-      rollup-plugin-sourcemaps: 0.4.2_rollup@2.70.0
+      rollup: 2.70.1
+      rollup-plugin-sourcemaps: 0.4.2_rollup@2.70.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - debug
       - encoding
@@ -12380,7 +12309,7 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
+      '@microsoft/api-extractor': 7.20.0
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-json': 4.1.0_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
@@ -12393,7 +12322,7 @@ packages:
       rollup-plugin-sourcemaps: 0.4.2_rollup@1.32.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - debug
       - encoding
@@ -12407,20 +12336,20 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
-      '@rollup/plugin-commonjs': 21.0.2_rollup@2.70.0
-      '@rollup/plugin-json': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-multi-entry': 3.0.1_rollup@2.70.0
-      '@rollup/plugin-node-resolve': 8.4.0_rollup@2.70.0
+      '@microsoft/api-extractor': 7.20.0
+      '@rollup/plugin-commonjs': 21.0.3_rollup@2.70.1
+      '@rollup/plugin-json': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-multi-entry': 3.0.1_rollup@2.70.1
+      '@rollup/plugin-node-resolve': 8.4.0_rollup@2.70.1
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
-      rollup: 2.70.0
-      rollup-plugin-sourcemaps: 0.4.2_rollup@2.70.0
+      rollup: 2.70.1
+      rollup-plugin-sourcemaps: 0.4.2_rollup@2.70.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - debug
       - encoding
@@ -12434,7 +12363,7 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
+      '@microsoft/api-extractor': 7.20.0
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-json': 4.1.0_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
@@ -12447,7 +12376,7 @@ packages:
       rollup-plugin-sourcemaps: 0.4.2_rollup@1.32.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - debug
       - encoding
@@ -12461,20 +12390,20 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
-      '@rollup/plugin-commonjs': 21.0.2_rollup@2.70.0
-      '@rollup/plugin-json': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-multi-entry': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-node-resolve': 13.1.3_rollup@2.70.0
+      '@microsoft/api-extractor': 7.20.0
+      '@rollup/plugin-commonjs': 21.0.3_rollup@2.70.1
+      '@rollup/plugin-json': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-multi-entry': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-node-resolve': 13.1.3_rollup@2.70.1
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
-      rollup: 2.70.0
-      rollup-plugin-sourcemaps: 0.6.3_rollup@2.70.0
+      rollup: 2.70.1
+      rollup-plugin-sourcemaps: 0.6.3_rollup@2.70.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - '@types/node'
       - debug
@@ -12489,7 +12418,7 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
+      '@microsoft/api-extractor': 7.20.0
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-json': 4.1.0_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
@@ -12502,7 +12431,7 @@ packages:
       rollup-plugin-sourcemaps: 0.4.2_rollup@1.32.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - debug
       - encoding
@@ -12516,7 +12445,7 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
+      '@microsoft/api-extractor': 7.20.0
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-json': 4.1.0_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
@@ -12529,7 +12458,7 @@ packages:
       rollup-plugin-sourcemaps: 0.4.2_rollup@1.32.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - debug
       - encoding
@@ -12543,7 +12472,7 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
+      '@microsoft/api-extractor': 7.20.0
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-json': 4.1.0_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
@@ -12556,7 +12485,7 @@ packages:
       rollup-plugin-sourcemaps: 0.4.2_rollup@1.32.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - debug
       - encoding
@@ -12570,7 +12499,7 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
+      '@microsoft/api-extractor': 7.20.0
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-json': 4.1.0_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
@@ -12583,7 +12512,7 @@ packages:
       rollup-plugin-sourcemaps: 0.4.2_rollup@1.32.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - debug
       - encoding
@@ -12597,20 +12526,20 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
-      '@rollup/plugin-commonjs': 21.0.2_rollup@2.70.0
-      '@rollup/plugin-json': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-multi-entry': 3.0.1_rollup@2.70.0
-      '@rollup/plugin-node-resolve': 8.4.0_rollup@2.70.0
+      '@microsoft/api-extractor': 7.20.0
+      '@rollup/plugin-commonjs': 21.0.3_rollup@2.70.1
+      '@rollup/plugin-json': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-multi-entry': 3.0.1_rollup@2.70.1
+      '@rollup/plugin-node-resolve': 8.4.0_rollup@2.70.1
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
-      rollup: 2.70.0
-      rollup-plugin-sourcemaps: 0.4.2_rollup@2.70.0
+      rollup: 2.70.1
+      rollup-plugin-sourcemaps: 0.4.2_rollup@2.70.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - debug
       - encoding
@@ -12624,7 +12553,7 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
+      '@microsoft/api-extractor': 7.20.0
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-json': 4.1.0_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
@@ -12637,7 +12566,7 @@ packages:
       rollup-plugin-sourcemaps: 0.4.2_rollup@1.32.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - debug
       - encoding
@@ -12651,20 +12580,20 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
-      '@rollup/plugin-commonjs': 21.0.2_rollup@2.70.0
-      '@rollup/plugin-json': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-multi-entry': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-node-resolve': 13.1.3_rollup@2.70.0
+      '@microsoft/api-extractor': 7.20.0
+      '@rollup/plugin-commonjs': 21.0.3_rollup@2.70.1
+      '@rollup/plugin-json': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-multi-entry': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-node-resolve': 13.1.3_rollup@2.70.1
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
-      rollup: 2.70.0
-      rollup-plugin-sourcemaps: 0.6.3_rollup@2.70.0
+      rollup: 2.70.1
+      rollup-plugin-sourcemaps: 0.6.3_rollup@2.70.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - '@types/node'
       - debug
@@ -12679,20 +12608,20 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
-      '@rollup/plugin-commonjs': 21.0.2_rollup@2.70.0
-      '@rollup/plugin-json': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-multi-entry': 3.0.1_rollup@2.70.0
-      '@rollup/plugin-node-resolve': 8.4.0_rollup@2.70.0
+      '@microsoft/api-extractor': 7.20.0
+      '@rollup/plugin-commonjs': 21.0.3_rollup@2.70.1
+      '@rollup/plugin-json': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-multi-entry': 3.0.1_rollup@2.70.1
+      '@rollup/plugin-node-resolve': 8.4.0_rollup@2.70.1
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
-      rollup: 2.70.0
-      rollup-plugin-sourcemaps: 0.4.2_rollup@2.70.0
+      rollup: 2.70.1
+      rollup-plugin-sourcemaps: 0.4.2_rollup@2.70.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - debug
       - encoding
@@ -12706,20 +12635,20 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
-      '@rollup/plugin-commonjs': 21.0.2_rollup@2.70.0
-      '@rollup/plugin-json': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-multi-entry': 3.0.1_rollup@2.70.0
-      '@rollup/plugin-node-resolve': 8.4.0_rollup@2.70.0
+      '@microsoft/api-extractor': 7.20.0
+      '@rollup/plugin-commonjs': 21.0.3_rollup@2.70.1
+      '@rollup/plugin-json': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-multi-entry': 3.0.1_rollup@2.70.1
+      '@rollup/plugin-node-resolve': 8.4.0_rollup@2.70.1
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
-      rollup: 2.70.0
-      rollup-plugin-sourcemaps: 0.4.2_rollup@2.70.0
+      rollup: 2.70.1
+      rollup-plugin-sourcemaps: 0.4.2_rollup@2.70.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - debug
       - encoding
@@ -12733,20 +12662,20 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
-      '@rollup/plugin-commonjs': 21.0.2_rollup@2.70.0
-      '@rollup/plugin-json': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-multi-entry': 3.0.1_rollup@2.70.0
-      '@rollup/plugin-node-resolve': 8.4.0_rollup@2.70.0
+      '@microsoft/api-extractor': 7.20.0
+      '@rollup/plugin-commonjs': 21.0.3_rollup@2.70.1
+      '@rollup/plugin-json': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-multi-entry': 3.0.1_rollup@2.70.1
+      '@rollup/plugin-node-resolve': 8.4.0_rollup@2.70.1
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
-      rollup: 2.70.0
-      rollup-plugin-sourcemaps: 0.4.2_rollup@2.70.0
+      rollup: 2.70.1
+      rollup-plugin-sourcemaps: 0.4.2_rollup@2.70.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - debug
       - encoding
@@ -12760,20 +12689,20 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
-      '@rollup/plugin-commonjs': 21.0.2_rollup@2.70.0
-      '@rollup/plugin-json': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-multi-entry': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-node-resolve': 13.1.3_rollup@2.70.0
+      '@microsoft/api-extractor': 7.20.0
+      '@rollup/plugin-commonjs': 21.0.3_rollup@2.70.1
+      '@rollup/plugin-json': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-multi-entry': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-node-resolve': 13.1.3_rollup@2.70.1
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
-      rollup: 2.70.0
-      rollup-plugin-sourcemaps: 0.6.3_rollup@2.70.0
+      rollup: 2.70.1
+      rollup-plugin-sourcemaps: 0.6.3_rollup@2.70.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - '@types/node'
       - debug
@@ -12788,20 +12717,20 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
-      '@rollup/plugin-commonjs': 21.0.2_rollup@2.70.0
-      '@rollup/plugin-json': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-multi-entry': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-node-resolve': 13.1.3_rollup@2.70.0
+      '@microsoft/api-extractor': 7.20.0
+      '@rollup/plugin-commonjs': 21.0.3_rollup@2.70.1
+      '@rollup/plugin-json': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-multi-entry': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-node-resolve': 13.1.3_rollup@2.70.1
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
-      rollup: 2.70.0
-      rollup-plugin-sourcemaps: 0.6.3_rollup@2.70.0
+      rollup: 2.70.1
+      rollup-plugin-sourcemaps: 0.6.3_rollup@2.70.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - '@types/node'
       - debug
@@ -12816,7 +12745,7 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
+      '@microsoft/api-extractor': 7.20.0
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-json': 4.1.0_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
@@ -12829,7 +12758,7 @@ packages:
       rollup-plugin-sourcemaps: 0.4.2_rollup@1.32.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - debug
       - encoding
@@ -12843,20 +12772,20 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
-      '@rollup/plugin-commonjs': 21.0.2_rollup@2.70.0
-      '@rollup/plugin-json': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-multi-entry': 3.0.1_rollup@2.70.0
-      '@rollup/plugin-node-resolve': 8.4.0_rollup@2.70.0
+      '@microsoft/api-extractor': 7.20.0
+      '@rollup/plugin-commonjs': 21.0.3_rollup@2.70.1
+      '@rollup/plugin-json': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-multi-entry': 3.0.1_rollup@2.70.1
+      '@rollup/plugin-node-resolve': 8.4.0_rollup@2.70.1
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
-      rollup: 2.70.0
-      rollup-plugin-sourcemaps: 0.4.2_rollup@2.70.0
+      rollup: 2.70.1
+      rollup-plugin-sourcemaps: 0.4.2_rollup@2.70.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - debug
       - encoding
@@ -12870,20 +12799,20 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
-      '@rollup/plugin-commonjs': 21.0.2_rollup@2.70.0
-      '@rollup/plugin-json': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-multi-entry': 3.0.1_rollup@2.70.0
-      '@rollup/plugin-node-resolve': 8.4.0_rollup@2.70.0
+      '@microsoft/api-extractor': 7.20.0
+      '@rollup/plugin-commonjs': 21.0.3_rollup@2.70.1
+      '@rollup/plugin-json': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-multi-entry': 3.0.1_rollup@2.70.1
+      '@rollup/plugin-node-resolve': 8.4.0_rollup@2.70.1
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
-      rollup: 2.70.0
-      rollup-plugin-sourcemaps: 0.4.2_rollup@2.70.0
+      rollup: 2.70.1
+      rollup-plugin-sourcemaps: 0.4.2_rollup@2.70.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - debug
       - encoding
@@ -12897,7 +12826,7 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
+      '@microsoft/api-extractor': 7.20.0
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-json': 4.1.0_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
@@ -12910,7 +12839,7 @@ packages:
       rollup-plugin-sourcemaps: 0.4.2_rollup@1.32.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - debug
       - encoding
@@ -12924,7 +12853,7 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
+      '@microsoft/api-extractor': 7.20.0
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-json': 4.1.0_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
@@ -12937,7 +12866,7 @@ packages:
       rollup-plugin-sourcemaps: 0.4.2_rollup@1.32.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - debug
       - encoding
@@ -12951,20 +12880,20 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
-      '@rollup/plugin-commonjs': 21.0.2_rollup@2.70.0
-      '@rollup/plugin-json': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-multi-entry': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-node-resolve': 13.1.3_rollup@2.70.0
+      '@microsoft/api-extractor': 7.20.0
+      '@rollup/plugin-commonjs': 21.0.3_rollup@2.70.1
+      '@rollup/plugin-json': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-multi-entry': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-node-resolve': 13.1.3_rollup@2.70.1
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
-      rollup: 2.70.0
-      rollup-plugin-sourcemaps: 0.6.3_rollup@2.70.0
+      rollup: 2.70.1
+      rollup-plugin-sourcemaps: 0.6.3_rollup@2.70.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - '@types/node'
       - debug
@@ -12979,20 +12908,20 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
-      '@rollup/plugin-commonjs': 21.0.2_rollup@2.70.0
-      '@rollup/plugin-json': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-multi-entry': 3.0.1_rollup@2.70.0
-      '@rollup/plugin-node-resolve': 8.4.0_rollup@2.70.0
+      '@microsoft/api-extractor': 7.20.0
+      '@rollup/plugin-commonjs': 21.0.3_rollup@2.70.1
+      '@rollup/plugin-json': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-multi-entry': 3.0.1_rollup@2.70.1
+      '@rollup/plugin-node-resolve': 8.4.0_rollup@2.70.1
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
-      rollup: 2.70.0
-      rollup-plugin-sourcemaps: 0.4.2_rollup@2.70.0
+      rollup: 2.70.1
+      rollup-plugin-sourcemaps: 0.4.2_rollup@2.70.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - debug
       - encoding
@@ -13006,20 +12935,20 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
-      '@rollup/plugin-commonjs': 21.0.2_rollup@2.70.0
-      '@rollup/plugin-json': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-multi-entry': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-node-resolve': 13.1.3_rollup@2.70.0
+      '@microsoft/api-extractor': 7.20.0
+      '@rollup/plugin-commonjs': 21.0.3_rollup@2.70.1
+      '@rollup/plugin-json': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-multi-entry': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-node-resolve': 13.1.3_rollup@2.70.1
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
-      rollup: 2.70.0
-      rollup-plugin-sourcemaps: 0.6.3_rollup@2.70.0
+      rollup: 2.70.1
+      rollup-plugin-sourcemaps: 0.6.3_rollup@2.70.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - '@types/node'
       - debug
@@ -13034,20 +12963,20 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
-      '@rollup/plugin-commonjs': 21.0.2_rollup@2.70.0
-      '@rollup/plugin-json': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-multi-entry': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-node-resolve': 13.1.3_rollup@2.70.0
+      '@microsoft/api-extractor': 7.20.0
+      '@rollup/plugin-commonjs': 21.0.3_rollup@2.70.1
+      '@rollup/plugin-json': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-multi-entry': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-node-resolve': 13.1.3_rollup@2.70.1
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
-      rollup: 2.70.0
-      rollup-plugin-sourcemaps: 0.6.3_rollup@2.70.0
+      rollup: 2.70.1
+      rollup-plugin-sourcemaps: 0.6.3_rollup@2.70.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - '@types/node'
       - debug
@@ -13062,20 +12991,20 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
-      '@rollup/plugin-commonjs': 21.0.2_rollup@2.70.0
-      '@rollup/plugin-json': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-multi-entry': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-node-resolve': 13.1.3_rollup@2.70.0
+      '@microsoft/api-extractor': 7.20.0
+      '@rollup/plugin-commonjs': 21.0.3_rollup@2.70.1
+      '@rollup/plugin-json': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-multi-entry': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-node-resolve': 13.1.3_rollup@2.70.1
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
-      rollup: 2.70.0
-      rollup-plugin-sourcemaps: 0.6.3_rollup@2.70.0
+      rollup: 2.70.1
+      rollup-plugin-sourcemaps: 0.6.3_rollup@2.70.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - '@types/node'
       - debug
@@ -13090,20 +13019,20 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
-      '@rollup/plugin-commonjs': 21.0.2_rollup@2.70.0
-      '@rollup/plugin-json': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-multi-entry': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-node-resolve': 13.1.3_rollup@2.70.0
+      '@microsoft/api-extractor': 7.20.0
+      '@rollup/plugin-commonjs': 21.0.3_rollup@2.70.1
+      '@rollup/plugin-json': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-multi-entry': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-node-resolve': 13.1.3_rollup@2.70.1
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
-      rollup: 2.70.0
-      rollup-plugin-sourcemaps: 0.6.3_rollup@2.70.0
+      rollup: 2.70.1
+      rollup-plugin-sourcemaps: 0.6.3_rollup@2.70.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - '@types/node'
       - debug
@@ -13118,7 +13047,7 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
+      '@microsoft/api-extractor': 7.20.0
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-json': 4.1.0_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
@@ -13131,7 +13060,7 @@ packages:
       rollup-plugin-sourcemaps: 0.4.2_rollup@1.32.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - debug
       - encoding
@@ -13145,7 +13074,7 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
+      '@microsoft/api-extractor': 7.20.0
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-json': 4.1.0_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
@@ -13158,7 +13087,7 @@ packages:
       rollup-plugin-sourcemaps: 0.4.2_rollup@1.32.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - debug
       - encoding
@@ -13172,7 +13101,7 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
+      '@microsoft/api-extractor': 7.20.0
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-json': 4.1.0_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
@@ -13185,7 +13114,7 @@ packages:
       rollup-plugin-sourcemaps: 0.4.2_rollup@1.32.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - debug
       - encoding
@@ -13199,7 +13128,7 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
+      '@microsoft/api-extractor': 7.20.0
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-json': 4.1.0_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
@@ -13212,7 +13141,7 @@ packages:
       rollup-plugin-sourcemaps: 0.4.2_rollup@1.32.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - debug
       - encoding
@@ -13226,20 +13155,20 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
-      '@rollup/plugin-commonjs': 21.0.2_rollup@2.70.0
-      '@rollup/plugin-json': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-multi-entry': 3.0.1_rollup@2.70.0
-      '@rollup/plugin-node-resolve': 8.4.0_rollup@2.70.0
+      '@microsoft/api-extractor': 7.20.0
+      '@rollup/plugin-commonjs': 21.0.3_rollup@2.70.1
+      '@rollup/plugin-json': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-multi-entry': 3.0.1_rollup@2.70.1
+      '@rollup/plugin-node-resolve': 8.4.0_rollup@2.70.1
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
-      rollup: 2.70.0
-      rollup-plugin-sourcemaps: 0.4.2_rollup@2.70.0
+      rollup: 2.70.1
+      rollup-plugin-sourcemaps: 0.4.2_rollup@2.70.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - debug
       - encoding
@@ -13253,20 +13182,20 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
-      '@rollup/plugin-commonjs': 21.0.2_rollup@2.70.0
-      '@rollup/plugin-json': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-multi-entry': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-node-resolve': 13.1.3_rollup@2.70.0
+      '@microsoft/api-extractor': 7.20.0
+      '@rollup/plugin-commonjs': 21.0.3_rollup@2.70.1
+      '@rollup/plugin-json': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-multi-entry': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-node-resolve': 13.1.3_rollup@2.70.1
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
-      rollup: 2.70.0
-      rollup-plugin-sourcemaps: 0.6.3_rollup@2.70.0
+      rollup: 2.70.1
+      rollup-plugin-sourcemaps: 0.6.3_rollup@2.70.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - '@types/node'
       - debug
@@ -13281,7 +13210,7 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
+      '@microsoft/api-extractor': 7.20.0
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-json': 4.1.0_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
@@ -13294,7 +13223,7 @@ packages:
       rollup-plugin-sourcemaps: 0.4.2_rollup@1.32.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - debug
       - encoding
@@ -13308,7 +13237,7 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
+      '@microsoft/api-extractor': 7.20.0
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-json': 4.1.0_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
@@ -13321,7 +13250,7 @@ packages:
       rollup-plugin-sourcemaps: 0.4.2_rollup@1.32.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - debug
       - encoding
@@ -13335,7 +13264,7 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
+      '@microsoft/api-extractor': 7.20.0
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-json': 4.1.0_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
@@ -13348,7 +13277,7 @@ packages:
       rollup-plugin-sourcemaps: 0.4.2_rollup@1.32.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - debug
       - encoding
@@ -13362,20 +13291,20 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
-      '@rollup/plugin-commonjs': 21.0.2_rollup@2.70.0
-      '@rollup/plugin-json': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-multi-entry': 3.0.1_rollup@2.70.0
-      '@rollup/plugin-node-resolve': 8.4.0_rollup@2.70.0
+      '@microsoft/api-extractor': 7.20.0
+      '@rollup/plugin-commonjs': 21.0.3_rollup@2.70.1
+      '@rollup/plugin-json': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-multi-entry': 3.0.1_rollup@2.70.1
+      '@rollup/plugin-node-resolve': 8.4.0_rollup@2.70.1
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
-      rollup: 2.70.0
-      rollup-plugin-sourcemaps: 0.4.2_rollup@2.70.0
+      rollup: 2.70.1
+      rollup-plugin-sourcemaps: 0.4.2_rollup@2.70.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - debug
       - encoding
@@ -13389,7 +13318,7 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
+      '@microsoft/api-extractor': 7.20.0
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-json': 4.1.0_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
@@ -13402,7 +13331,7 @@ packages:
       rollup-plugin-sourcemaps: 0.4.2_rollup@1.32.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - debug
       - encoding
@@ -13416,7 +13345,7 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
+      '@microsoft/api-extractor': 7.20.0
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-json': 4.1.0_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
@@ -13429,7 +13358,7 @@ packages:
       rollup-plugin-sourcemaps: 0.4.2_rollup@1.32.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - debug
       - encoding
@@ -13443,20 +13372,20 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
-      '@rollup/plugin-commonjs': 21.0.2_rollup@2.70.0
-      '@rollup/plugin-json': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-multi-entry': 3.0.1_rollup@2.70.0
-      '@rollup/plugin-node-resolve': 8.4.0_rollup@2.70.0
+      '@microsoft/api-extractor': 7.20.0
+      '@rollup/plugin-commonjs': 21.0.3_rollup@2.70.1
+      '@rollup/plugin-json': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-multi-entry': 3.0.1_rollup@2.70.1
+      '@rollup/plugin-node-resolve': 8.4.0_rollup@2.70.1
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
-      rollup: 2.70.0
-      rollup-plugin-sourcemaps: 0.4.2_rollup@2.70.0
+      rollup: 2.70.1
+      rollup-plugin-sourcemaps: 0.4.2_rollup@2.70.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - debug
       - encoding
@@ -13470,7 +13399,7 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
+      '@microsoft/api-extractor': 7.20.0
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-json': 4.1.0_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
@@ -13483,7 +13412,7 @@ packages:
       rollup-plugin-sourcemaps: 0.4.2_rollup@1.32.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - debug
       - encoding
@@ -13497,7 +13426,7 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
+      '@microsoft/api-extractor': 7.20.0
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-json': 4.1.0_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
@@ -13510,7 +13439,7 @@ packages:
       rollup-plugin-sourcemaps: 0.4.2_rollup@1.32.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - debug
       - encoding
@@ -13524,20 +13453,20 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
-      '@rollup/plugin-commonjs': 21.0.2_rollup@2.70.0
-      '@rollup/plugin-json': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-multi-entry': 3.0.1_rollup@2.70.0
-      '@rollup/plugin-node-resolve': 8.4.0_rollup@2.70.0
+      '@microsoft/api-extractor': 7.20.0
+      '@rollup/plugin-commonjs': 21.0.3_rollup@2.70.1
+      '@rollup/plugin-json': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-multi-entry': 3.0.1_rollup@2.70.1
+      '@rollup/plugin-node-resolve': 8.4.0_rollup@2.70.1
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
-      rollup: 2.70.0
-      rollup-plugin-sourcemaps: 0.4.2_rollup@2.70.0
+      rollup: 2.70.1
+      rollup-plugin-sourcemaps: 0.4.2_rollup@2.70.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - debug
       - encoding
@@ -13551,7 +13480,7 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
+      '@microsoft/api-extractor': 7.20.0
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-json': 4.1.0_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
@@ -13564,7 +13493,7 @@ packages:
       rollup-plugin-sourcemaps: 0.4.2_rollup@1.32.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - debug
       - encoding
@@ -13578,7 +13507,7 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
+      '@microsoft/api-extractor': 7.20.0
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-json': 4.1.0_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
@@ -13591,7 +13520,7 @@ packages:
       rollup-plugin-sourcemaps: 0.4.2_rollup@1.32.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - debug
       - encoding
@@ -13605,11 +13534,11 @@ packages:
     dependencies:
       '@azure/core-tracing': 1.0.0-preview.13
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
+      '@microsoft/api-extractor': 7.20.0
       '@types/chai': 4.3.0
       '@types/chai-as-promised': 7.1.5
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.46
+      '@types/node': 12.20.47
       buffer: 6.0.3
       chai: 4.3.6
       chai-as-promised: 7.1.1_chai@4.3.6
@@ -13619,9 +13548,9 @@ packages:
       eslint: 7.32.0
       esm: 3.2.25
       inherits: 2.0.4
-      jsrsasign: 10.5.8
+      jsrsasign: 10.5.14
       karma: 6.3.17
-      karma-chrome-launcher: 3.1.0
+      karma-chrome-launcher: 3.1.1
       karma-coverage: 2.2.0
       karma-edge-launcher: 0.4.2_karma@6.3.17
       karma-env-preprocessor: 0.1.1
@@ -13637,11 +13566,11 @@ packages:
       mocha: 7.2.0
       mocha-junit-reporter: 2.0.2_mocha@7.2.0
       nyc: 15.1.0
-      prettier: 2.5.1
+      prettier: 2.6.1
       rimraf: 3.0.2
       safe-buffer: 5.2.1
       source-map-support: 0.5.21
-      ts-node: 10.7.0_be7399ac25415134b30a5f1c20a06532
+      ts-node: 10.7.0_b23b0a2d2a25417b088e86bfb6fd069e
       tslib: 2.3.1
       typescript: 4.2.4
       util: 0.12.4
@@ -13659,14 +13588,12 @@ packages:
     name: '@rush-temp/communication-chat'
     version: 0.0.0
     dependencies:
-      '@azure/communication-common': 1.1.0
-      '@azure/communication-identity': 1.0.0
       '@azure/communication-signaling': 1.0.0-beta.13
       '@azure/core-tracing': 1.0.0-preview.13
-      '@microsoft/api-extractor': 7.19.4
+      '@microsoft/api-extractor': 7.20.0
       '@types/chai': 4.3.0
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.46
+      '@types/node': 12.20.47
       '@types/sinon': 9.0.11
       '@types/uuid': 8.3.4
       chai: 4.3.6
@@ -13676,7 +13603,7 @@ packages:
       events: 3.3.0
       inherits: 2.0.4
       karma: 6.3.17
-      karma-chrome-launcher: 3.1.0
+      karma-chrome-launcher: 3.1.1
       karma-coverage: 2.2.0
       karma-edge-launcher: 0.4.2_karma@6.3.17
       karma-env-preprocessor: 0.1.1
@@ -13691,7 +13618,7 @@ packages:
       mocha: 7.2.0
       mocha-junit-reporter: 2.0.2_mocha@7.2.0
       nyc: 15.1.0
-      prettier: 2.5.1
+      prettier: 2.6.1
       rimraf: 3.0.2
       sinon: 9.2.4
       tslib: 2.3.1
@@ -13712,11 +13639,11 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/core-tracing': 1.0.0-preview.13
-      '@microsoft/api-extractor': 7.19.4
+      '@microsoft/api-extractor': 7.20.0
       '@types/chai': 4.3.0
       '@types/chai-as-promised': 7.1.5
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.46
+      '@types/node': 12.20.47
       '@types/sinon': 9.0.11
       chai: 4.3.6
       chai-as-promised: 7.1.1_chai@4.3.6
@@ -13726,7 +13653,7 @@ packages:
       inherits: 2.0.4
       jwt-decode: 3.1.2
       karma: 6.3.17
-      karma-chrome-launcher: 3.1.0
+      karma-chrome-launcher: 3.1.1
       karma-coverage: 2.2.0
       karma-edge-launcher: 0.4.2_karma@6.3.17
       karma-env-preprocessor: 0.1.1
@@ -13739,7 +13666,7 @@ packages:
       mocha: 7.2.0
       mocha-junit-reporter: 2.0.2_mocha@7.2.0
       nyc: 15.1.0
-      prettier: 2.5.1
+      prettier: 2.6.1
       rimraf: 3.0.2
       sinon: 9.2.4
       tslib: 2.3.1
@@ -13757,14 +13684,12 @@ packages:
     name: '@rush-temp/communication-identity'
     version: 0.0.0
     dependencies:
-      '@azure-tools/test-recorder': 1.0.2
-      '@azure/communication-common': 1.1.0
       '@azure/core-tracing': 1.0.0-preview.13
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
+      '@microsoft/api-extractor': 7.20.0
       '@types/chai': 4.3.0
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.46
+      '@types/node': 12.20.47
       '@types/sinon': 9.0.11
       chai: 4.3.6
       cross-env: 7.0.3
@@ -13773,14 +13698,12 @@ packages:
       events: 3.3.0
       inherits: 2.0.4
       karma: 6.3.17
-      karma-chrome-launcher: 3.1.0
+      karma-chrome-launcher: 3.1.1
       karma-coverage: 2.2.0
       karma-edge-launcher: 0.4.2_karma@6.3.17
       karma-env-preprocessor: 0.1.1
       karma-firefox-launcher: 1.3.0
       karma-ie-launcher: 1.0.0_karma@6.3.17
-      karma-json-preprocessor: 0.3.3_karma@6.3.17
-      karma-json-to-file-reporter: 1.0.1
       karma-junit-reporter: 2.0.1_karma@6.3.17
       karma-mocha: 2.0.1
       karma-mocha-reporter: 2.2.5_karma@6.3.17
@@ -13788,7 +13711,7 @@ packages:
       mocha: 7.2.0
       mocha-junit-reporter: 2.0.2_mocha@7.2.0
       nyc: 15.1.0
-      prettier: 2.5.1
+      prettier: 2.6.1
       rimraf: 3.0.2
       sinon: 9.2.4
       tslib: 2.3.1
@@ -13810,15 +13733,15 @@ packages:
       '@azure/communication-identity': 1.0.0
       '@azure/core-tracing': 1.0.0-preview.13
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
-      '@rollup/plugin-commonjs': 21.0.2_rollup@2.70.0
-      '@rollup/plugin-json': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-multi-entry': 3.0.1_rollup@2.70.0
-      '@rollup/plugin-node-resolve': 8.4.0_rollup@2.70.0
-      '@rollup/plugin-replace': 2.4.2_rollup@2.70.0
+      '@microsoft/api-extractor': 7.20.0
+      '@rollup/plugin-commonjs': 21.0.3_rollup@2.70.1
+      '@rollup/plugin-json': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-multi-entry': 3.0.1_rollup@2.70.1
+      '@rollup/plugin-node-resolve': 8.4.0_rollup@2.70.1
+      '@rollup/plugin-replace': 2.4.2_rollup@2.70.1
       '@types/chai': 4.3.0
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.46
+      '@types/node': 12.20.47
       '@types/sinon': 9.0.11
       chai: 4.3.6
       cross-env: 7.0.3
@@ -13827,7 +13750,7 @@ packages:
       events: 3.3.0
       inherits: 2.0.4
       karma: 6.3.17
-      karma-chrome-launcher: 3.1.0
+      karma-chrome-launcher: 3.1.1
       karma-coverage: 2.2.0
       karma-edge-launcher: 0.4.2_karma@6.3.17
       karma-env-preprocessor: 0.1.1
@@ -13842,13 +13765,13 @@ packages:
       mocha: 7.2.0
       mocha-junit-reporter: 2.0.2_mocha@7.2.0
       nyc: 15.1.0
-      prettier: 2.5.1
+      prettier: 2.6.1
       rimraf: 3.0.2
-      rollup: 2.70.0
+      rollup: 2.70.1
       rollup-plugin-shim: 1.0.0
-      rollup-plugin-sourcemaps: 0.4.2_rollup@2.70.0
-      rollup-plugin-terser: 5.3.1_rollup@2.70.0
-      rollup-plugin-visualizer: 4.2.2_rollup@2.70.0
+      rollup-plugin-sourcemaps: 0.4.2_rollup@2.70.1
+      rollup-plugin-terser: 5.3.1_rollup@2.70.1
+      rollup-plugin-visualizer: 4.2.2_rollup@2.70.1
       sinon: 9.2.4
       tslib: 2.3.1
       typescript: 4.2.4
@@ -13866,13 +13789,12 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
-      '@azure/communication-common': 1.1.0
       '@azure/core-tracing': 1.0.0-preview.13
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
+      '@microsoft/api-extractor': 7.20.0
       '@types/chai': 4.3.0
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.46
+      '@types/node': 12.20.47
       '@types/sinon': 9.0.11
       chai: 4.3.6
       cross-env: 7.0.3
@@ -13881,7 +13803,7 @@ packages:
       events: 3.3.0
       inherits: 2.0.4
       karma: 6.3.17
-      karma-chrome-launcher: 3.1.0
+      karma-chrome-launcher: 3.1.1
       karma-coverage: 2.2.0
       karma-edge-launcher: 0.4.2_karma@6.3.17
       karma-env-preprocessor: 0.1.1
@@ -13896,7 +13818,7 @@ packages:
       mocha: 7.2.0
       mocha-junit-reporter: 2.0.2_mocha@7.2.0
       nyc: 15.1.0
-      prettier: 2.5.1
+      prettier: 2.6.1
       rimraf: 3.0.2
       sinon: 9.2.4
       tslib: 2.3.1
@@ -13915,13 +13837,12 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
-      '@azure/communication-common': 1.1.0
       '@azure/core-tracing': 1.0.0-preview.13
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
+      '@microsoft/api-extractor': 7.20.0
       '@types/chai': 4.3.0
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.46
+      '@types/node': 12.20.47
       '@types/sinon': 9.0.11
       chai: 4.3.6
       cross-env: 7.0.3
@@ -13930,7 +13851,7 @@ packages:
       events: 3.3.0
       inherits: 2.0.4
       karma: 6.3.17
-      karma-chrome-launcher: 3.1.0
+      karma-chrome-launcher: 3.1.1
       karma-coverage: 2.2.0
       karma-edge-launcher: 0.4.2_karma@6.3.17
       karma-env-preprocessor: 0.1.1
@@ -13945,7 +13866,7 @@ packages:
       mocha: 7.2.0
       mocha-junit-reporter: 2.0.2_mocha@7.2.0
       nyc: 15.1.0
-      prettier: 2.5.1
+      prettier: 2.6.1
       rimraf: 3.0.2
       sinon: 9.2.4
       tslib: 2.3.1
@@ -13967,10 +13888,10 @@ packages:
       '@azure/communication-common': 1.1.0
       '@azure/core-tracing': 1.0.0-preview.13
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
+      '@microsoft/api-extractor': 7.20.0
       '@types/chai': 4.3.0
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.46
+      '@types/node': 12.20.47
       '@types/sinon': 9.0.11
       chai: 4.3.6
       cross-env: 7.0.3
@@ -13979,7 +13900,7 @@ packages:
       events: 3.3.0
       inherits: 2.0.4
       karma: 6.3.17
-      karma-chrome-launcher: 3.1.0
+      karma-chrome-launcher: 3.1.1
       karma-coverage: 2.2.0
       karma-edge-launcher: 0.4.2_karma@6.3.17
       karma-env-preprocessor: 0.1.1
@@ -13992,7 +13913,7 @@ packages:
       mocha: 7.2.0
       mocha-junit-reporter: 2.0.2_mocha@7.2.0
       nyc: 15.1.0
-      prettier: 2.5.1
+      prettier: 2.6.1
       rimraf: 3.0.2
       sinon: 9.2.4
       tslib: 2.3.1
@@ -14013,16 +13934,16 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
+      '@microsoft/api-extractor': 7.20.0
       '@types/chai': 4.3.0
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.46
+      '@types/node': 12.20.47
       chai: 4.3.6
       cross-env: 7.0.3
       dotenv: 8.6.0
       eslint: 7.32.0
       karma: 6.3.17
-      karma-chrome-launcher: 3.1.0
+      karma-chrome-launcher: 3.1.1
       karma-coverage: 2.2.0
       karma-edge-launcher: 0.4.2_karma@6.3.17
       karma-env-preprocessor: 0.1.1
@@ -14038,7 +13959,7 @@ packages:
       mocha: 7.2.0
       mocha-junit-reporter: 2.0.2_mocha@7.2.0
       nyc: 15.1.0
-      prettier: 2.5.1
+      prettier: 2.6.1
       rimraf: 3.0.2
       source-map-support: 0.5.21
       tslib: 2.3.1
@@ -14057,12 +13978,11 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/core-tracing': 1.0.0-preview.13
-      '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
+      '@microsoft/api-extractor': 7.20.0
       '@types/chai': 4.3.0
       '@types/chai-as-promised': 7.1.5
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.46
+      '@types/node': 12.20.47
       chai: 4.3.6
       chai-as-promised: 7.1.1_chai@4.3.6
       cross-env: 7.0.3
@@ -14070,7 +13990,7 @@ packages:
       eslint: 7.32.0
       inherits: 2.0.4
       karma: 6.3.17
-      karma-chrome-launcher: 3.1.0
+      karma-chrome-launcher: 3.1.1
       karma-coverage: 2.2.0
       karma-edge-launcher: 0.4.2_karma@6.3.17
       karma-env-preprocessor: 0.1.1
@@ -14083,7 +14003,7 @@ packages:
       mocha: 7.2.0
       mocha-junit-reporter: 2.0.2_mocha@7.2.0
       nyc: 15.1.0
-      prettier: 2.5.1
+      prettier: 2.6.1
       rimraf: 3.0.2
       tslib: 2.3.1
       typescript: 4.2.4
@@ -14100,45 +14020,45 @@ packages:
     name: '@rush-temp/core-amqp'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.19.4
-      '@rollup/plugin-commonjs': 21.0.2_rollup@2.70.0
-      '@rollup/plugin-inject': 4.0.4_rollup@2.70.0
-      '@rollup/plugin-json': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-multi-entry': 3.0.1_rollup@2.70.0
-      '@rollup/plugin-node-resolve': 8.4.0_rollup@2.70.0
-      '@rollup/plugin-replace': 2.4.2_rollup@2.70.0
+      '@microsoft/api-extractor': 7.20.0
+      '@rollup/plugin-commonjs': 21.0.3_rollup@2.70.1
+      '@rollup/plugin-inject': 4.0.4_rollup@2.70.1
+      '@rollup/plugin-json': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-multi-entry': 3.0.1_rollup@2.70.1
+      '@rollup/plugin-node-resolve': 8.4.0_rollup@2.70.1
+      '@rollup/plugin-replace': 2.4.2_rollup@2.70.1
       '@types/chai': 4.3.0
       '@types/debug': 4.1.7
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.46
+      '@types/node': 12.20.47
       '@types/sinon': 9.0.11
       '@types/ws': 7.4.7
       buffer: 6.0.3
       chai: 4.3.6
       cross-env: 7.0.3
-      debug: 4.3.3
+      debug: 4.3.4
       downlevel-dts: 0.8.0
       eslint: 7.32.0
       events: 3.3.0
       jssha: 3.2.0
-      karma: 6.3.17_debug@4.3.3
-      karma-chrome-launcher: 3.1.0
+      karma: 6.3.17_debug@4.3.4
+      karma-chrome-launcher: 3.1.1
       karma-mocha: 2.0.1
       mocha: 7.2.0
       mocha-junit-reporter: 2.0.2_mocha@7.2.0
       nyc: 15.1.0
-      prettier: 2.5.1
+      prettier: 2.6.1
       process: 0.11.10
-      puppeteer: 13.5.1
+      puppeteer: 13.5.2
       rhea: 2.0.8
       rhea-promise: 2.1.0
       rimraf: 3.0.2
-      rollup: 2.70.0
+      rollup: 2.70.1
       rollup-plugin-shim: 1.0.0
-      rollup-plugin-sourcemaps: 0.4.2_rollup@2.70.0
-      rollup-plugin-terser: 5.3.1_rollup@2.70.0
+      rollup-plugin-sourcemaps: 0.4.2_rollup@2.70.1
+      rollup-plugin-terser: 5.3.1_rollup@2.70.1
       sinon: 9.2.4
-      ts-node: 10.7.0_be7399ac25415134b30a5f1c20a06532
+      ts-node: 10.7.0_b23b0a2d2a25417b088e86bfb6fd069e
       tslib: 2.3.1
       typescript: 4.2.4
       url: 0.11.0
@@ -14158,9 +14078,9 @@ packages:
     name: '@rush-temp/core-asynciterator-polyfill'
     version: 0.0.0
     dependencies:
-      '@types/node': 12.20.46
+      '@types/node': 12.20.47
       eslint: 7.32.0
-      prettier: 2.5.1
+      prettier: 2.6.1
       rimraf: 3.0.2
       typescript: 4.2.4
     transitivePeerDependencies:
@@ -14172,10 +14092,10 @@ packages:
     name: '@rush-temp/core-auth'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.19.4
+      '@microsoft/api-extractor': 7.20.0
       '@types/chai': 4.3.0
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.46
+      '@types/node': 12.20.47
       chai: 4.3.6
       cross-env: 7.0.3
       downlevel-dts: 0.8.0
@@ -14183,7 +14103,7 @@ packages:
       inherits: 2.0.4
       mocha: 7.2.0
       mocha-junit-reporter: 2.0.2_mocha@7.2.0
-      prettier: 2.5.1
+      prettier: 2.6.1
       rimraf: 3.0.2
       tslib: 2.3.1
       typescript: 4.2.4
@@ -14198,10 +14118,10 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/core-tracing': 1.0.0-preview.13
-      '@microsoft/api-extractor': 7.19.4
+      '@microsoft/api-extractor': 7.20.0
       '@types/chai': 4.3.0
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.46
+      '@types/node': 12.20.47
       '@types/sinon': 9.0.11
       chai: 4.3.6
       cross-env: 7.0.3
@@ -14209,7 +14129,7 @@ packages:
       eslint: 7.32.0
       inherits: 2.0.4
       karma: 6.3.17
-      karma-chrome-launcher: 3.1.0
+      karma-chrome-launcher: 3.1.1
       karma-coverage: 2.2.0
       karma-edge-launcher: 0.4.2_karma@6.3.17
       karma-env-preprocessor: 0.1.1
@@ -14221,10 +14141,10 @@ packages:
       karma-sourcemap-loader: 0.3.8
       mocha: 7.2.0
       mocha-junit-reporter: 2.0.2_mocha@7.2.0
-      prettier: 2.5.1
+      prettier: 2.6.1
       rimraf: 3.0.2
       sinon: 9.2.4
-      ts-node: 10.7.0_be7399ac25415134b30a5f1c20a06532
+      ts-node: 10.7.0_b23b0a2d2a25417b088e86bfb6fd069e
       tslib: 2.3.1
       typescript: 4.2.4
       util: 0.12.4
@@ -14242,17 +14162,17 @@ packages:
     name: '@rush-temp/core-client'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.19.4
+      '@microsoft/api-extractor': 7.20.0
       '@types/chai': 4.3.0
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.46
+      '@types/node': 12.20.47
       '@types/sinon': 9.0.11
       chai: 4.3.6
       cross-env: 7.0.3
       eslint: 7.32.0
       inherits: 2.0.4
       karma: 6.3.17
-      karma-chrome-launcher: 3.1.0
+      karma-chrome-launcher: 3.1.1
       karma-coverage: 2.2.0
       karma-edge-launcher: 0.4.2_karma@6.3.17
       karma-env-preprocessor: 0.1.1
@@ -14264,7 +14184,7 @@ packages:
       karma-sourcemap-loader: 0.3.8
       mocha: 7.2.0
       mocha-junit-reporter: 2.0.2_mocha@7.2.0
-      prettier: 2.5.1
+      prettier: 2.6.1
       rimraf: 3.0.2
       sinon: 9.2.4
       tslib: 2.3.1
@@ -14281,20 +14201,20 @@ packages:
     name: '@rush-temp/core-crypto'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.19.4
-      '@rollup/plugin-commonjs': 21.0.2_rollup@2.70.0
-      '@rollup/plugin-node-resolve': 8.4.0_rollup@2.70.0
-      '@rollup/plugin-replace': 2.4.2_rollup@2.70.0
+      '@microsoft/api-extractor': 7.20.0
+      '@rollup/plugin-commonjs': 21.0.3_rollup@2.70.1
+      '@rollup/plugin-node-resolve': 8.4.0_rollup@2.70.1
+      '@rollup/plugin-replace': 2.4.2_rollup@2.70.1
       '@types/chai': 4.3.0
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.46
+      '@types/node': 12.20.47
       '@types/sinon': 9.0.11
       chai: 4.3.6
       cross-env: 7.0.3
       downlevel-dts: 0.8.0
       eslint: 7.32.0
       karma: 6.3.17
-      karma-chrome-launcher: 3.1.0
+      karma-chrome-launcher: 3.1.1
       karma-coverage: 2.2.0
       karma-edge-launcher: 0.4.2_karma@6.3.17
       karma-env-preprocessor: 0.1.1
@@ -14306,10 +14226,10 @@ packages:
       karma-sourcemap-loader: 0.3.8
       mocha: 7.2.0
       mocha-junit-reporter: 2.0.2_mocha@7.2.0
-      prettier: 2.5.1
+      prettier: 2.6.1
       rimraf: 3.0.2
-      rollup: 2.70.0
-      rollup-plugin-sourcemaps: 0.4.2_rollup@2.70.0
+      rollup: 2.70.1
+      rollup-plugin-sourcemaps: 0.4.2_rollup@2.70.1
       sinon: 9.2.4
       tslib: 2.3.1
       typescript: 4.2.4
@@ -14325,13 +14245,13 @@ packages:
     name: '@rush-temp/core-http-compat'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.19.4
+      '@microsoft/api-extractor': 7.20.0
       cross-env: 7.0.3
       downlevel-dts: 0.8.0
       eslint: 7.32.0
       mocha: 7.2.0
       mocha-junit-reporter: 2.0.2_mocha@7.2.0
-      prettier: 2.5.1
+      prettier: 2.6.1
       rimraf: 3.0.2
       typescript: 4.2.4
     transitivePeerDependencies:
@@ -14345,20 +14265,19 @@ packages:
     dependencies:
       '@azure/core-tracing': 1.0.0-preview.13
       '@azure/logger-js': 1.3.2
-      '@microsoft/api-extractor': 7.19.4
+      '@microsoft/api-extractor': 7.20.0
       '@opentelemetry/api': 1.0.4
       '@types/chai': 4.3.0
       '@types/express': 4.17.13
       '@types/glob': 7.2.0
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.46
+      '@types/node': 12.20.47
       '@types/node-fetch': 2.6.1
       '@types/sinon': 9.0.11
       '@types/tough-cookie': 4.0.1
       '@types/tunnel': 0.0.3
       '@types/uuid': 8.3.4
       '@types/xml2js': 0.4.9
-      babel-runtime: 6.26.0
       chai: 4.3.6
       cross-env: 7.0.3
       downlevel-dts: 0.8.0
@@ -14369,7 +14288,7 @@ packages:
       glob: 7.2.0
       karma: 6.3.17
       karma-chai: 0.1.0_chai@4.3.6+karma@6.3.17
-      karma-chrome-launcher: 3.1.0
+      karma-chrome-launcher: 3.1.1
       karma-edge-launcher: 0.4.2_karma@6.3.17
       karma-firefox-launcher: 1.3.0
       karma-mocha: 2.0.1
@@ -14379,19 +14298,19 @@ packages:
       node-fetch: 2.6.7
       npm-run-all: 4.1.5
       nyc: 15.1.0
-      prettier: 2.5.1
+      prettier: 2.6.1
       process: 0.11.10
-      puppeteer: 13.5.1
+      puppeteer: 13.5.2
       regenerator-runtime: 0.13.9
       rimraf: 3.0.2
       shx: 0.3.4
       sinon: 9.2.4
       tough-cookie: 4.0.0
-      ts-node: 10.7.0_be7399ac25415134b30a5f1c20a06532
+      ts-node: 10.7.0_b23b0a2d2a25417b088e86bfb6fd069e
       tslib: 2.3.1
       tunnel: 0.0.6
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
       uuid: 8.3.2
       xhr-mock: 2.5.1
       xml2js: 0.4.23
@@ -14411,15 +14330,15 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/core-tracing': 1.0.0-preview.13
-      '@microsoft/api-extractor': 7.19.4
+      '@microsoft/api-extractor': 7.20.0
       '@types/chai': 4.3.0
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.46
+      '@types/node': 12.20.47
       chai: 4.3.6
       cross-env: 7.0.3
       eslint: 7.32.0
       karma: 6.3.17
-      karma-chrome-launcher: 3.1.0
+      karma-chrome-launcher: 3.1.1
       karma-coverage: 2.2.0
       karma-edge-launcher: 0.4.2_karma@6.3.17
       karma-env-preprocessor: 0.1.1
@@ -14433,12 +14352,12 @@ packages:
       mocha-junit-reporter: 2.0.2_mocha@7.2.0
       npm-run-all: 4.1.5
       nyc: 15.1.0
-      prettier: 2.5.1
+      prettier: 2.6.1
       rimraf: 3.0.2
-      ts-node: 10.7.0_be7399ac25415134b30a5f1c20a06532
+      ts-node: 10.7.0_b23b0a2d2a25417b088e86bfb6fd069e
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - '@swc/core'
       - '@swc/wasm'
@@ -14453,15 +14372,15 @@ packages:
     name: '@rush-temp/core-paging'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.19.4
+      '@microsoft/api-extractor': 7.20.0
       '@types/chai': 4.3.0
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.46
+      '@types/node': 12.20.47
       chai: 4.3.6
       downlevel-dts: 0.8.0
       eslint: 7.32.0
       karma: 6.3.17
-      karma-chrome-launcher: 3.1.0
+      karma-chrome-launcher: 3.1.1
       karma-coverage: 2.2.0
       karma-edge-launcher: 0.4.2_karma@6.3.17
       karma-env-preprocessor: 0.1.1
@@ -14473,7 +14392,7 @@ packages:
       karma-sourcemap-loader: 0.3.8
       mocha: 7.2.0
       mocha-junit-reporter: 2.0.2_mocha@7.2.0
-      prettier: 2.5.1
+      prettier: 2.6.1
       rimraf: 3.0.2
       tslib: 2.3.1
       typescript: 4.2.4
@@ -14490,12 +14409,12 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/core-tracing': 1.0.0-preview.13
-      '@microsoft/api-extractor': 7.19.4
+      '@microsoft/api-extractor': 7.20.0
       '@opentelemetry/api': 1.0.4
       '@types/chai': 4.3.0
       '@types/chai-as-promised': 7.1.5
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.46
+      '@types/node': 12.20.47
       '@types/sinon': 9.0.11
       '@types/uuid': 8.3.4
       chai: 4.3.6
@@ -14508,7 +14427,7 @@ packages:
       https-proxy-agent: 5.0.0
       inherits: 2.0.4
       karma: 6.3.17
-      karma-chrome-launcher: 3.1.0
+      karma-chrome-launcher: 3.1.1
       karma-coverage: 2.2.0
       karma-edge-launcher: 0.4.2_karma@6.3.17
       karma-env-preprocessor: 0.1.1
@@ -14520,8 +14439,8 @@ packages:
       karma-sourcemap-loader: 0.3.8
       mocha: 7.2.0
       mocha-junit-reporter: 2.0.2_mocha@7.2.0
-      prettier: 2.5.1
-      puppeteer: 13.5.1
+      prettier: 2.6.1
+      puppeteer: 13.5.2
       rimraf: 3.0.2
       sinon: 9.2.4
       source-map-support: 0.5.21
@@ -14542,17 +14461,17 @@ packages:
     name: '@rush-temp/core-tracing'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.19.4
+      '@microsoft/api-extractor': 7.20.0
       '@types/chai': 4.3.0
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.46
+      '@types/node': 12.20.47
       '@types/sinon': 9.0.11
       chai: 4.3.6
       cross-env: 7.0.3
       eslint: 7.32.0
       inherits: 2.0.4
       karma: 6.3.17
-      karma-chrome-launcher: 3.1.0
+      karma-chrome-launcher: 3.1.1
       karma-coverage: 2.2.0
       karma-edge-launcher: 0.4.2_karma@6.3.17
       karma-env-preprocessor: 0.1.1
@@ -14564,7 +14483,7 @@ packages:
       karma-sourcemap-loader: 0.3.8
       mocha: 7.2.0
       mocha-junit-reporter: 2.0.2_mocha@7.2.0
-      prettier: 2.5.1
+      prettier: 2.6.1
       rimraf: 3.0.2
       sinon: 9.2.4
       tslib: 2.3.1
@@ -14582,10 +14501,10 @@ packages:
     name: '@rush-temp/core-util'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.19.4
+      '@microsoft/api-extractor': 7.20.0
       '@types/chai': 4.3.0
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.46
+      '@types/node': 12.20.47
       '@types/sinon': 9.0.11
       chai: 4.3.6
       cross-env: 7.0.3
@@ -14593,7 +14512,7 @@ packages:
       eslint: 7.32.0
       inherits: 2.0.4
       karma: 6.3.17
-      karma-chrome-launcher: 3.1.0
+      karma-chrome-launcher: 3.1.1
       karma-coverage: 2.2.0
       karma-edge-launcher: 0.4.2_karma@6.3.17
       karma-env-preprocessor: 0.1.1
@@ -14605,7 +14524,7 @@ packages:
       karma-sourcemap-loader: 0.3.8
       mocha: 7.2.0
       mocha-junit-reporter: 2.0.2_mocha@7.2.0
-      prettier: 2.5.1
+      prettier: 2.6.1
       rimraf: 3.0.2
       sinon: 9.2.4
       tslib: 2.3.1
@@ -14623,20 +14542,20 @@ packages:
     name: '@rush-temp/core-xml'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.19.4
+      '@microsoft/api-extractor': 7.20.0
       '@types/chai': 4.3.0
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.46
+      '@types/node': 12.20.47
       '@types/sinon': 9.0.11
       '@types/xml2js': 0.4.9
       chai: 4.3.6
       cross-env: 7.0.3
       downlevel-dts: 0.8.0
       eslint: 7.32.0
-      fast-xml-parser: 4.0.5
+      fast-xml-parser: 4.0.7
       inherits: 2.0.4
       karma: 6.3.17
-      karma-chrome-launcher: 3.1.0
+      karma-chrome-launcher: 3.1.1
       karma-coverage: 2.2.0
       karma-edge-launcher: 0.4.2_karma@6.3.17
       karma-env-preprocessor: 0.1.1
@@ -14648,7 +14567,7 @@ packages:
       karma-sourcemap-loader: 0.3.8
       mocha: 7.2.0
       mocha-junit-reporter: 2.0.2_mocha@7.2.0
-      prettier: 2.5.1
+      prettier: 2.6.1
       rimraf: 3.0.2
       sinon: 9.2.4
       tslib: 2.3.1
@@ -14666,18 +14585,18 @@ packages:
     name: '@rush-temp/cosmos'
     version: 0.0.0
     dependencies:
-      '@azure/identity': 2.0.4_debug@4.3.3
-      '@microsoft/api-extractor': 7.19.4
+      '@azure/identity': 2.0.4_debug@4.3.4
+      '@microsoft/api-extractor': 7.20.0
       '@types/debug': 4.1.7
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.46
+      '@types/node': 12.20.47
       '@types/priorityqueuejs': 1.0.1
       '@types/semaphore': 1.1.1
       '@types/sinon': 9.0.11
       '@types/underscore': 1.11.4
       '@types/uuid': 8.3.4
       cross-env: 7.0.3
-      debug: 4.3.3
+      debug: 4.3.4
       dotenv: 8.6.0
       downlevel-dts: 0.8.0
       eslint: 7.32.0
@@ -14688,14 +14607,14 @@ packages:
       mocha: 7.2.0
       mocha-junit-reporter: 2.0.2_mocha@7.2.0
       node-abort-controller: 3.0.1
-      prettier: 2.5.1
+      prettier: 2.6.1
       priorityqueuejs: 1.0.0
       requirejs: 2.3.6
       rimraf: 3.0.2
       semaphore: 1.1.0
       sinon: 9.2.4
       source-map-support: 0.5.21
-      ts-node: 10.7.0_be7399ac25415134b30a5f1c20a06532
+      ts-node: 10.7.0_b23b0a2d2a25417b088e86bfb6fd069e
       tslib: 2.3.1
       typescript: 4.2.4
       universal-user-agent: 6.0.0
@@ -14711,12 +14630,11 @@ packages:
     name: '@rush-temp/data-tables'
     version: 0.0.0
     dependencies:
-      '@azure/core-tracing': 1.0.0-preview.14
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
+      '@microsoft/api-extractor': 7.20.0
       '@types/chai': 4.3.0
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.46
+      '@types/node': 12.20.47
       '@types/sinon': 9.0.11
       '@types/uuid': 8.3.4
       chai: 4.3.6
@@ -14726,7 +14644,7 @@ packages:
       eslint: 7.32.0
       inherits: 2.0.4
       karma: 6.3.17
-      karma-chrome-launcher: 3.1.0
+      karma-chrome-launcher: 3.1.1
       karma-coverage: 2.2.0
       karma-edge-launcher: 0.4.2_karma@6.3.17
       karma-env-preprocessor: 0.1.1
@@ -14739,10 +14657,10 @@ packages:
       mocha: 7.2.0
       mocha-junit-reporter: 2.0.2_mocha@7.2.0
       nyc: 15.1.0
-      prettier: 2.5.1
+      prettier: 2.6.1
       rimraf: 3.0.2
       sinon: 9.2.4
-      ts-node: 10.7.0_be7399ac25415134b30a5f1c20a06532
+      ts-node: 10.7.0_b23b0a2d2a25417b088e86bfb6fd069e
       tslib: 2.3.1
       typescript: 4.2.4
       util: 0.12.4
@@ -14761,17 +14679,17 @@ packages:
     name: '@rush-temp/dev-tool'
     version: 0.0.0
     dependencies:
-      '@rollup/plugin-commonjs': 21.0.1_rollup@2.70.0
-      '@rollup/plugin-json': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-multi-entry': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-node-resolve': 13.1.3_rollup@2.70.0
+      '@rollup/plugin-commonjs': 21.0.1_rollup@2.70.1
+      '@rollup/plugin-json': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-multi-entry': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-node-resolve': 13.1.3_rollup@2.70.1
       '@types/chai': 4.3.0
       '@types/chai-as-promised': 7.1.5
       '@types/concurrently': 6.4.0
       '@types/fs-extra': 9.0.13
       '@types/minimist': 1.2.2
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.46
+      '@types/node': 12.20.47
       '@types/prettier': 2.4.4
       builtin-modules: 3.2.0
       chai: 4.3.6
@@ -14781,15 +14699,15 @@ packages:
       dotenv: 8.6.0
       eslint: 7.32.0
       fs-extra: 10.0.1
-      minimist: 1.2.5
+      minimist: 1.2.6
       mocha: 7.2.0
-      prettier: 2.5.1
+      prettier: 2.6.1
       rimraf: 3.0.2
-      rollup: 2.70.0
-      rollup-plugin-polyfill-node: 0.8.0_rollup@2.70.0
-      rollup-plugin-sourcemaps: 0.6.3_7b21584653753493578248d33259a4c9
-      rollup-plugin-visualizer: 5.6.0_rollup@2.70.0
-      ts-node: 10.7.0_33a8d453f89e9f3bb66aee69722d1299
+      rollup: 2.70.1
+      rollup-plugin-polyfill-node: 0.8.0_rollup@2.70.1
+      rollup-plugin-sourcemaps: 0.6.3_0b8c6e9127356138a5eb10cf645561b8
+      rollup-plugin-visualizer: 5.6.0_rollup@2.70.1
+      ts-node: 10.7.0_c7b7062e0b9347939444ea76e6e422c3
       tslib: 2.3.1
       typescript: 4.4.4
       yaml: 1.10.2
@@ -14807,10 +14725,10 @@ packages:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/core-tracing': 1.0.0-preview.13
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
+      '@microsoft/api-extractor': 7.20.0
       '@types/chai': 4.3.0
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.46
+      '@types/node': 12.20.47
       '@types/sinon': 9.0.11
       '@types/uuid': 8.3.4
       chai: 4.3.6
@@ -14819,7 +14737,7 @@ packages:
       eslint: 7.32.0
       inherits: 2.0.4
       karma: 6.3.17
-      karma-chrome-launcher: 3.1.0
+      karma-chrome-launcher: 3.1.1
       karma-coverage: 2.2.0
       karma-edge-launcher: 0.4.2_karma@6.3.17
       karma-env-preprocessor: 0.1.1
@@ -14834,7 +14752,7 @@ packages:
       mocha: 7.2.0
       mocha-junit-reporter: 2.0.2_mocha@7.2.0
       nyc: 15.1.0
-      prettier: 2.5.1
+      prettier: 2.6.1
       rimraf: 3.0.2
       sinon: 9.2.4
       tslib: 2.3.1
@@ -14856,14 +14774,14 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@microsoft/api-extractor': 7.7.11
-      '@rollup/plugin-commonjs': 21.0.2_rollup@2.70.0
-      '@rollup/plugin-json': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-multi-entry': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-node-resolve': 13.1.3_rollup@2.70.0
+      '@rollup/plugin-commonjs': 21.0.3_rollup@2.70.1
+      '@rollup/plugin-json': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-multi-entry': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-node-resolve': 13.1.3_rollup@2.70.1
       '@types/chai': 4.3.0
       '@types/chai-as-promised': 7.1.5
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.46
+      '@types/node': 12.20.47
       '@types/sinon': 9.0.11
       chai: 4.3.6
       chai-as-promised: 7.1.1_chai@4.3.6
@@ -14871,7 +14789,7 @@ packages:
       eslint: 7.32.0
       inherits: 2.0.4
       karma: 6.3.17
-      karma-chrome-launcher: 3.1.0
+      karma-chrome-launcher: 3.1.1
       karma-coverage: 2.2.0
       karma-edge-launcher: 0.4.2_karma@6.3.17
       karma-env-preprocessor: 0.1.1
@@ -14887,10 +14805,10 @@ packages:
       nyc: 14.1.1
       prettier: 1.19.1
       rimraf: 3.0.2
-      rollup: 2.70.0
-      rollup-plugin-sourcemaps: 0.6.3_7b21584653753493578248d33259a4c9
-      rollup-plugin-terser: 5.3.1_rollup@2.70.0
-      rollup-plugin-visualizer: 5.6.0_rollup@2.70.0
+      rollup: 2.70.1
+      rollup-plugin-sourcemaps: 0.6.3_0b8c6e9127356138a5eb10cf645561b8
+      rollup-plugin-terser: 5.3.1_rollup@2.70.1
+      rollup-plugin-visualizer: 5.6.0_rollup@2.70.1
       sinon: 9.2.4
       ts-node: 9.1.1_typescript@4.2.4
       tslib: 2.3.1
@@ -14914,9 +14832,9 @@ packages:
       '@types/eslint': 7.2.14
       '@types/estree': 0.0.51
       '@types/glob': 7.2.0
-      '@types/json-schema': 7.0.9
+      '@types/json-schema': 7.0.11
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.46
+      '@types/node': 12.20.47
       '@typescript-eslint/eslint-plugin': 4.19.0_359354e87b989469ccdce12bde18eddc
       '@typescript-eslint/experimental-utils': 4.19.0_eslint@7.32.0+typescript@4.2.4
       '@typescript-eslint/parser': 4.19.0_eslint@7.32.0+typescript@4.2.4
@@ -14933,7 +14851,7 @@ packages:
       json-schema: 0.4.0
       mocha: 7.2.0
       mocha-junit-reporter: 2.0.2_mocha@7.2.0
-      prettier: 2.5.1
+      prettier: 2.6.1
       rimraf: 3.0.2
       source-map-support: 0.5.21
       tslib: 2.3.1
@@ -14947,15 +14865,14 @@ packages:
     name: '@rush-temp/event-hubs'
     version: 0.0.0
     dependencies:
-      '@azure/core-tracing': 1.0.0-preview.14
-      '@azure/identity': 2.0.4_debug@4.3.3
-      '@microsoft/api-extractor': 7.19.4
-      '@rollup/plugin-commonjs': 21.0.2_rollup@2.70.0
-      '@rollup/plugin-inject': 4.0.4_rollup@2.70.0
-      '@rollup/plugin-json': 4.1.0_rollup@2.70.0
-      '@rollup/plugin-multi-entry': 3.0.1_rollup@2.70.0
-      '@rollup/plugin-node-resolve': 8.4.0_rollup@2.70.0
-      '@rollup/plugin-replace': 2.4.2_rollup@2.70.0
+      '@azure/identity': 2.0.4_debug@4.3.4
+      '@microsoft/api-extractor': 7.20.0
+      '@rollup/plugin-commonjs': 21.0.3_rollup@2.70.1
+      '@rollup/plugin-inject': 4.0.4_rollup@2.70.1
+      '@rollup/plugin-json': 4.1.0_rollup@2.70.1
+      '@rollup/plugin-multi-entry': 3.0.1_rollup@2.70.1
+      '@rollup/plugin-node-resolve': 8.4.0_rollup@2.70.1
+      '@rollup/plugin-replace': 2.4.2_rollup@2.70.1
       '@types/async-lock': 1.1.3
       '@types/chai': 4.3.0
       '@types/chai-as-promised': 7.1.5
@@ -14963,7 +14880,7 @@ packages:
       '@types/debug': 4.1.7
       '@types/long': 4.0.1
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.46
+      '@types/node': 12.20.47
       '@types/sinon': 9.0.11
       '@types/uuid': 8.3.4
       '@types/ws': 7.4.7
@@ -14974,7 +14891,7 @@ packages:
       chai-string: 1.5.0_chai@4.3.6
       copyfiles: 2.4.1
       cross-env: 7.0.3
-      debug: 4.3.3
+      debug: 4.3.4
       dotenv: 8.6.0
       downlevel-dts: 0.8.0
       eslint: 7.32.0
@@ -14982,8 +14899,8 @@ packages:
       https-proxy-agent: 5.0.0
       is-buffer: 2.0.5
       jssha: 3.2.0
-      karma: 6.3.17_debug@4.3.3
-      karma-chrome-launcher: 3.1.0
+      karma: 6.3.17_debug@4.3.4
+      karma-chrome-launcher: 3.1.1
       karma-coverage: 2.2.0
       karma-edge-launcher: 0.4.2_karma@6.3.17
       karma-env-preprocessor: 0.1.1
@@ -14997,17 +14914,17 @@ packages:
       mocha-junit-reporter: 2.0.2_mocha@7.2.0
       moment: 2.29.1
       nyc: 15.1.0
-      prettier: 2.5.1
+      prettier: 2.6.1
       process: 0.11.10
-      puppeteer: 13.5.1
+      puppeteer: 13.5.2
       rhea-promise: 2.1.0
       rimraf: 3.0.2
-      rollup: 2.70.0
+      rollup: 2.70.1
       rollup-plugin-shim: 1.0.0
-      rollup-plugin-sourcemaps: 0.4.2_rollup@2.70.0
-      rollup-plugin-terser: 5.3.1_rollup@2.70.0
+      rollup-plugin-sourcemaps: 0.4.2_rollup@2.70.1
+      rollup-plugin-terser: 5.3.1_rollup@2.70.1
       sinon: 9.2.4
-      ts-node: 10.7.0_be7399ac25415134b30a5f1c20a06532
+      ts-node: 10.7.0_b23b0a2d2a25417b088e86bfb6fd069e
       tslib: 2.3.1
       typescript: 4.2.4
       uuid: 8.3.2
@@ -15028,11 +14945,11 @@ packages:
     dependencies:
       '@azure/core-tracing': 1.0.0-preview.13
       '@azure/service-bus': 7.5.1
-      '@microsoft/api-extractor': 7.19.4
+      '@microsoft/api-extractor': 7.20.0
       '@types/chai': 4.3.0
       '@types/chai-as-promised': 7.1.5
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.46
+      '@types/node': 12.20.47
       '@types/sinon': 9.0.11
       '@types/uuid': 8.3.4
       chai: 4.3.6
@@ -15041,7 +14958,7 @@ packages:
       dotenv: 8.6.0
       eslint: 7.32.0
       karma: 6.3.17
-      karma-chrome-launcher: 3.1.0
+      karma-chrome-launcher: 3.1.1
       karma-coverage: 2.2.0
       karma-edge-launcher: 0.4.2_karma@6.3.17
       karma-env-preprocessor: 0.1.1
@@ -15054,11 +14971,11 @@ packages:
       mocha: 7.2.0
       mocha-junit-reporter: 2.0.2_mocha@7.2.0
       nyc: 15.1.0
-      prettier: 2.5.1
+      prettier: 2.6.1
       rimraf: 3.0.2
       sinon: 9.2.4
       source-map-support: 0.5.21
-      ts-node: 10.7.0_be7399ac25415134b30a5f1c20a06532
+      ts-node: 10.7.0_b23b0a2d2a25417b088e86bfb6fd069e
       tslib: 2.3.1
       typescript: 4.2.4
       uuid: 8.3.2
@@ -15077,27 +14994,26 @@ packages:
     name: '@rush-temp/eventhubs-checkpointstore-blob'
     version: 0.0.0
     dependencies:
-      '@azure/storage-blob': 12.8.0
-      '@microsoft/api-extractor': 7.19.4
+      '@microsoft/api-extractor': 7.20.0
       '@types/chai': 4.3.0
       '@types/chai-as-promised': 7.1.5
       '@types/chai-string': 1.4.2
       '@types/debug': 4.1.7
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.46
+      '@types/node': 12.20.47
       chai: 4.3.6
       chai-as-promised: 7.1.1_chai@4.3.6
       chai-string: 1.5.0_chai@4.3.6
       cross-env: 7.0.3
-      debug: 4.3.3
+      debug: 4.3.4
       dotenv: 8.6.0
       eslint: 7.32.0
       esm: 3.2.25
       events: 3.3.0
       guid-typescript: 1.0.9
       inherits: 2.0.4
-      karma: 6.3.17_debug@4.3.3
-      karma-chrome-launcher: 3.1.0
+      karma: 6.3.17_debug@4.3.4
+      karma-chrome-launcher: 3.1.1
       karma-coverage: 2.2.0
       karma-edge-launcher: 0.4.2_karma@6.3.17
       karma-env-preprocessor: 0.1.1
@@ -15110,9 +15026,9 @@ packages:
       mocha: 7.2.0
       mocha-junit-reporter: 2.0.2_mocha@7.2.0
       nyc: 15.1.0
-      prettier: 2.5.1
+      prettier: 2.6.1
       rimraf: 3.0.2
-      ts-node: 10.7.0_be7399ac25415134b30a5f1c20a06532
+      ts-node: 10.7.0_b23b0a2d2a25417b088e86bfb6fd069e
       tslib: 2.3.1
       typescript: 4.2.4
       util: 0.12.4
@@ -15131,25 +15047,25 @@ packages:
     dependencies:
       '@azure/data-tables': 12.1.2
       '@azure/event-hubs': 5.7.0
-      '@microsoft/api-extractor': 7.19.4
+      '@microsoft/api-extractor': 7.20.0
       '@types/chai': 4.3.0
       '@types/chai-as-promised': 7.1.5
       '@types/chai-string': 1.4.2
       '@types/debug': 4.1.7
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.46
+      '@types/node': 12.20.47
       chai: 4.3.6
       chai-as-promised: 7.1.1_chai@4.3.6
       chai-string: 1.5.0_chai@4.3.6
       cross-env: 7.0.3
-      debug: 4.3.3
+      debug: 4.3.4
       dotenv: 8.6.0
       eslint: 7.32.0
       esm: 3.2.25
       guid-typescript: 1.0.9
       inherits: 2.0.4
-      karma: 6.3.17_debug@4.3.3
-      karma-chrome-launcher: 3.1.0
+      karma: 6.3.17_debug@4.3.4
+      karma-chrome-launcher: 3.1.1
       karma-coverage: 2.2.0
       karma-edge-launcher: 0.4.2_karma@6.3.17
       karma-env-preprocessor: 0.1.1
@@ -15162,9 +15078,9 @@ packages:
       mocha: 7.2.0
       mocha-junit-reporter: 2.0.2_mocha@7.2.0
       nyc: 15.1.0
-      prettier: 2.5.1
+      prettier: 2.6.1
       rimraf: 3.0.2
-      ts-node: 10.7.0_be7399ac25415134b30a5f1c20a06532
+      ts-node: 10.7.0_b23b0a2d2a25417b088e86bfb6fd069e
       tslib: 2.3.1
       typescript: 4.2.4
       util: 0.12.4
@@ -15181,13 +15097,12 @@ packages:
     name: '@rush-temp/identity-cache-persistence'
     version: 0.0.0
     dependencies:
-      '@azure-tools/test-recorder': 1.0.2
-      '@azure/msal-node': 1.6.0
+      '@azure/msal-node': 1.7.0
       '@azure/msal-node-extensions': 1.0.0-alpha.13
-      '@microsoft/api-extractor': 7.19.4
+      '@microsoft/api-extractor': 7.20.0
       '@types/jws': 3.2.4
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.46
+      '@types/node': 12.20.47
       '@types/qs': 6.9.7
       '@types/sinon': 9.0.11
       cross-env: 7.0.3
@@ -15197,8 +15112,8 @@ packages:
       keytar: 7.9.0
       mocha: 7.2.0
       mocha-junit-reporter: 2.0.2_mocha@7.2.0
-      prettier: 2.5.1
-      puppeteer: 13.5.1
+      prettier: 2.6.1
+      puppeteer: 13.5.2
       rimraf: 3.0.2
       sinon: 9.2.4
       tslib: 2.3.1
@@ -15217,11 +15132,10 @@ packages:
     name: '@rush-temp/identity-vscode'
     version: 0.0.0
     dependencies:
-      '@azure-tools/test-recorder': 1.0.2
-      '@microsoft/api-extractor': 7.19.4
+      '@microsoft/api-extractor': 7.20.0
       '@types/jws': 3.2.4
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.46
+      '@types/node': 12.20.47
       '@types/qs': 6.9.7
       '@types/sinon': 9.0.11
       '@types/uuid': 8.3.4
@@ -15232,8 +15146,8 @@ packages:
       keytar: 7.9.0
       mocha: 7.2.0
       mocha-junit-reporter: 2.0.2_mocha@7.2.0
-      prettier: 2.5.1
-      puppeteer: 13.5.1
+      prettier: 2.6.1
+      puppeteer: 13.5.2
       rimraf: 3.0.2
       sinon: 9.2.4
       tslib: 2.3.1
@@ -15251,17 +15165,16 @@ packages:
     name: '@rush-temp/identity'
     version: 0.0.0
     dependencies:
-      '@azure-tools/test-recorder': 1.0.2
       '@azure/core-tracing': 1.0.0-preview.13
       '@azure/keyvault-keys': 4.2.0
-      '@azure/msal-browser': 2.22.0
+      '@azure/msal-browser': 2.22.1
       '@azure/msal-common': 4.5.1
-      '@azure/msal-node': 1.6.0
-      '@microsoft/api-extractor': 7.19.4
+      '@azure/msal-node': 1.7.0
+      '@microsoft/api-extractor': 7.20.0
       '@types/chai': 4.3.0
       '@types/jws': 3.2.4
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.46
+      '@types/node': 12.20.47
       '@types/sinon': 9.0.11
       '@types/stoppable': 1.1.1
       '@types/uuid': 8.3.4
@@ -15273,7 +15186,7 @@ packages:
       inherits: 2.0.4
       jws: 4.0.0
       karma: 6.3.17
-      karma-chrome-launcher: 3.1.0
+      karma-chrome-launcher: 3.1.1
       karma-coverage: 2.2.0
       karma-env-preprocessor: 0.1.1
       karma-junit-reporter: 2.0.1_karma@6.3.17
@@ -15284,8 +15197,8 @@ packages:
       mocha-junit-reporter: 2.0.2_mocha@7.2.0
       nyc: 15.1.0
       open: 8.4.0
-      prettier: 2.5.1
-      puppeteer: 13.5.1
+      prettier: 2.6.1
+      puppeteer: 13.5.2
       rimraf: 3.0.2
       sinon: 9.2.4
       stoppable: 1.1.0
@@ -15307,16 +15220,16 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
+      '@microsoft/api-extractor': 7.20.0
       '@types/chai': 4.3.0
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.46
+      '@types/node': 12.20.47
       chai: 4.3.6
       cross-env: 7.0.3
       dotenv: 8.6.0
       eslint: 7.32.0
       karma: 6.3.17
-      karma-chrome-launcher: 3.1.0
+      karma-chrome-launcher: 3.1.1
       karma-coverage: 2.2.0
       karma-edge-launcher: 0.4.2_karma@6.3.17
       karma-env-preprocessor: 0.1.1
@@ -15352,10 +15265,10 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/core-tracing': 1.0.0-preview.13
-      '@microsoft/api-extractor': 7.19.4
+      '@microsoft/api-extractor': 7.20.0
       '@types/chai': 4.3.0
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.46
+      '@types/node': 12.20.47
       '@types/sinon': 9.0.11
       chai: 4.3.6
       cross-env: 7.0.3
@@ -15363,7 +15276,7 @@ packages:
       events: 3.3.0
       inherits: 2.0.4
       karma: 6.3.17
-      karma-chrome-launcher: 3.1.0
+      karma-chrome-launcher: 3.1.1
       karma-coverage: 2.2.0
       karma-edge-launcher: 0.4.2_karma@6.3.17
       karma-env-preprocessor: 0.1.1
@@ -15377,10 +15290,10 @@ packages:
       mocha: 7.2.0
       mocha-junit-reporter: 2.0.2_mocha@7.2.0
       nyc: 15.1.0
-      prettier: 2.5.1
+      prettier: 2.6.1
       rimraf: 3.0.2
       sinon: 9.2.4
-      ts-node: 10.7.0_be7399ac25415134b30a5f1c20a06532
+      ts-node: 10.7.0_b23b0a2d2a25417b088e86bfb6fd069e
       tslib: 2.3.1
       typescript: 4.2.4
       util: 0.12.4
@@ -15399,12 +15312,11 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
-      '@azure/core-tracing': 1.0.0-preview.13
       '@azure/identity': 2.0.4
-      '@azure/keyvault-keys': 4.3.0
-      '@microsoft/api-extractor': 7.19.4
+      '@azure/keyvault-keys': 4.4.0
+      '@microsoft/api-extractor': 7.20.0
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.46
+      '@types/node': 12.20.47
       '@types/sinon': 9.0.11
       '@types/uuid': 8.3.4
       cross-env: 7.0.3
@@ -15414,7 +15326,7 @@ packages:
       mocha: 7.2.0
       mocha-junit-reporter: 2.0.2_mocha@7.2.0
       nyc: 15.1.0
-      prettier: 2.5.1
+      prettier: 2.6.1
       rimraf: 3.0.2
       sinon: 9.2.4
       source-map-support: 0.5.21
@@ -15433,19 +15345,17 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
-      '@azure/core-tracing': 1.0.0-preview.13
-      '@azure/identity': 2.0.4
       '@azure/keyvault-secrets': 4.4.0
-      '@microsoft/api-extractor': 7.19.4
+      '@microsoft/api-extractor': 7.20.0
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.46
+      '@types/node': 12.20.47
       '@types/sinon': 9.0.11
       cross-env: 7.0.3
       dotenv: 8.6.0
       eslint: 7.32.0
       esm: 3.2.25
       karma: 6.3.17
-      karma-chrome-launcher: 3.1.0
+      karma-chrome-launcher: 3.1.1
       karma-coverage: 2.2.0
       karma-edge-launcher: 0.4.2_karma@6.3.17
       karma-env-preprocessor: 0.1.1
@@ -15460,8 +15370,8 @@ packages:
       mocha: 7.2.0
       mocha-junit-reporter: 2.0.2_mocha@7.2.0
       nyc: 15.1.0
-      prettier: 2.5.1
-      puppeteer: 13.5.1
+      prettier: 2.6.1
+      puppeteer: 13.5.2
       rimraf: 3.0.2
       sinon: 9.2.4
       source-map-support: 0.5.21
@@ -15481,9 +15391,8 @@ packages:
     name: '@rush-temp/keyvault-common'
     version: 0.0.0
     dependencies:
-      '@azure/core-tracing': 1.0.0-preview.13
       eslint: 7.32.0
-      prettier: 2.5.1
+      prettier: 2.6.1
       rimraf: 3.0.2
       tslib: 2.3.1
       typescript: 4.2.4
@@ -15497,19 +15406,17 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
-      '@azure/core-tracing': 1.0.0-preview.13
-      '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
+      '@microsoft/api-extractor': 7.20.0
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.46
+      '@types/node': 12.20.47
       '@types/sinon': 9.0.11
       cross-env: 7.0.3
-      dayjs: 1.10.8
+      dayjs: 1.11.0
       dotenv: 8.6.0
       eslint: 7.32.0
       esm: 3.2.25
       karma: 6.3.17
-      karma-chrome-launcher: 3.1.0
+      karma-chrome-launcher: 3.1.1
       karma-coverage: 2.2.0
       karma-edge-launcher: 0.4.2_karma@6.3.17
       karma-env-preprocessor: 0.1.1
@@ -15524,8 +15431,8 @@ packages:
       mocha: 7.2.0
       mocha-junit-reporter: 2.0.2_mocha@7.2.0
       nyc: 15.1.0
-      prettier: 2.5.1
-      puppeteer: 13.5.1
+      prettier: 2.6.1
+      puppeteer: 13.5.2
       rimraf: 3.0.2
       sinon: 9.2.4
       source-map-support: 0.5.21
@@ -15546,18 +15453,16 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
-      '@azure/core-tracing': 1.0.0-preview.13
-      '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
+      '@microsoft/api-extractor': 7.20.0
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.46
+      '@types/node': 12.20.47
       '@types/sinon': 9.0.11
       cross-env: 7.0.3
       dotenv: 8.6.0
       eslint: 7.32.0
       esm: 3.2.25
       karma: 6.3.17
-      karma-chrome-launcher: 3.1.0
+      karma-chrome-launcher: 3.1.1
       karma-coverage: 2.2.0
       karma-edge-launcher: 0.4.2_karma@6.3.17
       karma-env-preprocessor: 0.1.1
@@ -15572,8 +15477,8 @@ packages:
       mocha: 7.2.0
       mocha-junit-reporter: 2.0.2_mocha@7.2.0
       nyc: 15.1.0
-      prettier: 2.5.1
-      puppeteer: 13.5.1
+      prettier: 2.6.1
+      puppeteer: 13.5.2
       rimraf: 3.0.2
       sinon: 9.2.4
       source-map-support: 0.5.21
@@ -15593,10 +15498,10 @@ packages:
     name: '@rush-temp/logger'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.19.4
+      '@microsoft/api-extractor': 7.20.0
       '@types/chai': 4.3.0
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.46
+      '@types/node': 12.20.47
       '@types/sinon': 9.0.11
       chai: 4.3.6
       cross-env: 7.0.3
@@ -15604,7 +15509,7 @@ packages:
       dotenv: 8.6.0
       eslint: 7.32.0
       karma: 6.3.17
-      karma-chrome-launcher: 3.1.0
+      karma-chrome-launcher: 3.1.1
       karma-coverage: 2.2.0
       karma-edge-launcher: 0.4.2_karma@6.3.17
       karma-env-preprocessor: 0.1.1
@@ -15617,11 +15522,11 @@ packages:
       mocha: 7.2.0
       mocha-junit-reporter: 2.0.2_mocha@7.2.0
       nyc: 15.1.0
-      prettier: 2.5.1
-      puppeteer: 13.5.1
+      prettier: 2.6.1
+      puppeteer: 13.5.2
       rimraf: 3.0.2
       sinon: 9.2.4
-      ts-node: 10.7.0_be7399ac25415134b30a5f1c20a06532
+      ts-node: 10.7.0_b23b0a2d2a25417b088e86bfb6fd069e
       tslib: 2.3.1
       typescript: 4.2.4
     transitivePeerDependencies:
@@ -15641,11 +15546,11 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/core-tracing': 1.0.0-preview.13
-      '@microsoft/api-extractor': 7.19.4
+      '@microsoft/api-extractor': 7.20.0
       '@types/chai': 4.3.0
       '@types/chai-as-promised': 7.1.5
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.46
+      '@types/node': 12.20.47
       chai: 4.3.6
       chai-as-promised: 7.1.1_chai@4.3.6
       cross-env: 7.0.3
@@ -15653,7 +15558,7 @@ packages:
       eslint: 7.32.0
       inherits: 2.0.4
       karma: 6.3.17
-      karma-chrome-launcher: 3.1.0
+      karma-chrome-launcher: 3.1.1
       karma-coverage: 2.2.0
       karma-edge-launcher: 0.4.2_karma@6.3.17
       karma-env-preprocessor: 0.1.1
@@ -15668,7 +15573,7 @@ packages:
       mocha: 7.2.0
       mocha-junit-reporter: 2.0.2_mocha@7.2.0
       nyc: 15.1.0
-      prettier: 2.5.1
+      prettier: 2.6.1
       rimraf: 3.0.2
       tslib: 2.3.1
       typescript: 4.2.4
@@ -15688,11 +15593,11 @@ packages:
     dependencies:
       '@azure/core-tracing': 1.0.0-preview.13
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
+      '@microsoft/api-extractor': 7.20.0
       '@types/chai': 4.3.0
       '@types/chai-as-promised': 7.1.5
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.46
+      '@types/node': 12.20.47
       '@types/uuid': 8.3.4
       chai: 4.3.6
       chai-as-promised: 7.1.1_chai@4.3.6
@@ -15701,7 +15606,7 @@ packages:
       eslint: 7.32.0
       inherits: 2.0.4
       karma: 6.3.17
-      karma-chrome-launcher: 3.1.0
+      karma-chrome-launcher: 3.1.1
       karma-coverage: 2.2.0
       karma-edge-launcher: 0.4.2_karma@6.3.17
       karma-env-preprocessor: 0.1.1
@@ -15715,7 +15620,7 @@ packages:
       mocha: 7.2.0
       mocha-junit-reporter: 2.0.2_mocha@7.2.0
       nyc: 15.1.0
-      prettier: 2.5.1
+      prettier: 2.6.1
       rimraf: 3.0.2
       tslib: 2.3.1
       typescript: 4.2.4
@@ -15733,10 +15638,10 @@ packages:
     name: '@rush-temp/mock-hub'
     version: 0.0.0
     dependencies:
-      '@types/node': 12.20.46
+      '@types/node': 12.20.47
       dotenv: 8.6.0
       eslint: 7.32.0
-      prettier: 2.5.1
+      prettier: 2.6.1
       rhea: 2.0.8
       rimraf: 3.0.2
       tslib: 2.3.1
@@ -15750,7 +15655,7 @@ packages:
     name: '@rush-temp/monitor-opentelemetry-exporter'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.19.4
+      '@microsoft/api-extractor': 7.20.0
       '@opentelemetry/api': 1.0.4
       '@opentelemetry/core': 1.0.1_@opentelemetry+api@1.0.4
       '@opentelemetry/instrumentation': 0.27.0_@opentelemetry+api@1.0.4
@@ -15762,7 +15667,7 @@ packages:
       '@opentelemetry/semantic-conventions': 1.0.1
       '@opentelemetry/tracing': 0.24.0_@opentelemetry+api@1.0.4
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.46
+      '@types/node': 12.20.47
       dotenv: 8.6.0
       eslint: 7.32.0
       eslint-plugin-node: 11.1.0_eslint@7.32.0
@@ -15770,10 +15675,10 @@ packages:
       mocha: 7.2.0
       nock: 12.0.3
       nyc: 15.1.0
-      prettier: 2.5.1
+      prettier: 2.6.1
       rimraf: 3.0.2
       sinon: 9.2.4
-      ts-node: 10.7.0_be7399ac25415134b30a5f1c20a06532
+      ts-node: 10.7.0_b23b0a2d2a25417b088e86bfb6fd069e
       tslib: 2.3.1
       typescript: 4.2.4
     transitivePeerDependencies:
@@ -15790,14 +15695,14 @@ packages:
       '@azure/core-tracing': 1.0.0-preview.13
       '@azure/identity': 2.0.4
       '@azure/monitor-opentelemetry-exporter': 1.0.0-beta.4
-      '@microsoft/api-extractor': 7.19.4
+      '@microsoft/api-extractor': 7.20.0
       '@opentelemetry/api': 1.0.4
       '@opentelemetry/node': 0.24.0_@opentelemetry+api@1.0.4
       '@opentelemetry/tracing': 0.24.0_@opentelemetry+api@1.0.4
       '@types/chai': 4.3.0
       '@types/chai-as-promised': 7.1.5
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.46
+      '@types/node': 12.20.47
       chai: 4.3.6
       chai-as-promised: 7.1.1_chai@4.3.6
       cross-env: 7.0.3
@@ -15807,7 +15712,7 @@ packages:
       esm: 3.2.25
       inherits: 2.0.4
       karma: 6.3.17
-      karma-chrome-launcher: 3.1.0
+      karma-chrome-launcher: 3.1.1
       karma-coverage: 2.2.0
       karma-edge-launcher: 0.4.2_karma@6.3.17
       karma-env-preprocessor: 0.1.1
@@ -15819,7 +15724,7 @@ packages:
       mocha: 7.2.0
       mocha-junit-reporter: 2.0.2_mocha@7.2.0
       nyc: 15.1.0
-      prettier: 2.5.1
+      prettier: 2.6.1
       rimraf: 3.0.2
       source-map-support: 0.5.21
       tslib: 2.3.1
@@ -15838,8 +15743,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
-      '@azure/core-tracing': 1.0.0-preview.14
-      '@microsoft/api-extractor': 7.19.4
+      '@microsoft/api-extractor': 7.20.0
       '@opentelemetry/api': 1.0.4
       '@opentelemetry/core': 1.0.1_@opentelemetry+api@1.0.4
       '@opentelemetry/instrumentation': 0.27.0_@opentelemetry+api@1.0.4
@@ -15847,7 +15751,7 @@ packages:
       '@opentelemetry/sdk-trace-node': 1.0.1_@opentelemetry+api@1.0.4
       '@types/chai': 4.3.0
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.46
+      '@types/node': 12.20.47
       '@types/sinon': 10.0.11
       chai: 4.3.6
       cross-env: 7.0.3
@@ -15857,7 +15761,7 @@ packages:
       esm: 3.2.25
       inherits: 2.0.4
       karma: 6.3.17
-      karma-chrome-launcher: 3.1.0
+      karma-chrome-launcher: 3.1.1
       karma-coverage: 2.2.0
       karma-edge-launcher: 0.4.2_karma@6.3.17
       karma-env-preprocessor: 0.1.1
@@ -15871,7 +15775,7 @@ packages:
       mocha: 7.2.0
       mocha-junit-reporter: 1.23.3_mocha@7.2.0
       nyc: 14.1.1
-      prettier: 2.5.1
+      prettier: 2.6.1
       rimraf: 3.0.2
       sinon: 12.0.1
       source-map-support: 0.5.21
@@ -15894,12 +15798,12 @@ packages:
     dependencies:
       '@azure/ai-form-recognizer': 3.1.0-beta.3
       '@azure/identity': 2.0.4
-      '@types/node': 12.20.46
+      '@types/node': 12.20.47
       dotenv: 8.6.0
       eslint: 7.32.0
-      prettier: 2.5.1
+      prettier: 2.6.1
       rimraf: 3.0.2
-      ts-node: 10.7.0_be7399ac25415134b30a5f1c20a06532
+      ts-node: 10.7.0_b23b0a2d2a25417b088e86bfb6fd069e
       tslib: 2.3.1
       typescript: 4.2.4
     transitivePeerDependencies:
@@ -15916,12 +15820,12 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/ai-metrics-advisor': 1.0.0-beta.3
-      '@types/node': 12.20.46
+      '@types/node': 12.20.47
       dotenv: 8.6.0
       eslint: 7.32.0
-      prettier: 2.5.1
+      prettier: 2.6.1
       rimraf: 3.0.2
-      ts-node: 10.7.0_be7399ac25415134b30a5f1c20a06532
+      ts-node: 10.7.0_b23b0a2d2a25417b088e86bfb6fd069e
       tslib: 2.3.1
       typescript: 4.2.4
     transitivePeerDependencies:
@@ -15938,12 +15842,12 @@ packages:
     dependencies:
       '@azure/ai-text-analytics': 5.1.0
       '@azure/identity': 2.0.4
-      '@types/node': 12.20.46
+      '@types/node': 12.20.47
       dotenv: 8.6.0
       eslint: 7.32.0
-      prettier: 2.5.1
+      prettier: 2.6.1
       rimraf: 3.0.2
-      ts-node: 10.7.0_be7399ac25415134b30a5f1c20a06532
+      ts-node: 10.7.0_b23b0a2d2a25417b088e86bfb6fd069e
       tslib: 2.3.1
       typescript: 4.2.4
     transitivePeerDependencies:
@@ -15959,13 +15863,13 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/app-configuration': 1.3.1
-      '@types/node': 12.20.46
+      '@types/node': 12.20.47
       '@types/uuid': 8.3.4
       dotenv: 8.6.0
       eslint: 7.32.0
-      prettier: 2.5.1
+      prettier: 2.6.1
       rimraf: 3.0.2
-      ts-node: 10.7.0_be7399ac25415134b30a5f1c20a06532
+      ts-node: 10.7.0_b23b0a2d2a25417b088e86bfb6fd069e
       tslib: 2.3.1
       typescript: 4.2.4
       uuid: 8.3.2
@@ -15981,11 +15885,10 @@ packages:
     name: '@rush-temp/perf-container-registry'
     version: 0.0.0
     dependencies:
-      '@azure/container-registry': 1.0.0-beta.4
-      '@types/node': 12.20.46
+      '@types/node': 12.20.47
       dotenv: 8.6.0
       eslint: 7.32.0
-      prettier: 2.5.1
+      prettier: 2.6.1
       rimraf: 3.0.2
       ts-node: 9.1.1_typescript@4.2.4
       tslib: 2.3.1
@@ -15999,13 +15902,13 @@ packages:
     name: '@rush-temp/perf-core-rest-pipeline'
     version: 0.0.0
     dependencies:
-      '@types/node': 12.20.46
+      '@types/node': 12.20.47
       '@types/uuid': 8.3.4
       dotenv: 8.6.0
       eslint: 7.32.0
-      prettier: 2.5.1
+      prettier: 2.6.1
       rimraf: 3.0.2
-      ts-node: 10.7.0_be7399ac25415134b30a5f1c20a06532
+      ts-node: 10.7.0_b23b0a2d2a25417b088e86bfb6fd069e
       tslib: 2.3.1
       typescript: 4.2.4
     transitivePeerDependencies:
@@ -16019,13 +15922,13 @@ packages:
     name: '@rush-temp/perf-data-tables'
     version: 0.0.0
     dependencies:
-      '@types/node': 12.20.46
+      '@types/node': 12.20.47
       '@types/uuid': 8.3.4
       dotenv: 8.6.0
       eslint: 7.32.0
-      prettier: 2.5.1
+      prettier: 2.6.1
       rimraf: 3.0.2
-      ts-node: 10.7.0_be7399ac25415134b30a5f1c20a06532
+      ts-node: 10.7.0_b23b0a2d2a25417b088e86bfb6fd069e
       tslib: 2.3.1
       typescript: 4.2.4
       uuid: 8.3.2
@@ -16041,14 +15944,14 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/event-hubs': 5.7.0
-      '@types/node': 12.20.46
+      '@types/node': 12.20.47
       '@types/uuid': 8.3.4
       dotenv: 8.6.0
       eslint: 7.32.0
       moment: 2.29.1
-      prettier: 2.5.1
+      prettier: 2.6.1
       rimraf: 3.0.2
-      ts-node: 10.7.0_be7399ac25415134b30a5f1c20a06532
+      ts-node: 10.7.0_b23b0a2d2a25417b088e86bfb6fd069e
       tslib: 2.3.1
       typescript: 4.2.4
       uuid: 8.3.2
@@ -16063,12 +15966,12 @@ packages:
     name: '@rush-temp/perf-eventgrid'
     version: 0.0.0
     dependencies:
-      '@types/node': 12.20.46
+      '@types/node': 12.20.47
       dotenv: 8.6.0
       eslint: 7.32.0
-      prettier: 2.5.1
+      prettier: 2.6.1
       rimraf: 3.0.2
-      ts-node: 10.7.0_be7399ac25415134b30a5f1c20a06532
+      ts-node: 10.7.0_b23b0a2d2a25417b088e86bfb6fd069e
       tslib: 2.3.1
       typescript: 4.2.4
     transitivePeerDependencies:
@@ -16083,13 +15986,13 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.0.4
-      '@types/node': 12.20.46
+      '@types/node': 12.20.47
       '@types/uuid': 8.3.4
       dotenv: 8.6.0
       eslint: 7.32.0
-      prettier: 2.5.1
+      prettier: 2.6.1
       rimraf: 3.0.2
-      ts-node: 10.7.0_be7399ac25415134b30a5f1c20a06532
+      ts-node: 10.7.0_b23b0a2d2a25417b088e86bfb6fd069e
       tslib: 2.3.1
       typescript: 4.2.4
     transitivePeerDependencies:
@@ -16105,14 +16008,14 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.0.4
-      '@azure/keyvault-certificates': 4.3.0
-      '@types/node': 12.20.46
+      '@azure/keyvault-certificates': 4.4.0
+      '@types/node': 12.20.47
       '@types/uuid': 8.3.4
       dotenv: 8.6.0
       eslint: 7.32.0
-      prettier: 2.5.1
+      prettier: 2.6.1
       rimraf: 3.0.2
-      ts-node: 10.7.0_be7399ac25415134b30a5f1c20a06532
+      ts-node: 10.7.0_b23b0a2d2a25417b088e86bfb6fd069e
       tslib: 2.3.1
       typescript: 4.2.4
       uuid: 8.3.2
@@ -16130,14 +16033,14 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.0.4
-      '@azure/keyvault-keys': 4.3.0
-      '@types/node': 12.20.46
+      '@azure/keyvault-keys': 4.4.0
+      '@types/node': 12.20.47
       '@types/uuid': 8.3.4
       dotenv: 8.6.0
       eslint: 7.32.0
-      prettier: 2.5.1
+      prettier: 2.6.1
       rimraf: 3.0.2
-      ts-node: 10.7.0_be7399ac25415134b30a5f1c20a06532
+      ts-node: 10.7.0_b23b0a2d2a25417b088e86bfb6fd069e
       tslib: 2.3.1
       typescript: 4.2.4
       uuid: 8.3.2
@@ -16156,13 +16059,13 @@ packages:
     dependencies:
       '@azure/identity': 2.0.4
       '@azure/keyvault-secrets': 4.4.0
-      '@types/node': 12.20.46
+      '@types/node': 12.20.47
       '@types/uuid': 8.3.4
       dotenv: 8.6.0
       eslint: 7.32.0
-      prettier: 2.5.1
+      prettier: 2.6.1
       rimraf: 3.0.2
-      ts-node: 10.7.0_be7399ac25415134b30a5f1c20a06532
+      ts-node: 10.7.0_b23b0a2d2a25417b088e86bfb6fd069e
       tslib: 2.3.1
       typescript: 4.2.4
       uuid: 8.3.2
@@ -16180,12 +16083,12 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.0.4
-      '@types/node': 12.20.46
+      '@types/node': 12.20.47
       dotenv: 8.6.0
       eslint: 7.32.0
-      prettier: 2.5.1
+      prettier: 2.6.1
       rimraf: 3.0.2
-      ts-node: 10.7.0_be7399ac25415134b30a5f1c20a06532
+      ts-node: 10.7.0_b23b0a2d2a25417b088e86bfb6fd069e
       tslib: 2.3.1
       typescript: 4.2.4
     transitivePeerDependencies:
@@ -16201,12 +16104,12 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.0.4
-      '@types/node': 12.20.46
+      '@types/node': 12.20.47
       dotenv: 8.6.0
       eslint: 7.32.0
-      prettier: 2.5.1
+      prettier: 2.6.1
       rimraf: 3.0.2
-      ts-node: 10.7.0_be7399ac25415134b30a5f1c20a06532
+      ts-node: 10.7.0_b23b0a2d2a25417b088e86bfb6fd069e
       tslib: 2.3.1
       typescript: 4.2.4
     transitivePeerDependencies:
@@ -16223,12 +16126,12 @@ packages:
     dependencies:
       '@azure/identity': 2.0.4
       '@azure/search-documents': 11.3.0-beta.7
-      '@types/node': 12.20.46
+      '@types/node': 12.20.47
       dotenv: 8.6.0
       eslint: 7.32.0
-      prettier: 2.5.1
+      prettier: 2.6.1
       rimraf: 3.0.2
-      ts-node: 10.7.0_be7399ac25415134b30a5f1c20a06532
+      ts-node: 10.7.0_b23b0a2d2a25417b088e86bfb6fd069e
       tslib: 2.3.1
       typescript: 4.2.4
     transitivePeerDependencies:
@@ -16244,13 +16147,13 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/service-bus': 7.5.1
-      '@types/node': 12.20.46
+      '@types/node': 12.20.47
       '@types/uuid': 8.3.4
       dotenv: 8.6.0
       eslint: 7.32.0
-      prettier: 2.5.1
+      prettier: 2.6.1
       rimraf: 3.0.2
-      ts-node: 10.7.0_be7399ac25415134b30a5f1c20a06532
+      ts-node: 10.7.0_b23b0a2d2a25417b088e86bfb6fd069e
       tslib: 2.3.1
       typescript: 4.2.4
       uuid: 8.3.2
@@ -16266,15 +16169,15 @@ packages:
     name: '@rush-temp/perf-storage-blob'
     version: 0.0.0
     dependencies:
-      '@types/node': 12.20.46
+      '@types/node': 12.20.47
       '@types/node-fetch': 2.6.1
       '@types/uuid': 8.3.4
       dotenv: 8.6.0
       eslint: 7.32.0
       node-fetch: 2.6.7
-      prettier: 2.5.1
+      prettier: 2.6.1
       rimraf: 3.0.2
-      ts-node: 10.7.0_be7399ac25415134b30a5f1c20a06532
+      ts-node: 10.7.0_b23b0a2d2a25417b088e86bfb6fd069e
       tslib: 2.3.1
       typescript: 4.2.4
       uuid: 8.3.2
@@ -16290,13 +16193,13 @@ packages:
     name: '@rush-temp/perf-storage-file-datalake'
     version: 0.0.0
     dependencies:
-      '@types/node': 12.20.46
+      '@types/node': 12.20.47
       '@types/uuid': 8.3.4
       dotenv: 8.6.0
       eslint: 7.32.0
-      prettier: 2.5.1
+      prettier: 2.6.1
       rimraf: 3.0.2
-      ts-node: 10.7.0_be7399ac25415134b30a5f1c20a06532
+      ts-node: 10.7.0_b23b0a2d2a25417b088e86bfb6fd069e
       tslib: 2.3.1
       typescript: 4.2.4
       uuid: 8.3.2
@@ -16311,13 +16214,13 @@ packages:
     name: '@rush-temp/perf-storage-file-share'
     version: 0.0.0
     dependencies:
-      '@types/node': 12.20.46
+      '@types/node': 12.20.47
       '@types/uuid': 8.3.4
       dotenv: 8.6.0
       eslint: 7.32.0
-      prettier: 2.5.1
+      prettier: 2.6.1
       rimraf: 3.0.2
-      ts-node: 10.7.0_be7399ac25415134b30a5f1c20a06532
+      ts-node: 10.7.0_b23b0a2d2a25417b088e86bfb6fd069e
       tslib: 2.3.1
       typescript: 4.2.4
       uuid: 8.3.2
@@ -16334,13 +16237,13 @@ packages:
     dependencies:
       '@azure/app-configuration': 1.3.1
       '@azure/identity': 2.0.4
-      '@types/node': 12.20.46
+      '@types/node': 12.20.47
       '@types/uuid': 8.3.4
       dotenv: 8.6.0
       eslint: 7.32.0
-      prettier: 2.5.1
+      prettier: 2.6.1
       rimraf: 3.0.2
-      ts-node: 10.7.0_be7399ac25415134b30a5f1c20a06532
+      ts-node: 10.7.0_b23b0a2d2a25417b088e86bfb6fd069e
       tslib: 2.3.1
       typescript: 4.2.4
       uuid: 8.3.2
@@ -16358,16 +16261,16 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
+      '@microsoft/api-extractor': 7.20.0
       '@types/chai': 4.3.0
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.46
+      '@types/node': 12.20.47
       chai: 4.3.6
       cross-env: 7.0.3
       dotenv: 8.6.0
       eslint: 7.32.0
       karma: 6.3.17
-      karma-chrome-launcher: 3.1.0
+      karma-chrome-launcher: 3.1.1
       karma-coverage: 2.2.0
       karma-edge-launcher: 0.4.2_karma@6.3.17
       karma-env-preprocessor: 0.1.1
@@ -16400,16 +16303,16 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
+      '@microsoft/api-extractor': 7.20.0
       '@types/chai': 4.3.0
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.46
+      '@types/node': 12.20.47
       chai: 4.3.6
       cross-env: 7.0.3
       dotenv: 8.6.0
       eslint: 7.32.0
       karma: 6.3.17
-      karma-chrome-launcher: 3.1.0
+      karma-chrome-launcher: 3.1.1
       karma-coverage: 2.2.0
       karma-edge-launcher: 0.4.2_karma@6.3.17
       karma-env-preprocessor: 0.1.1
@@ -16442,16 +16345,16 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
+      '@microsoft/api-extractor': 7.20.0
       '@types/chai': 4.3.0
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.46
+      '@types/node': 12.20.47
       chai: 4.3.6
       cross-env: 7.0.3
       dotenv: 8.6.0
       eslint: 7.32.0
       karma: 6.3.17
-      karma-chrome-launcher: 3.1.0
+      karma-chrome-launcher: 3.1.1
       karma-coverage: 2.2.0
       karma-edge-launcher: 0.4.2_karma@6.3.17
       karma-env-preprocessor: 0.1.1
@@ -16486,11 +16389,10 @@ packages:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/core-tracing': 1.0.0-preview.13
       '@azure/identity': 2.0.4
-      '@azure/storage-blob': 12.8.0
-      '@microsoft/api-extractor': 7.19.4
+      '@microsoft/api-extractor': 7.20.0
       '@types/chai': 4.3.0
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.46
+      '@types/node': 12.20.47
       '@types/sinon': 9.0.11
       chai: 4.3.6
       cross-env: 7.0.3
@@ -16499,7 +16401,7 @@ packages:
       events: 3.3.0
       inherits: 2.0.4
       karma: 6.3.17
-      karma-chrome-launcher: 3.1.0
+      karma-chrome-launcher: 3.1.1
       karma-coverage: 2.2.0
       karma-edge-launcher: 0.4.2_karma@6.3.17
       karma-env-preprocessor: 0.1.1
@@ -16514,7 +16416,7 @@ packages:
       mocha: 7.2.0
       mocha-junit-reporter: 2.0.2_mocha@7.2.0
       nyc: 15.1.0
-      prettier: 2.5.1
+      prettier: 2.6.1
       rimraf: 3.0.2
       sinon: 9.2.4
       tslib: 2.3.1
@@ -16535,17 +16437,16 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
-      '@rollup/plugin-commonjs': 21.0.2_rollup@2.70.0
-      '@rollup/plugin-inject': 4.0.4_rollup@2.70.0
-      '@rollup/plugin-replace': 2.4.2_rollup@2.70.0
+      '@microsoft/api-extractor': 7.20.0
+      '@rollup/plugin-commonjs': 21.0.3_rollup@2.70.1
+      '@rollup/plugin-inject': 4.0.4_rollup@2.70.1
       '@types/chai': 4.3.0
       '@types/chai-as-promised': 7.1.5
-      '@types/lru-cache': 7.4.0
+      '@types/lru-cache': 7.6.1
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.46
+      '@types/node': 12.20.47
       '@types/uuid': 8.3.4
-      avsc: 5.7.3
+      avsc: 5.7.4
       buffer: 6.0.3
       chai: 4.3.6
       chai-as-promised: 7.1.1_chai@4.3.6
@@ -16553,7 +16454,7 @@ packages:
       dotenv: 8.6.0
       eslint: 7.32.0
       karma: 6.3.17
-      karma-chrome-launcher: 3.1.0
+      karma-chrome-launcher: 3.1.1
       karma-coverage: 2.2.0
       karma-edge-launcher: 0.4.2_karma@6.3.17
       karma-env-preprocessor: 0.1.1
@@ -16566,14 +16467,14 @@ packages:
       karma-mocha-reporter: 2.2.5_karma@6.3.17
       karma-source-map-support: 1.4.0
       karma-sourcemap-loader: 0.3.8
-      lru-cache: 7.4.2
+      lru-cache: 7.7.3
       mocha: 7.2.0
       mocha-junit-reporter: 2.0.2_mocha@7.2.0
       nyc: 15.1.0
-      prettier: 2.5.1
+      prettier: 2.6.1
       process: 0.11.10
       rimraf: 3.0.2
-      rollup: 2.70.0
+      rollup: 2.70.1
       rollup-plugin-shim: 1.0.0
       source-map-support: 0.5.21
       tslib: 2.3.1
@@ -16594,18 +16495,18 @@ packages:
     dependencies:
       '@azure/core-tracing': 1.0.0-preview.13
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
+      '@microsoft/api-extractor': 7.20.0
       '@types/chai': 4.3.0
       '@types/chai-as-promised': 7.1.5
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.46
+      '@types/node': 12.20.47
       chai: 4.3.6
       chai-as-promised: 7.1.1_chai@4.3.6
       cross-env: 7.0.3
       dotenv: 8.6.0
       eslint: 7.32.0
       karma: 6.3.17
-      karma-chrome-launcher: 3.1.0
+      karma-chrome-launcher: 3.1.1
       karma-coverage: 2.2.0
       karma-edge-launcher: 0.4.2_karma@6.3.17
       karma-env-preprocessor: 0.1.1
@@ -16620,7 +16521,7 @@ packages:
       mocha: 7.2.0
       mocha-junit-reporter: 2.0.2_mocha@7.2.0
       nyc: 15.1.0
-      prettier: 2.5.1
+      prettier: 2.6.1
       rimraf: 3.0.2
       source-map-support: 0.5.21
       tslib: 2.3.1
@@ -16638,10 +16539,10 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/core-tracing': 1.0.0-preview.13
-      '@microsoft/api-extractor': 7.19.4
+      '@microsoft/api-extractor': 7.20.0
       '@types/chai': 4.3.0
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.46
+      '@types/node': 12.20.47
       '@types/sinon': 9.0.11
       chai: 4.3.6
       cross-env: 7.0.3
@@ -16650,7 +16551,7 @@ packages:
       events: 3.3.0
       inherits: 2.0.4
       karma: 6.3.17
-      karma-chrome-launcher: 3.1.0
+      karma-chrome-launcher: 3.1.1
       karma-coverage: 2.2.0
       karma-edge-launcher: 0.4.2_karma@6.3.17
       karma-env-preprocessor: 0.1.1
@@ -16665,10 +16566,10 @@ packages:
       mocha: 7.2.0
       mocha-junit-reporter: 2.0.2_mocha@7.2.0
       nyc: 15.1.0
-      prettier: 2.5.1
+      prettier: 2.6.1
       rimraf: 3.0.2
       sinon: 9.2.4
-      ts-node: 10.7.0_be7399ac25415134b30a5f1c20a06532
+      ts-node: 10.7.0_b23b0a2d2a25417b088e86bfb6fd069e
       tslib: 2.3.1
       typescript: 4.2.4
       util: 0.12.4
@@ -16687,8 +16588,8 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/core-tracing': 1.0.0-preview.13
-      '@azure/identity': 2.0.4_debug@4.3.3
-      '@microsoft/api-extractor': 7.19.4
+      '@azure/identity': 2.0.4_debug@4.3.4
+      '@microsoft/api-extractor': 7.20.0
       '@types/chai': 4.3.0
       '@types/chai-as-promised': 7.1.5
       '@types/debug': 4.1.7
@@ -16696,7 +16597,7 @@ packages:
       '@types/is-buffer': 2.0.0
       '@types/long': 4.0.1
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.46
+      '@types/node': 12.20.47
       '@types/sinon': 9.0.11
       '@types/uuid': 8.3.4
       '@types/ws': 7.4.7
@@ -16705,7 +16606,7 @@ packages:
       chai-as-promised: 7.1.1_chai@4.3.6
       chai-exclude: 2.1.0_chai@4.3.6
       cross-env: 7.0.3
-      debug: 4.3.3
+      debug: 4.3.4
       dotenv: 8.6.0
       downlevel-dts: 0.8.0
       eslint: 7.32.0
@@ -16715,8 +16616,8 @@ packages:
       https-proxy-agent: 5.0.0
       is-buffer: 2.0.5
       jssha: 3.2.0
-      karma: 6.3.17_debug@4.3.3
-      karma-chrome-launcher: 3.1.0
+      karma: 6.3.17_debug@4.3.4
+      karma-chrome-launcher: 3.1.1
       karma-coverage: 2.2.0
       karma-edge-launcher: 0.4.2_karma@6.3.17
       karma-env-preprocessor: 0.1.1
@@ -16731,15 +16632,15 @@ packages:
       mocha-junit-reporter: 2.0.2_mocha@7.2.0
       moment: 2.29.1
       nyc: 15.1.0
-      prettier: 2.5.1
+      prettier: 2.6.1
       process: 0.11.10
       promise: 8.1.0
-      puppeteer: 13.5.1
+      puppeteer: 13.5.2
       rhea-promise: 2.1.0
       rimraf: 3.0.2
-      rollup: 2.70.0
+      rollup: 2.70.1
       sinon: 9.2.4
-      ts-node: 10.7.0_be7399ac25415134b30a5f1c20a06532
+      ts-node: 10.7.0_b23b0a2d2a25417b088e86bfb6fd069e
       tslib: 2.3.1
       typescript: 4.2.4
       uuid: 8.3.2
@@ -16760,11 +16661,10 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/core-tracing': 1.0.0-preview.13
-      '@azure/storage-blob': 12.8.0
-      '@microsoft/api-extractor': 7.19.4
+      '@microsoft/api-extractor': 7.20.0
       '@types/chai': 4.3.0
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.46
+      '@types/node': 12.20.47
       '@types/sinon': 9.0.11
       chai: 4.3.6
       cross-env: 7.0.3
@@ -16776,7 +16676,7 @@ packages:
       events: 3.3.0
       inherits: 2.0.4
       karma: 6.3.17
-      karma-chrome-launcher: 3.1.0
+      karma-chrome-launcher: 3.1.1
       karma-coverage: 2.2.0
       karma-edge-launcher: 0.4.2_karma@6.3.17
       karma-env-preprocessor: 0.1.1
@@ -16791,12 +16691,12 @@ packages:
       mocha: 7.2.0
       mocha-junit-reporter: 2.0.2_mocha@7.2.0
       nyc: 15.1.0
-      prettier: 2.5.1
-      puppeteer: 13.5.1
+      prettier: 2.6.1
+      puppeteer: 13.5.2
       rimraf: 3.0.2
       sinon: 9.2.4
       source-map-support: 0.5.21
-      ts-node: 10.7.0_be7399ac25415134b30a5f1c20a06532
+      ts-node: 10.7.0_b23b0a2d2a25417b088e86bfb6fd069e
       tslib: 2.3.1
       typescript: 4.2.4
       util: 0.12.4
@@ -16818,10 +16718,10 @@ packages:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/core-tracing': 1.0.0-preview.13
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
+      '@microsoft/api-extractor': 7.20.0
       '@types/chai': 4.3.0
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.46
+      '@types/node': 12.20.47
       '@types/node-fetch': 2.6.1
       chai: 4.3.6
       cross-env: 7.0.3
@@ -16833,7 +16733,7 @@ packages:
       events: 3.3.0
       inherits: 2.0.4
       karma: 6.3.17
-      karma-chrome-launcher: 3.1.0
+      karma-chrome-launcher: 3.1.1
       karma-coverage: 2.2.0
       karma-edge-launcher: 0.4.2_karma@6.3.17
       karma-env-preprocessor: 0.1.1
@@ -16848,11 +16748,11 @@ packages:
       mocha: 7.2.0
       mocha-junit-reporter: 2.0.2_mocha@7.2.0
       nyc: 15.1.0
-      prettier: 2.5.1
-      puppeteer: 13.5.1
+      prettier: 2.6.1
+      puppeteer: 13.5.2
       rimraf: 3.0.2
       source-map-support: 0.5.21
-      ts-node: 10.7.0_be7399ac25415134b30a5f1c20a06532
+      ts-node: 10.7.0_b23b0a2d2a25417b088e86bfb6fd069e
       tslib: 2.3.1
       typescript: 4.2.4
       util: 0.12.4
@@ -16874,10 +16774,10 @@ packages:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/core-tracing': 1.0.0-preview.13
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
+      '@microsoft/api-extractor': 7.20.0
       '@types/chai': 4.3.0
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.46
+      '@types/node': 12.20.47
       chai: 4.3.6
       cross-env: 7.0.3
       dotenv: 8.6.0
@@ -16889,7 +16789,7 @@ packages:
       execa: 6.1.0
       inherits: 2.0.4
       karma: 6.3.17
-      karma-chrome-launcher: 3.1.0
+      karma-chrome-launcher: 3.1.1
       karma-coverage: 2.2.0
       karma-edge-launcher: 0.4.2_karma@6.3.17
       karma-env-preprocessor: 0.1.1
@@ -16904,11 +16804,11 @@ packages:
       mocha: 7.2.0
       mocha-junit-reporter: 2.0.2_mocha@7.2.0
       nyc: 15.1.0
-      prettier: 2.5.1
-      puppeteer: 13.5.1
+      prettier: 2.6.1
+      puppeteer: 13.5.2
       rimraf: 3.0.2
       source-map-support: 0.5.21
-      ts-node: 10.7.0_be7399ac25415134b30a5f1c20a06532
+      ts-node: 10.7.0_b23b0a2d2a25417b088e86bfb6fd069e
       tslib: 2.3.1
       typescript: 4.2.4
       util: 0.12.4
@@ -16929,10 +16829,10 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/core-tracing': 1.0.0-preview.13
-      '@microsoft/api-extractor': 7.19.4
+      '@microsoft/api-extractor': 7.20.0
       '@types/chai': 4.3.0
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.46
+      '@types/node': 12.20.47
       chai: 4.3.6
       cross-env: 7.0.3
       dotenv: 8.6.0
@@ -16943,7 +16843,7 @@ packages:
       events: 3.3.0
       inherits: 2.0.4
       karma: 6.3.17
-      karma-chrome-launcher: 3.1.0
+      karma-chrome-launcher: 3.1.1
       karma-coverage: 2.2.0
       karma-edge-launcher: 0.4.2_karma@6.3.17
       karma-env-preprocessor: 0.1.1
@@ -16958,11 +16858,11 @@ packages:
       mocha: 7.2.0
       mocha-junit-reporter: 2.0.2_mocha@7.2.0
       nyc: 15.1.0
-      prettier: 2.5.1
-      puppeteer: 13.5.1
+      prettier: 2.6.1
+      puppeteer: 13.5.2
       rimraf: 3.0.2
       source-map-support: 0.5.21
-      ts-node: 10.7.0_be7399ac25415134b30a5f1c20a06532
+      ts-node: 10.7.0_b23b0a2d2a25417b088e86bfb6fd069e
       tslib: 2.3.1
       typescript: 4.2.4
       util: 0.12.4
@@ -16982,10 +16882,10 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
-      '@microsoft/api-extractor': 7.19.4
+      '@microsoft/api-extractor': 7.20.0
       '@types/chai': 4.3.0
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.46
+      '@types/node': 12.20.47
       chai: 4.3.6
       dotenv: 8.6.0
       downlevel-dts: 0.8.0
@@ -16994,7 +16894,7 @@ packages:
       esm: 3.2.25
       inherits: 2.0.4
       karma: 6.3.17
-      karma-chrome-launcher: 3.1.0
+      karma-chrome-launcher: 3.1.1
       karma-coverage: 2.2.0
       karma-edge-launcher: 0.4.2_karma@6.3.17
       karma-env-preprocessor: 0.1.1
@@ -17009,11 +16909,11 @@ packages:
       mocha: 7.2.0
       mocha-junit-reporter: 2.0.2_mocha@7.2.0
       nyc: 15.1.0
-      prettier: 2.5.1
-      puppeteer: 13.5.1
+      prettier: 2.6.1
+      puppeteer: 13.5.2
       rimraf: 3.0.2
       source-map-support: 0.5.21
-      ts-node: 10.7.0_be7399ac25415134b30a5f1c20a06532
+      ts-node: 10.7.0_b23b0a2d2a25417b088e86bfb6fd069e
       tslib: 2.3.1
       typescript: 4.2.4
       util: 0.12.4
@@ -17035,10 +16935,10 @@ packages:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/core-tracing': 1.0.0-preview.13
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
+      '@microsoft/api-extractor': 7.20.0
       '@types/chai': 4.3.0
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.46
+      '@types/node': 12.20.47
       chai: 4.3.6
       cross-env: 7.0.3
       dotenv: 8.6.0
@@ -17048,7 +16948,7 @@ packages:
       esm: 3.2.25
       inherits: 2.0.4
       karma: 6.3.17
-      karma-chrome-launcher: 3.1.0
+      karma-chrome-launcher: 3.1.1
       karma-coverage: 2.2.0
       karma-edge-launcher: 0.4.2_karma@6.3.17
       karma-env-preprocessor: 0.1.1
@@ -17063,11 +16963,11 @@ packages:
       mocha: 7.2.0
       mocha-junit-reporter: 2.0.2_mocha@7.2.0
       nyc: 15.1.0
-      prettier: 2.5.1
-      puppeteer: 13.5.1
+      prettier: 2.6.1
+      puppeteer: 13.5.2
       rimraf: 3.0.2
       source-map-support: 0.5.21
-      ts-node: 10.7.0_be7399ac25415134b30a5f1c20a06532
+      ts-node: 10.7.0_b23b0a2d2a25417b088e86bfb6fd069e
       tslib: 2.3.1
       typescript: 4.2.4
       util: 0.12.4
@@ -17089,11 +16989,11 @@ packages:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/core-tracing': 1.0.0-preview.13
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
+      '@microsoft/api-extractor': 7.20.0
       '@types/chai': 4.3.0
       '@types/chai-as-promised': 7.1.5
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.46
+      '@types/node': 12.20.47
       '@types/sinon': 9.0.11
       chai: 4.3.6
       chai-as-promised: 7.1.1_chai@4.3.6
@@ -17101,7 +17001,7 @@ packages:
       dotenv: 8.6.0
       eslint: 7.32.0
       karma: 6.3.17
-      karma-chrome-launcher: 3.1.0
+      karma-chrome-launcher: 3.1.1
       karma-coverage: 2.2.0
       karma-edge-launcher: 0.4.2_karma@6.3.17
       karma-env-preprocessor: 0.1.1
@@ -17117,14 +17017,14 @@ packages:
       mocha: 7.2.0
       mocha-junit-reporter: 2.0.2_mocha@7.2.0
       nyc: 15.1.0
-      prettier: 2.5.1
+      prettier: 2.6.1
       rimraf: 3.0.2
       sinon: 9.2.4
       source-map-support: 0.5.21
-      ts-node: 10.7.0_be7399ac25415134b30a5f1c20a06532
+      ts-node: 10.7.0_b23b0a2d2a25417b088e86bfb6fd069e
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - '@swc/core'
       - '@swc/wasm'
@@ -17142,11 +17042,11 @@ packages:
     dependencies:
       '@azure/core-util': 1.0.0-beta.1
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
+      '@microsoft/api-extractor': 7.20.0
       '@types/chai': 4.3.0
       '@types/chai-as-promised': 7.1.5
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.46
+      '@types/node': 12.20.47
       '@types/sinon': 9.0.11
       '@types/uuid': 8.3.4
       chai: 4.3.6
@@ -17155,7 +17055,7 @@ packages:
       dotenv: 8.6.0
       eslint: 7.32.0
       karma: 6.3.17
-      karma-chrome-launcher: 3.1.0
+      karma-chrome-launcher: 3.1.1
       karma-coverage: 2.2.0
       karma-edge-launcher: 0.4.2_karma@6.3.17
       karma-env-preprocessor: 0.1.1
@@ -17171,14 +17071,14 @@ packages:
       mocha: 7.2.0
       mocha-junit-reporter: 2.0.2_mocha@7.2.0
       nyc: 15.1.0
-      prettier: 2.5.1
+      prettier: 2.6.1
       rimraf: 3.0.2
       sinon: 9.2.4
       source-map-support: 0.5.21
-      ts-node: 10.7.0_be7399ac25415134b30a5f1c20a06532
+      ts-node: 10.7.0_b23b0a2d2a25417b088e86bfb6fd069e
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
       uuid: 8.3.2
     transitivePeerDependencies:
       - '@swc/core'
@@ -17196,11 +17096,11 @@ packages:
     dependencies:
       '@azure/core-tracing': 1.0.0-preview.13
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
+      '@microsoft/api-extractor': 7.20.0
       '@types/chai': 4.3.0
       '@types/chai-as-promised': 7.1.5
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.46
+      '@types/node': 12.20.47
       '@types/sinon': 9.0.11
       chai: 4.3.6
       chai-as-promised: 7.1.1_chai@4.3.6
@@ -17208,7 +17108,7 @@ packages:
       dotenv: 8.6.0
       eslint: 7.32.0
       karma: 6.3.17
-      karma-chrome-launcher: 3.1.0
+      karma-chrome-launcher: 3.1.1
       karma-coverage: 2.2.0
       karma-edge-launcher: 0.4.2_karma@6.3.17
       karma-env-preprocessor: 0.1.1
@@ -17224,14 +17124,14 @@ packages:
       mocha: 7.2.0
       mocha-junit-reporter: 2.0.2_mocha@7.2.0
       nyc: 15.1.0
-      prettier: 2.5.1
+      prettier: 2.6.1
       rimraf: 3.0.2
       sinon: 9.2.4
       source-map-support: 0.5.21
-      ts-node: 10.7.0_be7399ac25415134b30a5f1c20a06532
+      ts-node: 10.7.0_b23b0a2d2a25417b088e86bfb6fd069e
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - '@swc/core'
       - '@swc/wasm'
@@ -17249,7 +17149,7 @@ packages:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/core-tracing': 1.0.0-preview.13
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
+      '@microsoft/api-extractor': 7.20.0
       '@types/chai': 4.3.0
       '@types/chai-as-promised': 7.1.5
       '@types/mocha': 7.0.2
@@ -17259,7 +17159,7 @@ packages:
       dotenv: 8.6.0
       eslint: 7.32.0
       karma: 6.3.17
-      karma-chrome-launcher: 3.1.0
+      karma-chrome-launcher: 3.1.1
       karma-coverage: 2.2.0
       karma-edge-launcher: 0.4.2_karma@6.3.17
       karma-env-preprocessor: 0.1.1
@@ -17275,11 +17175,11 @@ packages:
       mocha: 7.2.0
       mocha-junit-reporter: 2.0.2_mocha@7.2.0
       nyc: 15.1.0
-      prettier: 2.5.1
+      prettier: 2.6.1
       rimraf: 3.0.2
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -17294,16 +17194,16 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/core-tracing': 1.0.0-preview.13
-      '@microsoft/api-extractor': 7.19.4
-      '@rollup/plugin-commonjs': 21.0.2_rollup@2.70.0
+      '@microsoft/api-extractor': 7.20.0
+      '@rollup/plugin-commonjs': 21.0.3_rollup@2.70.1
       eslint: 7.32.0
       rimraf: 3.0.2
-      rollup: 2.70.0
+      rollup: 2.70.1
       rollup-plugin-node-resolve: 3.4.0
-      rollup-plugin-sourcemaps: 0.4.2_rollup@2.70.0
+      rollup-plugin-sourcemaps: 0.4.2_rollup@2.70.1
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -17316,7 +17216,7 @@ packages:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/core-tracing': 1.0.0-preview.13
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
+      '@microsoft/api-extractor': 7.20.0
       '@types/chai': 4.3.0
       '@types/chai-as-promised': 7.1.5
       '@types/mocha': 7.0.2
@@ -17326,7 +17226,7 @@ packages:
       dotenv: 8.6.0
       eslint: 7.32.0
       karma: 6.3.17
-      karma-chrome-launcher: 3.1.0
+      karma-chrome-launcher: 3.1.1
       karma-coverage: 2.2.0
       karma-edge-launcher: 0.4.2_karma@6.3.17
       karma-env-preprocessor: 0.1.1
@@ -17342,11 +17242,11 @@ packages:
       mocha: 7.2.0
       mocha-junit-reporter: 2.0.2_mocha@7.2.0
       nyc: 15.1.0
-      prettier: 2.5.1
+      prettier: 2.6.1
       rimraf: 3.0.2
       tslib: 2.3.1
       typescript: 4.2.4
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -17360,12 +17260,11 @@ packages:
     name: '@rush-temp/template'
     version: 0.0.0
     dependencies:
-      '@azure/core-tracing': 1.0.0-preview.14
       '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
+      '@microsoft/api-extractor': 7.20.0
       '@types/chai': 4.3.0
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.46
+      '@types/node': 12.20.47
       chai: 4.3.6
       cross-env: 7.0.3
       dotenv: 8.6.0
@@ -17374,7 +17273,7 @@ packages:
       esm: 3.2.25
       inherits: 2.0.4
       karma: 6.3.17
-      karma-chrome-launcher: 3.1.0
+      karma-chrome-launcher: 3.1.1
       karma-coverage: 2.2.0
       karma-edge-launcher: 0.4.2_karma@6.3.17
       karma-env-preprocessor: 0.1.1
@@ -17388,7 +17287,7 @@ packages:
       mocha: 7.2.0
       mocha-junit-reporter: 2.0.2_mocha@7.2.0
       nyc: 15.1.0
-      prettier: 2.5.1
+      prettier: 2.6.1
       rimraf: 3.0.2
       source-map-support: 0.5.21
       tslib: 2.3.1
@@ -17407,10 +17306,9 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
-      '@azure/identity': 2.0.4
-      '@types/node': 12.20.46
+      '@types/node': 12.20.47
       eslint: 7.32.0
-      prettier: 2.5.1
+      prettier: 2.6.1
       rimraf: 3.0.2
       typescript: 4.2.4
     transitivePeerDependencies:
@@ -17419,7 +17317,7 @@ packages:
     dev: false
 
   file:projects/test-recorder.tgz:
-    resolution: {integrity: sha512-Xer6XFqtF+++PkuM8klXusuoFnbtFT0MYT+SSptHozyW84/FdCf2V5t0VZJmqSYF7AM42GVSnRMbl6KF/pzevA==, tarball: file:projects/test-recorder.tgz}
+    resolution: {integrity: sha512-I+6cy62A3fZO0CejOz4sYIld1JLcBtqgNxuBofi2ah7SuKDSXGYfPDk726RlCYb7thvK4JpXIm7Wh1J1DxQTYA==, tarball: file:projects/test-recorder.tgz}
     name: '@rush-temp/test-recorder'
     version: 0.0.0
     dependencies:
@@ -17427,7 +17325,7 @@ packages:
       '@types/express': 4.17.13
       '@types/fs-extra': 8.1.2
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.46
+      '@types/node': 12.20.47
       '@types/uuid': 8.3.4
       chai: 4.3.6
       concurrently: 6.5.1
@@ -17436,7 +17334,7 @@ packages:
       eslint: 7.32.0
       express: 4.17.3
       karma: 6.3.17
-      karma-chrome-launcher: 3.1.0
+      karma-chrome-launcher: 3.1.1
       karma-coverage: 2.2.0
       karma-edge-launcher: 0.4.2_karma@6.3.17
       karma-env-preprocessor: 0.1.1
@@ -17449,7 +17347,7 @@ packages:
       mocha: 7.2.0
       mocha-junit-reporter: 2.0.2_mocha@7.2.0
       nyc: 15.1.0
-      prettier: 2.5.1
+      prettier: 2.6.1
       rimraf: 3.0.2
       ts-node: 9.1.1_typescript@4.2.4
       tslib: 2.3.1
@@ -17468,16 +17366,16 @@ packages:
     version: 0.0.0
     dependencies:
       '@types/minimist': 1.2.2
-      '@types/node': 12.20.46
+      '@types/node': 12.20.47
       '@types/node-fetch': 2.6.1
       eslint: 7.32.0
       karma: 6.3.17
-      karma-chrome-launcher: 3.1.0
+      karma-chrome-launcher: 3.1.1
       karma-coverage: 2.2.0
       karma-env-preprocessor: 0.1.1
-      minimist: 1.2.5
+      minimist: 1.2.6
       node-fetch: 2.6.7
-      prettier: 2.5.1
+      prettier: 2.6.1
       rimraf: 3.0.2
       ts-node: 8.10.2_typescript@4.2.4
       tslib: 2.3.1
@@ -17496,13 +17394,12 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
-      '@azure/core-tracing': 1.0.0-preview.14
-      '@microsoft/api-extractor': 7.19.4
+      '@microsoft/api-extractor': 7.20.0
       '@opentelemetry/api': 1.0.4
       '@types/chai': 4.3.0
       '@types/chai-as-promised': 7.1.5
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.46
+      '@types/node': 12.20.47
       '@types/sinon': 9.0.11
       chai: 4.3.6
       chai-as-promised: 7.1.1_chai@4.3.6
@@ -17510,11 +17407,11 @@ packages:
       cross-env: 7.0.3
       eslint: 7.32.0
       karma: 6.3.17
-      karma-chrome-launcher: 3.1.0
+      karma-chrome-launcher: 3.1.1
       karma-coverage: 2.2.0
       karma-env-preprocessor: 0.1.1
       mocha: 7.2.0
-      prettier: 2.5.1
+      prettier: 2.6.1
       rimraf: 3.0.2
       sinon: 9.2.4
       tslib: 2.3.1
@@ -17533,20 +17430,19 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.0.4
-      '@azure/storage-queue': 12.7.0
       '@types/chai': 4.3.0
       '@types/md5': 2.3.2
       '@types/mocha': 7.0.2
       '@types/mock-fs': 4.13.1
       '@types/mock-require': 2.0.1
       '@types/nise': 1.4.0
-      '@types/node': 12.20.46
+      '@types/node': 12.20.47
       '@types/uuid': 8.3.4
       chai: 4.3.6
       dotenv: 8.6.0
       eslint: 7.32.0
       karma: 6.3.17
-      karma-chrome-launcher: 3.1.0
+      karma-chrome-launcher: 3.1.1
       karma-coverage: 2.2.0
       karma-edge-launcher: 0.4.2_karma@6.3.17
       karma-env-preprocessor: 0.1.1
@@ -17564,7 +17460,7 @@ packages:
       mock-require: 3.0.3
       npm-run-all: 4.1.5
       nyc: 15.1.0
-      prettier: 2.5.1
+      prettier: 2.6.1
       rimraf: 3.0.2
       typescript: 4.2.4
       uuid: 8.3.2
@@ -17582,11 +17478,11 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/core-tracing': 1.0.0-preview.13
-      '@microsoft/api-extractor': 7.19.4
+      '@microsoft/api-extractor': 7.20.0
       '@types/chai': 4.3.0
       '@types/chai-as-promised': 7.1.5
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.46
+      '@types/node': 12.20.47
       azure-iothub: 1.14.6
       chai: 4.3.6
       chai-as-promised: 7.1.1_chai@4.3.6
@@ -17596,7 +17492,7 @@ packages:
       events: 3.3.0
       inherits: 2.0.4
       karma: 6.3.17
-      karma-chrome-launcher: 3.1.0
+      karma-chrome-launcher: 3.1.1
       karma-coverage: 2.2.0
       karma-edge-launcher: 0.4.2_karma@6.3.17
       karma-env-preprocessor: 0.1.1
@@ -17609,7 +17505,7 @@ packages:
       mocha: 7.2.0
       mocha-junit-reporter: 2.0.2_mocha@7.2.0
       nyc: 15.1.0
-      prettier: 2.5.1
+      prettier: 2.6.1
       rimraf: 3.0.2
       tslib: 2.3.1
       typescript: 4.2.4
@@ -17628,13 +17524,13 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
-      '@microsoft/api-extractor': 7.19.4
+      '@microsoft/api-extractor': 7.20.0
       '@types/chai': 4.3.0
       '@types/express': 4.17.13
       '@types/express-serve-static-core': 4.17.28
       '@types/jsonwebtoken': 8.5.8
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.46
+      '@types/node': 12.20.47
       '@types/sinon': 9.0.11
       chai: 4.3.6
       cross-env: 7.0.3
@@ -17643,7 +17539,7 @@ packages:
       esm: 3.2.25
       express: 4.17.3
       karma: 6.3.17
-      karma-chrome-launcher: 3.1.0
+      karma-chrome-launcher: 3.1.1
       karma-coverage: 2.2.0
       karma-edge-launcher: 0.4.2_karma@6.3.17
       karma-env-preprocessor: 0.1.1
@@ -17658,8 +17554,8 @@ packages:
       mocha: 7.2.0
       mocha-junit-reporter: 2.0.2_mocha@7.2.0
       nyc: 15.1.0
-      prettier: 2.5.1
-      puppeteer: 13.5.1
+      prettier: 2.6.1
+      puppeteer: 13.5.2
       rimraf: 3.0.2
       sinon: 9.2.4
       source-map-support: 0.5.21
@@ -17678,16 +17574,14 @@ packages:
     name: '@rush-temp/web-pubsub'
     version: 0.0.0
     dependencies:
-      '@azure-tools/test-recorder': 1.0.2
       '@azure/core-tracing': 1.0.0-preview.13
-      '@azure/identity': 2.0.4
-      '@microsoft/api-extractor': 7.19.4
+      '@microsoft/api-extractor': 7.20.0
       '@types/chai': 4.3.0
       '@types/jsonwebtoken': 8.5.8
       '@types/mocha': 7.0.2
-      '@types/node': 12.20.46
+      '@types/node': 12.20.47
       '@types/sinon': 9.0.11
-      '@types/ws': 8.5.2
+      '@types/ws': 8.5.3
       chai: 4.3.6
       cross-env: 7.0.3
       dotenv: 8.6.0
@@ -17695,14 +17589,12 @@ packages:
       esm: 3.2.25
       jsonwebtoken: 8.5.1
       karma: 6.3.17
-      karma-chrome-launcher: 3.1.0
+      karma-chrome-launcher: 3.1.1
       karma-coverage: 2.2.0
       karma-edge-launcher: 0.4.2_karma@6.3.17
       karma-env-preprocessor: 0.1.1
       karma-firefox-launcher: 1.3.0
       karma-ie-launcher: 1.0.0_karma@6.3.17
-      karma-json-preprocessor: 0.3.3_karma@6.3.17
-      karma-json-to-file-reporter: 1.0.1
       karma-junit-reporter: 2.0.1_karma@6.3.17
       karma-mocha: 2.0.1
       karma-mocha-reporter: 2.2.5_karma@6.3.17
@@ -17710,8 +17602,8 @@ packages:
       mocha: 7.2.0
       mocha-junit-reporter: 2.0.2_mocha@7.2.0
       nyc: 15.1.0
-      prettier: 2.5.1
-      puppeteer: 13.5.1
+      prettier: 2.6.1
+      puppeteer: 13.5.2
       rimraf: 3.0.2
       sinon: 9.2.4
       source-map-support: 0.5.21


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/10452642/162535653-4f9fa9eb-9d75-445a-8c0f-8b572f5f7a94.png)

Does rush update with an older `pnpm-lock` file before my PR was merged #20766 .