### PR TITLE
[Identity] Remove the workaround for configure client options to fix the live tests

### DIFF
--- a/sdk/identity/identity/test/msalTestUtils.ts
+++ b/sdk/identity/identity/test/msalTestUtils.ts
@@ -212,16 +212,6 @@ export async function msalNodeTestSetup(
   const stub = sandbox.stub(MsalBaseUtilities.prototype, "generateUuid");
   stub.returns(playbackValues.correlationId);
 
-  recorder.configureClientOptions = (options: any) => ({
-    ...options,
-    additionalPolicies: [
-      {
-        policy: recorder["recorderHttpPolicy"](),
-        position: "perRetry",
-      },
-    ],
-  });
-
   return {
     sandbox,
     recorder,


### PR DESCRIPTION
### Packages impacted by this PR
@azure/identity

### Issues associated with this PR
None on this  repo but fixes - https://github.com/AzureAD/microsoft-authentication-library-for-js/issues/4942

### Describe the problem that is addressed by this PR
- Live tests fail on @azure/identity with this error -

`CredentialUnavailableError: endpoints_resolution_error: Error: could not resolve endpoints. Please check network and try again. Detail: ClientConfigurationError: untrusted_authority: The provided authority is not a trusted authority. Please include this authority in the knownAuthorities config parameter.`

Upon investigation, it was found that this error was being caused by an overriding of the configure client options function added for the recorder in the Identity tests. Earlier this workaround was needed because the recorder's implementation of this function was not available, but now this is available and is no longer needed. There's a bug in this workaround where it runs even in the "live" mode instead of only running in "record" or "playback" mode. The recorder's implementation of this function covers the scenario to not run it in live mode. 

Because of this bug, there were failures in the live tests of identity with the above error as the authority host was not getting resolved. It was altering the redirection to the proxy, which should not be needed.

Fixed live test run - https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1670728&view=logs&j=ee6ee801-1569-5613-d024-f8382a64b4f2