### PR TITLE
[ACR] Disable flaky/broken manifest upload test to fix build

### DIFF
--- a/sdk/containerregistry/container-registry/test/public/containerRegistryBlobClient.spec.ts
+++ b/sdk/containerregistry/container-registry/test/public/containerRegistryBlobClient.spec.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { Recorder, assertEnvironmentVariable } from "@azure-tools/test-recorder";
+import { Recorder, assertEnvironmentVariable, isPlaybackMode } from "@azure-tools/test-recorder";
 import { ContainerRegistryBlobClient, OciManifest } from "@azure/container-registry";
 import { assert, versionsToTest } from "@azure/test-utils";
 import { Context } from "mocha";
@@ -70,23 +70,6 @@ versionsToTest(serviceVersions, {}, (serviceVersion, onVersions): void => {
       await client.uploadBlob(config);
     };
 
-    /**
-     * The test proxy goes to the liberty of trimming whitespace from JSON (including our manifests) when responding to
-     * requests. This means that the recorded Docker-Content-Digest header from the does not match the digest our client
-     * computes, causing test failures.
-     *
-     * We use a transform to substitute in the digest of the whitespace-trimmed JSON so that our client doesn't reject
-     * the played back request.
-     */
-    const mockDockerContentDigestHeader = () =>
-      recorder.addTransform({
-        type: "HeaderTransform",
-        params: {
-          key: "Docker-Content-Digest",
-          value: "sha256:70e2ffca8e79adc4bd34b67363a972522d75933e435084826d39a19f958579ed",
-        },
-      });
-
     it("can upload OCI manifest", async () => {
       await uploadManifestPrerequisites();
 
@@ -99,11 +82,13 @@ versionsToTest(serviceVersions, {}, (serviceVersion, onVersions): void => {
       await client.deleteManifest(uploadResult.digest);
     });
 
-    // Tempoarily skip while dealing with recorder issue
-    it.skip("can upload OCI manifest from stream", async () => {
-      await uploadManifestPrerequisites();
+    it("can upload OCI manifest from stream", async function (this: Mocha.Context) {
+      if (isPlaybackMode()) {
+        // Temporarily skip during playback while dealing with recorder issue
+        this.skip();
+      }
 
-      await mockDockerContentDigestHeader();
+      await uploadManifestPrerequisites();
 
       const manifestStream = fs.createReadStream("test/data/oci-artifact/manifest.json");
       const uploadResult = await client.uploadManifest(manifestStream);
@@ -127,11 +112,13 @@ versionsToTest(serviceVersions, {}, (serviceVersion, onVersions): void => {
       await client.deleteManifest(uploadResult.digest);
     });
 
-    // Tempoarily skip while dealing with recorder issue
-    it.skip("can upload OCI manifest stream with tag", async () => {
-      await uploadManifestPrerequisites();
+    it.skip("can upload OCI manifest stream with tag", async function (this: Mocha.Context) {
+      if (isPlaybackMode()) {
+        // Temporarily skip during playback while dealing with recorder issue
+        this.skip();
+      }
 
-      await mockDockerContentDigestHeader();
+      await uploadManifestPrerequisites();
 
       const manifestStream = fs.createReadStream("test/data/oci-artifact/manifest.json");
       const uploadResult = await client.uploadManifest(manifestStream, { tag: "my_artifact" });

--- a/sdk/containerregistry/container-registry/test/public/containerRegistryBlobClient.spec.ts
+++ b/sdk/containerregistry/container-registry/test/public/containerRegistryBlobClient.spec.ts
@@ -127,7 +127,8 @@ versionsToTest(serviceVersions, {}, (serviceVersion, onVersions): void => {
       await client.deleteManifest(uploadResult.digest);
     });
 
-    it("can upload OCI manifest stream with tag", async () => {
+    // Tempoarily skip while dealing with recorder issue
+    it.skip("can upload OCI manifest stream with tag", async () => {
       await uploadManifestPrerequisites();
 
       await mockDockerContentDigestHeader();


### PR DESCRIPTION
### Packages impacted by this PR

- `@azure/container-registry`

### Describe the problem that is addressed by this PR

Due to an issue with the recorder serializing and deserializing request body, the computed digest from the request body does not match the recorded Docker-Content-Digest header during playback. Previously, I tried to mock this by overriding the Docker-Content-Digest header returned by the recording, but a recent change to the test proxy seems to have changed the formatting of the response returned by the proxy, breaking the mock.

The existing workaround is clearly flaky so this PR disables the test for the time being, until we can get a more robust fix in the test proxy.
