### PR TITLE
[ServiceBus][Test] fix tracing test

### DIFF
--- a/sdk/servicebus/service-bus/test/internal/operationOptionsForATOM.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/operationOptionsForATOM.spec.ts
@@ -259,12 +259,7 @@ describe("Operation Options", () => {
                 name: "Azure.ServiceBus.ServiceBusAdministrationClient-getNamespaceProperties",
                 children: [
                   {
-                    children: [
-                      {
-                        children: [],
-                        name: "HTTP GET",
-                      },
-                    ],
+                    children: [],
                     name: "Azure.ServiceBus.ServiceBusAdministrationClient-getResource",
                   },
                 ],


### PR DESCRIPTION
after core-rest-pipeline moved to core-tracing 1.0.0
