### PR TITLE
[core-amqp][test] add explicit type for clearTimeout parameter

### DIFF
--- a/sdk/core/core-amqp/test/requestResponse.spec.ts
+++ b/sdk/core/core-amqp/test/requestResponse.spec.ts
@@ -604,7 +604,7 @@ describe("RequestResponseLink", function () {
 
     beforeEach(() => {
       clearTimeoutCalledCount = 0;
-      _global.clearTimeout = (tid) => {
+      _global.clearTimeout = (tid: NodeJS.Timeout) => {
         clearTimeoutCalledCount++;
         return originalClearTimeout(tid);
       };


### PR DESCRIPTION
The compiler is having problem figuring it out in latest `rush update --full` run.

>test/requestResponse.spec.ts(607,31): error TS7006: Parameter 'tid' implicitly has an 'any' type.
