### PR TITLE
[ServiceBus] add custom endpoint support

### DIFF
--- a/sdk/servicebus/service-bus/CHANGELOG.md
+++ b/sdk/servicebus/service-bus/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 7.6.0-beta.2 (2022-05-10)
+
+### Features Added
+
+- Adds the `customEndpointAddress` field to `ServiceBusClientOptions`. This allows for specifying a custom endpoint to use when communicating with the Service Bus service, which is useful when your network does not allow communicating to the standard endpoint. Resolves [#21574](https://github.com/Azure/azure-sdk-for-js/issues/21574).
+
 ## 7.6.0-beta.1 (2022-04-05)
 
 ### Bugs Fixed

--- a/sdk/servicebus/service-bus/package.json
+++ b/sdk/servicebus/service-bus/package.json
@@ -2,7 +2,7 @@
   "name": "@azure/service-bus",
   "sdk-type": "client",
   "author": "Microsoft Corporation",
-  "version": "7.6.0-beta.1",
+  "version": "7.6.0-beta.2",
   "license": "MIT",
   "description": "Azure Service Bus SDK for JavaScript",
   "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/servicebus/service-bus/",

--- a/sdk/servicebus/service-bus/review/service-bus.api.md
+++ b/sdk/servicebus/service-bus/review/service-bus.api.md
@@ -337,6 +337,7 @@ export class ServiceBusClient {
 
 // @public
 export interface ServiceBusClientOptions {
+    customEndpointAddress?: string;
     retryOptions?: RetryOptions;
     userAgentOptions?: UserAgentPolicyOptions;
     webSocketOptions?: WebSocketOptions;

--- a/sdk/servicebus/service-bus/src/constructorHelpers.ts
+++ b/sdk/servicebus/service-bus/src/constructorHelpers.ts
@@ -41,9 +41,9 @@ import {
  */
 export interface ServiceBusClientOptions {
   /**
-   * A custom endpoint to use when connecting to the Event Hubs service.
+   * A custom endpoint to use when connecting to the Service Bus service.
    * This can be useful when your network does not allow connecting to the
-   * standard Azure Event Hubs endpoint address, but does allow connecting
+   * standard Azure Service Bus endpoint address, but does allow connecting
    * through an intermediary.
    *
    * Example: "https://my.custom.endpoint:100/"

--- a/sdk/servicebus/service-bus/src/constructorHelpers.ts
+++ b/sdk/servicebus/service-bus/src/constructorHelpers.ts
@@ -63,7 +63,6 @@ export interface ServiceBusClientOptions {
   userAgentOptions?: UserAgentPolicyOptions;
 }
 
-
 // TODO: extract parseEndpoint and setCustomEndpointAddress into core-amqp
 // ConnectionConfig so that it can be shared between Event Hubs and Service Bus
 /**
@@ -93,7 +92,7 @@ function setCustomEndpointAddress(config: ConnectionConfig, customEndpointAddres
   const { hostname, port } = parseEndpoint(customEndpointAddress);
   // Since we specify the port separately, set host to the customEndpointAddress hostname.
   config.host = hostname;
-  if(port) {
+  if (port) {
     config.port = parseInt(port, 10);
   }
 }
@@ -116,7 +115,6 @@ export function createConnectionContext(
   if (options?.customEndpointAddress) {
     setCustomEndpointAddress(config, options.customEndpointAddress);
   }
-
 
   return ConnectionContext.create(config, credential, options);
 }

--- a/sdk/servicebus/service-bus/src/constructorHelpers.ts
+++ b/sdk/servicebus/service-bus/src/constructorHelpers.ts
@@ -41,6 +41,15 @@ import {
  */
 export interface ServiceBusClientOptions {
   /**
+   * A custom endpoint to use when connecting to the Event Hubs service.
+   * This can be useful when your network does not allow connecting to the
+   * standard Azure Event Hubs endpoint address, but does allow connecting
+   * through an intermediary.
+   *
+   * Example: "https://my.custom.endpoint:100/"
+   */
+  customEndpointAddress?: string;
+  /**
    * Retry policy options that determine the mode, number of retries, retry interval etc.
    */
   retryOptions?: RetryOptions;
@@ -52,6 +61,41 @@ export interface ServiceBusClientOptions {
    * Options for adding user agent details to outgoing requests.
    */
   userAgentOptions?: UserAgentPolicyOptions;
+}
+
+
+// TODO: extract parseEndpoint and setCustomEndpointAddress into core-amqp
+// ConnectionConfig so that it can be shared between Event Hubs and Service Bus
+/**
+ * Parses the host, hostname, and port from an endpoint.
+ * @param endpoint - And endpoint to parse.
+ * @internal
+ */
+export function parseEndpoint(endpoint: string): { host: string; hostname: string; port?: string } {
+  const hostMatch = endpoint.match(/.*:\/\/([^/]*)/);
+  if (!hostMatch) {
+    throw new TypeError(`Invalid endpoint missing host: ${endpoint}`);
+  }
+
+  const [, host] = hostMatch;
+  const [hostname, port] = host.split(":");
+
+  return { host, hostname, port };
+}
+/**
+ * Updates the provided ConnectionConfig to use the custom endpoint address.
+ * @param config - An existing connection configuration to be updated.
+ * @param customEndpointAddress - The custom endpoint address to use.
+ */
+function setCustomEndpointAddress(config: ConnectionConfig, customEndpointAddress: string): void {
+  // The amqpHostname should match the host prior to using the custom endpoint.
+  config.amqpHostname = config.host;
+  const { hostname, port } = parseEndpoint(customEndpointAddress);
+  // Since we specify the port separately, set host to the customEndpointAddress hostname.
+  config.host = hostname;
+  if(port) {
+    config.port = parseInt(port, 10);
+  }
 }
 
 /**
@@ -68,6 +112,11 @@ export function createConnectionContext(
   config.webSocket = options?.webSocketOptions?.webSocket;
   config.webSocketEndpointPath = "$servicebus/websocket";
   config.webSocketConstructorOptions = options?.webSocketOptions?.webSocketConstructorOptions;
+
+  if (options?.customEndpointAddress) {
+    setCustomEndpointAddress(config, options.customEndpointAddress);
+  }
+
 
   return ConnectionContext.create(config, credential, options);
 }

--- a/sdk/servicebus/service-bus/src/util/constants.ts
+++ b/sdk/servicebus/service-bus/src/util/constants.ts
@@ -6,7 +6,7 @@
  */
 export const packageJsonInfo = {
   name: "@azure/service-bus",
-  version: "7.6.0-beta.1",
+  version: "7.6.0-beta.2",
 };
 
 /**

--- a/sdk/servicebus/service-bus/test/internal/unit/client.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/unit/client.spec.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
 import { ServiceBusClient, TokenCredential } from "../../../src";
 
 describe("ServiceBusClient unit tests", function(): void {

--- a/sdk/servicebus/service-bus/test/internal/unit/client.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/unit/client.spec.ts
@@ -3,12 +3,11 @@
 
 import { ServiceBusClient, TokenCredential } from "../../../src";
 
-describe("ServiceBusClient unit tests", function(): void {
+describe("ServiceBusClient unit tests", function (): void {
   describe("ServiceBusClient constructor", function (): void {
-
     it("respects customEndpointAddress when using connection string", () => {
       const client = new ServiceBusClient(
-"Endpoint=sb://test.servicebus.windows.net;SharedAccessKeyName=b;SharedAccessKey=c;EntityPath=my-event-hub-name",
+        "Endpoint=sb://test.servicebus.windows.net;SharedAccessKeyName=b;SharedAccessKey=c;EntityPath=my-event-hub-name",
         { customEndpointAddress: "sb://foo.private.bar:111" }
       );
       client.should.be.an.instanceof(ServiceBusClient);
@@ -26,11 +25,9 @@ describe("ServiceBusClient unit tests", function(): void {
           };
         },
       };
-      const client = new ServiceBusClient(
-        "test.servicebus.windows.net",
-        dummyCredential,
-        { customEndpointAddress: "sb://foo.private.bar:111" }
-      );
+      const client = new ServiceBusClient("test.servicebus.windows.net", dummyCredential, {
+        customEndpointAddress: "sb://foo.private.bar:111",
+      });
       client.should.be.an.instanceof(ServiceBusClient);
       client["_connectionContext"].config.host.should.equal("foo.private.bar");
       client["_connectionContext"].config.amqpHostname!.should.equal("test.servicebus.windows.net");

--- a/sdk/servicebus/service-bus/test/internal/unit/client.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/unit/client.spec.ts
@@ -1,0 +1,37 @@
+import { ServiceBusClient, TokenCredential } from "../../../src";
+
+describe("ServiceBusClient unit tests", function(): void {
+  describe("ServiceBusClient constructor", function (): void {
+
+    it("respects customEndpointAddress when using connection string", () => {
+      const client = new ServiceBusClient(
+"Endpoint=sb://test.servicebus.windows.net;SharedAccessKeyName=b;SharedAccessKey=c;EntityPath=my-event-hub-name",
+        { customEndpointAddress: "sb://foo.private.bar:111" }
+      );
+      client.should.be.an.instanceof(ServiceBusClient);
+      client["_connectionContext"].config.host.should.equal("foo.private.bar");
+      client["_connectionContext"].config.amqpHostname!.should.equal("test.servicebus.windows.net");
+      client["_connectionContext"].config.port!.should.equal(111);
+    });
+
+    it("respects customEndpointAddress when using credentials", () => {
+      const dummyCredential: TokenCredential = {
+        getToken: async () => {
+          return {
+            token: "boo",
+            expiresOnTimestamp: 12324,
+          };
+        },
+      };
+      const client = new ServiceBusClient(
+        "test.servicebus.windows.net",
+        dummyCredential,
+        { customEndpointAddress: "sb://foo.private.bar:111" }
+      );
+      client.should.be.an.instanceof(ServiceBusClient);
+      client["_connectionContext"].config.host.should.equal("foo.private.bar");
+      client["_connectionContext"].config.amqpHostname!.should.equal("test.servicebus.windows.net");
+      client["_connectionContext"].config.port!.should.equal(111);
+    });
+  });
+});


### PR DESCRIPTION
- Port relevant changes from Event Hubs PR https://github.com/Azure/azure-sdk-for-js/pull/12909. Most of work was done in core-amqp. This PR just
needs to connect the client options with the underlying connection context.

### Packages impacted by this PR
@azure/service-bus

### Issues associated with this PR

#21574 