### PR TITLE
fix dependency error in tools/versioning

### DIFF
--- a/eng/tools/dependency-testing/index.js
+++ b/eng/tools/dependency-testing/index.js
@@ -37,7 +37,7 @@ let argv = require("yargs")
 const fs = require("fs");
 const path = require("path");
 const semver = require("semver");
-const packageUtils = require("eng-package-utils");
+const packageUtils = require("@azure-tools/eng-package-utils");
 // crossSpawn is used because of its ability to better handle corner cases that break when using spawn in Windows environments.
 // For more details see - https://www.npmjs.com/package/cross-spawn
 let crossSpawn = require("cross-spawn");

--- a/eng/tools/versioning/VersionUtils.js
+++ b/eng/tools/versioning/VersionUtils.js
@@ -1,5 +1,5 @@
 const path = require("path");
-const { readFile, writeFile } = require("eng-package-utils");
+const { readFile, writeFile } = require("@azure-tools/eng-package-utils");
 var spawnSync = require("child_process").spawnSync,
   child;
 

--- a/eng/tools/versioning/increment.js
+++ b/eng/tools/versioning/increment.js
@@ -21,7 +21,7 @@ let argv = require("yargs")
 const path = require("path");
 const semver = require("semver");
 const versionUtils = require("./VersionUtils");
-const packageUtils = require("eng-package-utils");
+const packageUtils = require("@azure-tools/eng-package-utils");
 
 function incrementVersion(currentVersion) {
   const prerelease = semver.prerelease(currentVersion);

--- a/eng/tools/versioning/set-dev.js
+++ b/eng/tools/versioning/set-dev.js
@@ -22,7 +22,7 @@ let argv = require("yargs")
 const process = require("process");
 const semver = require("semver");
 const path = require("path");
-const packageUtils = require("eng-package-utils");
+const packageUtils = require("@azure-tools/eng-package-utils");
 
 const commitChanges = async (rushPackages, package) => {
   // Commit the new version to the JSON document

--- a/eng/tools/versioning/set-version.js
+++ b/eng/tools/versioning/set-version.js
@@ -37,7 +37,7 @@ let argv = require("yargs")
 
 const path = require("path");
 const versionUtils = require("./VersionUtils");
-const packageUtils = require("eng-package-utils");
+const packageUtils = require("@azure-tools/eng-package-utils");
 
 async function main(argv) {
   const artifactName = argv["artifact-name"];


### PR DESCRIPTION
It's found in pipeline error: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1658487&view=logs&j=e594813e-738e-5b20-1335-c7b2b68ed8dd&t=4c0c4aec-211a-5ded-3c08-c4e487a21e87

It's caused by the package name change in https://github.com/Azure/azure-sdk-for-js/pull/22319

This PR also changes the one in tools/dependency-testing