### PR TITLE
Revert dependency test internal ref finding regex

### DIFF
--- a/eng/tools/dependency-testing/index.js
+++ b/eng/tools/dependency-testing/index.js
@@ -281,7 +281,7 @@ async function readAndReplaceSourceReferences(filePath, packageName) {
     'path.resolve(path.join(process.cwd(),"..","..", "assets"'
   );
   // Regex for internal references = /* ["']+[../]*src[/][a-z]+["'] */
-  let internalrefs = testAssetsContent.match(/[\"\']+[..//]*src[//][a-zA-Z/]+[\"\']+/g);
+  let internalrefs = testAssetsContent.match(/[\"\']+[..//]*src[//][a-zA-Z]+[\"\']+/g);
   let writeContent = "";
   if (internalrefs) {
     console.log("internal refs = ");


### PR DESCRIPTION
JS min and max test is failing with not a module error. This PR is to revert recent change to check and unblock JS team.