### PR TITLE
[core-lro] 500 is unexpected status code

### DIFF
--- a/sdk/core/core-lro/src/lroEngine/requestUtils.ts
+++ b/sdk/core/core-lro/src/lroEngine/requestUtils.ts
@@ -88,7 +88,7 @@ class SimpleRestError extends Error {
 
 export function isUnexpectedInitialResponse(rawResponse: RawResponse): boolean {
   const code = rawResponse.statusCode;
-  if (![203, 204, 202, 201, 200, 500].includes(code)) {
+  if (![203, 204, 202, 201, 200].includes(code)) {
     throw new SimpleRestError(
       `Received unexpected HTTP status code ${code} in the initial response. This may indicate a server issue.`,
       code
@@ -99,7 +99,7 @@ export function isUnexpectedInitialResponse(rawResponse: RawResponse): boolean {
 
 export function isUnexpectedPollingResponse(rawResponse: RawResponse): boolean {
   const code = rawResponse.statusCode;
-  if (![202, 201, 200, 500].includes(code)) {
+  if (![202, 201, 200].includes(code)) {
     throw new SimpleRestError(
       `Received unexpected HTTP status code ${code} while polling. This may indicate a server issue.`,
       code


### PR DESCRIPTION
I am not sure why lroEngine was considering 500 as expected status code for initial and polling requests.