### PR TITLE
[Identity] Fixes to spawn a new instance on macOS

### DIFF
--- a/sdk/identity/identity/src/msal/nodeFlows/msalOpenBrowser.ts
+++ b/sdk/identity/identity/src/msal/nodeFlows/msalOpenBrowser.ts
@@ -244,7 +244,8 @@ export class MsalOpenBrowser extends MsalNode {
     const response = await this.publicApp!.getAuthCodeUrl(authCodeUrlParameters);
 
     try {
-      await interactiveBrowserMockable.open(response, { wait: true });
+      // A new instance on macOS only which allows it to not hang
+      await interactiveBrowserMockable.open(response, { wait: true, newInstance: true });
     } catch (e: any) {
       throw new CredentialUnavailableError(
         `InteractiveBrowserCredential: Could not open a browser window. Error: ${e.message}`


### PR DESCRIPTION
### Packages impacted by this PR

- [identity]

### Issues associated with this PR

- #21726

### Describe the problem that is addressed by this PR

On macOS, the default browser held open the connection, and refused to close the associated sockets unless the window was closed.  This forces a spawn of a new instance.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [ ] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
