### PR TITLE
[Text Analytics] Simplifying error handling

### DIFF
--- a/sdk/textanalytics/ai-text-analytics/src/transforms.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/transforms.ts
@@ -285,7 +285,7 @@ function appendReadableErrorMessage(currentMessage: string, innerMessage: string
  * parses incoming errors from the service/
  * @param error - the incoming error
  */
-export function transformError(errorResponse: unknown): any {
+function transformError(errorResponse: unknown): any {
   const strongErrorResponse = errorResponse as {
     response: {
       parsedBody?: ErrorResponse;
@@ -317,6 +317,14 @@ export function transformError(errorResponse: unknown): any {
     code,
     statusCode: strongErrorResponse.statusCode,
   });
+}
+
+export async function throwError<T>(p: Promise<T>): Promise<T> {
+  try {
+    return await p;
+  } catch (e: unknown) {
+    throw transformError(e);
+  }
 }
 
 function toHealthcareResult(


### PR DESCRIPTION
Use a `throwError` helper everywhere which in turn transforms the caught error before throwing it again.