### PR TITLE
[purview] fix linter error

### DIFF
--- a/sdk/purview/purview-catalog-rest/test/public/glossary.spec.ts
+++ b/sdk/purview/purview-catalog-rest/test/public/glossary.spec.ts
@@ -37,7 +37,7 @@ describe("purview catalog glossary test", () => {
     console.log("created glossary: ", glossary);
 
     assert.strictEqual(glossary.status, "200");
-    glossaryGuid = glossary.status == "200" ? glossary?.body?.guid || "" : "";
+    glossaryGuid = glossary.status === "200" ? glossary?.body?.guid || "" : "";
   });
 
   it("should work with LRO helper", async () => {


### PR DESCRIPTION
to unblock `js - eslint-plugin - ci` build, while we are still investigating why
the error is not reported by PR validation.
