### PR TITLE
[engsys] fix gulpfile error

### DIFF
--- a/gulpfile.ts
+++ b/gulpfile.ts
@@ -239,7 +239,7 @@ function pack(): void {
               const distTags: StringMap<string> | undefined = npmViewResult["dist-tags"];
               npmPackageVersion = distTags && distTags["latest"];
             }
-            catch (error: any) {
+            catch (error) {
               // This happens if the package doesn't exist in NPM.
             }
 
@@ -263,7 +263,7 @@ function pack(): void {
                 _logger.log(`Filename: ${packFileName}`);
                 packedPackages++;
               }
-              catch (error: any) {
+              catch (error) {
                 errorPackages++;
               }
             } else {
@@ -309,7 +309,7 @@ gulp.task("find-missing-sdks", async () => {
     _logger.log(`Found azure-rest-api-specs repository in ${azureRestApiSpecsRepositoryPath}`);
 
     await findMissingSdks(azureRestApiSpecsRepositoryPath);
-  } catch (error: any) {
+  } catch (error) {
     _logger.logError(error);
   }
 });


### PR DESCRIPTION
Looks that some very old version of TS is used, and `any` type for catch variable
is not recognized.  This reverts an earlier change of preparing to move to TS
v4.6 by adding `: any` type annotation to catch variable.  We can investigate upgrading separately.