### PR TITLE
removed resource group name regex constraint for front door and app service

### DIFF
--- a/sdk/appservice/arm-appservice/src/models/parameters.ts
+++ b/sdk/appservice/arm-appservice/src/models/parameters.ts
@@ -162,7 +162,6 @@ export const resourceGroupName: OperationURLParameter = {
   parameterPath: "resourceGroupName",
   mapper: {
     constraints: {
-      Pattern: new RegExp("^[-\\w\\._\\(\\)]+[^\\.]$"),
       MaxLength: 90,
       MinLength: 1
     },

--- a/sdk/frontdoor/arm-frontdoor/src/models/parameters.ts
+++ b/sdk/frontdoor/arm-frontdoor/src/models/parameters.ts
@@ -76,8 +76,7 @@ export const resourceGroupName: OperationURLParameter = {
   parameterPath: "resourceGroupName",
   mapper: {
     constraints: {
-      Pattern: new RegExp("^[a-zA-Z0-9_\\-\\(\\)\\.]*[^\\.]$"),
-      MaxLength: 80,
+      MaxLength: 90,
       MinLength: 1
     },
     serializedName: "resourceGroupName",


### PR DESCRIPTION

### Packages impacted by this PR
@azure/arm-appservice
@azure/arm-frontdoor

### Issues associated with this PR


### Describe the problem that is addressed by this PR
SDK fails to retrieve front-door/app-service resources from resource groups with non-alphanumeric names 

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?
Removed the regex constraint as been done in all other SDKs (e.g Azure SDK for Go) and in the REST API

### Are there test cases added in this PR? _(If not, why?)_
No, this is just a constraint removal

### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [X] Added impacted package name to the issue description
- [] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [] Added a changelog (if necessary)
