### PR TITLE
[Recorder] Do not set private to true to be able to release

### DIFF
--- a/sdk/test-utils/recorder/package.json
+++ b/sdk/test-utils/recorder/package.json
@@ -63,7 +63,6 @@
   },
   "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/test-utils/recorder/",
   "sideEffects": false,
-  "private": true,
   "dependencies": {
     "@azure/core-http": "^2.0.0",
     "@azure/core-rest-pipeline": "^1.1.0",

--- a/sdk/test-utils/test-credential/package.json
+++ b/sdk/test-utils/test-credential/package.json
@@ -51,7 +51,6 @@
   },
   "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/test-utils/test-credential/README.md",
   "sideEffects": false,
-  "private": true,
   "dependencies": {
     "@azure/core-auth": "^1.3.2",
     "@azure-tools/test-recorder": "^1.0.0",


### PR DESCRIPTION
Pipeline failed because of https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1497447&view=logs&j=5742d1c6-78e5-56de-b8e3-8788f4b41836&t=6c758387-9fbb-54a1-8544-1f7c5bb76fbc.

Unsetting `"private" : "true"` in package.json.

This has to be the last hurdle and should do trick to release