### PR TITLE
[core-paging] provide default continuation token support

### DIFF
--- a/sdk/core/core-paging/CHANGELOG.md
+++ b/sdk/core/core-paging/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.2.2 (Unreleased)
+## 1.3.0 (Unreleased)
 
 ### Features Added
 
@@ -9,6 +9,8 @@
 ### Bugs Fixed
 
 ### Other Changes
+
+- The default implementation of `byPage` now supports using the continuationToken option as a URL for the page to get first.
 
 ## 1.2.1 (2022-01-06)
 

--- a/sdk/core/core-paging/package.json
+++ b/sdk/core/core-paging/package.json
@@ -2,7 +2,7 @@
   "name": "@azure/core-paging",
   "author": "Microsoft Corporation",
   "sdk-type": "client",
-  "version": "1.2.2",
+  "version": "1.3.0",
   "description": "Core types for paging async iterable iterators",
   "tags": [
     "microsoft",

--- a/sdk/core/core-paging/src/getPagedAsyncIterator.ts
+++ b/sdk/core/core-paging/src/getPagedAsyncIterator.ts
@@ -29,19 +29,19 @@ export function getPagedAsyncIterator<
     byPage:
       pagedResult?.byPage ??
       ((settings?: PageSettings) => {
-        return getPageAsyncIterator(
-          pagedResult as PagedResult<TPage, PageSettings, TLink>,
-          settings?.maxPageSize
-        );
+        const { continuationToken, maxPageSize } = settings ?? {};
+        return getPageAsyncIterator(pagedResult as PagedResult<TPage, PageSettings, TLink>, {
+          continuationToken: continuationToken as unknown as TLink | undefined,
+          maxPageSize,
+        });
       }),
   };
 }
 
 async function* getItemAsyncIterator<TElement, TPage, TLink, TPageSettings>(
-  pagedResult: PagedResult<TPage, TPageSettings, TLink>,
-  maxPageSize?: number
+  pagedResult: PagedResult<TPage, TPageSettings, TLink>
 ): AsyncIterableIterator<TElement> {
-  const pages = getPageAsyncIterator(pagedResult, maxPageSize);
+  const pages = getPageAsyncIterator(pagedResult);
   const firstVal = await pages.next();
   // if the result does not have an array shape, i.e. TPage = TElement, then we return it as is
   if (!Array.isArray(firstVal.value)) {
@@ -60,9 +60,16 @@ async function* getItemAsyncIterator<TElement, TPage, TLink, TPageSettings>(
 
 async function* getPageAsyncIterator<TPage, TLink, TPageSettings>(
   pagedResult: PagedResult<TPage, TPageSettings, TLink>,
-  maxPageSize?: number
+  options: {
+    maxPageSize?: number;
+    continuationToken?: TLink;
+  } = {}
 ): AsyncIterableIterator<TPage> {
-  let response = await pagedResult.getPage(pagedResult.firstPageLink, maxPageSize);
+  const { continuationToken, maxPageSize } = options;
+  let response = await pagedResult.getPage(
+    continuationToken ?? pagedResult.firstPageLink,
+    maxPageSize
+  );
   yield response.page;
   while (response.nextPageLink) {
     response = await pagedResult.getPage(response.nextPageLink, maxPageSize);

--- a/sdk/core/core-paging/src/getPagedAsyncIterator.ts
+++ b/sdk/core/core-paging/src/getPagedAsyncIterator.ts
@@ -66,10 +66,7 @@ async function* getPageAsyncIterator<TPage, TLink, TPageSettings>(
   } = {}
 ): AsyncIterableIterator<TPage> {
   const { pageLink, maxPageSize } = options;
-  let response = await pagedResult.getPage(
-    pageLink ?? pagedResult.firstPageLink,
-    maxPageSize
-  );
+  let response = await pagedResult.getPage(pageLink ?? pagedResult.firstPageLink, maxPageSize);
   yield response.page;
   while (response.nextPageLink) {
     response = await pagedResult.getPage(response.nextPageLink, maxPageSize);

--- a/sdk/core/core-paging/src/getPagedAsyncIterator.ts
+++ b/sdk/core/core-paging/src/getPagedAsyncIterator.ts
@@ -31,7 +31,7 @@ export function getPagedAsyncIterator<
       ((settings?: PageSettings) => {
         const { continuationToken, maxPageSize } = settings ?? {};
         return getPageAsyncIterator(pagedResult as PagedResult<TPage, PageSettings, TLink>, {
-          continuationToken: continuationToken as unknown as TLink | undefined,
+          pageLink: continuationToken as unknown as TLink | undefined,
           maxPageSize,
         });
       }),
@@ -62,12 +62,12 @@ async function* getPageAsyncIterator<TPage, TLink, TPageSettings>(
   pagedResult: PagedResult<TPage, TPageSettings, TLink>,
   options: {
     maxPageSize?: number;
-    continuationToken?: TLink;
+    pageLink?: TLink;
   } = {}
 ): AsyncIterableIterator<TPage> {
-  const { continuationToken, maxPageSize } = options;
+  const { pageLink, maxPageSize } = options;
   let response = await pagedResult.getPage(
-    continuationToken ?? pagedResult.firstPageLink,
+    pageLink ?? pagedResult.firstPageLink,
     maxPageSize
   );
   yield response.page;


### PR DESCRIPTION
### Packages impacted by this PR
@azure/core-paging

### Issues associated with this PR


### Describe the problem that is addressed by this PR
The default implementation of `byPage` did not support input continuation tokens

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?
This PR adds default support for input continuation tokens in `byPage` by treating them opaquely.

### Are there test cases added in this PR? _(If not, why?)_
N/A

### Provide a list of related PRs _(if any)_
N/A

### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [x] Added a changelog (if necessary)
