### PR TITLE
Update the current API version to 2020-07-15

### DIFF
--- a/sdk/cosmosdb/cosmos/CHANGELOG.md
+++ b/sdk/cosmosdb/cosmos/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 3.16.0 (2022-05-23)
+
+### Features Added
+- Allow users like cosmos-explorer to specify hierarchical partition keys. https://github.com/Azure/azure-sdk-for-js/pull/21934
+- Support Dedicated Gateway RequestOptions and Max Integrated Cache Staleness. https://github.com/Azure/azure-sdk-for-js/pull/21240
+
 ## 3.15.1 (2022-01-24)
 
 ### Bugs Fixed

--- a/sdk/cosmosdb/cosmos/package.json
+++ b/sdk/cosmosdb/cosmos/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/cosmos",
-  "version": "3.15.1",
+  "version": "3.16.0",
   "description": "Microsoft Azure Cosmos DB Service Node.js SDK for SQL API",
   "sdk-type": "client",
   "keywords": [

--- a/sdk/cosmosdb/cosmos/src/common/constants.ts
+++ b/sdk/cosmosdb/cosmos/src/common/constants.ts
@@ -176,7 +176,7 @@ export const Constants = {
   ThrottleRetryCount: "x-ms-throttle-retry-count",
   ThrottleRetryWaitTimeInMs: "x-ms-throttle-retry-wait-time-ms",
 
-  CurrentVersion: "2018-12-31",
+  CurrentVersion: "2020-07-15",
 
   SDKName: "azure-cosmos-js",
   SDKVersion: "3.15.1",


### PR DESCRIPTION
Updating the current API version to 2020-07-15. This will unblock Data Explorer and Portal so that hierarchical partition keys support can be added
