### PR TITLE
[EventGrid] Support Channel Names for Partner Topics

### DIFF
--- a/sdk/eventgrid/eventgrid/CHANGELOG.md
+++ b/sdk/eventgrid/eventgrid/CHANGELOG.md
@@ -2,13 +2,9 @@
 
 ## 4.10.0-beta.1 (2022-04-14)
 
-- Add support for specifiying a channel to send to in a specific Partner Topic via the `channelName` property of `SendOptions`.
-
 ### Features Added
 
-### Breaking Changes
-
-### Bugs Fixed
+- Add support for specifiying a channel to send to in a specific Partner Topic via the `channelName` property of `SendOptions`.
 
 ### Other Changes
 

--- a/sdk/eventgrid/eventgrid/CHANGELOG.md
+++ b/sdk/eventgrid/eventgrid/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Release History
 
-## 4.10.0 (Unreleased)
+## 4.10.0-beta.1 (2022-04-14)
+
+- Add support for specifiying a channel to send to in a specific Partner Topic via the `channelName` property of `SendOptions`.
 
 ### Features Added
 

--- a/sdk/eventgrid/eventgrid/package.json
+++ b/sdk/eventgrid/eventgrid/package.json
@@ -3,7 +3,7 @@
   "sdk-type": "client",
   "author": "Microsoft Corporation",
   "description": "An isomorphic client library for the Azure Event Grid service.",
-  "version": "4.10.0",
+  "version": "4.10.0-beta.1",
   "keywords": [
     "node",
     "azure",

--- a/sdk/eventgrid/eventgrid/review/eventgrid.api.md
+++ b/sdk/eventgrid/eventgrid/review/eventgrid.api.md
@@ -543,7 +543,7 @@ export class EventGridPublisherClient<T extends InputSchema> {
     constructor(endpointUrl: string, inputSchema: T, credential: KeyCredential | SASCredential | TokenCredential, options?: EventGridPublisherClientOptions);
     readonly apiVersion: string;
     readonly endpointUrl: string;
-    send(events: InputSchemaToInputTypeMap[T][], options?: SendOptions): Promise<void>;
+    send(events: InputSchemaToInputTypeMap[T][], options?: InputSchemaToOptionsTypeMap[T]): Promise<void>;
 }
 
 // @public
@@ -605,6 +605,18 @@ export interface InputSchemaToInputTypeMap {
     CloudEvent: SendCloudEventInput<unknown>;
     Custom: Record<string, unknown>;
     EventGrid: SendEventGridEventInput<unknown>;
+}
+
+// @public
+export interface InputSchemaToOptionsTypeMap {
+    // Warning: (ae-forgotten-export) The symbol "CloudEventSendOptions" needs to be exported by the entry point index.d.ts
+    //
+    // (undocumented)
+    CloudEvent: CloudEventSendOptions;
+    // (undocumented)
+    Custom: SendOptions;
+    // (undocumented)
+    EventGrid: SendOptions;
 }
 
 // @public

--- a/sdk/eventgrid/eventgrid/review/eventgrid.api.md
+++ b/sdk/eventgrid/eventgrid/review/eventgrid.api.md
@@ -345,6 +345,11 @@ export interface CloudEvent<T> {
 }
 
 // @public
+export interface CloudEventSendOptions extends SendOptions {
+    channelName?: string;
+}
+
+// @public
 export type CommunicationCloudEnvironmentModel = string;
 
 // @public
@@ -609,8 +614,6 @@ export interface InputSchemaToInputTypeMap {
 
 // @public
 export interface InputSchemaToOptionsTypeMap {
-    // Warning: (ae-forgotten-export) The symbol "CloudEventSendOptions" needs to be exported by the entry point index.d.ts
-    //
     // (undocumented)
     CloudEvent: CloudEventSendOptions;
     // (undocumented)

--- a/sdk/eventgrid/eventgrid/review/eventgrid.api.md
+++ b/sdk/eventgrid/eventgrid/review/eventgrid.api.md
@@ -614,11 +614,8 @@ export interface InputSchemaToInputTypeMap {
 
 // @public
 export interface InputSchemaToOptionsTypeMap {
-    // (undocumented)
     CloudEvent: CloudEventSendOptions;
-    // (undocumented)
     Custom: SendOptions;
-    // (undocumented)
     EventGrid: SendOptions;
 }
 

--- a/sdk/eventgrid/eventgrid/src/eventGridClient.ts
+++ b/sdk/eventgrid/eventgrid/src/eventGridClient.ts
@@ -58,7 +58,6 @@ export interface InputSchemaToInputTypeMap {
   /**
    * The shape of the input to `send` when the client is configured to send events using a custom schema.
    */
-
   Custom: Record<string, unknown>;
 }
 
@@ -66,8 +65,17 @@ export interface InputSchemaToInputTypeMap {
  * A map of input schema names to shapes of the options bag for the send method on EventGridPublisherClient.
  */
 export interface InputSchemaToOptionsTypeMap {
+  /**
+   * The shape of the options parameter for `send` when the client is configured to send events using the Event Grid schema.
+   */
   EventGrid: SendOptions;
+  /**
+   * The shape of the options parameter for `send` when the client is configured to send events using the Cloud Event schema.
+   */
   CloudEvent: CloudEventSendOptions;
+  /**
+   * The shape of the options parameter for `send` when the client is configured to send events using a custom schema.
+   */
   Custom: SendOptions;
 }
 
@@ -166,11 +174,14 @@ export class EventGridPublisherClient<T extends InputSchema> {
           // The underlying REST API expects a header named `aeg-channel-name`, and so the generated client
           // expects that options bag has a property called `aegChannelName`, where as we expose it with the
           // friendlier name "channelName". Fix up the impedence mismatch here
-          const { channelName, ...sendOptions } = updatedOptions as CloudEventSendOptions;
+          const {
+            channelName,
+            ...sendOptions
+          }: { channelName?: string } & GeneratedClientPublishCloudEventEventsOptionalParams =
+            updatedOptions as CloudEventSendOptions;
 
           if (channelName) {
-            (sendOptions as GeneratedClientPublishCloudEventEventsOptionalParams).aegChannelName =
-              channelName;
+            sendOptions.aegChannelName = channelName;
           }
 
           return this.client.publishCloudEventEvents(

--- a/sdk/eventgrid/eventgrid/src/eventGridClient.ts
+++ b/sdk/eventgrid/eventgrid/src/eventGridClient.ts
@@ -36,12 +36,12 @@ export type SendOptions = OperationOptions;
 /***
  * Options for the send events operation, when the input schema is cloud event.
  */
-export type CloudEventSendOptions = SendOptions & {
-  /*
+export interface CloudEventSendOptions extends SendOptions {
+  /**
    * The name of the channel to send the event to (only valid for Partner Namespaces and Topics).
    */
   channelName?: string;
-};
+}
 
 /**
  * A map of input schema names to shapes of the input for the send method on EventGridPublisherClient.
@@ -166,22 +166,17 @@ export class EventGridPublisherClient<T extends InputSchema> {
           // The underlying REST API expects a header named `aeg-channel-name`, and so the generated client
           // expects that options bag has a property called `aegChannelName`, where as we expose it with the
           // friendlier name "channelName". Fix up the impedence mismatch here
-          const { channelName, ...sendOptions } = {
-            ...(updatedOptions as CloudEventSendOptions),
-          };
-
-          const generatedClientSendOptions: GeneratedClientPublishCloudEventEventsOptionalParams = {
-            ...sendOptions,
-          };
+          const { channelName, ...sendOptions } = updatedOptions as CloudEventSendOptions;
 
           if (channelName) {
-            generatedClientSendOptions.aegChannelName = channelName;
+            (sendOptions as GeneratedClientPublishCloudEventEventsOptionalParams).aegChannelName =
+              channelName;
           }
 
           return this.client.publishCloudEventEvents(
             this.endpointUrl,
             (events as InputSchemaToInputTypeMap["CloudEvent"][]).map(convertCloudEventToModelType),
-            generatedClientSendOptions
+            sendOptions
           );
         }
         case "Custom": {

--- a/sdk/eventgrid/eventgrid/src/generated/generatedClientContext.ts
+++ b/sdk/eventgrid/eventgrid/src/generated/generatedClientContext.ts
@@ -26,7 +26,7 @@ export class GeneratedClientContext extends coreClient.ServiceClient {
       requestContentType: "application/json; charset=utf-8"
     };
 
-    const packageDetails = `azsdk-js-eventgrid/4.10.0`;
+    const packageDetails = `azsdk-js-eventgrid/4.10.0-beta.1`;
     const userAgentPrefix =
       options.userAgentOptions && options.userAgentOptions.userAgentPrefix
         ? `${options.userAgentOptions.userAgentPrefix} ${packageDetails}`

--- a/sdk/eventgrid/eventgrid/src/index.ts
+++ b/sdk/eventgrid/eventgrid/src/index.ts
@@ -9,6 +9,7 @@ export {
   EventGridPublisherClient,
   EventGridPublisherClientOptions,
   SendOptions,
+  CloudEventSendOptions,
   InputSchema,
   InputSchemaToInputTypeMap,
   InputSchemaToOptionsTypeMap,

--- a/sdk/eventgrid/eventgrid/src/index.ts
+++ b/sdk/eventgrid/eventgrid/src/index.ts
@@ -11,6 +11,7 @@ export {
   SendOptions,
   InputSchema,
   InputSchemaToInputTypeMap,
+  InputSchemaToOptionsTypeMap,
 } from "./eventGridClient";
 
 export {

--- a/sdk/eventgrid/eventgrid/swagger/README.md
+++ b/sdk/eventgrid/eventgrid/swagger/README.md
@@ -7,7 +7,7 @@
 ```yaml
 require: "https://github.com/Azure/azure-rest-api-specs/blob/f8811b7dd784712c3fb0941e04d9042f59a4d367/specification/eventgrid/data-plane/readme.md"
 package-name: "@azure/eventgrid"
-package-version: "4.10.0"
+package-version: "4.10.0-beta.1"
 title: GeneratedClient
 description: EventGrid Client
 generate-metadata: false

--- a/sdk/eventgrid/perf-tests/eventgrid/package.json
+++ b/sdk/eventgrid/perf-tests/eventgrid/package.json
@@ -8,7 +8,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@azure/eventgrid": "^4.0.0",
+    "@azure/eventgrid": "^4.10.0-beta",
     "@azure/test-utils-perf": "^1.0.0",
     "dotenv": "^8.2.0"
   },


### PR DESCRIPTION
The EventGrid service team is adding a new feature called channels
which can be used by Partner Topics (note that "partners" here does
not mean internal Microsoft folks, but rather larger external
customers). The channels act as a sort of namespacing mechanism
(similar to the Domain Topics for topics using the classic
"EventGrid" schema) but are only supported when the schema of the
topic is set to Cloud Events.

Unlike domain topics, where the event payload incldues information on
which topic inside the domain to send to, the channel which is
published to is specificed in an `aeg-channel-name` header as part of
the request to send events.

To support this - we add a new property to our options bag,
`channelName` which can be used to specify the channel to use when
sending a set of events. Because this feature is specific to Partner
Topics, we did not try to model it as another named parameter of the
`send` function or create a new method which would be specific to
channels. Most customers won't be using Partner Topics (although,
again, this is a feature that can and is used by external customers)
so we did not want to introduce a new cognative burden.

We have authored our typescript typings for this function such that
the `channelName` property on the options bag only appears for clients
which are using the CloudEvent schema.

The service team has this feature in Preview today, so we'd like to
release a preview version of the library with support for this feature
that their customers can use.  We've manually validated this against a
partner topic provided by the service team and are working on getting
automated tests that we can record.