### PR TITLE
fixed spelling of outboundIpAddresses

### DIFF
--- a/sdk/app/arm-app/review/arm-app.api.md
+++ b/sdk/app/arm-app/review/arm-app.api.md
@@ -265,7 +265,7 @@ export type ContainerApp = TrackedResource & {
     readonly customDomainVerificationId?: string;
     configuration?: Configuration;
     template?: Template;
-    readonly outboundIPAddresses?: string[];
+    readonly outboundIpAddresses?: string[];
 };
 
 // @public

--- a/sdk/app/arm-app/src/models/index.ts
+++ b/sdk/app/arm-app/src/models/index.ts
@@ -1162,7 +1162,7 @@ export type ContainerApp = TrackedResource & {
    * Outbound IP Addresses for container app.
    * NOTE: This property will not be serialized. It can only be populated by the server.
    */
-  readonly outboundIPAddresses?: string[];
+  readonly outboundIpAddresses?: string[];
 };
 
 /** An environment for hosting container apps */

--- a/sdk/app/arm-app/src/models/mappers.ts
+++ b/sdk/app/arm-app/src/models/mappers.ts
@@ -3001,8 +3001,8 @@ export const ContainerApp: coreClient.CompositeMapper = {
           className: "Template"
         }
       },
-      outboundIPAddresses: {
-        serializedName: "properties.outboundIPAddresses",
+      outboundIpAddresses: {
+        serializedName: "properties.outboundIpAddresses",
         readOnly: true,
         type: {
           name: "Sequence",


### PR DESCRIPTION
### Packages impacted by this PR

sdk/app/arm-app

### Issues associated with this PR

-

### Describe the problem that is addressed by this PR

The readonly return attribute "outboundIPAddresses" was misspelled with a capital P. This PR changes the spelling to lowercase p as "outboundIpAddresses", which matches the actual property as returned by Azure. Previously, the outbound IP addresses could not be retrieved and the property would always be missing. With the fix, the addresses are now correctly included in the reponse.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?

-

### Are there test cases added in this PR? _(If not, why?)_

-

### Provide a list of related PRs _(if any)_

-

### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

-
