### PR TITLE
[ServiceBus] enable beta-trimmed api-extractor dts rollup

### DIFF
--- a/sdk/servicebus/service-bus/api-extractor.json
+++ b/sdk/servicebus/service-bus/api-extractor.json
@@ -11,7 +11,8 @@
   "dtsRollup": {
     "enabled": true,
     "untrimmedFilePath": "",
-    "publicTrimmedFilePath": "./types/latest/service-bus.d.ts"
+    "publicTrimmedFilePath": "./types/latest/service-bus.d.ts",
+    "betaTrimmedFilePath": "./types/latest/service-bus-beta.d.ts"
   },
   "messages": {
     "tsdocMessageReporting": {

--- a/sdk/servicebus/service-bus/package.json
+++ b/sdk/servicebus/service-bus/package.json
@@ -39,8 +39,8 @@
   "files": [
     "dist/",
     "dist-esm/src/",
-    "types/latest/service-bus.d.ts",
-    "types/3.1/service-bus.d.ts",
+    "types/latest/service-bus-beta.d.ts",
+    "types/3.1/service-bus-beta.d.ts",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/servicebus/service-bus/package.json
+++ b/sdk/servicebus/service-bus/package.json
@@ -40,7 +40,7 @@
     "dist/",
     "dist-esm/src/",
     "types/latest/service-bus.d.ts",
-    "types/3.1",
+    "types/3.1/service-bus.d.ts",
     "README.md",
     "LICENSE"
   ],


### PR DESCRIPTION
in public-trimmed dts rollup, @beta APIs are removed. Because we only ship
public-trimmed version it prevents us from gathering feedback for @beta APIs.
This PR enable generation of beta-trimmed dts rollup.

We still need the piece in the publishing process to use the proper version
depending on whether we are releasing a beta/dev version or not.
