### PR TITLE
Release check is failing for package when only one alpha version is p…

### DIFF
--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -38,7 +38,8 @@ function Get-javascript-PackageInfoFromRepo ($pkgPath, $serviceDirectory) {
 # Returns the npm publish status of a package id and version.
 function IsNPMPackageVersionPublished ($pkgId, $pkgVersion) {
   Confirm-NodeInstallation
-  $npmVersions = (npm show $pkgId versions)
+  $packageAndVersion = $pkgId + "@" + $pkgVersion
+  $npmVersion = (npm show $packageAndVersion version)
   if ($LastExitCode -ne 0) {
     npm ping
     if ($LastExitCode -eq 0) {
@@ -47,8 +48,7 @@ function IsNPMPackageVersionPublished ($pkgId, $pkgVersion) {
     Write-Host "Could not find a deployed version of $pkgId, and NPM connectivity check failed."
     exit(1)
   }
-  $npmVersionList = $npmVersions.split(",") | ForEach-Object { return $_.replace("[", "").replace("]", "").Trim() }
-  return $npmVersionList.Contains($pkgVersion)
+  return $npmVersion -eq $pkgVersion
 }
 
 # make certain to always take the package json closest to the top


### PR DESCRIPTION
If npm has only one version and if that is alpha version of current package, `npm show <package name> versions` returns only one version. Release check searches this returned versions using `contains` Powershell operator which returns true when only one version is present. That's because Powershell script returns string when only one version is present and returns array when more than one is present.

For .e.g Let's say package `abc` has alpha version 1.0.0-alpha<build-Id> present on npm. When we try to release a GA version of this package, script checks 1.0.0-alpha<build-Id>`.Contains`('1.0.0') and it fails.

This PR is to look for exact version we are trying to publish on npm rather than checking against all versions.