### PR TITLE
[Text Analytics] Bump core-lro dep version

### DIFF
--- a/sdk/textanalytics/ai-text-analytics/package.json
+++ b/sdk/textanalytics/ai-text-analytics/package.json
@@ -86,7 +86,7 @@
     "@azure/core-auth": "^1.3.0",
     "@azure/core-client": "^1.0.0",
     "@azure/core-rest-pipeline": "^1.1.0",
-    "@azure/core-lro": "^2.2.0",
+    "@azure/core-lro": "^2.3.0",
     "@azure/core-paging": "^1.2.0",
     "@azure/core-tracing": "1.0.0",
     "@azure/logger": "^1.0.0",


### PR DESCRIPTION
Because TA uses features available in the new version only and we don't want min testing to fail.