### PR TITLE
[engsys] Fix min-max version script error due to npm breaking change

### DIFF
--- a/eng/tools/dependency-testing/index.js
+++ b/eng/tools/dependency-testing/index.js
@@ -185,12 +185,16 @@ async function findAppropriateVersion(package, packageJsonDepVersion, repoRoot, 
   if (isUtility) {
     return packageJsonDepVersion;
   }
-  let allNPMVersions = await getVersions(package);
-  if (allNPMVersions) {
+  let allNPMVersionsString = await getVersions(package);
+  if (allNPMVersionsString) {
+    let allVersions = JSON.parse(allNPMVersionsString);
+    if (typeof allVersions === "string") {
+      allVersions = [ allVersions ];
+    }
     console.log(versionType);
     if (versionType === "min") {
       let minVersion = await semver.minSatisfying(
-        JSON.parse(allNPMVersions),
+        allVersions,
         packageJsonDepVersion
       );
       if (minVersion) {
@@ -207,7 +211,7 @@ async function findAppropriateVersion(package, packageJsonDepVersion, repoRoot, 
     } else if (versionType === "max") {
       console.log("calling semver max satisfying");
       let maxVersion = await semver.maxSatisfying(
-        JSON.parse(allNPMVersions),
+        allVersions,
         packageJsonDepVersion
       );
       if (maxVersion) {


### PR DESCRIPTION
Previously `npm view <packageName> versions --json` returns an array even when
the result only contains one version.  In latest NPM version in NodeJS v16 the
result is now a string, which isn't expected by `semver` APIs.

This PR wraps the single string result with an array.
