### PR TITLE
[sample][react-native] address Component Governance alert

### DIFF
--- a/samples/frameworks/react-native-expo/ts/storageBlob/package.json
+++ b/samples/frameworks/react-native-expo/ts/storageBlob/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "storageblob",
+  "name": "storageblob-rn-sample",
   "version": "1.0.0",
   "main": "node_modules/expo/AppEntry.js",
   "scripts": {


### PR DESCRIPTION
Component Governance is not smart enough to know that we are not using the
`storageblob` npm package.  This PR changes the blob sample to use a different
name.
