### PR TITLE
Override live test location default to westus

### DIFF
--- a/eng/pipelines/templates/stages/archetype-sdk-tests.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-tests.yml
@@ -40,8 +40,14 @@ parameters:
     default:
       Public:
         SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
+        # TODO: Migrate location override into azure-sdk-tools eng/common
+        # See https://github.com/Azure/azure-sdk-tools/issues/3398
+        Location: 'westus'
       Preview:
         SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources-preview)
+        # TODO: Migrate location override into azure-sdk-tools eng/common
+        # See https://github.com/Azure/azure-sdk-tools/issues/3398
+        Location: 'westus'
       Canary:
         SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
         Location: 'centraluseuap'


### PR DESCRIPTION
Temporary location override at the JS repo level as part of https://github.com/Azure/azure-sdk-tools/issues/3398 to address capacity restrictions.

## Validation Builds
### Passed
* [keyvault-admin](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1616970&view=results)
* [event-hubs](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1617246&view=results)
* [eventhubs-checkpointstore-blob](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1617247&view=results)

### Same Failures as Main
* [service-bus](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1617258&view=results)
* [keyvault-certificates](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1616970&view=results)
* [keyvault-keys](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1616980&view=ms.vss-test-web.build-test-results-tab)
* [keyvault-secrets](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1616980&view=ms.vss-test-web.build-test-results-tab)
