### PR TITLE
[opentelemetry] - Bump otel API min-version

### DIFF
--- a/sdk/instrumentation/opentelemetry-instrumentation-azure-sdk/package.json
+++ b/sdk/instrumentation/opentelemetry-instrumentation-azure-sdk/package.json
@@ -79,7 +79,7 @@
   "dependencies": {
     "@azure/core-tracing": "^1.0.0",
     "@azure/logger": "^1.0.0",
-    "@opentelemetry/api": "^1.0.0",
+    "@opentelemetry/api": "^1.0.2",
     "@opentelemetry/core": "^1.0.0",
     "@opentelemetry/instrumentation": "^0.27.0",
     "tslib": "^2.2.0"


### PR DESCRIPTION
### Packages impacted by this PR
opentelemetry-instrumentation-azure-sdk

### Issues associated with this PR
#21140

### Describe the problem that is addressed by this PR
OTel uses peer dependencies to request a version of @opentelemetry/api that is
compatible with their SDK. In min testing, that peer version is 1.0.2, so we
want to bump our min-version here as well.

This doesn't resolve the max part of min/max but I believe the next rush update
--full when merged will resolve it.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_


### Command used to generate this PR: _(Applicable only to SDK release request PRs)_


### Checklists
- [x] Added impacted package name to the issue description.
- [x] Does this PR need any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here.)_
- [x] Added a changelog (if necessary).
