### PR TITLE
[core-amqp] handle possible `undefined` receiver in timeout handler

### DIFF
--- a/sdk/core/core-amqp/CHANGELOG.md
+++ b/sdk/core/core-amqp/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Bugs Fixed
 
-- Fix an issue of accessing `undefined` receiver in timeout handler of `RequestResponseLink.sendRequest`.
+- Fix an issue of accessing `undefined` receiver in timeout handler of `RequestResponseLink.sendRequest`. [PR 21866](https://github.com/Azure/azure-sdk-for-js/pull/21866)
 
 ### Other Changes
 

--- a/sdk/core/core-amqp/CHANGELOG.md
+++ b/sdk/core/core-amqp/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Fix an issue of accessing `undefined` receiver in timeout handler of `RequestResponseLink.sendRequest`.
+
 ### Other Changes
 
 ## 3.1.0 (2022-02-03)

--- a/sdk/core/core-amqp/src/requestResponseLink.ts
+++ b/sdk/core/core-amqp/src/requestResponseLink.ts
@@ -155,7 +155,7 @@ export class RequestResponseLink implements ReqResLink {
         if (aborter) {
           aborter.removeEventListener("abort", onAbort);
         }
-        const address = this.receiver.address || "address";
+        const address = this.receiver?.address || "address";
         const desc: string =
           `The request with message_id "${request.message_id}" to "${address}" ` +
           `endpoint timed out. Please try again later.`;


### PR DESCRIPTION
The live test logs shows that under some circumstance `this.receiver` could be
`undefined`.  We do have code to clean up the timer already so that might have
happened before the clean up and after receiver is closed.

```
     Uncaught TypeError: Cannot read properties of undefined (reading 'address')
      at Receiver.get address [as address] (/Users/runner/work/1/s/common/temp/node_modules/.pnpm/rhea-promise@2.1.0/node_modules/rhea-promise/lib/link.ts:96:24)
      at Timeout._onTimeout (/Users/runner/work/1/s/sdk/core/core-amqp/src/requestResponseLink.ts:158:39)
      at listOnTimeout (node:internal/timers:559:17)
      at processTimers (node:internal/timers:502:7)
```

This PR ensures that we don't throw when `this.receiver` is undefined.  The
address is only used in logging.
