### PR TITLE
[core] bump core-auth version to 1.4.0

### DIFF
--- a/sdk/core/core-auth/CHANGELOG.md
+++ b/sdk/core/core-auth/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Release History
 
-## 1.3.3 (2022-07-06)
+## 1.4.0 (Unreleased)
+
+### Features Added
 
 - Added `claims` optional property to the `GetTokenOptions` interface. If `claims` is set, it indicates that we are in challenge process and force to refresh the token.
 

--- a/sdk/core/core-auth/package.json
+++ b/sdk/core/core-auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/core-auth",
-  "version": "1.3.3",
+  "version": "1.4.0",
   "description": "Provides low-level interfaces and helper methods for authentication in Azure SDK",
   "sdk-type": "client",
   "main": "dist/index.js",

--- a/sdk/core/core-rest-pipeline/CHANGELOG.md
+++ b/sdk/core/core-rest-pipeline/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.9.1 (2022-07-06)
+## 1.9.1 (Unreleased)
 
 ### Bugs Fixed
 

--- a/sdk/core/core-rest-pipeline/package.json
+++ b/sdk/core/core-rest-pipeline/package.json
@@ -86,7 +86,7 @@
   },
   "dependencies": {
     "@azure/abort-controller": "^1.0.0",
-    "@azure/core-auth": "^1.3.0",
+    "@azure/core-auth": "^1.4.0",
     "@azure/core-tracing": "^1.0.1",
     "@azure/core-util": "^1.0.0",
     "@azure/logger": "^1.0.0",


### PR DESCRIPTION
for the added `claims` option

Also update changelog release dates as the two packages haven't been released

