### PR TITLE
[core-amqp][test] fix build error in rush update --full

### DIFF
--- a/sdk/core/core-amqp/test/requestResponse.spec.ts
+++ b/sdk/core/core-amqp/test/requestResponse.spec.ts
@@ -604,7 +604,7 @@ describe("RequestResponseLink", function () {
 
     beforeEach(() => {
       clearTimeoutCalledCount = 0;
-      _global.clearTimeout = (tid: NodeJS.Timeout) => {
+      _global.clearTimeout = (tid: NodeJS.Timeout | string | number | undefined) => {
         clearTimeoutCalledCount++;
         return originalClearTimeout(tid);
       };

--- a/sdk/core/core-amqp/test/requestResponse.spec.ts
+++ b/sdk/core/core-amqp/test/requestResponse.spec.ts
@@ -604,7 +604,7 @@ describe("RequestResponseLink", function () {
 
     beforeEach(() => {
       clearTimeoutCalledCount = 0;
-      _global.clearTimeout = (tid: NodeJS.Timeout | string | number | undefined) => {
+      _global.clearTimeout = (tid: any) => {
         clearTimeoutCalledCount++;
         return originalClearTimeout(tid);
       };


### PR DESCRIPTION
The explicit parameter type was added in PR #21892 to resolve a compiler error.
It has been working for a while, but now broken due to @types/node fix in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/60591

This PR updates the parameter type to use `any` as we don't care about the parameter type in this test and it will not be affected by future type changes