### PR TITLE
Enable service level readme generation for daily docs.

### DIFF
--- a/eng/pipelines/docindex.yml
+++ b/eng/pipelines/docindex.yml
@@ -22,6 +22,7 @@ jobs:
             - ci-configs/
             - metadata/
             - docs-ref-mapping/
+            - docs-ref-services/
           Repositories:
             - Name: $(DocRepoOwner)/$(DocRepoName)
               WorkingDirectory: $(DocRepoLocation)
@@ -82,6 +83,17 @@ jobs:
           filePath: eng/common/scripts/Update-DocsMsPackages.ps1
           arguments: -DocRepoLocation $(DocRepoLocation)
         displayName: Update Docs Onboarding for Daily branch
+
+      - task: Powershell@2
+        inputs:
+          pwsh: true
+          filePath: eng/common/scripts/Service-Level-Readme-Automation.ps1
+          arguments: >-
+            -DocRepoLocation $(DocRepoLocation)
+            -TenantId '$(opensource-aad-tenant-id)' 
+            -ClientId '$(opensource-aad-app-id)' 
+            -ClientSecret '$(opensource-aad-secret)'
+        displayName: Generate Service Level Readme
 
       - task: Powershell@2
         inputs:

--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -5,11 +5,15 @@ $PackageRepository = "NPM"
 $packagePattern = "*.tgz"
 $MetadataUri = "https://raw.githubusercontent.com/Azure/azure-sdk/main/_data/releases/latest/js-packages.csv"
 $BlobStorageUrl = "https://azuresdkdocs.blob.core.windows.net/%24web?restype=container&comp=list&prefix=javascript%2F&delimiter=%2F"
+$GithubUri = "https://github.com/Azure/azure-sdk-for-js"
+$PackageRepositoryUri = "https://www.npmjs.com/package"
 
 . "$PSScriptRoot/docs/Docs-ToC.ps1"
 
-function Confirm-NodeInstallation {
-  if (!(Get-Command npm -ErrorAction SilentlyContinue)) {
+function Confirm-NodeInstallation
+{
+  if (!(Get-Command npm -ErrorAction SilentlyContinue))
+  {
     LogError "Could not locate npm. Install NodeJS (includes npm and npx) https://nodejs.org/en/download"
     exit 1
   }

--- a/eng/scripts/docs/Docs-ToC.ps1
+++ b/eng/scripts/docs/Docs-ToC.ps1
@@ -20,7 +20,39 @@ function Get-javascript-OnboardedDocsMsPackages($DocRepoLocation) {
   return $onboardedPackages
 }
 
-function Get-javascript-DocsMsTocData($packageMetadata, $docRepoLocation) {
+function Get-javascript-OnboardedDocsMsPackagesForMoniker($DocRepoLocation, $moniker) {
+  $packageOnboardingFile = ""
+  if ("latest" -eq $moniker) {
+    $packageOnboardingFile = "$DocRepoLocation/ci-configs/packages-latest.json"
+  }
+  if ("preview" -eq $moniker) {
+    $packageOnboardingFile = "$DocRepoLocation/ci-configs/packages-preview.json"
+  }
+
+  $onboardedPackages = @{}
+  $onboardingSpec = ConvertFrom-Json (Get-Content $packageOnboardingFile -Raw)
+  foreach ($spec in $onboardingSpec.npm_package_sources) {
+    $packageName = $spec.name
+
+    if ($packageName.LastIndexOf('@') -gt 0) {
+      # Package has an '@' symbol deliminting the end of the package name
+      $packageName = $packageName.Substring(0, $packageName.LastIndexOf('@'))
+    }
+    
+    $jsStylePkgName = $packageName.Replace("@", "").Replace("/", "-")
+    $jsonFile = "$DocRepoLocation/metadata/$moniker/$jsStylePkgName.json"
+    if (Test-Path $jsonFile) {
+      $onboardedPackages[$packageName] = ConvertFrom-Json (Get-Content $jsonFile -Raw)
+    }
+    else{
+      $onboardedPackages[$packageName] = $null
+    }
+  }
+
+  return $onboardedPackages
+}
+
+function GetPackageReadmeName($packageMetadata) {
   # Fallback to get package-level readme name if metadata file info does not exist
   $packageLevelReadmeName = $packageMetadata.Package.Replace('@azure/', '').Replace('@azure-tools/', '').Replace('azure-', '');
 
@@ -35,12 +67,16 @@ function Get-javascript-DocsMsTocData($packageMetadata, $docRepoLocation) {
     $readmeMetadata = &$GetDocsMsMetadataForPackageFn -PackageInfo $packageMetadata.FileMetadata
     $packageLevelReadmeName = $readmeMetadata.DocsMsReadMeName
   }
+  return $packageLevelReadmeName
+}
 
+function Get-javascript-PackageLevelReadme($packageMetadata)
+{
+  return GetPackageReadmeName -packageMetadata $packageMetadata
+}
 
-  $packageTocHeader = $packageMetadata.Package
-  if ($clientPackage.DisplayName) {
-    $packageTocHeader = $clientPackage.DisplayName
-  }
+function Get-javascript-DocsMsTocData($packageMetadata, $docRepoLocation) {
+  $packageLevelReadmeName = Get-javascript-PackageLevelReadme -packageMetadata $packageMetadata
   $output = [PSCustomObject]@{
     PackageLevelReadmeHref = "~/docs-ref-services/{moniker}/$packageLevelReadmeName-readme.md"
     PackageTocHeader       = $packageTocHeader
@@ -52,6 +88,10 @@ function Get-javascript-DocsMsTocData($packageMetadata, $docRepoLocation) {
 
 function Get-javascript-DocsMsTocChildrenForManagementPackages($packageMetadata, $docRepoLocation) {
   return @($packageMetadata.Package)
+}
+
+function Get-javascrpt-RepositoryLink ($packageInfo) {
+  return "$PackageRepositoryUri/$($packageInfo.Package)"
 }
 
 function Get-javascript-UpdatedDocsMsToc($toc) {

--- a/eng/scripts/docs/Docs-ToC.ps1
+++ b/eng/scripts/docs/Docs-ToC.ps1
@@ -76,7 +76,7 @@ function Get-javascript-PackageLevelReadme($packageMetadata)
 }
 
 function Get-javascript-DocsMsTocData($packageMetadata, $docRepoLocation) {
-  $packageLevelReadmeName = Get-javascript-PackageLevelReadme -packageMetadata $packageMetadata
+  $packageLevelReadmeName = GetPackageReadmeName -packageMetadata $packageMetadata
   $output = [PSCustomObject]@{
     PackageLevelReadmeHref = "~/docs-ref-services/{moniker}/$packageLevelReadmeName-readme.md"
     PackageTocHeader       = $packageTocHeader

--- a/eng/scripts/docs/Docs-ToC.ps1
+++ b/eng/scripts/docs/Docs-ToC.ps1
@@ -77,6 +77,10 @@ function Get-javascript-PackageLevelReadme($packageMetadata)
 
 function Get-javascript-DocsMsTocData($packageMetadata, $docRepoLocation) {
   $packageLevelReadmeName = GetPackageReadmeName -packageMetadata $packageMetadata
+  $packageTocHeader = $packageMetadata.Package
+  if ($clientPackage.DisplayName) {
+    $packageTocHeader = $clientPackage.DisplayName
+  }
   $output = [PSCustomObject]@{
     PackageLevelReadmeHref = "~/docs-ref-services/{moniker}/$packageLevelReadmeName-readme.md"
     PackageTocHeader       = $packageTocHeader


### PR DESCRIPTION
This is the PR for service overview automation work.
It depends pre-requisite common PR: https://github.com/Azure/azure-sdk-tools/pull/3578/files

This is testing review site: 
https://review.docs.microsoft.com/en-us/javascript/api/overview/azure/arm-confidentialledger-readme?view=azure-node-latest&branch=daily%2F2022-05-02-ci-succeeded

https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1712881&view=results