### PR TITLE
[Recorder] Make TEST_MODE environment variable value case-insensitive

### DIFF
--- a/sdk/test-utils/recorder/CHANGELOG.md
+++ b/sdk/test-utils/recorder/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### Bugs Fixed
 
 - Fixed redirects not being passed to the test proxy in the browser. [#21713](https://github.com/Azure/azure-sdk-for-js/pull/21713)
+- The value of the `TEST_MODE` environment variable is no longer case-sensitive. [#22118](https://github.com/Azure/azure-sdk-for-js/pull/22118)
 
 ### Other Changes
 

--- a/sdk/test-utils/recorder/src/utils/utils.ts
+++ b/sdk/test-utils/recorder/src/utils/utils.ts
@@ -317,7 +317,7 @@ export function getTestMode(): TestMode {
   if (isPlaybackMode()) {
     return "playback";
   }
-  return env.TEST_MODE as "record" | "live";
+  return env.TEST_MODE?.toLowerCase() as "record" | "live";
 }
 
 /** Make a lazy value that can be deferred and only computed once. */
@@ -327,11 +327,11 @@ export const once = <T>(make: () => T): (() => T) => {
 };
 
 export function isRecordMode() {
-  return env.TEST_MODE === "record";
+  return env.TEST_MODE?.toLowerCase() === "record";
 }
 
 export function isLiveMode() {
-  return env.TEST_MODE === "live";
+  return env.TEST_MODE?.toLowerCase() === "live";
 }
 
 export function isPlaybackMode() {

--- a/sdk/test-utils/recorder/test/testProxyClient.spec.ts
+++ b/sdk/test-utils/recorder/test/testProxyClient.spec.ts
@@ -11,7 +11,13 @@ import { expect } from "chai";
 import { env, Recorder } from "../src";
 import { createRecordingRequest } from "../src/utils/createRecordingRequest";
 import { paths } from "../src/utils/paths";
-import { getTestMode, isLiveMode, RecorderError, RecordingStateManager } from "../src/utils/utils";
+import {
+  getTestMode,
+  isLiveMode,
+  isRecordMode,
+  RecorderError,
+  RecordingStateManager,
+} from "../src/utils/utils";
 
 const testRedirectedRequest = (
   client: Recorder,
@@ -294,6 +300,27 @@ describe("TestProxyClient functions", () => {
       expect(returnedRequest.body).not.to.be.undefined;
       expect(returnedRequest.headers.get("x-recording-id")).to.equal(client.recordingId);
       expect(returnedRequest.url).to.equal(initialRequest.url);
+    });
+  });
+
+  describe("getTestMode", () => {
+    it("treats the TEST_MODE environment variable case-insensitively", () => {
+      [
+        "record",
+        "RECORD",
+        "Record",
+        "playback",
+        "PLAYBACK",
+        "Playback",
+        "live",
+        "LIVE",
+        "Live",
+      ].forEach((testMode) => {
+        env.TEST_MODE = testMode;
+        expect(getTestMode()).to.equal(testMode.toLowerCase());
+        expect(isRecordMode()).to.equal(testMode.toLowerCase() === "record");
+        expect(isLiveMode()).to.equal(testMode.toLowerCase() === "live");
+      });
     });
   });
 });


### PR DESCRIPTION
### Packages impacted by this PR

- `@azure/test-recorder`

### Issues associated with this PR

- Fixes #22012 

### Describe the problem that is addressed by this PR

The `TEST_MODE` environment variable was previously case sensitive, leading to confusing results when setting it to a value with any upper-case characters (e.g., `TEST_MODE=Live` would result in running tests in playback mode). This change makes `TEST_MODE` case-insensitive.

### Are there test cases added in this PR? _(If not, why?)_

Yes

### Checklists
- [ ] Added a changelog (if necessary)
