### PR TITLE
Move storage-blob resource location to westus2

### DIFF
--- a/sdk/storage/storage-blob/tests.yml
+++ b/sdk/storage/storage-blob/tests.yml
@@ -7,7 +7,7 @@ stages:
       ServiceDirectory: storage
       TimeoutInMinutes: 90
       Clouds: Preview
-      Location: westus
+      Location: westus2
       MatrixFilters:
         - DependencyVersion=^$
       MatrixConfigs:


### PR DESCRIPTION
- Ensures access is over ipv4, which is required for some SAS tests
- If both agent VMs and storage account are in westus, access is over ipv6
