### PR TITLE
[Azure Monitor Exporter] Add unref to avoid server to block samples execution

### DIFF
--- a/sdk/monitor/monitor-opentelemetry-exporter/samples-dev/httpSample.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/samples-dev/httpSample.ts
@@ -77,6 +77,7 @@ function handleRequest(request: any, response: any) {
       response.end("Hello World!");
       // terminate the process to stop CI pipeline from running forever
       server.close();
+      server.unref();
     }, 2000);
   });
 }


### PR DESCRIPTION
Fixes #22287 