### PR TITLE
Move storage-blob resource location to canadacentral

### DIFF
--- a/sdk/storage/storage-blob/tests.yml
+++ b/sdk/storage/storage-blob/tests.yml
@@ -7,7 +7,7 @@ stages:
       ServiceDirectory: storage
       TimeoutInMinutes: 90
       Clouds: Preview
-      Location: westus
+      Location: westus3
       MatrixFilters:
         - DependencyVersion=^$
       MatrixConfigs:

--- a/sdk/storage/storage-blob/tests.yml
+++ b/sdk/storage/storage-blob/tests.yml
@@ -7,7 +7,7 @@ stages:
       ServiceDirectory: storage
       TimeoutInMinutes: 90
       Clouds: Preview
-      Location: westus2
+      Location: canadacentral
       MatrixFilters:
         - DependencyVersion=^$
       MatrixConfigs:

--- a/sdk/storage/storage-blob/tests.yml
+++ b/sdk/storage/storage-blob/tests.yml
@@ -7,7 +7,7 @@ stages:
       ServiceDirectory: storage
       TimeoutInMinutes: 90
       Clouds: Preview
-      Location: westus3
+      Location: westus2
       MatrixFilters:
         - DependencyVersion=^$
       MatrixConfigs:


### PR DESCRIPTION
- Reverts unintentional move to westus in #13886
- Aligns storage-blob with storage-file-share and storage-file-datalake
- Ensures access is over ipv4, which is required for some SAS tests
- If both agent VMs and storage account are in westus, access is over ipv6
