### PR TITLE
Revert "[engsys] add @typescript-eslint/no-implicit-any-catch (#21386)"

### DIFF
--- a/common/tools/eslint-plugin-azure-sdk/src/configs/azure-sdk-base.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/configs/azure-sdk-base.ts
@@ -90,7 +90,6 @@ export default {
         ],
         "@typescript-eslint/no-angle-bracket-type-assertion": "off",
         "@typescript-eslint/no-array-constructor": "off",
-        "@typescript-eslint/no-implicit-any-catch": "warn",
         "@typescript-eslint/no-explicit-any": "off",
         "@typescript-eslint/explicit-function-return-type": [
           "warn",


### PR DESCRIPTION
This reverts commit 6d5a9e376ef33e5797af33248cb05d3aad8ec325.

It doesn't work as expected. While it reports warnings for explicit any catch variables, it doesn't understand unknown any catch variables and still reports them as explicit any errors.