### PR TITLE
[Storage] add `react-native` mapping to ESM entry point

### DIFF
--- a/sdk/storage/storage-blob/CHANGELOG.md
+++ b/sdk/storage/storage-blob/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Bugs Fixed
 
 - Fix incorrect browser mapping path for BufferScheduler.js
+- Add `react-native` mapping to ESM entrypoint
 
 ### Other Changes
 

--- a/sdk/storage/storage-blob/package.json
+++ b/sdk/storage/storage-blob/package.json
@@ -20,6 +20,9 @@
     "os": false,
     "process": false
   },
+  "react-native": {
+    "./dist/index.js": "./dist-esm/storage-blob/src/index.js"
+  },
   "types": "./types/latest/storage-blob.d.ts",
   "typesVersions": {
     "<3.6": {

--- a/sdk/storage/storage-file-datalake/CHANGELOG.md
+++ b/sdk/storage/storage-file-datalake/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Bugs Fixed
 
 - Add missing browser mapping for `./dist-esm/storage-common/src/BufferScheduler.js`
+- Add `react-native` mapping to ESM entry point
 
 ### Other Changes
 

--- a/sdk/storage/storage-file-datalake/package.json
+++ b/sdk/storage/storage-file-datalake/package.json
@@ -25,6 +25,9 @@
     "os": false,
     "process": false
   },
+  "react-native": {
+    "./dist/index.js": "./dist-esm/storage-file-datalake/src/index.js"
+  },
   "engines": {
     "node": ">=12.0.0"
   },

--- a/sdk/storage/storage-file-share/CHANGELOG.md
+++ b/sdk/storage/storage-file-share/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Add `react-native` mapping to ESM entry point
+
 ### Other Changes
 
 ## 12.9.0 (2022-03-11)

--- a/sdk/storage/storage-file-share/package.json
+++ b/sdk/storage/storage-file-share/package.json
@@ -15,6 +15,9 @@
     "os": false,
     "process": false
   },
+  "react-native": {
+    "./dist/index.js": "./dist-esm/src/index.js"
+  },
   "types": "./types/latest/storage-file-share.d.ts",
   "typesVersions": {
     "<3.6": {

--- a/sdk/storage/storage-queue/CHANGELOG.md
+++ b/sdk/storage/storage-queue/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Add `react-native` mapping to ESM entry point
+
 ### Other Changes
 
 ## 12.8.0 (2022-03-11)

--- a/sdk/storage/storage-queue/package.json
+++ b/sdk/storage/storage-queue/package.json
@@ -12,6 +12,9 @@
     "os": false,
     "process": false
   },
+  "react-native": {
+    "./dist/index.js": "./dist-esm/src/index.js"
+  },
   "types": "./types/latest/storage-queue.d.ts",
   "typesVersions": {
     "<3.6": {


### PR DESCRIPTION
This is the first step towards React-Native support for Storage libraries.  This change allows required polyfill modules to be loaded asynchronously rather than synchronously at bundling/packaging time.