### PR TITLE
[Monitor-query] Fixed the typo for the user-provided scope formation

### DIFF
--- a/sdk/monitor/monitor-query/CHANGELOG.md
+++ b/sdk/monitor/monitor-query/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Bugs Fixed
 
+- Fixed a typo in the string for user-provided scope for `MetricsQueryClient` and `LogsQueryClient`.
 ### Other Changes
 
 ## 1.0.1 (2022-02-10)

--- a/sdk/monitor/monitor-query/src/logsQueryClient.ts
+++ b/sdk/monitor/monitor-query/src/logsQueryClient.ts
@@ -56,7 +56,7 @@ export class LogsQueryClient {
     // host.
     let scope;
     if (options?.endpoint) {
-      scope = `${options?.endpoint}./default`;
+      scope = `${options?.endpoint}/.default`;
     }
     const credentialOptions = {
       credentialScopes: scope,

--- a/sdk/monitor/monitor-query/src/metricsQueryClient.ts
+++ b/sdk/monitor/monitor-query/src/metricsQueryClient.ts
@@ -59,7 +59,7 @@ export class MetricsQueryClient {
   constructor(tokenCredential: TokenCredential, options?: MetricsQueryClientOptions) {
     let scope;
     if (options?.endpoint) {
-      scope = `${options?.endpoint}./default`;
+      scope = `${options?.endpoint}/.default`;
     }
     const credentialOptions = {
       credentialScopes: scope,


### PR DESCRIPTION
### Packages impacted by this PR
@azure/monitor-query

### Issues associated with this PR
https://github.com/Azure/azure-sdk-for-js/issues/21984

### Describe the problem that is addressed by this PR
There was a typo in the scope formation for the case of user-provided scopes. This PR was an attempt to fix that.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_
- No tests since these are internal implementation details


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [x] Added impacted package name to the issue description
- [x] Added a changelog (if necessary)
