### PR TITLE
[ServiceBus] don't yield empty page when listing rules in RuleManager

### DIFF
--- a/sdk/servicebus/service-bus/CHANGELOG.md
+++ b/sdk/servicebus/service-bus/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Other Changes
 
+- Stop yielding empty page when listing rules using RuleManager.
+
 ## 7.6.0-beta.4 (2022-06-07)
 
 ### Features Added

--- a/sdk/servicebus/service-bus/src/serviceBusRuleManager.ts
+++ b/sdk/servicebus/service-bus/src/serviceBusRuleManager.ts
@@ -193,8 +193,8 @@ export class ServiceBusRuleManagerImpl implements ServiceBusRuleManager {
         maxCount: options.maxPageSize ?? 100,
         ...options,
       });
-      yield rules;
       if (rules.length > 0) {
+        yield rules;
         marker = String(Number(marker ?? 0) + rules.length);
       } else {
         break;

--- a/sdk/servicebus/service-bus/test/public/ruleManager.spec.ts
+++ b/sdk/servicebus/service-bus/test/public/ruleManager.spec.ts
@@ -232,8 +232,6 @@ describe("RuleManager tests", () => {
       assert.equal(result.value.length, 1, "Expecting one rule in third page");
       assert.equal(result.value[0].name, sqlRuleName);
       result = await iterator.next();
-      assert.equal(result.value.length, 0, "Not expecting any result in last page");
-      result = await iterator.next();
       assert.equal(result.value, undefined, "Not expecting any more pages");
     });
 
@@ -273,8 +271,6 @@ describe("RuleManager tests", () => {
       const iterator = ruleManager.listRules().byPage();
       let result = await iterator.next();
       assert.equal(result.value.length, 3, "Expecting one rule in first page");
-      result = await iterator.next();
-      assert.equal(result.value.length, 0, "Not expecting any result in last page");
       result = await iterator.next();
       assert.equal(result.value, undefined, "Not expecting any more pages");
     });


### PR DESCRIPTION
We should stop when there's no more returned rules. I did this previously
probably to support continuationToken as we have to make the last request to
know that there are no more results, and we then set continuationToken to
undefined on this empty page.  Now that the continuationToken is removed, we can
stop yielding empty page.


### Packages impacted by this PR
@azure/service-bus
