### PR TITLE
[core-tracing] - Narrow Options type in OptionsWithTracingContext

### DIFF
--- a/sdk/core/core-tracing/review/core-tracing.api.md
+++ b/sdk/core/core-tracing/review/core-tracing.api.md
@@ -31,7 +31,9 @@ export interface OperationTracingOptions {
 }
 
 // @public
-export type OptionsWithTracingContext<Options> = Options & {
+export type OptionsWithTracingContext<Options extends {
+    tracingOptions?: OperationTracingOptions;
+}> = Options & {
     tracingOptions: {
         tracingContext: TracingContext;
     };

--- a/sdk/core/core-tracing/src/interfaces.ts
+++ b/sdk/core/core-tracing/src/interfaces.ts
@@ -286,7 +286,9 @@ export interface OperationTracingOptions {
  * A utility type for when we know a TracingContext has been set
  * as part of an operation's options.
  */
-export type OptionsWithTracingContext<Options> = Options & {
+export type OptionsWithTracingContext<
+  Options extends { tracingOptions?: OperationTracingOptions }
+> = Options & {
   tracingOptions: {
     tracingContext: TracingContext;
   };

--- a/sdk/core/core-tracing/src/tracingClient.ts
+++ b/sdk/core/core-tracing/src/tracingClient.ts
@@ -54,7 +54,7 @@ export function createTracingClient(options: TracingClientOptions): TracingClien
   }
 
   async function withSpan<
-    Options extends { tracingOptions?: { tracingContext?: TracingContext } },
+    Options extends { tracingOptions?: OperationTracingOptions },
     Callback extends (
       updatedOptions: Options,
       span: Omit<TracingSpan, "end">


### PR DESCRIPTION
### Packages impacted by this PR
core-tracing

### Issues associated with this PR
N/A - API review for core-tracing

### Describe the problem that is addressed by this PR
We recently added the OptionsWithTracingContext type but it accepts an unbounded
type parameter which is not realistic in our scenarios.

This PR ensures we accept the type parameter we expect.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_


### Command used to generate this PR: _(Applicable only to SDK release request PRs)_


### Checklists
- [ ] Added impacted package name to the issue description.
- [ ] Does this PR need any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here.)_
- [ ] Added a changelog (if necessary).
