### PR TITLE
Add back missing @beta tag

### DIFF
--- a/sdk/cosmosdb/cosmos/CHANGELOG.md
+++ b/sdk/cosmosdb/cosmos/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 3.16.1 (2022-05-27)
+## 3.16.1 (2022-05-31)
 
 ### Bugs Fixed
 - Fix [#22003](https://github.com/Azure/azure-sdk-for-js/issues/22003) missing interface error. [#22015](https://github.com/Azure/azure-sdk-for-js/pull/22015)

--- a/sdk/cosmosdb/cosmos/review/cosmos.api.md
+++ b/sdk/cosmosdb/cosmos/review/cosmos.api.md
@@ -1718,6 +1718,7 @@ export function setAuthorizationTokenHeaderUsingMasterKey(verb: HTTPMethod, reso
 export interface SharedOptions {
     abortSignal?: AbortSignal_2;
     initialHeaders?: CosmosHeaders;
+    // @beta
     maxIntegratedCacheStalenessInMs?: number;
     sessionToken?: string;
 }

--- a/sdk/cosmosdb/cosmos/src/request/SharedOptions.ts
+++ b/sdk/cosmosdb/cosmos/src/request/SharedOptions.ts
@@ -32,6 +32,7 @@ export interface SharedOptions {
    * <p>Default value is null</p>
    *
    * <p>Cache Staleness is supported in milliseconds granularity. Anything smaller than milliseconds will be ignored.</p>
+   * @beta
    */
   maxIntegratedCacheStalenessInMs?: number;
 }


### PR DESCRIPTION
### Packages impacted by this PR
@azure/cosmos

### Issues associated with this PR
Missing @beta annotation on beta property

### Describe the problem that is addressed by this PR
The property was added directly to the `SharedOptions` interface instead of inheriting from a `@beta` interface, this prevents the TS issue where the stable interface depends on a beta interface.

This PR is adding a `@beta` tag missing on the new property.