### PR TITLE
[servicebus][test] assert on expected properties

### DIFF
--- a/sdk/servicebus/service-bus/test/public/amqpAnnotatedMessage.spec.ts
+++ b/sdk/servicebus/service-bus/test/public/amqpAnnotatedMessage.spec.ts
@@ -71,31 +71,41 @@ const assert = chai.assert;
         should.equal(Array.isArray(msgs), true, "`ReceivedMessages` is not an array");
         should.equal(msgs.length, 1, "Unexpected number of messages");
         should.equal(msgs[0].body, testMessage.body, "Unexpected body on the received message");
+        const rawAmqpMessage = msgs[0]._rawAmqpMessage;
         should.equal(
-          msgs[0]._rawAmqpMessage.messageAnnotations!["propMsgAnnotate"],
+          rawAmqpMessage.messageAnnotations!["propMsgAnnotate"],
           testMessage.messageAnnotations!["propMsgAnnotate"],
           "Unexpected messageAnnotations on the received message"
         );
-        assert.deepEqualExcluding(
-          msgs[0]._rawAmqpMessage,
-          testMessage,
-          ["deliveryAnnotations", "body", "messageAnnotations", "header", "properties"],
-          "Unexpected on the AmqpAnnotatedMessage"
+        should.equal(
+          rawAmqpMessage.bodyType,
+          testMessage.bodyType,
+          "Unexpected bodyType on the AmqpAnnotatedMessage"
+        );
+        assert.deepEqual(
+          rawAmqpMessage.applicationProperties,
+          testMessage.applicationProperties,
+          "Unexpected applicationProperties on the AmqpAnnotatedMessage"
+        );
+        assert.deepEqual(
+          rawAmqpMessage.footer,
+          testMessage.footer,
+          "Unexpected footer on the AmqpAnnotatedMessage"
         );
         assert.deepEqualExcluding(
-          msgs[0]._rawAmqpMessage.header!,
+          rawAmqpMessage.header!,
           testMessage.header!,
           ["deliveryCount"],
           "Unexpected header on the AmqpAnnotatedMessage"
         );
         assert.deepEqualExcluding(
-          msgs[0]._rawAmqpMessage.properties!,
+          rawAmqpMessage.properties!,
           testMessage.properties!,
           ["creationTime", "absoluteExpiryTime", "groupId"],
           "Unexpected properties on the AmqpAnnotatedMessage"
         );
         assert.equal(
-          msgs[0]._rawAmqpMessage.properties!.groupId,
+          rawAmqpMessage.properties!.groupId,
           testMessage.properties!.groupId,
           "Unexpected session-id on the AmqpAnnotatedMessage"
         );


### PR DESCRIPTION
This RP rewrites the assertion with excluded properties with assertion on
expected properties. as log of `deepEqualExcluding()` doesn't give enough
information on the difference when the assertion fails.

![image](https://user-images.githubusercontent.com/7583839/172463961-bc04d1f7-7409-4a96-8e02-e37bc6b7b94e.png)


### Issues associated with this PR

#22047 