### PR TITLE
[identity] upgrade dependency @azure/msal-common to ^v6.3.0

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -1123,7 +1123,7 @@ packages:
     resolution: {integrity: sha512-qxyWmsP/pf+xJFEhMgiJ0r1v6TjF+x8iMWYU5R63Lb/fjQfKalaNX9f5D6GbJYJS5s9OF3abtdGtB/Lxea15mQ==}
     engines: {node: '>=0.8.0'}
     dependencies:
-      '@azure/msal-common': 6.2.0
+      '@azure/msal-common': 6.3.0
     dev: false
 
   /@azure/msal-common/4.5.1:
@@ -1144,8 +1144,8 @@ packages:
       - supports-color
     dev: false
 
-  /@azure/msal-common/6.2.0:
-    resolution: {integrity: sha512-SU2/vfbKn1WvtKM8tsBKZAbmRJvO8E3H773ZT0GGKuO9rwLfxP5qOzTHV5crCEm8DgvL/IppmWh2lsUFieDi1A==}
+  /@azure/msal-common/6.3.0:
+    resolution: {integrity: sha512-ZyLq9GdnLBi/83YpysE86TFKbA0TuvfNAN5Psqu20cdAjLo/4rw4ttiItdh1G//XeGErHk9qn57gi2AYU1b5/Q==}
     engines: {node: '>=0.8.0'}
     dev: false
 
@@ -1178,7 +1178,7 @@ packages:
     resolution: {integrity: sha512-rA5KzhvNuNef6Bzap8Sm/LbuesvA1yY2dj/W+QZuKMtT5nboZ4n4w8LRjwMMxucvYfizybPbLGTFpbq2IJtOfQ==}
     engines: {node: 10 || 12 || 14 || 16}
     dependencies:
-      '@azure/msal-common': 6.2.0
+      '@azure/msal-common': 6.3.0
       axios: 0.21.4
       https-proxy-agent: 5.0.1
       jsonwebtoken: 8.5.1
@@ -1192,7 +1192,7 @@ packages:
     resolution: {integrity: sha512-rA5KzhvNuNef6Bzap8Sm/LbuesvA1yY2dj/W+QZuKMtT5nboZ4n4w8LRjwMMxucvYfizybPbLGTFpbq2IJtOfQ==}
     engines: {node: 10 || 12 || 14 || 16}
     dependencies:
-      '@azure/msal-common': 6.2.0
+      '@azure/msal-common': 6.3.0
       axios: 0.21.4_debug@4.3.4
       https-proxy-agent: 5.0.1
       jsonwebtoken: 8.5.1
@@ -15391,7 +15391,7 @@ packages:
     dev: false
 
   file:projects/eventhubs-checkpointstore-table.tgz:
-    resolution: {integrity: sha512-lV2JaA7ADYooOapQrBAwk+4lQXa/VWgdJLC2WoZsAi/l5yV9hlK9GhAiX/+x3GXQGFHfsqw/oSZO929dsMf0Ag==, tarball: file:projects/eventhubs-checkpointstore-table.tgz}
+    resolution: {integrity: sha512-TUGShiiPux1M2OTQRjDWGHM6uwmGI1iiCTccm9q9OiImdj3wnes/xn44h3Wvv3gzqkA0Fj8Xeo/DGJLt1RGitg==, tarball: file:projects/eventhubs-checkpointstore-table.tgz}
     name: '@rush-temp/eventhubs-checkpointstore-table'
     version: 0.0.0
     dependencies:
@@ -15511,13 +15511,13 @@ packages:
     dev: false
 
   file:projects/identity.tgz:
-    resolution: {integrity: sha512-sJuoRp2IAMTAMQ1HZTtCVjSBfeBidJicr777/fQnWoJHlWLBt7qXrOdpFDwRKncAIdDtaKpXD/rOqxpi4QdePQ==, tarball: file:projects/identity.tgz}
+    resolution: {integrity: sha512-HUgTi0UX+OhFi4lMKdNUYK/EDlInSizjj3OYRISa+tb0I+DapyschUK9ilOOGTIa3doqZ0Av3TnpnRAC84IlUw==, tarball: file:projects/identity.tgz}
     name: '@rush-temp/identity'
     version: 0.0.0
     dependencies:
       '@azure/keyvault-keys': 4.2.0
       '@azure/msal-browser': 2.23.0
-      '@azure/msal-common': 4.5.1
+      '@azure/msal-common': 6.3.0
       '@azure/msal-node': 1.8.0
       '@microsoft/api-extractor': 7.18.11
       '@types/chai': 4.3.1
@@ -16284,7 +16284,7 @@ packages:
     dev: false
 
   file:projects/perf-event-hubs.tgz:
-    resolution: {integrity: sha512-0Shj+f5HUSjnyL56js5KhwURz4fwSgQu9vAxnC5DawSdWpExDLiGSLG+pVm7YuDQ432ondadTZDYgdkVqlFE5A==, tarball: file:projects/perf-event-hubs.tgz}
+    resolution: {integrity: sha512-BHwbm1iu6BThr0P43MEqVdgEpQ984u4C6M9orgaZdvJXRqU9YvoSedqmIu4XNcBbIY1MsiH1DUT+gU6zDCudaw==, tarball: file:projects/perf-event-hubs.tgz}
     name: '@rush-temp/perf-event-hubs'
     version: 0.0.0
     dependencies:

--- a/sdk/identity/identity-cache-persistence/recordings/node/usernamepasswordcredential_internal/recording_accepts_tokencachepersistenceoptions.json
+++ b/sdk/identity/identity-cache-persistence/recordings/node/usernamepasswordcredential_internal/recording_accepts_tokencachepersistenceoptions.json
@@ -177,7 +177,7 @@
         "X-AnchorMailbox": "UPN: azure_username",
         "x-ms-client-request-id": "e136a6b8-1cb1-42c0-a3bf-cfa0e5e9df09"
       },
-      "RequestBody": "client_id=azure_client_id\u0026username=azure_username\u0026password=azure_password\u0026scope=https%3A%2F%2Fgraph.microsoft.com%2F.default%20openid%20profile%20offline_access\u0026grant_type=password\u0026client_info=1\u0026x-client-SKU=msal.js.node\u0026x-client-VER=identity-client-version\u0026x-client-OS=x-client-OS\u0026x-client-CPU=x-client-CPU\u0026x-ms-lib-capability=retry-after, h429\u0026x-client-current-telemetry=5|371,0,,,|,\u0026x-client-last-telemetry=5|0|||0,0\u0026client-request-id=client-request-id\u0026claims=%7B%22access_token%22%3A%7B%22xms_cc%22%3A%7B%22values%22%3A%5B%22cp1%22%5D%7D%7D%7D",
+      "RequestBody": "client_id=azure_client_id\u0026username=azure_username\u0026password=azure_password\u0026scope=https%3A%2F%2Fgraph.microsoft.com%2F.default%20openid%20profile%20offline_access\u0026response_type=token%20id_token\u0026grant_type=password\u0026client_info=1\u0026x-client-SKU=msal.js.node\u0026x-client-VER=identity-client-version\u0026x-client-OS=x-client-OS\u0026x-client-CPU=x-client-CPU\u0026x-ms-lib-capability=retry-after, h429\u0026x-client-current-telemetry=5|371,0,,,|,\u0026x-client-last-telemetry=5|0|||0,0\u0026client-request-id=client-request-id\u0026claims=%7B%22access_token%22%3A%7B%22xms_cc%22%3A%7B%22values%22%3A%5B%22cp1%22%5D%7D%7D%7D",
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-store, no-cache",

--- a/sdk/identity/identity-cache-persistence/recordings/node/usernamepasswordcredential_internal/recording_authenticates_silently_with_tokencachepersistenceoptions.json
+++ b/sdk/identity/identity-cache-persistence/recordings/node/usernamepasswordcredential_internal/recording_authenticates_silently_with_tokencachepersistenceoptions.json
@@ -177,7 +177,7 @@
         "X-AnchorMailbox": "UPN: azure_username",
         "x-ms-client-request-id": "6cae8e8e-3fd6-45f3-a0f4-ad2c6f3c8ad4"
       },
-      "RequestBody": "client_id=azure_client_id\u0026username=azure_username\u0026password=azure_password\u0026scope=https%3A%2F%2Fgraph.microsoft.com%2F.default%20openid%20profile%20offline_access\u0026grant_type=password\u0026client_info=1\u0026x-client-SKU=msal.js.node\u0026x-client-VER=identity-client-version\u0026x-client-OS=x-client-OS\u0026x-client-CPU=x-client-CPU\u0026x-ms-lib-capability=retry-after, h429\u0026x-client-current-telemetry=5|371,0,,,|,\u0026x-client-last-telemetry=5|0|||0,0\u0026client-request-id=client-request-id\u0026claims=%7B%22access_token%22%3A%7B%22xms_cc%22%3A%7B%22values%22%3A%5B%22cp1%22%5D%7D%7D%7D",
+      "RequestBody": "client_id=azure_client_id\u0026username=azure_username\u0026password=azure_password\u0026scope=https%3A%2F%2Fgraph.microsoft.com%2F.default%20openid%20profile%20offline_access\u0026response_type=token%20id_token\u0026grant_type=password\u0026client_info=1\u0026x-client-SKU=msal.js.node\u0026x-client-VER=identity-client-version\u0026x-client-OS=x-client-OS\u0026x-client-CPU=x-client-CPU\u0026x-ms-lib-capability=retry-after, h429\u0026x-client-current-telemetry=5|371,0,,,|,\u0026x-client-last-telemetry=5|0|||0,0\u0026client-request-id=client-request-id\u0026claims=%7B%22access_token%22%3A%7B%22xms_cc%22%3A%7B%22values%22%3A%5B%22cp1%22%5D%7D%7D%7D",
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-store, no-cache",

--- a/sdk/identity/identity/package.json
+++ b/sdk/identity/identity/package.json
@@ -109,7 +109,7 @@
     "@azure/core-rest-pipeline": "^1.1.0",
     "@azure/logger": "^1.0.0",
     "@azure/abort-controller": "^1.0.0",
-    "@azure/msal-common": "^4.5.1",
+    "@azure/msal-common": "^6.3.0",
     "@azure/msal-node": "^1.3.0",
     "@azure/msal-browser": "^2.16.0",
     "events": "^3.0.0",

--- a/sdk/identity/identity/recordings/node/usernamepasswordcredential/recording_authenticates.json
+++ b/sdk/identity/identity/recordings/node/usernamepasswordcredential/recording_authenticates.json
@@ -186,7 +186,7 @@
         "X-AnchorMailbox": "UPN: azure_username",
         "x-ms-client-request-id": "e221ecf5-cad9-4108-8e32-567a6de2eb6e"
       },
-      "RequestBody": "client_id=azure_client_id\u0026username=azure_username\u0026password=azure_password\u0026scope=https%3A%2F%2Fvault.azure.net%2F.default%20openid%20profile%20offline_access\u0026grant_type=password\u0026client_info=1\u0026x-client-SKU=msal.js.node\u0026x-client-VER=identity-client-version\u0026x-client-OS=x-client-OS\u0026x-client-CPU=x-client-CPU\u0026x-ms-lib-capability=retry-after, h429\u0026x-client-current-telemetry=5|371,0,,,|,\u0026x-client-last-telemetry=5|0|||0,0\u0026client-request-id=client-request-id\u0026claims=%7B%22access_token%22%3A%7B%22xms_cc%22%3A%7B%22values%22%3A%5B%22cp1%22%5D%7D%7D%7D",
+      "RequestBody": "client_id=azure_client_id\u0026username=azure_username\u0026password=azure_password\u0026scope=https%3A%2F%2Fvault.azure.net%2F.default%20openid%20profile%20offline_access\u0026response_type=token%20id_token\u0026grant_type=password\u0026client_info=1\u0026x-client-SKU=msal.js.node\u0026x-client-VER=identity-client-version\u0026x-client-OS=x-client-OS\u0026x-client-CPU=x-client-CPU\u0026x-ms-lib-capability=retry-after, h429\u0026x-client-current-telemetry=5|371,0,,,|,\u0026x-client-last-telemetry=5|0|||0,0\u0026client-request-id=client-request-id\u0026claims=%7B%22access_token%22%3A%7B%22xms_cc%22%3A%7B%22values%22%3A%5B%22cp1%22%5D%7D%7D%7D",
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-store, no-cache",

--- a/sdk/identity/identity/recordings/node/usernamepasswordcredential/recording_supports_tracing.json
+++ b/sdk/identity/identity/recordings/node/usernamepasswordcredential/recording_supports_tracing.json
@@ -177,7 +177,7 @@
         "X-AnchorMailbox": "UPN: azure_username",
         "x-ms-client-request-id": "54f8981e-d6b1-4edf-b523-f8960148e2a2"
       },
-      "RequestBody": "client_id=azure_client_id\u0026username=azure_username\u0026password=azure_password\u0026scope=https%3A%2F%2Fvault.azure.net%2F.default%20openid%20profile%20offline_access\u0026grant_type=password\u0026client_info=1\u0026x-client-SKU=msal.js.node\u0026x-client-VER=identity-client-version\u0026x-client-OS=x-client-OS\u0026x-client-CPU=x-client-CPU\u0026x-ms-lib-capability=retry-after, h429\u0026x-client-current-telemetry=5|371,0,,,|,\u0026x-client-last-telemetry=5|0|||0,0\u0026client-request-id=client-request-id\u0026claims=%7B%22access_token%22%3A%7B%22xms_cc%22%3A%7B%22values%22%3A%5B%22cp1%22%5D%7D%7D%7D",
+      "RequestBody": "client_id=azure_client_id\u0026username=azure_username\u0026password=azure_password\u0026scope=https%3A%2F%2Fvault.azure.net%2F.default%20openid%20profile%20offline_access\u0026response_type=token%20id_token\u0026grant_type=password\u0026client_info=1\u0026x-client-SKU=msal.js.node\u0026x-client-VER=identity-client-version\u0026x-client-OS=x-client-OS\u0026x-client-CPU=x-client-CPU\u0026x-ms-lib-capability=retry-after, h429\u0026x-client-current-telemetry=5|371,0,,,|,\u0026x-client-last-telemetry=5|0|||0,0\u0026client-request-id=client-request-id\u0026claims=%7B%22access_token%22%3A%7B%22xms_cc%22%3A%7B%22values%22%3A%5B%22cp1%22%5D%7D%7D%7D",
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-store, no-cache",

--- a/sdk/identity/identity/recordings/node/usernamepasswordcredential_internal/recording_authenticates_with_tenantid_on_gettoken.json
+++ b/sdk/identity/identity/recordings/node/usernamepasswordcredential_internal/recording_authenticates_with_tenantid_on_gettoken.json
@@ -186,7 +186,7 @@
         "X-AnchorMailbox": "UPN: azure_username",
         "x-ms-client-request-id": "aaedb864-3c08-4be9-ae9d-7022cc3f50aa"
       },
-      "RequestBody": "client_id=azure_client_id\u0026username=azure_username\u0026password=azure_password\u0026scope=https%3A%2F%2Fvault.azure.net%2F.default%20openid%20profile%20offline_access\u0026grant_type=password\u0026client_info=1\u0026x-client-SKU=msal.js.node\u0026x-client-VER=identity-client-version\u0026x-client-OS=x-client-OS\u0026x-client-CPU=x-client-CPU\u0026x-ms-lib-capability=retry-after, h429\u0026x-client-current-telemetry=5|371,0,,,|,\u0026x-client-last-telemetry=5|0|||0,0\u0026client-request-id=client-request-id\u0026claims=%7B%22access_token%22%3A%7B%22xms_cc%22%3A%7B%22values%22%3A%5B%22cp1%22%5D%7D%7D%7D",
+      "RequestBody": "client_id=azure_client_id\u0026username=azure_username\u0026password=azure_password\u0026scope=https%3A%2F%2Fvault.azure.net%2F.default%20openid%20profile%20offline_access\u0026response_type=token%20id_token\u0026grant_type=password\u0026client_info=1\u0026x-client-SKU=msal.js.node\u0026x-client-VER=identity-client-version\u0026x-client-OS=x-client-OS\u0026x-client-CPU=x-client-CPU\u0026x-ms-lib-capability=retry-after, h429\u0026x-client-current-telemetry=5|371,0,,,|,\u0026x-client-last-telemetry=5|0|||0,0\u0026client-request-id=client-request-id\u0026claims=%7B%22access_token%22%3A%7B%22xms_cc%22%3A%7B%22values%22%3A%5B%22cp1%22%5D%7D%7D%7D",
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-store, no-cache",


### PR DESCRIPTION
This unblocks the `rush update --full` automation. It looks that v6.3.0 has made
some typing improvement that makes v4.5.1 incompatible

```
src/msal/nodeFlows/msalNodeCommon.ts(270,7): error TS2322: Type 'import("/mnt/vss/_work/1/s/common/temp/node_modules/.pnpm/@azure+msal-common@4.5.1/node_modules/@azure/msal-common/dist/account/AccountInfo").AccountInfo' is not assignable to type 'import("/mnt/vss/_work/1/s/common/temp/node_modules/.pnpm/@azure+msal-common@6.3.0/node_modules/@azure/msal-common/dist/account/AccountInfo").AccountInfo'.
  Types of property 'idTokenClaims' are incompatible.
    Type 'object | undefined' is not assignable to type '(TokenClaims & { [key: string]: unknown; }) | undefined'.
      Type 'object' is not assignable to type 'TokenClaims & { [key: string]: unknown; }'.
        Type 'object' is not assignable to type '{ [key: string]: unknown; }'.
          Index signature for type 'string' is missing in type '{}'.
```
