### PR TITLE
[data-tables] add `react-native` mapping to ESM entry point

### DIFF
--- a/sdk/tables/data-tables/CHANGELOG.md
+++ b/sdk/tables/data-tables/CHANGELOG.md
@@ -8,6 +8,9 @@
 
 ### Bugs Fixed
 
+- fix react native bundling issue by adding a `react-native` mapping to ESM
+  entry point so that dependencies can be loaded asynchronously.
+
 ### Other Changes
 
 ## 13.1.1 (2022-04-14)

--- a/sdk/tables/data-tables/package.json
+++ b/sdk/tables/data-tables/package.json
@@ -13,6 +13,9 @@
     "./dist-esm/src/utils/transactionHeaders.js": "./dist-esm/src/utils/transactionHeaders.browser.js",
     "./dist-esm/test/public/utils/env.js": "./dist-esm/test/public/utils/env.browser.js"
   },
+  "react-native": {
+    "./dist/index.js": "./dist-esm/src/index.js"
+  },
   "types": "types/latest/data-tables.d.ts",
   "typesVersions": {
     "<3.6": {


### PR DESCRIPTION
- fix react native bundling issue by adding a `react-native` mapping to ESM
  entry point so that dependencies can be loaded asynchronously.