### PR TITLE
[EventGrid] Prepare EventGrid 4.10.0 release

### DIFF
--- a/sdk/eventgrid/eventgrid/CHANGELOG.md
+++ b/sdk/eventgrid/eventgrid/CHANGELOG.md
@@ -1,14 +1,14 @@
 # Release History
 
-## 4.10.0-beta.2 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
+## 4.10.0 (2022-07-11)
 
 ### Bugs Fixed
 
+- Fixed an issue where `generateSharedAccessSignature` would generate an invalid signature if the experation time was between 12:00pm and 1:00pm.  Thank you to @donut87 for discovering the issue and providing the fix.
+
 ### Other Changes
+
+- The channel name feature added in 4.10.0-beta.1 is now stable. There were no changes in this feature between 4.10.0-beta.1 and 4.10.0
 
 ## 4.10.0-beta.1 (2022-04-14)
 

--- a/sdk/eventgrid/eventgrid/package.json
+++ b/sdk/eventgrid/eventgrid/package.json
@@ -3,7 +3,7 @@
   "sdk-type": "client",
   "author": "Microsoft Corporation",
   "description": "An isomorphic client library for the Azure Event Grid service.",
-  "version": "4.10.0-beta.2",
+  "version": "4.10.0",
   "keywords": [
     "node",
     "azure",

--- a/sdk/eventgrid/eventgrid/src/generated/generatedClientContext.ts
+++ b/sdk/eventgrid/eventgrid/src/generated/generatedClientContext.ts
@@ -26,7 +26,7 @@ export class GeneratedClientContext extends coreClient.ServiceClient {
       requestContentType: "application/json; charset=utf-8"
     };
 
-    const packageDetails = `azsdk-js-eventgrid/4.10.0-beta.2`;
+    const packageDetails = `azsdk-js-eventgrid/4.10.0`;
     const userAgentPrefix =
       options.userAgentOptions && options.userAgentOptions.userAgentPrefix
         ? `${options.userAgentOptions.userAgentPrefix} ${packageDetails}`

--- a/sdk/eventgrid/eventgrid/src/tracing.ts
+++ b/sdk/eventgrid/eventgrid/src/tracing.ts
@@ -10,5 +10,5 @@ import { createTracingClient } from "@azure/core-tracing";
 export const tracingClient = createTracingClient({
   namespace: "Microsoft.Messaging.EventGrid",
   packageName: "@azure/event-grid",
-  packageVersion: "4.10.0-beta.2",
+  packageVersion: "4.10.0",
 });

--- a/sdk/eventgrid/eventgrid/swagger/README.md
+++ b/sdk/eventgrid/eventgrid/swagger/README.md
@@ -7,7 +7,7 @@
 ```yaml
 require: "https://github.com/Azure/azure-rest-api-specs/blob/f8811b7dd784712c3fb0941e04d9042f59a4d367/specification/eventgrid/data-plane/readme.md"
 package-name: "@azure/eventgrid"
-package-version: "4.10.0-beta.2"
+package-version: "4.10.0"
 title: GeneratedClient
 description: EventGrid Client
 generate-metadata: false


### PR DESCRIPTION
The service now supports the "channel name" feature added in
4.10.0-beta.1 and this release adds support in a GA package.

There are no changes in the implementation from 4.10.0-beta.1