### PR TITLE
[KeyVault] Add test case to verify port numbers preserved in vault URL

### DIFF
--- a/sdk/keyvault/keyvault-keys/test/public/identifier.spec.ts
+++ b/sdk/keyvault/keyvault-keys/test/public/identifier.spec.ts
@@ -40,4 +40,16 @@ describe("Key Vault Keys Identifier", () => {
       version: undefined,
     });
   });
+
+  it("It should work when using a URL that contains a port", async function () {
+    const uri = "https://localhost:8443/keys/key-name/version";
+    const identifier = parseKeyVaultKeyIdentifier(uri);
+
+    assert.deepEqual(identifier, {
+      sourceId: "https://localhost:8443/keys/key-name/version",
+      vaultUrl: "https://localhost:8443",
+      version: "version",
+      name: "key-name",
+    });
+  });
 });


### PR DESCRIPTION
### Packages impacted by this PR

- `@azure/keyvault-keys`

### Issues associated with this PR

- Fixes #21927

### Describe the problem that is addressed by this PR

Adds a test case to verify that the JS client does not have the same issue as Python described in https://github.com/Azure/azure-sdk-for-python/issues/24446.
