### PR TITLE
[monitor-query][test] fix build error

### DIFF
--- a/sdk/monitor/monitor-query/test/internal/unit/logsQueryClient.unittest.spec.ts
+++ b/sdk/monitor/monitor-query/test/internal/unit/logsQueryClient.unittest.spec.ts
@@ -33,7 +33,7 @@ describe("LogsQueryClient unit tests", () => {
     });
 
     assert.equal(client["_logAnalytics"].$host, "https://customEndpoint1");
-    assert.equal(client["_logAnalytics"]["_baseUri"], "https://customEndpoint1");
+    assert.equal(client["_logAnalytics"]["_endpoint"], "https://customEndpoint1");
 
     try {
       await client.queryWorkspace("workspaceId", "query", { duration: Durations.fiveMinutes });


### PR DESCRIPTION
The test is checking a private property of ServiceClient that just got renamed.

This PR fixes the build.