### PR TITLE
[service-bus] prepares an out-of-band beta release

### DIFF
--- a/sdk/servicebus/service-bus/CHANGELOG.md
+++ b/sdk/servicebus/service-bus/CHANGELOG.md
@@ -1,16 +1,10 @@
 # Release History
 
-## 7.6.0-beta.3 (Unreleased)
+## 7.6.0-beta.3 (2022-05-20)
 
 ### Features Added
 
 - Add an option `omitMessageBody` in `PeekMessagesOptions` allowing omitting message body when peeking messages using `receiver.peekMessages()`
-
-### Breaking Changes
-
-### Bugs Fixed
-
-### Other Changes
 
 ## 7.6.0-beta.2 (2022-05-10)
 

--- a/sdk/servicebus/service-bus/CHANGELOG.md
+++ b/sdk/servicebus/service-bus/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 7.6.0-beta.3 (2022-05-20)
+## 7.6.0-beta.3 (2022-05-19)
 
 ### Features Added
 


### PR DESCRIPTION
for the `omitMessageBody` feature.