### PR TITLE
[core-http] fix xml and user agent policy for react-native

### DIFF
--- a/sdk/core/core-http/CHANGELOG.md
+++ b/sdk/core/core-http/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 - Fix an issue where React-Native is loading the wrong file. Adding a `react-native` mapping to point to the ESM entrypoint file. [PR #21118](https://github.com/Azure/azure-sdk-for-js/pull/21118)
 - delay creating XML parser/builder objects so that packages not requiring XML functionality but running on platforms lacking XML support can still load this package. [PR #21118](https://github.com/Azure/azure-sdk-for-js/pull/21118)
+- Add a `react-native` mapping to use `xml2js` as it is already in our dependency list. Customer can get it to work after installing `stream` and `timers` packages in their React-Native project.
+- Fix a run-time error in user agent policy when running in React-Native.
 
 ### Other Changes
 

--- a/sdk/core/core-http/package.json
+++ b/sdk/core/core-http/package.json
@@ -57,7 +57,9 @@
     "./dist-esm/src/util/url.js": "./dist-esm/src/util/url.browser.js"
   },
   "react-native": {
-    "./dist/index.js": "./dist-esm/src/coreHttp.js"
+    "./dist/index.js": "./dist-esm/src/coreHttp.js",
+    "./dist-esm/src/util/xml.js": "./dist-esm/src/util/xml.js",
+    "./dist-esm/src/policies/msRestUserAgentPolicy.js": "./dist-esm/src/policies/msRestUserAgentPolicy.native.js"
   },
   "license": "MIT",
   "homepage": "https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/core/core-http/README.md",

--- a/sdk/core/core-http/src/policies/msRestUserAgentPolicy.browser.ts
+++ b/sdk/core/core-http/src/policies/msRestUserAgentPolicy.browser.ts
@@ -2,8 +2,7 @@
 // Licensed under the MIT license.
 
 /*
- * NOTE: When moving this file, please update "browser" section in package.json
- * and "plugins" section in webpack.testconfig.ts.
+ * NOTE: When moving this file, please update "browser" section in package.json.
  */
 
 import { TelemetryInfo } from "./userAgentPolicy";

--- a/sdk/core/core-http/src/policies/msRestUserAgentPolicy.native.ts
+++ b/sdk/core/core-http/src/policies/msRestUserAgentPolicy.native.ts
@@ -2,12 +2,11 @@
 // Licensed under the MIT license.
 
 /*
- * NOTE: When moving this file, please update "browser" section in package.json
- * and "plugins" section in webpack.testconfig.ts.
+ * NOTE: When moving this file, please update "react-native" section in package.json.
  */
 
 import { TelemetryInfo } from "./userAgentPolicy";
-const { Platform } = require("react-native");
+const { Platform } = require("react-native");  // eslint-disable-line import/no-extraneous-dependencies, @typescript-eslint/no-require-imports
 
 export function getDefaultUserAgentKey(): string {
   return "x-ms-useragent";

--- a/sdk/core/core-http/src/policies/msRestUserAgentPolicy.native.ts
+++ b/sdk/core/core-http/src/policies/msRestUserAgentPolicy.native.ts
@@ -1,0 +1,29 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+/*
+ * NOTE: When moving this file, please update "browser" section in package.json
+ * and "plugins" section in webpack.testconfig.ts.
+ */
+
+import { TelemetryInfo } from "./userAgentPolicy";
+const { Platform } = require("react-native");
+
+export function getDefaultUserAgentKey(): string {
+  return "x-ms-useragent";
+}
+
+export function getPlatformSpecificData(): TelemetryInfo[] {
+  const runtimeInfo = {
+    key: "react-native",
+    value: Platform.reactNativeVersion,
+  };
+
+  const osInfo = {
+    key: "OS",
+    value: `${Platform.OS}-${String(Platform.Version)}`,
+  };
+
+  console.log("Platform.constants", Platform.constants);
+  return [runtimeInfo, osInfo];
+}

--- a/sdk/core/core-http/src/policies/msRestUserAgentPolicy.native.ts
+++ b/sdk/core/core-http/src/policies/msRestUserAgentPolicy.native.ts
@@ -23,6 +23,5 @@ export function getPlatformSpecificData(): TelemetryInfo[] {
     value: `${Platform.OS}-${String(Platform.Version)}`,
   };
 
-  console.log("Platform.constants", Platform.constants);
   return [runtimeInfo, osInfo];
 }

--- a/sdk/core/core-http/src/policies/msRestUserAgentPolicy.native.ts
+++ b/sdk/core/core-http/src/policies/msRestUserAgentPolicy.native.ts
@@ -6,7 +6,7 @@
  */
 
 import { TelemetryInfo } from "./userAgentPolicy";
-const { Platform } = require("react-native");  // eslint-disable-line import/no-extraneous-dependencies, @typescript-eslint/no-require-imports
+const { Platform } = require("react-native"); // eslint-disable-line import/no-extraneous-dependencies, @typescript-eslint/no-require-imports
 
 export function getDefaultUserAgentKey(): string {
   return "x-ms-useragent";


### PR DESCRIPTION
- Add a react-native mapping to use xml2js for XML parsing/building.

- Add a react-native version of user agent policy to return proper information from the platform.  Without this the browser version is used, which caused run-time error as
`navigator` is not available. Using `require()` so we don't need to pull in `react-native` in our dependency list.
