### PR TITLE
Remove unused eslint-disable @typescript-eslint/member-ordering in keyvault sdk

### DIFF
--- a/sdk/keyvault/keyvault-certificates/src/index.ts
+++ b/sdk/keyvault/keyvault-certificates/src/index.ts
@@ -5,7 +5,6 @@
 /* eslint-disable @azure/azure-sdk/ts-apisurface-supportcancellation */
 
 // This file makes more sense if ordered based on how meaningful are some methods in relation to others.
-/* eslint-disable @typescript-eslint/member-ordering */
 
 /// <reference lib="esnext.asynciterable" />
 
@@ -743,11 +742,11 @@ export class CertificateClient {
             id: updatedOptions.organizationId,
             adminDetails: updatedOptions.administratorContacts
               ? updatedOptions.administratorContacts.map((x) => ({
-                  emailAddress: x.email,
-                  phone: x.phone,
-                  firstName: x.firstName,
-                  lastName: x.lastName,
-                }))
+                emailAddress: x.email,
+                phone: x.phone,
+                firstName: x.firstName,
+                lastName: x.lastName,
+              }))
               : undefined,
           };
         }
@@ -811,11 +810,11 @@ export class CertificateClient {
             id: updatedOptions.organizationId,
             adminDetails: updatedOptions.administratorContacts
               ? updatedOptions.administratorContacts.map((x) => ({
-                  emailAddress: x.email,
-                  phone: x.phone,
-                  firstName: x.firstName,
-                  lastName: x.lastName,
-                }))
+                emailAddress: x.email,
+                phone: x.phone,
+                firstName: x.firstName,
+                lastName: x.lastName,
+              }))
               : undefined,
           };
         }

--- a/sdk/keyvault/keyvault-certificates/src/index.ts
+++ b/sdk/keyvault/keyvault-certificates/src/index.ts
@@ -739,11 +739,11 @@ export class CertificateClient {
             id: updatedOptions.organizationId,
             adminDetails: updatedOptions.administratorContacts
               ? updatedOptions.administratorContacts.map((x) => ({
-                emailAddress: x.email,
-                phone: x.phone,
-                firstName: x.firstName,
-                lastName: x.lastName,
-              }))
+                  emailAddress: x.email,
+                  phone: x.phone,
+                  firstName: x.firstName,
+                  lastName: x.lastName,
+                }))
               : undefined,
           };
         }
@@ -807,11 +807,11 @@ export class CertificateClient {
             id: updatedOptions.organizationId,
             adminDetails: updatedOptions.administratorContacts
               ? updatedOptions.administratorContacts.map((x) => ({
-                emailAddress: x.email,
-                phone: x.phone,
-                firstName: x.firstName,
-                lastName: x.lastName,
-              }))
+                  emailAddress: x.email,
+                  phone: x.phone,
+                  firstName: x.firstName,
+                  lastName: x.lastName,
+                }))
               : undefined,
           };
         }

--- a/sdk/keyvault/keyvault-certificates/src/index.ts
+++ b/sdk/keyvault/keyvault-certificates/src/index.ts
@@ -1,9 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-// The eslint plugin mentioned below doesn't follow through the extended types.
-/* eslint-disable @azure/azure-sdk/ts-apisurface-supportcancellation */
-
 // This file makes more sense if ordered based on how meaningful are some methods in relation to others.
 
 /// <reference lib="esnext.asynciterable" />
@@ -742,11 +739,11 @@ export class CertificateClient {
             id: updatedOptions.organizationId,
             adminDetails: updatedOptions.administratorContacts
               ? updatedOptions.administratorContacts.map((x) => ({
-                  emailAddress: x.email,
-                  phone: x.phone,
-                  firstName: x.firstName,
-                  lastName: x.lastName,
-                }))
+                emailAddress: x.email,
+                phone: x.phone,
+                firstName: x.firstName,
+                lastName: x.lastName,
+              }))
               : undefined,
           };
         }
@@ -810,11 +807,11 @@ export class CertificateClient {
             id: updatedOptions.organizationId,
             adminDetails: updatedOptions.administratorContacts
               ? updatedOptions.administratorContacts.map((x) => ({
-                  emailAddress: x.email,
-                  phone: x.phone,
-                  firstName: x.firstName,
-                  lastName: x.lastName,
-                }))
+                emailAddress: x.email,
+                phone: x.phone,
+                firstName: x.firstName,
+                lastName: x.lastName,
+              }))
               : undefined,
           };
         }

--- a/sdk/keyvault/keyvault-certificates/src/index.ts
+++ b/sdk/keyvault/keyvault-certificates/src/index.ts
@@ -742,11 +742,11 @@ export class CertificateClient {
             id: updatedOptions.organizationId,
             adminDetails: updatedOptions.administratorContacts
               ? updatedOptions.administratorContacts.map((x) => ({
-                emailAddress: x.email,
-                phone: x.phone,
-                firstName: x.firstName,
-                lastName: x.lastName,
-              }))
+                  emailAddress: x.email,
+                  phone: x.phone,
+                  firstName: x.firstName,
+                  lastName: x.lastName,
+                }))
               : undefined,
           };
         }
@@ -810,11 +810,11 @@ export class CertificateClient {
             id: updatedOptions.organizationId,
             adminDetails: updatedOptions.administratorContacts
               ? updatedOptions.administratorContacts.map((x) => ({
-                emailAddress: x.email,
-                phone: x.phone,
-                firstName: x.firstName,
-                lastName: x.lastName,
-              }))
+                  emailAddress: x.email,
+                  phone: x.phone,
+                  firstName: x.firstName,
+                  lastName: x.lastName,
+                }))
               : undefined,
           };
         }

--- a/sdk/keyvault/keyvault-keys/src/index.ts
+++ b/sdk/keyvault/keyvault-keys/src/index.ts
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
-/* eslint @typescript-eslint/member-ordering: 0 */
 /// <reference lib="esnext.asynciterable" />
 
 import {

--- a/sdk/keyvault/keyvault-secrets/src/index.ts
+++ b/sdk/keyvault/keyvault-secrets/src/index.ts
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
-/* eslint @typescript-eslint/member-ordering: 0 */
 /// <reference lib="esnext.asynciterable" />
 
 import {


### PR DESCRIPTION
Fixed #7608 by removing unused `/* eslint-disable @typescript-eslint/member-ordering */` from
```
- sdk/keyvault/keyvault-certificates/src/index.ts:8
- sdk/keyvault/keyvault-secrets/src/index.ts:3
- sdk/keyvault/keyvault-keys/src/index.ts:3
```

 according to @jeremymeng in https://github.com/Azure/azure-sdk-for-js/issues/7608#issuecomment-984091941
