### PR TITLE
[ServiceBus] add subscription-level rule manager.

### DIFF
--- a/sdk/servicebus/perf-tests/service-bus/test/subscribe.spec.ts
+++ b/sdk/servicebus/perf-tests/service-bus/test/subscribe.spec.ts
@@ -69,7 +69,6 @@ export class SubscribeTest extends EventPerfTest<ReceiverOptions> {
   setup() {
     this.subscriber = this.receiver.subscribe(
       {
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
         processMessage: async (_message: ServiceBusReceivedMessage) => {
           // { event: _message }
           this.eventRaised();

--- a/sdk/servicebus/perf-tests/service-bus/test/subscribe.spec.ts
+++ b/sdk/servicebus/perf-tests/service-bus/test/subscribe.spec.ts
@@ -69,6 +69,7 @@ export class SubscribeTest extends EventPerfTest<ReceiverOptions> {
   setup() {
     this.subscriber = this.receiver.subscribe(
       {
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
         processMessage: async (_message: ServiceBusReceivedMessage) => {
           // { event: _message }
           this.eventRaised();

--- a/sdk/servicebus/service-bus/CHANGELOG.md
+++ b/sdk/servicebus/service-bus/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Features Added
 
+- Add support to add, retrieve and remove subscription-level rules. [PR #22018](https://github.com/Azure/azure-sdk-for-js/pull/22018)
+
 ### Breaking Changes
 
 ### Bugs Fixed

--- a/sdk/servicebus/service-bus/CHANGELOG.md
+++ b/sdk/servicebus/service-bus/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features Added
 
-- Add support to add, retrieve and remove subscription-level rules. [PR #22018](https://github.com/Azure/azure-sdk-for-js/pull/22018)
+- Add support to add, retrieve, and remove subscription-level rules via AMQP links. [PR #22018](https://github.com/Azure/azure-sdk-for-js/pull/22018)
 
 ### Breaking Changes
 

--- a/sdk/servicebus/service-bus/review/service-bus.api.md
+++ b/sdk/servicebus/service-bus/review/service-bus.api.md
@@ -507,7 +507,7 @@ export interface ServiceBusReceiverOptions {
 export interface ServiceBusRuleManager {
     createRule(ruleName: string, filter: SqlRuleFilter | CorrelationRuleFilter, ruleAction?: SqlRuleAction, options?: OperationOptionsBase): Promise<void>;
     deleteRule(ruleName: string, options?: OperationOptionsBase): Promise<void>;
-    getRules(options?: OperationOptionsBase): Promise<RuleProperties[]>;
+    listRules(options?: OperationOptions): PagedAsyncIterableIterator<RuleProperties>;
 }
 
 // @public

--- a/sdk/servicebus/service-bus/review/service-bus.api.md
+++ b/sdk/servicebus/service-bus/review/service-bus.api.md
@@ -333,6 +333,7 @@ export class ServiceBusClient {
     close(): Promise<void>;
     createReceiver(queueName: string, options?: ServiceBusReceiverOptions): ServiceBusReceiver;
     createReceiver(topicName: string, subscriptionName: string, options?: ServiceBusReceiverOptions): ServiceBusReceiver;
+    createRuleManager(topicName: string, subscriptionName: string): ServiceBusRuleManager;
     createSender(queueOrTopicName: string): ServiceBusSender;
     fullyQualifiedNamespace: string;
 }
@@ -500,6 +501,13 @@ export interface ServiceBusReceiverOptions {
     receiveMode?: "peekLock" | "receiveAndDelete";
     skipParsingBodyAsJson?: boolean;
     subQueueType?: "deadLetter" | "transferDeadLetter";
+}
+
+// @public
+export interface ServiceBusRuleManager {
+    createRule(ruleName: string, filter: SqlRuleFilter | CorrelationRuleFilter, ruleAction?: SqlRuleAction, options?: OperationOptionsBase): Promise<void>;
+    deleteRule(ruleName: string, options?: OperationOptionsBase): Promise<void>;
+    getRules(options?: OperationOptionsBase): Promise<RuleProperties[]>;
 }
 
 // @public

--- a/sdk/servicebus/service-bus/src/core/managementClient.ts
+++ b/sdk/servicebus/service-bus/src/core/managementClient.ts
@@ -53,7 +53,11 @@ import { ReceiveMode } from "../models";
 import { translateServiceBusError } from "../serviceBusError";
 import { defaultDataTransformer, tryToJsonDecode } from "../dataTransformer";
 import { isDefined, isObjectWithProperties } from "../util/typeGuards";
-import { RuleProperties, SqlRuleAction, SqlRuleFilter } from "../serializers/ruleResourceSerializer";
+import {
+  RuleProperties,
+  SqlRuleAction,
+  SqlRuleFilter,
+} from "../serializers/ruleResourceSerializer";
 
 /**
  * @internal
@@ -116,21 +120,17 @@ export interface CorrelationRuleFilter {
   applicationProperties?: { [key: string]: string | number | boolean | Date };
 }
 
-
 /**
  * @internal
  */
-const sqlRuleProperties = [
-  "sqlExpression",
-];
+const sqlRuleProperties = ["sqlExpression"];
 
 function isSqlRuleFilter(obj: unknown): obj is SqlRuleFilter {
   if (obj) {
-    return sqlRuleProperties.some((validProperty) =>
-      isObjectWithProperties(obj, [validProperty]))
+    return sqlRuleProperties.some((validProperty) => isObjectWithProperties(obj, [validProperty]));
   }
 
-  return false
+  return false;
 }
 
 /**
@@ -151,10 +151,11 @@ const correlationProperties = [
 function isCorrelationRuleFilter(obj: unknown): obj is CorrelationRuleFilter {
   if (obj) {
     return correlationProperties.some((validProperty) =>
-      isObjectWithProperties(obj, [validProperty]))
+      isObjectWithProperties(obj, [validProperty])
+    );
   }
 
-  return false
+  return false;
 }
 
 /**
@@ -308,7 +309,9 @@ export class ManagementClient extends LinkEntity<RequestResponseLink> {
       : undefined;
   }
 
-  private _decodeApplicationPropertiesMap(obj: Typed): Record<string, string | number | boolean | Date> {
+  private _decodeApplicationPropertiesMap(
+    obj: Typed
+  ): Record<string, string | number | boolean | Date> {
     if (!types.is_map(obj)) {
       throw new Error("object to decode is not of Map types");
     }
@@ -1191,14 +1194,13 @@ export class ManagementClient extends LinkEntity<RequestResponseLink> {
           Array.isArray(actionsRawData.value) &&
           actionsRawData.value.length
         ) {
-           sqlRuleAction = {
-             sqlExpression: this._safelyGetTypedValueFromArray(actionsRawData.value, 0)
-           };
+          sqlRuleAction = {
+            sqlExpression: this._safelyGetTypedValueFromArray(actionsRawData.value, 0),
+          };
         } else {
-          sqlRuleAction = {}
+          sqlRuleAction = {};
         }
 
-        let rule: RuleProperties;
         switch (filtersRawData.descriptor.value) {
           case Constants.descriptorCodes.trueFilterList:
             filter = {
@@ -1208,12 +1210,12 @@ export class ManagementClient extends LinkEntity<RequestResponseLink> {
           case Constants.descriptorCodes.falseFilterList:
             filter = {
               sqlExpression: "1=0",
-            }
+            };
             break;
           case Constants.descriptorCodes.sqlFilterList:
             filter = {
               sqlExpression: this._safelyGetTypedValueFromArray(filtersRawData.value, 0),
-            }
+            };
             break;
           case Constants.descriptorCodes.correlationFilterList:
             filter = {
@@ -1225,17 +1227,24 @@ export class ManagementClient extends LinkEntity<RequestResponseLink> {
               sessionId: this._safelyGetTypedValueFromArray(filtersRawData.value, 5),
               replyToSessionId: this._safelyGetTypedValueFromArray(filtersRawData.value, 6),
               contentType: this._safelyGetTypedValueFromArray(filtersRawData.value, 7),
-              applicationProperties: Array.isArray(filtersRawData.value) && filtersRawData.value.length > 8 && filtersRawData.value[8] ?  this._decodeApplicationPropertiesMap(filtersRawData.value[8]) : undefined,
+              applicationProperties:
+                Array.isArray(filtersRawData.value) &&
+                filtersRawData.value.length > 8 &&
+                filtersRawData.value[8]
+                  ? this._decodeApplicationPropertiesMap(filtersRawData.value[8])
+                  : undefined,
             };
             break;
           default:
-            throw new Error(`${this.logPrefix} Found unexpected descriptor code for the filter: ${filtersRawData.descriptor.value}`);
+            throw new Error(
+              `${this.logPrefix} Found unexpected descriptor code for the filter: ${filtersRawData.descriptor.value}`
+            );
         }
 
-        rule = {
+        const rule: RuleProperties = {
           name: ruleDescriptor.value[2].value,
           filter,
-          action: sqlRuleAction
+          action: sqlRuleAction,
         };
         rules.push(rule);
       });
@@ -1320,8 +1329,8 @@ export class ManagementClient extends LinkEntity<RequestResponseLink> {
       const ruleDescription: any = {};
       if (isSqlRuleFilter(filter)) {
         ruleDescription["sql-filter"] = {
-          expression: filter.sqlExpression
-        }
+          expression: filter.sqlExpression,
+        };
       } else {
         ruleDescription["correlation-filter"] = {
           "correlation-id": filter.correlationId,
@@ -1333,7 +1342,7 @@ export class ManagementClient extends LinkEntity<RequestResponseLink> {
           "reply-to-session-id": filter.replyToSessionId,
           "content-type": filter.contentType,
           properties: filter.applicationProperties,
-        }
+        };
       }
 
       if (sqlRuleActionExpression !== undefined) {

--- a/sdk/servicebus/service-bus/src/core/managementClient.ts
+++ b/sdk/servicebus/service-bus/src/core/managementClient.ts
@@ -1145,7 +1145,9 @@ export class ManagementClient extends LinkEntity<RequestResponseLink> {
     try {
       const request: RheaMessage = {
         body: {
-          top: options?.maxCount ? types.wrap_int(options.maxCount) : types.wrap_int(max32BitNumber),
+          top: options?.maxCount
+            ? types.wrap_int(options.maxCount)
+            : types.wrap_int(max32BitNumber),
           skip: options?.skip ? types.wrap_int(options.skip) : types.wrap_int(0),
         },
         reply_to: this.replyTo,

--- a/sdk/servicebus/service-bus/src/core/managementClient.ts
+++ b/sdk/servicebus/service-bus/src/core/managementClient.ts
@@ -58,6 +58,7 @@ import {
   SqlRuleAction,
   SqlRuleFilter,
 } from "../serializers/ruleResourceSerializer";
+import { ListRequestOptions } from "../serviceBusAtomManagementClient";
 
 /**
  * @internal
@@ -1138,14 +1139,14 @@ export class ManagementClient extends LinkEntity<RequestResponseLink> {
    * @returns A list of rules.
    */
   async getRules(
-    options?: OperationOptionsBase & SendManagementRequestOptions
+    options?: ListRequestOptions & OperationOptionsBase & SendManagementRequestOptions
   ): Promise<RuleProperties[]> {
     throwErrorIfConnectionClosed(this._context);
     try {
       const request: RheaMessage = {
         body: {
-          top: types.wrap_int(max32BitNumber),
-          skip: types.wrap_int(0),
+          top: options?.maxCount ? types.wrap_int(options.maxCount) : types.wrap_int(max32BitNumber),
+          skip: options?.skip ? types.wrap_int(options.skip) : types.wrap_int(0),
         },
         reply_to: this.replyTo,
         application_properties: {

--- a/sdk/servicebus/service-bus/src/core/managementClient.ts
+++ b/sdk/servicebus/service-bus/src/core/managementClient.ts
@@ -1177,7 +1177,9 @@ export class ManagementClient extends LinkEntity<RequestResponseLink> {
           Array.isArray(actionsRawData.value) &&
           actionsRawData.value.length
         ) {
-           sqlRuleAction = this._safelyGetTypedValueFromArray(actionsRawData.value, 0);
+           sqlRuleAction = {
+             sqlExpression: this._safelyGetTypedValueFromArray(actionsRawData.value, 0)
+           };
         } else {
           sqlRuleAction = {}
         }
@@ -1198,14 +1200,11 @@ export class ManagementClient extends LinkEntity<RequestResponseLink> {
             filter = {
               sqlExpression: this._safelyGetTypedValueFromArray(filtersRawData.value, 0),
             }
-            rule = {
-              name: ruleDescriptor.value[2].value,
-              filter,
-              action: sqlRuleAction
-            };
-            rules.push(rule);
             break;
           case Constants.descriptorCodes.correlationFilterList:
+            console.log("### raw data value", filtersRawData)
+            console.log("### raw data value[8] type", filtersRawData.value[8].type)
+            console.log("### raw application properties: ", this._safelyGetTypedValueFromArray(filtersRawData.value, 8));
             filter = {
               correlationId: this._safelyGetTypedValueFromArray(filtersRawData.value, 0),
               messageId: this._safelyGetTypedValueFromArray(filtersRawData.value, 1),
@@ -1310,7 +1309,7 @@ export class ManagementClient extends LinkEntity<RequestResponseLink> {
       const ruleDescription: any = {};
       if (isSqlRuleFilter(filter)) {
         ruleDescription["sql-filter"] = {
-          expression: filter.sqlExpression ? "1=1" : "1=0"
+          expression: filter.sqlExpression
         }
       } else {
         ruleDescription["correlation-filter"] = {
@@ -1318,12 +1317,11 @@ export class ManagementClient extends LinkEntity<RequestResponseLink> {
           "message-id": filter.messageId,
           to: filter.to,
           "reply-to": filter.replyTo,
-          subject: filter.subject,
+          label: filter.subject,
           "session-id": filter.sessionId,
           "reply-to-session-id": filter.replyToSessionId,
           "content-type": filter.contentType,
-          applicationProperties: filter.applicationProperties,
-
+          properties: filter.applicationProperties,
         }
       }
 

--- a/sdk/servicebus/service-bus/src/index.ts
+++ b/sdk/servicebus/service-bus/src/index.ts
@@ -32,6 +32,7 @@ export { OperationOptionsBase, TryAddOptions } from "./modelsToBeSharedWithEvent
 export { ServiceBusReceiver } from "./receivers/receiver";
 export { ServiceBusSessionReceiver } from "./receivers/sessionReceiver";
 export { ServiceBusSender } from "./sender";
+export { ServiceBusRuleManager } from "./serviceBusRuleManager";
 export { NamespaceProperties } from "./serializers/namespaceResourceSerializer";
 export {
   CreateQueueOptions,

--- a/sdk/servicebus/service-bus/src/log.ts
+++ b/sdk/servicebus/service-bus/src/log.ts
@@ -25,6 +25,12 @@ export const receiverLogger = createServiceBusLogger("service-bus:receiver");
 export const senderLogger = createServiceBusLogger("service-bus:sender");
 
 /**
+ * Logging for ServiceBusRuleManagers
+ * @internal
+ */
+export const ruleManagerLogger = createServiceBusLogger("service-bus:rulemanager");
+
+/**
  * Logging for connection management
  * @internal
  */

--- a/sdk/servicebus/service-bus/src/serializers/ruleResourceSerializer.ts
+++ b/sdk/servicebus/service-bus/src/serializers/ruleResourceSerializer.ts
@@ -137,7 +137,9 @@ export type SqlRuleAction = {
  */
 export interface SqlRuleFilter {
   /**
-   * SQL expression to use in the rule filter.
+   * SQL expression to use in the rule filter. It is evaluated against the messages'
+   * user-defined properties and system properties. All system properties will be prefixed with
+   * `sys.` in the condition expression.
    * Defaults to creating a true filter if none specified
    */
   sqlExpression: string;

--- a/sdk/servicebus/service-bus/src/serviceBusClient.ts
+++ b/sdk/servicebus/service-bus/src/serviceBusClient.ts
@@ -217,15 +217,18 @@ export class ServiceBusClient {
     );
   }
 
-  createRuleManager(
-    topicName: string,
-    subscriptionName: string): ServiceBusRuleManager {
+  /**
+   * Creates an instance of {@link ServiceBusRuleManager} that is used to manage
+   * the rules for a subscription.
+   *
+   * @param topicName - the topic to create {@link ServiceBusRuleManager}
+   * @param subscriptionName - the subscription specific to the specified topic to create a {@link ServiceBusRuleManager} for.
+   * @returns a {@link ServiceBusRuleManager} scoped to the specified subscription and topic.
+   */
+  createRuleManager(topicName: string, subscriptionName: string): ServiceBusRuleManager {
     validateEntityPath(this._connectionContext.config, topicName);
 
-    const { entityPath } = extractReceiverArguments(
-      topicName,
-      subscriptionName
-    );
+    const { entityPath } = extractReceiverArguments(topicName, subscriptionName);
     return new ServiceBusRuleManagerImpl(
       this._connectionContext,
       entityPath,

--- a/sdk/servicebus/service-bus/src/serviceBusClient.ts
+++ b/sdk/servicebus/service-bus/src/serviceBusClient.ts
@@ -15,6 +15,7 @@ import {
   ServiceBusSessionReceiver,
   ServiceBusSessionReceiverImpl,
 } from "./receivers/sessionReceiver";
+import { ServiceBusRuleManager, ServiceBusRuleManagerImpl } from "./serviceBusRuleManager";
 import { ServiceBusSender, ServiceBusSenderImpl } from "./sender";
 import { entityPathMisMatchError } from "./util/errors";
 import { MessageSession } from "./session/messageSession";
@@ -212,6 +213,22 @@ export class ServiceBusClient {
       receiveMode,
       maxLockAutoRenewDurationInMs,
       options?.skipParsingBodyAsJson ?? false,
+      this._clientOptions.retryOptions
+    );
+  }
+
+  createRuleManager(
+    topicName: string,
+    subscriptionName: string): ServiceBusRuleManager {
+    validateEntityPath(this._connectionContext.config, topicName);
+
+    const { entityPath } = extractReceiverArguments(
+      topicName,
+      subscriptionName
+    );
+    return new ServiceBusRuleManagerImpl(
+      this._connectionContext,
+      entityPath,
       this._clientOptions.retryOptions
     );
   }

--- a/sdk/servicebus/service-bus/src/serviceBusRuleManager.ts
+++ b/sdk/servicebus/service-bus/src/serviceBusRuleManager.ts
@@ -8,11 +8,12 @@ import { CorrelationRuleFilter } from "./core/managementClient";
 import { RuleProperties } from "./serializers/ruleResourceSerializer";
 import { getUniqueName } from "./util/utils";
 import { throwErrorIfConnectionClosed } from "./util/errors";
+import { SqlRuleFilter } from "./serializers/ruleResourceSerializer";
 
 export interface ServiceBusRuleManager {
   createRule(
     ruleName: string,
-    filter: boolean | string | CorrelationRuleFilter,
+    filter: SqlRuleFilter | CorrelationRuleFilter,
     sqlRuleActionExpression?: string,
     options?: OperationOptionsBase): Promise<void>;
   getRules(
@@ -32,9 +33,6 @@ export class ServiceBusRuleManagerImpl implements ServiceBusRuleManager {
   private name: string;
   public entityPath: string;
 
-  private get logPrefix(): string {
-    return `[${this._context.connectionId}|ruleManager:${this.entityPath}]`;
-  }
   /**
    * @internal
    * @throws Error if the underlying connection is closed.
@@ -56,7 +54,7 @@ export class ServiceBusRuleManagerImpl implements ServiceBusRuleManager {
 
   async createRule(
     ruleName: string,
-    filter: boolean | string | CorrelationRuleFilter,
+    filter: SqlRuleFilter | CorrelationRuleFilter,
     sqlRuleActionExpression?: string,
     options?: OperationOptionsBase): Promise<void> {
     const addRuleOperationPromise = async (): Promise<void> => {

--- a/sdk/servicebus/service-bus/src/serviceBusRuleManager.ts
+++ b/sdk/servicebus/service-bus/src/serviceBusRuleManager.ts
@@ -1,0 +1,126 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { OperationOptionsBase } from "./modelsToBeSharedWithEventHubs";
+import { ConnectionContext } from "./connectionContext";
+import { RetryConfig, RetryOperationType, RetryOptions, retry } from "@azure/core-amqp";
+import { CorrelationRuleFilter } from "./core/managementClient";
+import { RuleProperties } from "./serializers/ruleResourceSerializer";
+import { getUniqueName } from "./util/utils";
+import { throwErrorIfConnectionClosed } from "./util/errors";
+
+export interface ServiceBusRuleManager {
+  createRule(
+    ruleName: string,
+    filter: boolean | string | CorrelationRuleFilter,
+    sqlRuleActionExpression?: string,
+    options?: OperationOptionsBase): Promise<void>;
+  getRules(
+    options?: OperationOptionsBase): Promise<RuleProperties[]>;
+  removeRule(ruleName: string, options?: OperationOptionsBase): Promise<void>;
+}
+
+
+/**
+ * @internal
+ */
+export class ServiceBusRuleManagerImpl implements ServiceBusRuleManager {
+  /**
+   * Denotes if close() was called on this sender
+   */
+  private _isClosed: boolean = false;
+  private name: string;
+  public entityPath: string;
+
+  private get logPrefix(): string {
+    return `[${this._context.connectionId}|ruleManager:${this.entityPath}]`;
+  }
+  /**
+   * @internal
+   * @throws Error if the underlying connection is closed.
+   */
+  constructor(
+    private _context: ConnectionContext,
+    private _entityPath: string,
+    private _retryOptions: RetryOptions = {}
+  ) {
+    throwErrorIfConnectionClosed(_context);
+    this.entityPath = _entityPath;
+    this.name = getUniqueName("ruleManager");
+  }
+
+
+  public get isClosed(): boolean {
+    return this._isClosed || this._context.wasConnectionCloseCalled;
+  }
+
+  async createRule(
+    ruleName: string,
+    filter: boolean | string | CorrelationRuleFilter,
+    sqlRuleActionExpression?: string,
+    options?: OperationOptionsBase): Promise<void> {
+    const addRuleOperationPromise = async (): Promise<void> => {
+      return this._context
+        .getManagementClient(this._entityPath)
+        .addRule(ruleName, filter, sqlRuleActionExpression, {
+          ...options,
+          associatedLinkName: this.name,
+          requestName: "addRule",
+          timeoutInMs: this._retryOptions.timeoutInMs
+        });
+    };
+    const config: RetryConfig<void> = {
+      operation: addRuleOperationPromise,
+      connectionId: this._context.connectionId,
+      operationType: RetryOperationType.management,
+      retryOptions: this._retryOptions,
+      abortSignal: options?.abortSignal,
+    };
+    return retry<void>(config);
+  }
+
+  async getRules(
+    options?: OperationOptionsBase): Promise<RuleProperties[]> {
+    const getRulesOperationPromise = async (): Promise<RuleProperties[]> => {
+      return this._context
+        .getManagementClient(this._entityPath)
+        .getRules({
+          ...options,
+          associatedLinkName: this.name,
+          requestName: "getRules",
+          timeoutInMs: this._retryOptions.timeoutInMs
+        });
+    };
+    const config: RetryConfig<RuleProperties[]> = {
+      operation: getRulesOperationPromise,
+      connectionId: this._context.connectionId,
+      operationType: RetryOperationType.management,
+      retryOptions: this._retryOptions,
+      abortSignal: options?.abortSignal,
+    };
+    return retry<RuleProperties[]>(config);
+  }
+
+  async removeRule(
+    ruleName: string,
+    options?: OperationOptionsBase): Promise<void> {
+    const removeRuleOperationPromise = async (): Promise<void> => {
+      return this._context
+        .getManagementClient(this._entityPath)
+        .removeRule(ruleName, {
+          ...options,
+          associatedLinkName: this.name,
+          requestName: "removeRule",
+          timeoutInMs: this._retryOptions.timeoutInMs
+        });
+    };
+    const config: RetryConfig<void> = {
+      operation: removeRuleOperationPromise,
+      connectionId: this._context.connectionId,
+      operationType: RetryOperationType.management,
+      retryOptions: this._retryOptions,
+      abortSignal: options?.abortSignal,
+    };
+    return retry<void>(config);
+  }
+}

--- a/sdk/servicebus/service-bus/src/serviceBusRuleManager.ts
+++ b/sdk/servicebus/service-bus/src/serviceBusRuleManager.ts
@@ -5,7 +5,7 @@ import { OperationOptionsBase } from "./modelsToBeSharedWithEventHubs";
 import { ConnectionContext } from "./connectionContext";
 import { RetryConfig, RetryOperationType, RetryOptions, retry } from "@azure/core-amqp";
 import { CorrelationRuleFilter } from "./core/managementClient";
-import { RuleProperties } from "./serializers/ruleResourceSerializer";
+import { RuleProperties, SqlRuleAction } from "./serializers/ruleResourceSerializer";
 import { getUniqueName } from "./util/utils";
 import { throwErrorIfConnectionClosed } from "./util/errors";
 import { SqlRuleFilter } from "./serializers/ruleResourceSerializer";
@@ -14,7 +14,7 @@ export interface ServiceBusRuleManager {
   createRule(
     ruleName: string,
     filter: SqlRuleFilter | CorrelationRuleFilter,
-    sqlRuleActionExpression?: string,
+    sqlRuleAction?: SqlRuleAction,
     options?: OperationOptionsBase): Promise<void>;
   getRules(
     options?: OperationOptionsBase): Promise<RuleProperties[]>;
@@ -55,12 +55,12 @@ export class ServiceBusRuleManagerImpl implements ServiceBusRuleManager {
   async createRule(
     ruleName: string,
     filter: SqlRuleFilter | CorrelationRuleFilter,
-    sqlRuleActionExpression?: string,
+    sqlRuleAction?: SqlRuleAction,
     options?: OperationOptionsBase): Promise<void> {
     const addRuleOperationPromise = async (): Promise<void> => {
       return this._context
         .getManagementClient(this._entityPath)
-        .addRule(ruleName, filter, sqlRuleActionExpression, {
+        .addRule(ruleName, filter, sqlRuleAction?.sqlExpression, {
           ...options,
           associatedLinkName: this.name,
           requestName: "addRule",

--- a/sdk/servicebus/service-bus/src/serviceBusRuleManager.ts
+++ b/sdk/servicebus/service-bus/src/serviceBusRuleManager.ts
@@ -141,7 +141,9 @@ export class ServiceBusRuleManagerImpl implements ServiceBusRuleManager {
   /**
    * Get all rules associated with the subscription.
    */
-  private async getRules(options?: ListRequestOptions & OperationOptionsBase): Promise<RuleProperties[]> {
+  private async getRules(
+    options?: ListRequestOptions & OperationOptionsBase
+  ): Promise<RuleProperties[]> {
     const { span } = createServiceBusSpan(
       "ServiceBusRuleManager.getRules",
       options,
@@ -220,7 +222,7 @@ export class ServiceBusRuleManagerImpl implements ServiceBusRuleManager {
   public listRules(
     // eslint-disable-next-line @azure/azure-sdk/ts-naming-options
     options?: OperationOptions
-  ): PagedAsyncIterableIterator<RuleProperties, RuleProperties[], { maxPageSize?: number; }> {
+  ): PagedAsyncIterableIterator<RuleProperties, RuleProperties[], { maxPageSize?: number }> {
     logger.verbose(`Performing operation - listRules() with options: %j`, options);
     const iter = this.listRulesAll(options);
     return {
@@ -236,7 +238,7 @@ export class ServiceBusRuleManagerImpl implements ServiceBusRuleManager {
       },
       /**
        */
-      byPage: (settings: { maxPageSize?: number; } = {}) => {
+      byPage: (settings: { maxPageSize?: number } = {}) => {
         return this.listRulesPage(undefined, {
           maxPageSize: settings.maxPageSize,
           ...options,

--- a/sdk/servicebus/service-bus/test/public/ruleManager.spec.ts
+++ b/sdk/servicebus/service-bus/test/public/ruleManager.spec.ts
@@ -15,7 +15,7 @@ import {
   ServiceBusClientForTests,
   createServiceBusClientForTests,
 } from "../public/utils/testutils2";
-import { deleteSubscription, recreateSubscription } from "./utils/managementUtils";
+import { recreateSubscription } from "./utils/managementUtils";
 chai.use(chaiAsPromised);
 const assert = chai.assert;
 
@@ -69,8 +69,7 @@ describe("RuleManager tests", () => {
 
     beforeEach(async () => {
       sender = serviceBusClient.test.addToCleanup(serviceBusClient.createSender(topic));
-      await deleteSubscription(topic, subscription);
-      await recreateSubscription(topic, subscription);
+      await recreateSubscription(topic, subscription, { deleteFirst: true });
     });
 
     afterEach(async () => {

--- a/sdk/servicebus/service-bus/test/public/ruleManager.spec.ts
+++ b/sdk/servicebus/service-bus/test/public/ruleManager.spec.ts
@@ -45,7 +45,7 @@ const orders: Order[] = [
  * testing helper for convenience
  */
 async function getRules(ruleManager: any): Promise<RuleProperties[]> {
-  return (await (ruleManager).getRules()) as RuleProperties[];
+  return (await ruleManager.getRules()) as RuleProperties[];
 }
 
 /**
@@ -153,7 +153,7 @@ describe("RuleManager tests", () => {
       const sqlRuleName = "sqlRule";
       const correlationRuleName = "correlationRule";
 
-      let rules = await getRules(ruleManager);
+      const rules = await getRules(ruleManager);
       assert.equal(rules.length, 1); // default rule
       const firstRule = rules[0];
       assert.equal(firstRule.name, defaultRuleName);

--- a/sdk/servicebus/service-bus/test/public/ruleManager.spec.ts
+++ b/sdk/servicebus/service-bus/test/public/ruleManager.spec.ts
@@ -1,0 +1,117 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import {
+  CorrelationRuleFilter,
+  // ServiceBusSender,
+  SqlRuleAction,
+  SqlRuleFilter,
+} from "../../src";
+import { TestClientType } from "../public/utils/testUtils";
+import chai from "chai";
+import chaiAsPromised from "chai-as-promised";
+import {
+  ServiceBusClientForTests,
+  createServiceBusClientForTests,
+} from "../public/utils/testutils2";
+chai.use(chaiAsPromised);
+const assert = chai.assert;
+
+/**
+ * A basic suite that exercises most of the core functionality.
+ */
+describe("RuleManager tests", () => {
+  let serviceBusClient: ServiceBusClientForTests;
+
+  before(async () => {
+    serviceBusClient = createServiceBusClientForTests();
+  });
+
+  after(() => {
+    return serviceBusClient.test.after();
+  });
+  describe("subscriptions", () => {
+    // let sender: ServiceBusSender;
+    let topic: string;
+    let subscription: string;
+
+    before(async () => {
+      const entity = await serviceBusClient.test.createTestEntities(
+        TestClientType.UnpartitionedSubscription
+      );
+
+      topic = entity.topic!;
+      subscription = entity.subscription!;
+    });
+
+    beforeEach(async () => {
+      // sender = serviceBusClient.test.addToCleanup(serviceBusClient.createSender(topic));
+    });
+
+    afterEach(async () => {
+      return serviceBusClient.test.afterEach();
+    });
+
+    it("add get and remove rule", async () => {
+      const ruleManager = serviceBusClient.createRuleManager(topic, subscription);
+
+      const sqlRuleName = "sqlRule";
+      const correlationRuleName = "correlationRule";
+
+      let rules = await ruleManager.getRules();
+      assert.equal(rules.length, 1); // default rule
+      const firstRule = rules[0];
+      assert.equal(firstRule.name, "$Default");
+      assert.deepStrictEqual(firstRule.action, {});
+
+      await ruleManager.createRule(sqlRuleName, {
+          sqlExpression: "price > 10"
+        });
+
+      const correlationRuleFilter: CorrelationRuleFilter = {
+        correlationId: "correlationId",
+        subject: "label",
+        messageId: "messageId",
+        applicationProperties: {
+          key1: "value1"
+        },
+        replyTo: "replyTo",
+        replyToSessionId: "replyToSessionId",
+        sessionId: "sessionId",
+        to: "to"
+      };
+      const action: SqlRuleAction = {
+        sqlExpression: "Set CorrelationId = 'newValue'",
+      }
+      await ruleManager.createRule(correlationRuleName, correlationRuleFilter, action);
+
+      rules = await ruleManager.getRules();
+      assert.equal(rules.length, 3);
+
+      const sqlRules = rules.filter(r => r.name === sqlRuleName);
+      assert.ok(sqlRules.length >= 1, "expecting at least one sql rule")
+      assert.ok(sqlRules[0], "expecting valid sql rule");
+      const sqlRule = sqlRules[0];
+      assert.equal((sqlRule.filter as SqlRuleFilter).sqlExpression, "price > 10");
+
+      const correlationRules = rules.filter(r => r.name === correlationRuleName);
+      assert.ok(correlationRules.length >= 1, "expecting at least one correlation rule")
+      assert.ok(correlationRules[0], "expecting valid correlation rule")
+      const correlationRule = correlationRules[0];
+      console.log("### correlation rule ", correlationRule);
+      assert.equal(correlationRule.action.sqlExpression, "Set CorrelationId = 'newValue'")
+      assert.ok(correlationRule.filter);
+      const correlationFilter = correlationRule.filter as CorrelationRuleFilter;
+      assert.equal(correlationFilter.correlationId, "correlationId")
+      assert.equal(correlationFilter.subject, "label")
+      assert.equal(correlationFilter.messageId, "messageId")
+      assert.equal(correlationFilter.replyTo, "replyTo")
+      assert.equal(correlationFilter.replyToSessionId, "replyToSessionId")
+      assert.equal(correlationFilter.sessionId, "sessionId")
+      assert.equal(correlationFilter.to, "to")
+      assert.deepStrictEqual(correlationFilter.applicationProperties, {
+        key1: "value1"
+      })
+    });
+  });
+});

--- a/sdk/servicebus/service-bus/test/public/ruleManager.spec.ts
+++ b/sdk/servicebus/service-bus/test/public/ruleManager.spec.ts
@@ -184,7 +184,6 @@ describe("RuleManager tests", () => {
       let result = await iterator.next();
       assert.equal(result.value.length, 1, "Expecting one rule in first page");
       assert.equal(result.value[0].name, defaultRuleName);
-      const tokenForNextPage = result.value.continuationToken;
       result = await iterator.next();
       assert.equal(result.value.length, 1, "Expecting one rule in second page");
       assert.equal(result.value[0].name, correlationRuleName);
@@ -195,12 +194,6 @@ describe("RuleManager tests", () => {
       assert.equal(result.value.length, 0, "Not expecting any result in last page");
       result = await iterator.next();
       assert.equal(result.value, undefined, "Not expecting any more pages");
-
-      const iterNextPage = ruleManager.listRules().byPage({ maxPageSize: 2, continuationToken: tokenForNextPage });
-      result = await iterNextPage.next();
-      assert.equal(result.value.length, 2, "Expecting two rules in next page with continuation token");
-      assert.equal(result.value[0].name, correlationRuleName);
-      assert.equal(result.value[1].name, sqlRuleName);
     });
 
     it("throws if add rule with same name twice", async () => {

--- a/sdk/servicebus/service-bus/test/public/utils/managementUtils.ts
+++ b/sdk/servicebus/service-bus/test/public/utils/managementUtils.ts
@@ -142,6 +142,35 @@ export async function recreateTopic(
 }
 
 /**
+ * Utility that deletes a subscription using given parameters.
+ */
+export async function deleteSubscription(
+  topicName: string,
+  subscriptionName: string
+): Promise<void> {
+  getManagementClient();
+
+  const deleteSubscriptionOperation = async (): Promise<void> => {
+    await client.deleteSubscription(topicName, subscriptionName);
+  };
+
+  const checkIfSubscriptionExistsOperation = async (): Promise<boolean> => {
+    try {
+      await client.getSubscription(topicName, subscriptionName);
+    } catch (err: any) {
+      return false;
+    }
+    return true;
+  };
+
+  await retry(
+    deleteSubscriptionOperation,
+    async () => !(await checkIfSubscriptionExistsOperation()),
+    `Delete subscription "${subscriptionName}"`
+  );
+}
+
+/**
  * Utility that creates a subscription using given parameters.
  */
 export async function recreateSubscription(


### PR DESCRIPTION
### Packages impacted by this PR
@Azure/service-bus 

This existed in Track 1 and allowed users with only Listen claims to manage rules on the subscription that they had listen claims for. In Track 2, this can be done using the `ServiceBusAdministrationClient`, but Get Rules and List Rules require Manage claims.

This PR adds a rule manager that can add, delete, and retrieve rules for a specified subscription via AMQP link.

### Issues associated with this PR
#20890 

- [x] Added a changelog (if necessary)
