### PR TITLE
[Recorder] TEST_PROXY_{HTTP|HTTPS}_PORT

### DIFF
--- a/common/tools/dev-tool/src/util/testProxyUtils.ts
+++ b/common/tools/dev-tool/src/util/testProxyUtils.ts
@@ -14,7 +14,7 @@ const log = createPrinter("test-proxy");
 const CONTAINER_NAME = "js-azsdk-test-proxy";
 
 export async function startProxyTool(): Promise<void> {
-  log.info(`Attempting to start test proxy at http://localhost:${process.env.TEST_PROXY_HTTP_PORT ?? 5000} & https://localhost:5001.\n`);
+  log.info(`Attempting to start test proxy at http://localhost:${process.env.TEST_PROXY_HTTP_PORT ?? 5000} & https://localhost:${process.env.TEST_PROXY_HTTPS_PORT ?? 5001}.\n`);
 
   const subprocess = spawn(await getDockerRunCommand(), [], {
     shell: true,
@@ -59,7 +59,7 @@ async function getDockerRunCommand() {
   const testProxyRecordingsLocation = "/srv/testproxy";
   const allowLocalhostAccess = "--add-host host.docker.internal:host-gateway";
   const imageToLoad = `azsdkengsys.azurecr.io/engsys/testproxy-lin:${await getImageTag()}`;
-  return `docker run --rm --name ${CONTAINER_NAME} -v ${repoRoot}:${testProxyRecordingsLocation} -p 5001:5001 -p ${process.env.TEST_PROXY_HTTP_PORT ?? 5000}:5000 ${allowLocalhostAccess} ${imageToLoad}`;
+  return `docker run --rm --name ${CONTAINER_NAME} -v ${repoRoot}:${testProxyRecordingsLocation} -p ${process.env.TEST_PROXY_HTTPS_PORT ?? 5001}:5001 -p ${process.env.TEST_PROXY_HTTP_PORT ?? 5000}:5000 ${allowLocalhostAccess} ${imageToLoad}`;
 }
 
 export async function isProxyToolActive(): Promise<boolean> {

--- a/common/tools/dev-tool/src/util/testProxyUtils.ts
+++ b/common/tools/dev-tool/src/util/testProxyUtils.ts
@@ -14,7 +14,7 @@ const log = createPrinter("test-proxy");
 const CONTAINER_NAME = "js-azsdk-test-proxy";
 
 export async function startProxyTool(): Promise<void> {
-  log.info(`Attempting to start test proxy at http://localhost:5000 & https://localhost:5001.\n`);
+  log.info(`Attempting to start test proxy at http://localhost:${process.env.TEST_PROXY_HTTP_PORT ?? 5000} & https://localhost:5001.\n`);
 
   const subprocess = spawn(await getDockerRunCommand(), [], {
     shell: true,
@@ -59,13 +59,13 @@ async function getDockerRunCommand() {
   const testProxyRecordingsLocation = "/srv/testproxy";
   const allowLocalhostAccess = "--add-host host.docker.internal:host-gateway";
   const imageToLoad = `azsdkengsys.azurecr.io/engsys/testproxy-lin:${await getImageTag()}`;
-  return `docker run --rm --name ${CONTAINER_NAME} -v ${repoRoot}:${testProxyRecordingsLocation} -p 5001:5001 -p 5000:5000 ${allowLocalhostAccess} ${imageToLoad}`;
+  return `docker run --rm --name ${CONTAINER_NAME} -v ${repoRoot}:${testProxyRecordingsLocation} -p 5001:5001 -p ${process.env.TEST_PROXY_HTTP_PORT ?? 5000}:5000 ${allowLocalhostAccess} ${imageToLoad}`;
 }
 
 export async function isProxyToolActive(): Promise<boolean> {
   try {
-    await makeRequest("http://localhost:5000/info/available", {});
-    log.info(`Proxy tool seems to be active at http://localhost:5000\n`);
+    await makeRequest(`http://localhost:${process.env.TEST_PROXY_HTTP_PORT ?? 5000}/info/available`, {});
+    log.info(`Proxy tool seems to be active at http://localhost:${process.env.TEST_PROXY_HTTP_PORT ?? 5000}\n`);
     return true;
   } catch (error: any) {
     return false;

--- a/common/tools/dev-tool/src/util/testUtils.ts
+++ b/common/tools/dev-tool/src/util/testUtils.ts
@@ -15,7 +15,7 @@ async function shouldRunProxyTool(): Promise<boolean> {
       // No need to run a new one if it is already active
       // Especially, CI uses this path
       log.info(
-        `Proxy tool seems to be active, not attempting to start the test proxy at http://localhost:${process.env.TEST_PROXY_HTTP_PORT ?? 5000} & https://localhost:5001.\n`
+        `Proxy tool seems to be active, not attempting to start the test proxy at http://localhost:${process.env.TEST_PROXY_HTTP_PORT ?? 5000} & https://localhost:${process.env.TEST_PROXY_HTTPS_PORT ?? 5001}.\n`
       );
     }
     return !isActive;

--- a/common/tools/dev-tool/src/util/testUtils.ts
+++ b/common/tools/dev-tool/src/util/testUtils.ts
@@ -15,7 +15,7 @@ async function shouldRunProxyTool(): Promise<boolean> {
       // No need to run a new one if it is already active
       // Especially, CI uses this path
       log.info(
-        `Proxy tool seems to be active, not attempting to start the test proxy at http://localhost:5000 & https://localhost:5001.\n`
+        `Proxy tool seems to be active, not attempting to start the test proxy at http://localhost:${process.env.TEST_PROXY_HTTP_PORT ?? 5000} & https://localhost:5001.\n`
       );
     }
     return !isActive;

--- a/sdk/test-utils/recorder/CHANGELOG.md
+++ b/sdk/test-utils/recorder/CHANGELOG.md
@@ -6,7 +6,9 @@
 
 - Add support for session-level sanitization using the `Recorder.addSessionSanitizers` static method. [#21533](https://github.com/Azure/azure-sdk-for-js/pull/21533)
 - Added logging to help with debugging tests. [#21641](https://github.com/Azure/azure-sdk-for-js/pull/21641)
-- Allow mapping the test-proxy tool to ports other than just 5000(for HTTP) using the environment variable `TEST_PROXY_HTTP_PORT`. If `TEST_PROXY_HTTP_PORT` is undefined, we'll try for 5000 as usual.
+- Allow mapping the test-proxy tool to ports other than just 5000(for HTTP) using the environment variable `TEST_PROXY_HTTP_PORT`.
+  - If `TEST_PROXY_HTTP_PORT` is undefined, we'll try for 5000 as usual.
+  - For browsers, this variable has to be added as part of the environment variables listed under `envPreprocessor` array in `karma.conf.js` so that the recorder knows the port to hit.
 
 ### Breaking Changes
 

--- a/sdk/test-utils/recorder/CHANGELOG.md
+++ b/sdk/test-utils/recorder/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Add support for session-level sanitization using the `Recorder.addSessionSanitizers` static method. [#21533](https://github.com/Azure/azure-sdk-for-js/pull/21533)
 - Added logging to help with debugging tests. [#21641](https://github.com/Azure/azure-sdk-for-js/pull/21641)
+- Allow mapping the test-proxy tool to ports other than just 5000(for HTTP) using the environment variable `TEST_PROXY_HTTP_PORT`. If `TEST_PROXY_HTTP_PORT` is undefined, we'll try for 5000 as usual.
 
 ### Breaking Changes
 

--- a/sdk/test-utils/recorder/CHANGELOG.md
+++ b/sdk/test-utils/recorder/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - Add support for session-level sanitization using the `Recorder.addSessionSanitizers` static method. [#21533](https://github.com/Azure/azure-sdk-for-js/pull/21533)
 - Added logging to help with debugging tests. [#21641](https://github.com/Azure/azure-sdk-for-js/pull/21641)
-- Allow mapping the test-proxy tool to ports other than just 5000(for HTTP) using the environment variable `TEST_PROXY_HTTP_PORT`.
+- Allow mapping the test-proxy tool to ports other than just 5000(for HTTP) using the environment variable `TEST_PROXY_HTTP_PORT`(and `TEST_PROXY_HTTPS_PORT` for 5001(for HTTPS)).
   - If `TEST_PROXY_HTTP_PORT` is undefined, we'll try for 5000 as usual.
   - For browsers, this variable has to be added as part of the environment variables listed under `envPreprocessor` array in `karma.conf.js` so that the recorder knows the port to hit.
 

--- a/sdk/test-utils/recorder/src/recorder.ts
+++ b/sdk/test-utils/recorder/src/recorder.ts
@@ -40,6 +40,7 @@ import { AdditionalPolicyConfig } from "@azure/core-client";
 import { logger } from "./log";
 import { setRecordingOptions } from "./options";
 import { isNode } from "@azure/core-util";
+import { env } from "./utils/env";
 
 /**
  * This client manages the recorder life cycle and interacts with the proxy-tool to do the recording,
@@ -53,7 +54,7 @@ import { isNode } from "@azure/core-util";
  * Other than configuring your clients, use `start`, `stop`, `addSanitizers` methods to use the recorder.
  */
 export class Recorder {
-  private static url = "http://localhost:5000";
+  private static url = `http://localhost:${env.TEST_PROXY_HTTP_PORT ?? 5000}`;
   public recordingId?: string;
   private stateManager = new RecordingStateManager();
   private httpClient?: HttpClient;

--- a/sdk/test-utils/testing-recorder-new/karma.conf.js
+++ b/sdk/test-utils/testing-recorder-new/karma.conf.js
@@ -59,6 +59,7 @@ module.exports = function (config) {
       "AZURE_CLIENT_SECRET",
       "AZURE_TENANT_ID",
       "RECORDINGS_RELATIVE_PATH",
+      "TEST_PROXY_HTTP_PORT"
     ],
 
     // test results reporter to use


### PR DESCRIPTION
### Packages impacted by this PR
`@azure-tools/test-recorder` and all the SDKs/tests/users

### Issues associated with this PR
#22059 

### Describe the problem that is addressed by this PR
If the 5000 port is blocked on a client machine, they won't be able to use the recorder and dev-tool commands directly to run the test-proxy tool.
Means, that the test-proxy tool needs to be run at a different port, but the `test-recorder` expects the tool runs at 5000.

Adds a new environment variable `TEST_PROXY_HTTP_PORT` which will be used for both mapping the test-proxy instance to localhost and in the recorder code to avoid using the hardcoded 5000 port.
Defaults to 5000 if `TEST_PROXY_HTTP_PORT` isn't defined.