### PR TITLE
[core-lro] Update tests to be less verbose

### DIFF
--- a/sdk/core/core-lro/test/engine.spec.ts
+++ b/sdk/core/core-lro/test/engine.spec.ts
@@ -11,7 +11,7 @@ describe("Lro Engine", function () {
   describe("No polling", () => {
     it("should handle delete204Succeeded", async () => {
       const response = await runLro({
-        routes: [{ method: "DELETE", path: "/delete/204/succeeded", status: 204 }],
+        routes: [{ method: "DELETE", status: 204 }],
       });
       assert.equal(response.statusCode, 204);
     });
@@ -21,7 +21,6 @@ describe("Lro Engine", function () {
         routes: [
           {
             method: "PUT",
-            path: "/put/201/succeeded",
             status: 201,
             body: `{ "properties": { "provisioningState": "Succeeded"}, "id": "100", "name": "foo" }`,
           },
@@ -108,7 +107,6 @@ describe("Lro Engine", function () {
           routes: [
             {
               method: "DELETE",
-              path: "/delete/noheader",
               status: 200,
               headers: { Location: pollingPath },
             },
@@ -129,7 +127,6 @@ describe("Lro Engine", function () {
         routes: [
           {
             method: "PUT",
-            path: "/put/202/retry/200",
             status: 202,
             headers: { Location: pollingPath },
           },
@@ -145,7 +142,6 @@ describe("Lro Engine", function () {
         routes: [
           {
             method: "PUT",
-            path: "/put/noheader/202/200",
             status: 202,
             body: `{ "properties": { "provisioningState": "Accepted"}, "id": "100", "name": "foo" }`,
             headers: { Location: pollingPath },
@@ -170,7 +166,6 @@ describe("Lro Engine", function () {
         routes: [
           {
             method: "PUT",
-            path: "/putsubresource/202/200",
             status: 202,
             body: `{ "properties": { "provisioningState": "Accepted"}, "id": "100", "subresource": "sub1" }`,
             headers: { Location: pollingPath },
@@ -194,7 +189,6 @@ describe("Lro Engine", function () {
         routes: [
           {
             method: "PUT",
-            path: "/putnonresource/202/200",
             status: 202,
             headers: { Location: pollingPath },
           },
@@ -286,7 +280,6 @@ describe("Lro Engine", function () {
         routes: [
           {
             method: "DELETE",
-            path: "/delete/provisioning/202/accepted/200/succeeded",
             status: 202,
             headers: {
               location: pollingPath,
@@ -362,7 +355,6 @@ describe("Lro Engine", function () {
         routes: [
           {
             method: "PUT",
-            path: "/put/200/succeeded",
             status: 200,
             body: `{ "properties": { "provisioningState": "Succeeded"}, "id": "100", "name": "foo" }`,
           },
@@ -376,7 +368,6 @@ describe("Lro Engine", function () {
         routes: [
           {
             method: "PUT",
-            path: "/put/200/succeeded/nostate",
             status: 200,
             body: `{"id": "100", "name": "foo" }`,
           },
@@ -1372,12 +1363,9 @@ describe("Lro Engine", function () {
 
   describe("LRO Sad scenarios", () => {
     it("should handle PutNonRetry400 ", async () => {
-      await assertError(
-        runLro({ routes: [{ method: "PUT", path: "/nonretryerror/put/400", status: 400 }] }),
-        {
-          statusCode: 400,
-        }
-      );
+      await assertError(runLro({ routes: [{ method: "PUT", status: 400 }] }), {
+        statusCode: 400,
+      });
     });
 
     it("should handle putNonRetry201Creating400 ", async () => {
@@ -1437,7 +1425,6 @@ describe("Lro Engine", function () {
           routes: [
             {
               method: "PUT",
-              path: "/nonretryerror/putasync/retry/400",
               status: 200,
               body: `{ "properties": { "provisioningState": "Creating"}, "id": "100", "name": "foo" }`,
               headers: createDoubleHeaders({
@@ -1493,7 +1480,6 @@ describe("Lro Engine", function () {
           routes: [
             {
               method: "DELETE",
-              path: "/nonretryerror/delete/400",
               status: 400,
               body: `{ "message" : "Expected bad request message" }`,
             },
@@ -1512,7 +1498,6 @@ describe("Lro Engine", function () {
           routes: [
             {
               method: "DELETE",
-              path: "/nonretryerror/deleteasync/retry/400",
               status: 202,
               body: `{ "properties": { "provisioningState": "Creating"}, "id": "100", "name": "foo" }`,
               headers: createDoubleHeaders({
@@ -1540,7 +1525,6 @@ describe("Lro Engine", function () {
           routes: [
             {
               method: "POST",
-              path: "/nonretryerror/post/400",
               status: 400,
               body: `{ "message" : "Expected bad request message" }`,
             },
@@ -1588,7 +1572,6 @@ describe("Lro Engine", function () {
           routes: [
             {
               method: "POST",
-              path: "/nonretryerror/postasync/retry/400",
               status: 202,
               body: `{ "properties": { "provisioningState": "Creating"}, "id": "100", "name": "foo" }`,
               headers: createDoubleHeaders({
@@ -1615,7 +1598,6 @@ describe("Lro Engine", function () {
         routes: [
           {
             method: "PUT",
-            path: "/error/put/201/noprovisioningstatepayload",
             status: 201,
           },
         ],
@@ -1690,7 +1672,6 @@ describe("Lro Engine", function () {
         routes: [
           {
             method: "DELETE",
-            path: "/error/delete/204/nolocation",
             status: 204,
           },
         ],
@@ -1704,7 +1685,6 @@ describe("Lro Engine", function () {
         routes: [
           {
             method: "DELETE",
-            path: "/error/deleteasync/retry/nostatus",
             status: 202,
             headers: createDoubleHeaders({
               pollingPath,
@@ -1727,7 +1707,6 @@ describe("Lro Engine", function () {
         routes: [
           {
             method: "POST",
-            path: "/error/post/202/nolocation",
             status: 202,
           },
         ],
@@ -1741,7 +1720,6 @@ describe("Lro Engine", function () {
         routes: [
           {
             method: "POST",
-            path: "/error/postasync/retry/nopayload",
             status: 202,
             headers: createDoubleHeaders({
               pollingPath,
@@ -1769,7 +1747,6 @@ describe("Lro Engine", function () {
           routes: [
             {
               method: "PUT",
-              path: "/error/put/200/invalidjson",
               status: 200,
               body: `{ "properties": { "provisioningState": "Creating"}, "id": "100", "name": "foo"`,
             },
@@ -1787,7 +1764,6 @@ describe("Lro Engine", function () {
           routes: [
             {
               method: "PUT",
-              path: "/error/putasync/retry/invalidheader",
               status: 200,
               body: `{ "properties": { "provisioningState": "Creating"}, "id": "100", "name": "foo" }`,
               headers: createDoubleHeaders({
@@ -1810,7 +1786,6 @@ describe("Lro Engine", function () {
           routes: [
             {
               method: "PUT",
-              path: "/error/putasync/retry/invalidjsonpolling",
               status: 200,
               body: `{ "properties": { "provisioningState": "Creating"}, "id": "100", "name": "foo" }`,
               headers: createDoubleHeaders({
@@ -1838,7 +1813,6 @@ describe("Lro Engine", function () {
           routes: [
             {
               method: "DELETE",
-              path: "/error/delete/202/retry/invalidheader",
               status: 202,
               headers: {
                 Location: `/foo`,
@@ -1859,7 +1833,6 @@ describe("Lro Engine", function () {
           routes: [
             {
               method: "DELETE",
-              path: "/error/deleteasync/retry/invalidheader",
               status: 202,
               headers: createDoubleHeaders({
                 pollingPath: "/foo",
@@ -1881,7 +1854,6 @@ describe("Lro Engine", function () {
           routes: [
             {
               method: "DELETE",
-              path: "/error/deleteasync/retry/invalidjsonpolling",
               status: 202,
               headers: createDoubleHeaders({
                 pollingPath,
@@ -1908,7 +1880,6 @@ describe("Lro Engine", function () {
           routes: [
             {
               method: "POST",
-              path: "/error/post/202/retry/invalidheader",
               status: 202,
               headers: {
                 Location: `/foo`,
@@ -1929,7 +1900,6 @@ describe("Lro Engine", function () {
           routes: [
             {
               method: "POST",
-              path: "/error/postasync/retry/invalidheader",
               status: 202,
               headers: createDoubleHeaders({
                 pollingPath: "/foo",
@@ -1951,7 +1921,6 @@ describe("Lro Engine", function () {
           routes: [
             {
               method: "POST",
-              path: "/error/postasync/retry/invalidjsonpolling",
               status: 202,
               headers: createDoubleHeaders({
                 pollingPath,
@@ -1980,7 +1949,6 @@ describe("Lro Engine", function () {
         routes: [
           {
             method: "PUT",
-            path: "/put/200/succeeded",
             status: 200,
             body: `{ "properties": { "provisioningState": "Succeeded"}, "id": "100", "name": "foo" }`,
           },
@@ -2005,7 +1973,6 @@ describe("Lro Engine", function () {
         routes: [
           {
             method: "POST",
-            path: "/error/postasync/retry/nopayload",
             status: 202,
             headers: createDoubleHeaders({
               pollingPath,
@@ -2034,7 +2001,6 @@ describe("Lro Engine", function () {
         routes: [
           {
             method: "POST",
-            path: "/error/postasync/retry/nopayload",
             status: 202,
             headers: createDoubleHeaders({
               pollingPath,

--- a/sdk/core/core-lro/test/engine.spec.ts
+++ b/sdk/core/core-lro/test/engine.spec.ts
@@ -502,7 +502,6 @@ describe("Lro Engine", function () {
             routes: [
               {
                 method: "POST",
-                path: `/LROPostDoubleHeadersFinalLocationGet`,
                 status: 202,
                 headers: {
                   Location: resourceLocationPath,
@@ -534,7 +533,6 @@ describe("Lro Engine", function () {
             routes: [
               {
                 method: "GET",
-                path: `/LROPostDoubleHeadersFinalLocationGet`,
                 status: 202,
                 headers: {
                   Location: resourceLocationPath,
@@ -571,7 +569,6 @@ describe("Lro Engine", function () {
             routes: [
               {
                 method: "GET",
-                path: `/LROPostDoubleHeadersFinalLocationGet`,
                 status: 202,
                 headers: {
                   [headerName]: operationLocationPath,
@@ -600,7 +597,6 @@ describe("Lro Engine", function () {
             routes: [
               {
                 method: "GET",
-                path: `/LROPostDoubleHeadersFinalLocationGet`,
                 status: 200,
                 body: `{ "id": "100", "name": "foo" }`,
               },
@@ -617,7 +613,6 @@ describe("Lro Engine", function () {
             routes: [
               {
                 method: "POST",
-                path: `/LROPostDoubleHeadersFinalAzureHeaderGet`,
                 status: 202,
                 body: "",
                 headers: {
@@ -650,7 +645,6 @@ describe("Lro Engine", function () {
             routes: [
               {
                 method: "POST",
-                path: `/LROPostDoubleHeadersFinalAzureHeaderGetDefault`,
                 status: 202,
                 body: "",
                 headers: {
@@ -682,7 +676,6 @@ describe("Lro Engine", function () {
             routes: [
               {
                 method: "DELETE",
-                path: `/delete/retry/succeeded`,
                 status: 202,
                 headers: {
                   location: pollingPath,
@@ -718,7 +711,6 @@ describe("Lro Engine", function () {
             routes: [
               {
                 method: "DELETE",
-                path: `/delete/noretry/succeeded`,
                 status: 202,
                 headers: {
                   location: pollingPath,
@@ -753,7 +745,6 @@ describe("Lro Engine", function () {
               routes: [
                 {
                   method: "DELETE",
-                  path: `/delete/retry/canceled`,
                   status: 202,
                   headers: {
                     location: pollingPath,
@@ -788,7 +779,6 @@ describe("Lro Engine", function () {
               routes: [
                 {
                   method: "DELETE",
-                  path: `/delete/retry/failed`,
                   status: 202,
                   headers: {
                     location: pollingPath,
@@ -872,7 +862,6 @@ describe("Lro Engine", function () {
             routes: [
               {
                 method: "POST",
-                path: `/list`,
                 status: 200,
                 headers: {
                   Location: resourceLocationPath,
@@ -904,7 +893,6 @@ describe("Lro Engine", function () {
               routes: [
                 {
                   method: "PUT",
-                  path: `/put/retry/failed`,
                   status: 200,
                   body: `{"properties":{"provisioningState":"Accepted"},"id":"100","name":"foo"}`,
                   headers: {
@@ -983,7 +971,6 @@ describe("Lro Engine", function () {
             routes: [
               {
                 method: "PATCH",
-                path: `/patch/202/200`,
                 status: 202,
                 headers: {
                   Location: resourceLocationPath,
@@ -1107,7 +1094,6 @@ describe("Lro Engine", function () {
               routes: [
                 {
                   method: "PUT",
-                  path: `/put/noretry/canceled`,
                   status: 200,
                   headers: {
                     location: pollingPath,
@@ -1188,7 +1174,6 @@ describe("Lro Engine", function () {
             routes: [
               {
                 method: "DELETE",
-                path: `/delete/noheader/202/204`,
                 status: 202,
                 headers: {
                   Location: `somethingBadWhichShouldNotBeUsed`,
@@ -1219,7 +1204,6 @@ describe("Lro Engine", function () {
             routes: [
               {
                 method: "POST",
-                path: `/post/noretry/succeeded`,
                 status: 202,
                 headers: {
                   location: locationPath,
@@ -1261,7 +1245,6 @@ describe("Lro Engine", function () {
               routes: [
                 {
                   method: "POST",
-                  path: `/post/retry/failed`,
                   status: 202,
                   headers: {
                     location: "/postlocation/retry/succeeded/operationResults/foo/200/",
@@ -1291,7 +1274,6 @@ describe("Lro Engine", function () {
             routes: [
               {
                 method: "POST",
-                path: `/post/retry/succeeded`,
                 status: 202,
                 headers: {
                   location: locationPath,
@@ -1335,7 +1317,6 @@ describe("Lro Engine", function () {
               routes: [
                 {
                   method: "POST",
-                  path: `/post/retry/canceled`,
                   status: 202,
                   headers: {
                     location: "/postasync/retry/succeeded/operationResults/foo/200/",
@@ -2035,7 +2016,6 @@ describe("Lro Engine", function () {
         routes: [
           {
             method: "POST",
-            path: `/post/noretry/succeeded`,
             status: 202,
             headers: {
               location: locationPath,
@@ -2089,7 +2069,6 @@ describe("Lro Engine", function () {
         routes: [
           {
             method: "POST",
-            path: `/LROPostDoubleHeadersFinalAzureHeaderGetDefault`,
             status: 202,
             body: "",
             headers: {
@@ -2139,7 +2118,6 @@ describe("Lro Engine", function () {
         routes: [
           {
             method: "POST",
-            path: `/LROPostDoubleHeadersFinalAzureHeaderGetDefault`,
             status: 202,
             body: "",
             headers: {
@@ -2179,7 +2157,6 @@ describe("Lro Engine", function () {
         routes: [
           {
             method: "POST",
-            path: `/LROPostDoubleHeadersFinalAzureHeaderGetDefault`,
             status: 202,
             body: "",
             headers: {

--- a/sdk/core/core-lro/test/utils/router.ts
+++ b/sdk/core/core-lro/test/utils/router.ts
@@ -21,6 +21,11 @@ import { CoreRestPipelineLro } from "./coreRestPipelineLro";
 import { getYieldedValue } from "@azure/test-utils";
 
 /**
+ * Dummy value for the path of the initial request
+ */
+const initialPath = "path";
+
+/**
  * This helper creates an array of route processors where each processor is represented
  * as a generator. This generator representation is needed to handle a sequence of GET
  * requests to the same route. In particular, the first GET request may get
@@ -37,13 +42,17 @@ function toLroProcessors(responses: LroResponseSpec[]): RouteProcessor[] {
     }
   >();
   for (const response of responses) {
-    const key = createRouteKey(response);
+    const { method, path = initialPath, status, body, headers } = response;
+    const key = createRouteKey({ method, path });
     const routeProcessor = routeCountMap.get(key);
     if (routeProcessor !== undefined) {
-      routeProcessor.responseProcessors.push(createProcessor(response));
+      routeProcessor.responseProcessors.push(createProcessor({ status, body, headers }));
     } else {
-      const { method, path } = response;
-      routeCountMap.set(key, { method, path, responseProcessors: [createProcessor(response)] });
+      routeCountMap.set(key, {
+        method,
+        path,
+        responseProcessors: [createProcessor({ status, body, headers })],
+      });
     }
   }
   return [...routeCountMap.values()].map(({ responseProcessors, ...rest }) => ({
@@ -111,7 +120,7 @@ export function createPoller<TState>(settings: {
 }): PollerLike<PollOperationState<Response>, Response> {
   const { routes, lroResourceLocationConfig, processResult, updateState, cancel } = settings;
   const client = createClient(toLroProcessors(routes));
-  const { method: requestMethod, path } = routes[0];
+  const { method: requestMethod, path = initialPath } = routes[0];
   const lro = new CoreRestPipelineLro(createSendOp({ client }), {
     method: throwIfUndefined(requestMethod),
     url: throwIfUndefined(path),

--- a/sdk/core/core-lro/test/utils/utils.ts
+++ b/sdk/core/core-lro/test/utils/utils.ts
@@ -18,7 +18,7 @@ export interface RouteProcessor {
 
 export interface LroResponseSpec {
   method: HttpMethods;
-  path: string;
+  path?: string;
   status: number;
   body?: string;
   headers?: Record<string, string>;


### PR DESCRIPTION
From the tests point of view, the path of the initial request is inconsequential and could be anything. I updated the path property to be optional in `LroResponseSpec` and the implementation defaults it to "path". This simplifies the tests a bit because `path` now doesn't have to be specified in the first item in the routes list.