### PR TITLE
[core-paging] Remove handling of pageable objects

### DIFF
--- a/sdk/core/core-paging/src/getPagedAsyncIterator.ts
+++ b/sdk/core/core-paging/src/getPagedAsyncIterator.ts
@@ -43,8 +43,6 @@ async function* getItemAsyncIterator<TElement, TPage, TLink, TPageSettings>(
 ): AsyncIterableIterator<TElement> {
   const pages = getPageAsyncIterator(pagedResult);
   for await (const page of pages) {
-    // pages is of type `AsyncIterableIterator<TPage>` so `page` is of type `TPage`. In this branch,
-    // it must be the case that `TPage = TElement[]`
     yield* page as unknown as TElement[];
   }
 }

--- a/sdk/core/core-paging/src/getPagedAsyncIterator.ts
+++ b/sdk/core/core-paging/src/getPagedAsyncIterator.ts
@@ -42,19 +42,10 @@ async function* getItemAsyncIterator<TElement, TPage, TLink, TPageSettings>(
   pagedResult: PagedResult<TPage, TPageSettings, TLink>
 ): AsyncIterableIterator<TElement> {
   const pages = getPageAsyncIterator(pagedResult);
-  const firstVal = await pages.next();
-  // if the result does not have an array shape, i.e. TPage = TElement, then we return it as is
-  if (!Array.isArray(firstVal.value)) {
-    yield firstVal.value;
-    // `pages` is of type `AsyncIterableIterator<TPage>` but TPage = TElement in this case
-    yield* pages as unknown as AsyncIterableIterator<TElement>;
-  } else {
-    yield* firstVal.value;
-    for await (const page of pages) {
-      // pages is of type `AsyncIterableIterator<TPage>` so `page` is of type `TPage`. In this branch,
-      // it must be the case that `TPage = TElement[]`
-      yield* page as unknown as TElement[];
-    }
+  for await (const page of pages) {
+    // pages is of type `AsyncIterableIterator<TPage>` so `page` is of type `TPage`. In this branch,
+    // it must be the case that `TPage = TElement[]`
+    yield* page as unknown as TElement[];
   }
 }
 

--- a/sdk/core/core-paging/test/getPagedAsyncIterator.spec.ts
+++ b/sdk/core/core-paging/test/getPagedAsyncIterator.spec.ts
@@ -31,13 +31,6 @@ describe("getPagedAsyncIterator", function () {
     assert.deepEqual(expected, collection);
   });
 
-  it("should return an iterator over an non-collection", async function () {
-    const iterator = buildIterator({});
-    for await (const val of iterator) {
-      assert.deepEqual(val, {});
-    }
-  });
-
   it("should return an iterator over no pages", async function () {
     const iterator = buildIterator([]);
     for await (const val of iterator.byPage({ maxPageSize: 5 })) {
@@ -45,7 +38,7 @@ describe("getPagedAsyncIterator", function () {
     }
   });
 
-  it("should return an iterator over multiple pages (collections)", async function () {
+  it("should return an iterator over multiple pages", async function () {
     const collection = Array.from(Array(10), (_, i) => i + 1);
     const pagedResult: PagedResult<number[], PageSettings, number> = {
       firstPageLink: 0,
@@ -74,50 +67,6 @@ describe("getPagedAsyncIterator", function () {
       ++pagesCount;
       assert.isAtMost(val.length, maxPageSize);
       receivedPages.push(val);
-    }
-    assert.equal(pagesCount, Math.ceil(collection.length / maxPageSize));
-    assert.deepEqual([].concat(...receivedPages), collection);
-  });
-
-  it("should return an iterator over multiple pages (non-collections)", async function () {
-    const maxPageSize = 5;
-    const collection = Array.from(Array(10), (_, i) => i + 1);
-    const pagedResult: PagedResult<Record<string, unknown>, PageSettings, number> = {
-      firstPageLink: 0,
-      async getPage(pageLink, maxPageSize) {
-        const top = maxPageSize || 5;
-        if (pageLink < collection.length) {
-          return Promise.resolve({
-            page: {
-              res: collection.slice(pageLink, Math.min(pageLink + top, collection.length)),
-            },
-            nextPageLink: top < collection.length - pageLink ? pageLink + top : undefined,
-          });
-        } else {
-          throw new Error("should not get here");
-        }
-      },
-    };
-    const iterator = getPagedAsyncIterator<
-      Record<string, any>,
-      Record<string, any>,
-      PageSettings,
-      number
-    >(pagedResult);
-    let receivedItems = []; // they're pages too
-    let pagesCount = 0;
-    for await (const val of iterator) {
-      ++pagesCount;
-      receivedItems.push((val as any).res);
-    }
-    assert.equal(pagesCount, Math.ceil(collection.length / maxPageSize));
-    assert.deepEqual([].concat(...receivedItems), collection);
-    pagesCount = 0;
-    const receivedPages = [];
-    for await (const val of iterator.byPage({ maxPageSize: maxPageSize })) {
-      ++pagesCount;
-      assert.isAtMost(val.res.length, maxPageSize);
-      receivedPages.push(val.res);
     }
     assert.equal(pagesCount, Math.ceil(collection.length / maxPageSize));
     assert.deepEqual([].concat(...receivedPages), collection);


### PR DESCRIPTION
### Packages impacted by this PR
@azure/core-paging

### Issues associated with this PR


### Describe the problem that is addressed by this PR
The paging logic handles the case where a page is not an array, a corner case that showed up in Text Analytics API. However, the new Language API that replaced TA's one returns arrays so AFAIK, there is no need to handle that corner case anymore.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?
Alternatively, we could leave the corner case handling logic just in case but I find it complex and unnecessary at the moment.

### Are there test cases added in this PR? _(If not, why?)_
N/A

### Provide a list of related PRs _(if any)_
N/A

### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
