### PR TITLE
[eventhubs] - Update mocks to return TracingContext

### DIFF
--- a/sdk/eventhub/event-hubs/test/internal/diagnostics/tracing.spec.ts
+++ b/sdk/eventhub/event-hubs/test/internal/diagnostics/tracing.spec.ts
@@ -1,11 +1,17 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
-import { assert, MockInstrumenter, MockTracingSpan } from "@azure/test-utils";
 import {
-  instrumentEventData,
+  MockInstrumenter,
+  MockTracingSpan,
+  assert,
+  createMockTracingContext,
+} from "@azure/test-utils";
+import {
   TRACEPARENT_PROPERTY,
+  instrumentEventData,
 } from "../../../src/diagnostics/instrumentEventData";
 import { toSpanOptions, tracingClient } from "../../../src/diagnostics/tracing";
+
 import Sinon from "sinon";
 
 describe("tracing", () => {
@@ -59,7 +65,7 @@ describe("tracing", () => {
       // Setup our tracingClient to ensure we reach the happy path.
       Sinon.stub(tracingClient, "startSpan").returns({
         span: nonRecordingSpan,
-        updatedOptions: {},
+        updatedOptions: { tracingOptions: { tracingContext: createMockTracingContext() } },
       });
       const { event, spanContext } = instrumentEventData({ body: "" }, {}, "testPath", "testHost");
       assert.notExists(spanContext); // was not instrumented
@@ -75,7 +81,7 @@ describe("tracing", () => {
         // Setup our tracingClient to ensure we reach the happy path.
         Sinon.stub(tracingClient, "startSpan").returns({
           span: recordingSpan,
-          updatedOptions: {},
+          updatedOptions: { tracingOptions: { tracingContext: createMockTracingContext() } },
         });
         Sinon.stub(tracingClient, "createRequestHeaders").returns({
           traceparent: "fake-traceparent-header",

--- a/sdk/test-utils/test-utils/src/index.ts
+++ b/sdk/test-utils/test-utils/src/index.ts
@@ -22,3 +22,5 @@ export * from "./tracing/testTracerProvider";
 export * from "./tracing/spanGraphModel";
 
 export { createXhrHttpClient } from "./xhrHttpClient";
+
+export { createMockTracingContext } from "./tracing/mockContext";

--- a/sdk/test-utils/test-utils/src/tracing/mockContext.ts
+++ b/sdk/test-utils/test-utils/src/tracing/mockContext.ts
@@ -42,3 +42,7 @@ export class MockContext implements TracingContext {
 }
 
 export const spanKey = Symbol.for("span");
+
+export function createMockTracingContext(parentContext?: MockContext): TracingContext {
+  return new MockContext(parentContext);
+}


### PR DESCRIPTION
### Packages impacted by this PR
event-hubs

### Issues associated with this PR
Fixes eventhubs build

### Describe the problem that is addressed by this PR
In https://github.com/Azure/azure-sdk-for-js/pull/21264 we updated our
tracing interfaces' startSpan to match runtime behavior of always returning a
context. 

This PR will then match our mocks in eventhubs to align with that behavior.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?
I originally just used `{ tracingOptions: { tracingContext: {} as TracingContext
} },` which felt brittle. We already have a mock context in test-utils so
exposing it made sense here and for anyone else that needs a TracingContext in
tests...

### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_


### Command used to generate this PR: _(Applicable only to SDK release request PRs)_


### Checklists
- [ ] Added impacted package name to the issue description.
- [ ] Does this PR need any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here.)_
- [ ] Added a changelog (if necessary).
