### PR TITLE
[monitor-ot-exporter][test] remove 15 minutes timeout limit

### DIFF
--- a/sdk/monitor/monitor-opentelemetry-exporter/tests.yml
+++ b/sdk/monitor/monitor-opentelemetry-exporter/tests.yml
@@ -3,7 +3,6 @@ trigger: none
 stages:
   - template: /eng/pipelines/templates/stages/archetype-sdk-tests.yml
     parameters:
-      TimeoutInMinutes: 15
       PackageName: "@azure/monitor-opentelemetry-exporter"
       ServiceDirectory: monitor
       MatrixFilters:


### PR DESCRIPTION
This build pipelines occasionally went over 15 minutes limit. This PR removes the limit, so that default of 60 minutes is used.
