### PR TITLE
[eslint-plugin] add a rule to discourage usage of `any` type for catch variable

### DIFF
--- a/common/tools/eslint-plugin-azure-sdk/docs/rules/ts-catch-error-any.md
+++ b/common/tools/eslint-plugin-azure-sdk/docs/rules/ts-catch-error-any.md
@@ -1,0 +1,54 @@
+# ts-catch-error-any
+
+Discourage usage of `any` as the catch variable type. Users should narrow the type of a catch variable before processing it, or justify the usage of `any` suppress this rule explicitly.
+
+Starting from TypeScript v4.4, the catch variables' type now defaults to `unknown`. It is more correct and forces users to test against arbitrary values. See the following TypeScript doc for more details:
+
+https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-4.html#defaulting-to-the-unknown-type-in-catch-variables---useunknownincatchvariables
+
+## Examples
+
+### Good
+
+    {
+      code: "try {} catch (e: unknown) {}",
+    },
+    {
+      code: "try {} catch (e: RestError) {}",
+    },
+    {
+      code: "try {} catch (e: Error) {}",
+    },
+
+```ts
+try {
+} catch (e: unknown) {
+  if (error instanceof Error) {
+  }
+}
+```
+
+```ts
+try {
+} catch (e: RestError) {}
+```
+
+```ts
+try {
+} catch (e: Error) {}
+```
+
+### Bad
+
+```ts
+try {
+} catch (e: any) {
+  assert.equal(e.message, "some error");
+}
+```
+
+## When to turn off
+
+If your SDK doesn't intend to support cancellation.
+
+## [Source](https://azure.github.io/azure-sdk/typescript_design.html#ts-apisurface-supportcancellation)

--- a/common/tools/eslint-plugin-azure-sdk/src/configs/index.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/configs/index.ts
@@ -26,6 +26,7 @@ export = {
       "@azure/azure-sdk/ts-apiextractor-json-types": "error",
       "@azure/azure-sdk/ts-apisurface-standardized-verbs": "error",
       "@azure/azure-sdk/ts-apisurface-supportcancellation": "error",
+      "@azure/azure-sdk/ts-catch-error-any": "off",
       "@azure/azure-sdk/ts-config-include": "error",
       "@azure/azure-sdk/ts-doc-internal": "error",
       "@azure/azure-sdk/ts-doc-internal-private-member": "warn",

--- a/common/tools/eslint-plugin-azure-sdk/src/rules/index.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/rules/index.ts
@@ -10,6 +10,7 @@ import githubSourceHeaders from "./github-source-headers";
 import tsApiExtractorPublicTypes from "./ts-apiextractor-json-types";
 import tsApisurfaceStandardizedVerbs from "./ts-apisurface-standardized-verbs";
 import tsApisurfaceSupportcancellation from "./ts-apisurface-supportcancellation";
+import tsCatchErrorAny from "./ts-catch-error-any";
 import tsConfigInclude from "./ts-config-include";
 import tsDocInternal from "./ts-doc-internal";
 import tsDocInternalPrivateMember from "./ts-doc-internal-private-member";
@@ -48,6 +49,7 @@ export = {
   "ts-apiextractor-json-types": tsApiExtractorPublicTypes,
   "ts-apisurface-standardized-verbs": tsApisurfaceStandardizedVerbs,
   "ts-apisurface-supportcancellation": tsApisurfaceSupportcancellation,
+  "ts-catch-error-any": tsCatchErrorAny,
   "ts-config-include": tsConfigInclude,
   "ts-doc-internal": tsDocInternal,
   "ts-doc-internal-private-member": tsDocInternalPrivateMember,

--- a/common/tools/eslint-plugin-azure-sdk/src/rules/ts-catch-error-any.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/rules/ts-catch-error-any.ts
@@ -32,9 +32,12 @@ export = {
       // callback functions
 
       // call on Client classes
-      "CatchClause": (node: CatchClause): void => {
+      CatchClause: (node: CatchClause): void => {
         // TODO: better to cast to a typescript node instead of `any`?
-        if (node.param && (node.param as any).typeAnnotation?.typeAnnotation?.type === "TSAnyKeyword") {
+        if (
+          node.param &&
+          (node.param as any).typeAnnotation?.typeAnnotation?.type === "TSAnyKeyword"
+        ) {
           context.report({
             node: node.param!,
             message: "please verify the usage of `any` type for the catch variable",

--- a/common/tools/eslint-plugin-azure-sdk/src/rules/ts-catch-error-any.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/rules/ts-catch-error-any.ts
@@ -7,56 +7,12 @@
 
 import { CatchClause } from "estree";
 import { ParserServices } from "@typescript-eslint/experimental-utils";
-import { Symbol as TSSymbol, Type, TypeChecker, TypeFlags } from "typescript";
-import { getRuleMetaData } from "../utils";
-// import { ParserWeakMapESTreeToTSNode } from "@typescript-eslint/typescript-estree/dist/parser-options";
 import { Rule } from "eslint";
+import { getRuleMetaData } from "../utils";
 
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
-
-/**
- * Fetches a defined Type from a union Type.
- * @param type the input Type.
- * @returns the first encountered defined Type from a union, or the Type itself.
- */
-const getDefinedType = (type: any): Type => {
-  if (type.types === undefined) {
-    return type;
-  }
-  const nonUndefinedType = type.types.find(
-    (candidate: Type): boolean => candidate.getFlags() !== TypeFlags.Undefined
-  );
-  return nonUndefinedType !== undefined ? nonUndefinedType : type;
-};
-
-/**
- * Determines if a Symbol is or contains AbortSignalLike.
- * @param symbol the Symbol in question.
- * @param typeChecker a TypeScript TypeChecker.
- * @returns if the Symbol is or contains AbortSignalLike.
- */
-const isValidSymbol = (symbol: TSSymbol, typeChecker: TypeChecker): boolean => {
-  const type = getDefinedType(typeChecker.getTypeAtLocation(symbol.valueDeclaration));
-  const typeSymbol = type.getSymbol();
-  if (typeSymbol === undefined) {
-    return false;
-  }
-  if (typeSymbol.getEscapedName() === "AbortSignalLike") {
-    return true;
-  }
-  if (typeSymbol.members === undefined) {
-    return false;
-  }
-  let foundValidMember = false;
-  typeSymbol.members.forEach((memberSymbol: TSSymbol): void => {
-    if (isValidSymbol(memberSymbol, typeChecker)) {
-      foundValidMember = true;
-    }
-  });
-  return foundValidMember;
-};
 
 export = {
   meta: getRuleMetaData(
@@ -71,16 +27,16 @@ export = {
     ) {
       return {};
     }
-    // const typeChecker = parserServices.program.getTypeChecker();
-    // const converter = parserServices.esTreeNodeToTSNodeMap;
+
     return {
       // callback functions
 
       // call on Client classes
       "CatchClause": (node: CatchClause): void => {
-        if (node.param && (node?.param as any).typeAnnotation?.typeAnnotation?.type === "TSAnyKeyword") {
+        // TODO: better to cast to a typescript node instead of `any`?
+        if (node.param && (node.param as any).typeAnnotation?.typeAnnotation?.type === "TSAnyKeyword") {
           context.report({
-            node: node?.param!,
+            node: node.param!,
             message: "please verify the usage of `any` type for the catch variable",
           });
         }

--- a/common/tools/eslint-plugin-azure-sdk/src/rules/ts-catch-error-any.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/rules/ts-catch-error-any.ts
@@ -1,0 +1,90 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+/**
+ * @file Rule to discourage usage of `any` as the catch variable type.
+ */
+
+import { CatchClause } from "estree";
+import { ParserServices } from "@typescript-eslint/experimental-utils";
+import { Symbol as TSSymbol, Type, TypeChecker, TypeFlags } from "typescript";
+import { getRuleMetaData } from "../utils";
+// import { ParserWeakMapESTreeToTSNode } from "@typescript-eslint/typescript-estree/dist/parser-options";
+import { Rule } from "eslint";
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+/**
+ * Fetches a defined Type from a union Type.
+ * @param type the input Type.
+ * @returns the first encountered defined Type from a union, or the Type itself.
+ */
+const getDefinedType = (type: any): Type => {
+  if (type.types === undefined) {
+    return type;
+  }
+  const nonUndefinedType = type.types.find(
+    (candidate: Type): boolean => candidate.getFlags() !== TypeFlags.Undefined
+  );
+  return nonUndefinedType !== undefined ? nonUndefinedType : type;
+};
+
+/**
+ * Determines if a Symbol is or contains AbortSignalLike.
+ * @param symbol the Symbol in question.
+ * @param typeChecker a TypeScript TypeChecker.
+ * @returns if the Symbol is or contains AbortSignalLike.
+ */
+const isValidSymbol = (symbol: TSSymbol, typeChecker: TypeChecker): boolean => {
+  const type = getDefinedType(typeChecker.getTypeAtLocation(symbol.valueDeclaration));
+  const typeSymbol = type.getSymbol();
+  if (typeSymbol === undefined) {
+    return false;
+  }
+  if (typeSymbol.getEscapedName() === "AbortSignalLike") {
+    return true;
+  }
+  if (typeSymbol.members === undefined) {
+    return false;
+  }
+  let foundValidMember = false;
+  typeSymbol.members.forEach((memberSymbol: TSSymbol): void => {
+    if (isValidSymbol(memberSymbol, typeChecker)) {
+      foundValidMember = true;
+    }
+  });
+  return foundValidMember;
+};
+
+export = {
+  meta: getRuleMetaData(
+    "ts-catch-error-any",
+    "discourage usage of `any` as the catch variable type"
+  ),
+  create: (context: Rule.RuleContext): Rule.RuleListener => {
+    const parserServices = context.parserServices as ParserServices;
+    if (
+      parserServices.program === undefined ||
+      parserServices.esTreeNodeToTSNodeMap === undefined
+    ) {
+      return {};
+    }
+    // const typeChecker = parserServices.program.getTypeChecker();
+    // const converter = parserServices.esTreeNodeToTSNodeMap;
+    return {
+      // callback functions
+
+      // call on Client classes
+      "CatchClause": (node: CatchClause): void => {
+        if (node.param && (node?.param as any).typeAnnotation?.typeAnnotation?.type === "TSAnyKeyword") {
+          context.report({
+            node: node?.param!,
+            message: "please verify the usage of `any` type for the catch variable",
+          });
+        }
+      },
+    } as Rule.RuleListener;
+  },
+};

--- a/common/tools/eslint-plugin-azure-sdk/tests/plugin.ts
+++ b/common/tools/eslint-plugin-azure-sdk/tests/plugin.ts
@@ -18,6 +18,7 @@ const ruleList = [
   "ts-apiextractor-json-types",
   "ts-apisurface-standardized-verbs",
   "ts-apisurface-supportcancellation",
+  "ts-catch-error-any",
   "ts-config-include",
   "ts-doc-internal",
   "ts-doc-internal-private-member",

--- a/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-catch-error-any.ts
+++ b/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-catch-error-any.ts
@@ -1,0 +1,48 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+/**
+ * @file Testing the ts-catch-error-any rule.
+ */
+
+import { RuleTester } from "eslint";
+import rule from "../../src/rules/ts-catch-error-any";
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+const ruleTester = new RuleTester({
+  parser: require.resolve("@typescript-eslint/parser"),
+  parserOptions: {
+    createDefaultProgram: true,
+    project: "./tsconfig.json",
+  },
+});
+
+ruleTester.run("ts-catch-error-any", rule, {
+  valid: [
+    {
+      code: "try {} catch (e: unknown) {}",
+    },
+    {
+      code: "try {} catch {}",
+    },
+    {
+      code: "try {} catch (e: RestError) {}",
+    },
+    {
+      code: "try {} catch (e: Error) {}",
+    },
+  ],
+  invalid: [
+    {
+      code: "try {} catch (e: any) {}",
+      errors: [
+        {
+          message: "please verify the usage of `any` type for the catch variable",
+        },
+      ],
+    },
+  ],
+});


### PR DESCRIPTION
This rule is turned off by default, and can be turned on individual packages
while working on improving code quality (removing or justifying the use of
explicit `any` catch variable type)
