### PR TITLE
[Identity] authorization code credential bug fixes

### DIFF
--- a/sdk/identity/identity/CHANGELOG.md
+++ b/sdk/identity/identity/CHANGELOG.md
@@ -8,6 +8,9 @@
 
 ### Bugs Fixed
 
+- Fixed a bug in `AuthorizationCodeCredential` where the tenant id was not being used. The `common` tenant was the only tenant being used by this credential.
+- Fixed a bug in `AuthorizationCodeCredential` where the public client was not being used. Due to this bug, without passing in the client secret, this credential would fail.
+
 ### Other Changes
 
 - Upgraded to `@azure/core-tracing` version `^1.0.0`.

--- a/sdk/identity/identity/src/credentials/authorizationCodeCredential.ts
+++ b/sdk/identity/identity/src/credentials/authorizationCodeCredential.ts
@@ -114,6 +114,7 @@ export class AuthorizationCodeCredential implements TokenCredential {
       ...options,
       clientSecret,
       clientId,
+      tenantId,
       tokenCredentialOptions: options || {},
       logger,
       redirectUri: this.redirectUri,

--- a/sdk/identity/identity/src/msal/nodeFlows/msalAuthorizationCode.ts
+++ b/sdk/identity/identity/src/msal/nodeFlows/msalAuthorizationCode.ts
@@ -37,7 +37,7 @@ export class MsalAuthorizationCode extends MsalNode {
 
   async getAuthCodeUrl(options: { scopes: string[]; redirectUri: string }): Promise<string> {
     await this.init();
-    return this.confidentialApp!.getAuthCodeUrl(options);
+    return (this.confidentialApp || this.publicApp)!.getAuthCodeUrl(options);
   }
 
   protected async doGetToken(
@@ -45,7 +45,7 @@ export class MsalAuthorizationCode extends MsalNode {
     options?: CredentialFlowGetTokenOptions
   ): Promise<AccessToken> {
     try {
-      const result = await this.confidentialApp?.acquireTokenByCode({
+      const result = await (this.confidentialApp || this.publicApp)?.acquireTokenByCode({
         scopes,
         redirectUri: this.redirectUri,
         code: this.authorizationCode,


### PR DESCRIPTION
### Packages impacted by this PR
@azure/identity

### Issues associated with this PR
- Fixes https://github.com/Azure/azure-sdk-for-js/issues/21392

### Describe the problem that is addressed by this PR

We are fixing two bugs in this PR -
- In the Authorization Code Credential, the public client was not being used. Due to this bug, without passing in the client secret, this credential would fail.
-  In the Authorization Code Credential, the tenant id was not being used. The `common` tenant was the only tenant being used by this credential.

### Checklists
- [x] Added impacted package name to the issue description
- [x] Added a changelog (if necessary)
