### PR TITLE
[engsys] Namespace internal package names for eng tooling

### DIFF
--- a/eng/tools/analyze-deps/package-lock.json
+++ b/eng/tools/analyze-deps/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "analyze-deps",
+  "name": "@azure-tools/analyze-deps",
   "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "analyze-deps",
+      "name": "@azure-tools/analyze-deps",
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {

--- a/eng/tools/analyze-deps/package.json
+++ b/eng/tools/analyze-deps/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "analyze-deps",
+  "name": "@azure-tools/analyze-deps",
   "version": "1.0.0",
   "description": "",
   "main": "index.js",

--- a/eng/tools/dependency-testing/package.json
+++ b/eng/tools/dependency-testing/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "dependency-testing",
+  "name": "@azure-tools/dependency-testing",
   "version": "1.0.0",
   "description": "Utilities for min/max dependency testing",
   "scripts": {
@@ -21,6 +21,6 @@
     "prettier": "^2.5.1",
     "semver": "^7.3.2",
     "yargs": "^14.2.0",
-    "eng-package-utils": "file:../eng-package-utils"
+    "@azure-tools/eng-package-utils": "file:../eng-package-utils"
   }
 }

--- a/eng/tools/eng-package-utils/package.json
+++ b/eng/tools/eng-package-utils/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "eng-package-utils",
+  "name": "@azure-tools/eng-package-utils",
   "version": "1.0.0",
   "description": "Utility functions for eng system tools",
   "main": "index.js",

--- a/eng/tools/versioning/package.json
+++ b/eng/tools/versioning/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "versioning",
+  "name": "@azure-tools/versioning",
   "version": "1.0.0",
   "description": "Utilities to manipulate version information",
   "main": "echo \"use increment.js or set-dev.js\"",
@@ -17,7 +17,7 @@
   },
   "homepage": "https://github.com/Azure/azure-sdk-for-js#readme",
   "dependencies": {
-    "eng-package-utils": "file:../eng-package-utils",
+    "@azure-tools/eng-package-utils": "file:../eng-package-utils",
     "semver": "^6.3.0",
     "yargs": "^14.2.0",
     "yargs-parser": "^21.0.0"


### PR DESCRIPTION
To avoid squatters in the global registry, let's keep these packages namespaced under @azure-tools. Nothing imports them by name though, so I don't think we have to update anywhere else.