### PR TITLE
Fix dockerfile copy ref

### DIFF
--- a/sdk/identity/identity/test/manual-integration/Kubernetes/Dockerfile
+++ b/sdk/identity/identity/test/manual-integration/Kubernetes/Dockerfile
@@ -2,14 +2,14 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
-ARG NODE_VERSION=10
+ARG NODE_VERSION=18
 
 # docker can't tell when the repo has changed and will therefore cache this layer
 # internal users should provide MCR registry to build via 'docker build . --build-arg REGISTRY="mcr.microsoft.com/mirror/docker/library/"'
 # public OSS users should simply leave this argument blank or ignore its presence entirely
 ARG REGISTRY=""
 
-FROM ${REGISTRY}node:18-alpine as repo
+FROM ${REGISTRY}node:${NODE_VERSION}-alpine as repo
 RUN apk --no-cache add git
 RUN git clone https://github.com/azure/azure-sdk-for-js --single-branch --branch main --depth 1 /azure-sdk-for-js
 

--- a/sdk/identity/identity/test/manual-integration/Kubernetes/Dockerfile
+++ b/sdk/identity/identity/test/manual-integration/Kubernetes/Dockerfile
@@ -8,15 +8,18 @@ ARG NODE_VERSION=10
 # internal users should provide MCR registry to build via 'docker build . --build-arg REGISTRY="mcr.microsoft.com/mirror/docker/library/"'
 # public OSS users should simply leave this argument blank or ignore its presence entirely
 ARG REGISTRY=""
+# oss flags COPY --from also if it uses default registry.
+# In this case, COPY --from copies from github repo but we still need to override using empty arg to disable this check
+ARG REPO="repo"
 FROM ${REGISTRY}alpine:3.14 as repo
 RUN apk --no-cache add git
 RUN git clone https://github.com/azure/azure-sdk-for-js --single-branch --branch master --depth 1 /azure-sdk-for-js
 
 FROM ${REGISTRY}node:${NODE_VERSION}-slim
 
-COPY --from=repo /azure-sdk-for-js/sdk/identity /sdk/identity
-COPY --from=repo /azure-sdk-for-js/sdk/core /sdk/core
-COPY --from=repo /azure-sdk-for-js/sdk/keyvault/keyvault-secrets /sdk/keyvault/keyvault-secrets
+COPY --from=${REPO} /azure-sdk-for-js/sdk/identity /sdk/identity
+COPY --from=${REPO} /azure-sdk-for-js/sdk/core /sdk/core
+COPY --from=${REPO} /azure-sdk-for-js/sdk/keyvault/keyvault-secrets /sdk/keyvault/keyvault-secrets
 
 WORKDIR /sdk/identity/identity/test/manual-integration/Kubernetes
 RUN npm install

--- a/sdk/identity/identity/test/manual-integration/Kubernetes/Dockerfile
+++ b/sdk/identity/identity/test/manual-integration/Kubernetes/Dockerfile
@@ -8,20 +8,12 @@ ARG NODE_VERSION=10
 # internal users should provide MCR registry to build via 'docker build . --build-arg REGISTRY="mcr.microsoft.com/mirror/docker/library/"'
 # public OSS users should simply leave this argument blank or ignore its presence entirely
 ARG REGISTRY=""
-# oss flags COPY --from also if it uses default registry.
-# In this case, COPY --from copies from github repo but we still need to override using empty arg to disable this check
-ARG REPO="repo"
-FROM ${REGISTRY}alpine:3.14 as repo
+
+FROM ${REGISTRY}node:18-alpine as repo
 RUN apk --no-cache add git
-RUN git clone https://github.com/azure/azure-sdk-for-js --single-branch --branch master --depth 1 /azure-sdk-for-js
+RUN git clone https://github.com/azure/azure-sdk-for-js --single-branch --branch main --depth 1 /azure-sdk-for-js
 
-FROM ${REGISTRY}node:${NODE_VERSION}-slim
-
-COPY --from=${REPO} /azure-sdk-for-js/sdk/identity /sdk/identity
-COPY --from=${REPO} /azure-sdk-for-js/sdk/core /sdk/core
-COPY --from=${REPO} /azure-sdk-for-js/sdk/keyvault/keyvault-secrets /sdk/keyvault/keyvault-secrets
-
-WORKDIR /sdk/identity/identity/test/manual-integration/Kubernetes
+WORKDIR /azure-sdk-for-js/sdk/identity/identity/test/manual-integration/Kubernetes
 RUN npm install
 RUN npm install -g typescript
 RUN tsc -p .


### PR DESCRIPTION
Update docker file to use different image for node alpine and also update the branch to main. This docker file seems not used for a while since it was still referring master branch.