### PR TITLE
[Key Vault] Fix tests that rely on now-removed constraint validation

### DIFF
--- a/sdk/keyvault/keyvault-certificates/recordings/browsers/certificates_client__create_read_update_and_delete/recording_cannot_create_a_certificate_with_an_empty_name.json
+++ b/sdk/keyvault/keyvault-certificates/recordings/browsers/certificates_client__create_read_update_and_delete/recording_cannot_create_a_certificate_with_an_empty_name.json
@@ -1,8 +1,86 @@
 {
- "recordings": [],
+ "recordings": [
+  {
+   "method": "POST",
+   "url": "https://keyvault_name.vault.azure.net/certificates//create",
+   "query": {
+    "api-version": "7.3"
+   },
+   "requestBody": "",
+   "status": 401,
+   "response": "{\"error\":{\"code\":\"Unauthorized\",\"message\":\"AKV10000: Request is missing a Bearer or PoP token.\"}}",
+   "responseHeaders": {
+    "cache-control": "no-cache",
+    "content-length": "97",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Thu, 02 Jun 2022 16:53:57 GMT",
+    "expires": "-1",
+    "pragma": "no-cache",
+    "strict-transport-security": "max-age=31536000;includeSubDomains",
+    "www-authenticate": "Bearer authorization=\"https://login.windows.net/12345678-1234-1234-1234-123456789012\", resource=\"https://vault.azure.net\"",
+    "x-content-type-options": "nosniff",
+    "x-ms-client-request-id": "655a68bd-fa5e-4851-835b-1f9090b634e8",
+    "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=167.220.80.222;act_addr_fam=InterNetwork;",
+    "x-ms-keyvault-region": "northcentralus",
+    "x-ms-keyvault-service-version": "1.9.422.1",
+    "x-ms-request-id": "38ca9436-99e4-4ea0-a215-10c69cfa60f5"
+   }
+  },
+  {
+   "method": "POST",
+   "url": "https://login.microsoftonline.com/12345678-1234-1234-1234-123456789012/oauth2/v2.0/token",
+   "query": {},
+   "requestBody": "response_type=token&grant_type=client_credentials&client_id=azure_client_id&client_secret=azure_client_secret&scope=https%3A%2F%2Fsanitized%2F",
+   "status": 200,
+   "response": "{\"token_type\":\"Bearer\",\"expires_in\":86399,\"ext_expires_in\":86399,\"access_token\":\"access_token\"}",
+   "responseHeaders": {
+    "cache-control": "no-store, no-cache",
+    "content-length": "1315",
+    "content-security-policy-report-only": "script-src 'self' 'nonce-8UsX--1KtYgWndZHfvyeUQ' 'unsafe-eval' 'unsafe-inline'; object-src 'none'; base-uri 'none'; report-uri https://csp.microsoft.com/report/ESTS-UX-All",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Thu, 02 Jun 2022 16:53:57 GMT",
+    "expires": "-1",
+    "nel": "{\"report_to\":\"network-errors\",\"max_age\":86400,\"success_fraction\":0.001,\"failure_fraction\":1.0}",
+    "p3p": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\"",
+    "pragma": "no-cache",
+    "referrer-policy": "strict-origin-when-cross-origin",
+    "report-to": "{\"group\":\"network-errors\",\"max_age\":86400,\"endpoints\":[{\"url\":\"https://identity.nel.measure.office.net/api/report?catId=GW+estsfd+est\"}]}",
+    "strict-transport-security": "max-age=31536000; includeSubDomains",
+    "x-content-type-options": "nosniff",
+    "x-ms-ests-server": "2.1.12851.6 - WUS2 ProdSlices",
+    "x-ms-request-id": "ac17b9e9-1925-41ad-8cfc-b283c8c82300",
+    "x-xss-protection": "0"
+   }
+  },
+  {
+   "method": "POST",
+   "url": "https://keyvault_name.vault.azure.net/certificates//create",
+   "query": {
+    "api-version": "7.3"
+   },
+   "requestBody": "{\"policy\":{\"key_props\":{},\"secret_props\":{},\"x509_props\":{\"subject\":\"cn=MyCert\",\"sans\":{}},\"issuer\":{\"name\":\"Self\"},\"attributes\":{}},\"attributes\":{}}",
+   "status": 405,
+   "response": "{\"error\":{\"code\":\"MethodNotAllowed\",\"message\":\"HTTP POST not allowed\"}}",
+   "responseHeaders": {
+    "cache-control": "no-cache",
+    "content-length": "71",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Thu, 02 Jun 2022 16:53:57 GMT",
+    "expires": "-1",
+    "pragma": "no-cache",
+    "strict-transport-security": "max-age=31536000;includeSubDomains",
+    "x-content-type-options": "nosniff",
+    "x-ms-client-request-id": "655a68bd-fa5e-4851-835b-1f9090b634e8",
+    "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=167.220.80.222;act_addr_fam=InterNetwork;",
+    "x-ms-keyvault-region": "northcentralus",
+    "x-ms-keyvault-service-version": "1.9.422.1",
+    "x-ms-request-id": "235ba3a5-6ab3-46f1-82c1-286ed6cc943c"
+   }
+  }
+ ],
  "uniqueTestInfo": {
   "uniqueName": {},
   "newDate": {}
  },
- "hash": "4adbf991856b33c4c1b20357cb8f22e5"
+ "hash": "7cedc71fc39ac038dec880f46eec1102"
 }

--- a/sdk/keyvault/keyvault-certificates/recordings/node/certificates_client__create_read_update_and_delete/recording_cannot_create_a_certificate_with_an_empty_name.js
+++ b/sdk/keyvault/keyvault-certificates/recordings/node/certificates_client__create_read_update_and_delete/recording_cannot_create_a_certificate_with_an_empty_name.js
@@ -1,5 +1,185 @@
 let nock = require('nock');
 
-module.exports.hash = "ead8dcfc61c2aea18d764a4f0a000268";
+module.exports.hash = "4681804706158c875a521223637e49a9";
 
 module.exports.testInfo = {"uniqueName":{},"newDate":{}}
+
+nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
+  .post('/certificates//create')
+  .query(true)
+  .reply(401, {"error":{"code":"Unauthorized","message":"AKV10000: Request is missing a Bearer or PoP token."}}, [
+  'Cache-Control',
+  'no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Length',
+  '97',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'WWW-Authenticate',
+  'Bearer authorization="https://login.windows.net/12345678-1234-1234-1234-123456789012", resource="https://vault.azure.net"',
+  'x-ms-keyvault-region',
+  'northcentralus',
+  'x-ms-client-request-id',
+  'dfd4ef55-27dc-4d77-925e-60ebee982dbe',
+  'x-ms-request-id',
+  'eaecdbc8-733e-4481-865c-bffb3b809a1b',
+  'x-ms-keyvault-service-version',
+  '1.9.422.1',
+  'x-ms-keyvault-network-info',
+  'conn_type=Ipv4;addr=167.220.80.222;act_addr_fam=InterNetwork;',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Strict-Transport-Security',
+  'max-age=31536000;includeSubDomains',
+  'Date',
+  'Thu, 02 Jun 2022 16:53:51 GMT'
+]);
+
+nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
+  .get('/common/discovery/instance')
+  .query(true)
+  .reply(200, {"tenant_discovery_endpoint":"https://login.microsoftonline.com/12345678-1234-1234-1234-123456789012/v2.0/.well-known/openid-configuration","api-version":"1.1","metadata":[{"preferred_network":"login.microsoftonline.com","preferred_cache":"login.windows.net","aliases":["login.microsoftonline.com","login.windows.net","login.microsoft.com","sts.windows.net"]},{"preferred_network":"login.partner.microsoftonline.cn","preferred_cache":"login.partner.microsoftonline.cn","aliases":["login.partner.microsoftonline.cn","login.chinacloudapi.cn"]},{"preferred_network":"login.microsoftonline.de","preferred_cache":"login.microsoftonline.de","aliases":["login.microsoftonline.de"]},{"preferred_network":"login.microsoftonline.us","preferred_cache":"login.microsoftonline.us","aliases":["login.microsoftonline.us","login.usgovcloudapi.net"]},{"preferred_network":"login-us.microsoftonline.com","preferred_cache":"login-us.microsoftonline.com","aliases":["login-us.microsoftonline.com"]}]}, [
+  'Cache-Control',
+  'max-age=86400, private',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Access-Control-Allow-Origin',
+  '*',
+  'Access-Control-Allow-Methods',
+  'GET, OPTIONS',
+  'P3P',
+  'CP="DSP CUR OTPi IND OTRi ONL FIN"',
+  'x-ms-request-id',
+  '8823200f-f0eb-4f8b-b6c8-66f0ebbf2400',
+  'x-ms-ests-server',
+  '2.1.12851.6 - NCUS ProdSlices',
+  'X-XSS-Protection',
+  '0',
+  'Set-Cookie',
+  'fpc=AinfxfrUjXtOrIzlQ-6RoD0; expires=Sat, 02-Jul-2022 16:53:52 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'Set-Cookie',
+  'esctx=AQABAAAAAAD--DLA3VO7QrddgJg7WevrgFYnxAzFc3j_eDEsPO57DInKnrA1YviwnxwwNCTQ1SiRK7V414BXqMcbIAnslhwb6lq1Iq02tanUwYXRNK8sdcASiM1-BgE3I6diwZvcAUwVHQ3VDWcfZTateAsYPP_MqZRwSzWab0_GlXXDp8-aPyskVGTcd0N2BEglspMih7ggAA; domain=.login.microsoftonline.com; path=/; secure; HttpOnly; SameSite=None',
+  'Set-Cookie',
+  'x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly',
+  'Set-Cookie',
+  'stsservicecookie=estsfd; path=/; secure; samesite=none; httponly',
+  'Date',
+  'Thu, 02 Jun 2022 16:53:52 GMT',
+  'Content-Length',
+  '980'
+]);
+
+nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
+  .get('/12345678-1234-1234-1234-123456789012/v2.0/.well-known/openid-configuration')
+  .reply(200, {"token_endpoint":"https://login.microsoftonline.com/12345678-1234-1234-1234-123456789012/oauth2/v2.0/token","token_endpoint_auth_methods_supported":["client_secret_post","private_key_jwt","client_secret_basic"],"jwks_uri":"https://login.microsoftonline.com/12345678-1234-1234-1234-123456789012/discovery/v2.0/keys","response_modes_supported":["query","fragment","form_post"],"subject_types_supported":["pairwise"],"id_token_signing_alg_values_supported":["RS256"],"response_types_supported":["code","id_token","code id_token","id_token token"],"scopes_supported":["openid","profile","email","offline_access"],"issuer":"https://login.microsoftonline.com/12345678-1234-1234-1234-123456789012/v2.0","request_uri_parameter_supported":false,"userinfo_endpoint":"https://graph.microsoft.com/oidc/userinfo","authorization_endpoint":"https://login.microsoftonline.com/12345678-1234-1234-1234-123456789012/oauth2/v2.0/authorize","device_authorization_endpoint":"https://login.microsoftonline.com/12345678-1234-1234-1234-123456789012/oauth2/v2.0/devicecode","http_logout_supported":true,"frontchannel_logout_supported":true,"end_session_endpoint":"https://login.microsoftonline.com/12345678-1234-1234-1234-123456789012/oauth2/v2.0/logout","claims_supported":["sub","iss","cloud_instance_name","cloud_instance_host_name","cloud_graph_host_name","msgraph_host","aud","exp","iat","auth_time","acr","nonce","preferred_username","name","tid","ver","at_hash","c_hash","email"],"kerberos_endpoint":"https://login.microsoftonline.com/12345678-1234-1234-1234-123456789012/kerberos","tenant_region_scope":"WW","cloud_instance_name":"microsoftonline.com","cloud_graph_host_name":"graph.windows.net","msgraph_host":"graph.microsoft.com","rbac_url":"https://pas.windows.net"}, [
+  'Cache-Control',
+  'max-age=86400, private',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Access-Control-Allow-Origin',
+  '*',
+  'Access-Control-Allow-Methods',
+  'GET, OPTIONS',
+  'P3P',
+  'CP="DSP CUR OTPi IND OTRi ONL FIN"',
+  'x-ms-request-id',
+  '17d5940a-3a4d-4449-b453-0241c6922000',
+  'x-ms-ests-server',
+  '2.1.12851.6 - NCUS ProdSlices',
+  'X-XSS-Protection',
+  '0',
+  'Set-Cookie',
+  'fpc=ApgORPs9tBBDgRcQ-0llnYk; expires=Sat, 02-Jul-2022 16:53:53 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'Set-Cookie',
+  'esctx=AQABAAAAAAD--DLA3VO7QrddgJg7WevrhqWOJYn31rt6peqc5-YnwqRgQJNgDSY5V8J62lm7fw5qzAtaLNhjpSxU5m5oWJIx9NS_oA5TIzRpX90lIrHoXeh0GqE_48XcYJXQBZU9BI_uUOVYqz-nJIvPfRvvvaiEbFDD57cWfpe-7hrYQ_CeKjZFZ2uKzErlNbgyUTyiSuogAA; domain=.login.microsoftonline.com; path=/; secure; HttpOnly; SameSite=None',
+  'Set-Cookie',
+  'x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly',
+  'Set-Cookie',
+  'stsservicecookie=estsfd; path=/; secure; samesite=none; httponly',
+  'Date',
+  'Thu, 02 Jun 2022 16:53:52 GMT',
+  'Content-Length',
+  '1753'
+]);
+
+nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
+  .post('/12345678-1234-1234-1234-123456789012/oauth2/v2.0/token', "client_id=azure_client_id&scope=https%3A%2F%2Fsanitized%2F&grant_type=client_credentials&x-client-SKU=msal.js.node&x-client-VER=1.9.0&x-client-OS=linux&x-client-CPU=x64&x-ms-lib-capability=retry-after, h429&x-client-current-telemetry=5|771,2,,,|,&x-client-last-telemetry=5|0|||0,0&client-request-id=a3f3fb4d-476f-4534-a85f-ea88e4ee38dd&client_secret=azure_client_secret&claims=%7B%22access_token%22%3A%7B%22xms_cc%22%3A%7B%22values%22%3A%5B%22cp1%22%5D%7D%7D%7D")
+  .reply(200, {"token_type":"Bearer","expires_in":86399,"ext_expires_in":86399,"access_token":"access_token"}, [
+  'Cache-Control',
+  'no-store, no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'P3P',
+  'CP="DSP CUR OTPi IND OTRi ONL FIN"',
+  'x-ms-request-id',
+  '86128017-8159-4c86-bdf3-adfdb99e2200',
+  'x-ms-ests-server',
+  '2.1.12851.6 - WUS2 ProdSlices',
+  'x-ms-clitelem',
+  '1,0,0,,',
+  'Content-Security-Policy-Report-Only',
+  "script-src 'self' 'nonce-CGWOo2vbZGIye1-PEt8ifw' 'unsafe-eval' 'unsafe-inline'; object-src 'none'; base-uri 'none'; report-uri https://csp.microsoft.com/report/ESTS-UX-All",
+  'X-XSS-Protection',
+  '0',
+  'Set-Cookie',
+  'fpc=AumWVQMWbEdNi0cwvcUn2toyrjFTAQAAACDiKtoOAAAA; expires=Sat, 02-Jul-2022 16:53:53 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'Set-Cookie',
+  'x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly',
+  'Set-Cookie',
+  'stsservicecookie=estsfd; path=/; secure; samesite=none; httponly',
+  'Date',
+  'Thu, 02 Jun 2022 16:53:53 GMT',
+  'Content-Length',
+  '1315'
+]);
+
+nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
+  .post('/certificates//create', {"policy":{"key_props":{},"secret_props":{},"x509_props":{"subject":"cn=MyCert","sans":{}},"issuer":{"name":"Self"},"attributes":{}},"attributes":{}})
+  .query(true)
+  .reply(405, {"error":{"code":"MethodNotAllowed","message":"HTTP POST not allowed"}}, [
+  'Cache-Control',
+  'no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Length',
+  '71',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'x-ms-keyvault-region',
+  'northcentralus',
+  'x-ms-client-request-id',
+  'dfd4ef55-27dc-4d77-925e-60ebee982dbe',
+  'x-ms-request-id',
+  '04812200-bcf9-44a9-b2eb-772ca52c16a6',
+  'x-ms-keyvault-service-version',
+  '1.9.422.1',
+  'x-ms-keyvault-network-info',
+  'conn_type=Ipv4;addr=167.220.80.222;act_addr_fam=InterNetwork;',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Strict-Transport-Security',
+  'max-age=31536000;includeSubDomains',
+  'Date',
+  'Thu, 02 Jun 2022 16:53:52 GMT'
+]);

--- a/sdk/keyvault/keyvault-certificates/test/public/CRUD.spec.ts
+++ b/sdk/keyvault/keyvault-certificates/test/public/CRUD.spec.ts
@@ -105,7 +105,9 @@ describe("Certificates client - create, read, update and delete", () => {
         testPollerProperties
       );
       assert.fail("Expected an error");
-    } catch (e) {}
+    } catch (e) {
+      // Ignore expected error
+    }
   });
 
   it("can update the tags of a certificate", async function (this: Context) {

--- a/sdk/keyvault/keyvault-certificates/test/public/CRUD.spec.ts
+++ b/sdk/keyvault/keyvault-certificates/test/public/CRUD.spec.ts
@@ -98,22 +98,14 @@ describe("Certificates client - create, read, update and delete", () => {
 
   it("cannot create a certificate with an empty name", async function () {
     const certificateName = "";
-    let error;
     try {
       await client.beginCreateCertificate(
         certificateName,
         basicCertificatePolicy,
         testPollerProperties
       );
-      throw Error("Expecting an error but not catching one.");
-    } catch (e: any) {
-      error = e;
-    }
-    assert.equal(
-      error.message,
-      `"certificateName" with value "" should satisfy the constraint "Pattern": /^[0-9a-zA-Z-]+$/.`,
-      "Unexpected error while running beginCreateCertificate with an empty string as the name."
-    );
+      assert.fail("Expected an error");
+    } catch (e: any) {}
   });
 
   it("can update the tags of a certificate", async function (this: Context) {

--- a/sdk/keyvault/keyvault-certificates/test/public/CRUD.spec.ts
+++ b/sdk/keyvault/keyvault-certificates/test/public/CRUD.spec.ts
@@ -105,7 +105,7 @@ describe("Certificates client - create, read, update and delete", () => {
         testPollerProperties
       );
       assert.fail("Expected an error");
-    } catch (e: any) {}
+    } catch (e) {}
   });
 
   it("can update the tags of a certificate", async function (this: Context) {

--- a/sdk/keyvault/keyvault-keys/recordings/browsers/keys_client__create_read_update_and_delete_operations/recording_cannot_create_a_key_with_an_empty_name.json
+++ b/sdk/keyvault/keyvault-keys/recordings/browsers/keys_client__create_read_update_and_delete_operations/recording_cannot_create_a_key_with_an_empty_name.json
@@ -1,8 +1,85 @@
 {
- "recordings": [],
+ "recordings": [
+  {
+   "method": "POST",
+   "url": "https://keyvault_name.vault.azure.net/keys//create",
+   "query": {
+    "api-version": "7.3"
+   },
+   "requestBody": "",
+   "status": 401,
+   "response": "{\"error\":{\"code\":\"Unauthorized\",\"message\":\"AKV10000: Request is missing a Bearer or PoP token.\"}}",
+   "responseHeaders": {
+    "cache-control": "no-cache",
+    "content-length": "97",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Thu, 02 Jun 2022 21:21:30 GMT",
+    "expires": "-1",
+    "pragma": "no-cache",
+    "strict-transport-security": "max-age=31536000;includeSubDomains",
+    "www-authenticate": "Bearer authorization=\"https://login.windows.net/12345678-1234-1234-1234-123456789012\", resource=\"https://vault.azure.net\"",
+    "x-content-type-options": "nosniff",
+    "x-ms-client-request-id": "964cb4a6-efcb-4771-9a98-4f93db028554",
+    "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=167.220.80.222;act_addr_fam=InterNetwork;",
+    "x-ms-keyvault-region": "northcentralus",
+    "x-ms-keyvault-service-version": "1.9.422.1",
+    "x-ms-request-id": "6625779d-f5bf-4e4c-ace0-23a227a788c7"
+   }
+  },
+  {
+   "method": "POST",
+   "url": "https://login.microsoftonline.com/12345678-1234-1234-1234-123456789012/oauth2/v2.0/token",
+   "query": {},
+   "requestBody": "response_type=token&grant_type=client_credentials&client_id=azure_client_id&client_secret=azure_client_secret&scope=https%3A%2F%2Fsanitized%2F",
+   "status": 200,
+   "response": "{\"token_type\":\"Bearer\",\"expires_in\":86399,\"ext_expires_in\":86399,\"access_token\":\"access_token\"}",
+   "responseHeaders": {
+    "cache-control": "no-store, no-cache",
+    "content-length": "1315",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Thu, 02 Jun 2022 21:21:30 GMT",
+    "expires": "-1",
+    "nel": "{\"report_to\":\"network-errors\",\"max_age\":86400,\"success_fraction\":0.001,\"failure_fraction\":1.0}",
+    "p3p": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\"",
+    "pragma": "no-cache",
+    "referrer-policy": "strict-origin-when-cross-origin",
+    "report-to": "{\"group\":\"network-errors\",\"max_age\":86400,\"endpoints\":[{\"url\":\"https://identity.nel.measure.office.net/api/report?catId=GW+estsfd+est\"}]}",
+    "strict-transport-security": "max-age=31536000; includeSubDomains",
+    "x-content-type-options": "nosniff",
+    "x-ms-ests-server": "2.1.12851.6 - SCUS ProdSlices",
+    "x-ms-request-id": "05833e79-8a99-47a9-b24d-e521469f3200",
+    "x-xss-protection": "0"
+   }
+  },
+  {
+   "method": "POST",
+   "url": "https://keyvault_name.vault.azure.net/keys//create",
+   "query": {
+    "api-version": "7.3"
+   },
+   "requestBody": "{\"kty\":\"RSA\"}",
+   "status": 400,
+   "response": "{\"error\":{\"code\":\"BadParameter\",\"message\":\"Operation not specified\"}}",
+   "responseHeaders": {
+    "cache-control": "no-cache",
+    "content-length": "69",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Thu, 02 Jun 2022 21:21:31 GMT",
+    "expires": "-1",
+    "pragma": "no-cache",
+    "strict-transport-security": "max-age=31536000;includeSubDomains",
+    "x-content-type-options": "nosniff",
+    "x-ms-client-request-id": "964cb4a6-efcb-4771-9a98-4f93db028554",
+    "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=167.220.80.222;act_addr_fam=InterNetwork;",
+    "x-ms-keyvault-region": "northcentralus",
+    "x-ms-keyvault-service-version": "1.9.422.1",
+    "x-ms-request-id": "5484c8c6-90f4-4d66-aa4f-2a3d486c4fb7"
+   }
+  }
+ ],
  "uniqueTestInfo": {
   "uniqueName": {},
   "newDate": {}
  },
- "hash": "7077c535e87fc080351bf272e637ec5e"
+ "hash": "d5adc7296f725338fd7610ba67b687ce"
 }

--- a/sdk/keyvault/keyvault-keys/recordings/browsers/keys_client__create_read_update_and_delete_operations_for_managed_hsm_getrandombytes/recording_returns_an_error_when_bytes_is_out_of_range.json
+++ b/sdk/keyvault/keyvault-keys/recordings/browsers/keys_client__create_read_update_and_delete_operations_for_managed_hsm_getrandombytes/recording_returns_an_error_when_bytes_is_out_of_range.json
@@ -1,8 +1,119 @@
 {
- "recordings": [],
+ "recordings": [
+  {
+   "method": "POST",
+   "url": "https://azure_managedhsm.managedhsm.azure.net/rng",
+   "query": {
+    "api-version": "7.3"
+   },
+   "requestBody": "",
+   "status": 401,
+   "response": "",
+   "responseHeaders": {
+    "cache-control": "no-cache",
+    "content-length": "0",
+    "content-security-policy": "default-src 'self'",
+    "content-type": "application/json; charset=utf-8",
+    "strict-transport-security": "max-age=31536000; includeSubDomains",
+    "www-authenticate": "Bearer authorization=\"https://login.microsoftonline.com/12345678-1234-1234-1234-123456789012\", resource=\"https://managedhsm.azure.net\"",
+    "x-content-type-options": "nosniff",
+    "x-frame-options": "SAMEORIGIN",
+    "x-ms-request-id": "1d25e29c-e2c7-11ec-8bc7-0022488ca45f",
+    "x-ms-server-latency": "1"
+   }
+  },
+  {
+   "method": "POST",
+   "url": "https://login.microsoftonline.com/12345678-1234-1234-1234-123456789012/oauth2/v2.0/token",
+   "query": {},
+   "requestBody": "response_type=token&grant_type=client_credentials&client_id=azure_client_id&client_secret=azure_client_secret&scope=https%3A%2F%2Fsanitized%2F",
+   "status": 200,
+   "response": "{\"token_type\":\"Bearer\",\"expires_in\":86399,\"ext_expires_in\":86399,\"access_token\":\"access_token\"}",
+   "responseHeaders": {
+    "cache-control": "no-store, no-cache",
+    "content-length": "1322",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Thu, 02 Jun 2022 22:55:35 GMT",
+    "expires": "-1",
+    "nel": "{\"report_to\":\"network-errors\",\"max_age\":86400,\"success_fraction\":0.001,\"failure_fraction\":1.0}",
+    "p3p": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\"",
+    "pragma": "no-cache",
+    "referrer-policy": "strict-origin-when-cross-origin",
+    "report-to": "{\"group\":\"network-errors\",\"max_age\":86400,\"endpoints\":[{\"url\":\"https://identity.nel.measure.office.net/api/report?catId=GW+estsfd+wst\"}]}",
+    "strict-transport-security": "max-age=31536000; includeSubDomains",
+    "x-content-type-options": "nosniff",
+    "x-ms-ests-server": "2.1.12851.6 - SCUS ProdSlices",
+    "x-ms-request-id": "bb234d9f-7b6c-4915-a273-f7d76e852d00",
+    "x-xss-protection": "0"
+   }
+  },
+  {
+   "method": "POST",
+   "url": "https://azure_managedhsm.managedhsm.azure.net/rng",
+   "query": {
+    "api-version": "7.3"
+   },
+   "requestBody": "{\"count\":-1}",
+   "status": 400,
+   "response": "{\"error\":{\"code\":\"BadParameter\",\"message\":\"GetRandomBytesRequest: count cannot be greater than 128 or less than 1 (Activity ID: 1d56c024-e2c7-11ec-8bc7-0022488ca45f)\"}}",
+   "responseHeaders": {
+    "cache-control": "no-cache",
+    "content-length": "168",
+    "content-security-policy": "default-src 'self'",
+    "content-type": "application/json; charset=utf-8",
+    "strict-transport-security": "max-age=31536000; includeSubDomains",
+    "x-content-type-options": "nosniff",
+    "x-frame-options": "SAMEORIGIN",
+    "x-ms-request-id": "1d56c024-e2c7-11ec-8bc7-0022488ca45f",
+    "x-ms-server-latency": "1"
+   }
+  },
+  {
+   "method": "POST",
+   "url": "https://azure_managedhsm.managedhsm.azure.net/rng",
+   "query": {
+    "api-version": "7.3"
+   },
+   "requestBody": "{\"count\":0}",
+   "status": 400,
+   "response": "{\"error\":{\"code\":\"BadParameter\",\"message\":\"GetRandomBytesRequest: count cannot be greater than 128 or less than 1 (Activity ID: 1d609356-e2c7-11ec-8bc7-0022488ca45f)\"}}",
+   "responseHeaders": {
+    "cache-control": "no-cache",
+    "content-length": "168",
+    "content-security-policy": "default-src 'self'",
+    "content-type": "application/json; charset=utf-8",
+    "strict-transport-security": "max-age=31536000; includeSubDomains",
+    "x-content-type-options": "nosniff",
+    "x-frame-options": "SAMEORIGIN",
+    "x-ms-request-id": "1d609356-e2c7-11ec-8bc7-0022488ca45f",
+    "x-ms-server-latency": "0"
+   }
+  },
+  {
+   "method": "POST",
+   "url": "https://azure_managedhsm.managedhsm.azure.net/rng",
+   "query": {
+    "api-version": "7.3"
+   },
+   "requestBody": "{\"count\":129}",
+   "status": 400,
+   "response": "{\"error\":{\"code\":\"BadParameter\",\"message\":\"GetRandomBytesRequest: count cannot be greater than 128 or less than 1 (Activity ID: 1d6a0b48-e2c7-11ec-8bc7-0022488ca45f)\"}}",
+   "responseHeaders": {
+    "cache-control": "no-cache",
+    "content-length": "168",
+    "content-security-policy": "default-src 'self'",
+    "content-type": "application/json; charset=utf-8",
+    "strict-transport-security": "max-age=31536000; includeSubDomains",
+    "x-content-type-options": "nosniff",
+    "x-frame-options": "SAMEORIGIN",
+    "x-ms-request-id": "1d6a0b48-e2c7-11ec-8bc7-0022488ca45f",
+    "x-ms-server-latency": "0"
+   }
+  }
+ ],
  "uniqueTestInfo": {
   "uniqueName": {},
   "newDate": {}
  },
- "hash": "b4deb846148bd9998061b157d310dfaf"
+ "hash": "bd13b308002e9d2b079191bb5943ffb4"
 }

--- a/sdk/keyvault/keyvault-keys/recordings/node/keys_client__create_read_update_and_delete_operations/recording_cannot_create_a_key_with_an_empty_name.js
+++ b/sdk/keyvault/keyvault-keys/recordings/node/keys_client__create_read_update_and_delete_operations/recording_cannot_create_a_key_with_an_empty_name.js
@@ -1,5 +1,185 @@
 let nock = require('nock');
 
-module.exports.hash = "9c5bc612eab80f1fe1ef5dbcc2100866";
+module.exports.hash = "d718aff34beed80070ae1eb6864a76f0";
 
 module.exports.testInfo = {"uniqueName":{},"newDate":{}}
+
+nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
+  .post('/keys//create')
+  .query(true)
+  .reply(401, {"error":{"code":"Unauthorized","message":"AKV10000: Request is missing a Bearer or PoP token."}}, [
+  'Cache-Control',
+  'no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Length',
+  '97',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'WWW-Authenticate',
+  'Bearer authorization="https://login.windows.net/12345678-1234-1234-1234-123456789012", resource="https://vault.azure.net"',
+  'x-ms-keyvault-region',
+  'northcentralus',
+  'x-ms-client-request-id',
+  '507a10f6-7129-4708-8901-85bcb5bc96ae',
+  'x-ms-request-id',
+  '95b77cb9-b1e2-4e15-9e97-7b179dae4e0b',
+  'x-ms-keyvault-service-version',
+  '1.9.422.1',
+  'x-ms-keyvault-network-info',
+  'conn_type=Ipv4;addr=167.220.80.222;act_addr_fam=InterNetwork;',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Strict-Transport-Security',
+  'max-age=31536000;includeSubDomains',
+  'Date',
+  'Thu, 02 Jun 2022 21:21:25 GMT'
+]);
+
+nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
+  .get('/common/discovery/instance')
+  .query(true)
+  .reply(200, {"tenant_discovery_endpoint":"https://login.microsoftonline.com/12345678-1234-1234-1234-123456789012/v2.0/.well-known/openid-configuration","api-version":"1.1","metadata":[{"preferred_network":"login.microsoftonline.com","preferred_cache":"login.windows.net","aliases":["login.microsoftonline.com","login.windows.net","login.microsoft.com","sts.windows.net"]},{"preferred_network":"login.partner.microsoftonline.cn","preferred_cache":"login.partner.microsoftonline.cn","aliases":["login.partner.microsoftonline.cn","login.chinacloudapi.cn"]},{"preferred_network":"login.microsoftonline.de","preferred_cache":"login.microsoftonline.de","aliases":["login.microsoftonline.de"]},{"preferred_network":"login.microsoftonline.us","preferred_cache":"login.microsoftonline.us","aliases":["login.microsoftonline.us","login.usgovcloudapi.net"]},{"preferred_network":"login-us.microsoftonline.com","preferred_cache":"login-us.microsoftonline.com","aliases":["login-us.microsoftonline.com"]}]}, [
+  'Cache-Control',
+  'max-age=86400, private',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Access-Control-Allow-Origin',
+  '*',
+  'Access-Control-Allow-Methods',
+  'GET, OPTIONS',
+  'P3P',
+  'CP="DSP CUR OTPi IND OTRi ONL FIN"',
+  'x-ms-request-id',
+  '4c32e2eb-4207-4bcd-b464-76ee81e02700',
+  'x-ms-ests-server',
+  '2.1.12851.6 - EUS ProdSlices',
+  'X-XSS-Protection',
+  '0',
+  'Set-Cookie',
+  'fpc=AjvK0-FOnK1BkMXIgSB50zY; expires=Sat, 02-Jul-2022 21:21:26 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'Set-Cookie',
+  'esctx=AQABAAAAAAD--DLA3VO7QrddgJg7WevrAcd4Te2n8AEw0Ce081GU0UCmM-U0fPE9Kqh1Yv-QettHW9RWiGDCAvljjoY_YezmjIXmetEVt5W0yvNdKtGApLIUNC7m0jNipjFuZ9SBRBJ5Q0KuoQmpmkAXrx9ggZ0Ym-2lr6znhuseFiNyES8DG3c0d8NkfFZl98UhNjE_n8kgAA; domain=.login.microsoftonline.com; path=/; secure; HttpOnly; SameSite=None',
+  'Set-Cookie',
+  'x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly',
+  'Set-Cookie',
+  'stsservicecookie=estsfd; path=/; secure; samesite=none; httponly',
+  'Date',
+  'Thu, 02 Jun 2022 21:21:26 GMT',
+  'Content-Length',
+  '980'
+]);
+
+nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
+  .get('/12345678-1234-1234-1234-123456789012/v2.0/.well-known/openid-configuration')
+  .reply(200, {"token_endpoint":"https://login.microsoftonline.com/12345678-1234-1234-1234-123456789012/oauth2/v2.0/token","token_endpoint_auth_methods_supported":["client_secret_post","private_key_jwt","client_secret_basic"],"jwks_uri":"https://login.microsoftonline.com/12345678-1234-1234-1234-123456789012/discovery/v2.0/keys","response_modes_supported":["query","fragment","form_post"],"subject_types_supported":["pairwise"],"id_token_signing_alg_values_supported":["RS256"],"response_types_supported":["code","id_token","code id_token","id_token token"],"scopes_supported":["openid","profile","email","offline_access"],"issuer":"https://login.microsoftonline.com/12345678-1234-1234-1234-123456789012/v2.0","request_uri_parameter_supported":false,"userinfo_endpoint":"https://graph.microsoft.com/oidc/userinfo","authorization_endpoint":"https://login.microsoftonline.com/12345678-1234-1234-1234-123456789012/oauth2/v2.0/authorize","device_authorization_endpoint":"https://login.microsoftonline.com/12345678-1234-1234-1234-123456789012/oauth2/v2.0/devicecode","http_logout_supported":true,"frontchannel_logout_supported":true,"end_session_endpoint":"https://login.microsoftonline.com/12345678-1234-1234-1234-123456789012/oauth2/v2.0/logout","claims_supported":["sub","iss","cloud_instance_name","cloud_instance_host_name","cloud_graph_host_name","msgraph_host","aud","exp","iat","auth_time","acr","nonce","preferred_username","name","tid","ver","at_hash","c_hash","email"],"kerberos_endpoint":"https://login.microsoftonline.com/12345678-1234-1234-1234-123456789012/kerberos","tenant_region_scope":"WW","cloud_instance_name":"microsoftonline.com","cloud_graph_host_name":"graph.windows.net","msgraph_host":"graph.microsoft.com","rbac_url":"https://pas.windows.net"}, [
+  'Cache-Control',
+  'max-age=86400, private',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Access-Control-Allow-Origin',
+  '*',
+  'Access-Control-Allow-Methods',
+  'GET, OPTIONS',
+  'P3P',
+  'CP="DSP CUR OTPi IND OTRi ONL FIN"',
+  'x-ms-request-id',
+  'cba5d49e-5ba4-4ce6-9a56-7c51de022c00',
+  'x-ms-ests-server',
+  '2.1.12851.6 - WUS2 ProdSlices',
+  'Content-Security-Policy-Report-Only',
+  "script-src 'self' 'nonce-9WdNODcC8uhwIu-ajVJq0Q' 'unsafe-eval' 'unsafe-inline'; object-src 'none'; base-uri 'none'; report-uri https://csp.microsoft.com/report/ESTS-UX-All",
+  'X-XSS-Protection',
+  '0',
+  'Set-Cookie',
+  'fpc=AqI5mTf0MipOvTaVjK_jZDE; expires=Sat, 02-Jul-2022 21:21:27 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'Set-Cookie',
+  'esctx=AQABAAAAAAD--DLA3VO7QrddgJg7WevrSmRUOluSiO0KpgUEgRGjsT9HeWzSvEG6PJ1bN6FWPPq73Xdb_fXDB_HvLC_xxxDS-6-ssjqFGSJcKnRoqoI3CeSHQ9RYl-kDW2YmnHsnr_UvWQLXvIIwYkgf5B3DVSfh8m5ef_CJhejAM6qPiLfYnhQ3EKqy8NN7YuUkpQkCQQ8gAA; domain=.login.microsoftonline.com; path=/; secure; HttpOnly; SameSite=None',
+  'Set-Cookie',
+  'x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly',
+  'Set-Cookie',
+  'stsservicecookie=estsfd; path=/; secure; samesite=none; httponly',
+  'Date',
+  'Thu, 02 Jun 2022 21:21:26 GMT',
+  'Content-Length',
+  '1753'
+]);
+
+nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
+  .post('/12345678-1234-1234-1234-123456789012/oauth2/v2.0/token', "client_id=azure_client_id&scope=https%3A%2F%2Fsanitized%2F&grant_type=client_credentials&x-client-SKU=msal.js.node&x-client-VER=1.9.0&x-client-OS=linux&x-client-CPU=x64&x-ms-lib-capability=retry-after, h429&x-client-current-telemetry=5|771,2,,,|,&x-client-last-telemetry=5|0|||0,0&client-request-id=51efe0aa-116e-45ca-90a2-2c70d7ebe582&client_secret=azure_client_secret&claims=%7B%22access_token%22%3A%7B%22xms_cc%22%3A%7B%22values%22%3A%5B%22cp1%22%5D%7D%7D%7D")
+  .reply(200, {"token_type":"Bearer","expires_in":86399,"ext_expires_in":86399,"access_token":"access_token"}, [
+  'Cache-Control',
+  'no-store, no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'P3P',
+  'CP="DSP CUR OTPi IND OTRi ONL FIN"',
+  'x-ms-request-id',
+  'ea556792-99d6-4932-b39e-1c10283a2d00',
+  'x-ms-ests-server',
+  '2.1.12851.6 - EUS ProdSlices',
+  'x-ms-clitelem',
+  '1,0,0,,',
+  'X-XSS-Protection',
+  '0',
+  'Set-Cookie',
+  'fpc=Agh28yu1vFlAnQEKvHQcYaWv93uCAQAAANYgK9oOAAAA; expires=Sat, 02-Jul-2022 21:21:27 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'Set-Cookie',
+  'x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly',
+  'Set-Cookie',
+  'stsservicecookie=estsfd; path=/; secure; samesite=none; httponly',
+  'Date',
+  'Thu, 02 Jun 2022 21:21:26 GMT',
+  'Content-Length',
+  '1315'
+]);
+
+nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
+  .post('/keys//create', {"kty":"RSA"})
+  .query(true)
+  .reply(400, {"error":{"code":"BadParameter","message":"Operation not specified"}}, [
+  'Cache-Control',
+  'no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Length',
+  '69',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'x-ms-keyvault-region',
+  'northcentralus',
+  'x-ms-client-request-id',
+  '507a10f6-7129-4708-8901-85bcb5bc96ae',
+  'x-ms-request-id',
+  'bc06269a-77bd-47b8-abfc-75d90dbac980',
+  'x-ms-keyvault-service-version',
+  '1.9.422.1',
+  'x-ms-keyvault-network-info',
+  'conn_type=Ipv4;addr=167.220.80.222;act_addr_fam=InterNetwork;',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Strict-Transport-Security',
+  'max-age=31536000;includeSubDomains',
+  'Date',
+  'Thu, 02 Jun 2022 21:21:26 GMT'
+]);

--- a/sdk/keyvault/keyvault-keys/recordings/node/keys_client__create_read_update_and_delete_operations_for_managed_hsm_getrandombytes/recording_returns_an_error_when_bytes_is_out_of_range.js
+++ b/sdk/keyvault/keyvault-keys/recordings/node/keys_client__create_read_update_and_delete_operations_for_managed_hsm_getrandombytes/recording_returns_an_error_when_bytes_is_out_of_range.js
@@ -1,5 +1,215 @@
 let nock = require('nock');
 
-module.exports.hash = "158ce47d15852a6b852fa60cf649dd23";
+module.exports.hash = "a4edbae9e3236b92cf191e3cc9bc555a";
 
 module.exports.testInfo = {"uniqueName":{},"newDate":{}}
+
+nock('https://azure_managedhsm.managedhsm.azure.net:443', {"encodedQueryParams":true})
+  .post('/rng')
+  .query(true)
+  .reply(401, "", [
+  'content-type',
+  'application/json; charset=utf-8',
+  'x-ms-server-latency',
+  '1',
+  'x-content-type-options',
+  'nosniff',
+  'www-authenticate',
+  'Bearer authorization="https://login.microsoftonline.com/12345678-1234-1234-1234-123456789012", resource="https://managedhsm.azure.net"',
+  'x-frame-options',
+  'SAMEORIGIN',
+  'content-length',
+  '0',
+  'x-ms-request-id',
+  '1b18395a-e2c7-11ec-b2b3-0022488ca45f',
+  'strict-transport-security',
+  'max-age=31536000; includeSubDomains',
+  'content-security-policy',
+  "default-src 'self'",
+  'cache-control',
+  'no-cache'
+]);
+
+nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
+  .get('/common/discovery/instance')
+  .query(true)
+  .reply(200, {"tenant_discovery_endpoint":"https://login.microsoftonline.com/12345678-1234-1234-1234-123456789012/v2.0/.well-known/openid-configuration","api-version":"1.1","metadata":[{"preferred_network":"login.microsoftonline.com","preferred_cache":"login.windows.net","aliases":["login.microsoftonline.com","login.windows.net","login.microsoft.com","sts.windows.net"]},{"preferred_network":"login.partner.microsoftonline.cn","preferred_cache":"login.partner.microsoftonline.cn","aliases":["login.partner.microsoftonline.cn","login.chinacloudapi.cn"]},{"preferred_network":"login.microsoftonline.de","preferred_cache":"login.microsoftonline.de","aliases":["login.microsoftonline.de"]},{"preferred_network":"login.microsoftonline.us","preferred_cache":"login.microsoftonline.us","aliases":["login.microsoftonline.us","login.usgovcloudapi.net"]},{"preferred_network":"login-us.microsoftonline.com","preferred_cache":"login-us.microsoftonline.com","aliases":["login-us.microsoftonline.com"]}]}, [
+  'Cache-Control',
+  'max-age=86400, private',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Access-Control-Allow-Origin',
+  '*',
+  'Access-Control-Allow-Methods',
+  'GET, OPTIONS',
+  'P3P',
+  'CP="DSP CUR OTPi IND OTRi ONL FIN"',
+  'x-ms-request-id',
+  'b78c0a85-c7e0-4ca7-815e-88ead2e93400',
+  'x-ms-ests-server',
+  '2.1.12851.6 - SCUS ProdSlices',
+  'X-XSS-Protection',
+  '0',
+  'Set-Cookie',
+  'fpc=Alc6N-PgWV9JjnFiwftEbPA; expires=Sat, 02-Jul-2022 22:55:32 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'Set-Cookie',
+  'esctx=AQABAAAAAAD--DLA3VO7QrddgJg7WevrB-eFGkhYwRjnKoQAKJakQRMRWCnUUpMEJ7qIjNJ8ikMdPrBzjZBIBBNcKRNPBufBhtdrFARBro8Uk7bhvuqTR9TeDR_ZCjfrNQBaIUTbYH7EWpk3i3BDNn5Uc2T2JGttptkYHT3xMn7_JC-z-KtFC2KzYgM0iWAow-EAr2BPndogAA; domain=.login.microsoftonline.com; path=/; secure; HttpOnly; SameSite=None',
+  'Set-Cookie',
+  'x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly',
+  'Set-Cookie',
+  'stsservicecookie=estsfd; path=/; secure; samesite=none; httponly',
+  'Date',
+  'Thu, 02 Jun 2022 22:55:31 GMT',
+  'Content-Length',
+  '980'
+]);
+
+nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
+  .get('/12345678-1234-1234-1234-123456789012/v2.0/.well-known/openid-configuration')
+  .reply(200, {"token_endpoint":"https://login.microsoftonline.com/12345678-1234-1234-1234-123456789012/oauth2/v2.0/token","token_endpoint_auth_methods_supported":["client_secret_post","private_key_jwt","client_secret_basic"],"jwks_uri":"https://login.microsoftonline.com/12345678-1234-1234-1234-123456789012/discovery/v2.0/keys","response_modes_supported":["query","fragment","form_post"],"subject_types_supported":["pairwise"],"id_token_signing_alg_values_supported":["RS256"],"response_types_supported":["code","id_token","code id_token","id_token token"],"scopes_supported":["openid","profile","email","offline_access"],"issuer":"https://login.microsoftonline.com/12345678-1234-1234-1234-123456789012/v2.0","request_uri_parameter_supported":false,"userinfo_endpoint":"https://graph.microsoft.com/oidc/userinfo","authorization_endpoint":"https://login.microsoftonline.com/12345678-1234-1234-1234-123456789012/oauth2/v2.0/authorize","device_authorization_endpoint":"https://login.microsoftonline.com/12345678-1234-1234-1234-123456789012/oauth2/v2.0/devicecode","http_logout_supported":true,"frontchannel_logout_supported":true,"end_session_endpoint":"https://login.microsoftonline.com/12345678-1234-1234-1234-123456789012/oauth2/v2.0/logout","claims_supported":["sub","iss","cloud_instance_name","cloud_instance_host_name","cloud_graph_host_name","msgraph_host","aud","exp","iat","auth_time","acr","nonce","preferred_username","name","tid","ver","at_hash","c_hash","email"],"kerberos_endpoint":"https://login.microsoftonline.com/12345678-1234-1234-1234-123456789012/kerberos","tenant_region_scope":"WW","cloud_instance_name":"microsoftonline.com","cloud_graph_host_name":"graph.windows.net","msgraph_host":"graph.microsoft.com","rbac_url":"https://pas.windows.net"}, [
+  'Cache-Control',
+  'max-age=86400, private',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Access-Control-Allow-Origin',
+  '*',
+  'Access-Control-Allow-Methods',
+  'GET, OPTIONS',
+  'P3P',
+  'CP="DSP CUR OTPi IND OTRi ONL FIN"',
+  'x-ms-request-id',
+  'b78c0a85-c7e0-4ca7-815e-88ead7e93400',
+  'x-ms-ests-server',
+  '2.1.12851.6 - SCUS ProdSlices',
+  'X-XSS-Protection',
+  '0',
+  'Set-Cookie',
+  'fpc=AgT3f-zKOrJEtp5pxGFfjD4; expires=Sat, 02-Jul-2022 22:55:32 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'Set-Cookie',
+  'esctx=AQABAAAAAAD--DLA3VO7QrddgJg7Wevr1bp3BM4BfXnCkv3ulbWVI2Bi6pVaM4h9Vi0c2VmdkFw8-8piiE-Va2N_frYmndUaU_PIH9WinNkGjga6PSzEN0zU0r-hTYha-GeE7-3tfcyyrfHYyZ7lqYlnyOZLUzmKrQfs0ddohreD_rPLxiYGw6dNnrxZ8nCBL6swFh0XvoggAA; domain=.login.microsoftonline.com; path=/; secure; HttpOnly; SameSite=None',
+  'Set-Cookie',
+  'x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly',
+  'Set-Cookie',
+  'stsservicecookie=estsfd; path=/; secure; samesite=none; httponly',
+  'Date',
+  'Thu, 02 Jun 2022 22:55:31 GMT',
+  'Content-Length',
+  '1753'
+]);
+
+nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
+  .post('/12345678-1234-1234-1234-123456789012/oauth2/v2.0/token', "client_id=azure_client_id&scope=https%3A%2F%2Fsanitized%2F&grant_type=client_credentials&x-client-SKU=msal.js.node&x-client-VER=1.9.0&x-client-OS=linux&x-client-CPU=x64&x-ms-lib-capability=retry-after, h429&x-client-current-telemetry=5|771,2,,,|,&x-client-last-telemetry=5|0|||0,0&client-request-id=d7521821-24e0-4320-bb15-4b54706fe8f1&client_secret=azure_client_secret&claims=%7B%22access_token%22%3A%7B%22xms_cc%22%3A%7B%22values%22%3A%5B%22cp1%22%5D%7D%7D%7D")
+  .reply(200, {"token_type":"Bearer","expires_in":86399,"ext_expires_in":86399,"access_token":"access_token"}, [
+  'Cache-Control',
+  'no-store, no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'P3P',
+  'CP="DSP CUR OTPi IND OTRi ONL FIN"',
+  'x-ms-request-id',
+  '37487863-145f-4507-ac7a-5f11c8fb2b00',
+  'x-ms-ests-server',
+  '2.1.12851.6 - EUS ProdSlices',
+  'x-ms-clitelem',
+  '1,0,0,,',
+  'X-XSS-Protection',
+  '0',
+  'Set-Cookie',
+  'fpc=ApFDUu4CRjdAiPPNTigDtfKXBN7YAQAAAOQ2K9oOAAAA; expires=Sat, 02-Jul-2022 22:55:32 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'Set-Cookie',
+  'x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly',
+  'Set-Cookie',
+  'stsservicecookie=estsfd; path=/; secure; samesite=none; httponly',
+  'Date',
+  'Thu, 02 Jun 2022 22:55:31 GMT',
+  'Content-Length',
+  '1322'
+]);
+
+nock('https://azure_managedhsm.managedhsm.azure.net:443', {"encodedQueryParams":true})
+  .post('/rng', {"count":-1})
+  .query(true)
+  .reply(400, {"error":{"code":"BadParameter","message":"GetRandomBytesRequest: count cannot be greater than 128 or less than 1 (Activity ID: 1b5ff8da-e2c7-11ec-b2b3-0022488ca45f)"}}, [
+  'content-type',
+  'application/json; charset=utf-8',
+  'x-ms-server-latency',
+  '2',
+  'cache-control',
+  'no-cache',
+  'x-content-type-options',
+  'nosniff',
+  'content-length',
+  '168',
+  'x-ms-request-id',
+  '1b5ff8da-e2c7-11ec-b2b3-0022488ca45f',
+  'strict-transport-security',
+  'max-age=31536000; includeSubDomains',
+  'content-security-policy',
+  "default-src 'self'",
+  'x-frame-options',
+  'SAMEORIGIN'
+]);
+
+nock('https://azure_managedhsm.managedhsm.azure.net:443', {"encodedQueryParams":true})
+  .post('/rng', {"count":0})
+  .query(true)
+  .reply(400, {"error":{"code":"BadParameter","message":"GetRandomBytesRequest: count cannot be greater than 128 or less than 1 (Activity ID: 1b6ae970-e2c7-11ec-b2b3-0022488ca45f)"}}, [
+  'content-type',
+  'application/json; charset=utf-8',
+  'x-ms-server-latency',
+  '0',
+  'cache-control',
+  'no-cache',
+  'x-content-type-options',
+  'nosniff',
+  'content-length',
+  '168',
+  'x-ms-request-id',
+  '1b6ae970-e2c7-11ec-b2b3-0022488ca45f',
+  'strict-transport-security',
+  'max-age=31536000; includeSubDomains',
+  'content-security-policy',
+  "default-src 'self'",
+  'x-frame-options',
+  'SAMEORIGIN'
+]);
+
+nock('https://azure_managedhsm.managedhsm.azure.net:443', {"encodedQueryParams":true})
+  .post('/rng', {"count":129})
+  .query(true)
+  .reply(400, {"error":{"code":"BadParameter","message":"GetRandomBytesRequest: count cannot be greater than 128 or less than 1 (Activity ID: 1b746da6-e2c7-11ec-b2b3-0022488ca45f)"}}, [
+  'content-type',
+  'application/json; charset=utf-8',
+  'x-ms-server-latency',
+  '1',
+  'cache-control',
+  'no-cache',
+  'x-content-type-options',
+  'nosniff',
+  'content-length',
+  '168',
+  'x-ms-request-id',
+  '1b746da6-e2c7-11ec-b2b3-0022488ca45f',
+  'strict-transport-security',
+  'max-age=31536000; includeSubDomains',
+  'content-security-policy',
+  "default-src 'self'",
+  'x-frame-options',
+  'SAMEORIGIN'
+]);

--- a/sdk/keyvault/keyvault-keys/test/public/keyClient.spec.ts
+++ b/sdk/keyvault/keyvault-keys/test/public/keyClient.spec.ts
@@ -79,7 +79,7 @@ describe("Keys client - create, read, update and delete operations", () => {
     });
   });
 
-  it.only("cannot create a key with an empty name", async function () {
+  it("cannot create a key with an empty name", async function () {
     const keyName = "";
     try {
       await client.createKey(keyName, "RSA");

--- a/sdk/keyvault/keyvault-keys/test/public/keyClient.spec.ts
+++ b/sdk/keyvault/keyvault-keys/test/public/keyClient.spec.ts
@@ -79,20 +79,14 @@ describe("Keys client - create, read, update and delete operations", () => {
     });
   });
 
-  it("cannot create a key with an empty name", async function () {
+  it.only("cannot create a key with an empty name", async function () {
     const keyName = "";
-    let error;
     try {
       await client.createKey(keyName, "RSA");
-      throw Error("Expecting an error but not catching one.");
-    } catch (e: any) {
-      error = e;
+      assert.fail("Expected an error");
+    } catch (e) {
+      // Catch expected error
     }
-    assert.equal(
-      error.message,
-      `"keyName" with value "" should satisfy the constraint "Pattern": /^[0-9a-zA-Z-]+$/.`,
-      "Unexpected error while running createKey with an empty string as the name."
-    );
   });
 
   it("can create a RSA key", async function (this: Context) {

--- a/sdk/keyvault/keyvault-secrets/recordings/browsers/secret_client__create_read_update_and_delete_operations/recording_cannot_create_a_secret_with_an_empty_name.json
+++ b/sdk/keyvault/keyvault-secrets/recordings/browsers/secret_client__create_read_update_and_delete_operations/recording_cannot_create_a_secret_with_an_empty_name.json
@@ -4,5 +4,5 @@
   "uniqueName": {},
   "newDate": {}
  },
- "hash": "a872b8f1d335ebbea607cbce029a4b80"
+ "hash": "b477e9fb27c473018075b4c7ebc4ac42"
 }

--- a/sdk/keyvault/keyvault-secrets/recordings/browsers/secret_client__create_read_update_and_delete_operations/recording_cannot_create_a_secret_with_an_empty_name.json
+++ b/sdk/keyvault/keyvault-secrets/recordings/browsers/secret_client__create_read_update_and_delete_operations/recording_cannot_create_a_secret_with_an_empty_name.json
@@ -1,8 +1,86 @@
 {
- "recordings": [],
+ "recordings": [
+  {
+   "method": "PUT",
+   "url": "https://keyvault_name.vault.azure.net/secrets/",
+   "query": {
+    "api-version": "7.3"
+   },
+   "requestBody": "",
+   "status": 401,
+   "response": "{\"error\":{\"code\":\"Unauthorized\",\"message\":\"AKV10000: Request is missing a Bearer or PoP token.\"}}",
+   "responseHeaders": {
+    "cache-control": "no-cache",
+    "content-length": "97",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Thu, 02 Jun 2022 22:27:12 GMT",
+    "expires": "-1",
+    "pragma": "no-cache",
+    "strict-transport-security": "max-age=31536000;includeSubDomains",
+    "www-authenticate": "Bearer authorization=\"https://login.windows.net/12345678-1234-1234-1234-123456789012\", resource=\"https://vault.azure.net\"",
+    "x-content-type-options": "nosniff",
+    "x-ms-client-request-id": "6ceba46b-28a1-46fe-8457-01a4d14bb764",
+    "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=167.220.80.222;act_addr_fam=InterNetwork;",
+    "x-ms-keyvault-region": "northcentralus",
+    "x-ms-keyvault-service-version": "1.9.422.1",
+    "x-ms-request-id": "7897431a-7e4a-4421-82dd-fc2d9ce0d72b"
+   }
+  },
+  {
+   "method": "POST",
+   "url": "https://login.microsoftonline.com/12345678-1234-1234-1234-123456789012/oauth2/v2.0/token",
+   "query": {},
+   "requestBody": "response_type=token&grant_type=client_credentials&client_id=azure_client_id&client_secret=azure_client_secret&scope=https%3A%2F%2Fsanitized%2F",
+   "status": 200,
+   "response": "{\"token_type\":\"Bearer\",\"expires_in\":86399,\"ext_expires_in\":86399,\"access_token\":\"access_token\"}",
+   "responseHeaders": {
+    "cache-control": "no-store, no-cache",
+    "content-length": "1315",
+    "content-security-policy-report-only": "script-src 'self' 'nonce-RQJ3oHaPYqc7_PgtWmGFmw' 'unsafe-eval' 'unsafe-inline'; object-src 'none'; base-uri 'none'; report-uri https://csp.microsoft.com/report/ESTS-UX-All",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Thu, 02 Jun 2022 22:27:13 GMT",
+    "expires": "-1",
+    "nel": "{\"report_to\":\"network-errors\",\"max_age\":86400,\"success_fraction\":0.001,\"failure_fraction\":1.0}",
+    "p3p": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\"",
+    "pragma": "no-cache",
+    "referrer-policy": "strict-origin-when-cross-origin",
+    "report-to": "{\"group\":\"network-errors\",\"max_age\":86400,\"endpoints\":[{\"url\":\"https://identity.nel.measure.office.net/api/report?catId=GW+estsfd+wst\"}]}",
+    "strict-transport-security": "max-age=31536000; includeSubDomains",
+    "x-content-type-options": "nosniff",
+    "x-ms-ests-server": "2.1.12851.6 - WUS2 ProdSlices",
+    "x-ms-request-id": "597d278c-3c7c-4f93-94ab-4cc953cf2f00",
+    "x-xss-protection": "0"
+   }
+  },
+  {
+   "method": "PUT",
+   "url": "https://keyvault_name.vault.azure.net/secrets/",
+   "query": {
+    "api-version": "7.3"
+   },
+   "requestBody": "{\"value\":\"SECRET_VALUE\",\"attributes\":{}}",
+   "status": 405,
+   "response": "{\"error\":{\"code\":\"MethodNotAllowed\",\"message\":\"HTTP PUT not allowed\"}}",
+   "responseHeaders": {
+    "cache-control": "no-cache",
+    "content-length": "70",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Thu, 02 Jun 2022 22:27:12 GMT",
+    "expires": "-1",
+    "pragma": "no-cache",
+    "strict-transport-security": "max-age=31536000;includeSubDomains",
+    "x-content-type-options": "nosniff",
+    "x-ms-client-request-id": "6ceba46b-28a1-46fe-8457-01a4d14bb764",
+    "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=167.220.80.222;act_addr_fam=InterNetwork;",
+    "x-ms-keyvault-region": "northcentralus",
+    "x-ms-keyvault-service-version": "1.9.422.1",
+    "x-ms-request-id": "123e0485-f378-4f78-b035-2a9fb0678524"
+   }
+  }
+ ],
  "uniqueTestInfo": {
   "uniqueName": {},
   "newDate": {}
  },
- "hash": "b477e9fb27c473018075b4c7ebc4ac42"
+ "hash": "ef83e657b030e3f37ce7da71ef5c670b"
 }

--- a/sdk/keyvault/keyvault-secrets/recordings/node/secret_client__create_read_update_and_delete_operations/recording_cannot_create_a_secret_with_an_empty_name.js
+++ b/sdk/keyvault/keyvault-secrets/recordings/node/secret_client__create_read_update_and_delete_operations/recording_cannot_create_a_secret_with_an_empty_name.js
@@ -1,5 +1,187 @@
 let nock = require('nock');
 
-module.exports.hash = "8c16ba3c7b3f383cd443223b6403fbb9";
+module.exports.hash = "2bbc69497a6a750fc72f51f42755f292";
 
 module.exports.testInfo = {"uniqueName":{},"newDate":{}}
+
+nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
+  .put('/secrets/')
+  .query(true)
+  .reply(401, {"error":{"code":"Unauthorized","message":"AKV10000: Request is missing a Bearer or PoP token."}}, [
+  'Cache-Control',
+  'no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Length',
+  '97',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'WWW-Authenticate',
+  'Bearer authorization="https://login.windows.net/12345678-1234-1234-1234-123456789012", resource="https://vault.azure.net"',
+  'x-ms-keyvault-region',
+  'northcentralus',
+  'x-ms-client-request-id',
+  'be7d91ab-0b47-4e00-a50a-90d031312d0f',
+  'x-ms-request-id',
+  'a2805fc3-c960-4c95-bd12-4d5840b2c4c9',
+  'x-ms-keyvault-service-version',
+  '1.9.422.1',
+  'x-ms-keyvault-network-info',
+  'conn_type=Ipv4;addr=167.220.80.222;act_addr_fam=InterNetwork;',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Strict-Transport-Security',
+  'max-age=31536000;includeSubDomains',
+  'Date',
+  'Thu, 02 Jun 2022 17:11:45 GMT'
+]);
+
+nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
+  .get('/common/discovery/instance')
+  .query(true)
+  .reply(200, {"tenant_discovery_endpoint":"https://login.microsoftonline.com/12345678-1234-1234-1234-123456789012/v2.0/.well-known/openid-configuration","api-version":"1.1","metadata":[{"preferred_network":"login.microsoftonline.com","preferred_cache":"login.windows.net","aliases":["login.microsoftonline.com","login.windows.net","login.microsoft.com","sts.windows.net"]},{"preferred_network":"login.partner.microsoftonline.cn","preferred_cache":"login.partner.microsoftonline.cn","aliases":["login.partner.microsoftonline.cn","login.chinacloudapi.cn"]},{"preferred_network":"login.microsoftonline.de","preferred_cache":"login.microsoftonline.de","aliases":["login.microsoftonline.de"]},{"preferred_network":"login.microsoftonline.us","preferred_cache":"login.microsoftonline.us","aliases":["login.microsoftonline.us","login.usgovcloudapi.net"]},{"preferred_network":"login-us.microsoftonline.com","preferred_cache":"login-us.microsoftonline.com","aliases":["login-us.microsoftonline.com"]}]}, [
+  'Cache-Control',
+  'max-age=86400, private',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Access-Control-Allow-Origin',
+  '*',
+  'Access-Control-Allow-Methods',
+  'GET, OPTIONS',
+  'P3P',
+  'CP="DSP CUR OTPi IND OTRi ONL FIN"',
+  'x-ms-request-id',
+  '92e0a119-8571-4217-8b62-d4ef68fc2000',
+  'x-ms-ests-server',
+  '2.1.12851.6 - WUS2 ProdSlices',
+  'Content-Security-Policy-Report-Only',
+  "script-src 'self' 'nonce-8blV7IaK2OulnLXv3ZmIzA' 'unsafe-eval' 'unsafe-inline'; object-src 'none'; base-uri 'none'; report-uri https://csp.microsoft.com/report/ESTS-UX-All",
+  'X-XSS-Protection',
+  '0',
+  'Set-Cookie',
+  'fpc=AoS4nbhwoqpPlVAUVWFIHtw; expires=Sat, 02-Jul-2022 17:11:45 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'Set-Cookie',
+  'esctx=AQABAAAAAAD--DLA3VO7QrddgJg7WevrWcrp9xD3NNSj-FbA-JwUM24wWst31OgyAnjNBG5Rimr88vowUxBrZcfN_GD7iUJuhoE50AdkWkXEzXrMzAr3KGfZjViOZ2mcBlu6FZbaWehrBOWsiea-mokj-DBHF8QU5NoNgiTU2mdlV_mLrnXN8k65qXnugCJVdCvuJez_L04gAA; domain=.login.microsoftonline.com; path=/; secure; HttpOnly; SameSite=None',
+  'Set-Cookie',
+  'x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly',
+  'Set-Cookie',
+  'stsservicecookie=estsfd; path=/; secure; samesite=none; httponly',
+  'Date',
+  'Thu, 02 Jun 2022 17:11:45 GMT',
+  'Content-Length',
+  '980'
+]);
+
+nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
+  .get('/12345678-1234-1234-1234-123456789012/v2.0/.well-known/openid-configuration')
+  .reply(200, {"token_endpoint":"https://login.microsoftonline.com/12345678-1234-1234-1234-123456789012/oauth2/v2.0/token","token_endpoint_auth_methods_supported":["client_secret_post","private_key_jwt","client_secret_basic"],"jwks_uri":"https://login.microsoftonline.com/12345678-1234-1234-1234-123456789012/discovery/v2.0/keys","response_modes_supported":["query","fragment","form_post"],"subject_types_supported":["pairwise"],"id_token_signing_alg_values_supported":["RS256"],"response_types_supported":["code","id_token","code id_token","id_token token"],"scopes_supported":["openid","profile","email","offline_access"],"issuer":"https://login.microsoftonline.com/12345678-1234-1234-1234-123456789012/v2.0","request_uri_parameter_supported":false,"userinfo_endpoint":"https://graph.microsoft.com/oidc/userinfo","authorization_endpoint":"https://login.microsoftonline.com/12345678-1234-1234-1234-123456789012/oauth2/v2.0/authorize","device_authorization_endpoint":"https://login.microsoftonline.com/12345678-1234-1234-1234-123456789012/oauth2/v2.0/devicecode","http_logout_supported":true,"frontchannel_logout_supported":true,"end_session_endpoint":"https://login.microsoftonline.com/12345678-1234-1234-1234-123456789012/oauth2/v2.0/logout","claims_supported":["sub","iss","cloud_instance_name","cloud_instance_host_name","cloud_graph_host_name","msgraph_host","aud","exp","iat","auth_time","acr","nonce","preferred_username","name","tid","ver","at_hash","c_hash","email"],"kerberos_endpoint":"https://login.microsoftonline.com/12345678-1234-1234-1234-123456789012/kerberos","tenant_region_scope":"WW","cloud_instance_name":"microsoftonline.com","cloud_graph_host_name":"graph.windows.net","msgraph_host":"graph.microsoft.com","rbac_url":"https://pas.windows.net"}, [
+  'Cache-Control',
+  'max-age=86400, private',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Access-Control-Allow-Origin',
+  '*',
+  'Access-Control-Allow-Methods',
+  'GET, OPTIONS',
+  'P3P',
+  'CP="DSP CUR OTPi IND OTRi ONL FIN"',
+  'x-ms-request-id',
+  '8d47d79c-aa27-427d-9252-e6ca5c252100',
+  'x-ms-ests-server',
+  '2.1.12851.6 - EUS ProdSlices',
+  'X-XSS-Protection',
+  '0',
+  'Set-Cookie',
+  'fpc=AnPg0M0SS31Jsjx-lsoNYCE; expires=Sat, 02-Jul-2022 17:11:45 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'Set-Cookie',
+  'esctx=AQABAAAAAAD--DLA3VO7QrddgJg7WevrLpZf_25NGXkLgHBwkqlsgB6AwlvHlCDpy6PbLS55R4v2e1SfxJf0HbKd1Bkd8F_AxQUiED8iFHfB7ZIzYplYwAKS9ZuhD6HYMUfjPp6regNWJ4BXPd5c4-aVkWpPeEbBBGHFOnr73ha5PUxdpst5Y9rW0mXXLXblrq_-nhhkDFIgAA; domain=.login.microsoftonline.com; path=/; secure; HttpOnly; SameSite=None',
+  'Set-Cookie',
+  'x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly',
+  'Set-Cookie',
+  'stsservicecookie=estsfd; path=/; secure; samesite=none; httponly',
+  'Date',
+  'Thu, 02 Jun 2022 17:11:45 GMT',
+  'Content-Length',
+  '1753'
+]);
+
+nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
+  .post('/12345678-1234-1234-1234-123456789012/oauth2/v2.0/token', "client_id=azure_client_id&scope=https%3A%2F%2Fsanitized%2F&grant_type=client_credentials&x-client-SKU=msal.js.node&x-client-VER=1.9.0&x-client-OS=linux&x-client-CPU=x64&x-ms-lib-capability=retry-after, h429&x-client-current-telemetry=5|771,2,,,|,&x-client-last-telemetry=5|0|||0,0&client-request-id=94331742-6e33-400a-9165-b8565f7bc71d&client_secret=azure_client_secret&claims=%7B%22access_token%22%3A%7B%22xms_cc%22%3A%7B%22values%22%3A%5B%22cp1%22%5D%7D%7D%7D")
+  .reply(200, {"token_type":"Bearer","expires_in":86399,"ext_expires_in":86399,"access_token":"access_token"}, [
+  'Cache-Control',
+  'no-store, no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'P3P',
+  'CP="DSP CUR OTPi IND OTRi ONL FIN"',
+  'x-ms-request-id',
+  'ad39dfaa-af21-4270-8306-f2bd31492000',
+  'x-ms-ests-server',
+  '2.1.12851.6 - WUS2 ProdSlices',
+  'x-ms-clitelem',
+  '1,0,0,,',
+  'Content-Security-Policy-Report-Only',
+  "script-src 'self' 'nonce-Wqb8N8-Ba2ozlZsLxzWQcQ' 'unsafe-eval' 'unsafe-inline'; object-src 'none'; base-uri 'none'; report-uri https://csp.microsoft.com/report/ESTS-UX-All",
+  'X-XSS-Protection',
+  '0',
+  'Set-Cookie',
+  'fpc=AlnYYs3NY9FLh4Rq1HiGqTcyrjFTAQAAAFHmKtoOAAAA; expires=Sat, 02-Jul-2022 17:11:46 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'Set-Cookie',
+  'x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly',
+  'Set-Cookie',
+  'stsservicecookie=estsfd; path=/; secure; samesite=none; httponly',
+  'Date',
+  'Thu, 02 Jun 2022 17:11:45 GMT',
+  'Content-Length',
+  '1315'
+]);
+
+nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
+  .put('/secrets/', {"value":"SECRET_VALUE","attributes":{}})
+  .query(true)
+  .reply(405, {"error":{"code":"MethodNotAllowed","message":"HTTP PUT not allowed"}}, [
+  'Cache-Control',
+  'no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Length',
+  '70',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'x-ms-keyvault-region',
+  'northcentralus',
+  'x-ms-client-request-id',
+  'be7d91ab-0b47-4e00-a50a-90d031312d0f',
+  'x-ms-request-id',
+  '85d7ec5d-c165-40cb-9dc6-53ca6229ddea',
+  'x-ms-keyvault-service-version',
+  '1.9.422.1',
+  'x-ms-keyvault-network-info',
+  'conn_type=Ipv4;addr=167.220.80.222;act_addr_fam=InterNetwork;',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Strict-Transport-Security',
+  'max-age=31536000;includeSubDomains',
+  'Date',
+  'Thu, 02 Jun 2022 17:11:46 GMT'
+]);

--- a/sdk/keyvault/keyvault-secrets/recordings/node/secret_client__create_read_update_and_delete_operations/recording_cannot_create_a_secret_with_an_empty_name.js
+++ b/sdk/keyvault/keyvault-secrets/recordings/node/secret_client__create_read_update_and_delete_operations/recording_cannot_create_a_secret_with_an_empty_name.js
@@ -1,6 +1,6 @@
 let nock = require('nock');
 
-module.exports.hash = "2bbc69497a6a750fc72f51f42755f292";
+module.exports.hash = "398e4806b12e4a4b1e51c29200cfb3be";
 
 module.exports.testInfo = {"uniqueName":{},"newDate":{}}
 
@@ -23,9 +23,9 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'x-ms-keyvault-region',
   'northcentralus',
   'x-ms-client-request-id',
-  'be7d91ab-0b47-4e00-a50a-90d031312d0f',
+  '1ee59d55-48db-43d2-85d3-0003e6473e08',
   'x-ms-request-id',
-  'a2805fc3-c960-4c95-bd12-4d5840b2c4c9',
+  '8b8dd40f-9e73-4166-a559-537d8d652438',
   'x-ms-keyvault-service-version',
   '1.9.422.1',
   'x-ms-keyvault-network-info',
@@ -35,7 +35,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'Strict-Transport-Security',
   'max-age=31536000;includeSubDomains',
   'Date',
-  'Thu, 02 Jun 2022 17:11:45 GMT'
+  'Thu, 02 Jun 2022 22:27:03 GMT'
 ]);
 
 nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
@@ -57,23 +57,21 @@ nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
   'P3P',
   'CP="DSP CUR OTPi IND OTRi ONL FIN"',
   'x-ms-request-id',
-  '92e0a119-8571-4217-8b62-d4ef68fc2000',
+  '6e4f5498-0204-45ae-b695-31a6ca622b00',
   'x-ms-ests-server',
-  '2.1.12851.6 - WUS2 ProdSlices',
-  'Content-Security-Policy-Report-Only',
-  "script-src 'self' 'nonce-8blV7IaK2OulnLXv3ZmIzA' 'unsafe-eval' 'unsafe-inline'; object-src 'none'; base-uri 'none'; report-uri https://csp.microsoft.com/report/ESTS-UX-All",
+  '2.1.12851.6 - EUS ProdSlices',
   'X-XSS-Protection',
   '0',
   'Set-Cookie',
-  'fpc=AoS4nbhwoqpPlVAUVWFIHtw; expires=Sat, 02-Jul-2022 17:11:45 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'fpc=Alvt51rfnRZBjoA9XhreMgs; expires=Sat, 02-Jul-2022 22:27:05 GMT; path=/; secure; HttpOnly; SameSite=None',
   'Set-Cookie',
-  'esctx=AQABAAAAAAD--DLA3VO7QrddgJg7WevrWcrp9xD3NNSj-FbA-JwUM24wWst31OgyAnjNBG5Rimr88vowUxBrZcfN_GD7iUJuhoE50AdkWkXEzXrMzAr3KGfZjViOZ2mcBlu6FZbaWehrBOWsiea-mokj-DBHF8QU5NoNgiTU2mdlV_mLrnXN8k65qXnugCJVdCvuJez_L04gAA; domain=.login.microsoftonline.com; path=/; secure; HttpOnly; SameSite=None',
+  'esctx=AQABAAAAAAD--DLA3VO7QrddgJg7Wevre9Np5aSRApx3AeI5zu6OxlNPR5VvEi9dHKbBwbu9nnMHoSLQy37lZIbta-Ud0TcWRTc6OLTCwQ9lxS50YSZDD2CbU_bq7bmzB1VsmViOX3g6jz16PHmuBqGf80_LX0yFA7SAMvrZKoudsxdicQ3PR_JEQfW5N4tbpnwMNaDIGQMgAA; domain=.login.microsoftonline.com; path=/; secure; HttpOnly; SameSite=None',
   'Set-Cookie',
   'x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly',
   'Set-Cookie',
   'stsservicecookie=estsfd; path=/; secure; samesite=none; httponly',
   'Date',
-  'Thu, 02 Jun 2022 17:11:45 GMT',
+  'Thu, 02 Jun 2022 22:27:05 GMT',
   'Content-Length',
   '980'
 ]);
@@ -96,27 +94,29 @@ nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
   'P3P',
   'CP="DSP CUR OTPi IND OTRi ONL FIN"',
   'x-ms-request-id',
-  '8d47d79c-aa27-427d-9252-e6ca5c252100',
+  '86128017-8159-4c86-bdf3-adfd68062f00',
   'x-ms-ests-server',
-  '2.1.12851.6 - EUS ProdSlices',
+  '2.1.12851.6 - WUS2 ProdSlices',
+  'Content-Security-Policy-Report-Only',
+  "script-src 'self' 'nonce-3zLwx_cMRPr_1l-IHVTvxg' 'unsafe-eval' 'unsafe-inline'; object-src 'none'; base-uri 'none'; report-uri https://csp.microsoft.com/report/ESTS-UX-All",
   'X-XSS-Protection',
   '0',
   'Set-Cookie',
-  'fpc=AnPg0M0SS31Jsjx-lsoNYCE; expires=Sat, 02-Jul-2022 17:11:45 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'fpc=Ap-WprSQ8mlFuKlPoIxDXIs; expires=Sat, 02-Jul-2022 22:27:05 GMT; path=/; secure; HttpOnly; SameSite=None',
   'Set-Cookie',
-  'esctx=AQABAAAAAAD--DLA3VO7QrddgJg7WevrLpZf_25NGXkLgHBwkqlsgB6AwlvHlCDpy6PbLS55R4v2e1SfxJf0HbKd1Bkd8F_AxQUiED8iFHfB7ZIzYplYwAKS9ZuhD6HYMUfjPp6regNWJ4BXPd5c4-aVkWpPeEbBBGHFOnr73ha5PUxdpst5Y9rW0mXXLXblrq_-nhhkDFIgAA; domain=.login.microsoftonline.com; path=/; secure; HttpOnly; SameSite=None',
+  'esctx=AQABAAAAAAD--DLA3VO7QrddgJg7WevrnCQECZN0IduOuS5JDI9WRYmwNObu6sVpXSCVc3qbQqTN0GqVgS7bKBBAYdiHUqFgJCZy_89dk8hSE8bE0yvO4PWuMueftwDPBbBY_RvZ6c2we_ImNCDQUz9Rmy7UnpnN4Q-BfTJc2LaPzxiCr4zmI94xcC0P2E4GLO29r2Qlx8kgAA; domain=.login.microsoftonline.com; path=/; secure; HttpOnly; SameSite=None',
   'Set-Cookie',
   'x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly',
   'Set-Cookie',
   'stsservicecookie=estsfd; path=/; secure; samesite=none; httponly',
   'Date',
-  'Thu, 02 Jun 2022 17:11:45 GMT',
+  'Thu, 02 Jun 2022 22:27:05 GMT',
   'Content-Length',
   '1753'
 ]);
 
 nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
-  .post('/12345678-1234-1234-1234-123456789012/oauth2/v2.0/token', "client_id=azure_client_id&scope=https%3A%2F%2Fsanitized%2F&grant_type=client_credentials&x-client-SKU=msal.js.node&x-client-VER=1.9.0&x-client-OS=linux&x-client-CPU=x64&x-ms-lib-capability=retry-after, h429&x-client-current-telemetry=5|771,2,,,|,&x-client-last-telemetry=5|0|||0,0&client-request-id=94331742-6e33-400a-9165-b8565f7bc71d&client_secret=azure_client_secret&claims=%7B%22access_token%22%3A%7B%22xms_cc%22%3A%7B%22values%22%3A%5B%22cp1%22%5D%7D%7D%7D")
+  .post('/12345678-1234-1234-1234-123456789012/oauth2/v2.0/token', "client_id=azure_client_id&scope=https%3A%2F%2Fsanitized%2F&grant_type=client_credentials&x-client-SKU=msal.js.node&x-client-VER=1.9.0&x-client-OS=linux&x-client-CPU=x64&x-ms-lib-capability=retry-after, h429&x-client-current-telemetry=5|771,2,,,|,&x-client-last-telemetry=5|0|||0,0&client-request-id=af91a876-605c-4c7e-828d-d08d9eacd12f&client_secret=azure_client_secret&claims=%7B%22access_token%22%3A%7B%22xms_cc%22%3A%7B%22values%22%3A%5B%22cp1%22%5D%7D%7D%7D")
   .reply(200, {"token_type":"Bearer","expires_in":86399,"ext_expires_in":86399,"access_token":"access_token"}, [
   'Cache-Control',
   'no-store, no-cache',
@@ -133,23 +133,21 @@ nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
   'P3P',
   'CP="DSP CUR OTPi IND OTRi ONL FIN"',
   'x-ms-request-id',
-  'ad39dfaa-af21-4270-8306-f2bd31492000',
+  '6e4f5498-0204-45ae-b695-31a6d4622b00',
   'x-ms-ests-server',
-  '2.1.12851.6 - WUS2 ProdSlices',
+  '2.1.12851.6 - EUS ProdSlices',
   'x-ms-clitelem',
   '1,0,0,,',
-  'Content-Security-Policy-Report-Only',
-  "script-src 'self' 'nonce-Wqb8N8-Ba2ozlZsLxzWQcQ' 'unsafe-eval' 'unsafe-inline'; object-src 'none'; base-uri 'none'; report-uri https://csp.microsoft.com/report/ESTS-UX-All",
   'X-XSS-Protection',
   '0',
   'Set-Cookie',
-  'fpc=AlnYYs3NY9FLh4Rq1HiGqTcyrjFTAQAAAFHmKtoOAAAA; expires=Sat, 02-Jul-2022 17:11:46 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'fpc=Av6k9AMKucdHjZB0CI8iZcEyrjFTAQAAADkwK9oOAAAA; expires=Sat, 02-Jul-2022 22:27:05 GMT; path=/; secure; HttpOnly; SameSite=None',
   'Set-Cookie',
   'x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly',
   'Set-Cookie',
   'stsservicecookie=estsfd; path=/; secure; samesite=none; httponly',
   'Date',
-  'Thu, 02 Jun 2022 17:11:45 GMT',
+  'Thu, 02 Jun 2022 22:27:05 GMT',
   'Content-Length',
   '1315'
 ]);
@@ -171,9 +169,9 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'x-ms-keyvault-region',
   'northcentralus',
   'x-ms-client-request-id',
-  'be7d91ab-0b47-4e00-a50a-90d031312d0f',
+  '1ee59d55-48db-43d2-85d3-0003e6473e08',
   'x-ms-request-id',
-  '85d7ec5d-c165-40cb-9dc6-53ca6229ddea',
+  '47efa768-f6fa-4988-9634-7033db4a3e4d',
   'x-ms-keyvault-service-version',
   '1.9.422.1',
   'x-ms-keyvault-network-info',
@@ -183,5 +181,5 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'Strict-Transport-Security',
   'max-age=31536000;includeSubDomains',
   'Date',
-  'Thu, 02 Jun 2022 17:11:46 GMT'
+  'Thu, 02 Jun 2022 22:27:05 GMT'
 ]);

--- a/sdk/keyvault/keyvault-secrets/test/public/CRUD.spec.ts
+++ b/sdk/keyvault/keyvault-secrets/test/public/CRUD.spec.ts
@@ -75,18 +75,10 @@ describe("Secret client - create, read, update and delete operations", () => {
 
   it("cannot create a secret with an empty name", async function () {
     const secretName = "";
-    let error;
     try {
       await client.setSecret(secretName, secretValue);
       throw Error("Expecting an error but not catching one.");
-    } catch (e: any) {
-      error = e;
-    }
-    assert.equal(
-      error.message,
-      `"secretName" with value "" should satisfy the constraint "Pattern": /^[0-9a-zA-Z-]+$/.`,
-      "Unexpected error while running setSecret with an empty string as the name."
-    );
+    } catch (e: any) {}
   });
 
   it("can set a secret with Empty Value", async function (this: Context) {

--- a/sdk/keyvault/keyvault-secrets/test/public/CRUD.spec.ts
+++ b/sdk/keyvault/keyvault-secrets/test/public/CRUD.spec.ts
@@ -78,7 +78,9 @@ describe("Secret client - create, read, update and delete operations", () => {
     try {
       await client.setSecret(secretName, secretValue);
       throw Error("Expecting an error but not catching one.");
-    } catch (e) {}
+    } catch (e) {
+      // Ignore expected error
+    }
   });
 
   it("can set a secret with Empty Value", async function (this: Context) {

--- a/sdk/keyvault/keyvault-secrets/test/public/CRUD.spec.ts
+++ b/sdk/keyvault/keyvault-secrets/test/public/CRUD.spec.ts
@@ -78,7 +78,7 @@ describe("Secret client - create, read, update and delete operations", () => {
     try {
       await client.setSecret(secretName, secretValue);
       throw Error("Expecting an error but not catching one.");
-    } catch (e: any) {}
+    } catch (e) {}
   });
 
   it("can set a secret with Empty Value", async function (this: Context) {

--- a/sdk/keyvault/keyvault-secrets/test/public/CRUD.spec.ts
+++ b/sdk/keyvault/keyvault-secrets/test/public/CRUD.spec.ts
@@ -77,7 +77,7 @@ describe("Secret client - create, read, update and delete operations", () => {
     const secretName = "";
     try {
       await client.setSecret(secretName, secretValue);
-      throw Error("Expecting an error but not catching one.");
+      assert.fail("Expected an error");
     } catch (e) {
       // Ignore expected error
     }


### PR DESCRIPTION
### Packages impacted by this PR

- `@azure/keyvault-certificates`
- `@azure/keyvault-secrets`

### Issues associated with this PR

- Fixes #22087

### Describe the problem that is addressed by this PR

Removes error message check that relies on now-removed constraint validation.