### PR TITLE
fix api-extractor version in purview administration

### DIFF
--- a/sdk/purview/purview-administration-rest/package.json
+++ b/sdk/purview/purview-administration-rest/package.json
@@ -94,7 +94,7 @@
     "@azure/identity": "^2.0.1",
     "@azure/test-utils": "^1.0.0",
     "@azure-tools/test-recorder": "^2.0.0",
-    "@microsoft/api-extractor": "^7.18.0",
+    "@microsoft/api-extractor": "7.18.11",
     "@types/chai": "^4.1.6",
     "@types/mocha": "^7.0.2",
     "@types/node": "^12.0.0",


### PR DESCRIPTION
It leads to the failure of apiview service.