### PR TITLE
Fix error handling in deleteTable

### DIFF
--- a/sdk/tables/data-tables/CHANGELOG.md
+++ b/sdk/tables/data-tables/CHANGELOG.md
@@ -1,14 +1,9 @@
 # Release History
 
-## 13.1.1 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
+## 13.1.1 (2022-04-14)
 
 ### Bugs Fixed
-
-### Other Changes
+- Fixed issue where `deleteTable()` doesn't throw any errors [21408](https://github.com/Azure/azure-sdk-for-js/pull/21408).
 
 ## 13.1.0 (2022-04-07)
 

--- a/sdk/tables/data-tables/src/TableClient.ts
+++ b/sdk/tables/data-tables/src/TableClient.ts
@@ -299,6 +299,8 @@ export class TableClient {
       } catch (e) {
         if (e.statusCode === 404) {
           logger.info("TableClient.deleteTable: Table doesn't exist");
+        } else {
+          throw e;
         }
       }
     });

--- a/sdk/tables/data-tables/test/internal/errorHandling.spec.ts
+++ b/sdk/tables/data-tables/test/internal/errorHandling.spec.ts
@@ -1,0 +1,86 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { HttpClient, PipelineResponse, createHttpHeaders } from "@azure/core-rest-pipeline";
+import { TableClient, TableServiceClient } from "../../src";
+import { assert } from "chai";
+
+describe("ErrorHandling", () => {
+  describe("TableClient", () => {
+    it("should not throw on delete table not found", async () => {
+      const client = new TableClient("https://example.org", "fakeTable", {
+        httpClient: buildTestHttpClient({ status: 404 }),
+      });
+
+      let threw = false;
+
+      try {
+        await client.deleteTable();
+      } catch {
+        threw = true;
+      } finally {
+        assert.isFalse(threw, "Expected not to throw on 404");
+      }
+    });
+
+    it("should throw on delete table with non 404 error", async () => {
+      const client = new TableClient("https://example.org", "fakeTable", {
+        httpClient: buildTestHttpClient({ status: 400 }),
+      });
+      let threw = false;
+
+      try {
+        await client.deleteTable();
+      } catch {
+        threw = true;
+      } finally {
+        assert.isTrue(threw, "Expected to throw on non-404");
+      }
+    });
+  });
+
+  describe("TableServiceClient", () => {
+    it("should not throw on delete table not found", async () => {
+      const client = new TableServiceClient("https://example.org", {
+        httpClient: buildTestHttpClient({ status: 404 }),
+      });
+      let threw = false;
+
+      try {
+        await client.deleteTable("fakeTable");
+      } catch {
+        threw = true;
+      } finally {
+        assert.isFalse(threw, "Expected not to throw on 404");
+      }
+    });
+
+    it("should throw on delete table with non 404 error", async () => {
+      const client = new TableServiceClient("https://example.org", {
+        httpClient: buildTestHttpClient({ status: 400 }),
+      });
+      let threw = false;
+
+      try {
+        await client.deleteTable("FakeTable");
+      } catch {
+        threw = true;
+      } finally {
+        assert.isTrue(threw, "Expected to throw on non-404");
+      }
+    });
+  });
+});
+
+function buildTestHttpClient(response?: Partial<PipelineResponse>): HttpClient {
+  return {
+    async sendRequest(req) {
+      return {
+        headers: createHttpHeaders(),
+        request: req,
+        status: 200,
+        ...response,
+      };
+    },
+  };
+}


### PR DESCRIPTION
### Packages impacted by this PR
@Azure/data-tables

### Issues associated with this PR
#21385

### Describe the problem that is addressed by this PR
When migrating to the new @azure/core-tracing version we accidentally removed the code that throws when a delete operation returns a non-404 status code

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?
Added back the deleted code

### Are there test cases added in this PR? _(If not, why?)_
Yes, added test to prevent this regression from happening again

### Provide a list of related PRs _(if any)_
N/A

### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_
n/a
### Checklists
- [x] Added impacted package name to the issue description
- [x] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [x] Added a changelog (if necessary)
