### PR TITLE
[ServiceBus] Fix `types` for beta release

### DIFF
--- a/sdk/servicebus/service-bus/.eslintrc.json
+++ b/sdk/servicebus/service-bus/.eslintrc.json
@@ -1,5 +1,8 @@
 {
   "plugins": ["@azure/azure-sdk"],
   "extends": ["plugin:@azure/azure-sdk/azure-sdk-base"],
-  "ignorePatterns": ["test/perf/track-1", "test/perf-js-libs", "test/stress"]
+  "ignorePatterns": ["test/perf/track-1", "test/perf-js-libs", "test/stress"],
+  "rules": {
+    "@azure/azure-sdk/ts-package-json-types": "off"
+  }
 }

--- a/sdk/servicebus/service-bus/package.json
+++ b/sdk/servicebus/service-bus/package.json
@@ -25,7 +25,7 @@
     "buffer": "buffer",
     "./dist-esm/src/util/runtimeInfo.js": "./dist-esm/src/util/runtimeInfo.browser.js"
   },
-  "types": "./types/latest/service-bus.d.ts",
+  "types": "./types/latest/service-bus-beta.d.ts",
   "typesVersions": {
     "<3.6": {
       "types/latest/*": [


### PR DESCRIPTION
Previous change update the package to include beta-trimmed dts rollup but missed
updating the `types` field.  This PR fixes it.