### PR TITLE
[core-lro] Set isCancelled when operation status is cancelled

### DIFF
--- a/sdk/core/core-lro/src/lroEngine/models.ts
+++ b/sdk/core/core-lro/src/lroEngine/models.ts
@@ -33,7 +33,8 @@ export interface LroEngineOptions<TResult, TState> {
   isDone?: (lastResponse: unknown, state: TState) => boolean;
 
   /**
-   * A function to cancel the LRO.
+   * A function that takes the mutable state as input and attempts to cancel the
+   * LRO.
    */
   cancel?: (state: TState) => Promise<void>;
 }

--- a/sdk/core/core-lro/src/lroEngine/operation.ts
+++ b/sdk/core/core-lro/src/lroEngine/operation.ts
@@ -86,7 +86,12 @@ export class GenericPollOperation<TResult, TState extends PollOperationState<TRe
               ...response,
               done: isDone(response.flatResponse, this.state),
             })
-          : createGetLroStatusFromResponse(this.lro, state.config, this.lroResourceLocationConfig);
+          : createGetLroStatusFromResponse(
+              this.lro,
+              state.config,
+              this.state,
+              this.lroResourceLocationConfig
+            );
         this.poll = createPoll(this.lro);
       }
       if (!state.pollingURL) {
@@ -122,8 +127,12 @@ export class GenericPollOperation<TResult, TState extends PollOperationState<TRe
   }
 
   async cancel(): Promise<PollOperation<TState, TResult>> {
-    this.state.isCancelled = true;
-    await this.cancelOp?.(this.state);
+    const cancelOp =
+      this.cancelOp ??
+      (async (state: TState) => {
+        state.isCancelled = true;
+      });
+    await cancelOp(this.state);
     return this;
   }
 

--- a/sdk/core/core-lro/src/lroEngine/stateMachine.ts
+++ b/sdk/core/core-lro/src/lroEngine/stateMachine.ts
@@ -16,19 +16,22 @@ import { isBodyPollingDone, processBodyPollingOperationResult } from "./bodyPoll
 import { logger } from "./logger";
 import { processLocationPollingOperationResult } from "./locationPolling";
 import { processPassthroughOperationResult } from "./passthrough";
+import { PollOperationState } from "../pollOperation";
 
 /**
  * creates a stepping function that maps an LRO state to another.
  */
-export function createGetLroStatusFromResponse<TResult>(
+export function createGetLroStatusFromResponse<TResult, TState extends PollOperationState<TResult>>(
   lroPrimitives: LongRunningOperation<TResult>,
   config: LroConfig,
+  state: TState,
   lroResourceLocationConfig?: LroResourceLocationConfig
 ): GetLroStatusFromResponse<TResult> {
   switch (config.mode) {
     case "Location": {
       return processLocationPollingOperationResult(
         lroPrimitives,
+        state,
         config.resourceLocation,
         lroResourceLocationConfig
       );

--- a/sdk/core/core-lro/test/engine.spec.ts
+++ b/sdk/core/core-lro/test/engine.spec.ts
@@ -216,10 +216,7 @@ describe("Lro Engine", function () {
           await runMockedLro("DELETE", `/delete${rootPrefix}/retry/canceled`);
           throw new Error("should have thrown instead");
         } catch (e: any) {
-          assert.equal(
-            e.message,
-            "The long running operation has failed. The provisioning state: canceled."
-          );
+          assert.equal(e.message, "The long running operation has been canceled.");
         }
       });
 
@@ -228,10 +225,7 @@ describe("Lro Engine", function () {
           await runMockedLro("DELETE", `/delete${rootPrefix}/retry/failed`);
           throw new Error("should have thrown instead");
         } catch (e: any) {
-          assert.equal(
-            e.message,
-            "The long running operation has failed. The provisioning state: failed."
-          );
+          assert.equal(e.message, "The long running operation has failed.");
         }
       });
 
@@ -256,10 +250,7 @@ describe("Lro Engine", function () {
           await runMockedLro("PUT", `/put${rootPrefix}/retry/failed`);
           throw new Error("should have thrown instead");
         } catch (e: any) {
-          assert.equal(
-            e.message,
-            "The long running operation has failed. The provisioning state: failed."
-          );
+          assert.equal(e.message, "The long running operation has failed.");
         }
       });
 
@@ -293,10 +284,7 @@ describe("Lro Engine", function () {
           await runMockedLro("PUT", `/put${rootPrefix}/noretry/canceled`);
           throw new Error("should have thrown instead");
         } catch (e: any) {
-          assert.equal(
-            e.message,
-            "The long running operation has failed. The provisioning state: canceled."
-          );
+          assert.equal(e.message, "The long running operation has been canceled.");
         }
       });
 
@@ -321,10 +309,7 @@ describe("Lro Engine", function () {
           await runMockedLro("POST", `/post${rootPrefix}/retry/failed`);
           throw new Error("should have thrown instead");
         } catch (e: any) {
-          assert.equal(
-            e.message,
-            "The long running operation has failed. The provisioning state: failed."
-          );
+          assert.equal(e.message, "The long running operation has failed.");
         }
       });
 
@@ -335,15 +320,8 @@ describe("Lro Engine", function () {
       });
 
       it("should handle postAsyncRetrycanceled", async () => {
-        try {
-          await runMockedLro("POST", `/post${rootPrefix}/retry/canceled`);
-          throw new Error("should have thrown instead");
-        } catch (e: any) {
-          assert.equal(
-            e.message,
-            "The long running operation has failed. The provisioning state: canceled."
-          );
-        }
+        const results = await runMockedLro("POST", `/post${rootPrefix}/retry/canceled`);
+        assert.equal(results.status, "Canceled");
       });
     });
   });


### PR DESCRIPTION
The `cancel` operation on the poller can be implemented dynamically by passing a function to the `cancel` option in the `lroEngine`'s options bag. However, @witemple-msft pointed out that the poller is being marked as cancelled prematurely before even calling the user-provided `cancel` callback.

I remedied this situation by updating the cancel API to not set `isCancelled` in the poller's state at all and leave that to the library author to do inside their callbacks. Also, the implementation of the location polling mode (the most common mode for data-plane LRO APIs) sets the `isCanceled` field in the poller state if the operation status returned from the service is set to `canceled`. This way, most library authors do not even need to worry about setting `isCanceled` themselves.

A concrete example of providing a cancellation callback can be found in the text analytics library. It simply sends a cancellation request to the service and that is literally it. With this PR, the `isCanceled` will be no longer be maturely set and will instead be automatically set when the operation is truly canceled by the service.

For services with a different status monitoring mechanism, the library author can manually set `isCanceled` inside an `updateState` callback. I believe this is the simplest and most natural implementation of poller cancellation given that there is no standard REST API guidelines.

One important behavioral change in this PR to call out is that an operation status set to `canceled` caused the poller to throw an error saying the operation has failed. With this PR, canceling a POST LRO request will not longer throw an error by default. I believe this behavioral change is necessary because some POST LROs support access to partial results even if the operation was canceled (Text Analytics for example). However, library authors can throw errors manually in their callbacks as needed.

Please note that this PR is scoped to fixing the issue of prematurely setting `isCanceled`. I am happy to look at any feature requests or other issues in other github issues/pull requests.