### PR TITLE
Added two new features for change feed package.

### DIFF
--- a/sdk/storage/storage-blob-changefeed/CHANGELOG.md
+++ b/sdk/storage/storage-blob-changefeed/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Features Added
 
+- Updated Change Feed to return 0 events when meta/segments.json file hasn't been created yet.
+- Added ability to specify chunk download size with BlobChangeFeedClientOptions.maximumTransferSize.
+
 ### Breaking Changes
 
 ### Bugs Fixed
@@ -19,7 +22,7 @@
 ## 12.0.0-preview.1 (2020.07)
 
 - This is the first release supporting Azure Storage Blob Change Feed.
+
 ## 12.0.0-preview.2 (2020-09-08)
 
 - This release contains bug fixes to improve quality.
-

--- a/sdk/storage/storage-blob-changefeed/review/storage-blob-changefeed.api.md
+++ b/sdk/storage/storage-blob-changefeed/review/storage-blob-changefeed.api.md
@@ -18,10 +18,15 @@ export type AccessTier = "P4" | "P6" | "P10" | "P15" | "P20" | "P30" | "P40" | "
 
 // @public
 export class BlobChangeFeedClient {
-    constructor(url: string, credential?: StorageSharedKeyCredential | AnonymousCredential | TokenCredential, options?: StoragePipelineOptions);
+    constructor(url: string, credential?: StorageSharedKeyCredential | AnonymousCredential | TokenCredential, options?: StoragePipelineOptions, changeFeedClientOptions?: BlobChangeFeedClientOptions);
     constructor(url: string, pipeline: Pipeline);
-    static fromConnectionString(connectionString: string, options?: StoragePipelineOptions): BlobChangeFeedClient;
+    static fromConnectionString(connectionString: string, options?: StoragePipelineOptions, changeFeedClientOptions?: BlobChangeFeedClientOptions): BlobChangeFeedClient;
     listChanges(options?: BlobChangeFeedListChangesOptions): PagedAsyncIterableIterator<BlobChangeFeedEvent, BlobChangeFeedEventPage>;
+}
+
+// @public
+export interface BlobChangeFeedClientOptions {
+    maximumTransferSize?: number;
 }
 
 // @public

--- a/sdk/storage/storage-blob-changefeed/src/BlobChangeFeedClient.ts
+++ b/sdk/storage/storage-blob-changefeed/src/BlobChangeFeedClient.ts
@@ -68,6 +68,16 @@ function appendUserAgentPrefix(options?: StoragePipelineOptions): StoragePipelin
 }
 
 /**
+ * Blob Change Feed client options.
+ */
+export interface BlobChangeFeedClientOptions {
+  /**
+   * The maximum length of an transfer in bytes.
+   */
+  maximumTransferSize?: number;
+}
+
+/**
  * BlobChangeFeedClient.
  * @see https://docs.microsoft.com/en-us/azure/storage/blobs/storage-blob-change-feed?tabs=azure-portal
  */
@@ -77,6 +87,7 @@ export class BlobChangeFeedClient {
    */
   private blobServiceClient: BlobServiceClient;
   private changeFeedFactory: ChangeFeedFactory;
+  private changeFeedClientOptions: BlobChangeFeedClientOptions;
 
   /**
    *
@@ -94,13 +105,17 @@ export class BlobChangeFeedClient {
     connectionString: string,
     // Legacy, no way to fix the eslint error without breaking. Disable the rule for this line.
     /* eslint-disable-next-line @azure/azure-sdk/ts-naming-options */
-    options?: StoragePipelineOptions
+    options?: StoragePipelineOptions,
+    // Static method to construct an object, the option is for the object not for the method.
+    /* eslint-disable-next-line @azure/azure-sdk/ts-naming-options */
+    changeFeedClientOptions?: BlobChangeFeedClientOptions
   ): BlobChangeFeedClient {
     const blobServiceClient = BlobServiceClient.fromConnectionString(connectionString, options);
     return new BlobChangeFeedClient(
       blobServiceClient.url,
       blobServiceClient.credential,
-      appendUserAgentPrefix(options)
+      appendUserAgentPrefix(options),
+      changeFeedClientOptions
     );
   }
 
@@ -143,7 +158,8 @@ export class BlobChangeFeedClient {
     credential?: StorageSharedKeyCredential | AnonymousCredential | TokenCredential,
     // Legacy, no way to fix the eslint error without breaking. Disable the rule for this line.
     /* eslint-disable-next-line @azure/azure-sdk/ts-naming-options */
-    options?: StoragePipelineOptions
+    options?: StoragePipelineOptions,
+    changeFeedClientOptions?: BlobChangeFeedClientOptions
   );
 
   /**
@@ -165,9 +181,13 @@ export class BlobChangeFeedClient {
       | Pipeline,
     // Legacy, no way to fix the eslint error without breaking. Disable the rule for this line.
     /* eslint-disable-next-line @azure/azure-sdk/ts-naming-options */
-    options?: StoragePipelineOptions
+    options?: StoragePipelineOptions,
+    changeFeedClientOptions?: BlobChangeFeedClientOptions
   ) {
-    this.changeFeedFactory = new ChangeFeedFactory();
+    this.changeFeedClientOptions = changeFeedClientOptions || {};
+    this.changeFeedFactory = new ChangeFeedFactory(
+      this.changeFeedClientOptions.maximumTransferSize
+    );
 
     if (credentialOrPipeline instanceof Pipeline) {
       this.blobServiceClient = new BlobServiceClient(urlOrClient, credentialOrPipeline);

--- a/sdk/storage/storage-blob-changefeed/src/ChangeFeedFactory.ts
+++ b/sdk/storage/storage-blob-changefeed/src/ChangeFeedFactory.ts
@@ -96,10 +96,19 @@ export class ChangeFeedFactory {
 
       // Get last consumable.
       const blobClient = containerClient.getBlobClient(CHANGE_FEED_META_SEGMENT_PATH);
-      const blobDownloadRes = await blobClient.download(undefined, undefined, {
-        abortSignal: options.abortSignal,
-        tracingOptions: updatedOptions.tracingOptions,
-      });
+      let blobDownloadRes;
+      try {
+        blobDownloadRes = await blobClient.download(undefined, undefined, {
+          abortSignal: options.abortSignal,
+          tracingOptions: updatedOptions.tracingOptions,
+        });
+      } catch (err: any) {
+        if (err.statusCode === 404) {
+          return new ChangeFeed();
+        } else {
+          throw err;
+        }
+      }
       const lastConsumable = new Date(
         (JSON.parse(await bodyToString(blobDownloadRes)) as MetaSegments).lastConsumable
       );

--- a/sdk/storage/storage-blob-changefeed/src/ChangeFeedFactory.ts
+++ b/sdk/storage/storage-blob-changefeed/src/ChangeFeedFactory.ts
@@ -32,16 +32,30 @@ interface MetaSegments {
 
 export class ChangeFeedFactory {
   private readonly segmentFactory: SegmentFactory;
+  private readonly maxTransferSize?: number;
 
-  constructor();
+  constructor(maxTransferSize?: number);
   constructor(segmentFactory: SegmentFactory);
-  constructor(segmentFactory?: SegmentFactory) {
+  constructor(segmentFactoryOrMaxTransferSize?: SegmentFactory | number) {
+    let segmentFactory: SegmentFactory | undefined;
+    if (segmentFactoryOrMaxTransferSize) {
+      if (Number.isFinite(segmentFactoryOrMaxTransferSize)) {
+        this.maxTransferSize = segmentFactoryOrMaxTransferSize as number;
+      } else if (segmentFactoryOrMaxTransferSize instanceof SegmentFactory) {
+        segmentFactory = segmentFactoryOrMaxTransferSize as SegmentFactory;
+      }
+    }
+
     if (segmentFactory) {
       this.segmentFactory = segmentFactory;
     } else {
       this.segmentFactory = new SegmentFactory(
         new ShardFactory(
-          new ChunkFactory(new AvroReaderFactory(), new LazyLoadingBlobStreamFactory())
+          new ChunkFactory(
+            new AvroReaderFactory(),
+            new LazyLoadingBlobStreamFactory(),
+            this.maxTransferSize
+          )
         )
       );
     }

--- a/sdk/storage/storage-blob-changefeed/src/ChunkFactory.ts
+++ b/sdk/storage/storage-blob-changefeed/src/ChunkFactory.ts
@@ -24,13 +24,16 @@ export interface CreateChunkOptions extends CommonOptions {
 export class ChunkFactory {
   private readonly avroReaderFactory: AvroReaderFactory;
   private readonly lazyLoadingBlobStreamFactory: LazyLoadingBlobStreamFactory;
+  private readonly maxTransferSize?: number;
 
   constructor(
     avroReaderFactory: AvroReaderFactory,
-    lazyLoadingBlobStreamFactory: LazyLoadingBlobStreamFactory
+    lazyLoadingBlobStreamFactory: LazyLoadingBlobStreamFactory,
+    maxTransferSize?: number
   ) {
     this.avroReaderFactory = avroReaderFactory;
     this.lazyLoadingBlobStreamFactory = lazyLoadingBlobStreamFactory;
+    this.maxTransferSize = maxTransferSize;
   }
 
   public async create(
@@ -48,7 +51,7 @@ export class ChunkFactory {
       this.lazyLoadingBlobStreamFactory.create(
         blobClient,
         blockOffset,
-        CHANGE_FEED_CHUNK_BLOCK_DOWNLOAD_SIZE,
+        this.maxTransferSize ? this.maxTransferSize : CHANGE_FEED_CHUNK_BLOCK_DOWNLOAD_SIZE,
         options
       )
     );
@@ -59,7 +62,7 @@ export class ChunkFactory {
         this.lazyLoadingBlobStreamFactory.create(
           blobClient,
           0,
-          CHANGE_FEED_CHUNK_BLOCK_DOWNLOAD_SIZE,
+          this.maxTransferSize ? this.maxTransferSize : CHANGE_FEED_CHUNK_BLOCK_DOWNLOAD_SIZE,
           options
         )
       );

--- a/sdk/storage/storage-blob-changefeed/test/changefeed.spec.ts
+++ b/sdk/storage/storage-blob-changefeed/test/changefeed.spec.ts
@@ -241,4 +241,14 @@ describe("Change Feed", async () => {
     const event2 = await changeFeed3.getChange();
     assert.equal(event2, 4 as unknown as BlobChangeFeedEvent | undefined);
   });
+
+  it("getChange - no meta", async () => {
+    blobClientStub.download.callsFake(() => {
+      throw {
+        statusCode: 404,
+      };
+    });
+    const changeFeed = await changeFeedFactory.create(serviceClientStub as any, undefined);
+    assert.ok(!changeFeed.hasNext(), "Should return empty change feed");
+  });
 });


### PR DESCRIPTION
- Change to return empty change feed when meta/segments.json is not created
- Add ability to set Change Feed chunk download size

### Packages impacted by this PR
@azure/storage-blob-changefeed

### Issues associated with this PR


### Describe the problem that is addressed by this PR
- Change to return empty change feed when meta/segments.json is not created
- Add ability to set Change Feed chunk download size

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? 


### Provide a list of related PRs 


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** No
- [ ] Added a changelog (if necessary)
