### PR TITLE
[Recorder] Ensure redirected requests are passed to the recorder in Node

### DIFF
--- a/sdk/test-utils/recorder/test/testProxyClient.spec.ts
+++ b/sdk/test-utils/recorder/test/testProxyClient.spec.ts
@@ -57,17 +57,23 @@ describe("TestProxyClient functions", () => {
     });
 
     ["record", "playback"].forEach((testMode) => {
-      it(`${testMode} mode: ` + "request unchanged if `x-recording-id` in headers", function () {
-        env.TEST_MODE = testMode;
-        testRedirectedRequest(
-          client,
-          () => ({
-            ...initialRequest,
-            headers: createHttpHeaders({ "x-recording-id": "dummy-recording-id" }),
-          }),
-          (req) => req
-        );
-      });
+      it(
+        `${testMode} mode: ` + "request unchanged if request URL already points to test proxy",
+        function () {
+          env.TEST_MODE = testMode;
+          testRedirectedRequest(
+            client,
+            () => ({
+              ...initialRequest,
+              url: "http://localhost:5000/dummy_path?sas=sas",
+              headers: createHttpHeaders({
+                "x-recording-upstream-uri": "https://dummy_url.windows.net/dummy_path?sas=sas",
+              }),
+            }),
+            (req) => req
+          );
+        }
+      );
 
       it(
         `${testMode} mode: ` + "url and headers get updated if no `x-recording-id` in headers",

--- a/sdk/test-utils/recorder/test/testProxyTests.spec.ts
+++ b/sdk/test-utils/recorder/test/testProxyTests.spec.ts
@@ -38,12 +38,13 @@ import { getTestServerUrl, makeRequestAndVerifyResponse, setTestMode } from "./u
     });
 
     it("redirect (redirect location has host)", async function (this: Mocha.Context) {
+      await recorder.start({ envSetupForPlayback: {} });
+
       if (!isNode) {
         // In the browser, redirects get handled by fetch/XHR and we can't guarantee redirect behavior.
         this.skip();
       }
 
-      await recorder.start({ envSetupForPlayback: {} });
       await makeRequestAndVerifyResponse(
         client,
         { path: `/redirectWithHost`, method: "GET" },
@@ -52,12 +53,13 @@ import { getTestServerUrl, makeRequestAndVerifyResponse, setTestMode } from "./u
     });
 
     it("redirect (redirect location is relative)", async function (this: Mocha.Context) {
+      await recorder.start({ envSetupForPlayback: {} });
+
       if (!isNode) {
         // In the browser, redirects get handled by fetch/XHR and we can't guarantee redirect behavior.
         this.skip();
       }
 
-      await recorder.start({ envSetupForPlayback: {} });
       await makeRequestAndVerifyResponse(
         client,
         { path: `/redirectWithoutHost`, method: "GET" },

--- a/sdk/test-utils/recorder/test/testProxyTests.spec.ts
+++ b/sdk/test-utils/recorder/test/testProxyTests.spec.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 import { ServiceClient } from "@azure/core-client";
+import { isNode } from "@azure/core-util";
 import { CustomMatcherOptions, isPlaybackMode, Recorder } from "../src";
 import { isLiveMode, TestMode } from "../src/utils/utils";
 import { getTestServerUrl, makeRequestAndVerifyResponse, setTestMode } from "./utils/utils";
@@ -34,6 +35,44 @@ import { getTestServerUrl, makeRequestAndVerifyResponse, setTestMode } from "./u
         { path: `/sample_response`, method: "GET" },
         { val: "abc" }
       );
+    });
+
+    it("redirect (redirect location has host)", async function (this: Mocha.Context) {
+      if (!isNode) {
+        // In the browser, redirects get handled by fetch/XHR and we can't guarantee redirect behavior.
+        this.skip();
+      }
+
+      await recorder.start({ envSetupForPlayback: {} });
+      await makeRequestAndVerifyResponse(
+        client,
+        { path: `/redirectWithHost`, method: "GET" },
+        { val: "abc" }
+      );
+    });
+
+    it("redirect (redirect location is relative)", async function (this: Mocha.Context) {
+      if (!isNode) {
+        // In the browser, redirects get handled by fetch/XHR and we can't guarantee redirect behavior.
+        this.skip();
+      }
+
+      await recorder.start({ envSetupForPlayback: {} });
+      await makeRequestAndVerifyResponse(
+        client,
+        { path: `/redirectWithoutHost`, method: "GET" },
+        { val: "abc" }
+      );
+    });
+
+    it("retry", async () => {
+      await recorder.start({ envSetupForPlayback: {} });
+      await makeRequestAndVerifyResponse(
+        client,
+        { path: "/reset_retry", method: "GET" },
+        undefined
+      );
+      await makeRequestAndVerifyResponse(client, { path: "/retry", method: "GET" }, { val: "abc" });
     });
 
     it("sample_response with random string in path", async () => {

--- a/sdk/test-utils/recorder/test/utils/server.ts
+++ b/sdk/test-utils/recorder/test/utils/server.ts
@@ -15,7 +15,39 @@ app.get("/", (_, res) => {
   res.send("Hello world!");
 });
 
-app.get("/sample_response", (_, res) => {
+app.get("/redirectWithHost", (req, res) => {
+  res.redirect(307, `http://${req.hostname}:${port}/sample_response`);
+});
+
+app.get("/redirectWithoutHost", (_, res) => {
+  res.redirect(307, `/sample_response`);
+});
+
+let sendRetryResponse = true;
+
+app.get("/reset_retry", (_, res) => {
+  sendRetryResponse = true;
+  res.send("The retry flag was reset. The next call to /retry will return a 429 status.");
+});
+
+app.get("/retry", (_, res) => {
+  if (sendRetryResponse) {
+    res
+      .status(429)
+      .header("Retry-After", new Date().toUTCString())
+      .send({ error: "429 Too Many Requests" });
+    sendRetryResponse = false;
+  } else {
+    res.send({ val: "abc" });
+  }
+});
+
+app.get("/sample_response", (req, res) => {
+  if (req.header("x-recording-id") !== undefined) {
+    res.status(400).send({ error: "This request bypassed the proxy tool!" });
+    return;
+  }
+
   res.send({ val: "abc" });
 });
 


### PR DESCRIPTION
### Packages impacted by this PR

* `@azure-tools/test-recorder`

### Issues associated with this PR

* Fixes #21219

### Describe the problem that is addressed by this PR

When the service returns a redirect response, our test proxy policy would not properly rewrite the second request that is made by the pipeline due to the redirection. This meant that the second request would go to the service directly, instead of via the test proxy, which causes a number of issues.

Until recently, the test proxy has been following redirects before returning responses during record mode. This has been identified as incorrect behavior (see some discussion at https://github.com/Azure/azure-sdk-tools/issues/2982), and a change is in the works to make the test proxy follow redirects by default (although the old behavior will still be configurable -- we'll need this for the browser scenario, since we don't control redirection behavior there). This meant that the issue this PR fixes couldn't be encountered until now, since the test proxy would not return a redirect response under any circumstance.

The fix involves changing the recorder HTTP policy slightly. Previously, we didn't rewrite the request if the `X-Recording-Id` header was present (suggesting we had already redirected the request). This logic falls through if the second time the request passes through the HTTP policy, the request hostname has been changed (e.g. due to a redirect). That case would mean we _should_ rewrite the request to point to the test proxy a second time. I have updated the logic so that we instead check if the request URL is already pointing to the test proxy, and if so, then we don't need to rewrite the request. This check is more robust and works in the case of a cross-domain redirect.

### Are there test cases added in this PR? _(If not, why?)_

Yes. Added a few cases:
* Redirects: testing to ensure correct behavior during redirect, regardless of whether the redirect is a full URL or is just relative. The previous logic handled relative redirects correctly, so I added a test case for both cases to ensure that there was no regression.
* Retrying: retrying was the original reason we had logic to not rewrite the request twice, so I have added a test case to make sure that retrying works OK.
