### PR TITLE
use local config in retry<T>

### DIFF
--- a/sdk/core/core-amqp/src/retry.ts
+++ b/sdk/core/core-amqp/src/retry.ts
@@ -173,49 +173,50 @@ function calculateDelay(
  */
 export async function retry<T>(config: RetryConfig<T>): Promise<T> {
   validateRetryConfig(config);
-  if (!config.retryOptions) {
-    config.retryOptions = {};
+  const updatedConfig = config;
+  if (!updatedConfig.retryOptions) {
+    updatedConfig.retryOptions = {};
   }
-  if (config.retryOptions.maxRetries == undefined || config.retryOptions.maxRetries < 0) {
-    config.retryOptions.maxRetries = Constants.defaultMaxRetries;
+  if (updatedConfig.retryOptions.maxRetries == undefined || updatedConfig.retryOptions.maxRetries < 0) {
+    updatedConfig.retryOptions.maxRetries = Constants.defaultMaxRetries;
   }
-  if (config.retryOptions.retryDelayInMs == undefined || config.retryOptions.retryDelayInMs < 0) {
-    config.retryOptions.retryDelayInMs = Constants.defaultDelayBetweenOperationRetriesInMs;
+  if (updatedConfig.retryOptions.retryDelayInMs == undefined || updatedConfig.retryOptions.retryDelayInMs < 0) {
+    updatedConfig.retryOptions.retryDelayInMs = Constants.defaultDelayBetweenOperationRetriesInMs;
   }
   if (
-    config.retryOptions.maxRetryDelayInMs == undefined ||
-    config.retryOptions.maxRetryDelayInMs < 0
+    updatedConfig.retryOptions.maxRetryDelayInMs == undefined ||
+    updatedConfig.retryOptions.maxRetryDelayInMs < 0
   ) {
-    config.retryOptions.maxRetryDelayInMs = Constants.defaultMaxDelayForExponentialRetryInMs;
+    updatedConfig.retryOptions.maxRetryDelayInMs = Constants.defaultMaxDelayForExponentialRetryInMs;
   }
-  if (config.retryOptions.mode == undefined) {
-    config.retryOptions.mode = RetryMode.Fixed;
+  if (updatedConfig.retryOptions.mode == undefined) {
+    updatedConfig.retryOptions.mode = RetryMode.Fixed;
   }
   let lastError: MessagingError | Error | undefined;
   let result: any;
   let success = false;
-  const totalNumberOfAttempts = config.retryOptions.maxRetries + 1;
+  const totalNumberOfAttempts = updatedConfig.retryOptions.maxRetries + 1;
   for (let i = 1; i <= totalNumberOfAttempts; i++) {
     logger.verbose(
       "[%s] Attempt number for '%s': %d.",
-      config.connectionId,
-      config.operationType,
+      updatedConfig.connectionId,
+      updatedConfig.operationType,
       i
     );
     try {
-      result = await config.operation();
+      result = await updatedConfig.operation();
       success = true;
       logger.verbose(
         "[%s] Success for '%s', after attempt number: %d.",
-        config.connectionId,
-        config.operationType,
+        updatedConfig.connectionId,
+        updatedConfig.operationType,
         i
       );
       if (result && !isDelivery(result)) {
         logger.verbose(
           "[%s] Success result for '%s': %O",
-          config.connectionId,
-          config.operationType,
+          updatedConfig.connectionId,
+          updatedConfig.operationType,
           result
         );
       }
@@ -226,9 +227,9 @@ export async function retry<T>(config: RetryConfig<T>): Promise<T> {
       if (
         !(err as any).retryable &&
         err.name === "ServiceCommunicationError" &&
-        config.connectionHost
+        updatedConfig.connectionHost
       ) {
-        const isConnected = await checkNetworkConnection(config.connectionHost);
+        const isConnected = await checkNetworkConnection(updatedConfig.connectionHost);
         if (!isConnected) {
           err.name = "ConnectionLostError";
           (err as any).retryable = true;
@@ -236,8 +237,8 @@ export async function retry<T>(config: RetryConfig<T>): Promise<T> {
       }
       logger.verbose(
         "[%s] Error occurred for '%s' in attempt number %d: %O",
-        config.connectionId,
-        config.operationType,
+        updatedConfig.connectionId,
+        updatedConfig.operationType,
         i,
         err
       );
@@ -246,19 +247,19 @@ export async function retry<T>(config: RetryConfig<T>): Promise<T> {
       if ((lastError as any).retryable && totalNumberOfAttempts > i) {
         const targetDelayInMs = calculateDelay(
           i,
-          config.retryOptions.retryDelayInMs,
-          config.retryOptions.maxRetryDelayInMs,
-          config.retryOptions.mode
+          updatedConfig.retryOptions.retryDelayInMs,
+          updatedConfig.retryOptions.maxRetryDelayInMs,
+          updatedConfig.retryOptions.mode
         );
         logger.verbose(
           "[%s] Sleeping for %d milliseconds for '%s'.",
-          config.connectionId,
+          updatedConfig.connectionId,
           targetDelayInMs,
-          config.operationType
+          updatedConfig.operationType
         );
         await delay(
           targetDelayInMs,
-          config.abortSignal,
+          updatedConfig.abortSignal,
           `The retry operation has been cancelled by the user.`
         );
         continue;

--- a/sdk/core/core-amqp/src/retry.ts
+++ b/sdk/core/core-amqp/src/retry.ts
@@ -177,10 +177,16 @@ export async function retry<T>(config: RetryConfig<T>): Promise<T> {
   if (!updatedConfig.retryOptions) {
     updatedConfig.retryOptions = {};
   }
-  if (updatedConfig.retryOptions.maxRetries == undefined || updatedConfig.retryOptions.maxRetries < 0) {
+  if (
+    updatedConfig.retryOptions.maxRetries == undefined ||
+    updatedConfig.retryOptions.maxRetries < 0
+  ) {
     updatedConfig.retryOptions.maxRetries = Constants.defaultMaxRetries;
   }
-  if (updatedConfig.retryOptions.retryDelayInMs == undefined || updatedConfig.retryOptions.retryDelayInMs < 0) {
+  if (
+    updatedConfig.retryOptions.retryDelayInMs == undefined ||
+    updatedConfig.retryOptions.retryDelayInMs < 0
+  ) {
     updatedConfig.retryOptions.retryDelayInMs = Constants.defaultDelayBetweenOperationRetriesInMs;
   }
   if (

--- a/sdk/core/core-amqp/src/retry.ts
+++ b/sdk/core/core-amqp/src/retry.ts
@@ -173,7 +173,7 @@ function calculateDelay(
  */
 export async function retry<T>(config: RetryConfig<T>): Promise<T> {
   validateRetryConfig(config);
-  const updatedConfig = config;
+  const updatedConfig = { ...config };
   if (!updatedConfig.retryOptions) {
     updatedConfig.retryOptions = {};
   }


### PR DESCRIPTION
This PR fixed #14864.

I use a local variable `updatedConfig` instead of the passed in `config` to avoid modifying the original argument. I choose to use the local variable even when the config options is defined because if I were to use the original config, 

```
if (!configConfig.retryOptions) {
  updatedConfig.retryOptions = {};
}

// config.retryOptions might be undefined.
if (config.retryOptions.maxRetries == undefined || config.retryOptions.maxRetries < 0) {  
  ...
}
```
Another workaround would be saving the argument in a local variable and reset the argument at the end of the function (but this would not work asynchronously)

