### PR TITLE
Adds support for "id" values with whitespace at the end

### DIFF
--- a/sdk/cosmosdb/cosmos/src/client/Item/Item.ts
+++ b/sdk/cosmosdb/cosmos/src/client/Item/Item.ts
@@ -6,6 +6,7 @@ import {
   getIdFromLink,
   getPathFromLink,
   isResourceValid,
+  getResourceIdForUri,
   ResourceType,
   StatusCodes,
 } from "../../common";
@@ -29,7 +30,11 @@ export class Item {
    * Returns a reference URL to the resource. Used for linking in Permissions.
    */
   public get url(): string {
-    return createDocumentUri(this.container.database.id, this.container.id, this.id);
+    return createDocumentUri(
+      this.container.database.id,
+      this.container.id,
+      getResourceIdForUri(this)
+    );
   }
 
   /**

--- a/sdk/cosmosdb/cosmos/src/common/helper.ts
+++ b/sdk/cosmosdb/cosmos/src/common/helper.ts
@@ -203,12 +203,26 @@ export function isResourceValid(resource: { id?: string }, err: { message?: stri
       err.message = "Id contains illegal chars.";
       return false;
     }
-    if (resource.id[resource.id.length - 1] === " ") {
-      err.message = "Id ends with a space.";
-      return false;
-    }
   }
   return true;
+}
+
+export function getResourceIdForUri(resource: { id?: string }): string {
+  const err = {};
+  if (!isResourceValid(resource, err)) {
+    throw err;
+  }
+
+  if (resource.id && resource.id[resource.id.length - 1] === " ") {
+    let i = resource.id.length - 1;
+    while (resource.id.charAt(i) === " ") {
+      i--;
+    }
+
+    return resource.id.substring(0, i + 1) + "%20".repeat(resource.id.length - i - 1);
+  }
+
+  return resource.id;
 }
 
 /** @hidden */

--- a/sdk/cosmosdb/cosmos/src/utils/headers.ts
+++ b/sdk/cosmosdb/cosmos/src/utils/headers.ts
@@ -27,6 +27,19 @@ export async function generateHeaders(
   };
 }
 
+function getEffectiveResourceIdForSignature(resourceId: string) {
+  if (resourceId.endsWith("%20")) {
+    let i = resourceId.length;
+    while (resourceId.substring(i - 3, i) === "%20") {
+      i -= 3;
+    }
+
+    return resourceId.substring(0, i) + " ".repeat((resourceId.length - i) / 3);
+  }
+
+  return resourceId;
+}
+
 async function signature(
   masterKey: string,
   method: HTTPMethod,
@@ -36,12 +49,13 @@ async function signature(
 ): Promise<string> {
   const type = "master";
   const version = "1.0";
+
   const text =
     method.toLowerCase() +
     "\n" +
     resourceType.toLowerCase() +
     "\n" +
-    resourceId +
+    getEffectiveResourceIdForSignature(resourceId) +
     "\n" +
     date.toUTCString().toLowerCase() +
     "\n" +


### PR DESCRIPTION
### Packages impacted by this PR
@azure/cosmos

### Issues associated with this PR
ICM#315831633

### Describe the problem that is addressed by this PR
Node.JS had a bug preventing any pint operations on documents with an "id" value ending on whitespace (" "). This is a supported character for id - the bug came from relying on node.js to do proper Uri encoding - which works for spaces at the end or in the middle of an id - but not the end. The fix is to make sure the whitespace(s) at the end are manually encoded --> %20 and correspondingly in authorization the resourceId needs to be decoded again for encoded %20 at the end. This can cause issues when %20 is at the end of an id - but even in Java via Gateway this issue exists. Effectively % is also a disallowed character in id (at least when Gateway and Direct need to be supported) - would be good to correct the list here - https://docs.microsoft.com/en-us/dotnet/api/microsoft.azure.documents.resource.id?view=azure-dotnet#remarks
Ultimately, I really think we should redesign the id encoding - both in the backend and the SDKs - we could switch to a more robust id-encoding and signal this to the backend via header - for example base64UrlEncodign or custom base64 encoding the one character that could cause issues in Uris.
Anyway this change fixes the whitespace encoding - something more common than the %20 at the end. And also more consistent with other SDKs

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?
see above

### Are there test cases added in this PR? _(If not, why?)_
Yes

### Provide a list of related PRs _(if any)_
n/a

### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_
n/a

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [x] Added a changelog (if necessary)
