### PR TITLE
[KeyVault] keyvault-admin - Don't hard code request scope

### DIFF
--- a/sdk/keyvault/keyvault-admin/src/accessControlClient.ts
+++ b/sdk/keyvault/keyvault-admin/src/accessControlClient.ts
@@ -89,6 +89,8 @@ export class KeyVaultAccessControlClient {
     this.client.pipeline.addPolicy(
       bearerTokenAuthenticationPolicy({
         credential,
+        // The scopes will be populated in the challenge callbacks based on the WWW-authenticate header
+        // returned by the challenge, so pass an empty array as a placeholder.
         scopes: [],
         challengeCallbacks: createChallengeCallbacks(),
       })

--- a/sdk/keyvault/keyvault-admin/src/accessControlClient.ts
+++ b/sdk/keyvault/keyvault-admin/src/accessControlClient.ts
@@ -18,8 +18,8 @@ import {
   ListRoleDefinitionsPageSettings,
   SetRoleDefinitionOptions,
 } from "./accessControlModels";
-import { LATEST_API_VERSION } from "./constants";
 import { KeyVaultClient } from "./generated/keyVaultClient";
+import { LATEST_API_VERSION } from "./constants";
 import { PagedAsyncIterableIterator } from "@azure/core-paging";
 import { RoleAssignmentsListForScopeOptionalParams } from "./generated/models";
 import { TokenCredential } from "@azure/core-auth";

--- a/sdk/keyvault/keyvault-admin/src/accessControlClient.ts
+++ b/sdk/keyvault/keyvault-admin/src/accessControlClient.ts
@@ -18,7 +18,7 @@ import {
   ListRoleDefinitionsPageSettings,
   SetRoleDefinitionOptions,
 } from "./accessControlModels";
-import { LATEST_API_VERSION, authenticationScopes } from "./constants";
+import { LATEST_API_VERSION } from "./constants";
 import { KeyVaultClient } from "./generated/keyVaultClient";
 import { PagedAsyncIterableIterator } from "@azure/core-paging";
 import { RoleAssignmentsListForScopeOptionalParams } from "./generated/models";
@@ -89,7 +89,7 @@ export class KeyVaultAccessControlClient {
     this.client.pipeline.addPolicy(
       bearerTokenAuthenticationPolicy({
         credential,
-        scopes: authenticationScopes,
+        scopes: [],
         challengeCallbacks: createChallengeCallbacks(),
       })
     );

--- a/sdk/keyvault/keyvault-admin/src/backupClient.ts
+++ b/sdk/keyvault/keyvault-admin/src/backupClient.ts
@@ -10,7 +10,7 @@ import {
   KeyVaultRestoreResult,
   KeyVaultSelectiveKeyRestoreResult,
 } from "./backupClientModels";
-import { LATEST_API_VERSION, authenticationScopes } from "./constants";
+import { LATEST_API_VERSION } from "./constants";
 import { KeyVaultAdminPollOperationState } from "./lro/keyVaultAdminPoller";
 import { KeyVaultBackupOperationState } from "./lro/backup/operation";
 import { KeyVaultBackupPoller } from "./lro/backup/poller";
@@ -92,7 +92,7 @@ export class KeyVaultBackupClient {
     this.client.pipeline.addPolicy(
       bearerTokenAuthenticationPolicy({
         credential,
-        scopes: authenticationScopes,
+        scopes: [],
         challengeCallbacks: createChallengeCallbacks(),
       })
     );

--- a/sdk/keyvault/keyvault-admin/src/backupClient.ts
+++ b/sdk/keyvault/keyvault-admin/src/backupClient.ts
@@ -10,7 +10,6 @@ import {
   KeyVaultRestoreResult,
   KeyVaultSelectiveKeyRestoreResult,
 } from "./backupClientModels";
-import { LATEST_API_VERSION } from "./constants";
 import { KeyVaultAdminPollOperationState } from "./lro/keyVaultAdminPoller";
 import { KeyVaultBackupOperationState } from "./lro/backup/operation";
 import { KeyVaultBackupPoller } from "./lro/backup/poller";
@@ -19,6 +18,7 @@ import { KeyVaultRestoreOperationState } from "./lro/restore/operation";
 import { KeyVaultRestorePoller } from "./lro/restore/poller";
 import { KeyVaultSelectiveKeyRestoreOperationState } from "./lro/selectiveKeyRestore/operation";
 import { KeyVaultSelectiveKeyRestorePoller } from "./lro/selectiveKeyRestore/poller";
+import { LATEST_API_VERSION } from "./constants";
 import { PollerLike } from "@azure/core-lro";
 import { TokenCredential } from "@azure/core-auth";
 import { bearerTokenAuthenticationPolicy } from "@azure/core-rest-pipeline";

--- a/sdk/keyvault/keyvault-admin/src/backupClient.ts
+++ b/sdk/keyvault/keyvault-admin/src/backupClient.ts
@@ -92,6 +92,8 @@ export class KeyVaultBackupClient {
     this.client.pipeline.addPolicy(
       bearerTokenAuthenticationPolicy({
         credential,
+        // The scopes will be populated in the challenge callbacks based on the WWW-authenticate header
+        // returned by the challenge, so pass an empty array as a placeholder.
         scopes: [],
         challengeCallbacks: createChallengeCallbacks(),
       })

--- a/sdk/keyvault/keyvault-admin/src/constants.ts
+++ b/sdk/keyvault/keyvault-admin/src/constants.ts
@@ -15,8 +15,3 @@ export const LATEST_API_VERSION = "7.3";
  * Supported API versions
  */
 export type SUPPORTED_API_VERSIONS = "7.2" | "7.3";
-
-/**
- * Authentication scopes
- */
-export const authenticationScopes = ["https://managedhsm.azure.net/.default"];

--- a/sdk/keyvault/keyvault-admin/test/internal/challengeAuthenticationCallbacks.spec.ts
+++ b/sdk/keyvault/keyvault-admin/test/internal/challengeAuthenticationCallbacks.spec.ts
@@ -59,7 +59,7 @@ describe("Challenge based authentication tests", function () {
         request,
         response: {
           headers: createHttpHeaders({
-            "WWW-Authenticate": `Bearer scope="cae_scope"`,
+            "WWW-Authenticate": `Bearer resource="cae_scope"`,
           }),
           request,
           status: 200,
@@ -129,6 +129,27 @@ describe("Challenge based authentication tests", function () {
       assert.sameMembers(getAccessTokenScopes, ["cae_scope"]);
     });
 
+    it("prefers resource scope and adds .default to resource when provided", async () => {
+      let getAccessTokenScopes: string[] = [];
+      await challengeCallbacks.authorizeRequestOnChallenge!({
+        getAccessToken: (scopes) => {
+          getAccessTokenScopes = scopes;
+          return Promise.resolve(null);
+        },
+        request,
+        response: {
+          headers: createHttpHeaders({
+            "WWW-Authenticate": `Bearer resource="cae_resource", scope="cae_scope"`,
+          }),
+          request,
+          status: 200,
+        },
+        scopes: [],
+      });
+
+      assert.sameMembers(getAccessTokenScopes, ["cae_resource/.default"]);
+    });
+
     it("passes the tenantId if provided", async () => {
       const expectedTenantId = "expectedTenantId";
 
@@ -142,7 +163,7 @@ describe("Challenge based authentication tests", function () {
         request,
         response: {
           headers: createHttpHeaders({
-            "WWW-Authenticate": `Bearer scope="cae_scope" authorization="http://login.windows.net/${expectedTenantId}"`,
+            "WWW-Authenticate": `Bearer resource="cae_scope" authorization="http://login.windows.net/${expectedTenantId}"`,
           }),
           request,
           status: 200,
@@ -161,7 +182,7 @@ describe("Challenge based authentication tests", function () {
         request,
         response: {
           headers: createHttpHeaders({
-            "WWW-Authenticate": `Bearer scope="cae_scope"`,
+            "WWW-Authenticate": `Bearer resource="cae_scope"`,
           }),
           request,
           status: 200,
@@ -179,7 +200,7 @@ describe("Challenge based authentication tests", function () {
         request,
         response: {
           headers: createHttpHeaders({
-            "WWW-Authenticate": `Bearer scope="cae_scope"`,
+            "WWW-Authenticate": `Bearer resource="cae_scope"`,
           }),
           request,
           status: 200,


### PR DESCRIPTION
### Packages impacted by this PR

- `@azure/keyvault-admin`

### Issues associated with this PR

- Fixes #22028

### Describe the problem that is addressed by this PR

Currently keyvault-admin falls back to a hard-coded scope when making subsequent requests after the challenge-based authentication flow has been completed. This causes issues when the scope conflicts with the scope returned by the `WWW-Authenticate` header in the challenge. Hard-coding the scope means that the SDK can't be used in other clouds (e.g., as pointed out by the service team, Dogfood having a scope of `https://managedhsm-int.azure-int.net`).

This PR updates the logic so that the scope from the original `WWW-Authenticate` response is used on subsequent requests instead of the hard-coded value.

### Are there test cases added in this PR? _(If not, why?)_

This is tricky to test. There's some validation in the fact that the existing tests continue to pass with these changes. Might be worth adding a test case though...