### PR TITLE
[core-lro] lroEngine to support cancellation

### DIFF
--- a/sdk/core/core-lro/CHANGELOG.md
+++ b/sdk/core/core-lro/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Release History
 
-## 2.2.5 (Unreleased)
+## 2.3.0 (Unreleased)
 
 ### Features Added
+
+- `lroEngine` now supports cancellation of the long-running operation.
 
 ### Breaking Changes
 

--- a/sdk/core/core-lro/package.json
+++ b/sdk/core/core-lro/package.json
@@ -2,7 +2,7 @@
   "name": "@azure/core-lro",
   "author": "Microsoft Corporation",
   "sdk-type": "client",
-  "version": "2.2.5",
+  "version": "2.3.0",
   "description": "Isomorphic client library for supporting long-running operations in node.js and browser.",
   "tags": [
     "isomorphic",

--- a/sdk/core/core-lro/review/core-lro.api.md
+++ b/sdk/core/core-lro/review/core-lro.api.md
@@ -25,6 +25,7 @@ export class LroEngine<TResult, TState extends PollOperationState<TResult>> exte
 
 // @public
 export interface LroEngineOptions<TResult, TState> {
+    cancel?: (state: TState) => Promise<void>;
     intervalInMs?: number;
     isDone?: (lastResponse: unknown, state: TState) => boolean;
     lroResourceLocationConfig?: LroResourceLocationConfig;
@@ -124,7 +125,6 @@ export interface RawResponse {
     };
     statusCode: number;
 }
-
 
 // (No @packageDocumentation comment for this package)
 

--- a/sdk/core/core-lro/src/lroEngine/lroEngine.ts
+++ b/sdk/core/core-lro/src/lroEngine/lroEngine.ts
@@ -16,7 +16,7 @@ function deserializeState<TResult, TState>(
 ): TState & ResumablePollOperationState<TResult> {
   try {
     return JSON.parse(serializedState).state;
-  } catch (e: unknown) {
+  } catch (e) {
     throw new Error(`LroEngine: Unable to deserialize state: ${serializedState}`);
   }
 }

--- a/sdk/core/core-lro/src/lroEngine/lroEngine.ts
+++ b/sdk/core/core-lro/src/lroEngine/lroEngine.ts
@@ -16,7 +16,7 @@ function deserializeState<TResult, TState>(
 ): TState & ResumablePollOperationState<TResult> {
   try {
     return JSON.parse(serializedState).state;
-  } catch (e: any) {
+  } catch (e: unknown) {
     throw new Error(`LroEngine: Unable to deserialize state: ${serializedState}`);
   }
 }
@@ -42,7 +42,8 @@ export class LroEngine<TResult, TState extends PollOperationState<TResult>> exte
       options?.lroResourceLocationConfig,
       options?.processResult,
       options?.updateState,
-      options?.isDone
+      options?.isDone,
+      options?.cancel
     );
     super(operation);
 

--- a/sdk/core/core-lro/src/lroEngine/models.ts
+++ b/sdk/core/core-lro/src/lroEngine/models.ts
@@ -31,6 +31,11 @@ export interface LroEngineOptions<TResult, TState> {
    * A predicate to determine whether the LRO finished processing.
    */
   isDone?: (lastResponse: unknown, state: TState) => boolean;
+
+  /**
+   * A function to cancel the LRO.
+   */
+  cancel?: (state: TState) => Promise<void>;
 }
 
 export const successStates = ["succeeded"];

--- a/sdk/core/core-lro/src/lroEngine/operation.ts
+++ b/sdk/core/core-lro/src/lroEngine/operation.ts
@@ -34,7 +34,8 @@ export class GenericPollOperation<TResult, TState extends PollOperationState<TRe
     private lroResourceLocationConfig?: LroResourceLocationConfig,
     private processResult?: (result: unknown, state: TState) => TResult,
     private updateState?: (state: TState, lastResponse: RawResponse) => void,
-    private isDone?: (lastResponse: TResult, state: TState) => boolean
+    private isDone?: (lastResponse: TResult, state: TState) => boolean,
+    private cancelOp?: (state: TState) => Promise<void>
   ) {}
 
   public setPollerConfig(pollerConfig: PollerConfig): void {
@@ -122,6 +123,7 @@ export class GenericPollOperation<TResult, TState extends PollOperationState<TRe
 
   async cancel(): Promise<PollOperation<TState, TResult>> {
     this.state.isCancelled = true;
+    await this.cancelOp?.(this.state);
     return this;
   }
 


### PR DESCRIPTION
### Packages impacted by this PR
@@azure/core-lro

### Issues associated with this PR


### Describe the problem that is addressed by this PR
lroEngine provides a default implementation of client-side polling for LROs and the default cancellation method is a no-op.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?
This PR makes cancellation configurable by adding an optional function that specifies how cancellation should work. Currently, cancellation requests are not standardized according to the [REST API spec](https://github.com/microsoft/api-guidelines/blob/vNext/azure/Guidelines.md#long-running-operations--jobs) so I am not sure if we could provide a reasonable default implementation. 

### Are there test cases added in this PR? _(If not, why?)_
N/A

### Provide a list of related PRs _(if any)_
N/A

### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [x] Added a changelog (if necessary)
