### PR TITLE
[agrifood-farming-rest] downgrade dep @azure/core-paging to ^1.2.0

### DIFF
--- a/sdk/agrifood/agrifood-farming-rest/package.json
+++ b/sdk/agrifood/agrifood-farming-rest/package.json
@@ -85,7 +85,7 @@
     "@azure-rest/core-client": "1.0.0-beta.9",
     "@azure/core-auth": "^1.3.0",
     "@azure/core-lro": "^2.2.4",
-    "@azure/core-paging": "^1.2.2",
+    "@azure/core-paging": "^1.2.0",
     "@azure/logger": "^1.0.0",
     "tslib": "^2.2.0"
   },


### PR DESCRIPTION
This is consistent with most of other packages in the repo.  Version 1.2.2 is
never released, and we already bumped the version to 1.3.0.

This fix js - core nightly because we tried to use 1.2.2 there but failed to resolve it.