### PR TITLE
[core-rest-pipeline] - Bump core-tracing min-version to 1.0.1

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -14472,7 +14472,7 @@ packages:
     dev: false
 
   file:projects/core-rest-pipeline.tgz:
-    resolution: {integrity: sha512-9ZxxeAF7BAgOvK0Mk05qB3s6ZRG9oBcrJrDJOebXYFqD2EAnbkmCKKQt1RBIX1tFYrBKY3wgimFJzgtlOv2SHQ==, tarball: file:projects/core-rest-pipeline.tgz}
+    resolution: {integrity: sha512-9cRj5F0bEb7SfVpuWvnANbN+to1qMNca2hSQSpYapPuz0Z9oVgOfj2PViNKTxXoPU+dzEAoqtDop2aRFU7QEKg==, tarball: file:projects/core-rest-pipeline.tgz}
     name: '@rush-temp/core-rest-pipeline'
     version: 0.0.0
     dependencies:

--- a/sdk/core/core-rest-pipeline/package.json
+++ b/sdk/core/core-rest-pipeline/package.json
@@ -88,7 +88,7 @@
   "dependencies": {
     "@azure/abort-controller": "^1.0.0",
     "@azure/core-auth": "^1.3.0",
-    "@azure/core-tracing": "^1.0.0",
+    "@azure/core-tracing": "^1.0.1",
     "@azure/core-util": "^1.0.0",
     "@azure/logger": "^1.0.0",
     "form-data": "^4.0.0",

--- a/sdk/core/core-rest-pipeline/src/policies/tracingPolicy.ts
+++ b/sdk/core/core-rest-pipeline/src/policies/tracingPolicy.ts
@@ -100,8 +100,10 @@ function tryCreateSpan(
       }
     );
 
-    // If the span is not recording, don't do any more work.
-    if (!span.isRecording()) {
+    const tracingContext = updatedOptions.tracingOptions?.tracingContext;
+
+    // If the span is not recording, or we don't have valid context don't do any more work.
+    if (!tracingContext || !span.isRecording()) {
       span.end();
       return undefined;
     }
@@ -111,13 +113,11 @@ function tryCreateSpan(
     }
 
     // set headers
-    const headers = tracingClient.createRequestHeaders(
-      updatedOptions.tracingOptions.tracingContext
-    );
+    const headers = tracingClient.createRequestHeaders(tracingContext);
     for (const [key, value] of Object.entries(headers)) {
       request.headers.set(key, value);
     }
-    return { span, tracingContext: updatedOptions.tracingOptions.tracingContext };
+    return { span, tracingContext };
   } catch (e) {
     logger.warning(`Skipping creating a tracing span due to an error: ${getErrorMessage(e)}`);
     return undefined;

--- a/sdk/core/core-rest-pipeline/src/policies/tracingPolicy.ts
+++ b/sdk/core/core-rest-pipeline/src/policies/tracingPolicy.ts
@@ -100,10 +100,8 @@ function tryCreateSpan(
       }
     );
 
-    const tracingContext = updatedOptions.tracingOptions?.tracingContext;
-
-    // If the span is not recording, or we don't have valid context don't do any more work.
-    if (!tracingContext || !span.isRecording()) {
+    // If the span is not recording, don't do any more work.
+    if (!span.isRecording()) {
       span.end();
       return undefined;
     }
@@ -113,11 +111,13 @@ function tryCreateSpan(
     }
 
     // set headers
-    const headers = tracingClient.createRequestHeaders(tracingContext);
+    const headers = tracingClient.createRequestHeaders(
+      updatedOptions.tracingOptions.tracingContext
+    );
     for (const [key, value] of Object.entries(headers)) {
       request.headers.set(key, value);
     }
-    return { span, tracingContext };
+    return { span, tracingContext: updatedOptions.tracingOptions.tracingContext };
   } catch (e) {
     logger.warning(`Skipping creating a tracing span due to an error: ${getErrorMessage(e)}`);
     return undefined;


### PR DESCRIPTION
### Packages impacted by this PR
core-rest-pipeline

### Issues associated with this PR
N/A

### Describe the problem that is addressed by this PR
We recently narrowed the types in core-tracing to reflect that `updatedOptions.tracingOptions` will always be defined.
Since core-rest-pipeline still depends on core-tracing@^1.0.0 our nightly build runs our code against core-tracing 1.0
causing a compilation failure.

The test using the min dev version is great as it found this issue. 

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_


### Command used to generate this PR: _(Applicable only to SDK release request PRs)_


### Checklists
- [ ] Added impacted package name to the issue description.
- [ ] Does this PR need any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here.)_
- [ ] Added a changelog (if necessary).
