### PR TITLE
[engsys] increase aggregate-report timeout limit to 6 hours

### DIFF
--- a/eng/pipelines/aggregate-reports.yml
+++ b/eng/pipelines/aggregate-reports.yml
@@ -19,7 +19,7 @@ stages:
 
     jobs:
       - job: GenerateReports
-        timeoutInMinutes: 240
+        timeoutInMinutes: 360
         steps:
           - template: /eng/pipelines/templates/steps/use-node-version.yml
             parameters:


### PR DESCRIPTION
The pipeline has been timed out after 4 hours recently.  The last successful run took 3h 55m.  Increase the limit to a larger value to give it some room.