### PR TITLE
[ServiceBus] workaround a service issue by using page size of 100

### DIFF
--- a/sdk/servicebus/service-bus/src/serviceBusRuleManager.ts
+++ b/sdk/servicebus/service-bus/src/serviceBusRuleManager.ts
@@ -190,7 +190,7 @@ export class ServiceBusRuleManagerImpl implements ServiceBusRuleManager {
     do {
       const rules = await this.getRules({
         skip: Number(marker),
-        maxCount: options.maxPageSize,
+        maxCount: options.maxPageSize ?? 100,
         ...options,
       });
       yield rules;

--- a/sdk/servicebus/service-bus/test/public/ruleManager.spec.ts
+++ b/sdk/servicebus/service-bus/test/public/ruleManager.spec.ts
@@ -147,7 +147,48 @@ describe("RuleManager tests", () => {
       assert.deepStrictEqual(correlationFilter.applicationProperties, applicationProperties);
     });
 
-    it("list rules by page", async () => {
+    it("list rules", async () => {
+      const ruleManager = serviceBusClient.createRuleManager(topic, subscription);
+
+      const sqlRuleName = "sqlRule";
+      const correlationRuleName = "correlationRule";
+
+      const rules = await getRules(ruleManager);
+      assert.equal(rules.length, 1); // default rule
+      const firstRule = rules[0];
+      assert.equal(firstRule.name, defaultRuleName);
+
+      await ruleManager.createRule(sqlRuleName, {
+        sqlExpression: "price > 10",
+      });
+
+      const applicationProperties = {
+        key1: "value1",
+      };
+      const correlationRuleFilter: CorrelationRuleFilter = {
+        correlationId: "correlationId",
+        subject: "label",
+        messageId: "messageId",
+        applicationProperties,
+        replyTo: "replyTo",
+        replyToSessionId: "replyToSessionId",
+        sessionId: "sessionId",
+        to: "to",
+      };
+      const action: SqlRuleAction = {
+        sqlExpression: "Set CorrelationId = 'newValue'",
+      };
+      await ruleManager.createRule(correlationRuleName, correlationRuleFilter, action);
+
+      const iterator = ruleManager.listRules();
+      const result: RuleProperties[] = [];
+      for await (const rule of iterator) {
+        result.push(rule);
+      }
+      assert.equal(result.length, 3, "Expecting three rules");
+    });
+
+    it("list rules by page specifying page size", async () => {
       const ruleManager = serviceBusClient.createRuleManager(topic, subscription);
 
       const sqlRuleName = "sqlRule";
@@ -190,6 +231,48 @@ describe("RuleManager tests", () => {
       result = await iterator.next();
       assert.equal(result.value.length, 1, "Expecting one rule in third page");
       assert.equal(result.value[0].name, sqlRuleName);
+      result = await iterator.next();
+      assert.equal(result.value.length, 0, "Not expecting any result in last page");
+      result = await iterator.next();
+      assert.equal(result.value, undefined, "Not expecting any more pages");
+    });
+
+    it("list rules by page without specifying page size", async () => {
+      const ruleManager = serviceBusClient.createRuleManager(topic, subscription);
+
+      const sqlRuleName = "sqlRule";
+      const correlationRuleName = "correlationRule";
+
+      const rules = await getRules(ruleManager);
+      assert.equal(rules.length, 1); // default rule
+      const firstRule = rules[0];
+      assert.equal(firstRule.name, defaultRuleName);
+
+      await ruleManager.createRule(sqlRuleName, {
+        sqlExpression: "price > 10",
+      });
+
+      const applicationProperties = {
+        key1: "value1",
+      };
+      const correlationRuleFilter: CorrelationRuleFilter = {
+        correlationId: "correlationId",
+        subject: "label",
+        messageId: "messageId",
+        applicationProperties,
+        replyTo: "replyTo",
+        replyToSessionId: "replyToSessionId",
+        sessionId: "sessionId",
+        to: "to",
+      };
+      const action: SqlRuleAction = {
+        sqlExpression: "Set CorrelationId = 'newValue'",
+      };
+      await ruleManager.createRule(correlationRuleName, correlationRuleFilter, action);
+
+      const iterator = ruleManager.listRules().byPage();
+      let result = await iterator.next();
+      assert.equal(result.value.length, 3, "Expecting one rule in first page");
       result = await iterator.next();
       assert.equal(result.value.length, 0, "Not expecting any result in last page");
       result = await iterator.next();


### PR DESCRIPTION
Testing reveals that if we use max int as maxCount, and also use top then
service will return InternalServerError.

This PR workarounds around that by defaulting to 100 as maxPageSize.
