### PR TITLE
Disable docker image warning in CI

### DIFF
--- a/eng/pipelines/templates/variables/globals.yml
+++ b/eng/pipelines/templates/variables/globals.yml
@@ -6,3 +6,5 @@ variables:
   coalesceResultFilter: $[ coalesce(variables['packageGlobFilter'], '**') ]
   ServiceVersion: ""
   Package.EnableSBOMSigning: true
+  # Disable warning until issue 21765 and 21766 are closed
+  DisableDockerDetector: true


### PR DESCRIPTION
Disable auto injected docker image check step temporarily until issues #21765 and #21766 are fixed.