### PR TITLE
[monitor-query] Update tracing.ts comment

### DIFF
--- a/sdk/monitor/monitor-query/src/tracing.ts
+++ b/sdk/monitor/monitor-query/src/tracing.ts
@@ -1,14 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
-//
+
 import { createTracingClient } from "@azure/core-tracing";
 import { SDK_VERSION } from "./constants";
 
 /**
- * Creates a span using the global tracer.
- *
- * @param name - The name of the operation being performed.
- * @param tracingOptions - The options for the underlying http request.
+ * Global tracing client used by this package.
  *
  * @internal
  */


### PR DESCRIPTION
This is a holdover from when we used `createTracingFunction`. Now that this package is using TracingClient, the comment should reflect that.