### PR TITLE
[smoke-tests] skip overriding version for dependency not managed in this repo

### DIFF
--- a/common/smoke-test/Initialize-SmokeTests.ps1
+++ b/common/smoke-test/Initialize-SmokeTests.ps1
@@ -148,7 +148,7 @@ function Update-SampleDependencies {
   # some @azure/ packages are not managed in our repo thus should not be overriden
   $packagesToSkip = @("@azure/msal-node")
   foreach ($dep in $packageSpec.dependencies.Keys) {
-    if ($dep.StartsWith('@azure/') -and (-not ($dep -in $packagesToSkip))) {
+    if ($dep.StartsWith('@azure/') -and ($dep -notin $packagesToSkip)) {
       if ($Daily) {
         $dependencies[$dep] = "dev"
       } elseif ($dep -in $TagOverridePackages) {

--- a/common/smoke-test/Initialize-SmokeTests.ps1
+++ b/common/smoke-test/Initialize-SmokeTests.ps1
@@ -145,8 +145,10 @@ function Update-SampleDependencies {
   $packageSpec = (Get-Content -Path "$($sample.SamplesDirectory)/package.json"
     | ConvertFrom-Json -AsHashtable)
 
+  # some @azure/ packages are not managed in our repo thus should not be overriden
+  $packagesToSkip = @("@azure/msal-node")
   foreach ($dep in $packageSpec.dependencies.Keys) {
-    if ($dep.StartsWith('@azure/')) {
+    if ($dep.StartsWith('@azure/') -and (-not ($dep -in $packagesToSkip))) {
       if ($Daily) {
         $dependencies[$dep] = "dev"
       } elseif ($dep -in $TagOverridePackages) {


### PR DESCRIPTION
`@azure/msal-node` is not managed in this repo, so we should keep the version
specified in package.json.
