### PR TITLE
[Recorder] Add support for session-level sanitizers

### DIFF
--- a/sdk/test-utils/recorder/CHANGELOG.md
+++ b/sdk/test-utils/recorder/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 2.1.0 (Unreleased)
+## 2.0.1 (Unreleased)
 
 ### Features Added
 

--- a/sdk/test-utils/recorder/CHANGELOG.md
+++ b/sdk/test-utils/recorder/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Release History
 
-## 2.0.1 (Unreleased)
+## 2.1.0 (Unreleased)
 
 ### Features Added
+
+- Add support for session-level sanitization using the `Recorder.addSessionSanitizers` static method. [#21533](https://github.com/Azure/azure-sdk-for-js/pull/21533)
 
 ### Breaking Changes
 

--- a/sdk/test-utils/recorder/src/recorder.ts
+++ b/sdk/test-utils/recorder/src/recorder.ts
@@ -50,7 +50,7 @@ import { AdditionalPolicyConfig } from "@azure/core-client";
  * Other than configuring your clients, use `start`, `stop`, `addSanitizers` methods to use the recorder.
  */
 export class Recorder {
-  private url = "http://localhost:5000";
+  private static url = "http://localhost:5000";
   public recordingId?: string;
   private stateManager = new RecordingStateManager();
   private httpClient?: HttpClient;
@@ -81,7 +81,7 @@ export class Recorder {
   private redirectRequest(request: WebResource | PipelineRequest): void {
     const upstreamUrl = new URL(request.url);
     const redirectedUrl = new URL(request.url);
-    const testProxyUrl = new URL(this.url);
+    const testProxyUrl = new URL(Recorder.url);
 
     // Sometimes, due to the service returning a redirect or due to the retry policy, redirectRequest
     // may be called multiple times. We only want to update the request the second time if the request's
@@ -104,6 +104,7 @@ export class Recorder {
       redirectedUrl.host = testProxyUrl.host;
       redirectedUrl.port = testProxyUrl.port;
       redirectedUrl.protocol = testProxyUrl.protocol;
+
       request.headers.set("x-recording-upstream-base-uri", upstreamUrl.toString());
       request.url = redirectedUrl.toString();
 
@@ -134,7 +135,33 @@ export class Recorder {
       ensureExistence(this.httpClient, "this.httpClient") &&
       ensureExistence(this.recordingId, "this.recordingId")
     ) {
-      return addSanitizers(this.httpClient, this.url, this.recordingId, options);
+      return addSanitizers(this.httpClient, Recorder.url, this.recordingId, options);
+    }
+  }
+
+  /**
+   * addSessionSanitizers adds the sanitizers for all the following recordings which will be applied on it before being saved.
+   * This lets you call addSessionSanitizers once (e.g. in a global before() in your tests). The sanitizers will be applied
+   * to every subsequent test.
+   *
+   * Takes SanitizerOptions as the input, passes on to the proxy-tool.
+   *
+   * By default, it applies only to record mode.
+   *
+   * If you want this to be applied in a specific mode or in a combination of modes, use the "mode" argument.
+   */
+  static async addSessionSanitizers(
+    options: SanitizerOptions,
+    mode: ("record" | "playback")[] = ["record"]
+  ): Promise<void> {
+    if (isLiveMode()) {
+      return;
+    }
+
+    const actualTestMode = getTestMode() as "record" | "playback";
+    if (mode.includes(actualTestMode)) {
+      const httpClient = createDefaultHttpClient();
+      return addSanitizers(httpClient, Recorder.url, undefined, options);
     }
   }
 
@@ -144,7 +171,7 @@ export class Recorder {
       ensureExistence(this.httpClient, "this.httpClient") &&
       ensureExistence(this.recordingId, "this.recordingId")
     ) {
-      await addTransform(this.url, this.httpClient, transform, this.recordingId);
+      await addTransform(Recorder.url, this.httpClient, transform, this.recordingId);
     }
   }
 
@@ -162,7 +189,7 @@ export class Recorder {
     if (isLiveMode()) return;
     this.stateManager.state = "started";
     if (this.recordingId === undefined) {
-      const startUri = `${this.url}${isPlaybackMode() ? paths.playback : paths.record}${
+      const startUri = `${Recorder.url}${isPlaybackMode() ? paths.playback : paths.record}${
         paths.start
       }`;
       const req = createRecordingRequest(startUri, this.sessionFile, this.recordingId);
@@ -186,7 +213,7 @@ export class Recorder {
 
         await handleEnvSetup(
           this.httpClient,
-          this.url,
+          Recorder.url,
           this.recordingId,
           options.envSetupForPlayback
         );
@@ -208,7 +235,9 @@ export class Recorder {
     if (isLiveMode()) return;
     this.stateManager.state = "stopped";
     if (this.recordingId !== undefined) {
-      const stopUri = `${this.url}${isPlaybackMode() ? paths.playback : paths.record}${paths.stop}`;
+      const stopUri = `${Recorder.url}${isPlaybackMode() ? paths.playback : paths.record}${
+        paths.stop
+      }`;
       const req = createRecordingRequest(stopUri, undefined, this.recordingId);
       req.headers.set("x-recording-save", "true");
 
@@ -247,7 +276,7 @@ export class Recorder {
         throw new RecorderError("httpClient should be defined in playback mode");
       }
 
-      await setMatcher(this.url, this.httpClient, matcher, this.recordingId, options);
+      await setMatcher(Recorder.url, this.httpClient, matcher, this.recordingId, options);
     }
   }
 
@@ -257,7 +286,7 @@ export class Recorder {
     }
 
     if (ensureExistence(this.httpClient, "this.httpClient")) {
-      return await transformsInfo(this.httpClient, this.url, this.recordingId!);
+      return await transformsInfo(this.httpClient, Recorder.url, this.recordingId!);
     }
 
     throw new RecorderError("Expected httpClient to be defined");


### PR DESCRIPTION
### Packages impacted by this PR

- `@azure/test-recorder`

### Issues associated with this PR
- Fixes #18223

### Describe the problem that is addressed by this PR

The test proxy has support for adding sanitizers at two levels: at the per-recording level and at the session level. Before this PR, the JS recorder client only allowed for sanitizers to be added at the per-recording level (using the `addSanitizers` instance method on the Recorder class). This PR adds a static `Recorder.addSessionSanitizers(...)` method which allows for sanitizers to be set at the session level. These sanitizers will be applied to every recording following the call.

### Are there test cases added in this PR? _(If not, why?)_

Yes ✅

### Checklists
- [x] Added impacted package name to the issue description
- [x] Added a changelog entry
