### PR TITLE
[EventHubs] Fix rollup circular dependency warnings

### DIFF
--- a/common/tools/dev-tool/src/config/rollup.base.config.ts
+++ b/common/tools/dev-tool/src/config/rollup.base.config.ts
@@ -83,6 +83,14 @@ function ignoreChaiCircularDependency(warning: RollupWarning): boolean {
   );
 }
 
+
+function ignoreRheaPromiseCircularDependency(warning: RollupWarning): boolean {
+  return (
+    warning.code === "CIRCULAR_DEPENDENCY" &&
+    warning.importer?.includes(["node_modules", "rhea-promise"].join(path.sep)) === true
+  );
+}
+
 function ignoreOpenTelemetryThisIsUndefined(warning: RollupWarning): boolean {
   return (
     warning.code === "THIS_IS_UNDEFINED" &&
@@ -104,6 +112,7 @@ function ignoreMissingExportsFromEmpty(warning: RollupWarning): boolean {
 
 const warningInhibitors: Array<(warning: RollupWarning) => boolean> = [
   ignoreChaiCircularDependency,
+  ignoreRheaPromiseCircularDependency,
   ignoreNiseSinonEval,
   ignoreOpenTelemetryThisIsUndefined,
   ignoreMissingExportsFromEmpty,

--- a/sdk/eventhub/event-hubs/src/eventHubBufferedProducerClient.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubBufferedProducerClient.ts
@@ -1,7 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { EventData, EventHubProducerClient, OperationOptions } from "./index";
+import { EventData } from "./eventData";
+import { EventHubProducerClient } from "./eventHubProducerClient";
+import { OperationOptions } from "./util/operationOptions";
 import {
   EventHubClientOptions,
   GetEventHubPropertiesOptions,

--- a/sdk/eventhub/event-hubs/src/eventHubSender.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubSender.ts
@@ -22,11 +22,9 @@ import {
   translate,
 } from "@azure/core-amqp";
 import {
-  commitIdempotentSequenceNumbers,
   EventData,
   EventDataInternal,
   populateIdempotentMessageAnnotations,
-  rollbackIdempotentSequenceNumbers,
   toRheaMessage,
 } from "./eventData";
 import { EventDataBatch, EventDataBatchImpl, isEventDataBatch } from "./eventDataBatch";
@@ -840,5 +838,40 @@ export function transformEventsForSend(
 
     // Finally encode the envelope (batch message).
     return message.encode(batchMessage);
+  }
+}
+
+/**
+ * Commits the pending publish sequence number events.
+ * EventDataBatch exposes this as `startingPublishSequenceNumber`,
+ * EventData not in a batch exposes this as `publishedSequenceNumber`.
+ */
+function commitIdempotentSequenceNumbers(
+  events: Omit<EventDataInternal, "getRawAmqpMessage">[] | EventDataBatch
+): void {
+  if (isEventDataBatch(events)) {
+    (events as EventDataBatchImpl)._commitPublish();
+  } else {
+    // For each event, set the `publishedSequenceNumber` equal to the sequence number
+    // we set when we attempted to send the events to the service.
+    for (const event of events) {
+      event._publishedSequenceNumber = event[PENDING_PUBLISH_SEQ_NUM_SYMBOL];
+      delete event[PENDING_PUBLISH_SEQ_NUM_SYMBOL];
+    }
+  }
+}
+
+/**
+ * Rolls back any pending publish sequence number in the events.
+ */
+function rollbackIdempotentSequenceNumbers(
+  events: Omit<EventDataInternal, "getRawAmqpMessage">[] | EventDataBatch
+): void {
+  if (isEventDataBatch(events)) {
+    /* No action required. */
+  } else {
+    for (const event of events) {
+      delete event[PENDING_PUBLISH_SEQ_NUM_SYMBOL];
+    }
   }
 }


### PR DESCRIPTION
- remove circular refs of eventHubBufferedProducerClient -> index ->
eventHubBufferedProducerClient

- remove circular refs of eventData -> eventDataBatch -> eventData

- suppress circular refs from dependency `rhea-promise`
