### PR TITLE
[dev-tool] also check for rollup warning match using "/"

### DIFF
--- a/common/tools/dev-tool/src/config/rollup.base.config.ts
+++ b/common/tools/dev-tool/src/config/rollup.base.config.ts
@@ -69,10 +69,8 @@ export function sourcemapsExtra() {
 export type WarningInhibitor = (warning: RollupWarning) => boolean;
 
 function matchesPathSegments(str: string | undefined, segments: string[]): boolean {
-  return (
-    // Reported warnings use "/"
-    str?.includes(segments.join("/")) ?? false
-  );
+  // Reported warnings use "/"
+  return str?.includes(segments.join("/")) ?? false;
 }
 
 function ignoreNiseSinonEval(warning: RollupWarning): boolean {

--- a/common/tools/dev-tool/src/config/rollup.base.config.ts
+++ b/common/tools/dev-tool/src/config/rollup.base.config.ts
@@ -70,9 +70,8 @@ export type WarningInhibitor = (warning: RollupWarning) => boolean;
 
 function matchesPathSegments(str: string | undefined, segments: string[]): boolean {
   return (
-    str?.includes(segments.join(path.sep)) ||
-    // on Windows in powershell, path.sep is "\\" but reported warnings use "/"
-    str?.includes(segments.join("/"))
+    // Reported warnings use "/"
+    str?.includes(segments.join("/")) ?? false
   );
 }
 

--- a/common/tools/dev-tool/src/config/rollup.base.config.ts
+++ b/common/tools/dev-tool/src/config/rollup.base.config.ts
@@ -68,33 +68,40 @@ export function sourcemapsExtra() {
  */
 export type WarningInhibitor = (warning: RollupWarning) => boolean;
 
+function matchesPathSegments(str: string | undefined, segments: string[]): boolean {
+  return (
+    str?.includes(segments.join(path.sep)) ||
+    // on Windows in powershell, path.sep is "\\" but reported warnings use "/"
+    str?.includes(segments.join("/")) === true
+  );
+}
+
 function ignoreNiseSinonEval(warning: RollupWarning): boolean {
   return (
     warning.code === "EVAL" &&
-    (warning.id?.includes(["node_modules", "nise"].join(path.sep)) ||
-      warning.id?.includes(["node_modules", "sinon"].join(path.sep))) === true
+    (matchesPathSegments(warning.id, ["node_modules", "nise"]) ||
+      matchesPathSegments(warning.id, ["node_modules", "sinon"]))
   );
 }
 
 function ignoreChaiCircularDependency(warning: RollupWarning): boolean {
   return (
     warning.code === "CIRCULAR_DEPENDENCY" &&
-    warning.importer?.includes(["node_modules", "chai"].join(path.sep)) === true
+    matchesPathSegments(warning.importer, ["node_modules", "chai"])
   );
 }
-
 
 function ignoreRheaPromiseCircularDependency(warning: RollupWarning): boolean {
   return (
     warning.code === "CIRCULAR_DEPENDENCY" &&
-    warning.importer?.includes(["node_modules", "rhea-promise"].join(path.sep)) === true
+    matchesPathSegments(warning.importer, ["node_modules", "rhea-promise"])
   );
 }
 
 function ignoreOpenTelemetryThisIsUndefined(warning: RollupWarning): boolean {
   return (
     warning.code === "THIS_IS_UNDEFINED" &&
-    warning.id?.includes(["node_modules", "@opentelemetry", "api"].join(path.sep)) === true
+    matchesPathSegments(warning.id, ["node_modules", "@opentelemetry", "api"])
   );
 }
 

--- a/common/tools/dev-tool/src/config/rollup.base.config.ts
+++ b/common/tools/dev-tool/src/config/rollup.base.config.ts
@@ -72,7 +72,7 @@ function matchesPathSegments(str: string | undefined, segments: string[]): boole
   return (
     str?.includes(segments.join(path.sep)) ||
     // on Windows in powershell, path.sep is "\\" but reported warnings use "/"
-    str?.includes(segments.join("/")) === true
+    str?.includes(segments.join("/"))
   );
 }
 


### PR DESCRIPTION
in addition to `path.sep` as on Windows in PowerShell, even though
`path.sep` is `"\\"`, the rollup warnings are still using `"/"`.
