### PR TITLE
[Identity] Fixes to spawn a new instance on macOS

### DIFF
--- a/sdk/identity/identity/CHANGELOG.md
+++ b/sdk/identity/identity/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release History
 
+## 2.0.5 (2022-06-22)
+
+### Bugs Fixed
+
+- Fixed a bug in `InteractiveBrowserCredential` for Mac OS where the [app was not getting closed](https://github.com/Azure/azure-sdk-for-js/issues/21726) after the authorization succeeded.
 ## 2.0.4 (2022-02-18)
 
 ### Bugs Fixed

--- a/sdk/identity/identity/src/msal/nodeFlows/msalOpenBrowser.ts
+++ b/sdk/identity/identity/src/msal/nodeFlows/msalOpenBrowser.ts
@@ -244,7 +244,8 @@ export class MsalOpenBrowser extends MsalNode {
     const response = await this.publicApp!.getAuthCodeUrl(authCodeUrlParameters);
 
     try {
-      await interactiveBrowserMockable.open(response, { wait: true });
+      // A new instance on macOS only which allows it to not hang, does not fix the issue on linux
+      await interactiveBrowserMockable.open(response, { wait: true, newInstance: true });
     } catch (e) {
       throw new CredentialUnavailableError(
         `InteractiveBrowserCredential: Could not open a browser window. Error: ${e.message}`


### PR DESCRIPTION
### Packages impacted by this PR
@azure/identity

### Issues associated with this PR
https://github.com/Azure/azure-sdk-for-js/issues/21726


### Describe the problem that is addressed by this PR
On macOS, the default browser held open the connection, and refused to close the associated sockets unless the window was closed. The workaround with the setting ` newInstance` forces a spawn of a new browser instance, not causing the application to hang or the socket to not close.

**Note : This issue happens in Linux too and is not fixed by the PR. [Filed an issue ](https://github.com/sindresorhus/open/issues/287) on the `open` dependency for linux**

### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_
PR by @mpodwysocki - https://github.com/Azure/azure-sdk-for-js/pull/22195

### Checklists
- [ ] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
