### PR TITLE
[Schema Registry Avro] Fix min/max testing

### DIFF
--- a/sdk/schemaregistry/schema-registry-avro/test/public/utils/mockedRegistryClient.ts
+++ b/sdk/schemaregistry/schema-registry-avro/test/public/utils/mockedRegistryClient.ts
@@ -75,12 +75,12 @@ function createMockedTestRegistry(): SchemaRegistry {
           format: schema.format,
           groupName: schema.groupName,
           name: schema.name,
-        },
+        } as any,
       };
       mapByContent.set(result.definition, result);
       mapById.set(result.properties.id, result);
     }
-    return result!.properties;
+    return result.properties;
 
     function newId(): string {
       if (idCounter >= testSchemaIds.length) {

--- a/sdk/schemaregistry/schema-registry-avro/test/public/utils/mockedSerializer.ts
+++ b/sdk/schemaregistry/schema-registry-avro/test/public/utils/mockedSerializer.ts
@@ -21,7 +21,7 @@ export async function createTestSerializer<T>(
   if (!serializerOptions.autoRegisterSchemas) {
     await registerTestSchema(registry);
   }
-  return new AvroSerializer(registry, serializerOptions);
+  return new AvroSerializer(registry as any, serializerOptions);
 }
 
 export async function registerTestSchema(registry: SchemaRegistry): Promise<string> {


### PR DESCRIPTION
### Packages impacted by this PR
@azure/schema-registry-avro's tests

### Issues associated with this PR
N/A

### Describe the problem that is addressed by this PR
[Min max tests](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1491520&view=logs&j=1c9a204a-48a9-5154-5204-230e40dbc42f&t=ef1f7f64-d4f7-5d9c-c677-8688f034a2b8) are failing because `SchemaProperties` interface has evolved and it now contains more things than the versions in older @azure/schema-registry so the mocked schema registry being used in the serializer tests does not type-check correctly.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?
I am casting objects of that interface to `any` for now to not bother with typechecking in tests between older and new versions. Successful run: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1493832&view=results

Alternatively, we can update the semver for the @azure/schema-registry dependency to `^1.1.0` but that will rule out testing against all schema registry releases made so far which would make min/max testing not very useful.


### Are there test cases added in this PR? _(If not, why?)_
N/A

### Provide a list of related PRs _(if any)_
N/A

### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
