### PR TITLE
[KeyVault] Fix HSM security domain download logging

### DIFF
--- a/sdk/keyvault/test-resources-post.ps1
+++ b/sdk/keyvault/test-resources-post.ps1
@@ -99,7 +99,7 @@ if (Test-Path $sdpath) {
     Remove-Item $sdPath -Force
 }
 
-Export-AzKeyVaultSecurityDomain -Name $hsmName -Quorum 2 -Certificates $wrappingFiles -OutputPath $sdPath
+Export-AzKeyVaultSecurityDomain -Name $hsmName -Quorum 2 -Certificates $wrappingFiles -OutputPath $sdPath -ErrorAction SilentlyContinue -Verbose
 if ( !$? ) {
     Write-Host $Error[0].Exception
     Write-Error $Error[0]


### PR DESCRIPTION
### Packages impacted by this PR

- Key Vault packages

### Issues associated with this PR

- #22074 

### Describe the problem that is addressed by this PR

Add some more options to `Export-AzKeyVaultSecurityDomain` to make sure that exceptions are logged as they should be.

When making the changes in #22093 I forgot to copy over the changes in the actual command, so we weren't getting the verbose error logging like we should have :(. This fixes that issue.

### Provide a list of related PRs _(if any)_

- Follows up #22093