### PR TITLE
Fix $package variable in docs ms validation function

### DIFF
--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -444,13 +444,12 @@ function Validate-javascript-DocMsPackages ($PackageInfo, $PackageInfos, $DocRep
 
   $outputPackages = @()
 
-  foreach ($packageInfo in $PackageInfos)
-  {
+  foreach ($packageInfo in $PackageInfos) {
     $fileLocation = ""
     if ($packageInfo.DevVersion -or $packageInfo.Version -contains "beta") {
       $fileLocation = (Join-Path $DocRepoLocation 'ci-configs/packages-preview.json')
       if ($packageInfo.DevVersion) {
-        $package.Version = $package.DevVersion
+        $packageInfo.Version = $packageInfo.DevVersion
       }
     }
     else {


### PR DESCRIPTION
This is blocking js docs publishing:
https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1522200&view=results