### PR TITLE
[Logger] update logger readme with info on sanitizing headers

### DIFF
--- a/sdk/core/core-rest-pipeline/src/util/sanitizer.ts
+++ b/sdk/core/core-rest-pipeline/src/util/sanitizer.ts
@@ -25,6 +25,7 @@ export interface SanitizerOptions {
 
 const RedactedString = "REDACTED";
 
+// Make sure this list is up-to-date with the one under core/logger/Readme#Keyconcepts
 const defaultAllowedHeaderNames = [
   "x-ms-client-request-id",
   "x-ms-return-client-request-id",

--- a/sdk/core/logger/README.md
+++ b/sdk/core/logger/README.md
@@ -38,6 +38,48 @@ will be emitted.
 For example, setting the log level to `warning` will cause all logs that have the log
 level `warning` or `error` to be emitted.
 
+
+**NOTE**: When logging the body of request and response, we sanitize headers like `Authorization` that contain secrets. The headers that are logged are:
+- "x-ms-client-request-id",
+- "x-ms-return-client-request-id",
+- "x-ms-useragent",
+- "x-ms-correlation-request-id",
+- "x-ms-request-id",
+- "client-request-id",
+- "ms-cv",
+- "return-client-request-id",
+- "traceparent", 
+- "Access-Control-Allow-Credentials",
+- "Access-Control-Allow-Headers",
+- "Access-Control-Allow-Methods",
+- "Access-Control-Allow-Origin",
+- "Access-Control-Expose-Headers",
+- "Access-Control-Max-Age",
+- "Access-Control-Request-Headers",
+- "Access-Control-Request-Method",
+- "Origin",
+- "Accept",
+- "Accept-Encoding",
+- "Cache-Control",
+- "Connection",
+- "Content-Length",
+- "Content-Type",
+- "Date",
+- "ETag",
+- "Expires",
+- "If-Match",
+- "If-Modified-Since",
+- "If-None-Match",
+- "If-Unmodified-Since",
+- "Last-Modified",
+- "Pragma",
+- "Request-Id",
+- "Retry-After",
+- "Server",
+- "Transfer-Encoding",
+- "User-Agent",
+- "WWW-Authenticate",
+
 ## Examples
 
 ### Example 1 - basic usage


### PR DESCRIPTION
### Packages impacted by this PR
@Azure/logger
@azure/core-rest-pipeline

### Issues associated with this PR
- None

### Describe the problem that is addressed by this PR
- Adding some more information in the logger readme about secrets already being sanitized in the header and what headers get logged as part of the logger. Discussion - https://github.com/Azure/azure-sdk-for-js/pull/21136#discussion_r850026149
