### PR TITLE
[Service Bus] Improves documentation for `maxAutoLockRenewalDurationInMs`

### DIFF
--- a/sdk/servicebus/service-bus/CHANGELOG.md
+++ b/sdk/servicebus/service-bus/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Other Changes
 
 - Stop yielding empty page when listing rules using RuleManager.
+- Improves documentation for `maxAutoLockRenewalDurationInMs` with an example to clarify its usage.
 
 ## 7.6.0-beta.4 (2022-06-07)
 

--- a/sdk/servicebus/service-bus/CHANGELOG.md
+++ b/sdk/servicebus/service-bus/CHANGELOG.md
@@ -11,7 +11,7 @@
 ### Other Changes
 
 - Stop yielding empty page when listing rules using RuleManager.
-- Improves documentation for `maxAutoLockRenewalDurationInMs` with an example to clarify its usage.
+- Improves documentation for `maxAutoLockRenewalDurationInMs` with an example to clarify its usage. [#22343](https://github.com/Azure/azure-sdk-for-js/pull/22343)
 
 ## 7.6.0-beta.4 (2022-06-07)
 

--- a/sdk/servicebus/service-bus/src/models.ts
+++ b/sdk/servicebus/service-bus/src/models.ts
@@ -146,12 +146,12 @@ export interface ServiceBusReceiverOptions {
    *
    * - **Default**: `300 * 1000` milliseconds (5 minutes).
    * - **To disable autolock renewal**, set this to `0`.
-   * 
+   *
    * **Example:**
-   *    
+   *
    *    If the message lock expires in 2 minutes and your message processing time is 8 minutes...
-   * 
-   *    Set maxAutoLockRenewalDurationInMs to 10 minutes, and the message lock will be automatically renewed for 4 times 
+   *
+   *    Set maxAutoLockRenewalDurationInMs to 10 minutes, and the message lock will be automatically renewed for 4 times
    *    (equivalent to having the message locked for 4 times its lock duration by leveraging the lock renewals).
    */
   maxAutoLockRenewalDurationInMs?: number;
@@ -195,7 +195,7 @@ export interface ReceiveMessagesOptions extends OperationOptionsBase {
 /**
  * Options when getting an iterable iterator from Service Bus.
  */
-export interface GetMessageIteratorOptions extends OperationOptionsBase { }
+export interface GetMessageIteratorOptions extends OperationOptionsBase {}
 
 /**
  * Options used when subscribing to a Service Bus queue or subscription.
@@ -253,15 +253,15 @@ export interface ServiceBusSessionReceiverOptions extends OperationOptionsBase {
   receiveMode?: "peekLock" | "receiveAndDelete";
   /**
    * The maximum duration, in milliseconds, that the lock on the session will be renewed automatically by the client.
-   * 
+   *
    * - **Default**: `300000` milliseconds (5 minutes).
    * - **To disable autolock renewal**, set this to `0`.
-   * 
+   *
    * **Example:**
-   *    
+   *
    *    If the lock expires in 2 minutes and your processing time is 8 minutes...
-   * 
-   *    Set maxAutoLockRenewalDurationInMs to 10 minutes, and the lock will be automatically renewed about 4 times 
+   *
+   *    Set maxAutoLockRenewalDurationInMs to 10 minutes, and the lock will be automatically renewed about 4 times
    *    (equivalent to having the session locked for 4 times its lock duration by leveraging the lock renewals).
    */
   maxAutoLockRenewalDurationInMs?: number;

--- a/sdk/servicebus/service-bus/src/models.ts
+++ b/sdk/servicebus/service-bus/src/models.ts
@@ -146,6 +146,13 @@ export interface ServiceBusReceiverOptions {
    *
    * - **Default**: `300 * 1000` milliseconds (5 minutes).
    * - **To disable autolock renewal**, set this to `0`.
+   * 
+   * **Example:**
+   *    
+   *    If the message lock expires in 2 minutes and your message processing time is say, 8 minutes...
+   * 
+   *    Set maxAutoLockRenewalDurationInMs to 8 minutes, and the message lock will be automatically renewed for about 3 times 
+   *    (equivalent to having the message locked for 4 times its lock duration by leveraging the lock renewals).
    */
   maxAutoLockRenewalDurationInMs?: number;
   /**
@@ -245,10 +252,17 @@ export interface ServiceBusSessionReceiverOptions extends OperationOptionsBase {
    */
   receiveMode?: "peekLock" | "receiveAndDelete";
   /**
-   * The maximum duration in milliseconds
-   * until which, the lock on the session will be renewed automatically by the sdk.
+   * The maximum duration in milliseconds until which, the lock on the session will be renewed automatically by the sdk.
+   * 
    * - **Default**: `300000` milliseconds (5 minutes).
    * - **To disable autolock renewal**, set this to `0`.
+   * 
+   * **Example:**
+   *    
+   *    If the lock expires in 2 minutes and your processing time is say, 8 minutes...
+   * 
+   *    Set maxAutoLockRenewalDurationInMs to 8 minutes, and the lock will be automatically renewed for about 3 times 
+   *    (equivalent to having the session locked for 4 times its lock duration by leveraging the lock renewals).
    */
   maxAutoLockRenewalDurationInMs?: number;
   /**

--- a/sdk/servicebus/service-bus/src/models.ts
+++ b/sdk/servicebus/service-bus/src/models.ts
@@ -259,7 +259,7 @@ export interface ServiceBusSessionReceiverOptions extends OperationOptionsBase {
    * 
    * **Example:**
    *    
-   *    If the lock expires in 2 minutes and your processing time is say, 8 minutes...
+   *    If the lock expires in 2 minutes and your processing time is 8 minutes...
    * 
    *    Set maxAutoLockRenewalDurationInMs to 8 minutes, and the lock will be automatically renewed for about 3 times 
    *    (equivalent to having the session locked for 4 times its lock duration by leveraging the lock renewals).

--- a/sdk/servicebus/service-bus/src/models.ts
+++ b/sdk/servicebus/service-bus/src/models.ts
@@ -252,7 +252,7 @@ export interface ServiceBusSessionReceiverOptions extends OperationOptionsBase {
    */
   receiveMode?: "peekLock" | "receiveAndDelete";
   /**
-   * The maximum duration in milliseconds until which, the lock on the session will be renewed automatically by the sdk.
+   * The maximum duration, in milliseconds, that the lock on the session will be renewed automatically by the client.
    * 
    * - **Default**: `300000` milliseconds (5 minutes).
    * - **To disable autolock renewal**, set this to `0`.

--- a/sdk/servicebus/service-bus/src/models.ts
+++ b/sdk/servicebus/service-bus/src/models.ts
@@ -261,7 +261,7 @@ export interface ServiceBusSessionReceiverOptions extends OperationOptionsBase {
    *    
    *    If the lock expires in 2 minutes and your processing time is 8 minutes...
    * 
-   *    Set maxAutoLockRenewalDurationInMs to 8 minutes, and the lock will be automatically renewed for about 3 times 
+   *    Set maxAutoLockRenewalDurationInMs to 10 minutes, and the lock will be automatically renewed about 4 times 
    *    (equivalent to having the session locked for 4 times its lock duration by leveraging the lock renewals).
    */
   maxAutoLockRenewalDurationInMs?: number;

--- a/sdk/servicebus/service-bus/src/models.ts
+++ b/sdk/servicebus/service-bus/src/models.ts
@@ -141,8 +141,8 @@ export interface ServiceBusReceiverOptions {
   subQueueType?: "deadLetter" | "transferDeadLetter";
 
   /**
-   * The maximum duration in milliseconds until which the lock on the message will be renewed
-   * by the sdk automatically. This auto renewal stops once the message is settled.
+   * The maximum duration, in milliseconds, that the lock on the message will be renewed automatically by the client.
+   * This auto renewal stops once the message is settled.
    *
    * - **Default**: `300 * 1000` milliseconds (5 minutes).
    * - **To disable autolock renewal**, set this to `0`.
@@ -151,7 +151,7 @@ export interface ServiceBusReceiverOptions {
    *    
    *    If the message lock expires in 2 minutes and your message processing time is say, 8 minutes...
    * 
-   *    Set maxAutoLockRenewalDurationInMs to 8 minutes, and the message lock will be automatically renewed for about 3 times 
+   *    Set maxAutoLockRenewalDurationInMs to 10 minutes, and the message lock will be automatically renewed for about 3 times 
    *    (equivalent to having the message locked for 4 times its lock duration by leveraging the lock renewals).
    */
   maxAutoLockRenewalDurationInMs?: number;
@@ -195,7 +195,7 @@ export interface ReceiveMessagesOptions extends OperationOptionsBase {
 /**
  * Options when getting an iterable iterator from Service Bus.
  */
-export interface GetMessageIteratorOptions extends OperationOptionsBase {}
+export interface GetMessageIteratorOptions extends OperationOptionsBase { }
 
 /**
  * Options used when subscribing to a Service Bus queue or subscription.


### PR DESCRIPTION
### Packages impacted by this PR
`@azure/service-bus`

### Issues associated with this PR
Fixes #22301

### Describe the problem that is addressed by this PR
User(s) were confused about the  `maxAutoLockRenewalDurationInMs` option, partly owing to the naming and arguably incomplete documentation.

Adds an example to the JS docs, to clear any confusions the users may have.
