### PR TITLE
[Identity] Improving the errors of the AzureCliCredential

### DIFF
--- a/sdk/identity/identity/CHANGELOG.md
+++ b/sdk/identity/identity/CHANGELOG.md
@@ -15,6 +15,7 @@
 ### Other Changes
 
 - Upgraded to `@azure/core-tracing` version `^1.0.0`.
+- Improved the errors displayed on the `AzureCliCredential`.
 
 ## 2.1.0-beta.2 (2022-03-22)
 

--- a/sdk/identity/identity/src/credentials/azureCliCredential.ts
+++ b/sdk/identity/identity/src/credentials/azureCliCredential.ts
@@ -117,7 +117,10 @@ export class AzureCliCredential implements TokenCredential {
     return tracingClient.withSpan(`${this.constructor.name}.getToken`, options, async () => {
       try {
         const obj = await cliCredentialInternals.getAzureCliAccessToken(resource, tenantId);
-        const isLoginError = obj.stderr?.match("(.*)az login(.*)");
+        const unknownPlatform = obj.stderr?.match(
+          "(.*)User tried to log in to a device from a platform(.*)"
+        );
+        const isLoginError = obj.stderr?.match("(.*)az login(.*)") && !unknownPlatform;
         const isNotInstallError =
           obj.stderr?.match("az:(.*)not found") || obj.stderr?.startsWith("'az' is not recognized");
 

--- a/sdk/identity/identity/test/internal/node/azureCliCredential.spec.ts
+++ b/sdk/identity/identity/test/internal/node/azureCliCredential.spec.ts
@@ -170,6 +170,24 @@ describe("AzureCliCredential (internal)", function () {
     }
   });
 
+  // Reported by https://github.com/Azure/azure-sdk-for-js/issues/21151
+  it("get access token when having other access token error", async () => {
+    stdout = "";
+    stderr = `Error: Command failed: az account get-access-token --output json --resource https://database.windows.net/
+ERROR: AADSTS50005: User tried to log in to a device from a platform (Unknown) that's currently not supported through Conditional Access policy. Supported device platforms are: iOS, Android, Mac, and Windows flavors.
+Trace ID: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
+Correlation ID: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
+Timestamp: 2022-02-22 10:11:12Z
+To re-authenticate, please run:
+az login --scope https://database.windows.net//.default`;
+    const credential = new AzureCliCredential();
+    try {
+      await credential.getToken("https://service/.default");
+    } catch (error: any) {
+      assert.equal(error.message, stderr);
+    }
+  });
+
   it("get access token when having a warning on stderr", async () => {
     stdout = '{"accessToken": "token","expiresOn": "01/01/1900 00:00:00 +00:00"}';
     stderr = "Argument '--tenant' is in preview. It may be changed/removed in a future release.";


### PR DESCRIPTION
The `AzureCliCredential` is currently unable to display some errors properly to our consumers. This PR extends our error detection to bubble up errors similar to the one shown on this issue: #21151

If approved:
Fixes #21151