### PR TITLE
[core-amqp] Fix a regression

### DIFF
--- a/sdk/core/core-amqp/src/errors.ts
+++ b/sdk/core/core-amqp/src/errors.ts
@@ -677,7 +677,7 @@ export function translate(err: unknown): MessagingError | Error {
     return error;
   }
 
-  if (err instanceof MessagingError) {
+  if (err instanceof Error && err.name === "MessagingError") {
     // already translated
     return err;
   }


### PR DESCRIPTION
by reverting to the old runtime behavior of checking whether a message has
already been translated.

The regression was introduced in PR #21485 and caused a Service Bus live test to
fail.
