### PR TITLE
[Schema Registry Avro] Remove old format compatability

### DIFF
--- a/sdk/schemaregistry/schema-registry-avro/CHANGELOG.md
+++ b/sdk/schemaregistry/schema-registry-avro/CHANGELOG.md
@@ -1,14 +1,11 @@
 # Release History
 
-## 1.0.0-beta.9 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
-
-### Bugs Fixed
+## 1.0.0 (2022-05-10)
 
 ### Other Changes
+
+- Compatability for old payload format has been removed.
+- Errors may include a `cause` field that stores inner errors if any.
 
 ## 1.0.0-beta.8 (2022-04-05)
 

--- a/sdk/schemaregistry/schema-registry-avro/README.md
+++ b/sdk/schemaregistry/schema-registry-avro/README.md
@@ -58,16 +58,6 @@ by setting the `messageAdapter` option in the constructor with a corresponding
 message producer and consumer. Azure messaging client libraries export default
 adapters for their message types.
 
-### Backward Compatibility
-
-The serializer v1.0.0-beta.5 and under serializes data into binary arrays. Starting from
-v1.0.0-beta.6, the serializer returns messages instead that contain the serialized payload.
-For a smooth transition to using the newer versions, the serializer also supports
-deserializing messages with payloads that follow the old format where the schema ID
-is part of the payload.
-
-This backward compatibility is temporary and will be removed in v1.0.0.
-
 ## Examples
 
 ### Serialize and deserialize an `@azure/event-hubs`'s `EventData`

--- a/sdk/schemaregistry/schema-registry-avro/package.json
+++ b/sdk/schemaregistry/schema-registry-avro/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/schema-registry-avro",
-  "version": "1.0.0-beta.9",
+  "version": "1.0.0",
   "description": "Schema Registry Avro Serializer Library with typescript type definitions for node.js and browser.",
   "sdk-type": "client",
   "main": "dist/index.js",

--- a/sdk/schemaregistry/schema-registry-avro/test/public/avroSerializer.spec.ts
+++ b/sdk/schemaregistry/schema-registry-avro/test/public/avroSerializer.spec.ts
@@ -130,7 +130,7 @@ describe("AvroSerializer", function () {
     assert.equal(deserializedValue.age, 30);
   });
 
-  it("deserializes from the old format", async () => {
+  it("ignores the old format", async () => {
     const registry = createTestRegistry();
     const schemaId = await registerTestSchema(registry);
     const serializer = await createTestSerializer<MessageContent>({
@@ -142,12 +142,12 @@ describe("AvroSerializer", function () {
 
     data.write(schemaId, 4, 32, "utf-8");
     payload.copy(data, 36);
-    assert.deepStrictEqual(
-      await serializer.deserialize({
+    await assert.isRejected(
+      serializer.deserialize({
         data,
         contentType: "avro/binary+000",
       }),
-      testValue
+      `Schema does not exist`
     );
   });
 


### PR DESCRIPTION
### Packages impacted by this PR
@azure/schema-registry-avro

### Issues associated with this PR
Fixes https://github.com/Azure/azure-sdk-for-js/issues/20063

### Describe the problem that is addressed by this PR
The old payload format was planned to be supported until the last beta before the first stable release and since the first stable release is scheduled for May, the compatability should be removed now.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [x] Added a changelog (if necessary)
