### PR TITLE
Deprecate Old Profiles

### DIFF
--- a/sdk/appservice/arm-appservice-profile-2019-03-01-hybrid/README.md
+++ b/sdk/appservice/arm-appservice-profile-2019-03-01-hybrid/README.md
@@ -2,6 +2,8 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for WebSiteManagementClient.
 
+> Please note, this package is deprecated and not functional as it uses an older version of the Javascript SDK generator. As of April 2022, you can instead use [@azure/arm-appservice-profile-2020-09-01-hybrid](https://www.npmjs.com/package/@azure/arm-appservice-profile-2020-09-01-hybrid).
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)

--- a/sdk/appservice/arm-appservice-profile-2019-03-01-hybrid/package.json
+++ b/sdk/appservice/arm-appservice-profile-2019-03-01-hybrid/package.json
@@ -2,7 +2,7 @@
   "name": "@azure/arm-appservice-profile-2019-03-01-hybrid",
   "author": "Microsoft Corporation",
   "description": "WebSiteManagementClient Library with typescript type definitions for node.js and browser.",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "dependencies": {
     "@azure/ms-rest-azure-js": "^1.4.0",
     "@azure/ms-rest-js": "^1.11.0",

--- a/sdk/authorization/arm-authorization-profile-2019-03-01-hybrid/README.md
+++ b/sdk/authorization/arm-authorization-profile-2019-03-01-hybrid/README.md
@@ -2,6 +2,8 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for AuthorizationManagementClient.
 
+> Please note, this package is deprecated and not functional as it uses an older version of the Javascript SDK generator. As of April 2022, you can instead use [@azure/arm-authorization-profile-2020-09-01-hybrid](https://www.npmjs.com/package/@azure/arm-authorization-profile-2020-09-01-hybrid).
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)

--- a/sdk/authorization/arm-authorization-profile-2019-03-01-hybrid/package.json
+++ b/sdk/authorization/arm-authorization-profile-2019-03-01-hybrid/package.json
@@ -2,7 +2,7 @@
   "name": "@azure/arm-authorization-profile-2019-03-01-hybrid",
   "author": "Microsoft Corporation",
   "description": "AuthorizationManagementClient Library with typescript type definitions for node.js and browser.",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "dependencies": {
     "@azure/ms-rest-azure-js": "^1.4.0",
     "@azure/ms-rest-js": "^1.11.0",

--- a/sdk/compute/arm-compute-profile-2019-03-01-hybrid/README.md
+++ b/sdk/compute/arm-compute-profile-2019-03-01-hybrid/README.md
@@ -2,6 +2,8 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for ComputeManagementClient.
 
+> Please note, this package is deprecated and not functional as it uses an older version of the Javascript SDK generator. As of April 2022, you can instead use [@azure/arm-compute-profile-2020-09-01-hybrid](https://www.npmjs.com/package/@azure/arm-compute-profile-2020-09-01-hybrid).
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)

--- a/sdk/compute/arm-compute-profile-2019-03-01-hybrid/package.json
+++ b/sdk/compute/arm-compute-profile-2019-03-01-hybrid/package.json
@@ -2,7 +2,7 @@
   "name": "@azure/arm-compute-profile-2019-03-01-hybrid",
   "author": "Microsoft Corporation",
   "description": "ComputeManagementClient Library with typescript type definitions for node.js and browser.",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "dependencies": {
     "@azure/ms-rest-azure-js": "^1.4.0",
     "@azure/ms-rest-js": "^1.11.0",

--- a/sdk/dns/arm-dns-profile-2019-03-01-hybrid/README.md
+++ b/sdk/dns/arm-dns-profile-2019-03-01-hybrid/README.md
@@ -2,6 +2,8 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for DnsManagementClient.
 
+> Please note, this package is deprecated and not functional as it uses an older version of the Javascript SDK generator. As of April 2022, you can instead use [@azure/arm-dns-profile-2020-09-01-hybrid](https://www.npmjs.com/package/@azure/arm-dns-profile-2020-09-01-hybrid).
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)

--- a/sdk/dns/arm-dns-profile-2019-03-01-hybrid/package.json
+++ b/sdk/dns/arm-dns-profile-2019-03-01-hybrid/package.json
@@ -2,7 +2,7 @@
   "name": "@azure/arm-dns-profile-2019-03-01-hybrid",
   "author": "Microsoft Corporation",
   "description": "DnsManagementClient Library with typescript type definitions for node.js and browser.",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "dependencies": {
     "@azure/ms-rest-azure-js": "^1.4.0",
     "@azure/ms-rest-js": "^1.11.0",

--- a/sdk/keyvault/arm-keyvault-profile-2019-03-01-hybrid/README.md
+++ b/sdk/keyvault/arm-keyvault-profile-2019-03-01-hybrid/README.md
@@ -2,6 +2,8 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for KeyVaultManagementClient.
 
+> Please note, this package is deprecated and not functional as it uses an older version of the Javascript SDK generator. As of April 2022, you can instead use [@azure/arm-keyvault-profile-2020-09-01-hybrid](https://www.npmjs.com/package/@azure/arm-keyvault-profile-2020-09-01-hybrid).
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)

--- a/sdk/keyvault/arm-keyvault-profile-2019-03-01-hybrid/package.json
+++ b/sdk/keyvault/arm-keyvault-profile-2019-03-01-hybrid/package.json
@@ -2,7 +2,7 @@
   "name": "@azure/arm-keyvault-profile-2019-03-01-hybrid",
   "author": "Microsoft Corporation",
   "description": "KeyVaultManagementClient Library with typescript type definitions for node.js and browser.",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "dependencies": {
     "@azure/ms-rest-azure-js": "^1.4.0",
     "@azure/ms-rest-js": "^1.11.0",

--- a/sdk/locks/arm-locks-profile-hybrid-2019-03-01/README.md
+++ b/sdk/locks/arm-locks-profile-hybrid-2019-03-01/README.md
@@ -2,6 +2,8 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for ManagementLockClient.
 
+> Please note, this package is deprecated and not functional as it uses an older version of the Javascript SDK generator. As of April 2022, you can instead use [@azure/arm-locks-profile-2020-09-01-hybrid](https://www.npmjs.com/package/@azure/arm-locks-profile-2020-09-01-hybrid).
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)

--- a/sdk/locks/arm-locks-profile-hybrid-2019-03-01/package.json
+++ b/sdk/locks/arm-locks-profile-hybrid-2019-03-01/package.json
@@ -2,7 +2,7 @@
   "name": "@azure/arm-locks-profile-hybrid-2019-03-01",
   "author": "Microsoft Corporation",
   "description": "ManagementLockClient Library with typescript type definitions for node.js and browser.",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "dependencies": {
     "@azure/ms-rest-azure-js": "^1.4.0",
     "@azure/ms-rest-js": "^1.11.0",

--- a/sdk/monitor/arm-monitor-profile-2019-03-01-hybrid/README.md
+++ b/sdk/monitor/arm-monitor-profile-2019-03-01-hybrid/README.md
@@ -2,6 +2,8 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for MonitorManagementClient.
 
+> Please note, this package is deprecated and not functional as it uses an older version of the Javascript SDK generator. As of April 2022, you can instead use [@azure/arm-monitor-profile-2020-09-01-hybrid](https://www.npmjs.com/package/@azure/arm-monitor-profile-2020-09-01-hybrid).
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)

--- a/sdk/monitor/arm-monitor-profile-2019-03-01-hybrid/package.json
+++ b/sdk/monitor/arm-monitor-profile-2019-03-01-hybrid/package.json
@@ -2,7 +2,7 @@
   "name": "@azure/arm-monitor-profile-2019-03-01-hybrid",
   "author": "Microsoft Corporation",
   "description": "MonitorManagementClient Library with typescript type definitions for node.js and browser.",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "dependencies": {
     "@azure/ms-rest-azure-js": "^1.4.0",
     "@azure/ms-rest-js": "^1.11.0",

--- a/sdk/network/arm-network-profile-2019-03-01-hybrid/README.md
+++ b/sdk/network/arm-network-profile-2019-03-01-hybrid/README.md
@@ -2,6 +2,8 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for NetworkManagementClient.
 
+> Please note, this package is deprecated and not functional as it uses an older version of the Javascript SDK generator. As of April 2022, you can instead use [@azure/arm-network-profile-2020-09-01-hybrid](https://www.npmjs.com/package/@azure/arm-network-profile-2020-09-01-hybrid).
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)

--- a/sdk/network/arm-network-profile-2019-03-01-hybrid/package.json
+++ b/sdk/network/arm-network-profile-2019-03-01-hybrid/package.json
@@ -2,7 +2,7 @@
   "name": "@azure/arm-network-profile-2019-03-01-hybrid",
   "author": "Microsoft Corporation",
   "description": "NetworkManagementClient Library with typescript type definitions for node.js and browser.",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "dependencies": {
     "@azure/ms-rest-azure-js": "^1.4.0",
     "@azure/ms-rest-js": "^1.11.0",

--- a/sdk/policy/arm-policy-profile-hybrid-2019-03-01/README.md
+++ b/sdk/policy/arm-policy-profile-hybrid-2019-03-01/README.md
@@ -2,6 +2,8 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for PolicyClient.
 
+> Please note, this package is deprecated and not functional as it uses an older version of the Javascript SDK generator. As of April 2022, you can instead use [@azure/arm-policy-profile-2020-09-01-hybrid](https://www.npmjs.com/package/@azure/arm-policy-profile-2020-09-01-hybrid).
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)

--- a/sdk/policy/arm-policy-profile-hybrid-2019-03-01/package.json
+++ b/sdk/policy/arm-policy-profile-hybrid-2019-03-01/package.json
@@ -2,7 +2,7 @@
   "name": "@azure/arm-policy-profile-hybrid-2019-03-01",
   "author": "Microsoft Corporation",
   "description": "PolicyClient Library with typescript type definitions for node.js and browser.",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "dependencies": {
     "@azure/ms-rest-azure-js": "^1.4.0",
     "@azure/ms-rest-js": "^1.11.0",

--- a/sdk/resources/arm-resources-profile-hybrid-2019-03-01/README.md
+++ b/sdk/resources/arm-resources-profile-hybrid-2019-03-01/README.md
@@ -2,6 +2,8 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for ResourceManagementClient.
 
+> Please note, this package is deprecated and not functional as it uses an older version of the Javascript SDK generator. As of April 2022, you can instead use [@azure/arm-resources-profile-2020-09-01-hybrid](https://www.npmjs.com/package/@azure/arm-resources-profile-2020-09-01-hybrid).
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)

--- a/sdk/resources/arm-resources-profile-hybrid-2019-03-01/package.json
+++ b/sdk/resources/arm-resources-profile-hybrid-2019-03-01/package.json
@@ -2,7 +2,7 @@
   "name": "@azure/arm-resources-profile-hybrid-2019-03-01",
   "author": "Microsoft Corporation",
   "description": "ResourceManagementClient Library with typescript type definitions for node.js and browser.",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "dependencies": {
     "@azure/ms-rest-azure-js": "^1.4.0",
     "@azure/ms-rest-js": "^1.11.0",

--- a/sdk/storage/arm-storage-profile-2019-03-01-hybrid/README.md
+++ b/sdk/storage/arm-storage-profile-2019-03-01-hybrid/README.md
@@ -2,6 +2,8 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for StorageManagementClient.
 
+> Please note, this package is deprecated and not functional as it uses an older version of the Javascript SDK generator. As of April 2022, you can instead use [@azure/arm-storage-profile-2020-09-01-hybrid](https://www.npmjs.com/package/@azure/arm-storage-profile-2020-09-01-hybrid).
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)

--- a/sdk/storage/arm-storage-profile-2019-03-01-hybrid/package.json
+++ b/sdk/storage/arm-storage-profile-2019-03-01-hybrid/package.json
@@ -2,7 +2,7 @@
   "name": "@azure/arm-storage-profile-2019-03-01-hybrid",
   "author": "Microsoft Corporation",
   "description": "StorageManagementClient Library with typescript type definitions for node.js and browser.",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "dependencies": {
     "@azure/ms-rest-azure-js": "^1.4.0",
     "@azure/ms-rest-js": "^1.11.0",

--- a/sdk/subscription/arm-subscriptions-profile-hybrid-2019-03-01/README.md
+++ b/sdk/subscription/arm-subscriptions-profile-hybrid-2019-03-01/README.md
@@ -2,6 +2,8 @@
 
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for SubscriptionClient.
 
+> Please note, this package is deprecated and not functional as it uses an older version of the Javascript SDK generator. As of April 2022, you can instead use [@azure/arm-subscriptions-profile-2020-09-01-hybrid](https://www.npmjs.com/package/@azure/arm-subscriptions-profile-2020-09-01-hybrid).
+
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)

--- a/sdk/subscription/arm-subscriptions-profile-hybrid-2019-03-01/package.json
+++ b/sdk/subscription/arm-subscriptions-profile-hybrid-2019-03-01/package.json
@@ -2,7 +2,7 @@
   "name": "@azure/arm-subscriptions-profile-hybrid-2019-03-01",
   "author": "Microsoft Corporation",
   "description": "SubscriptionClient Library with typescript type definitions for node.js and browser.",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "dependencies": {
     "@azure/ms-rest-azure-js": "^1.4.0",
     "@azure/ms-rest-js": "^1.11.0",


### PR DESCRIPTION
### Packages impacted by this PR
1. @azure/arm-appservice-profile-2019-03-01-hybrid
2. @azure/arm-authorization-profile-2019-03-01-hybrid
3. @azure/arm-compute-profile-2019-03-01-hybrid
4. @azure/arm-dns-profile-2019-03-01-hybrid
5. @azure/arm-keyvault-profile-2019-03-01-hybrid
6. @azure/arm-locks-profile-hybrid-2019-03-01
7. @azure/arm-monitor-profile-2019-03-01-hybrid
8. @azure/arm-network-profile-2019-03-01-hybrid
9. @azure/arm-policy-profile-hybrid-2019-03-01
10. @azure/arm-resources-profile-hybrid-2019-03-01
11. @azure/arm-storage-profile-2019-03-01-hybrid
12. @azure/arm-subscriptions-profile-hybrid-2019-03-01

### Issues associated with this PR
N/A

### Describe the problem that is addressed by this PR
There are 12 profiles that got generated with v4x generator. During management plane migrations, new 12 profile packages have been generated to replace the above 12 packages. So, they have already become obsolete. So, we have to officially start the deprecation process. The idea is to update the `README.md` file with a deprecation message - release a new minor version - and then deprecate it. This is the first step in the deprecation process.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?
None

### Are there test cases added in this PR? _(If not, why?)_
No. None required for deprecation

### Provide a list of related PRs _(if any)_
N/A

### Checklists
- [ ] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)