### PR TITLE
[communication-common] Communication identifier to raw id translation

### DIFF
--- a/sdk/communication/communication-chat/package.json
+++ b/sdk/communication/communication-chat/package.json
@@ -63,7 +63,7 @@
   "prettier": "@azure/eslint-plugin-azure-sdk/prettier.json",
   "dependencies": {
     "@azure/abort-controller": "^1.0.0",
-    "@azure/communication-common": "^2.0.0",
+    "@azure/communication-common": "^2.1.0",
     "@azure/communication-signaling": "1.0.0-beta.13",
     "@azure/core-auth": "^1.3.0",
     "@azure/core-client": "^1.3.0",

--- a/sdk/communication/communication-chat/recordings/browsers/chatclient_chat_operations/recording_successfully_creates_a_thread.json
+++ b/sdk/communication/communication-chat/recordings/browsers/chatclient_chat_operations/recording_successfully_creates_a_thread.json
@@ -19,11 +19,11 @@
         "Sec-Fetch-Dest": "empty",
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
-        "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/100.0.4889.0 Safari/537.36",
-        "x-ms-client-request-id": "91c91a60-4eb2-4bc2-a254-944b92da7f5d",
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/101.0.4950.0 Safari/537.36",
+        "x-ms-client-request-id": "1aff0c17-1bd6-44da-b293-b4d2167613d6",
         "x-ms-content-sha256": "WTRvgEjjVd\u002BbvyKw3WgXgDkU81aV8FWq\u002B4/BE\u002Bhe0\u002BA=",
-        "x-ms-date": "Wed, 30 Mar 2022 21:36:40 GMT",
-        "x-ms-useragent": "azsdk-js-communication-identity/1.1.0-beta.2 core-rest-pipeline/1.8.0 OS/MacIntel"
+        "x-ms-date": "Mon, 02 May 2022 22:48:57 GMT",
+        "x-ms-useragent": "azsdk-js-communication-identity/1.1.0-beta.2 core-rest-pipeline/1.8.1 OS/Win32"
       },
       "RequestBody": {
         "createTokenWithScopes": [
@@ -34,24 +34,25 @@
       "ResponseHeaders": {
         "Access-Control-Allow-Origin": "*",
         "api-supported-versions": "2020-07-20-preview2, 2021-02-22-preview1, 2021-03-07, 2021-10-31-preview, 2021-11-01, 2022-06-01",
-        "Content-Length": "290",
+        "Connection": "keep-alive",
+        "Content-Length": "286",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 30 Mar 2022 21:36:40 GMT",
-        "MS-CV": "0IqzmqvM1Eut5BUKh0603w.0",
+        "Date": "Mon, 02 May 2022 22:49:02 GMT",
+        "MS-CV": "trYCM6hVj02sYBG/4ouP8Q.0",
         "Request-Context": "appId=",
         "Strict-Transport-Security": "max-age=2592000",
-        "X-Azure-Ref": "0aM1EYgAAAAA4WRkdN3oxSqNQIaw7\u002BEBoUERYMzFFREdFMDIxMgBjYzkyNzU4ZC0wNWY3LTRhZDYtYWE1ZS0wZmE5NzE4ZDg5ODU=",
+        "x-azure-ref": "20220502T224902Z-1kdy40ce594zxd7ayzepxvrcq0000000052000000002q9z3",
         "X-Cache": "CONFIG_NOCACHE",
-        "x-ms-client-request-id": "91c91a60-4eb2-4bc2-a254-944b92da7f5d",
-        "X-Processing-Time": "180ms"
+        "x-ms-client-request-id": "1aff0c17-1bd6-44da-b293-b4d2167613d6",
+        "X-Processing-Time": "285ms"
       },
       "ResponseBody": {
         "identity": {
-          "id": "8:acs:188d4cea-0a9b-4840-8fdc-7a5c71fe9bd0_00000010-7ca4-04ab-5896-09482200137e"
+          "id": "8:acs:b6aada1f-0b1d-47ac-866f-91aae00a1d01_00000011-26d8-0ced-570c-113a0d00b7e1"
         },
         "accessToken": {
-          "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE2NDg2Nzk4MDAuMzU2fQ==.adM-ddBZZlQ1WlN3pdPBOF5G4Wh9iZpxNP_fSvpF4cWs",
-          "expiresOn": "2022-03-31T21:36:40.7812772\u002B00:00"
+          "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE2NTE1MzUzMjkuNDd9.adM-ddBZZlQ1WlN3pdPBOF5G4Wh9iZpxNP_fSvpF4cWs",
+          "expiresOn": "2022-05-03T22:48:57.5909213\u002B00:00"
         }
       }
     },
@@ -74,11 +75,11 @@
         "Sec-Fetch-Dest": "empty",
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
-        "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/100.0.4889.0 Safari/537.36",
-        "x-ms-client-request-id": "f64417dc-3fab-47bd-8937-2e6ff02ba89c",
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/101.0.4950.0 Safari/537.36",
+        "x-ms-client-request-id": "48bae57f-36b2-47aa-83c5-59b28acb949d",
         "x-ms-content-sha256": "WTRvgEjjVd\u002BbvyKw3WgXgDkU81aV8FWq\u002B4/BE\u002Bhe0\u002BA=",
-        "x-ms-date": "Wed, 30 Mar 2022 21:36:40 GMT",
-        "x-ms-useragent": "azsdk-js-communication-identity/1.1.0-beta.2 core-rest-pipeline/1.8.0 OS/MacIntel"
+        "x-ms-date": "Mon, 02 May 2022 22:48:57 GMT",
+        "x-ms-useragent": "azsdk-js-communication-identity/1.1.0-beta.2 core-rest-pipeline/1.8.1 OS/Win32"
       },
       "RequestBody": {
         "createTokenWithScopes": [
@@ -89,24 +90,25 @@
       "ResponseHeaders": {
         "Access-Control-Allow-Origin": "*",
         "api-supported-versions": "2020-07-20-preview2, 2021-02-22-preview1, 2021-03-07, 2021-10-31-preview, 2021-11-01, 2022-06-01",
-        "Content-Length": "290",
+        "Connection": "keep-alive",
+        "Content-Length": "286",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 30 Mar 2022 21:36:40 GMT",
-        "MS-CV": "PhUOplpW\u002BEG6ij1seqp09A.0",
+        "Date": "Mon, 02 May 2022 22:49:03 GMT",
+        "MS-CV": "9GzPPcOtcE28VKoa4XV/Nw.0",
         "Request-Context": "appId=",
         "Strict-Transport-Security": "max-age=2592000",
-        "X-Azure-Ref": "0aM1EYgAAAACmWd8Bga3DS5ZXarm6BTRDUERYMzFFREdFMDIxMgBjYzkyNzU4ZC0wNWY3LTRhZDYtYWE1ZS0wZmE5NzE4ZDg5ODU=",
+        "x-azure-ref": "20220502T224902Z-1kdy40ce594zxd7ayzepxvrcq0000000052000000002qa28",
         "X-Cache": "CONFIG_NOCACHE",
-        "x-ms-client-request-id": "f64417dc-3fab-47bd-8937-2e6ff02ba89c",
-        "X-Processing-Time": "180ms"
+        "x-ms-client-request-id": "48bae57f-36b2-47aa-83c5-59b28acb949d",
+        "X-Processing-Time": "220ms"
       },
       "ResponseBody": {
         "identity": {
-          "id": "8:acs:188d4cea-0a9b-4840-8fdc-7a5c71fe9bd0_00000010-7ca4-0592-5896-09482200137f"
+          "id": "8:acs:b6aada1f-0b1d-47ac-866f-91aae00a1d01_00000011-26d8-0e84-570c-113a0d00b7e2"
         },
         "accessToken": {
-          "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE2NDg2Nzk4MDAuMzU2fQ==.adM-ddBZZlQ1WlN3pdPBOF5G4Wh9iZpxNP_fSvpF4cWs",
-          "expiresOn": "2022-03-31T21:36:41.0122016\u002B00:00"
+          "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE2NTE1MzUzMjkuNDd9.adM-ddBZZlQ1WlN3pdPBOF5G4Wh9iZpxNP_fSvpF4cWs",
+          "expiresOn": "2022-05-03T22:48:57.9359585\u002B00:00"
         }
       }
     },
@@ -119,35 +121,37 @@
         "Accept-Language": "en-US",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "Content-Length": "317",
+        "Content-Length": "497",
         "Content-Type": "application/json",
         "Origin": "http://localhost:9876",
         "Referer": "http://localhost:9876/",
-        "repeatability-request-id": "5b1756b2-20a0-4ecd-9623-30bab4a2795d",
+        "repeatability-request-id": "955d6d7f-9106-4cea-ad49-15abdabf6221",
         "sec-ch-ua": "",
         "sec-ch-ua-mobile": "?0",
         "sec-ch-ua-platform": "",
         "Sec-Fetch-Dest": "empty",
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
-        "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/100.0.4889.0 Safari/537.36",
-        "x-ms-client-request-id": "47dc0580-92f4-4ac5-a01c-d27702df550a",
-        "x-ms-useragent": "azsdk-js-azure-communication-chat/1.2.0 core-rest-pipeline/1.8.0 OS/MacIntel"
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/101.0.4950.0 Safari/537.36",
+        "x-ms-client-request-id": "533c7a4b-9e7b-4fb5-be7f-cc0e752ff8a4",
+        "x-ms-useragent": "azsdk-js-communication-chat/1.2.0 core-rest-pipeline/1.8.1 OS/Win32"
       },
       "RequestBody": {
         "topic": "test topic",
         "participants": [
           {
             "communicationIdentifier": {
+              "rawId": "8:acs:b6aada1f-0b1d-47ac-866f-91aae00a1d01_00000011-26d8-0ced-570c-113a0d00b7e1",
               "communicationUser": {
-                "id": "8:acs:188d4cea-0a9b-4840-8fdc-7a5c71fe9bd0_00000010-7ca4-04ab-5896-09482200137e"
+                "id": "8:acs:b6aada1f-0b1d-47ac-866f-91aae00a1d01_00000011-26d8-0ced-570c-113a0d00b7e1"
               }
             }
           },
           {
             "communicationIdentifier": {
+              "rawId": "8:acs:b6aada1f-0b1d-47ac-866f-91aae00a1d01_00000011-26d8-0e84-570c-113a0d00b7e2",
               "communicationUser": {
-                "id": "8:acs:188d4cea-0a9b-4840-8fdc-7a5c71fe9bd0_00000010-7ca4-0592-5896-09482200137f"
+                "id": "8:acs:b6aada1f-0b1d-47ac-866f-91aae00a1d01_00000011-26d8-0e84-570c-113a0d00b7e2"
               }
             }
           }
@@ -158,25 +162,26 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "Location",
         "api-supported-versions": "2021-03-07, 2021-04-05-preview6, 2021-09-07, 2021-10-01-preview7",
+        "Connection": "keep-alive",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 30 Mar 2022 21:36:41 GMT",
-        "Location": "https://endpoint/chat/threads/19%3AnNhdRK9uq2rP1Y4a4ODZaJj7fRjAfh3ZSFaC1_zTs041@thread.v2",
-        "MS-CV": "D6FOK4uHzU68\u002ByAWeyLlVA.0",
+        "Date": "Mon, 02 May 2022 22:49:03 GMT",
+        "Location": "https://endpoint/chat/threads/19%3AZb-0eSb-gDC6N8dFMUbBb9H9To1o9fEt9vz5uQ4IvXc1@thread.v2",
+        "MS-CV": "607LcIcOMkKun7aohFxpdg.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0ac1EYgAAAAArwINsp8q5Sb4h2tSeyBdVUERYMzFFREdFMDIxMgBjYzkyNzU4ZC0wNWY3LTRhZDYtYWE1ZS0wZmE5NzE4ZDg5ODU=",
+        "x-azure-ref": "20220502T224903Z-1kdy40ce594zxd7ayzepxvrcq0000000052000000002qa4k",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "854ms"
+        "X-Processing-Time": "494ms"
       },
       "ResponseBody": {
         "chatThread": {
-          "id": "19:nNhdRK9uq2rP1Y4a4ODZaJj7fRjAfh3ZSFaC1_zTs041@thread.v2",
+          "id": "19:Zb-0eSb-gDC6N8dFMUbBb9H9To1o9fEt9vz5uQ4IvXc1@thread.v2",
           "topic": "test topic",
-          "createdOn": "2022-03-30T21:36:41Z",
+          "createdOn": "2022-05-02T22:48:58Z",
           "createdByCommunicationIdentifier": {
-            "rawId": "8:acs:188d4cea-0a9b-4840-8fdc-7a5c71fe9bd0_00000010-7ca4-04ab-5896-09482200137e",
+            "rawId": "8:acs:b6aada1f-0b1d-47ac-866f-91aae00a1d01_00000011-26d8-0ced-570c-113a0d00b7e1",
             "communicationUser": {
-              "id": "8:acs:188d4cea-0a9b-4840-8fdc-7a5c71fe9bd0_00000010-7ca4-04ab-5896-09482200137e"
+              "id": "8:acs:b6aada1f-0b1d-47ac-866f-91aae00a1d01_00000011-26d8-0ced-570c-113a0d00b7e1"
             }
           }
         }

--- a/sdk/communication/communication-chat/recordings/browsers/chatclient_chat_operations/recording_successfully_deletes_a_thread.json
+++ b/sdk/communication/communication-chat/recordings/browsers/chatclient_chat_operations/recording_successfully_deletes_a_thread.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://endpoint/chat/threads/19%3AnNhdRK9uq2rP1Y4a4ODZaJj7fRjAfh3ZSFaC1_zTs041%40thread.v2?api-version=2021-09-07",
+      "RequestUri": "https://endpoint/chat/threads/19%3AZb-0eSb-gDC6N8dFMUbBb9H9To1o9fEt9vz5uQ4IvXc1%40thread.v2?api-version=2021-09-07",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -17,9 +17,9 @@
         "Sec-Fetch-Dest": "empty",
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
-        "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/100.0.4889.0 Safari/537.36",
-        "x-ms-client-request-id": "be6195e1-690b-4b72-8ddf-abfa7b4a8e64",
-        "x-ms-useragent": "azsdk-js-azure-communication-chat/1.2.0 core-rest-pipeline/1.8.0 OS/MacIntel"
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/101.0.4950.0 Safari/537.36",
+        "x-ms-client-request-id": "43137d48-5729-4a18-940c-776077f026a0",
+        "x-ms-useragent": "azsdk-js-communication-chat/1.2.0 core-rest-pipeline/1.8.1 OS/Win32"
       },
       "RequestBody": null,
       "StatusCode": 204,
@@ -27,12 +27,13 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "Location",
         "api-supported-versions": "2021-03-07, 2021-04-05-preview6, 2021-09-07, 2021-10-01-preview7",
-        "Date": "Wed, 30 Mar 2022 21:36:41 GMT",
-        "MS-CV": "feW4Z4cqMUqfjTxGL8YSUw.0",
+        "Connection": "keep-alive",
+        "Date": "Mon, 02 May 2022 22:49:04 GMT",
+        "MS-CV": "w4upMMru20SYMjSF3ffiwg.0",
         "Strict-Transport-Security": "max-age=2592000",
-        "X-Azure-Ref": "0as1EYgAAAADjz847FLQnTb9PcuO/BhIhUERYMzFFREdFMDIxMgBjYzkyNzU4ZC0wNWY3LTRhZDYtYWE1ZS0wZmE5NzE4ZDg5ODU=",
+        "x-azure-ref": "20220502T224903Z-1kdy40ce594zxd7ayzepxvrcq0000000052000000002qa9g",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "295ms"
+        "X-Processing-Time": "212ms"
       },
       "ResponseBody": null
     }

--- a/sdk/communication/communication-chat/recordings/browsers/chatthreadclient/recording_successfully_adds_participants.json
+++ b/sdk/communication/communication-chat/recordings/browsers/chatthreadclient/recording_successfully_adds_participants.json
@@ -19,11 +19,11 @@
         "Sec-Fetch-Dest": "empty",
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
-        "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/100.0.4889.0 Safari/537.36",
-        "x-ms-client-request-id": "2478bf91-3016-4299-985a-d0a91053e059",
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/101.0.4950.0 Safari/537.36",
+        "x-ms-client-request-id": "e20bd41b-a602-49fa-a1d3-392f9fa4419b",
         "x-ms-content-sha256": "WTRvgEjjVd\u002BbvyKw3WgXgDkU81aV8FWq\u002B4/BE\u002Bhe0\u002BA=",
-        "x-ms-date": "Wed, 30 Mar 2022 21:36:48 GMT",
-        "x-ms-useragent": "azsdk-js-communication-identity/1.1.0-beta.2 core-rest-pipeline/1.8.0 OS/MacIntel"
+        "x-ms-date": "Mon, 02 May 2022 22:48:55 GMT",
+        "x-ms-useragent": "azsdk-js-communication-identity/1.1.0-beta.2 core-rest-pipeline/1.8.1 OS/Win32"
       },
       "RequestBody": {
         "createTokenWithScopes": [
@@ -34,29 +34,30 @@
       "ResponseHeaders": {
         "Access-Control-Allow-Origin": "*",
         "api-supported-versions": "2020-07-20-preview2, 2021-02-22-preview1, 2021-03-07, 2021-10-31-preview, 2021-11-01, 2022-06-01",
-        "Content-Length": "290",
+        "Connection": "keep-alive",
+        "Content-Length": "286",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 30 Mar 2022 21:36:48 GMT",
-        "MS-CV": "zh5ya3crVk6ZLWY7\u002BKLsEg.0",
+        "Date": "Mon, 02 May 2022 22:49:01 GMT",
+        "MS-CV": "wPIGraELTkyAoeUfVXmsNA.0",
         "Request-Context": "appId=",
         "Strict-Transport-Security": "max-age=2592000",
-        "X-Azure-Ref": "0cc1EYgAAAADVC6\u002Bmzm6mTJO7Er52hOvvUERYMzFFREdFMDIxMgBjYzkyNzU4ZC0wNWY3LTRhZDYtYWE1ZS0wZmE5NzE4ZDg5ODU=",
+        "x-azure-ref": "20220502T224900Z-1kdy40ce594zxd7ayzepxvrcq0000000052000000002q9nm",
         "X-Cache": "CONFIG_NOCACHE",
-        "x-ms-client-request-id": "2478bf91-3016-4299-985a-d0a91053e059",
-        "X-Processing-Time": "180ms"
+        "x-ms-client-request-id": "e20bd41b-a602-49fa-a1d3-392f9fa4419b",
+        "X-Processing-Time": "222ms"
       },
       "ResponseBody": {
         "identity": {
-          "id": "8:acs:188d4cea-0a9b-4840-8fdc-7a5c71fe9bd0_00000010-7ca4-25e4-5896-094822001385"
+          "id": "8:acs:b6aada1f-0b1d-47ac-866f-91aae00a1d01_00000011-26d8-06b8-570c-113a0d00b7e0"
         },
         "accessToken": {
-          "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE2NDg2Nzk4MDAuMzU2fQ==.adM-ddBZZlQ1WlN3pdPBOF5G4Wh9iZpxNP_fSvpF4cWs",
-          "expiresOn": "2022-03-31T21:36:49.2857002\u002B00:00"
+          "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE2NTE1MzUzMjkuNDd9.adM-ddBZZlQ1WlN3pdPBOF5G4Wh9iZpxNP_fSvpF4cWs",
+          "expiresOn": "2022-05-03T22:48:55.9409798\u002B00:00"
         }
       }
     },
     {
-      "RequestUri": "https://endpoint/chat/threads/19%3ASWkac8Ohhun6cBYZUJu7GWyUwrnSppuvzamOFUDuz641%40thread.v2/participants/:add?api-version=2021-09-07",
+      "RequestUri": "https://endpoint/chat/threads/19%3AsGfC1p7_xma4fP7m2-tcS2pt9gpte6sdXThKfUNLYFQ1%40thread.v2/participants/:add?api-version=2021-09-07",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -64,7 +65,7 @@
         "Accept-Language": "en-US",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "Content-Length": "157",
+        "Content-Length": "247",
         "Content-Type": "application/json",
         "Origin": "http://localhost:9876",
         "Referer": "http://localhost:9876/",
@@ -74,16 +75,17 @@
         "Sec-Fetch-Dest": "empty",
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
-        "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/100.0.4889.0 Safari/537.36",
-        "x-ms-client-request-id": "58d5f38e-1844-47f4-b917-3ce448819fd5",
-        "x-ms-useragent": "azsdk-js-azure-communication-chat/1.2.0 core-rest-pipeline/1.8.0 OS/MacIntel"
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/101.0.4950.0 Safari/537.36",
+        "x-ms-client-request-id": "8aaf00bf-8542-4a60-99d0-7a64031e7966",
+        "x-ms-useragent": "azsdk-js-communication-chat/1.2.0 core-rest-pipeline/1.8.1 OS/Win32"
       },
       "RequestBody": {
         "participants": [
           {
             "communicationIdentifier": {
+              "rawId": "8:acs:b6aada1f-0b1d-47ac-866f-91aae00a1d01_00000011-26d8-06b8-570c-113a0d00b7e0",
               "communicationUser": {
-                "id": "8:acs:188d4cea-0a9b-4840-8fdc-7a5c71fe9bd0_00000010-7ca4-25e4-5896-094822001385"
+                "id": "8:acs:b6aada1f-0b1d-47ac-866f-91aae00a1d01_00000011-26d8-06b8-570c-113a0d00b7e0"
               }
             }
           }
@@ -94,14 +96,15 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "Location",
         "api-supported-versions": "2021-03-07, 2021-04-05-preview6, 2021-09-07, 2021-10-01-preview7",
+        "Connection": "keep-alive",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 30 Mar 2022 21:36:49 GMT",
-        "MS-CV": "biEIjPWE30SWyP3MgXIvfA.0",
+        "Date": "Mon, 02 May 2022 22:49:01 GMT",
+        "MS-CV": "PvQPRexN\u002BEGABj3xVGuXIQ.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0cc1EYgAAAABQHZiXn9mJRY3WXrZdFtmHUERYMzFFREdFMDIxMgBjYzkyNzU4ZC0wNWY3LTRhZDYtYWE1ZS0wZmE5NzE4ZDg5ODU=",
+        "x-azure-ref": "20220502T224901Z-1kdy40ce594zxd7ayzepxvrcq0000000052000000002q9qp",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "396ms"
+        "X-Processing-Time": "176ms"
       },
       "ResponseBody": {}
     }

--- a/sdk/communication/communication-chat/recordings/browsers/chatthreadclient/recording_successfully_deletes_a_message.json
+++ b/sdk/communication/communication-chat/recordings/browsers/chatthreadclient/recording_successfully_deletes_a_message.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://endpoint/chat/threads/19%3ASWkac8Ohhun6cBYZUJu7GWyUwrnSppuvzamOFUDuz641%40thread.v2/messages/1648676205175?api-version=2021-09-07",
+      "RequestUri": "https://endpoint/chat/threads/19%3AsGfC1p7_xma4fP7m2-tcS2pt9gpte6sdXThKfUNLYFQ1%40thread.v2/messages/1651531732983?api-version=2021-09-07",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -17,9 +17,9 @@
         "Sec-Fetch-Dest": "empty",
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
-        "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/100.0.4889.0 Safari/537.36",
-        "x-ms-client-request-id": "c73d11d9-d075-4d8b-a5bb-9e87cecf2e81",
-        "x-ms-useragent": "azsdk-js-azure-communication-chat/1.2.0 core-rest-pipeline/1.8.0 OS/MacIntel"
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/101.0.4950.0 Safari/537.36",
+        "x-ms-client-request-id": "5017c91d-28d8-4e2b-aad2-a865626dab80",
+        "x-ms-useragent": "azsdk-js-communication-chat/1.2.0 core-rest-pipeline/1.8.1 OS/Win32"
       },
       "RequestBody": null,
       "StatusCode": 204,
@@ -27,12 +27,13 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "Location",
         "api-supported-versions": "2021-03-07, 2021-04-05-preview6, 2021-09-07, 2021-10-01-preview7",
-        "Date": "Wed, 30 Mar 2022 21:36:48 GMT",
-        "MS-CV": "gKOzqBp\u002BAEawbP7LkJSezQ.0",
+        "Connection": "keep-alive",
+        "Date": "Mon, 02 May 2022 22:49:00 GMT",
+        "MS-CV": "zSJraO96n0yABfdXiuOnIA.0",
         "Strict-Transport-Security": "max-age=2592000",
-        "X-Azure-Ref": "0cM1EYgAAAAAj0ekoJujFTYf\u002BcAtnJZMpUERYMzFFREdFMDIxMgBjYzkyNzU4ZC0wNWY3LTRhZDYtYWE1ZS0wZmE5NzE4ZDg5ODU=",
+        "x-azure-ref": "20220502T224900Z-1kdy40ce594zxd7ayzepxvrcq0000000052000000002q9kc",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "407ms"
+        "X-Processing-Time": "85ms"
       },
       "ResponseBody": null
     }

--- a/sdk/communication/communication-chat/recordings/browsers/chatthreadclient/recording_successfully_gets_the_thread_properties.json
+++ b/sdk/communication/communication-chat/recordings/browsers/chatthreadclient/recording_successfully_gets_the_thread_properties.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://endpoint/chat/threads/19%3ASWkac8Ohhun6cBYZUJu7GWyUwrnSppuvzamOFUDuz641%40thread.v2?api-version=2021-09-07",
+      "RequestUri": "https://endpoint/chat/threads/19%3AsGfC1p7_xma4fP7m2-tcS2pt9gpte6sdXThKfUNLYFQ1%40thread.v2?api-version=2021-09-07",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -17,9 +17,9 @@
         "Sec-Fetch-Dest": "empty",
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
-        "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/100.0.4889.0 Safari/537.36",
-        "x-ms-client-request-id": "36a79d49-9934-4674-9cd5-ec68af409c22",
-        "x-ms-useragent": "azsdk-js-azure-communication-chat/1.2.0 core-rest-pipeline/1.8.0 OS/MacIntel"
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/101.0.4950.0 Safari/537.36",
+        "x-ms-client-request-id": "f228c533-eca3-468e-b405-74ae0efc7b80",
+        "x-ms-useragent": "azsdk-js-communication-chat/1.2.0 core-rest-pipeline/1.8.1 OS/Win32"
       },
       "RequestBody": null,
       "StatusCode": 200,
@@ -27,23 +27,24 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "Location",
         "api-supported-versions": "2021-03-07, 2021-04-05-preview6, 2021-09-07, 2021-10-01-preview7",
+        "Connection": "keep-alive",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 30 Mar 2022 21:36:43 GMT",
-        "MS-CV": "LNKsyNkqaUyudw94G36bjg.0",
+        "Date": "Mon, 02 May 2022 22:48:57 GMT",
+        "MS-CV": "8wEnr5GfsES9cGWTkwWzdg.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0a81EYgAAAABn5ZVX9KxeRZJ9SyoCU4e6UERYMzFFREdFMDIxMgBjYzkyNzU4ZC0wNWY3LTRhZDYtYWE1ZS0wZmE5NzE4ZDg5ODU=",
+        "x-azure-ref": "20220502T224856Z-1kdy40ce594zxd7ayzepxvrcq0000000052000000002q8uc",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "254ms"
+        "X-Processing-Time": "80ms"
       },
       "ResponseBody": {
-        "id": "19:SWkac8Ohhun6cBYZUJu7GWyUwrnSppuvzamOFUDuz641@thread.v2",
+        "id": "19:sGfC1p7_xma4fP7m2-tcS2pt9gpte6sdXThKfUNLYFQ1@thread.v2",
         "topic": "test topic",
-        "createdOn": "2022-03-30T21:36:43Z",
+        "createdOn": "2022-05-02T22:48:51Z",
         "createdByCommunicationIdentifier": {
-          "rawId": "8:acs:188d4cea-0a9b-4840-8fdc-7a5c71fe9bd0_00000010-7ca4-0bb6-5896-094822001382",
+          "rawId": "8:acs:b6aada1f-0b1d-47ac-866f-91aae00a1d01_00000011-26d7-f203-570c-113a0d00b7dc",
           "communicationUser": {
-            "id": "8:acs:188d4cea-0a9b-4840-8fdc-7a5c71fe9bd0_00000010-7ca4-0bb6-5896-094822001382"
+            "id": "8:acs:b6aada1f-0b1d-47ac-866f-91aae00a1d01_00000011-26d7-f203-570c-113a0d00b7dc"
           }
         }
       }

--- a/sdk/communication/communication-chat/recordings/browsers/chatthreadclient/recording_successfully_initializes_chatthreadclient.json
+++ b/sdk/communication/communication-chat/recordings/browsers/chatthreadclient/recording_successfully_initializes_chatthreadclient.json
@@ -19,11 +19,11 @@
         "Sec-Fetch-Dest": "empty",
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
-        "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/100.0.4889.0 Safari/537.36",
-        "x-ms-client-request-id": "94a7603d-e7db-42f9-b6b2-0e7b2dd47ca4",
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/101.0.4950.0 Safari/537.36",
+        "x-ms-client-request-id": "a0c503ec-ef1e-489d-ba3f-b77aa4404784",
         "x-ms-content-sha256": "WTRvgEjjVd\u002BbvyKw3WgXgDkU81aV8FWq\u002B4/BE\u002Bhe0\u002BA=",
-        "x-ms-date": "Wed, 30 Mar 2022 21:36:42 GMT",
-        "x-ms-useragent": "azsdk-js-communication-identity/1.1.0-beta.2 core-rest-pipeline/1.8.0 OS/MacIntel"
+        "x-ms-date": "Mon, 02 May 2022 22:48:50 GMT",
+        "x-ms-useragent": "azsdk-js-communication-identity/1.1.0-beta.2 core-rest-pipeline/1.8.1 OS/Win32"
       },
       "RequestBody": {
         "createTokenWithScopes": [
@@ -34,24 +34,25 @@
       "ResponseHeaders": {
         "Access-Control-Allow-Origin": "*",
         "api-supported-versions": "2020-07-20-preview2, 2021-02-22-preview1, 2021-03-07, 2021-10-31-preview, 2021-11-01, 2022-06-01",
-        "Content-Length": "290",
+        "Connection": "keep-alive",
+        "Content-Length": "286",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 30 Mar 2022 21:36:42 GMT",
-        "MS-CV": "kx9HEvvzqUy\u002BNwUuyylysw.0",
+        "Date": "Mon, 02 May 2022 22:48:55 GMT",
+        "MS-CV": "Zjoq4\u002B6FxUqO0hvOEBtX\u002Bw.0",
         "Request-Context": "appId=",
         "Strict-Transport-Security": "max-age=2592000",
-        "X-Azure-Ref": "0as1EYgAAAADJTn2fLVTBRq6o6jLinjuuUERYMzFFREdFMDIxMgBjYzkyNzU4ZC0wNWY3LTRhZDYtYWE1ZS0wZmE5NzE4ZDg5ODU=",
+        "x-azure-ref": "20220502T224855Z-1kdy40ce594zxd7ayzepxvrcq0000000052000000002q8k5",
         "X-Cache": "CONFIG_NOCACHE",
-        "x-ms-client-request-id": "94a7603d-e7db-42f9-b6b2-0e7b2dd47ca4",
-        "X-Processing-Time": "180ms"
+        "x-ms-client-request-id": "a0c503ec-ef1e-489d-ba3f-b77aa4404784",
+        "X-Processing-Time": "224ms"
       },
       "ResponseBody": {
         "identity": {
-          "id": "8:acs:188d4cea-0a9b-4840-8fdc-7a5c71fe9bd0_00000010-7ca4-0bb6-5896-094822001382"
+          "id": "8:acs:b6aada1f-0b1d-47ac-866f-91aae00a1d01_00000011-26d7-f203-570c-113a0d00b7dc"
         },
         "accessToken": {
-          "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE2NDg2Nzk4MDAuMzU2fQ==.adM-ddBZZlQ1WlN3pdPBOF5G4Wh9iZpxNP_fSvpF4cWs",
-          "expiresOn": "2022-03-31T21:36:42.5834315\u002B00:00"
+          "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE2NTE1MzUzMjkuNDd9.adM-ddBZZlQ1WlN3pdPBOF5G4Wh9iZpxNP_fSvpF4cWs",
+          "expiresOn": "2022-05-03T22:48:50.6444162\u002B00:00"
         }
       }
     },
@@ -74,11 +75,11 @@
         "Sec-Fetch-Dest": "empty",
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
-        "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/100.0.4889.0 Safari/537.36",
-        "x-ms-client-request-id": "c6c1c85a-7baf-4e6f-8585-8415da3a40bd",
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/101.0.4950.0 Safari/537.36",
+        "x-ms-client-request-id": "618bd32d-bb99-4284-b89b-623d4575227a",
         "x-ms-content-sha256": "WTRvgEjjVd\u002BbvyKw3WgXgDkU81aV8FWq\u002B4/BE\u002Bhe0\u002BA=",
-        "x-ms-date": "Wed, 30 Mar 2022 21:36:42 GMT",
-        "x-ms-useragent": "azsdk-js-communication-identity/1.1.0-beta.2 core-rest-pipeline/1.8.0 OS/MacIntel"
+        "x-ms-date": "Mon, 02 May 2022 22:48:50 GMT",
+        "x-ms-useragent": "azsdk-js-communication-identity/1.1.0-beta.2 core-rest-pipeline/1.8.1 OS/Win32"
       },
       "RequestBody": {
         "createTokenWithScopes": [
@@ -89,24 +90,25 @@
       "ResponseHeaders": {
         "Access-Control-Allow-Origin": "*",
         "api-supported-versions": "2020-07-20-preview2, 2021-02-22-preview1, 2021-03-07, 2021-10-31-preview, 2021-11-01, 2022-06-01",
-        "Content-Length": "290",
+        "Connection": "keep-alive",
+        "Content-Length": "286",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 30 Mar 2022 21:36:42 GMT",
-        "MS-CV": "yKE0rSMYiEOmT11be2xNMw.0",
+        "Date": "Mon, 02 May 2022 22:48:56 GMT",
+        "MS-CV": "G1edxZNqXE2g6bq1Ew\u002BLuQ.0",
         "Request-Context": "appId=",
         "Strict-Transport-Security": "max-age=2592000",
-        "X-Azure-Ref": "0as1EYgAAAABR8mxDybwGQ4t\u002BRj8Ly\u002BHUUERYMzFFREdFMDIxMgBjYzkyNzU4ZC0wNWY3LTRhZDYtYWE1ZS0wZmE5NzE4ZDg5ODU=",
+        "x-azure-ref": "20220502T224855Z-1kdy40ce594zxd7ayzepxvrcq0000000052000000002q8n8",
         "X-Cache": "CONFIG_NOCACHE",
-        "x-ms-client-request-id": "c6c1c85a-7baf-4e6f-8585-8415da3a40bd",
-        "X-Processing-Time": "218ms"
+        "x-ms-client-request-id": "618bd32d-bb99-4284-b89b-623d4575227a",
+        "X-Processing-Time": "221ms"
       },
       "ResponseBody": {
         "identity": {
-          "id": "8:acs:188d4cea-0a9b-4840-8fdc-7a5c71fe9bd0_00000010-7ca4-0cc0-5896-094822001383"
+          "id": "8:acs:b6aada1f-0b1d-47ac-866f-91aae00a1d01_00000011-26d7-f36f-570c-113a0d00b7de"
         },
         "accessToken": {
-          "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE2NDg2Nzk4MDAuMzU2fQ==.adM-ddBZZlQ1WlN3pdPBOF5G4Wh9iZpxNP_fSvpF4cWs",
-          "expiresOn": "2022-03-31T21:36:42.8513184\u002B00:00"
+          "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE2NTE1MzUzMjkuNDd9.adM-ddBZZlQ1WlN3pdPBOF5G4Wh9iZpxNP_fSvpF4cWs",
+          "expiresOn": "2022-05-03T22:48:51.0035631\u002B00:00"
         }
       }
     },
@@ -119,35 +121,37 @@
         "Accept-Language": "en-US",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "Content-Length": "317",
+        "Content-Length": "497",
         "Content-Type": "application/json",
         "Origin": "http://localhost:9876",
         "Referer": "http://localhost:9876/",
-        "repeatability-request-id": "729866e3-b405-4673-b598-496512ce64fa",
+        "repeatability-request-id": "12332a37-84d7-4834-9a0d-40a2787c7bf7",
         "sec-ch-ua": "",
         "sec-ch-ua-mobile": "?0",
         "sec-ch-ua-platform": "",
         "Sec-Fetch-Dest": "empty",
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
-        "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/100.0.4889.0 Safari/537.36",
-        "x-ms-client-request-id": "305d6e46-f5a3-46c0-9faa-15da8d4fe9b5",
-        "x-ms-useragent": "azsdk-js-azure-communication-chat/1.2.0 core-rest-pipeline/1.8.0 OS/MacIntel"
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/101.0.4950.0 Safari/537.36",
+        "x-ms-client-request-id": "1c0ff491-7a79-40d5-b635-62ed39970c7a",
+        "x-ms-useragent": "azsdk-js-communication-chat/1.2.0 core-rest-pipeline/1.8.1 OS/Win32"
       },
       "RequestBody": {
         "topic": "test topic",
         "participants": [
           {
             "communicationIdentifier": {
+              "rawId": "8:acs:b6aada1f-0b1d-47ac-866f-91aae00a1d01_00000011-26d7-f203-570c-113a0d00b7dc",
               "communicationUser": {
-                "id": "8:acs:188d4cea-0a9b-4840-8fdc-7a5c71fe9bd0_00000010-7ca4-0bb6-5896-094822001382"
+                "id": "8:acs:b6aada1f-0b1d-47ac-866f-91aae00a1d01_00000011-26d7-f203-570c-113a0d00b7dc"
               }
             }
           },
           {
             "communicationIdentifier": {
+              "rawId": "8:acs:b6aada1f-0b1d-47ac-866f-91aae00a1d01_00000011-26d7-f36f-570c-113a0d00b7de",
               "communicationUser": {
-                "id": "8:acs:188d4cea-0a9b-4840-8fdc-7a5c71fe9bd0_00000010-7ca4-0cc0-5896-094822001383"
+                "id": "8:acs:b6aada1f-0b1d-47ac-866f-91aae00a1d01_00000011-26d7-f36f-570c-113a0d00b7de"
               }
             }
           }
@@ -158,25 +162,26 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "Location",
         "api-supported-versions": "2021-03-07, 2021-04-05-preview6, 2021-09-07, 2021-10-01-preview7",
+        "Connection": "keep-alive",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 30 Mar 2022 21:36:43 GMT",
-        "Location": "https://endpoint/chat/threads/19%3ASWkac8Ohhun6cBYZUJu7GWyUwrnSppuvzamOFUDuz641@thread.v2",
-        "MS-CV": "YLM2JClk7E\u002BJKhlAVZz1zw.0",
+        "Date": "Mon, 02 May 2022 22:48:56 GMT",
+        "Location": "https://endpoint/chat/threads/19%3AsGfC1p7_xma4fP7m2-tcS2pt9gpte6sdXThKfUNLYFQ1@thread.v2",
+        "MS-CV": "rM2jLqMr30Sq8tj8wtOUpA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0as1EYgAAAADYSHnElio7SaGZ0sd5Z2clUERYMzFFREdFMDIxMgBjYzkyNzU4ZC0wNWY3LTRhZDYtYWE1ZS0wZmE5NzE4ZDg5ODU=",
+        "x-azure-ref": "20220502T224856Z-1kdy40ce594zxd7ayzepxvrcq0000000052000000002q8qq",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "862ms"
+        "X-Processing-Time": "406ms"
       },
       "ResponseBody": {
         "chatThread": {
-          "id": "19:SWkac8Ohhun6cBYZUJu7GWyUwrnSppuvzamOFUDuz641@thread.v2",
+          "id": "19:sGfC1p7_xma4fP7m2-tcS2pt9gpte6sdXThKfUNLYFQ1@thread.v2",
           "topic": "test topic",
-          "createdOn": "2022-03-30T21:36:43Z",
+          "createdOn": "2022-05-02T22:48:51Z",
           "createdByCommunicationIdentifier": {
-            "rawId": "8:acs:188d4cea-0a9b-4840-8fdc-7a5c71fe9bd0_00000010-7ca4-0bb6-5896-094822001382",
+            "rawId": "8:acs:b6aada1f-0b1d-47ac-866f-91aae00a1d01_00000011-26d7-f203-570c-113a0d00b7dc",
             "communicationUser": {
-              "id": "8:acs:188d4cea-0a9b-4840-8fdc-7a5c71fe9bd0_00000010-7ca4-0bb6-5896-094822001382"
+              "id": "8:acs:b6aada1f-0b1d-47ac-866f-91aae00a1d01_00000011-26d7-f203-570c-113a0d00b7dc"
             }
           }
         }

--- a/sdk/communication/communication-chat/recordings/browsers/chatthreadclient/recording_successfully_lists_messages_one_by_one_and_by_page.json
+++ b/sdk/communication/communication-chat/recordings/browsers/chatthreadclient/recording_successfully_lists_messages_one_by_one_and_by_page.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://endpoint/chat/threads/19%3ASWkac8Ohhun6cBYZUJu7GWyUwrnSppuvzamOFUDuz641%40thread.v2/messages?api-version=2021-09-07",
+      "RequestUri": "https://endpoint/chat/threads/19%3AsGfC1p7_xma4fP7m2-tcS2pt9gpte6sdXThKfUNLYFQ1%40thread.v2/messages?api-version=2021-09-07",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -17,9 +17,9 @@
         "Sec-Fetch-Dest": "empty",
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
-        "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/100.0.4889.0 Safari/537.36",
-        "x-ms-client-request-id": "ed8f4471-f5a6-4026-a9f0-aa7433e416b3",
-        "x-ms-useragent": "azsdk-js-azure-communication-chat/1.2.0 core-rest-pipeline/1.8.0 OS/MacIntel"
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/101.0.4950.0 Safari/537.36",
+        "x-ms-client-request-id": "c385c774-0b8a-45e7-a1d5-9d267ad3fd72",
+        "x-ms-useragent": "azsdk-js-communication-chat/1.2.0 core-rest-pipeline/1.8.1 OS/Win32"
       },
       "RequestBody": null,
       "StatusCode": 200,
@@ -27,31 +27,32 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "Location",
         "api-supported-versions": "2021-03-07, 2021-04-05-preview6, 2021-09-07, 2021-10-01-preview7",
+        "Connection": "keep-alive",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 30 Mar 2022 21:36:47 GMT",
-        "MS-CV": "LsPXkFb3yUOYaBuiu\u002Bu7qQ.0",
+        "Date": "Mon, 02 May 2022 22:48:59 GMT",
+        "MS-CV": "kpnL6OjpaEqgIwE0dUrf\u002BA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0b81EYgAAAAD1XXW2O8sVTKH53HmfmDqZUERYMzFFREdFMDIxMgBjYzkyNzU4ZC0wNWY3LTRhZDYtYWE1ZS0wZmE5NzE4ZDg5ODU=",
+        "x-azure-ref": "20220502T224859Z-1kdy40ce594zxd7ayzepxvrcq0000000052000000002q9d0",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "282ms"
+        "X-Processing-Time": "111ms"
       },
       "ResponseBody": {
         "value": [
           {
-            "id": "1648676205175",
+            "id": "1651531732983",
             "type": "text",
             "sequenceId": "4",
-            "version": "1648676205175",
+            "version": "1651531732983",
             "content": {
               "message": "content"
             },
             "senderDisplayName": "",
-            "createdOn": "2022-03-30T21:36:45Z",
+            "createdOn": "2022-05-02T22:48:52Z",
             "senderCommunicationIdentifier": {
-              "rawId": "8:acs:188d4cea-0a9b-4840-8fdc-7a5c71fe9bd0_00000010-7ca4-0bb6-5896-094822001382",
+              "rawId": "8:acs:b6aada1f-0b1d-47ac-866f-91aae00a1d01_00000011-26d7-f203-570c-113a0d00b7dc",
               "communicationUser": {
-                "id": "8:acs:188d4cea-0a9b-4840-8fdc-7a5c71fe9bd0_00000010-7ca4-0bb6-5896-094822001382"
+                "id": "8:acs:b6aada1f-0b1d-47ac-866f-91aae00a1d01_00000011-26d7-f203-570c-113a0d00b7dc"
               }
             },
             "metadata": {
@@ -59,77 +60,77 @@
             }
           },
           {
-            "id": "1648676204416",
+            "id": "1651531732282",
             "type": "topicUpdated",
             "sequenceId": "3",
-            "version": "1648676204416",
+            "version": "1651531732282",
             "content": {
               "topic": "new topic",
               "initiatorCommunicationIdentifier": {
-                "rawId": "8:acs:188d4cea-0a9b-4840-8fdc-7a5c71fe9bd0_00000010-7ca4-0bb6-5896-094822001382",
+                "rawId": "8:acs:b6aada1f-0b1d-47ac-866f-91aae00a1d01_00000011-26d7-f203-570c-113a0d00b7dc",
                 "communicationUser": {
-                  "id": "8:acs:188d4cea-0a9b-4840-8fdc-7a5c71fe9bd0_00000010-7ca4-0bb6-5896-094822001382"
+                  "id": "8:acs:b6aada1f-0b1d-47ac-866f-91aae00a1d01_00000011-26d7-f203-570c-113a0d00b7dc"
                 }
               }
             },
-            "createdOn": "2022-03-30T21:36:44Z"
+            "createdOn": "2022-05-02T22:48:52Z"
           },
           {
-            "id": "1648676203338",
+            "id": "1651531731365",
             "type": "topicUpdated",
             "sequenceId": "2",
-            "version": "1648676203338",
+            "version": "1651531731365",
             "content": {
               "topic": "test topic",
               "initiatorCommunicationIdentifier": {
-                "rawId": "8:acs:188d4cea-0a9b-4840-8fdc-7a5c71fe9bd0_00000010-7ca4-0bb6-5896-094822001382",
+                "rawId": "8:acs:b6aada1f-0b1d-47ac-866f-91aae00a1d01_00000011-26d7-f203-570c-113a0d00b7dc",
                 "communicationUser": {
-                  "id": "8:acs:188d4cea-0a9b-4840-8fdc-7a5c71fe9bd0_00000010-7ca4-0bb6-5896-094822001382"
+                  "id": "8:acs:b6aada1f-0b1d-47ac-866f-91aae00a1d01_00000011-26d7-f203-570c-113a0d00b7dc"
                 }
               }
             },
-            "createdOn": "2022-03-30T21:36:43Z"
+            "createdOn": "2022-05-02T22:48:51Z"
           },
           {
-            "id": "1648676203307",
+            "id": "1651531731341",
             "type": "participantAdded",
             "sequenceId": "1",
-            "version": "1648676203307",
+            "version": "1651531731341",
             "content": {
               "participants": [
                 {
                   "communicationIdentifier": {
-                    "rawId": "8:acs:188d4cea-0a9b-4840-8fdc-7a5c71fe9bd0_00000010-7ca4-0bb6-5896-094822001382",
+                    "rawId": "8:acs:b6aada1f-0b1d-47ac-866f-91aae00a1d01_00000011-26d7-f203-570c-113a0d00b7dc",
                     "communicationUser": {
-                      "id": "8:acs:188d4cea-0a9b-4840-8fdc-7a5c71fe9bd0_00000010-7ca4-0bb6-5896-094822001382"
+                      "id": "8:acs:b6aada1f-0b1d-47ac-866f-91aae00a1d01_00000011-26d7-f203-570c-113a0d00b7dc"
                     }
                   },
                   "shareHistoryTime": "1970-01-01T00:00:00Z"
                 },
                 {
                   "communicationIdentifier": {
-                    "rawId": "8:acs:188d4cea-0a9b-4840-8fdc-7a5c71fe9bd0_00000010-7ca4-0cc0-5896-094822001383",
+                    "rawId": "8:acs:b6aada1f-0b1d-47ac-866f-91aae00a1d01_00000011-26d7-f36f-570c-113a0d00b7de",
                     "communicationUser": {
-                      "id": "8:acs:188d4cea-0a9b-4840-8fdc-7a5c71fe9bd0_00000010-7ca4-0cc0-5896-094822001383"
+                      "id": "8:acs:b6aada1f-0b1d-47ac-866f-91aae00a1d01_00000011-26d7-f36f-570c-113a0d00b7de"
                     }
                   },
                   "shareHistoryTime": "1970-01-01T00:00:00Z"
                 }
               ],
               "initiatorCommunicationIdentifier": {
-                "rawId": "8:acs:188d4cea-0a9b-4840-8fdc-7a5c71fe9bd0_00000010-7ca4-0bb6-5896-094822001382",
+                "rawId": "8:acs:b6aada1f-0b1d-47ac-866f-91aae00a1d01_00000011-26d7-f203-570c-113a0d00b7dc",
                 "communicationUser": {
-                  "id": "8:acs:188d4cea-0a9b-4840-8fdc-7a5c71fe9bd0_00000010-7ca4-0bb6-5896-094822001382"
+                  "id": "8:acs:b6aada1f-0b1d-47ac-866f-91aae00a1d01_00000011-26d7-f203-570c-113a0d00b7dc"
                 }
               }
             },
-            "createdOn": "2022-03-30T21:36:43Z"
+            "createdOn": "2022-05-02T22:48:51Z"
           }
         ]
       }
     },
     {
-      "RequestUri": "https://endpoint/chat/threads/19%3ASWkac8Ohhun6cBYZUJu7GWyUwrnSppuvzamOFUDuz641%40thread.v2/messages?maxPageSize=3\u0026api-version=2021-09-07",
+      "RequestUri": "https://endpoint/chat/threads/19%3AsGfC1p7_xma4fP7m2-tcS2pt9gpte6sdXThKfUNLYFQ1%40thread.v2/messages?maxPageSize=3\u0026api-version=2021-09-07",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -145,9 +146,9 @@
         "Sec-Fetch-Dest": "empty",
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
-        "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/100.0.4889.0 Safari/537.36",
-        "x-ms-client-request-id": "292d7a0d-50a6-4d5b-bcb5-1b76786105fd",
-        "x-ms-useragent": "azsdk-js-azure-communication-chat/1.2.0 core-rest-pipeline/1.8.0 OS/MacIntel"
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/101.0.4950.0 Safari/537.36",
+        "x-ms-client-request-id": "a44bc3e0-e4e1-46a9-9de5-c081c7021ae0",
+        "x-ms-useragent": "azsdk-js-communication-chat/1.2.0 core-rest-pipeline/1.8.1 OS/Win32"
       },
       "RequestBody": null,
       "StatusCode": 200,
@@ -155,31 +156,32 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "Location",
         "api-supported-versions": "2021-03-07, 2021-04-05-preview6, 2021-09-07, 2021-10-01-preview7",
+        "Connection": "keep-alive",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 30 Mar 2022 21:36:47 GMT",
-        "MS-CV": "wzNeKVKjp0GXaVHOkbwjHg.0",
+        "Date": "Mon, 02 May 2022 22:49:00 GMT",
+        "MS-CV": "yzRdeNp/IUK/hQNLYOwy7Q.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0b81EYgAAAABsL35xwbxNQ4msemX8L/Z\u002BUERYMzFFREdFMDIxMgBjYzkyNzU4ZC0wNWY3LTRhZDYtYWE1ZS0wZmE5NzE4ZDg5ODU=",
+        "x-azure-ref": "20220502T224859Z-1kdy40ce594zxd7ayzepxvrcq0000000052000000002q9fa",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "276ms"
+        "X-Processing-Time": "93ms"
       },
       "ResponseBody": {
         "value": [
           {
-            "id": "1648676205175",
+            "id": "1651531732983",
             "type": "text",
             "sequenceId": "4",
-            "version": "1648676205175",
+            "version": "1651531732983",
             "content": {
               "message": "content"
             },
             "senderDisplayName": "",
-            "createdOn": "2022-03-30T21:36:45Z",
+            "createdOn": "2022-05-02T22:48:52Z",
             "senderCommunicationIdentifier": {
-              "rawId": "8:acs:188d4cea-0a9b-4840-8fdc-7a5c71fe9bd0_00000010-7ca4-0bb6-5896-094822001382",
+              "rawId": "8:acs:b6aada1f-0b1d-47ac-866f-91aae00a1d01_00000011-26d7-f203-570c-113a0d00b7dc",
               "communicationUser": {
-                "id": "8:acs:188d4cea-0a9b-4840-8fdc-7a5c71fe9bd0_00000010-7ca4-0bb6-5896-094822001382"
+                "id": "8:acs:b6aada1f-0b1d-47ac-866f-91aae00a1d01_00000011-26d7-f203-570c-113a0d00b7dc"
               }
             },
             "metadata": {
@@ -187,43 +189,43 @@
             }
           },
           {
-            "id": "1648676204416",
+            "id": "1651531732282",
             "type": "topicUpdated",
             "sequenceId": "3",
-            "version": "1648676204416",
+            "version": "1651531732282",
             "content": {
               "topic": "new topic",
               "initiatorCommunicationIdentifier": {
-                "rawId": "8:acs:188d4cea-0a9b-4840-8fdc-7a5c71fe9bd0_00000010-7ca4-0bb6-5896-094822001382",
+                "rawId": "8:acs:b6aada1f-0b1d-47ac-866f-91aae00a1d01_00000011-26d7-f203-570c-113a0d00b7dc",
                 "communicationUser": {
-                  "id": "8:acs:188d4cea-0a9b-4840-8fdc-7a5c71fe9bd0_00000010-7ca4-0bb6-5896-094822001382"
+                  "id": "8:acs:b6aada1f-0b1d-47ac-866f-91aae00a1d01_00000011-26d7-f203-570c-113a0d00b7dc"
                 }
               }
             },
-            "createdOn": "2022-03-30T21:36:44Z"
+            "createdOn": "2022-05-02T22:48:52Z"
           },
           {
-            "id": "1648676203338",
+            "id": "1651531731365",
             "type": "topicUpdated",
             "sequenceId": "2",
-            "version": "1648676203338",
+            "version": "1651531731365",
             "content": {
               "topic": "test topic",
               "initiatorCommunicationIdentifier": {
-                "rawId": "8:acs:188d4cea-0a9b-4840-8fdc-7a5c71fe9bd0_00000010-7ca4-0bb6-5896-094822001382",
+                "rawId": "8:acs:b6aada1f-0b1d-47ac-866f-91aae00a1d01_00000011-26d7-f203-570c-113a0d00b7dc",
                 "communicationUser": {
-                  "id": "8:acs:188d4cea-0a9b-4840-8fdc-7a5c71fe9bd0_00000010-7ca4-0bb6-5896-094822001382"
+                  "id": "8:acs:b6aada1f-0b1d-47ac-866f-91aae00a1d01_00000011-26d7-f203-570c-113a0d00b7dc"
                 }
               }
             },
-            "createdOn": "2022-03-30T21:36:43Z"
+            "createdOn": "2022-05-02T22:48:51Z"
           }
         ],
-        "nextLink": "https://endpoint/chat/threads/19:SWkac8Ohhun6cBYZUJu7GWyUwrnSppuvzamOFUDuz641@thread.v2/messages?syncState=3e3900000031393a53576b6163384f6868756e366342595a554a75374757795577726e53707075767a616d4f465544757a363431407468726561642e7632014a6bc2dc7f0100007772c2dc7f010000\u0026startTime=1%2F1%2F1970%2012%3A00%3A00%20AM%20%2B00%3A00\u0026maxPageSize=3\u0026api-version=2021-09-07"
+        "nextLink": "https://endpoint/chat/threads/19:sGfC1p7_xma4fP7m2-tcS2pt9gpte6sdXThKfUNLYFQ1@thread.v2/messages?syncState=3e3900000031393a734766433170375f786d61346650376d322d74635332707439677074653673645854684b66554e4c59465131407468726561642e763201a551f68680010000f757f68680010000\u0026startTime=1%2F1%2F1970%2012%3A00%3A00%20AM%20%2B00%3A00\u0026maxPageSize=3\u0026api-version=2021-09-07"
       }
     },
     {
-      "RequestUri": "https://endpoint/chat/threads/19:SWkac8Ohhun6cBYZUJu7GWyUwrnSppuvzamOFUDuz641@thread.v2/messages?syncState=3e3900000031393a53576b6163384f6868756e366342595a554a75374757795577726e53707075767a616d4f465544757a363431407468726561642e7632014a6bc2dc7f0100007772c2dc7f010000\u0026startTime=1%2F1%2F1970%2012%3A00%3A00%20AM%20%2B00%3A00\u0026maxPageSize=3\u0026api-version=2021-09-07",
+      "RequestUri": "https://endpoint/chat/threads/19:sGfC1p7_xma4fP7m2-tcS2pt9gpte6sdXThKfUNLYFQ1@thread.v2/messages?syncState=3e3900000031393a734766433170375f786d61346650376d322d74635332707439677074653673645854684b66554e4c59465131407468726561642e763201a551f68680010000f757f68680010000\u0026startTime=1%2F1%2F1970%2012%3A00%3A00%20AM%20%2B00%3A00\u0026maxPageSize=3\u0026api-version=2021-09-07",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -239,9 +241,9 @@
         "Sec-Fetch-Dest": "empty",
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
-        "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/100.0.4889.0 Safari/537.36",
-        "x-ms-client-request-id": "1d08c032-38de-482c-8723-3dc5d5053642",
-        "x-ms-useragent": "azsdk-js-azure-communication-chat/1.2.0 core-rest-pipeline/1.8.0 OS/MacIntel"
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/101.0.4950.0 Safari/537.36",
+        "x-ms-client-request-id": "9b1823e8-ad5a-4f42-aa68-a8086ebe4df0",
+        "x-ms-useragent": "azsdk-js-communication-chat/1.2.0 core-rest-pipeline/1.8.1 OS/Win32"
       },
       "RequestBody": null,
       "StatusCode": 200,
@@ -249,51 +251,52 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "Location",
         "api-supported-versions": "2021-03-07, 2021-04-05-preview6, 2021-09-07, 2021-10-01-preview7",
+        "Connection": "keep-alive",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 30 Mar 2022 21:36:48 GMT",
-        "MS-CV": "\u002BzxNkeIOk0W6vfqxXQZCgw.0",
+        "Date": "Mon, 02 May 2022 22:49:00 GMT",
+        "MS-CV": "c3lPo8pBA0m4g9ap/Q8\u002Bxw.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0cM1EYgAAAAAwSy3\u002BGzLRRqk2XRDUvgHlUERYMzFFREdFMDIxMgBjYzkyNzU4ZC0wNWY3LTRhZDYtYWE1ZS0wZmE5NzE4ZDg5ODU=",
+        "x-azure-ref": "20220502T224900Z-1kdy40ce594zxd7ayzepxvrcq0000000052000000002q9h2",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "483ms"
+        "X-Processing-Time": "41ms"
       },
       "ResponseBody": {
         "value": [
           {
-            "id": "1648676203307",
+            "id": "1651531731341",
             "type": "participantAdded",
             "sequenceId": "1",
-            "version": "1648676203307",
+            "version": "1651531731341",
             "content": {
               "participants": [
                 {
                   "communicationIdentifier": {
-                    "rawId": "8:acs:188d4cea-0a9b-4840-8fdc-7a5c71fe9bd0_00000010-7ca4-0bb6-5896-094822001382",
+                    "rawId": "8:acs:b6aada1f-0b1d-47ac-866f-91aae00a1d01_00000011-26d7-f203-570c-113a0d00b7dc",
                     "communicationUser": {
-                      "id": "8:acs:188d4cea-0a9b-4840-8fdc-7a5c71fe9bd0_00000010-7ca4-0bb6-5896-094822001382"
+                      "id": "8:acs:b6aada1f-0b1d-47ac-866f-91aae00a1d01_00000011-26d7-f203-570c-113a0d00b7dc"
                     }
                   },
                   "shareHistoryTime": "1970-01-01T00:00:00Z"
                 },
                 {
                   "communicationIdentifier": {
-                    "rawId": "8:acs:188d4cea-0a9b-4840-8fdc-7a5c71fe9bd0_00000010-7ca4-0cc0-5896-094822001383",
+                    "rawId": "8:acs:b6aada1f-0b1d-47ac-866f-91aae00a1d01_00000011-26d7-f36f-570c-113a0d00b7de",
                     "communicationUser": {
-                      "id": "8:acs:188d4cea-0a9b-4840-8fdc-7a5c71fe9bd0_00000010-7ca4-0cc0-5896-094822001383"
+                      "id": "8:acs:b6aada1f-0b1d-47ac-866f-91aae00a1d01_00000011-26d7-f36f-570c-113a0d00b7de"
                     }
                   },
                   "shareHistoryTime": "1970-01-01T00:00:00Z"
                 }
               ],
               "initiatorCommunicationIdentifier": {
-                "rawId": "8:acs:188d4cea-0a9b-4840-8fdc-7a5c71fe9bd0_00000010-7ca4-0bb6-5896-094822001382",
+                "rawId": "8:acs:b6aada1f-0b1d-47ac-866f-91aae00a1d01_00000011-26d7-f203-570c-113a0d00b7dc",
                 "communicationUser": {
-                  "id": "8:acs:188d4cea-0a9b-4840-8fdc-7a5c71fe9bd0_00000010-7ca4-0bb6-5896-094822001382"
+                  "id": "8:acs:b6aada1f-0b1d-47ac-866f-91aae00a1d01_00000011-26d7-f203-570c-113a0d00b7dc"
                 }
               }
             },
-            "createdOn": "2022-03-30T21:36:43Z"
+            "createdOn": "2022-05-02T22:48:51Z"
           }
         ]
       }

--- a/sdk/communication/communication-chat/recordings/browsers/chatthreadclient/recording_successfully_lists_participants.json
+++ b/sdk/communication/communication-chat/recordings/browsers/chatthreadclient/recording_successfully_lists_participants.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://endpoint/chat/threads/19%3ASWkac8Ohhun6cBYZUJu7GWyUwrnSppuvzamOFUDuz641%40thread.v2/participants?api-version=2021-09-07",
+      "RequestUri": "https://endpoint/chat/threads/19%3AsGfC1p7_xma4fP7m2-tcS2pt9gpte6sdXThKfUNLYFQ1%40thread.v2/participants?api-version=2021-09-07",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -17,9 +17,9 @@
         "Sec-Fetch-Dest": "empty",
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
-        "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/100.0.4889.0 Safari/537.36",
-        "x-ms-client-request-id": "2e59e646-1fde-4637-932c-5d707919c09f",
-        "x-ms-useragent": "azsdk-js-azure-communication-chat/1.2.0 core-rest-pipeline/1.8.0 OS/MacIntel"
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/101.0.4950.0 Safari/537.36",
+        "x-ms-client-request-id": "68785a4f-3419-43b0-94aa-8c9dda31d77a",
+        "x-ms-useragent": "azsdk-js-communication-chat/1.2.0 core-rest-pipeline/1.8.1 OS/Win32"
       },
       "RequestBody": null,
       "StatusCode": 200,
@@ -27,40 +27,41 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "Location",
         "api-supported-versions": "2021-03-07, 2021-04-05-preview6, 2021-09-07, 2021-10-01-preview7",
+        "Connection": "keep-alive",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 30 Mar 2022 21:36:49 GMT",
-        "MS-CV": "aEjqpcTtn0a4VGBaCQGlZw.0",
+        "Date": "Mon, 02 May 2022 22:49:01 GMT",
+        "MS-CV": "yMTvONg8gk\u002BZav2VCWAouA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0cc1EYgAAAAAo9J40mzS8TLqitGr7NnkZUERYMzFFREdFMDIxMgBjYzkyNzU4ZC0wNWY3LTRhZDYtYWE1ZS0wZmE5NzE4ZDg5ODU=",
+        "x-azure-ref": "20220502T224901Z-1kdy40ce594zxd7ayzepxvrcq0000000052000000002q9ta",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "263ms"
+        "X-Processing-Time": "94ms"
       },
       "ResponseBody": {
         "value": [
           {
             "communicationIdentifier": {
-              "rawId": "8:acs:188d4cea-0a9b-4840-8fdc-7a5c71fe9bd0_00000010-7ca4-0bb6-5896-094822001382",
+              "rawId": "8:acs:b6aada1f-0b1d-47ac-866f-91aae00a1d01_00000011-26d7-f203-570c-113a0d00b7dc",
               "communicationUser": {
-                "id": "8:acs:188d4cea-0a9b-4840-8fdc-7a5c71fe9bd0_00000010-7ca4-0bb6-5896-094822001382"
+                "id": "8:acs:b6aada1f-0b1d-47ac-866f-91aae00a1d01_00000011-26d7-f203-570c-113a0d00b7dc"
               }
             },
             "shareHistoryTime": "1970-01-01T00:00:00Z"
           },
           {
             "communicationIdentifier": {
-              "rawId": "8:acs:188d4cea-0a9b-4840-8fdc-7a5c71fe9bd0_00000010-7ca4-0cc0-5896-094822001383",
+              "rawId": "8:acs:b6aada1f-0b1d-47ac-866f-91aae00a1d01_00000011-26d7-f36f-570c-113a0d00b7de",
               "communicationUser": {
-                "id": "8:acs:188d4cea-0a9b-4840-8fdc-7a5c71fe9bd0_00000010-7ca4-0cc0-5896-094822001383"
+                "id": "8:acs:b6aada1f-0b1d-47ac-866f-91aae00a1d01_00000011-26d7-f36f-570c-113a0d00b7de"
               }
             },
             "shareHistoryTime": "1970-01-01T00:00:00Z"
           },
           {
             "communicationIdentifier": {
-              "rawId": "8:acs:188d4cea-0a9b-4840-8fdc-7a5c71fe9bd0_00000010-7ca4-25e4-5896-094822001385",
+              "rawId": "8:acs:b6aada1f-0b1d-47ac-866f-91aae00a1d01_00000011-26d8-06b8-570c-113a0d00b7e0",
               "communicationUser": {
-                "id": "8:acs:188d4cea-0a9b-4840-8fdc-7a5c71fe9bd0_00000010-7ca4-25e4-5896-094822001385"
+                "id": "8:acs:b6aada1f-0b1d-47ac-866f-91aae00a1d01_00000011-26d8-06b8-570c-113a0d00b7e0"
               }
             },
             "shareHistoryTime": "1970-01-01T00:00:00Z"

--- a/sdk/communication/communication-chat/recordings/browsers/chatthreadclient/recording_successfully_lists_read_receipts.json
+++ b/sdk/communication/communication-chat/recordings/browsers/chatthreadclient/recording_successfully_lists_read_receipts.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://endpoint/chat/threads/19%3ASWkac8Ohhun6cBYZUJu7GWyUwrnSppuvzamOFUDuz641%40thread.v2/readReceipts?api-version=2021-09-07",
+      "RequestUri": "https://endpoint/chat/threads/19%3AsGfC1p7_xma4fP7m2-tcS2pt9gpte6sdXThKfUNLYFQ1%40thread.v2/readReceipts?api-version=2021-09-07",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -17,9 +17,9 @@
         "Sec-Fetch-Dest": "empty",
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
-        "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/100.0.4889.0 Safari/537.36",
-        "x-ms-client-request-id": "18dd36e9-ca47-4290-8705-2a11a6079255",
-        "x-ms-useragent": "azsdk-js-azure-communication-chat/1.2.0 core-rest-pipeline/1.8.0 OS/MacIntel"
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/101.0.4950.0 Safari/537.36",
+        "x-ms-client-request-id": "662eef5d-b856-46b1-a8e0-c9044554e1bc",
+        "x-ms-useragent": "azsdk-js-communication-chat/1.2.0 core-rest-pipeline/1.8.1 OS/Win32"
       },
       "RequestBody": null,
       "StatusCode": 200,
@@ -27,26 +27,27 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "Location",
         "api-supported-versions": "2021-03-07, 2021-04-05-preview6, 2021-09-07, 2021-10-01-preview7",
+        "Connection": "keep-alive",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 30 Mar 2022 21:36:50 GMT",
-        "MS-CV": "GtrFYoJubkWa3sO\u002BUQviIw.0",
+        "Date": "Mon, 02 May 2022 22:49:02 GMT",
+        "MS-CV": "YajXsPo6yEOBiJ3PHmVp8A.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0cs1EYgAAAADCpFBcfCojRJBkV9iRg4aiUERYMzFFREdFMDIxMgBjYzkyNzU4ZC0wNWY3LTRhZDYtYWE1ZS0wZmE5NzE4ZDg5ODU=",
+        "x-azure-ref": "20220502T224902Z-1kdy40ce594zxd7ayzepxvrcq0000000052000000002q9xh",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "253ms"
+        "X-Processing-Time": "85ms"
       },
       "ResponseBody": {
         "value": [
           {
             "senderCommunicationIdentifier": {
-              "rawId": "8:acs:188d4cea-0a9b-4840-8fdc-7a5c71fe9bd0_00000010-7ca4-0bb6-5896-094822001382",
+              "rawId": "8:acs:b6aada1f-0b1d-47ac-866f-91aae00a1d01_00000011-26d7-f203-570c-113a0d00b7dc",
               "communicationUser": {
-                "id": "8:acs:188d4cea-0a9b-4840-8fdc-7a5c71fe9bd0_00000010-7ca4-0bb6-5896-094822001382"
+                "id": "8:acs:b6aada1f-0b1d-47ac-866f-91aae00a1d01_00000011-26d7-f203-570c-113a0d00b7dc"
               }
             },
-            "chatMessageId": "1648676205175",
-            "readOn": "2022-03-30T21:36:46Z"
+            "chatMessageId": "1651531732983",
+            "readOn": "2022-05-02T22:48:53Z"
           }
         ]
       }

--- a/sdk/communication/communication-chat/recordings/browsers/chatthreadclient/recording_successfully_remove_a_participant.json
+++ b/sdk/communication/communication-chat/recordings/browsers/chatthreadclient/recording_successfully_remove_a_participant.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://endpoint/chat/threads/19%3ASWkac8Ohhun6cBYZUJu7GWyUwrnSppuvzamOFUDuz641%40thread.v2/participants/:remove?api-version=2021-09-07",
+      "RequestUri": "https://endpoint/chat/threads/19%3AsGfC1p7_xma4fP7m2-tcS2pt9gpte6sdXThKfUNLYFQ1%40thread.v2/participants/:remove?api-version=2021-09-07",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -9,7 +9,7 @@
         "Accept-Language": "en-US",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "Content-Length": "110",
+        "Content-Length": "200",
         "Content-Type": "application/json",
         "Origin": "http://localhost:9876",
         "Referer": "http://localhost:9876/",
@@ -19,13 +19,14 @@
         "Sec-Fetch-Dest": "empty",
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
-        "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/100.0.4889.0 Safari/537.36",
-        "x-ms-client-request-id": "f7a78342-322d-49f1-a9ea-239dee3856e8",
-        "x-ms-useragent": "azsdk-js-azure-communication-chat/1.2.0 core-rest-pipeline/1.8.0 OS/MacIntel"
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/101.0.4950.0 Safari/537.36",
+        "x-ms-client-request-id": "f9791974-ffce-4b99-b7cd-a12f8094377b",
+        "x-ms-useragent": "azsdk-js-communication-chat/1.2.0 core-rest-pipeline/1.8.1 OS/Win32"
       },
       "RequestBody": {
+        "rawId": "8:acs:b6aada1f-0b1d-47ac-866f-91aae00a1d01_00000011-26d7-f36f-570c-113a0d00b7de",
         "communicationUser": {
-          "id": "8:acs:188d4cea-0a9b-4840-8fdc-7a5c71fe9bd0_00000010-7ca4-0cc0-5896-094822001383"
+          "id": "8:acs:b6aada1f-0b1d-47ac-866f-91aae00a1d01_00000011-26d7-f36f-570c-113a0d00b7de"
         }
       },
       "StatusCode": 204,
@@ -33,12 +34,13 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "Location",
         "api-supported-versions": "2021-03-07, 2021-04-05-preview6, 2021-09-07, 2021-10-01-preview7",
-        "Date": "Wed, 30 Mar 2022 21:36:50 GMT",
-        "MS-CV": "UHv3fJfK0UKTAuGV2o52Fg.0",
+        "Connection": "keep-alive",
+        "Date": "Mon, 02 May 2022 22:49:01 GMT",
+        "MS-CV": "OC32qpnJPU26o77d5ogI0g.0",
         "Strict-Transport-Security": "max-age=2592000",
-        "X-Azure-Ref": "0cs1EYgAAAACpYbk43ZEWQKkiqW08BLsNUERYMzFFREdFMDIxMgBjYzkyNzU4ZC0wNWY3LTRhZDYtYWE1ZS0wZmE5NzE4ZDg5ODU=",
+        "x-azure-ref": "20220502T224901Z-1kdy40ce594zxd7ayzepxvrcq0000000052000000002q9va",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "460ms"
+        "X-Processing-Time": "180ms"
       },
       "ResponseBody": null
     }

--- a/sdk/communication/communication-chat/recordings/browsers/chatthreadclient/recording_successfully_retrieves_a_message.json
+++ b/sdk/communication/communication-chat/recordings/browsers/chatthreadclient/recording_successfully_retrieves_a_message.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://endpoint/chat/threads/19%3ASWkac8Ohhun6cBYZUJu7GWyUwrnSppuvzamOFUDuz641%40thread.v2/messages/1648676205175?api-version=2021-09-07",
+      "RequestUri": "https://endpoint/chat/threads/19%3AsGfC1p7_xma4fP7m2-tcS2pt9gpte6sdXThKfUNLYFQ1%40thread.v2/messages/1651531732983?api-version=2021-09-07",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -17,9 +17,9 @@
         "Sec-Fetch-Dest": "empty",
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
-        "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/100.0.4889.0 Safari/537.36",
-        "x-ms-client-request-id": "74797c06-5e89-466a-9ff8-2d057fd74b91",
-        "x-ms-useragent": "azsdk-js-azure-communication-chat/1.2.0 core-rest-pipeline/1.8.0 OS/MacIntel"
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/101.0.4950.0 Safari/537.36",
+        "x-ms-client-request-id": "f48ae982-153c-471a-8ad3-3bf973c230d6",
+        "x-ms-useragent": "azsdk-js-communication-chat/1.2.0 core-rest-pipeline/1.8.1 OS/Win32"
       },
       "RequestBody": null,
       "StatusCode": 200,
@@ -27,29 +27,30 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "Location",
         "api-supported-versions": "2021-03-07, 2021-04-05-preview6, 2021-09-07, 2021-10-01-preview7",
+        "Connection": "keep-alive",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 30 Mar 2022 21:36:46 GMT",
-        "MS-CV": "8pl1XQbfDk\u002B2JRbKrX2W0A.0",
+        "Date": "Mon, 02 May 2022 22:48:59 GMT",
+        "MS-CV": "wTxiqqATwECZgENEA2zlnA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0b81EYgAAAACeEI0pIHVQSa56osxOTOC4UERYMzFFREdFMDIxMgBjYzkyNzU4ZC0wNWY3LTRhZDYtYWE1ZS0wZmE5NzE4ZDg5ODU=",
+        "x-azure-ref": "20220502T224858Z-1kdy40ce594zxd7ayzepxvrcq0000000052000000002q98u",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "265ms"
+        "X-Processing-Time": "279ms"
       },
       "ResponseBody": {
-        "id": "1648676205175",
+        "id": "1651531732983",
         "type": "text",
         "sequenceId": "4",
-        "version": "1648676205175",
+        "version": "1651531732983",
         "content": {
           "message": "content"
         },
         "senderDisplayName": "",
-        "createdOn": "2022-03-30T21:36:45Z",
+        "createdOn": "2022-05-02T22:48:52Z",
         "senderCommunicationIdentifier": {
-          "rawId": "8:acs:188d4cea-0a9b-4840-8fdc-7a5c71fe9bd0_00000010-7ca4-0bb6-5896-094822001382",
+          "rawId": "8:acs:b6aada1f-0b1d-47ac-866f-91aae00a1d01_00000011-26d7-f203-570c-113a0d00b7dc",
           "communicationUser": {
-            "id": "8:acs:188d4cea-0a9b-4840-8fdc-7a5c71fe9bd0_00000010-7ca4-0bb6-5896-094822001382"
+            "id": "8:acs:b6aada1f-0b1d-47ac-866f-91aae00a1d01_00000011-26d7-f203-570c-113a0d00b7dc"
           }
         },
         "metadata": {

--- a/sdk/communication/communication-chat/recordings/browsers/chatthreadclient/recording_successfully_sends_a_message.json
+++ b/sdk/communication/communication-chat/recordings/browsers/chatthreadclient/recording_successfully_sends_a_message.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://endpoint/chat/threads/19%3ASWkac8Ohhun6cBYZUJu7GWyUwrnSppuvzamOFUDuz641%40thread.v2/messages?api-version=2021-09-07",
+      "RequestUri": "https://endpoint/chat/threads/19%3AsGfC1p7_xma4fP7m2-tcS2pt9gpte6sdXThKfUNLYFQ1%40thread.v2/messages?api-version=2021-09-07",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -19,9 +19,9 @@
         "Sec-Fetch-Dest": "empty",
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
-        "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/100.0.4889.0 Safari/537.36",
-        "x-ms-client-request-id": "70a11f5e-8190-41c3-a4d3-b71a3cc0256e",
-        "x-ms-useragent": "azsdk-js-azure-communication-chat/1.2.0 core-rest-pipeline/1.8.0 OS/MacIntel"
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/101.0.4950.0 Safari/537.36",
+        "x-ms-client-request-id": "a946b21e-de98-4012-b58a-0262b668d719",
+        "x-ms-useragent": "azsdk-js-communication-chat/1.2.0 core-rest-pipeline/1.8.1 OS/Win32"
       },
       "RequestBody": {
         "content": "content",
@@ -34,18 +34,19 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "Location",
         "api-supported-versions": "2021-03-07, 2021-04-05-preview6, 2021-09-07, 2021-10-01-preview7",
+        "Connection": "keep-alive",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 30 Mar 2022 21:36:44 GMT",
-        "Location": "https://endpoint/chat/threads/19%3ASWkac8Ohhun6cBYZUJu7GWyUwrnSppuvzamOFUDuz641@thread.v2/messages/1648676205175",
-        "MS-CV": "ZghnXY8F5kqZT45drRQe1w.0",
+        "Date": "Mon, 02 May 2022 22:48:58 GMT",
+        "Location": "https://endpoint/chat/threads/19%3AsGfC1p7_xma4fP7m2-tcS2pt9gpte6sdXThKfUNLYFQ1@thread.v2/messages/1651531732983",
+        "MS-CV": "afBl20lDuk6YFj66ZFzIAw.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0bM1EYgAAAACldOsLcHmgRbCT3WSqVt49UERYMzFFREdFMDIxMgBjYzkyNzU4ZC0wNWY3LTRhZDYtYWE1ZS0wZmE5NzE4ZDg5ODU=",
+        "x-azure-ref": "20220502T224857Z-1kdy40ce594zxd7ayzepxvrcq0000000052000000002q90g",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "377ms"
+        "X-Processing-Time": "191ms"
       },
       "ResponseBody": {
-        "id": "1648676205175"
+        "id": "1651531732983"
       }
     }
   ],

--- a/sdk/communication/communication-chat/recordings/browsers/chatthreadclient/recording_successfully_sends_read_receipt.json
+++ b/sdk/communication/communication-chat/recordings/browsers/chatthreadclient/recording_successfully_sends_read_receipt.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://endpoint/chat/threads/19%3ASWkac8Ohhun6cBYZUJu7GWyUwrnSppuvzamOFUDuz641%40thread.v2/readReceipts?api-version=2021-09-07",
+      "RequestUri": "https://endpoint/chat/threads/19%3AsGfC1p7_xma4fP7m2-tcS2pt9gpte6sdXThKfUNLYFQ1%40thread.v2/readReceipts?api-version=2021-09-07",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -19,25 +19,27 @@
         "Sec-Fetch-Dest": "empty",
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
-        "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/100.0.4889.0 Safari/537.36",
-        "x-ms-client-request-id": "62d94baa-2fe2-4a06-963f-0ee79af93838",
-        "x-ms-useragent": "azsdk-js-azure-communication-chat/1.2.0 core-rest-pipeline/1.8.0 OS/MacIntel"
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/101.0.4950.0 Safari/537.36",
+        "x-ms-client-request-id": "d37ede95-f806-4858-8d79-b2cb09e30eb1",
+        "x-ms-useragent": "azsdk-js-communication-chat/1.2.0 core-rest-pipeline/1.8.1 OS/Win32"
       },
       "RequestBody": {
-        "chatMessageId": "1648676205175"
+        "chatMessageId": "1651531732983"
       },
       "StatusCode": 200,
       "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "Location",
         "api-supported-versions": "2021-03-07, 2021-04-05-preview6, 2021-09-07, 2021-10-01-preview7",
+        "Connection": "keep-alive",
         "Content-Length": "0",
-        "Date": "Wed, 30 Mar 2022 21:36:46 GMT",
-        "MS-CV": "mMaplOU\u002BI0i5dBm4M1oHCw.0",
+        "Date": "Mon, 02 May 2022 22:48:58 GMT",
+        "MS-CV": "VZ6sILEDl0eqccA4qF92rg.0",
         "Strict-Transport-Security": "max-age=2592000",
-        "X-Azure-Ref": "0bs1EYgAAAACtqfIEsuciSJLuLdfbalBTUERYMzFFREdFMDIxMgBjYzkyNzU4ZC0wNWY3LTRhZDYtYWE1ZS0wZmE5NzE4ZDg5ODU=",
+        "x-azure-ref": "20220502T224858Z-1kdy40ce594zxd7ayzepxvrcq0000000052000000002q963",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "585ms"
+        "X-Processing-Time": "175ms"
       },
       "ResponseBody": null
     }

--- a/sdk/communication/communication-chat/recordings/browsers/chatthreadclient/recording_successfully_sends_typing_notification.json
+++ b/sdk/communication/communication-chat/recordings/browsers/chatthreadclient/recording_successfully_sends_typing_notification.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://endpoint/chat/threads/19%3ASWkac8Ohhun6cBYZUJu7GWyUwrnSppuvzamOFUDuz641%40thread.v2/typing?api-version=2021-09-07",
+      "RequestUri": "https://endpoint/chat/threads/19%3AsGfC1p7_xma4fP7m2-tcS2pt9gpte6sdXThKfUNLYFQ1%40thread.v2/typing?api-version=2021-09-07",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -19,23 +19,25 @@
         "Sec-Fetch-Dest": "empty",
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
-        "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/100.0.4889.0 Safari/537.36",
-        "x-ms-client-request-id": "9282c129-e092-4367-8eca-59501a45d02c",
-        "x-ms-useragent": "azsdk-js-azure-communication-chat/1.2.0 core-rest-pipeline/1.8.0 OS/MacIntel"
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/101.0.4950.0 Safari/537.36",
+        "x-ms-client-request-id": "d21c5816-847c-45ff-a17a-6fc4416d4aa5",
+        "x-ms-useragent": "azsdk-js-communication-chat/1.2.0 core-rest-pipeline/1.8.1 OS/Win32"
       },
       "RequestBody": {},
       "StatusCode": 200,
       "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "Location",
         "api-supported-versions": "2021-04-05-preview6, 2021-09-07, 2021-10-01-preview7",
+        "Connection": "keep-alive",
         "Content-Length": "0",
-        "Date": "Wed, 30 Mar 2022 21:36:45 GMT",
-        "MS-CV": "e7UcScdL\u002BEm8usXsxlp2vQ.0",
+        "Date": "Mon, 02 May 2022 22:48:58 GMT",
+        "MS-CV": "Z8fM1rcSHUmzhFBgNDg4sQ.0",
         "Strict-Transport-Security": "max-age=2592000",
-        "X-Azure-Ref": "0bc1EYgAAAADNJo2iFM1kQZ6H9fl6qiEnUERYMzFFREdFMDIxMgBjYzkyNzU4ZC0wNWY3LTRhZDYtYWE1ZS0wZmE5NzE4ZDg5ODU=",
+        "x-azure-ref": "20220502T224858Z-1kdy40ce594zxd7ayzepxvrcq0000000052000000002q92z",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "404ms"
+        "X-Processing-Time": "150ms"
       },
       "ResponseBody": null
     }

--- a/sdk/communication/communication-chat/recordings/browsers/chatthreadclient/recording_successfully_updates_the_thread_topic.json
+++ b/sdk/communication/communication-chat/recordings/browsers/chatthreadclient/recording_successfully_updates_the_thread_topic.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://endpoint/chat/threads/19%3ASWkac8Ohhun6cBYZUJu7GWyUwrnSppuvzamOFUDuz641%40thread.v2?api-version=2021-09-07",
+      "RequestUri": "https://endpoint/chat/threads/19%3AsGfC1p7_xma4fP7m2-tcS2pt9gpte6sdXThKfUNLYFQ1%40thread.v2?api-version=2021-09-07",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -19,9 +19,9 @@
         "Sec-Fetch-Dest": "empty",
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
-        "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/100.0.4889.0 Safari/537.36",
-        "x-ms-client-request-id": "08dc1a69-000d-4491-809d-d69b699cedeb",
-        "x-ms-useragent": "azsdk-js-azure-communication-chat/1.2.0 core-rest-pipeline/1.8.0 OS/MacIntel"
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/101.0.4950.0 Safari/537.36",
+        "x-ms-client-request-id": "a470f430-2788-4afe-ba1c-cacad0b24f32",
+        "x-ms-useragent": "azsdk-js-communication-chat/1.2.0 core-rest-pipeline/1.8.1 OS/Win32"
       },
       "RequestBody": {
         "topic": "new topic"
@@ -31,17 +31,18 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "Location",
         "api-supported-versions": "2021-03-07, 2021-04-05-preview6, 2021-09-07, 2021-10-01-preview7",
-        "Date": "Wed, 30 Mar 2022 21:36:44 GMT",
-        "MS-CV": "3nP5OEVGo0GKFM5BPWIr6A.0",
+        "Connection": "keep-alive",
+        "Date": "Mon, 02 May 2022 22:48:57 GMT",
+        "MS-CV": "/Dpih\u002BH60kylQZzOBqTteQ.0",
         "Strict-Transport-Security": "max-age=2592000",
-        "X-Azure-Ref": "0bM1EYgAAAAB78S6LqEeZQb/VWWfBxHdjUERYMzFFREdFMDIxMgBjYzkyNzU4ZC0wNWY3LTRhZDYtYWE1ZS0wZmE5NzE4ZDg5ODU=",
+        "x-azure-ref": "20220502T224857Z-1kdy40ce594zxd7ayzepxvrcq0000000052000000002q8vt",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "392ms"
+        "X-Processing-Time": "241ms"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://endpoint/chat/threads/19%3ASWkac8Ohhun6cBYZUJu7GWyUwrnSppuvzamOFUDuz641%40thread.v2?api-version=2021-09-07",
+      "RequestUri": "https://endpoint/chat/threads/19%3AsGfC1p7_xma4fP7m2-tcS2pt9gpte6sdXThKfUNLYFQ1%40thread.v2?api-version=2021-09-07",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -57,9 +58,9 @@
         "Sec-Fetch-Dest": "empty",
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
-        "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/100.0.4889.0 Safari/537.36",
-        "x-ms-client-request-id": "9ea44e14-c4d5-42ae-b379-02a9c1919825",
-        "x-ms-useragent": "azsdk-js-azure-communication-chat/1.2.0 core-rest-pipeline/1.8.0 OS/MacIntel"
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/101.0.4950.0 Safari/537.36",
+        "x-ms-client-request-id": "54a66257-56b6-4d57-bea8-fe70fb9fd9a7",
+        "x-ms-useragent": "azsdk-js-communication-chat/1.2.0 core-rest-pipeline/1.8.1 OS/Win32"
       },
       "RequestBody": null,
       "StatusCode": 200,
@@ -67,23 +68,24 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "Location",
         "api-supported-versions": "2021-03-07, 2021-04-05-preview6, 2021-09-07, 2021-10-01-preview7",
+        "Connection": "keep-alive",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 30 Mar 2022 21:36:44 GMT",
-        "MS-CV": "8D7nrx/4G0OqvnFGi0Wgow.0",
+        "Date": "Mon, 02 May 2022 22:48:57 GMT",
+        "MS-CV": "im8MWlajbkCvQGEOXWeooA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0bM1EYgAAAADB1tiTERBXRIoCgq\u002B4tFiEUERYMzFFREdFMDIxMgBjYzkyNzU4ZC0wNWY3LTRhZDYtYWE1ZS0wZmE5NzE4ZDg5ODU=",
+        "x-azure-ref": "20220502T224857Z-1kdy40ce594zxd7ayzepxvrcq0000000052000000002q8y8",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "259ms"
+        "X-Processing-Time": "86ms"
       },
       "ResponseBody": {
-        "id": "19:SWkac8Ohhun6cBYZUJu7GWyUwrnSppuvzamOFUDuz641@thread.v2",
+        "id": "19:sGfC1p7_xma4fP7m2-tcS2pt9gpte6sdXThKfUNLYFQ1@thread.v2",
         "topic": "new topic",
-        "createdOn": "2022-03-30T21:36:43Z",
+        "createdOn": "2022-05-02T22:48:51Z",
         "createdByCommunicationIdentifier": {
-          "rawId": "8:acs:188d4cea-0a9b-4840-8fdc-7a5c71fe9bd0_00000010-7ca4-0bb6-5896-094822001382",
+          "rawId": "8:acs:b6aada1f-0b1d-47ac-866f-91aae00a1d01_00000011-26d7-f203-570c-113a0d00b7dc",
           "communicationUser": {
-            "id": "8:acs:188d4cea-0a9b-4840-8fdc-7a5c71fe9bd0_00000010-7ca4-0bb6-5896-094822001382"
+            "id": "8:acs:b6aada1f-0b1d-47ac-866f-91aae00a1d01_00000011-26d7-f203-570c-113a0d00b7dc"
           }
         }
       }

--- a/sdk/communication/communication-chat/recordings/node/chatclient_chat_operations/recording_successfully_creates_a_thread.json
+++ b/sdk/communication/communication-chat/recordings/node/chatclient_chat_operations/recording_successfully_creates_a_thread.json
@@ -10,10 +10,10 @@
         "Connection": "keep-alive",
         "Content-Length": "34",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-js-communication-identity/1.1.0-beta.2 core-rest-pipeline/1.8.0 Node/v16.14.2 OS/(arm64-Darwin-21.4.0)",
-        "x-ms-client-request-id": "5be99a15-e5d4-480b-a500-b89ecd6ee325",
+        "User-Agent": "azsdk-js-communication-identity/1.1.0-beta.2 core-rest-pipeline/1.8.1 Node/v14.15.4 OS/(x64-Windows_NT-10.0.22000)",
+        "x-ms-client-request-id": "686a0111-e2e8-457b-b161-9464e767aef9",
         "x-ms-content-sha256": "WTRvgEjjVd\u002BbvyKw3WgXgDkU81aV8FWq\u002B4/BE\u002Bhe0\u002BA=",
-        "x-ms-date": "Wed, 30 Mar 2022 21:36:27 GMT"
+        "x-ms-date": "Mon, 02 May 2022 22:48:31 GMT"
       },
       "RequestBody": {
         "createTokenWithScopes": [
@@ -23,24 +23,25 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "api-supported-versions": "2020-07-20-preview2, 2021-02-22-preview1, 2021-03-07, 2021-10-31-preview, 2021-11-01, 2022-06-01",
+        "Connection": "keep-alive",
         "Content-Length": "290",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 30 Mar 2022 21:36:27 GMT",
-        "MS-CV": "RH5bUZ0Lk0GU2SKOUsUQ3A.0",
+        "Date": "Mon, 02 May 2022 22:48:36 GMT",
+        "MS-CV": "IYkvZmmGQEyXP2Z0hu6ZfQ.0",
         "Request-Context": "appId=",
         "Strict-Transport-Security": "max-age=2592000",
-        "X-Azure-Ref": "0W81EYgAAAACpcB1MJEqhQ5yjxlenKD9QUERYMzFFREdFMDIxMgBjYzkyNzU4ZC0wNWY3LTRhZDYtYWE1ZS0wZmE5NzE4ZDg5ODU=",
+        "x-azure-ref": "20220502T224836Z-1kdy40ce594zxd7ayzepxvrcq0000000052000000002q51d",
         "X-Cache": "CONFIG_NOCACHE",
-        "x-ms-client-request-id": "5be99a15-e5d4-480b-a500-b89ecd6ee325",
-        "X-Processing-Time": "188ms"
+        "x-ms-client-request-id": "686a0111-e2e8-457b-b161-9464e767aef9",
+        "X-Processing-Time": "228ms"
       },
       "ResponseBody": {
         "identity": {
-          "id": "8:acs:188d4cea-0a9b-4840-8fdc-7a5c71fe9bd0_00000010-7ca3-d2ba-5896-094822001377"
+          "id": "8:acs:b6aada1f-0b1d-47ac-866f-91aae00a1d01_00000011-26d7-a759-570c-113a0d00b7d4"
         },
         "accessToken": {
-          "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE2NDg2Nzk3ODcuNTc5fQ==.adM-ddBZZlQ1WlN3pdPBOF5G4Wh9iZpxNP_fSvpF4cWs",
-          "expiresOn": "2022-03-31T21:36:27.9999744\u002B00:00"
+          "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE2NTE1MzUzMTAuOTk4fQ==.adM-ddBZZlQ1WlN3pdPBOF5G4Wh9iZpxNP_fSvpF4cWs",
+          "expiresOn": "2022-05-03T22:48:31.5313219\u002B00:00"
         }
       }
     },
@@ -54,10 +55,10 @@
         "Connection": "keep-alive",
         "Content-Length": "34",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-js-communication-identity/1.1.0-beta.2 core-rest-pipeline/1.8.0 Node/v16.14.2 OS/(arm64-Darwin-21.4.0)",
-        "x-ms-client-request-id": "f0063abd-77dc-4f08-9e10-93b1adf9dcce",
+        "User-Agent": "azsdk-js-communication-identity/1.1.0-beta.2 core-rest-pipeline/1.8.1 Node/v14.15.4 OS/(x64-Windows_NT-10.0.22000)",
+        "x-ms-client-request-id": "c09c1242-95ac-4837-bfef-2f7e809fa356",
         "x-ms-content-sha256": "WTRvgEjjVd\u002BbvyKw3WgXgDkU81aV8FWq\u002B4/BE\u002Bhe0\u002BA=",
-        "x-ms-date": "Wed, 30 Mar 2022 21:36:27 GMT"
+        "x-ms-date": "Mon, 02 May 2022 22:48:31 GMT"
       },
       "RequestBody": {
         "createTokenWithScopes": [
@@ -67,24 +68,25 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "api-supported-versions": "2020-07-20-preview2, 2021-02-22-preview1, 2021-03-07, 2021-10-31-preview, 2021-11-01, 2022-06-01",
+        "Connection": "keep-alive",
         "Content-Length": "290",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 30 Mar 2022 21:36:27 GMT",
-        "MS-CV": "pnLusVFjkkypAxv8pv6y0g.0",
+        "Date": "Mon, 02 May 2022 22:48:37 GMT",
+        "MS-CV": "KJphM/Mafk6Tjy07L0kSJw.0",
         "Request-Context": "appId=",
         "Strict-Transport-Security": "max-age=2592000",
-        "X-Azure-Ref": "0XM1EYgAAAAD59GjwjqYSS5whh7vLv1J4UERYMzFFREdFMDIxMgBjYzkyNzU4ZC0wNWY3LTRhZDYtYWE1ZS0wZmE5NzE4ZDg5ODU=",
+        "x-azure-ref": "20220502T224836Z-1kdy40ce594zxd7ayzepxvrcq0000000052000000002q53v",
         "X-Cache": "CONFIG_NOCACHE",
-        "x-ms-client-request-id": "f0063abd-77dc-4f08-9e10-93b1adf9dcce",
-        "X-Processing-Time": "180ms"
+        "x-ms-client-request-id": "c09c1242-95ac-4837-bfef-2f7e809fa356",
+        "X-Processing-Time": "290ms"
       },
       "ResponseBody": {
         "identity": {
-          "id": "8:acs:188d4cea-0a9b-4840-8fdc-7a5c71fe9bd0_00000010-7ca3-d396-5896-094822001378"
+          "id": "8:acs:b6aada1f-0b1d-47ac-866f-91aae00a1d01_00000011-26d7-a8c3-570c-113a0d00b7d5"
         },
         "accessToken": {
-          "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE2NDg2Nzk3ODcuNTc5fQ==.adM-ddBZZlQ1WlN3pdPBOF5G4Wh9iZpxNP_fSvpF4cWs",
-          "expiresOn": "2022-03-31T21:36:28.2163043\u002B00:00"
+          "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE2NTE1MzUzMTAuOTk4fQ==.adM-ddBZZlQ1WlN3pdPBOF5G4Wh9iZpxNP_fSvpF4cWs",
+          "expiresOn": "2022-05-03T22:48:31.9546901\u002B00:00"
         }
       }
     },
@@ -96,26 +98,28 @@
         "Accept-Encoding": "gzip,deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "Content-Length": "317",
+        "Content-Length": "497",
         "Content-Type": "application/json",
-        "repeatability-request-id": "bc80fd11-a1c2-487e-b884-d49873146f37",
-        "User-Agent": "azsdk-js-azure-communication-chat/1.2.0 core-rest-pipeline/1.8.0 Node/v16.14.2 OS/(arm64-Darwin-21.4.0)",
-        "x-ms-client-request-id": "423d4629-9a5b-48ce-ba23-aaea2d8e9186"
+        "repeatability-request-id": "26bb965b-56d2-46b7-a4e7-4bcb77defc22",
+        "User-Agent": "azsdk-js-communication-chat/1.2.0 core-rest-pipeline/1.8.1 Node/v14.15.4 OS/(x64-Windows_NT-10.0.22000)",
+        "x-ms-client-request-id": "c2bc92fa-5f62-49c9-b24f-ec6b1c7c373a"
       },
       "RequestBody": {
         "topic": "test topic",
         "participants": [
           {
             "communicationIdentifier": {
+              "rawId": "8:acs:b6aada1f-0b1d-47ac-866f-91aae00a1d01_00000011-26d7-a759-570c-113a0d00b7d4",
               "communicationUser": {
-                "id": "8:acs:188d4cea-0a9b-4840-8fdc-7a5c71fe9bd0_00000010-7ca3-d2ba-5896-094822001377"
+                "id": "8:acs:b6aada1f-0b1d-47ac-866f-91aae00a1d01_00000011-26d7-a759-570c-113a0d00b7d4"
               }
             }
           },
           {
             "communicationIdentifier": {
+              "rawId": "8:acs:b6aada1f-0b1d-47ac-866f-91aae00a1d01_00000011-26d7-a8c3-570c-113a0d00b7d5",
               "communicationUser": {
-                "id": "8:acs:188d4cea-0a9b-4840-8fdc-7a5c71fe9bd0_00000010-7ca3-d396-5896-094822001378"
+                "id": "8:acs:b6aada1f-0b1d-47ac-866f-91aae00a1d01_00000011-26d7-a8c3-570c-113a0d00b7d5"
               }
             }
           }
@@ -124,25 +128,26 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "api-supported-versions": "2021-03-07, 2021-04-05-preview6, 2021-09-07, 2021-10-01-preview7",
+        "Connection": "keep-alive",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 30 Mar 2022 21:36:28 GMT",
-        "Location": "https://endpoint/chat/threads/19%3AwyqCsCWuK9lOvLsUbbCW5GyAVCwXcxce6BFiK9l3ngI1@thread.v2",
-        "MS-CV": "rvQAL\u002BmqfkaVXuc6aB10/A.0",
+        "Date": "Mon, 02 May 2022 22:48:37 GMT",
+        "Location": "https://endpoint/chat/threads/19%3ATmcW77e0F-oWu8vIY5UNtSQoC47GOiQ1wqG3i5s5wkE1@thread.v2",
+        "MS-CV": "G7clVw3o90OFkHGSGgRvlg.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0XM1EYgAAAADciHpbYOdFS5sQjVrip4xtUERYMzFFREdFMDIxMgBjYzkyNzU4ZC0wNWY3LTRhZDYtYWE1ZS0wZmE5NzE4ZDg5ODU=",
+        "x-azure-ref": "20220502T224837Z-1kdy40ce594zxd7ayzepxvrcq0000000052000000002q565",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "829ms"
+        "X-Processing-Time": "491ms"
       },
       "ResponseBody": {
         "chatThread": {
-          "id": "19:wyqCsCWuK9lOvLsUbbCW5GyAVCwXcxce6BFiK9l3ngI1@thread.v2",
+          "id": "19:TmcW77e0F-oWu8vIY5UNtSQoC47GOiQ1wqG3i5s5wkE1@thread.v2",
           "topic": "test topic",
-          "createdOn": "2022-03-30T21:36:28Z",
+          "createdOn": "2022-05-02T22:48:32Z",
           "createdByCommunicationIdentifier": {
-            "rawId": "8:acs:188d4cea-0a9b-4840-8fdc-7a5c71fe9bd0_00000010-7ca3-d2ba-5896-094822001377",
+            "rawId": "8:acs:b6aada1f-0b1d-47ac-866f-91aae00a1d01_00000011-26d7-a759-570c-113a0d00b7d4",
             "communicationUser": {
-              "id": "8:acs:188d4cea-0a9b-4840-8fdc-7a5c71fe9bd0_00000010-7ca3-d2ba-5896-094822001377"
+              "id": "8:acs:b6aada1f-0b1d-47ac-866f-91aae00a1d01_00000011-26d7-a759-570c-113a0d00b7d4"
             }
           }
         }

--- a/sdk/communication/communication-chat/recordings/node/chatclient_chat_operations/recording_successfully_deletes_a_thread.json
+++ b/sdk/communication/communication-chat/recordings/node/chatclient_chat_operations/recording_successfully_deletes_a_thread.json
@@ -1,26 +1,27 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://endpoint/chat/threads/19%3AwyqCsCWuK9lOvLsUbbCW5GyAVCwXcxce6BFiK9l3ngI1%40thread.v2?api-version=2021-09-07",
+      "RequestUri": "https://endpoint/chat/threads/19%3ATmcW77e0F-oWu8vIY5UNtSQoC47GOiQ1wqG3i5s5wkE1%40thread.v2?api-version=2021-09-07",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-azure-communication-chat/1.2.0 core-rest-pipeline/1.8.0 Node/v16.14.2 OS/(arm64-Darwin-21.4.0)",
-        "x-ms-client-request-id": "413d8112-b33c-417f-8250-18b5e9fb2df2"
+        "User-Agent": "azsdk-js-communication-chat/1.2.0 core-rest-pipeline/1.8.1 Node/v14.15.4 OS/(x64-Windows_NT-10.0.22000)",
+        "x-ms-client-request-id": "402dd4f9-c556-4d9e-b02f-942a321dd76f"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
         "api-supported-versions": "2021-03-07, 2021-04-05-preview6, 2021-09-07, 2021-10-01-preview7",
-        "Date": "Wed, 30 Mar 2022 21:36:29 GMT",
-        "MS-CV": "ij0gpCQqFkes\u002BfdWI\u002BXedQ.0",
+        "Connection": "keep-alive",
+        "Date": "Mon, 02 May 2022 22:48:38 GMT",
+        "MS-CV": "POvN3adMC0a3neTKax15RQ.0",
         "Strict-Transport-Security": "max-age=2592000",
-        "X-Azure-Ref": "0Xc1EYgAAAAAmtZKJtvNhR6ANoSbzMECbUERYMzFFREdFMDIxMgBjYzkyNzU4ZC0wNWY3LTRhZDYtYWE1ZS0wZmE5NzE4ZDg5ODU=",
+        "x-azure-ref": "20220502T224837Z-1kdy40ce594zxd7ayzepxvrcq0000000052000000002q5am",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "287ms"
+        "X-Processing-Time": "193ms"
       },
       "ResponseBody": null
     }

--- a/sdk/communication/communication-chat/recordings/node/chatthreadclient/recording_successfully_adds_participants.json
+++ b/sdk/communication/communication-chat/recordings/node/chatthreadclient/recording_successfully_adds_participants.json
@@ -10,10 +10,10 @@
         "Connection": "keep-alive",
         "Content-Length": "34",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-js-communication-identity/1.1.0-beta.2 core-rest-pipeline/1.8.0 Node/v16.14.2 OS/(arm64-Darwin-21.4.0)",
-        "x-ms-client-request-id": "1f9033ea-3d71-4119-80dd-aa72051fb03a",
+        "User-Agent": "azsdk-js-communication-identity/1.1.0-beta.2 core-rest-pipeline/1.8.1 Node/v14.15.4 OS/(x64-Windows_NT-10.0.22000)",
+        "x-ms-client-request-id": "30961954-f4ad-4107-bc5c-90a8828ba645",
         "x-ms-content-sha256": "WTRvgEjjVd\u002BbvyKw3WgXgDkU81aV8FWq\u002B4/BE\u002Bhe0\u002BA=",
-        "x-ms-date": "Wed, 30 Mar 2022 21:36:35 GMT"
+        "x-ms-date": "Mon, 02 May 2022 22:48:37 GMT"
       },
       "RequestBody": {
         "createTokenWithScopes": [
@@ -23,46 +23,48 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "api-supported-versions": "2020-07-20-preview2, 2021-02-22-preview1, 2021-03-07, 2021-10-31-preview, 2021-11-01, 2022-06-01",
+        "Connection": "keep-alive",
         "Content-Length": "290",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 30 Mar 2022 21:36:35 GMT",
-        "MS-CV": "GjT\u002BFPdJkk6AEEkb7sFNgA.0",
+        "Date": "Mon, 02 May 2022 22:48:42 GMT",
+        "MS-CV": "5ozGQVzp5kOQfOkv5Zne\u002BQ.0",
         "Request-Context": "appId=",
         "Strict-Transport-Security": "max-age=2592000",
-        "X-Azure-Ref": "0ZM1EYgAAAACRKcmpN6yeRpcHG1W5thwYUERYMzFFREdFMDIxMgBjYzkyNzU4ZC0wNWY3LTRhZDYtYWE1ZS0wZmE5NzE4ZDg5ODU=",
+        "x-azure-ref": "20220502T224842Z-1kdy40ce594zxd7ayzepxvrcq0000000052000000002q614",
         "X-Cache": "CONFIG_NOCACHE",
-        "x-ms-client-request-id": "1f9033ea-3d71-4119-80dd-aa72051fb03a",
-        "X-Processing-Time": "182ms"
+        "x-ms-client-request-id": "30961954-f4ad-4107-bc5c-90a8828ba645",
+        "X-Processing-Time": "229ms"
       },
       "ResponseBody": {
         "identity": {
-          "id": "8:acs:188d4cea-0a9b-4840-8fdc-7a5c71fe9bd0_00000010-7ca3-f2c8-5896-09482200137d"
+          "id": "8:acs:b6aada1f-0b1d-47ac-866f-91aae00a1d01_00000011-26d7-bf83-570c-113a0d00b7d8"
         },
         "accessToken": {
-          "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE2NDg2Nzk3ODcuNTc5fQ==.adM-ddBZZlQ1WlN3pdPBOF5G4Wh9iZpxNP_fSvpF4cWs",
-          "expiresOn": "2022-03-31T21:36:36.2014804\u002B00:00"
+          "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE2NTE1MzUzMTAuOTk4fQ==.adM-ddBZZlQ1WlN3pdPBOF5G4Wh9iZpxNP_fSvpF4cWs",
+          "expiresOn": "2022-05-03T22:48:37.7183177\u002B00:00"
         }
       }
     },
     {
-      "RequestUri": "https://endpoint/chat/threads/19%3ACVY6cS046Q76bICKk00-dR7_y5RHQo3_3ONhDTEIrk41%40thread.v2/participants/:add?api-version=2021-09-07",
+      "RequestUri": "https://endpoint/chat/threads/19%3A1LP8h-5WKvPuwtMH3edl4AihPeEZu3VWYitvgn-9uDw1%40thread.v2/participants/:add?api-version=2021-09-07",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "Content-Length": "157",
+        "Content-Length": "247",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-js-azure-communication-chat/1.2.0 core-rest-pipeline/1.8.0 Node/v16.14.2 OS/(arm64-Darwin-21.4.0)",
-        "x-ms-client-request-id": "d6277aa5-560b-435f-a575-9bd9deed2cf1"
+        "User-Agent": "azsdk-js-communication-chat/1.2.0 core-rest-pipeline/1.8.1 Node/v14.15.4 OS/(x64-Windows_NT-10.0.22000)",
+        "x-ms-client-request-id": "fdee61f9-de7d-4675-9510-94e473d5314b"
       },
       "RequestBody": {
         "participants": [
           {
             "communicationIdentifier": {
+              "rawId": "8:acs:b6aada1f-0b1d-47ac-866f-91aae00a1d01_00000011-26d7-bf83-570c-113a0d00b7d8",
               "communicationUser": {
-                "id": "8:acs:188d4cea-0a9b-4840-8fdc-7a5c71fe9bd0_00000010-7ca3-f2c8-5896-09482200137d"
+                "id": "8:acs:b6aada1f-0b1d-47ac-866f-91aae00a1d01_00000011-26d7-bf83-570c-113a0d00b7d8"
               }
             }
           }
@@ -71,14 +73,15 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "api-supported-versions": "2021-03-07, 2021-04-05-preview6, 2021-09-07, 2021-10-01-preview7",
+        "Connection": "keep-alive",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 30 Mar 2022 21:36:36 GMT",
-        "MS-CV": "V8nUHg9wP06fI3cg\u002BLLKLg.0",
+        "Date": "Mon, 02 May 2022 22:48:43 GMT",
+        "MS-CV": "csYgaJIznUOYXmpcivW\u002B\u002BQ.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0ZM1EYgAAAABzfVWb7HIPQrQQFwiGU\u002BHyUERYMzFFREdFMDIxMgBjYzkyNzU4ZC0wNWY3LTRhZDYtYWE1ZS0wZmE5NzE4ZDg5ODU=",
+        "x-azure-ref": "20220502T224842Z-1kdy40ce594zxd7ayzepxvrcq0000000052000000002q62s",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "419ms"
+        "X-Processing-Time": "220ms"
       },
       "ResponseBody": {}
     }

--- a/sdk/communication/communication-chat/recordings/node/chatthreadclient/recording_successfully_deletes_a_message.json
+++ b/sdk/communication/communication-chat/recordings/node/chatthreadclient/recording_successfully_deletes_a_message.json
@@ -1,26 +1,27 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://endpoint/chat/threads/19%3ACVY6cS046Q76bICKk00-dR7_y5RHQo3_3ONhDTEIrk41%40thread.v2/messages/1648676192118?api-version=2021-09-07",
+      "RequestUri": "https://endpoint/chat/threads/19%3A1LP8h-5WKvPuwtMH3edl4AihPeEZu3VWYitvgn-9uDw1%40thread.v2/messages/1651531715497?api-version=2021-09-07",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-azure-communication-chat/1.2.0 core-rest-pipeline/1.8.0 Node/v16.14.2 OS/(arm64-Darwin-21.4.0)",
-        "x-ms-client-request-id": "999b1d21-dbc2-4e73-9771-a09076e12d87"
+        "User-Agent": "azsdk-js-communication-chat/1.2.0 core-rest-pipeline/1.8.1 Node/v14.15.4 OS/(x64-Windows_NT-10.0.22000)",
+        "x-ms-client-request-id": "5e1638b8-57d6-48ee-b4d1-4432f7dfa28d"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
         "api-supported-versions": "2021-03-07, 2021-04-05-preview6, 2021-09-07, 2021-10-01-preview7",
-        "Date": "Wed, 30 Mar 2022 21:36:35 GMT",
-        "MS-CV": "lueU6h6S\u002Bke7QB\u002BrNekMGg.0",
+        "Connection": "keep-alive",
+        "Date": "Mon, 02 May 2022 22:48:42 GMT",
+        "MS-CV": "l3XFjCqvj0iqrWb1H2E4PA.0",
         "Strict-Transport-Security": "max-age=2592000",
-        "X-Azure-Ref": "0Y81EYgAAAABBBdNeQO6jQ6TZ3LfWtRhVUERYMzFFREdFMDIxMgBjYzkyNzU4ZC0wNWY3LTRhZDYtYWE1ZS0wZmE5NzE4ZDg5ODU=",
+        "x-azure-ref": "20220502T224842Z-1kdy40ce594zxd7ayzepxvrcq0000000052000000002q5zg",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "399ms"
+        "X-Processing-Time": "134ms"
       },
       "ResponseBody": null
     }

--- a/sdk/communication/communication-chat/recordings/node/chatthreadclient/recording_successfully_gets_the_thread_properties.json
+++ b/sdk/communication/communication-chat/recordings/node/chatthreadclient/recording_successfully_gets_the_thread_properties.json
@@ -1,37 +1,38 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://endpoint/chat/threads/19%3ACVY6cS046Q76bICKk00-dR7_y5RHQo3_3ONhDTEIrk41%40thread.v2?api-version=2021-09-07",
+      "RequestUri": "https://endpoint/chat/threads/19%3A1LP8h-5WKvPuwtMH3edl4AihPeEZu3VWYitvgn-9uDw1%40thread.v2?api-version=2021-09-07",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-azure-communication-chat/1.2.0 core-rest-pipeline/1.8.0 Node/v16.14.2 OS/(arm64-Darwin-21.4.0)",
-        "x-ms-client-request-id": "b2d92d76-e885-48fd-a49c-44a78110e007"
+        "User-Agent": "azsdk-js-communication-chat/1.2.0 core-rest-pipeline/1.8.1 Node/v14.15.4 OS/(x64-Windows_NT-10.0.22000)",
+        "x-ms-client-request-id": "4caef604-203a-4262-bab5-1d454bd81f5e"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "api-supported-versions": "2021-03-07, 2021-04-05-preview6, 2021-09-07, 2021-10-01-preview7",
+        "Connection": "keep-alive",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 30 Mar 2022 21:36:30 GMT",
-        "MS-CV": "Ex0N2f7NmUixdzk9GMVPAw.0",
+        "Date": "Mon, 02 May 2022 22:48:39 GMT",
+        "MS-CV": "Zd6Xx/GniE2e6f5zB1IdTA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0Xs1EYgAAAACZbVLnphkNS5d8kG5IqtoCUERYMzFFREdFMDIxMgBjYzkyNzU4ZC0wNWY3LTRhZDYtYWE1ZS0wZmE5NzE4ZDg5ODU=",
+        "x-azure-ref": "20220502T224839Z-1kdy40ce594zxd7ayzepxvrcq0000000052000000002q5nr",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "253ms"
+        "X-Processing-Time": "80ms"
       },
       "ResponseBody": {
-        "id": "19:CVY6cS046Q76bICKk00-dR7_y5RHQo3_3ONhDTEIrk41@thread.v2",
+        "id": "19:1LP8h-5WKvPuwtMH3edl4AihPeEZu3VWYitvgn-9uDw1@thread.v2",
         "topic": "test topic",
-        "createdOn": "2022-03-30T21:36:30Z",
+        "createdOn": "2022-05-02T22:48:34Z",
         "createdByCommunicationIdentifier": {
-          "rawId": "8:acs:188d4cea-0a9b-4840-8fdc-7a5c71fe9bd0_00000010-7ca3-d956-5896-094822001379",
+          "rawId": "8:acs:b6aada1f-0b1d-47ac-866f-91aae00a1d01_00000011-26d7-aecb-570c-113a0d00b7d6",
           "communicationUser": {
-            "id": "8:acs:188d4cea-0a9b-4840-8fdc-7a5c71fe9bd0_00000010-7ca3-d956-5896-094822001379"
+            "id": "8:acs:b6aada1f-0b1d-47ac-866f-91aae00a1d01_00000011-26d7-aecb-570c-113a0d00b7d6"
           }
         }
       }

--- a/sdk/communication/communication-chat/recordings/node/chatthreadclient/recording_successfully_initializes_chatthreadclient.json
+++ b/sdk/communication/communication-chat/recordings/node/chatthreadclient/recording_successfully_initializes_chatthreadclient.json
@@ -10,10 +10,10 @@
         "Connection": "keep-alive",
         "Content-Length": "34",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-js-communication-identity/1.1.0-beta.2 core-rest-pipeline/1.8.0 Node/v16.14.2 OS/(arm64-Darwin-21.4.0)",
-        "x-ms-client-request-id": "9c3f8827-0b93-404f-9b08-283f0b48aaf8",
+        "User-Agent": "azsdk-js-communication-identity/1.1.0-beta.2 core-rest-pipeline/1.8.1 Node/v14.15.4 OS/(x64-Windows_NT-10.0.22000)",
+        "x-ms-client-request-id": "42287ed2-84be-47c1-836b-6b77da5f5deb",
         "x-ms-content-sha256": "WTRvgEjjVd\u002BbvyKw3WgXgDkU81aV8FWq\u002B4/BE\u002Bhe0\u002BA=",
-        "x-ms-date": "Wed, 30 Mar 2022 21:36:29 GMT"
+        "x-ms-date": "Mon, 02 May 2022 22:48:33 GMT"
       },
       "RequestBody": {
         "createTokenWithScopes": [
@@ -23,24 +23,25 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "api-supported-versions": "2020-07-20-preview2, 2021-02-22-preview1, 2021-03-07, 2021-10-31-preview, 2021-11-01, 2022-06-01",
-        "Content-Length": "289",
+        "Connection": "keep-alive",
+        "Content-Length": "290",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 30 Mar 2022 21:36:29 GMT",
-        "MS-CV": "zQl\u002BD7zijEyjt6yavZR9GA.0",
+        "Date": "Mon, 02 May 2022 22:48:38 GMT",
+        "MS-CV": "K0voIHrAHk2DapxYU9DjzQ.0",
         "Request-Context": "appId=",
         "Strict-Transport-Security": "max-age=2592000",
-        "X-Azure-Ref": "0Xc1EYgAAAAB\u002BxZvbJrHlT7svNiTQGLZOUERYMzFFREdFMDIxMgBjYzkyNzU4ZC0wNWY3LTRhZDYtYWE1ZS0wZmE5NzE4ZDg5ODU=",
+        "x-azure-ref": "20220502T224838Z-1kdy40ce594zxd7ayzepxvrcq0000000052000000002q5d1",
         "X-Cache": "CONFIG_NOCACHE",
-        "x-ms-client-request-id": "9c3f8827-0b93-404f-9b08-283f0b48aaf8",
-        "X-Processing-Time": "182ms"
+        "x-ms-client-request-id": "42287ed2-84be-47c1-836b-6b77da5f5deb",
+        "X-Processing-Time": "283ms"
       },
       "ResponseBody": {
         "identity": {
-          "id": "8:acs:188d4cea-0a9b-4840-8fdc-7a5c71fe9bd0_00000010-7ca3-d956-5896-094822001379"
+          "id": "8:acs:b6aada1f-0b1d-47ac-866f-91aae00a1d01_00000011-26d7-aecb-570c-113a0d00b7d6"
         },
         "accessToken": {
-          "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE2NDg2Nzk3ODcuNTc5fQ==.adM-ddBZZlQ1WlN3pdPBOF5G4Wh9iZpxNP_fSvpF4cWs",
-          "expiresOn": "2022-03-31T21:36:29.688949\u002B00:00"
+          "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE2NTE1MzUzMTAuOTk4fQ==.adM-ddBZZlQ1WlN3pdPBOF5G4Wh9iZpxNP_fSvpF4cWs",
+          "expiresOn": "2022-05-03T22:48:33.4946113\u002B00:00"
         }
       }
     },
@@ -54,10 +55,10 @@
         "Connection": "keep-alive",
         "Content-Length": "34",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-js-communication-identity/1.1.0-beta.2 core-rest-pipeline/1.8.0 Node/v16.14.2 OS/(arm64-Darwin-21.4.0)",
-        "x-ms-client-request-id": "93f53c28-f5c9-4d49-ba88-0926b259bfdf",
+        "User-Agent": "azsdk-js-communication-identity/1.1.0-beta.2 core-rest-pipeline/1.8.1 Node/v14.15.4 OS/(x64-Windows_NT-10.0.22000)",
+        "x-ms-client-request-id": "90cfc176-b1e8-4560-a940-2d02102ebe7a",
         "x-ms-content-sha256": "WTRvgEjjVd\u002BbvyKw3WgXgDkU81aV8FWq\u002B4/BE\u002Bhe0\u002BA=",
-        "x-ms-date": "Wed, 30 Mar 2022 21:36:29 GMT"
+        "x-ms-date": "Mon, 02 May 2022 22:48:33 GMT"
       },
       "RequestBody": {
         "createTokenWithScopes": [
@@ -67,24 +68,25 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "api-supported-versions": "2020-07-20-preview2, 2021-02-22-preview1, 2021-03-07, 2021-10-31-preview, 2021-11-01, 2022-06-01",
+        "Connection": "keep-alive",
         "Content-Length": "290",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 30 Mar 2022 21:36:29 GMT",
-        "MS-CV": "h88oUOvUtUuj743FE42URA.0",
+        "Date": "Mon, 02 May 2022 22:48:38 GMT",
+        "MS-CV": "/XBxPrH5lEmdh6GItxEBJA.0",
         "Request-Context": "appId=",
         "Strict-Transport-Security": "max-age=2592000",
-        "X-Azure-Ref": "0Xc1EYgAAAAB3lIHbDp97SrbE76YUKTMcUERYMzFFREdFMDIxMgBjYzkyNzU4ZC0wNWY3LTRhZDYtYWE1ZS0wZmE5NzE4ZDg5ODU=",
+        "x-azure-ref": "20220502T224838Z-1kdy40ce594zxd7ayzepxvrcq0000000052000000002q5f0",
         "X-Cache": "CONFIG_NOCACHE",
-        "x-ms-client-request-id": "93f53c28-f5c9-4d49-ba88-0926b259bfdf",
-        "X-Processing-Time": "192ms"
+        "x-ms-client-request-id": "90cfc176-b1e8-4560-a940-2d02102ebe7a",
+        "X-Processing-Time": "226ms"
       },
       "ResponseBody": {
         "identity": {
-          "id": "8:acs:188d4cea-0a9b-4840-8fdc-7a5c71fe9bd0_00000010-7ca3-da35-5896-09482200137a"
+          "id": "8:acs:b6aada1f-0b1d-47ac-866f-91aae00a1d01_00000011-26d7-b05b-570c-113a0d00b7d7"
         },
         "accessToken": {
-          "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE2NDg2Nzk3ODcuNTc5fQ==.adM-ddBZZlQ1WlN3pdPBOF5G4Wh9iZpxNP_fSvpF4cWs",
-          "expiresOn": "2022-03-31T21:36:29.9241579\u002B00:00"
+          "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE2NTE1MzUzMTAuOTk4fQ==.adM-ddBZZlQ1WlN3pdPBOF5G4Wh9iZpxNP_fSvpF4cWs",
+          "expiresOn": "2022-05-03T22:48:33.8366547\u002B00:00"
         }
       }
     },
@@ -96,26 +98,28 @@
         "Accept-Encoding": "gzip,deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "Content-Length": "317",
+        "Content-Length": "497",
         "Content-Type": "application/json",
-        "repeatability-request-id": "a3845398-8b77-428d-8fbe-b57cc2bda58d",
-        "User-Agent": "azsdk-js-azure-communication-chat/1.2.0 core-rest-pipeline/1.8.0 Node/v16.14.2 OS/(arm64-Darwin-21.4.0)",
-        "x-ms-client-request-id": "d232564b-0389-448b-8739-a8de813ce1d6"
+        "repeatability-request-id": "f40806fd-3ea8-4d77-ad5a-95f81d4c949b",
+        "User-Agent": "azsdk-js-communication-chat/1.2.0 core-rest-pipeline/1.8.1 Node/v14.15.4 OS/(x64-Windows_NT-10.0.22000)",
+        "x-ms-client-request-id": "58c09a3a-3c2a-4f46-892f-ae0670f662fb"
       },
       "RequestBody": {
         "topic": "test topic",
         "participants": [
           {
             "communicationIdentifier": {
+              "rawId": "8:acs:b6aada1f-0b1d-47ac-866f-91aae00a1d01_00000011-26d7-aecb-570c-113a0d00b7d6",
               "communicationUser": {
-                "id": "8:acs:188d4cea-0a9b-4840-8fdc-7a5c71fe9bd0_00000010-7ca3-d956-5896-094822001379"
+                "id": "8:acs:b6aada1f-0b1d-47ac-866f-91aae00a1d01_00000011-26d7-aecb-570c-113a0d00b7d6"
               }
             }
           },
           {
             "communicationIdentifier": {
+              "rawId": "8:acs:b6aada1f-0b1d-47ac-866f-91aae00a1d01_00000011-26d7-b05b-570c-113a0d00b7d7",
               "communicationUser": {
-                "id": "8:acs:188d4cea-0a9b-4840-8fdc-7a5c71fe9bd0_00000010-7ca3-da35-5896-09482200137a"
+                "id": "8:acs:b6aada1f-0b1d-47ac-866f-91aae00a1d01_00000011-26d7-b05b-570c-113a0d00b7d7"
               }
             }
           }
@@ -124,25 +128,26 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "api-supported-versions": "2021-03-07, 2021-04-05-preview6, 2021-09-07, 2021-10-01-preview7",
+        "Connection": "keep-alive",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 30 Mar 2022 21:36:30 GMT",
-        "Location": "https://endpoint/chat/threads/19%3ACVY6cS046Q76bICKk00-dR7_y5RHQo3_3ONhDTEIrk41@thread.v2",
-        "MS-CV": "ogxEOrk/UUah61F4rnaYvA.0",
+        "Date": "Mon, 02 May 2022 22:48:39 GMT",
+        "Location": "https://endpoint/chat/threads/19%3A1LP8h-5WKvPuwtMH3edl4AihPeEZu3VWYitvgn-9uDw1@thread.v2",
+        "MS-CV": "JeCl8XYBG0eqDGIgm9N\u002BgA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0Xc1EYgAAAABCXFf0sOyMSbH0QvgLO5rHUERYMzFFREdFMDIxMgBjYzkyNzU4ZC0wNWY3LTRhZDYtYWE1ZS0wZmE5NzE4ZDg5ODU=",
+        "x-azure-ref": "20220502T224838Z-1kdy40ce594zxd7ayzepxvrcq0000000052000000002q5hr",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "834ms"
+        "X-Processing-Time": "460ms"
       },
       "ResponseBody": {
         "chatThread": {
-          "id": "19:CVY6cS046Q76bICKk00-dR7_y5RHQo3_3ONhDTEIrk41@thread.v2",
+          "id": "19:1LP8h-5WKvPuwtMH3edl4AihPeEZu3VWYitvgn-9uDw1@thread.v2",
           "topic": "test topic",
-          "createdOn": "2022-03-30T21:36:30Z",
+          "createdOn": "2022-05-02T22:48:34Z",
           "createdByCommunicationIdentifier": {
-            "rawId": "8:acs:188d4cea-0a9b-4840-8fdc-7a5c71fe9bd0_00000010-7ca3-d956-5896-094822001379",
+            "rawId": "8:acs:b6aada1f-0b1d-47ac-866f-91aae00a1d01_00000011-26d7-aecb-570c-113a0d00b7d6",
             "communicationUser": {
-              "id": "8:acs:188d4cea-0a9b-4840-8fdc-7a5c71fe9bd0_00000010-7ca3-d956-5896-094822001379"
+              "id": "8:acs:b6aada1f-0b1d-47ac-866f-91aae00a1d01_00000011-26d7-aecb-570c-113a0d00b7d6"
             }
           }
         }

--- a/sdk/communication/communication-chat/recordings/node/chatthreadclient/recording_successfully_lists_messages_one_by_one_and_by_page.json
+++ b/sdk/communication/communication-chat/recordings/node/chatthreadclient/recording_successfully_lists_messages_one_by_one_and_by_page.json
@@ -1,45 +1,46 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://endpoint/chat/threads/19%3ACVY6cS046Q76bICKk00-dR7_y5RHQo3_3ONhDTEIrk41%40thread.v2/messages?api-version=2021-09-07",
+      "RequestUri": "https://endpoint/chat/threads/19%3A1LP8h-5WKvPuwtMH3edl4AihPeEZu3VWYitvgn-9uDw1%40thread.v2/messages?api-version=2021-09-07",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-azure-communication-chat/1.2.0 core-rest-pipeline/1.8.0 Node/v16.14.2 OS/(arm64-Darwin-21.4.0)",
-        "x-ms-client-request-id": "f7143658-5286-4207-a116-7cd9f9154104"
+        "User-Agent": "azsdk-js-communication-chat/1.2.0 core-rest-pipeline/1.8.1 Node/v14.15.4 OS/(x64-Windows_NT-10.0.22000)",
+        "x-ms-client-request-id": "edee634b-2c81-4f1f-8454-6278298ada3f"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "api-supported-versions": "2021-03-07, 2021-04-05-preview6, 2021-09-07, 2021-10-01-preview7",
+        "Connection": "keep-alive",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 30 Mar 2022 21:36:34 GMT",
-        "MS-CV": "cI2YfrDUQky2XUWhta3fLQ.0",
+        "Date": "Mon, 02 May 2022 22:48:41 GMT",
+        "MS-CV": "q1e0p42vUE\u002B7/9X1qIlb/Q.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0Ys1EYgAAAADANPnRaQJ1Sq6rOV/jdmnlUERYMzFFREdFMDIxMgBjYzkyNzU4ZC0wNWY3LTRhZDYtYWE1ZS0wZmE5NzE4ZDg5ODU=",
+        "x-azure-ref": "20220502T224841Z-1kdy40ce594zxd7ayzepxvrcq0000000052000000002q5xk",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "276ms"
+        "X-Processing-Time": "52ms"
       },
       "ResponseBody": {
         "value": [
           {
-            "id": "1648676192118",
+            "id": "1651531715497",
             "type": "text",
             "sequenceId": "4",
-            "version": "1648676192118",
+            "version": "1651531715497",
             "content": {
               "message": "content"
             },
             "senderDisplayName": "",
-            "createdOn": "2022-03-30T21:36:32Z",
+            "createdOn": "2022-05-02T22:48:35Z",
             "senderCommunicationIdentifier": {
-              "rawId": "8:acs:188d4cea-0a9b-4840-8fdc-7a5c71fe9bd0_00000010-7ca3-d956-5896-094822001379",
+              "rawId": "8:acs:b6aada1f-0b1d-47ac-866f-91aae00a1d01_00000011-26d7-aecb-570c-113a0d00b7d6",
               "communicationUser": {
-                "id": "8:acs:188d4cea-0a9b-4840-8fdc-7a5c71fe9bd0_00000010-7ca3-d956-5896-094822001379"
+                "id": "8:acs:b6aada1f-0b1d-47ac-866f-91aae00a1d01_00000011-26d7-aecb-570c-113a0d00b7d6"
               }
             },
             "metadata": {
@@ -47,115 +48,116 @@
             }
           },
           {
-            "id": "1648676191400",
+            "id": "1651531714927",
             "type": "topicUpdated",
             "sequenceId": "3",
-            "version": "1648676191400",
+            "version": "1651531714927",
             "content": {
               "topic": "new topic",
               "initiatorCommunicationIdentifier": {
-                "rawId": "8:acs:188d4cea-0a9b-4840-8fdc-7a5c71fe9bd0_00000010-7ca3-d956-5896-094822001379",
+                "rawId": "8:acs:b6aada1f-0b1d-47ac-866f-91aae00a1d01_00000011-26d7-aecb-570c-113a0d00b7d6",
                 "communicationUser": {
-                  "id": "8:acs:188d4cea-0a9b-4840-8fdc-7a5c71fe9bd0_00000010-7ca3-d956-5896-094822001379"
+                  "id": "8:acs:b6aada1f-0b1d-47ac-866f-91aae00a1d01_00000011-26d7-aecb-570c-113a0d00b7d6"
                 }
               }
             },
-            "createdOn": "2022-03-30T21:36:31Z"
+            "createdOn": "2022-05-02T22:48:34Z"
           },
           {
-            "id": "1648676190376",
+            "id": "1651531714250",
             "type": "topicUpdated",
             "sequenceId": "2",
-            "version": "1648676190376",
+            "version": "1651531714250",
             "content": {
               "topic": "test topic",
               "initiatorCommunicationIdentifier": {
-                "rawId": "8:acs:188d4cea-0a9b-4840-8fdc-7a5c71fe9bd0_00000010-7ca3-d956-5896-094822001379",
+                "rawId": "8:acs:b6aada1f-0b1d-47ac-866f-91aae00a1d01_00000011-26d7-aecb-570c-113a0d00b7d6",
                 "communicationUser": {
-                  "id": "8:acs:188d4cea-0a9b-4840-8fdc-7a5c71fe9bd0_00000010-7ca3-d956-5896-094822001379"
+                  "id": "8:acs:b6aada1f-0b1d-47ac-866f-91aae00a1d01_00000011-26d7-aecb-570c-113a0d00b7d6"
                 }
               }
             },
-            "createdOn": "2022-03-30T21:36:30Z"
+            "createdOn": "2022-05-02T22:48:34Z"
           },
           {
-            "id": "1648676190344",
+            "id": "1651531714216",
             "type": "participantAdded",
             "sequenceId": "1",
-            "version": "1648676190344",
+            "version": "1651531714216",
             "content": {
               "participants": [
                 {
                   "communicationIdentifier": {
-                    "rawId": "8:acs:188d4cea-0a9b-4840-8fdc-7a5c71fe9bd0_00000010-7ca3-d956-5896-094822001379",
+                    "rawId": "8:acs:b6aada1f-0b1d-47ac-866f-91aae00a1d01_00000011-26d7-aecb-570c-113a0d00b7d6",
                     "communicationUser": {
-                      "id": "8:acs:188d4cea-0a9b-4840-8fdc-7a5c71fe9bd0_00000010-7ca3-d956-5896-094822001379"
+                      "id": "8:acs:b6aada1f-0b1d-47ac-866f-91aae00a1d01_00000011-26d7-aecb-570c-113a0d00b7d6"
                     }
                   },
                   "shareHistoryTime": "1970-01-01T00:00:00Z"
                 },
                 {
                   "communicationIdentifier": {
-                    "rawId": "8:acs:188d4cea-0a9b-4840-8fdc-7a5c71fe9bd0_00000010-7ca3-da35-5896-09482200137a",
+                    "rawId": "8:acs:b6aada1f-0b1d-47ac-866f-91aae00a1d01_00000011-26d7-b05b-570c-113a0d00b7d7",
                     "communicationUser": {
-                      "id": "8:acs:188d4cea-0a9b-4840-8fdc-7a5c71fe9bd0_00000010-7ca3-da35-5896-09482200137a"
+                      "id": "8:acs:b6aada1f-0b1d-47ac-866f-91aae00a1d01_00000011-26d7-b05b-570c-113a0d00b7d7"
                     }
                   },
                   "shareHistoryTime": "1970-01-01T00:00:00Z"
                 }
               ],
               "initiatorCommunicationIdentifier": {
-                "rawId": "8:acs:188d4cea-0a9b-4840-8fdc-7a5c71fe9bd0_00000010-7ca3-d956-5896-094822001379",
+                "rawId": "8:acs:b6aada1f-0b1d-47ac-866f-91aae00a1d01_00000011-26d7-aecb-570c-113a0d00b7d6",
                 "communicationUser": {
-                  "id": "8:acs:188d4cea-0a9b-4840-8fdc-7a5c71fe9bd0_00000010-7ca3-d956-5896-094822001379"
+                  "id": "8:acs:b6aada1f-0b1d-47ac-866f-91aae00a1d01_00000011-26d7-aecb-570c-113a0d00b7d6"
                 }
               }
             },
-            "createdOn": "2022-03-30T21:36:30Z"
+            "createdOn": "2022-05-02T22:48:34Z"
           }
         ]
       }
     },
     {
-      "RequestUri": "https://endpoint/chat/threads/19%3ACVY6cS046Q76bICKk00-dR7_y5RHQo3_3ONhDTEIrk41%40thread.v2/messages?maxPageSize=3\u0026api-version=2021-09-07",
+      "RequestUri": "https://endpoint/chat/threads/19%3A1LP8h-5WKvPuwtMH3edl4AihPeEZu3VWYitvgn-9uDw1%40thread.v2/messages?maxPageSize=3\u0026api-version=2021-09-07",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-azure-communication-chat/1.2.0 core-rest-pipeline/1.8.0 Node/v16.14.2 OS/(arm64-Darwin-21.4.0)",
-        "x-ms-client-request-id": "900cd6ab-e183-4004-98f3-69900c2b66e2"
+        "User-Agent": "azsdk-js-communication-chat/1.2.0 core-rest-pipeline/1.8.1 Node/v14.15.4 OS/(x64-Windows_NT-10.0.22000)",
+        "x-ms-client-request-id": "10fea2ab-1dba-47e9-a9fb-50ded8067dbe"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "api-supported-versions": "2021-03-07, 2021-04-05-preview6, 2021-09-07, 2021-10-01-preview7",
+        "Connection": "keep-alive",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 30 Mar 2022 21:36:34 GMT",
-        "MS-CV": "Ncajb\u002BqapUK68JHVFN1dmg.0",
+        "Date": "Mon, 02 May 2022 22:48:41 GMT",
+        "MS-CV": "LqtyFPihIk6HAPTMWA8IbQ.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0Ys1EYgAAAACg44MP70bORIs6zO3rYsxtUERYMzFFREdFMDIxMgBjYzkyNzU4ZC0wNWY3LTRhZDYtYWE1ZS0wZmE5NzE4ZDg5ODU=",
+        "x-azure-ref": "20220502T224841Z-1kdy40ce594zxd7ayzepxvrcq0000000052000000002q5yf",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "272ms"
+        "X-Processing-Time": "24ms"
       },
       "ResponseBody": {
         "value": [
           {
-            "id": "1648676192118",
+            "id": "1651531715497",
             "type": "text",
             "sequenceId": "4",
-            "version": "1648676192118",
+            "version": "1651531715497",
             "content": {
               "message": "content"
             },
             "senderDisplayName": "",
-            "createdOn": "2022-03-30T21:36:32Z",
+            "createdOn": "2022-05-02T22:48:35Z",
             "senderCommunicationIdentifier": {
-              "rawId": "8:acs:188d4cea-0a9b-4840-8fdc-7a5c71fe9bd0_00000010-7ca3-d956-5896-094822001379",
+              "rawId": "8:acs:b6aada1f-0b1d-47ac-866f-91aae00a1d01_00000011-26d7-aecb-570c-113a0d00b7d6",
               "communicationUser": {
-                "id": "8:acs:188d4cea-0a9b-4840-8fdc-7a5c71fe9bd0_00000010-7ca3-d956-5896-094822001379"
+                "id": "8:acs:b6aada1f-0b1d-47ac-866f-91aae00a1d01_00000011-26d7-aecb-570c-113a0d00b7d6"
               }
             },
             "metadata": {
@@ -163,101 +165,102 @@
             }
           },
           {
-            "id": "1648676191400",
+            "id": "1651531714927",
             "type": "topicUpdated",
             "sequenceId": "3",
-            "version": "1648676191400",
+            "version": "1651531714927",
             "content": {
               "topic": "new topic",
               "initiatorCommunicationIdentifier": {
-                "rawId": "8:acs:188d4cea-0a9b-4840-8fdc-7a5c71fe9bd0_00000010-7ca3-d956-5896-094822001379",
+                "rawId": "8:acs:b6aada1f-0b1d-47ac-866f-91aae00a1d01_00000011-26d7-aecb-570c-113a0d00b7d6",
                 "communicationUser": {
-                  "id": "8:acs:188d4cea-0a9b-4840-8fdc-7a5c71fe9bd0_00000010-7ca3-d956-5896-094822001379"
+                  "id": "8:acs:b6aada1f-0b1d-47ac-866f-91aae00a1d01_00000011-26d7-aecb-570c-113a0d00b7d6"
                 }
               }
             },
-            "createdOn": "2022-03-30T21:36:31Z"
+            "createdOn": "2022-05-02T22:48:34Z"
           },
           {
-            "id": "1648676190376",
+            "id": "1651531714250",
             "type": "topicUpdated",
             "sequenceId": "2",
-            "version": "1648676190376",
+            "version": "1651531714250",
             "content": {
               "topic": "test topic",
               "initiatorCommunicationIdentifier": {
-                "rawId": "8:acs:188d4cea-0a9b-4840-8fdc-7a5c71fe9bd0_00000010-7ca3-d956-5896-094822001379",
+                "rawId": "8:acs:b6aada1f-0b1d-47ac-866f-91aae00a1d01_00000011-26d7-aecb-570c-113a0d00b7d6",
                 "communicationUser": {
-                  "id": "8:acs:188d4cea-0a9b-4840-8fdc-7a5c71fe9bd0_00000010-7ca3-d956-5896-094822001379"
+                  "id": "8:acs:b6aada1f-0b1d-47ac-866f-91aae00a1d01_00000011-26d7-aecb-570c-113a0d00b7d6"
                 }
               }
             },
-            "createdOn": "2022-03-30T21:36:30Z"
+            "createdOn": "2022-05-02T22:48:34Z"
           }
         ],
-        "nextLink": "https://endpoint/chat/threads/19:CVY6cS046Q76bICKk00-dR7_y5RHQo3_3ONhDTEIrk41@thread.v2/messages?syncState=3e3900000031393a4356593663533034365137366249434b6b30302d6452375f79355248516f335f334f4e6844544549726b3431407468726561642e763201a838c2dc7f010000763fc2dc7f010000\u0026startTime=1%2F1%2F1970%2012%3A00%3A00%20AM%20%2B00%3A00\u0026maxPageSize=3\u0026api-version=2021-09-07"
+        "nextLink": "https://endpoint/chat/threads/19:1LP8h-5WKvPuwtMH3edl4AihPeEZu3VWYitvgn-9uDw1@thread.v2/messages?syncState=3e3900000031393a314c5038682d35574b76507577744d483365646c344169685065455a7533565759697476676e2d3975447731407468726561642e763201ca0ef68680010000a913f68680010000\u0026startTime=1%2F1%2F1970%2012%3A00%3A00%20AM%20%2B00%3A00\u0026maxPageSize=3\u0026api-version=2021-09-07"
       }
     },
     {
-      "RequestUri": "https://endpoint/chat/threads/19:CVY6cS046Q76bICKk00-dR7_y5RHQo3_3ONhDTEIrk41@thread.v2/messages?syncState=3e3900000031393a4356593663533034365137366249434b6b30302d6452375f79355248516f335f334f4e6844544549726b3431407468726561642e763201a838c2dc7f010000763fc2dc7f010000\u0026startTime=1%2F1%2F1970%2012%3A00%3A00%20AM%20%2B00%3A00\u0026maxPageSize=3\u0026api-version=2021-09-07",
+      "RequestUri": "https://endpoint/chat/threads/19:1LP8h-5WKvPuwtMH3edl4AihPeEZu3VWYitvgn-9uDw1@thread.v2/messages?syncState=3e3900000031393a314c5038682d35574b76507577744d483365646c344169685065455a7533565759697476676e2d3975447731407468726561642e763201ca0ef68680010000a913f68680010000\u0026startTime=1%2F1%2F1970%2012%3A00%3A00%20AM%20%2B00%3A00\u0026maxPageSize=3\u0026api-version=2021-09-07",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-azure-communication-chat/1.2.0 core-rest-pipeline/1.8.0 Node/v16.14.2 OS/(arm64-Darwin-21.4.0)",
-        "x-ms-client-request-id": "0473436b-65e6-4688-a2ff-e81ec2416d1a"
+        "User-Agent": "azsdk-js-communication-chat/1.2.0 core-rest-pipeline/1.8.1 Node/v14.15.4 OS/(x64-Windows_NT-10.0.22000)",
+        "x-ms-client-request-id": "2255d0e4-bb69-4227-b8c6-c6cb3d665a32"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "api-supported-versions": "2021-03-07, 2021-04-05-preview6, 2021-09-07, 2021-10-01-preview7",
+        "Connection": "keep-alive",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 30 Mar 2022 21:36:35 GMT",
-        "MS-CV": "NnpoHx0rTkekybJXFUMx9Q.0",
+        "Date": "Mon, 02 May 2022 22:48:42 GMT",
+        "MS-CV": "EvsulIYQukOEXDctAi/MaA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0Y81EYgAAAABh/6yJ6aKOSaQvYoD8RkSsUERYMzFFREdFMDIxMgBjYzkyNzU4ZC0wNWY3LTRhZDYtYWE1ZS0wZmE5NzE4ZDg5ODU=",
+        "x-azure-ref": "20220502T224841Z-1kdy40ce594zxd7ayzepxvrcq0000000052000000002q5yp",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "479ms"
+        "X-Processing-Time": "50ms"
       },
       "ResponseBody": {
         "value": [
           {
-            "id": "1648676190344",
+            "id": "1651531714216",
             "type": "participantAdded",
             "sequenceId": "1",
-            "version": "1648676190344",
+            "version": "1651531714216",
             "content": {
               "participants": [
                 {
                   "communicationIdentifier": {
-                    "rawId": "8:acs:188d4cea-0a9b-4840-8fdc-7a5c71fe9bd0_00000010-7ca3-d956-5896-094822001379",
+                    "rawId": "8:acs:b6aada1f-0b1d-47ac-866f-91aae00a1d01_00000011-26d7-aecb-570c-113a0d00b7d6",
                     "communicationUser": {
-                      "id": "8:acs:188d4cea-0a9b-4840-8fdc-7a5c71fe9bd0_00000010-7ca3-d956-5896-094822001379"
+                      "id": "8:acs:b6aada1f-0b1d-47ac-866f-91aae00a1d01_00000011-26d7-aecb-570c-113a0d00b7d6"
                     }
                   },
                   "shareHistoryTime": "1970-01-01T00:00:00Z"
                 },
                 {
                   "communicationIdentifier": {
-                    "rawId": "8:acs:188d4cea-0a9b-4840-8fdc-7a5c71fe9bd0_00000010-7ca3-da35-5896-09482200137a",
+                    "rawId": "8:acs:b6aada1f-0b1d-47ac-866f-91aae00a1d01_00000011-26d7-b05b-570c-113a0d00b7d7",
                     "communicationUser": {
-                      "id": "8:acs:188d4cea-0a9b-4840-8fdc-7a5c71fe9bd0_00000010-7ca3-da35-5896-09482200137a"
+                      "id": "8:acs:b6aada1f-0b1d-47ac-866f-91aae00a1d01_00000011-26d7-b05b-570c-113a0d00b7d7"
                     }
                   },
                   "shareHistoryTime": "1970-01-01T00:00:00Z"
                 }
               ],
               "initiatorCommunicationIdentifier": {
-                "rawId": "8:acs:188d4cea-0a9b-4840-8fdc-7a5c71fe9bd0_00000010-7ca3-d956-5896-094822001379",
+                "rawId": "8:acs:b6aada1f-0b1d-47ac-866f-91aae00a1d01_00000011-26d7-aecb-570c-113a0d00b7d6",
                 "communicationUser": {
-                  "id": "8:acs:188d4cea-0a9b-4840-8fdc-7a5c71fe9bd0_00000010-7ca3-d956-5896-094822001379"
+                  "id": "8:acs:b6aada1f-0b1d-47ac-866f-91aae00a1d01_00000011-26d7-aecb-570c-113a0d00b7d6"
                 }
               }
             },
-            "createdOn": "2022-03-30T21:36:30Z"
+            "createdOn": "2022-05-02T22:48:34Z"
           }
         ]
       }

--- a/sdk/communication/communication-chat/recordings/node/chatthreadclient/recording_successfully_lists_participants.json
+++ b/sdk/communication/communication-chat/recordings/node/chatthreadclient/recording_successfully_lists_participants.json
@@ -1,54 +1,55 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://endpoint/chat/threads/19%3ACVY6cS046Q76bICKk00-dR7_y5RHQo3_3ONhDTEIrk41%40thread.v2/participants?api-version=2021-09-07",
+      "RequestUri": "https://endpoint/chat/threads/19%3A1LP8h-5WKvPuwtMH3edl4AihPeEZu3VWYitvgn-9uDw1%40thread.v2/participants?api-version=2021-09-07",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-azure-communication-chat/1.2.0 core-rest-pipeline/1.8.0 Node/v16.14.2 OS/(arm64-Darwin-21.4.0)",
-        "x-ms-client-request-id": "9754d98c-d11f-4862-a232-916146f2ddf8"
+        "User-Agent": "azsdk-js-communication-chat/1.2.0 core-rest-pipeline/1.8.1 Node/v14.15.4 OS/(x64-Windows_NT-10.0.22000)",
+        "x-ms-client-request-id": "e8eea453-aac9-4f83-bc98-596886887bd3"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "api-supported-versions": "2021-03-07, 2021-04-05-preview6, 2021-09-07, 2021-10-01-preview7",
+        "Connection": "keep-alive",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 30 Mar 2022 21:36:36 GMT",
-        "MS-CV": "eB6SqIoQREehxwM/Mdi7gA.0",
+        "Date": "Mon, 02 May 2022 22:48:43 GMT",
+        "MS-CV": "VhenmJyTAUucwOm8/LgjWQ.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0ZM1EYgAAAACqkFC41255Tpivyttk\u002B8iqUERYMzFFREdFMDIxMgBjYzkyNzU4ZC0wNWY3LTRhZDYtYWE1ZS0wZmE5NzE4ZDg5ODU=",
+        "x-azure-ref": "20220502T224843Z-1kdy40ce594zxd7ayzepxvrcq0000000052000000002q653",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "267ms"
+        "X-Processing-Time": "88ms"
       },
       "ResponseBody": {
         "value": [
           {
             "communicationIdentifier": {
-              "rawId": "8:acs:188d4cea-0a9b-4840-8fdc-7a5c71fe9bd0_00000010-7ca3-d956-5896-094822001379",
+              "rawId": "8:acs:b6aada1f-0b1d-47ac-866f-91aae00a1d01_00000011-26d7-aecb-570c-113a0d00b7d6",
               "communicationUser": {
-                "id": "8:acs:188d4cea-0a9b-4840-8fdc-7a5c71fe9bd0_00000010-7ca3-d956-5896-094822001379"
+                "id": "8:acs:b6aada1f-0b1d-47ac-866f-91aae00a1d01_00000011-26d7-aecb-570c-113a0d00b7d6"
               }
             },
             "shareHistoryTime": "1970-01-01T00:00:00Z"
           },
           {
             "communicationIdentifier": {
-              "rawId": "8:acs:188d4cea-0a9b-4840-8fdc-7a5c71fe9bd0_00000010-7ca3-da35-5896-09482200137a",
+              "rawId": "8:acs:b6aada1f-0b1d-47ac-866f-91aae00a1d01_00000011-26d7-b05b-570c-113a0d00b7d7",
               "communicationUser": {
-                "id": "8:acs:188d4cea-0a9b-4840-8fdc-7a5c71fe9bd0_00000010-7ca3-da35-5896-09482200137a"
+                "id": "8:acs:b6aada1f-0b1d-47ac-866f-91aae00a1d01_00000011-26d7-b05b-570c-113a0d00b7d7"
               }
             },
             "shareHistoryTime": "1970-01-01T00:00:00Z"
           },
           {
             "communicationIdentifier": {
-              "rawId": "8:acs:188d4cea-0a9b-4840-8fdc-7a5c71fe9bd0_00000010-7ca3-f2c8-5896-09482200137d",
+              "rawId": "8:acs:b6aada1f-0b1d-47ac-866f-91aae00a1d01_00000011-26d7-bf83-570c-113a0d00b7d8",
               "communicationUser": {
-                "id": "8:acs:188d4cea-0a9b-4840-8fdc-7a5c71fe9bd0_00000010-7ca3-f2c8-5896-09482200137d"
+                "id": "8:acs:b6aada1f-0b1d-47ac-866f-91aae00a1d01_00000011-26d7-bf83-570c-113a0d00b7d8"
               }
             },
             "shareHistoryTime": "1970-01-01T00:00:00Z"

--- a/sdk/communication/communication-chat/recordings/node/chatthreadclient/recording_successfully_lists_read_receipts.json
+++ b/sdk/communication/communication-chat/recordings/node/chatthreadclient/recording_successfully_lists_read_receipts.json
@@ -1,40 +1,41 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://endpoint/chat/threads/19%3ACVY6cS046Q76bICKk00-dR7_y5RHQo3_3ONhDTEIrk41%40thread.v2/readReceipts?api-version=2021-09-07",
+      "RequestUri": "https://endpoint/chat/threads/19%3A1LP8h-5WKvPuwtMH3edl4AihPeEZu3VWYitvgn-9uDw1%40thread.v2/readReceipts?api-version=2021-09-07",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-azure-communication-chat/1.2.0 core-rest-pipeline/1.8.0 Node/v16.14.2 OS/(arm64-Darwin-21.4.0)",
-        "x-ms-client-request-id": "0fd2fc23-6803-4ab2-9f34-76903323e66c"
+        "User-Agent": "azsdk-js-communication-chat/1.2.0 core-rest-pipeline/1.8.1 Node/v14.15.4 OS/(x64-Windows_NT-10.0.22000)",
+        "x-ms-client-request-id": "7371b32f-d9ac-4919-8971-efdd6921c40d"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "api-supported-versions": "2021-03-07, 2021-04-05-preview6, 2021-09-07, 2021-10-01-preview7",
+        "Connection": "keep-alive",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 30 Mar 2022 21:36:37 GMT",
-        "MS-CV": "INpbvvSfy02w2U\u002Bp7by1OA.0",
+        "Date": "Mon, 02 May 2022 22:48:44 GMT",
+        "MS-CV": "WkMAN0SSf0\u002B/xyt1w\u002BskzQ.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0Zc1EYgAAAAAT6it4Kik6TplAZ6T0\u002BO2pUERYMzFFREdFMDIxMgBjYzkyNzU4ZC0wNWY3LTRhZDYtYWE1ZS0wZmE5NzE4ZDg5ODU=",
+        "x-azure-ref": "20220502T224843Z-1kdy40ce594zxd7ayzepxvrcq0000000052000000002q69y",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "254ms"
+        "X-Processing-Time": "88ms"
       },
       "ResponseBody": {
         "value": [
           {
             "senderCommunicationIdentifier": {
-              "rawId": "8:acs:188d4cea-0a9b-4840-8fdc-7a5c71fe9bd0_00000010-7ca3-d956-5896-094822001379",
+              "rawId": "8:acs:b6aada1f-0b1d-47ac-866f-91aae00a1d01_00000011-26d7-aecb-570c-113a0d00b7d6",
               "communicationUser": {
-                "id": "8:acs:188d4cea-0a9b-4840-8fdc-7a5c71fe9bd0_00000010-7ca3-d956-5896-094822001379"
+                "id": "8:acs:b6aada1f-0b1d-47ac-866f-91aae00a1d01_00000011-26d7-aecb-570c-113a0d00b7d6"
               }
             },
-            "chatMessageId": "1648676192118",
-            "readOn": "2022-03-30T21:36:33Z"
+            "chatMessageId": "1651531715497",
+            "readOn": "2022-05-02T22:48:36Z"
           }
         ]
       }

--- a/sdk/communication/communication-chat/recordings/node/chatthreadclient/recording_successfully_remove_a_participant.json
+++ b/sdk/communication/communication-chat/recordings/node/chatthreadclient/recording_successfully_remove_a_participant.json
@@ -1,32 +1,34 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://endpoint/chat/threads/19%3ACVY6cS046Q76bICKk00-dR7_y5RHQo3_3ONhDTEIrk41%40thread.v2/participants/:remove?api-version=2021-09-07",
+      "RequestUri": "https://endpoint/chat/threads/19%3A1LP8h-5WKvPuwtMH3edl4AihPeEZu3VWYitvgn-9uDw1%40thread.v2/participants/:remove?api-version=2021-09-07",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "Content-Length": "110",
+        "Content-Length": "200",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-js-azure-communication-chat/1.2.0 core-rest-pipeline/1.8.0 Node/v16.14.2 OS/(arm64-Darwin-21.4.0)",
-        "x-ms-client-request-id": "c71eb94a-1607-49ee-bc8f-fd9f1cf31422"
+        "User-Agent": "azsdk-js-communication-chat/1.2.0 core-rest-pipeline/1.8.1 Node/v14.15.4 OS/(x64-Windows_NT-10.0.22000)",
+        "x-ms-client-request-id": "76f92dc6-7a95-466e-b2b6-63f6667e6a84"
       },
       "RequestBody": {
+        "rawId": "8:acs:b6aada1f-0b1d-47ac-866f-91aae00a1d01_00000011-26d7-b05b-570c-113a0d00b7d7",
         "communicationUser": {
-          "id": "8:acs:188d4cea-0a9b-4840-8fdc-7a5c71fe9bd0_00000010-7ca3-da35-5896-09482200137a"
+          "id": "8:acs:b6aada1f-0b1d-47ac-866f-91aae00a1d01_00000011-26d7-b05b-570c-113a0d00b7d7"
         }
       },
       "StatusCode": 204,
       "ResponseHeaders": {
         "api-supported-versions": "2021-03-07, 2021-04-05-preview6, 2021-09-07, 2021-10-01-preview7",
-        "Date": "Wed, 30 Mar 2022 21:36:37 GMT",
-        "MS-CV": "YJJyFcA74kO4BBR3X7WuFw.0",
+        "Connection": "keep-alive",
+        "Date": "Mon, 02 May 2022 22:48:43 GMT",
+        "MS-CV": "Y3manl1K70K8PbIXPHn7oQ.0",
         "Strict-Transport-Security": "max-age=2592000",
-        "X-Azure-Ref": "0Zc1EYgAAAAAuMU7/JuDhQ7JVNL5pAJ9/UERYMzFFREdFMDIxMgBjYzkyNzU4ZC0wNWY3LTRhZDYtYWE1ZS0wZmE5NzE4ZDg5ODU=",
+        "x-azure-ref": "20220502T224843Z-1kdy40ce594zxd7ayzepxvrcq0000000052000000002q66h",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "443ms"
+        "X-Processing-Time": "322ms"
       },
       "ResponseBody": null
     }

--- a/sdk/communication/communication-chat/recordings/node/chatthreadclient/recording_successfully_retrieves_a_message.json
+++ b/sdk/communication/communication-chat/recordings/node/chatthreadclient/recording_successfully_retrieves_a_message.json
@@ -1,43 +1,44 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://endpoint/chat/threads/19%3ACVY6cS046Q76bICKk00-dR7_y5RHQo3_3ONhDTEIrk41%40thread.v2/messages/1648676192118?api-version=2021-09-07",
+      "RequestUri": "https://endpoint/chat/threads/19%3A1LP8h-5WKvPuwtMH3edl4AihPeEZu3VWYitvgn-9uDw1%40thread.v2/messages/1651531715497?api-version=2021-09-07",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-azure-communication-chat/1.2.0 core-rest-pipeline/1.8.0 Node/v16.14.2 OS/(arm64-Darwin-21.4.0)",
-        "x-ms-client-request-id": "25fa3b1f-225c-497d-b89f-42f79950a7e2"
+        "User-Agent": "azsdk-js-communication-chat/1.2.0 core-rest-pipeline/1.8.1 Node/v14.15.4 OS/(x64-Windows_NT-10.0.22000)",
+        "x-ms-client-request-id": "caa7c9ba-95c7-4c8d-8c4d-7e3b1a1bfb43"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "api-supported-versions": "2021-03-07, 2021-04-05-preview6, 2021-09-07, 2021-10-01-preview7",
+        "Connection": "keep-alive",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 30 Mar 2022 21:36:33 GMT",
-        "MS-CV": "Q9w17IYkDke/R6oFYNTFIw.0",
+        "Date": "Mon, 02 May 2022 22:48:41 GMT",
+        "MS-CV": "ZOIFz2pppkKEg5/d8LOG5Q.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0Ys1EYgAAAADd2L2Bt76rQJRadA/DVYatUERYMzFFREdFMDIxMgBjYzkyNzU4ZC0wNWY3LTRhZDYtYWE1ZS0wZmE5NzE4ZDg5ODU=",
+        "x-azure-ref": "20220502T224841Z-1kdy40ce594zxd7ayzepxvrcq0000000052000000002q5wq",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "264ms"
+        "X-Processing-Time": "94ms"
       },
       "ResponseBody": {
-        "id": "1648676192118",
+        "id": "1651531715497",
         "type": "text",
         "sequenceId": "4",
-        "version": "1648676192118",
+        "version": "1651531715497",
         "content": {
           "message": "content"
         },
         "senderDisplayName": "",
-        "createdOn": "2022-03-30T21:36:32Z",
+        "createdOn": "2022-05-02T22:48:35Z",
         "senderCommunicationIdentifier": {
-          "rawId": "8:acs:188d4cea-0a9b-4840-8fdc-7a5c71fe9bd0_00000010-7ca3-d956-5896-094822001379",
+          "rawId": "8:acs:b6aada1f-0b1d-47ac-866f-91aae00a1d01_00000011-26d7-aecb-570c-113a0d00b7d6",
           "communicationUser": {
-            "id": "8:acs:188d4cea-0a9b-4840-8fdc-7a5c71fe9bd0_00000010-7ca3-d956-5896-094822001379"
+            "id": "8:acs:b6aada1f-0b1d-47ac-866f-91aae00a1d01_00000011-26d7-aecb-570c-113a0d00b7d6"
           }
         },
         "metadata": {

--- a/sdk/communication/communication-chat/recordings/node/chatthreadclient/recording_successfully_sends_a_message.json
+++ b/sdk/communication/communication-chat/recordings/node/chatthreadclient/recording_successfully_sends_a_message.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://endpoint/chat/threads/19%3ACVY6cS046Q76bICKk00-dR7_y5RHQo3_3ONhDTEIrk41%40thread.v2/messages?api-version=2021-09-07",
+      "RequestUri": "https://endpoint/chat/threads/19%3A1LP8h-5WKvPuwtMH3edl4AihPeEZu3VWYitvgn-9uDw1%40thread.v2/messages?api-version=2021-09-07",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -10,8 +10,8 @@
         "Connection": "keep-alive",
         "Content-Length": "51",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-js-azure-communication-chat/1.2.0 core-rest-pipeline/1.8.0 Node/v16.14.2 OS/(arm64-Darwin-21.4.0)",
-        "x-ms-client-request-id": "a2984bb4-6ba1-456b-af95-359b94b67970"
+        "User-Agent": "azsdk-js-communication-chat/1.2.0 core-rest-pipeline/1.8.1 Node/v14.15.4 OS/(x64-Windows_NT-10.0.22000)",
+        "x-ms-client-request-id": "12b3e31b-ba7d-42f8-822f-5c1ae2b59cf9"
       },
       "RequestBody": {
         "content": "content",
@@ -22,18 +22,19 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "api-supported-versions": "2021-03-07, 2021-04-05-preview6, 2021-09-07, 2021-10-01-preview7",
+        "Connection": "keep-alive",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 30 Mar 2022 21:36:31 GMT",
-        "Location": "https://endpoint/chat/threads/19%3ACVY6cS046Q76bICKk00-dR7_y5RHQo3_3ONhDTEIrk41@thread.v2/messages/1648676192118",
-        "MS-CV": "Z7RiSWwJXk\u002BvQqDJEGpX\u002BQ.0",
+        "Date": "Mon, 02 May 2022 22:48:40 GMT",
+        "Location": "https://endpoint/chat/threads/19%3A1LP8h-5WKvPuwtMH3edl4AihPeEZu3VWYitvgn-9uDw1@thread.v2/messages/1651531715497",
+        "MS-CV": "Z\u002Bf/nu5BQkGf3tjcY102PQ.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0X81EYgAAAAASvAh8FSMaSbkjpBeIW9ViUERYMzFFREdFMDIxMgBjYzkyNzU4ZC0wNWY3LTRhZDYtYWE1ZS0wZmE5NzE4ZDg5ODU=",
+        "x-azure-ref": "20220502T224840Z-1kdy40ce594zxd7ayzepxvrcq0000000052000000002q5se",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "400ms"
+        "X-Processing-Time": "155ms"
       },
       "ResponseBody": {
-        "id": "1648676192118"
+        "id": "1651531715497"
       }
     }
   ],

--- a/sdk/communication/communication-chat/recordings/node/chatthreadclient/recording_successfully_sends_read_receipt.json
+++ b/sdk/communication/communication-chat/recordings/node/chatthreadclient/recording_successfully_sends_read_receipt.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://endpoint/chat/threads/19%3ACVY6cS046Q76bICKk00-dR7_y5RHQo3_3ONhDTEIrk41%40thread.v2/readReceipts?api-version=2021-09-07",
+      "RequestUri": "https://endpoint/chat/threads/19%3A1LP8h-5WKvPuwtMH3edl4AihPeEZu3VWYitvgn-9uDw1%40thread.v2/readReceipts?api-version=2021-09-07",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -10,22 +10,24 @@
         "Connection": "keep-alive",
         "Content-Length": "33",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-js-azure-communication-chat/1.2.0 core-rest-pipeline/1.8.0 Node/v16.14.2 OS/(arm64-Darwin-21.4.0)",
-        "x-ms-client-request-id": "63099a22-acbf-4fa4-ace5-349b43a30cd0"
+        "User-Agent": "azsdk-js-communication-chat/1.2.0 core-rest-pipeline/1.8.1 Node/v14.15.4 OS/(x64-Windows_NT-10.0.22000)",
+        "x-ms-client-request-id": "326b6943-d828-4c50-bd8f-11a92caf606b"
       },
       "RequestBody": {
-        "chatMessageId": "1648676192118"
+        "chatMessageId": "1651531715497"
       },
       "StatusCode": 200,
       "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
         "api-supported-versions": "2021-03-07, 2021-04-05-preview6, 2021-09-07, 2021-10-01-preview7",
+        "Connection": "keep-alive",
         "Content-Length": "0",
-        "Date": "Wed, 30 Mar 2022 21:36:33 GMT",
-        "MS-CV": "Cf56G0abrE\u002BH3U47WqSJUQ.0",
+        "Date": "Mon, 02 May 2022 22:48:41 GMT",
+        "MS-CV": "8QVV\u002BNjzLkayogqlTbfwZg.0",
         "Strict-Transport-Security": "max-age=2592000",
-        "X-Azure-Ref": "0Yc1EYgAAAABA0MA0Mvn3S7fEWBjP25pKUERYMzFFREdFMDIxMgBjYzkyNzU4ZC0wNWY3LTRhZDYtYWE1ZS0wZmE5NzE4ZDg5ODU=",
+        "x-azure-ref": "20220502T224841Z-1kdy40ce594zxd7ayzepxvrcq0000000052000000002q5v9",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "577ms"
+        "X-Processing-Time": "161ms"
       },
       "ResponseBody": null
     }

--- a/sdk/communication/communication-chat/recordings/node/chatthreadclient/recording_successfully_sends_typing_notification.json
+++ b/sdk/communication/communication-chat/recordings/node/chatthreadclient/recording_successfully_sends_typing_notification.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://endpoint/chat/threads/19%3ACVY6cS046Q76bICKk00-dR7_y5RHQo3_3ONhDTEIrk41%40thread.v2/typing?api-version=2021-09-07",
+      "RequestUri": "https://endpoint/chat/threads/19%3A1LP8h-5WKvPuwtMH3edl4AihPeEZu3VWYitvgn-9uDw1%40thread.v2/typing?api-version=2021-09-07",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -10,20 +10,22 @@
         "Connection": "keep-alive",
         "Content-Length": "2",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-js-azure-communication-chat/1.2.0 core-rest-pipeline/1.8.0 Node/v16.14.2 OS/(arm64-Darwin-21.4.0)",
-        "x-ms-client-request-id": "726266d2-e7a7-4e72-ab25-d09754c49d94"
+        "User-Agent": "azsdk-js-communication-chat/1.2.0 core-rest-pipeline/1.8.1 Node/v14.15.4 OS/(x64-Windows_NT-10.0.22000)",
+        "x-ms-client-request-id": "589c6ada-6356-4205-a20b-a325a564dcda"
       },
       "RequestBody": {},
       "StatusCode": 200,
       "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
         "api-supported-versions": "2021-04-05-preview6, 2021-09-07, 2021-10-01-preview7",
+        "Connection": "keep-alive",
         "Content-Length": "0",
-        "Date": "Wed, 30 Mar 2022 21:36:33 GMT",
-        "MS-CV": "puYS8ib1B0W3ym5QOX\u002BpRA.0",
+        "Date": "Mon, 02 May 2022 22:48:40 GMT",
+        "MS-CV": "QpSL4US2Kkq7ZWmcGWHkYw.0",
         "Strict-Transport-Security": "max-age=2592000",
-        "X-Azure-Ref": "0YM1EYgAAAACPFZ/ahqIRT61wxbj0BmUQUERYMzFFREdFMDIxMgBjYzkyNzU4ZC0wNWY3LTRhZDYtYWE1ZS0wZmE5NzE4ZDg5ODU=",
+        "x-azure-ref": "20220502T224840Z-1kdy40ce594zxd7ayzepxvrcq0000000052000000002q5tx",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "360ms"
+        "X-Processing-Time": "101ms"
       },
       "ResponseBody": null
     }

--- a/sdk/communication/communication-chat/recordings/node/chatthreadclient/recording_successfully_updates_the_thread_topic.json
+++ b/sdk/communication/communication-chat/recordings/node/chatthreadclient/recording_successfully_updates_the_thread_topic.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://endpoint/chat/threads/19%3ACVY6cS046Q76bICKk00-dR7_y5RHQo3_3ONhDTEIrk41%40thread.v2?api-version=2021-09-07",
+      "RequestUri": "https://endpoint/chat/threads/19%3A1LP8h-5WKvPuwtMH3edl4AihPeEZu3VWYitvgn-9uDw1%40thread.v2?api-version=2021-09-07",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -10,8 +10,8 @@
         "Connection": "keep-alive",
         "Content-Length": "21",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "User-Agent": "azsdk-js-azure-communication-chat/1.2.0 core-rest-pipeline/1.8.0 Node/v16.14.2 OS/(arm64-Darwin-21.4.0)",
-        "x-ms-client-request-id": "4a6f0375-673f-442a-b54e-f549cdd69603"
+        "User-Agent": "azsdk-js-communication-chat/1.2.0 core-rest-pipeline/1.8.1 Node/v14.15.4 OS/(x64-Windows_NT-10.0.22000)",
+        "x-ms-client-request-id": "63be230e-ea65-4275-96c5-81caa46dc568"
       },
       "RequestBody": {
         "topic": "new topic"
@@ -19,47 +19,49 @@
       "StatusCode": 204,
       "ResponseHeaders": {
         "api-supported-versions": "2021-03-07, 2021-04-05-preview6, 2021-09-07, 2021-10-01-preview7",
-        "Date": "Wed, 30 Mar 2022 21:36:31 GMT",
-        "MS-CV": "GP67jz2CpUS4j42N1BYGSQ.0",
+        "Connection": "keep-alive",
+        "Date": "Mon, 02 May 2022 22:48:40 GMT",
+        "MS-CV": "lSGaykxntUeHPScRhFJ90g.0",
         "Strict-Transport-Security": "max-age=2592000",
-        "X-Azure-Ref": "0X81EYgAAAACunXP/89TtS7DPPQflMHpmUERYMzFFREdFMDIxMgBjYzkyNzU4ZC0wNWY3LTRhZDYtYWE1ZS0wZmE5NzE4ZDg5ODU=",
+        "x-azure-ref": "20220502T224839Z-1kdy40ce594zxd7ayzepxvrcq0000000052000000002q5q0",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "389ms"
+        "X-Processing-Time": "125ms"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://endpoint/chat/threads/19%3ACVY6cS046Q76bICKk00-dR7_y5RHQo3_3ONhDTEIrk41%40thread.v2?api-version=2021-09-07",
+      "RequestUri": "https://endpoint/chat/threads/19%3A1LP8h-5WKvPuwtMH3edl4AihPeEZu3VWYitvgn-9uDw1%40thread.v2?api-version=2021-09-07",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-azure-communication-chat/1.2.0 core-rest-pipeline/1.8.0 Node/v16.14.2 OS/(arm64-Darwin-21.4.0)",
-        "x-ms-client-request-id": "c4386e81-4fe7-4b07-8842-567a11d1849c"
+        "User-Agent": "azsdk-js-communication-chat/1.2.0 core-rest-pipeline/1.8.1 Node/v14.15.4 OS/(x64-Windows_NT-10.0.22000)",
+        "x-ms-client-request-id": "e2cebee4-0707-4d28-9385-56e24ee016c2"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "api-supported-versions": "2021-03-07, 2021-04-05-preview6, 2021-09-07, 2021-10-01-preview7",
+        "Connection": "keep-alive",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 30 Mar 2022 21:36:31 GMT",
-        "MS-CV": "Oy3xVm1uhEGtMAVpXBCvzg.0",
+        "Date": "Mon, 02 May 2022 22:48:40 GMT",
+        "MS-CV": "3vneP7qT4UKSCHf\u002BTm6Gpg.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0X81EYgAAAAAwtVN8/\u002BwiSZz9vUz11MEQUERYMzFFREdFMDIxMgBjYzkyNzU4ZC0wNWY3LTRhZDYtYWE1ZS0wZmE5NzE4ZDg5ODU=",
+        "x-azure-ref": "20220502T224840Z-1kdy40ce594zxd7ayzepxvrcq0000000052000000002q5r4",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "256ms"
+        "X-Processing-Time": "87ms"
       },
       "ResponseBody": {
-        "id": "19:CVY6cS046Q76bICKk00-dR7_y5RHQo3_3ONhDTEIrk41@thread.v2",
+        "id": "19:1LP8h-5WKvPuwtMH3edl4AihPeEZu3VWYitvgn-9uDw1@thread.v2",
         "topic": "new topic",
-        "createdOn": "2022-03-30T21:36:30Z",
+        "createdOn": "2022-05-02T22:48:34Z",
         "createdByCommunicationIdentifier": {
-          "rawId": "8:acs:188d4cea-0a9b-4840-8fdc-7a5c71fe9bd0_00000010-7ca3-d956-5896-094822001379",
+          "rawId": "8:acs:b6aada1f-0b1d-47ac-866f-91aae00a1d01_00000011-26d7-aecb-570c-113a0d00b7d6",
           "communicationUser": {
-            "id": "8:acs:188d4cea-0a9b-4840-8fdc-7a5c71fe9bd0_00000010-7ca3-d956-5896-094822001379"
+            "id": "8:acs:b6aada1f-0b1d-47ac-866f-91aae00a1d01_00000011-26d7-aecb-570c-113a0d00b7d6"
           }
         }
       }

--- a/sdk/communication/communication-chat/samples/v1/javascript/package.json
+++ b/sdk/communication/communication-chat/samples/v1/javascript/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@azure/communication-chat": "latest",
     "dotenv": "latest",
-    "@azure/communication-common": "^1.1.0",
+    "@azure/communication-common": "^2.1.0",
     "@azure/communication-identity": "^1.0.0"
   }
 }

--- a/sdk/communication/communication-chat/samples/v1/typescript/package.json
+++ b/sdk/communication/communication-chat/samples/v1/typescript/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "@azure/communication-chat": "latest",
     "dotenv": "latest",
-    "@azure/communication-common": "^1.1.0",
+    "@azure/communication-common": "^2.1.0",
     "@azure/communication-identity": "^1.0.0"
   },
   "devDependencies": {

--- a/sdk/communication/communication-chat/src/chatThreadClient.ts
+++ b/sdk/communication/communication-chat/src/chatThreadClient.ts
@@ -11,9 +11,9 @@ import { PagedAsyncIterableIterator } from "@azure/core-paging";
 import { SpanStatusCode } from "@azure/core-tracing";
 import { createSpan } from "./tracing";
 import {
-  SendReadReceiptRequest,
   AddParticipantsRequest,
   SendMessageRequest,
+  SendReadReceiptRequest,
 } from "./models/requests";
 
 import {
@@ -22,8 +22,8 @@ import {
   ChatMessageReadReceipt,
   ChatParticipant,
   ChatThreadProperties,
-  SendChatMessageResult,
   ListPageSettings,
+  SendChatMessageResult,
 } from "./models/models";
 import {
   mapToAddChatParticipantsRequestRestModel,
@@ -33,20 +33,20 @@ import {
   mapToReadReceiptSdkModel,
 } from "./models/mappers";
 import {
+  AddParticipantsOptions,
   ChatThreadClientOptions,
-  SendMessageOptions,
-  GetMessageOptions,
   DeleteMessageOptions,
+  GetMessageOptions,
+  GetPropertiesOptions,
   ListMessagesOptions,
+  ListParticipantsOptions,
+  ListReadReceiptsOptions,
+  RemoveParticipantOptions,
+  SendMessageOptions,
+  SendReadReceiptOptions,
+  SendTypingNotificationOptions,
   UpdateMessageOptions,
   UpdateTopicOptions,
-  AddParticipantsOptions,
-  ListParticipantsOptions,
-  RemoveParticipantOptions,
-  SendTypingNotificationOptions,
-  SendReadReceiptOptions,
-  ListReadReceiptsOptions,
-  GetPropertiesOptions,
 } from "./models/options";
 import { ChatApiClient } from "./generated/src";
 import { createCommunicationTokenCredentialPolicy } from "./credential/communicationTokenCredentialPolicy";

--- a/sdk/communication/communication-chat/src/credential/communicationTokenCredentialPolicy.ts
+++ b/sdk/communication/communication-chat/src/credential/communicationTokenCredentialPolicy.ts
@@ -3,9 +3,9 @@
 
 import { CommunicationTokenCredential } from "@azure/communication-common";
 import {
-  bearerTokenAuthenticationPolicy,
   BearerTokenAuthenticationPolicyOptions,
   PipelinePolicy,
+  bearerTokenAuthenticationPolicy,
 } from "@azure/core-rest-pipeline";
 
 /**

--- a/sdk/communication/communication-chat/src/models/events.ts
+++ b/sdk/communication/communication-chat/src/models/events.ts
@@ -2,16 +2,16 @@
 // Licensed under the MIT license.
 
 import {
-  ChatMessageReceivedEvent,
-  ChatMessageEditedEvent,
   ChatMessageDeletedEvent,
-  ReadReceiptReceivedEvent,
-  TypingIndicatorReceivedEvent,
+  ChatMessageEditedEvent,
+  ChatMessageReceivedEvent,
   ChatThreadCreatedEvent,
   ChatThreadDeletedEvent,
   ChatThreadPropertiesUpdatedEvent,
   ParticipantsAddedEvent,
   ParticipantsRemovedEvent,
+  ReadReceiptReceivedEvent,
+  TypingIndicatorReceivedEvent,
 } from "@azure/communication-signaling";
 
 type ChatEventId =

--- a/sdk/communication/communication-chat/src/models/mappers.ts
+++ b/sdk/communication/communication-chat/src/models/mappers.ts
@@ -2,19 +2,19 @@
 // Licensed under the MIT license.
 
 import {
+  SerializedCommunicationIdentifier,
   deserializeCommunicationIdentifier,
   serializeCommunicationIdentifier,
-  SerializedCommunicationIdentifier,
 } from "@azure/communication-common";
 import * as RestModel from "../generated/src/models";
 import { AddParticipantsRequest } from "./requests";
 import { CreateChatThreadOptions } from "./options";
 import {
   ChatMessage,
-  ChatThreadProperties,
-  ChatParticipant,
-  ChatMessageReadReceipt,
   ChatMessageContent,
+  ChatMessageReadReceipt,
+  ChatParticipant,
+  ChatThreadProperties,
   CreateChatThreadResult,
 } from "./models";
 

--- a/sdk/communication/communication-chat/src/models/models.ts
+++ b/sdk/communication/communication-chat/src/models/models.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 
 import { CommunicationIdentifier, CommunicationIdentifierKind } from "@azure/communication-common";
-import { ChatMessageType, ChatError } from "../generated/src";
+import { ChatError, ChatMessageType } from "../generated/src";
 
 export {
   AddChatParticipantsResult,

--- a/sdk/communication/communication-chat/src/models/options.ts
+++ b/sdk/communication/communication-chat/src/models/options.ts
@@ -2,11 +2,11 @@
 // Licensed under the MIT license.
 import { CommonClientOptions, OperationOptions } from "@azure/core-client";
 import {
-  ChatThreadListChatMessagesOptionalParams as RestListMessagesOptions,
-  ChatListChatThreadsOptionalParams as RestListChatThreadsOptions,
-  ChatThreadListChatReadReceiptsOptionalParams as RestListReadReceiptsOptions,
-  ChatThreadListChatParticipantsOptionalParams as RestListParticipantsOptions,
   ChatMessageType,
+  ChatListChatThreadsOptionalParams as RestListChatThreadsOptions,
+  ChatThreadListChatMessagesOptionalParams as RestListMessagesOptions,
+  ChatThreadListChatParticipantsOptionalParams as RestListParticipantsOptions,
+  ChatThreadListChatReadReceiptsOptionalParams as RestListReadReceiptsOptions,
 } from "../generated/src/models";
 import { ChatParticipant } from "./models";
 

--- a/sdk/communication/communication-chat/test/internal/chatClient.mocked.spec.ts
+++ b/sdk/communication/communication-chat/test/internal/chatClient.mocked.spec.ts
@@ -12,11 +12,11 @@ import {
   CommunicationUserIdentifier,
 } from "@azure/communication-common";
 import {
-  mockThread,
-  generateHttpClient,
   createChatClient,
-  mockThreadItem,
+  generateHttpClient,
   mockCreateThreadResult,
+  mockThread,
+  mockThreadItem,
 } from "./utils/mockClient";
 
 const API_VERSION = apiVersion.mapper.defaultValue;

--- a/sdk/communication/communication-chat/test/internal/chatThreadClient.mocked.spec.ts
+++ b/sdk/communication/communication-chat/test/internal/chatThreadClient.mocked.spec.ts
@@ -8,22 +8,22 @@ import {
   CommunicationUserIdentifier,
 } from "@azure/communication-common";
 import {
-  ChatThreadClient,
-  SendMessageRequest,
-  SendMessageOptions,
-  UpdateMessageOptions,
   AddParticipantsRequest,
+  ChatThreadClient,
+  SendMessageOptions,
+  SendMessageRequest,
+  UpdateMessageOptions,
 } from "../../src";
 import * as RestModel from "../../src/generated/src/models";
 import { apiVersion } from "../../src/generated/src/models/parameters";
 import { baseUri, generateToken } from "../public/utils/connectionUtils";
 import {
-  generateHttpClient,
   createChatThreadClient,
+  generateHttpClient,
+  mockChatMessageReadReceipt,
   mockMessage,
   mockParticipant,
   mockSdkModelParticipant,
-  mockChatMessageReadReceipt,
   mockThread,
 } from "./utils/mockClient";
 

--- a/sdk/communication/communication-chat/test/internal/utils/mockClient.ts
+++ b/sdk/communication/communication-chat/test/internal/utils/mockClient.ts
@@ -3,10 +3,10 @@
 
 import { AzureCommunicationTokenCredential } from "@azure/communication-common";
 import {
-  createHttpHeaders,
   HttpClient,
   PipelineRequest,
   PipelineResponse,
+  createHttpHeaders,
 } from "@azure/core-rest-pipeline";
 import * as RestModel from "../../../src/generated/src/models";
 import { ChatClient, ChatParticipant, ChatThreadClient } from "../../../src";
@@ -15,6 +15,7 @@ import { baseUri, generateToken } from "../../public/utils/connectionUtils";
 
 export const mockCommunicationIdentifier: CommunicationIdentifierModel = {
   communicationUser: { id: "id" },
+  rawId: "id",
 };
 
 export const mockParticipant: RestModel.ChatParticipant = {

--- a/sdk/communication/communication-chat/test/public/chatClient.spec.ts
+++ b/sdk/communication/communication-chat/test/public/chatClient.spec.ts
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { isLiveMode, Recorder } from "@azure-tools/test-recorder";
+import { Recorder, isLiveMode } from "@azure-tools/test-recorder";
 import { assert } from "chai";
 import { ChatClient, ChatThreadClient } from "../../src";
-import { createTestUser, createRecorder, createChatClient } from "./utils/recordedClient";
+import { createChatClient, createRecorder, createTestUser } from "./utils/recordedClient";
 import { isNode } from "@azure/core-util";
 import sinon from "sinon";
 import { CommunicationIdentifier } from "@azure/communication-common";

--- a/sdk/communication/communication-chat/test/public/chatThreadClient.spec.ts
+++ b/sdk/communication/communication-chat/test/public/chatThreadClient.spec.ts
@@ -4,8 +4,8 @@
 
 import { Recorder } from "@azure-tools/test-recorder";
 import { assert } from "chai";
-import { ChatClient, ChatThreadClient, ChatMessage } from "../../src";
-import { createTestUser, createRecorder, createChatClient } from "./utils/recordedClient";
+import { ChatClient, ChatMessage, ChatThreadClient } from "../../src";
+import { createChatClient, createRecorder, createTestUser } from "./utils/recordedClient";
 import { CommunicationIdentifier, getIdentifierKind } from "@azure/communication-common";
 import { Context } from "mocha";
 import { CommunicationUserToken } from "@azure/communication-identity";

--- a/sdk/communication/communication-chat/test/public/utils/recordedClient.ts
+++ b/sdk/communication/communication-chat/test/public/utils/recordedClient.ts
@@ -4,15 +4,15 @@
 import { Test } from "mocha";
 
 import {
-  assertEnvironmentVariable,
-  env,
   Recorder,
   RecorderStartOptions,
+  assertEnvironmentVariable,
+  env,
 } from "@azure-tools/test-recorder";
 import { ChatClient } from "../../../src";
 import {
-  CommunicationUserIdentifier,
   AzureCommunicationTokenCredential,
+  CommunicationUserIdentifier,
   parseClientArguments,
 } from "@azure/communication-common";
 import { CommunicationIdentityClient, CommunicationUserToken } from "@azure/communication-identity";

--- a/sdk/communication/communication-common/CHANGELOG.md
+++ b/sdk/communication/communication-common/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ### Features Added
 
-- Added `getRawId` and `createIdentifierFromRawId` to translate between a `CommunicationIdentifier` and its underlying canonical rawId representation. Developers can now use the rawId as an encoded format for identifiers to store in their databases or as stable keys in general.
+- Added `getIdentifierRawId` and `createIdentifierFromRawId` to translate between a `CommunicationIdentifier` and its underlying canonical rawId representation. Developers can now use the rawId as an encoded format for identifiers to store in their databases or as stable keys in general.
+- Always include `rawId` when serializing identifiers to wire format.
 
 ## 2.0.0 (2022-03-08)
 

--- a/sdk/communication/communication-common/CHANGELOG.md
+++ b/sdk/communication/communication-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 2.1.0 (Unreleased)
+
+### Features Added
+
+- Added `getRawId` and `createIdentifierFromRawId` to translate between a `CommunicationIdentifier` and its underlying canonical rawId representation. Developers can now use the rawId as an encoded format for identifiers to store in their databases or as stable keys in general.
+
 ## 2.0.0 (2022-03-08)
 
 ### Features Added

--- a/sdk/communication/communication-common/package.json
+++ b/sdk/communication/communication-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/communication-common",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Common package for Azure Communication services.",
   "sdk-type": "client",
   "main": "dist/index.js",

--- a/sdk/communication/communication-common/review/communication-common.api.md
+++ b/sdk/communication/communication-common/review/communication-common.api.md
@@ -59,6 +59,9 @@ export function createCommunicationAccessKeyCredentialPolicy(credential: KeyCred
 export function createCommunicationAuthPolicy(credential: KeyCredential | TokenCredential): PipelinePolicy;
 
 // @public
+export const createIdentifierFromRawId: (rawId: string) => CommunicationIdentifierKind;
+
+// @public
 export const deserializeCommunicationIdentifier: (serializedIdentifier: SerializedCommunicationIdentifier) => CommunicationIdentifierKind;
 
 // @public
@@ -69,6 +72,9 @@ export interface EndpointCredential {
 
 // @public
 export const getIdentifierKind: (identifier: CommunicationIdentifier) => CommunicationIdentifierKind;
+
+// @public
+export const getRawId: (identifier: CommunicationIdentifier) => string;
 
 // @public
 export const isCommunicationUserIdentifier: (identifier: CommunicationIdentifier) => identifier is CommunicationUserIdentifier;

--- a/sdk/communication/communication-common/review/communication-common.api.md
+++ b/sdk/communication/communication-common/review/communication-common.api.md
@@ -74,7 +74,7 @@ export interface EndpointCredential {
 export const getIdentifierKind: (identifier: CommunicationIdentifier) => CommunicationIdentifierKind;
 
 // @public
-export const getRawId: (identifier: CommunicationIdentifier) => string;
+export const getIdentifierRawId: (identifier: CommunicationIdentifier) => string;
 
 // @public
 export const isCommunicationUserIdentifier: (identifier: CommunicationIdentifier) => identifier is CommunicationUserIdentifier;

--- a/sdk/communication/communication-common/src/identifierModelSerializer.ts
+++ b/sdk/communication/communication-common/src/identifierModelSerializer.ts
@@ -5,6 +5,7 @@ import {
   CommunicationIdentifier,
   CommunicationIdentifierKind,
   getIdentifierKind,
+  getRawId,
 } from "./identifierModels";
 
 /**
@@ -77,13 +78,6 @@ export interface SerializedMicrosoftTeamsUserIdentifier {
  */
 export type SerializedCommunicationCloudEnvironment = "public" | "dod" | "gcch";
 
-const addRawIdIfExisting = <T>(
-  identifier: T,
-  rawId: string | undefined
-): T & { rawId?: string } => {
-  return rawId === undefined ? identifier : { ...identifier, rawId: rawId };
-};
-
 const assertNotNullOrUndefined = <
   T extends Record<string, unknown>,
   P extends keyof T,
@@ -119,23 +113,26 @@ export const serializeCommunicationIdentifier = (
   const identifierKind = getIdentifierKind(identifier);
   switch (identifierKind.kind) {
     case "communicationUser":
-      return { communicationUser: { id: identifierKind.communicationUserId } };
+      return {
+        rawId: getRawId(identifierKind),
+        communicationUser: { id: identifierKind.communicationUserId },
+      };
     case "phoneNumber":
-      return addRawIdIfExisting(
-        { phoneNumber: { value: identifierKind.phoneNumber } },
-        identifierKind.rawId
-      );
-    case "microsoftTeamsUser":
-      return addRawIdIfExisting(
-        {
-          microsoftTeamsUser: {
-            userId: identifierKind.microsoftTeamsUserId,
-            isAnonymous: identifierKind.isAnonymous ?? false,
-            cloud: identifierKind.cloud ?? "public",
-          },
+      return {
+        rawId: identifierKind.rawId ?? getRawId(identifierKind),
+        phoneNumber: {
+          value: identifierKind.phoneNumber,
         },
-        identifierKind.rawId
-      );
+      };
+    case "microsoftTeamsUser":
+      return {
+        rawId: identifierKind.rawId ?? getRawId(identifierKind),
+        microsoftTeamsUser: {
+          userId: identifierKind.microsoftTeamsUserId,
+          isAnonymous: identifierKind.isAnonymous ?? false,
+          cloud: identifierKind.cloud ?? "public",
+        },
+      };
     case "unknown":
       return { rawId: identifierKind.id };
     default:

--- a/sdk/communication/communication-common/src/identifierModelSerializer.ts
+++ b/sdk/communication/communication-common/src/identifierModelSerializer.ts
@@ -5,7 +5,7 @@ import {
   CommunicationIdentifier,
   CommunicationIdentifierKind,
   getIdentifierKind,
-  getRawId,
+  getIdentifierRawId,
 } from "./identifierModels";
 
 /**
@@ -114,19 +114,19 @@ export const serializeCommunicationIdentifier = (
   switch (identifierKind.kind) {
     case "communicationUser":
       return {
-        rawId: getRawId(identifierKind),
+        rawId: getIdentifierRawId(identifierKind),
         communicationUser: { id: identifierKind.communicationUserId },
       };
     case "phoneNumber":
       return {
-        rawId: identifierKind.rawId ?? getRawId(identifierKind),
+        rawId: identifierKind.rawId ?? getIdentifierRawId(identifierKind),
         phoneNumber: {
           value: identifierKind.phoneNumber,
         },
       };
     case "microsoftTeamsUser":
       return {
-        rawId: identifierKind.rawId ?? getRawId(identifierKind),
+        rawId: identifierKind.rawId ?? getIdentifierRawId(identifierKind),
         microsoftTeamsUser: {
           userId: identifierKind.microsoftTeamsUserId,
           isAnonymous: identifierKind.isAnonymous ?? false,

--- a/sdk/communication/communication-common/src/identifierModels.ts
+++ b/sdk/communication/communication-common/src/identifierModels.ts
@@ -181,3 +181,89 @@ export const getIdentifierKind = (
   }
   return { ...identifier, kind: "unknown" };
 };
+
+/**
+ * Returns the rawId for a given CommunicationIdentifier. You can use the rawId for encoding the identifier and then use it as a key in a database.
+ *
+ * @param identifier - The identifier to be translated to its rawId.
+ */
+export const getRawId = (identifier: CommunicationIdentifier): string => {
+  const identifierKind = getIdentifierKind(identifier);
+  switch (identifierKind.kind) {
+    case "communicationUser":
+      return identifierKind.communicationUserId;
+    case "microsoftTeamsUser": {
+      const { microsoftTeamsUserId, rawId, cloud, isAnonymous } = identifierKind;
+      if (rawId) return rawId;
+      if (isAnonymous) return `8:teamsvisitor:${microsoftTeamsUserId}`;
+      switch (cloud) {
+        case "dod":
+          return `8:dod:${microsoftTeamsUserId}`;
+        case "gcch":
+          return `8:gcch:${microsoftTeamsUserId}`;
+        case "public":
+          return `8:orgid:${microsoftTeamsUserId}`;
+      }
+      return `8:orgid:${microsoftTeamsUserId}`;
+    }
+    case "phoneNumber": {
+      const { phoneNumber, rawId } = identifierKind;
+      if (rawId) return rawId;
+      // strip the leading +. We just assume correct E.164 format here because validation should only happen server-side, not client-side.
+      return `4:${phoneNumber.replace(/^\+/, "")}`;
+    }
+    case "unknown": {
+      return identifierKind.id;
+    }
+  }
+};
+
+/**
+ * Creates a CommunicationIdentifierKind from a given rawId. When storing rawIds use this function to restore the identifier that was encoded in the rawId.
+ *
+ * @param rawId - The rawId to be translated to its identifier representation.
+ */
+export const createIdentifierFromRawId = (rawId: string): CommunicationIdentifierKind => {
+  if (rawId.startsWith("4:")) return { kind: "phoneNumber", phoneNumber: `+${rawId.substring(2)}` };
+
+  const segments = rawId.split(":");
+  if (segments.length < 3) return { kind: "unknown", id: rawId };
+
+  const prefix = `${segments[0]}:${segments[1]}:`;
+  const suffix = rawId.substring(prefix.length);
+
+  switch (prefix) {
+    case "8:teamsvisitor:":
+      return { kind: "microsoftTeamsUser", microsoftTeamsUserId: suffix, isAnonymous: true };
+    case "8:orgid:":
+      return {
+        kind: "microsoftTeamsUser",
+        microsoftTeamsUserId: suffix,
+        isAnonymous: false,
+        cloud: "public",
+      };
+    case "8:dod:":
+      return {
+        kind: "microsoftTeamsUser",
+        microsoftTeamsUserId: suffix,
+        isAnonymous: false,
+        cloud: "dod",
+      };
+    case "8:gcch:":
+      return {
+        kind: "microsoftTeamsUser",
+        microsoftTeamsUserId: suffix,
+        isAnonymous: false,
+        cloud: "gcch",
+      };
+    case "8:acs:":
+      return { kind: "communicationUser", communicationUserId: rawId };
+    case "8:spool:":
+      return { kind: "communicationUser", communicationUserId: rawId };
+    case "8:dod-acs:":
+      return { kind: "communicationUser", communicationUserId: rawId };
+    case "8:gcch-acs:":
+      return { kind: "communicationUser", communicationUserId: rawId };
+  }
+  return { kind: "unknown", id: rawId };
+};

--- a/sdk/communication/communication-common/src/identifierModels.ts
+++ b/sdk/communication/communication-common/src/identifierModels.ts
@@ -187,7 +187,7 @@ export const getIdentifierKind = (
  *
  * @param identifier - The identifier to be translated to its rawId.
  */
-export const getRawId = (identifier: CommunicationIdentifier): string => {
+export const getIdentifierRawId = (identifier: CommunicationIdentifier): string => {
   const identifierKind = getIdentifierKind(identifier);
   switch (identifierKind.kind) {
     case "communicationUser":
@@ -224,7 +224,8 @@ export const getRawId = (identifier: CommunicationIdentifier): string => {
  * @param rawId - The rawId to be translated to its identifier representation.
  */
 export const createIdentifierFromRawId = (rawId: string): CommunicationIdentifierKind => {
-  if (rawId.startsWith("4:")) return { kind: "phoneNumber", phoneNumber: `+${rawId.substring(2)}` };
+  if (rawId.startsWith("4:"))
+    {return { kind: "phoneNumber", phoneNumber: `+${rawId.substring("4:".length)}` };}
 
   const segments = rawId.split(":");
   if (segments.length < 3) return { kind: "unknown", id: rawId };
@@ -257,11 +258,8 @@ export const createIdentifierFromRawId = (rawId: string): CommunicationIdentifie
         cloud: "gcch",
       };
     case "8:acs:":
-      return { kind: "communicationUser", communicationUserId: rawId };
     case "8:spool:":
-      return { kind: "communicationUser", communicationUserId: rawId };
     case "8:dod-acs:":
-      return { kind: "communicationUser", communicationUserId: rawId };
     case "8:gcch-acs:":
       return { kind: "communicationUser", communicationUserId: rawId };
   }

--- a/sdk/communication/communication-common/src/identifierModels.ts
+++ b/sdk/communication/communication-common/src/identifierModels.ts
@@ -224,8 +224,9 @@ export const getIdentifierRawId = (identifier: CommunicationIdentifier): string 
  * @param rawId - The rawId to be translated to its identifier representation.
  */
 export const createIdentifierFromRawId = (rawId: string): CommunicationIdentifierKind => {
-  if (rawId.startsWith("4:"))
-    {return { kind: "phoneNumber", phoneNumber: `+${rawId.substring("4:".length)}` };}
+  if (rawId.startsWith("4:")) {
+    return { kind: "phoneNumber", phoneNumber: `+${rawId.substring("4:".length)}` };
+  }
 
   const segments = rawId.split(":");
   if (segments.length < 3) return { kind: "unknown", id: rawId };

--- a/sdk/communication/communication-common/test/identifierModelSerializer.spec.ts
+++ b/sdk/communication/communication-common/test/identifierModelSerializer.spec.ts
@@ -54,15 +54,16 @@ describe("Identifier model serializer", () => {
           "8:acs:37691ec4-57fb-4c0f-ae31-32791610cb14_37691ec4-57fb-4c0f-ae31-32791610cb14",
       },
       {
+        rawId: "8:acs:37691ec4-57fb-4c0f-ae31-32791610cb14_37691ec4-57fb-4c0f-ae31-32791610cb14",
         communicationUser: {
           id: "8:acs:37691ec4-57fb-4c0f-ae31-32791610cb14_37691ec4-57fb-4c0f-ae31-32791610cb14",
         },
       }
     );
-    assertSerialize({ phoneNumber: "+1234555000" }, { phoneNumber: { value: "+1234555000" } });
     assertSerialize(
       { microsoftTeamsUserId: "37691ec4-57fb-4c0f-ae31-32791610cb14" },
       {
+        rawId: "8:orgid:37691ec4-57fb-4c0f-ae31-32791610cb14",
         microsoftTeamsUser: {
           userId: "37691ec4-57fb-4c0f-ae31-32791610cb14",
           isAnonymous: false,
@@ -73,6 +74,7 @@ describe("Identifier model serializer", () => {
     assertSerialize(
       { microsoftTeamsUserId: "37691ec4-57fb-4c0f-ae31-32791610cb14", isAnonymous: false },
       {
+        rawId: "8:orgid:37691ec4-57fb-4c0f-ae31-32791610cb14",
         microsoftTeamsUser: {
           userId: "37691ec4-57fb-4c0f-ae31-32791610cb14",
           isAnonymous: false,
@@ -83,6 +85,7 @@ describe("Identifier model serializer", () => {
     assertSerialize(
       { microsoftTeamsUserId: "37691ec4-57fb-4c0f-ae31-32791610cb14", isAnonymous: true },
       {
+        rawId: "8:teamsvisitor:37691ec4-57fb-4c0f-ae31-32791610cb14",
         microsoftTeamsUser: {
           userId: "37691ec4-57fb-4c0f-ae31-32791610cb14",
           isAnonymous: true,
@@ -91,16 +94,45 @@ describe("Identifier model serializer", () => {
       }
     );
     assertSerialize(
+      { microsoftTeamsUserId: "37691ec4-57fb-4c0f-ae31-32791610cb14", rawId: "override" },
+      {
+        rawId: "override",
+        microsoftTeamsUser: {
+          userId: "37691ec4-57fb-4c0f-ae31-32791610cb14",
+          isAnonymous: false,
+          cloud: "public",
+        },
+      }
+    );
+    assertSerialize(
       {
         microsoftTeamsUserId: "37691ec4-57fb-4c0f-ae31-32791610cb14",
-        isAnonymous: true,
         cloud: "dod",
       },
       {
+        rawId: "8:dod:37691ec4-57fb-4c0f-ae31-32791610cb14",
         microsoftTeamsUser: {
           userId: "37691ec4-57fb-4c0f-ae31-32791610cb14",
-          isAnonymous: true,
+          isAnonymous: false,
           cloud: "dod",
+        },
+      }
+    );
+    assertSerialize(
+      { phoneNumber: "+12345556789" },
+      {
+        rawId: "4:12345556789",
+        phoneNumber: {
+          value: "+12345556789",
+        },
+      }
+    );
+    assertSerialize(
+      { phoneNumber: "+12345556789", rawId: "override" },
+      {
+        rawId: "override",
+        phoneNumber: {
+          value: "+12345556789",
         },
       }
     );

--- a/sdk/communication/communication-common/test/identifierModels.spec.ts
+++ b/sdk/communication/communication-common/test/identifierModels.spec.ts
@@ -2,16 +2,16 @@
 // Licensed under the MIT license.
 
 import {
+  CommunicationIdentifier,
+  CommunicationIdentifierKind,
   PhoneNumberIdentifier,
+  createIdentifierFromRawId,
   getIdentifierKind,
+  getIdentifierRawId,
   isCommunicationUserIdentifier,
   isMicrosoftTeamsUserIdentifier,
   isPhoneNumberIdentifier,
   isUnknownIdentifier,
-  getRawId,
-  CommunicationIdentifier,
-  CommunicationIdentifierKind,
-  createIdentifierFromRawId,
 } from "../src";
 import { assert } from "chai";
 
@@ -36,7 +36,7 @@ describe("Identifier models", () => {
 
   it("get raw id of identifier", () => {
     const assertRawId = (identifier: CommunicationIdentifier, expectedRawId: string) =>
-      assert.strictEqual(getRawId(identifier), expectedRawId);
+      assert.strictEqual(getIdentifierRawId(identifier), expectedRawId);
 
     assertRawId(
       {
@@ -222,7 +222,7 @@ describe("Identifier models", () => {
 
   it("rawId stays the same after conversion to identifier and back", () => {
     const assertRoundtrip = (rawId: string) =>
-      assert.strictEqual(getRawId(createIdentifierFromRawId(rawId)), rawId);
+      assert.strictEqual(getIdentifierRawId(createIdentifierFromRawId(rawId)), rawId);
 
     assertRoundtrip(
       "8:acs:bbbcbc1e-9f06-482a-b5d8-20e3f26ef0cd_45ab2481-1c1c-4005-be24-0ffb879b1130"

--- a/sdk/communication/communication-common/test/identifierModels.spec.ts
+++ b/sdk/communication/communication-common/test/identifierModels.spec.ts
@@ -8,6 +8,10 @@ import {
   isMicrosoftTeamsUserIdentifier,
   isPhoneNumberIdentifier,
   isUnknownIdentifier,
+  getRawId,
+  CommunicationIdentifier,
+  CommunicationIdentifierKind,
+  createIdentifierFromRawId,
 } from "../src";
 import { assert } from "chai";
 
@@ -28,5 +32,219 @@ describe("Identifier models", () => {
       (identifierKind as PhoneNumberIdentifier).phoneNumber,
       phoneNumber.phoneNumber
     );
+  });
+
+  it("get raw id of identifier", () => {
+    const assertRawId = (identifier: CommunicationIdentifier, expectedRawId: string) =>
+      assert.strictEqual(getRawId(identifier), expectedRawId);
+
+    assertRawId(
+      {
+        communicationUserId:
+          "8:acs:bbbcbc1e-9f06-482a-b5d8-20e3f26ef0cd_45ab2481-1c1c-4005-be24-0ffb879b1130",
+      },
+      "8:acs:bbbcbc1e-9f06-482a-b5d8-20e3f26ef0cd_45ab2481-1c1c-4005-be24-0ffb879b1130"
+    );
+    assertRawId(
+      {
+        communicationUserId:
+          "8:gcch-acs:bbbcbc1e-9f06-482a-b5d8-20e3f26ef0cd_45ab2481-1c1c-4005-be24-0ffb879b1130",
+      },
+      "8:gcch-acs:bbbcbc1e-9f06-482a-b5d8-20e3f26ef0cd_45ab2481-1c1c-4005-be24-0ffb879b1130"
+    );
+    assertRawId(
+      {
+        communicationUserId: "someFutureFormat",
+      },
+      "someFutureFormat"
+    );
+    assertRawId(
+      { microsoftTeamsUserId: "45ab2481-1c1c-4005-be24-0ffb879b1130" },
+      "8:orgid:45ab2481-1c1c-4005-be24-0ffb879b1130"
+    );
+    assertRawId(
+      {
+        microsoftTeamsUserId: "45ab2481-1c1c-4005-be24-0ffb879b1130",
+        cloud: "public",
+      },
+      "8:orgid:45ab2481-1c1c-4005-be24-0ffb879b1130"
+    );
+    assertRawId(
+      {
+        microsoftTeamsUserId: "45ab2481-1c1c-4005-be24-0ffb879b1130",
+        cloud: "dod",
+      },
+      "8:dod:45ab2481-1c1c-4005-be24-0ffb879b1130"
+    );
+    assertRawId(
+      {
+        microsoftTeamsUserId: "45ab2481-1c1c-4005-be24-0ffb879b1130",
+        cloud: "gcch",
+      },
+      "8:gcch:45ab2481-1c1c-4005-be24-0ffb879b1130"
+    );
+    assertRawId(
+      {
+        microsoftTeamsUserId: "45ab2481-1c1c-4005-be24-0ffb879b1130",
+        isAnonymous: false,
+      },
+      "8:orgid:45ab2481-1c1c-4005-be24-0ffb879b1130"
+    );
+    assertRawId(
+      {
+        microsoftTeamsUserId: "45ab2481-1c1c-4005-be24-0ffb879b1130",
+        isAnonymous: true,
+      },
+      "8:teamsvisitor:45ab2481-1c1c-4005-be24-0ffb879b1130"
+    );
+    assertRawId(
+      {
+        microsoftTeamsUserId: "45ab2481-1c1c-4005-be24-0ffb879b1130",
+        rawId: "8:orgid:legacyFormat",
+      },
+      "8:orgid:legacyFormat"
+    );
+    assertRawId(
+      {
+        phoneNumber: "+112345556789",
+      },
+      "4:112345556789"
+    );
+    assertRawId(
+      {
+        phoneNumber: "+112345556789",
+        rawId: "4:otherFormat",
+      },
+      "4:otherFormat"
+    );
+    assertRawId(
+      {
+        id: "28:45ab2481-1c1c-4005-be24-0ffb879b1130",
+      },
+      "28:45ab2481-1c1c-4005-be24-0ffb879b1130"
+    );
+    assertRawId(
+      {
+        foo: "nonsense",
+      } as any,
+      undefined as unknown as string
+    );
+  });
+
+  it("create identifier from raw id", () => {
+    const assertIdentifier = (rawId: string, expectedIdentifier: CommunicationIdentifierKind) =>
+      assert.deepStrictEqual(createIdentifierFromRawId(rawId), expectedIdentifier);
+
+    assertIdentifier(
+      "8:acs:bbbcbc1e-9f06-482a-b5d8-20e3f26ef0cd_45ab2481-1c1c-4005-be24-0ffb879b1130",
+      {
+        communicationUserId:
+          "8:acs:bbbcbc1e-9f06-482a-b5d8-20e3f26ef0cd_45ab2481-1c1c-4005-be24-0ffb879b1130",
+        kind: "communicationUser",
+      }
+    );
+    assertIdentifier(
+      "8:spool:bbbcbc1e-9f06-482a-b5d8-20e3f26ef0cd_45ab2481-1c1c-4005-be24-0ffb879b1130",
+      {
+        communicationUserId:
+          "8:spool:bbbcbc1e-9f06-482a-b5d8-20e3f26ef0cd_45ab2481-1c1c-4005-be24-0ffb879b1130",
+        kind: "communicationUser",
+      }
+    );
+    assertIdentifier(
+      "8:dod-acs:bbbcbc1e-9f06-482a-b5d8-20e3f26ef0cd_45ab2481-1c1c-4005-be24-0ffb879b1130",
+      {
+        communicationUserId:
+          "8:dod-acs:bbbcbc1e-9f06-482a-b5d8-20e3f26ef0cd_45ab2481-1c1c-4005-be24-0ffb879b1130",
+        kind: "communicationUser",
+      }
+    );
+    assertIdentifier(
+      "8:gcch-acs:bbbcbc1e-9f06-482a-b5d8-20e3f26ef0cd_45ab2481-1c1c-4005-be24-0ffb879b1130",
+      {
+        communicationUserId:
+          "8:gcch-acs:bbbcbc1e-9f06-482a-b5d8-20e3f26ef0cd_45ab2481-1c1c-4005-be24-0ffb879b1130",
+        kind: "communicationUser",
+      }
+    );
+    assertIdentifier("8:acs:something", {
+      communicationUserId: "8:acs:something",
+      kind: "communicationUser",
+    });
+    assertIdentifier("8:orgid:45ab2481-1c1c-4005-be24-0ffb879b1130", {
+      microsoftTeamsUserId: "45ab2481-1c1c-4005-be24-0ffb879b1130",
+      cloud: "public",
+      isAnonymous: false,
+      kind: "microsoftTeamsUser",
+    });
+    assertIdentifier("8:dod:45ab2481-1c1c-4005-be24-0ffb879b1130", {
+      microsoftTeamsUserId: "45ab2481-1c1c-4005-be24-0ffb879b1130",
+      cloud: "dod",
+      isAnonymous: false,
+      kind: "microsoftTeamsUser",
+    });
+    assertIdentifier("8:gcch:45ab2481-1c1c-4005-be24-0ffb879b1130", {
+      microsoftTeamsUserId: "45ab2481-1c1c-4005-be24-0ffb879b1130",
+      cloud: "gcch",
+      isAnonymous: false,
+      kind: "microsoftTeamsUser",
+    });
+    assertIdentifier("8:teamsvisitor:45ab2481-1c1c-4005-be24-0ffb879b1130", {
+      microsoftTeamsUserId: "45ab2481-1c1c-4005-be24-0ffb879b1130",
+      isAnonymous: true,
+      kind: "microsoftTeamsUser",
+    });
+    assertIdentifier("8:orgid:legacyFormat", {
+      microsoftTeamsUserId: "legacyFormat",
+      cloud: "public",
+      isAnonymous: false,
+      kind: "microsoftTeamsUser",
+    });
+    assertIdentifier("4:112345556789", {
+      phoneNumber: "+112345556789",
+      kind: "phoneNumber",
+    });
+    assertIdentifier("4:otherFormat", {
+      phoneNumber: "+otherFormat",
+      kind: "phoneNumber",
+    });
+    assertIdentifier("28:45ab2481-1c1c-4005-be24-0ffb879b1130", {
+      id: "28:45ab2481-1c1c-4005-be24-0ffb879b1130",
+      kind: "unknown",
+    });
+    assertIdentifier("", {
+      id: "",
+      kind: "unknown",
+    });
+    assert.throws(() => createIdentifierFromRawId(undefined as unknown as string));
+    assert.throws(() => createIdentifierFromRawId(null as unknown as string));
+  });
+
+  it("rawId stays the same after conversion to identifier and back", () => {
+    const assertRoundtrip = (rawId: string) =>
+      assert.strictEqual(getRawId(createIdentifierFromRawId(rawId)), rawId);
+
+    assertRoundtrip(
+      "8:acs:bbbcbc1e-9f06-482a-b5d8-20e3f26ef0cd_45ab2481-1c1c-4005-be24-0ffb879b1130"
+    );
+    assertRoundtrip(
+      "8:spool:bbbcbc1e-9f06-482a-b5d8-20e3f26ef0cd_45ab2481-1c1c-4005-be24-0ffb879b1130"
+    );
+    assertRoundtrip(
+      "8:dod-acs:bbbcbc1e-9f06-482a-b5d8-20e3f26ef0cd_45ab2481-1c1c-4005-be24-0ffb879b1130"
+    );
+    assertRoundtrip(
+      "8:gcch-acs:bbbcbc1e-9f06-482a-b5d8-20e3f26ef0cd_45ab2481-1c1c-4005-be24-0ffb879b1130"
+    );
+    assertRoundtrip("8:acs:something");
+    assertRoundtrip("8:orgid:45ab2481-1c1c-4005-be24-0ffb879b1130");
+    assertRoundtrip("8:dod:45ab2481-1c1c-4005-be24-0ffb879b1130");
+    assertRoundtrip("8:gcch:45ab2481-1c1c-4005-be24-0ffb879b1130");
+    assertRoundtrip("8:teamsvisitor:45ab2481-1c1c-4005-be24-0ffb879b1130");
+    assertRoundtrip("8:orgid:legacyFormat");
+    assertRoundtrip("4:112345556789");
+    assertRoundtrip("4:otherFormat");
+    assertRoundtrip("28:45ab2481-1c1c-4005-be24-0ffb879b1130");
+    assertRoundtrip("");
   });
 });

--- a/sdk/communication/communication-identity/package.json
+++ b/sdk/communication/communication-identity/package.json
@@ -88,7 +88,7 @@
   "prettier": "@azure/eslint-plugin-azure-sdk/prettier.json",
   "dependencies": {
     "@azure/abort-controller": "^1.0.0",
-    "@azure/communication-common": "^2.0.0",
+    "@azure/communication-common": "^2.1.0",
     "@azure/core-auth": "^1.3.0",
     "@azure/core-client": "^1.3.0",
     "@azure/core-rest-pipeline": "^1.3.0",

--- a/sdk/communication/communication-network-traversal/package.json
+++ b/sdk/communication/communication-network-traversal/package.json
@@ -88,7 +88,7 @@
   "prettier": "@azure/eslint-plugin-azure-sdk/prettier.json",
   "dependencies": {
     "@azure/abort-controller": "^1.0.0",
-    "@azure/communication-common": "^2.0.0",
+    "@azure/communication-common": "^2.1.0",
     "@azure/core-auth": "^1.3.0",
     "@azure/core-client": "^1.3.0",
     "@azure/core-rest-pipeline": "^1.3.0",

--- a/sdk/communication/communication-phone-numbers/package.json
+++ b/sdk/communication/communication-phone-numbers/package.json
@@ -60,7 +60,7 @@
   "sideEffects": false,
   "prettier": "@azure/eslint-plugin-azure-sdk/prettier.json",
   "dependencies": {
-    "@azure/communication-common": "^2.0.0",
+    "@azure/communication-common": "^2.1.0",
     "@azure/abort-controller": "^1.0.0",
     "@azure/core-auth": "^1.3.0",
     "@azure/core-client": "^1.5.0",

--- a/sdk/communication/communication-short-codes/package.json
+++ b/sdk/communication/communication-short-codes/package.json
@@ -60,7 +60,7 @@
   "prettier": "@azure/eslint-plugin-azure-sdk/prettier.json",
   "dependencies": {
     "@azure/abort-controller": "^1.0.0",
-    "@azure/communication-common": "^2.0.0",
+    "@azure/communication-common": "^2.1.0",
     "@azure/core-auth": "^1.3.0",
     "@azure/core-client": "^1.3.2",
     "@azure/core-lro": "^2.2.0",

--- a/sdk/communication/communication-sms/package.json
+++ b/sdk/communication/communication-sms/package.json
@@ -64,7 +64,7 @@
   "prettier": "@azure/eslint-plugin-azure-sdk/prettier.json",
   "dependencies": {
     "@azure/abort-controller": "^1.0.0",
-    "@azure/communication-common": "^2.0.0",
+    "@azure/communication-common": "^2.1.0",
     "@azure/core-auth": "^1.3.0",
     "@azure/core-client": "^1.3.2",
     "@azure/core-rest-pipeline": "^1.3.2",

--- a/sdk/communication/communication-sms/samples/v1/javascript/package.json
+++ b/sdk/communication/communication-sms/samples/v1/javascript/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@azure/communication-sms": "latest",
     "dotenv": "latest",
-    "@azure/communication-common": "^1.1.0",
+    "@azure/communication-common": "^2.1.0",
     "@azure/core-http": "^2.0.0",
     "@azure/identity": "^2.0.1"
   }

--- a/sdk/communication/communication-sms/samples/v1/typescript/package.json
+++ b/sdk/communication/communication-sms/samples/v1/typescript/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "@azure/communication-sms": "latest",
     "dotenv": "latest",
-    "@azure/communication-common": "^1.1.0",
+    "@azure/communication-common": "^2.1.0",
     "@azure/core-http": "^2.0.0",
     "@azure/identity": "^2.0.1"
   },


### PR DESCRIPTION
### Packages impacted by this PR
communication-common
communication-chat

### Issues associated with this PR


### Describe the problem that is addressed by this PR
The `CommunicationIdentifier` design provides a good abstraction of Azure Communication Services internal id format with better type safety, auto-complete and hides internal knowledge.

However, it doesn't lend well to storing identifiers in a database or using them as keys because there is no clear canonical way how to encode them. This PR introduces translation functions that lets developers use the underlying `rawId` for these purposes.


Details [Internal wiki](https://skype.visualstudio.com/SPOOL/_wiki/wikis/SPOOL.wiki/31075/Design-change-request-RawId-support-for-(de)serialization)

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?

See internal wiki

### Are there test cases added in this PR? _(If not, why?)_
Yes.

### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [ ] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
