### PR TITLE
[engsys] enable @typescript-eslint/no-implicit-any-catch rule

### DIFF
--- a/common/tools/eslint-plugin-azure-sdk/src/configs/azure-sdk-base.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/configs/azure-sdk-base.ts
@@ -87,6 +87,7 @@ export default {
         ],
         "@typescript-eslint/no-angle-bracket-type-assertion": "off",
         "@typescript-eslint/no-array-constructor": "off",
+        "@typescript-eslint/no-implicit-any-catch": "warn",
         "@typescript-eslint/no-explicit-any": "off",
         "@typescript-eslint/explicit-function-return-type": [
           "warn",


### PR DESCRIPTION
and report violation as warning.  Note that by default it also reports the cases where `: any` is specified explicitly.

The implicit `any` catch variable will be reported as error after we upgrade to typescript 4.6 or later.  However, the warning for explicit `any` catch variable can help us track the work to move away from any catch variable.