### PR TITLE
[Table] Add option to transaction.updateEntity() command

### DIFF
--- a/sdk/tables/data-tables/recordings/browsers/batch_operations/recording_should_send_a_set_of_update_batch_operations_with_options.json
+++ b/sdk/tables/data-tables/recordings/browsers/batch_operations/recording_should_send_a_set_of_update_batch_operations_with_options.json
@@ -1,0 +1,255 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://fakeaccountname.table.core.windows.net/batchTableTestbrowser(PartitionKey=\u0027batchTest\u0027,RowKey=\u00271\u0027)?st=2021-08-03T08:52:15Z\u0026spr=https\u0026sig=fakesigval",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json;odata=minimalmetadata",
+        "Accept-Encoding": "gzip, deflate, br",
+        "Accept-Language": "en-GB",
+        "dataserviceversion": "3.0",
+        "Referer": "http://localhost:9876/",
+        "sec-ch-ua": "",
+        "sec-ch-ua-mobile": "?0",
+        "sec-ch-ua-platform": "",
+        "Sec-Fetch-Dest": "empty",
+        "Sec-Fetch-Mode": "cors",
+        "Sec-Fetch-Site": "same-site",
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
+        "x-ms-client-request-id": "2188b404-c1df-4b97-a270-d20cc04f82dd",
+        "x-ms-useragent": "azsdk-js-data-tables/13.1.2 core-rest-pipeline/1.9.1 OS/Win32",
+        "x-ms-version": "2019-02-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,X-Content-Type-Options,Cache-Control,ETag,Content-Type,Content-Length,Date,Transfer-Encoding",
+        "Cache-Control": "no-cache",
+        "Content-Type": "application/json; odata=minimalmetadata; streaming=true; charset=utf-8",
+        "Date": "Thu, 14 Jul 2022 22:53:53 GMT",
+        "ETag": "W/\u0022datetime\u00272022-07-14T22%3A53%3A53.837539Z\u0027\u0022",
+        "Server": [
+          "Windows-Azure-Table/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "2188b404-c1df-4b97-a270-d20cc04f82dd",
+        "x-ms-request-id": "0b62bf62-8002-0019-4cd4-97ef01000000",
+        "x-ms-version": "2019-02-02"
+      },
+      "ResponseBody": {
+        "odata.metadata": "https://fakeaccountname.table.core.windows.net/$metadata#batchTableTestbrowser/@Element",
+        "odata.etag": "W/\u0022datetime\u00272022-07-14T22%3A53%3A53.837539Z\u0027\u0022",
+        "PartitionKey": "batchTest",
+        "RowKey": "1",
+        "Timestamp": "2022-07-14T22:53:53.837539Z",
+        "name": "updated"
+      }
+    },
+    {
+      "RequestUri": "https://fakeaccountname.table.core.windows.net/batchTableTestbrowser(PartitionKey=\u0027batchTest\u0027,RowKey=\u00272\u0027)?st=2021-08-03T08:52:15Z\u0026spr=https\u0026sig=fakesigval",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json;odata=minimalmetadata",
+        "Accept-Encoding": "gzip, deflate, br",
+        "Accept-Language": "en-GB",
+        "dataserviceversion": "3.0",
+        "Referer": "http://localhost:9876/",
+        "sec-ch-ua": "",
+        "sec-ch-ua-mobile": "?0",
+        "sec-ch-ua-platform": "",
+        "Sec-Fetch-Dest": "empty",
+        "Sec-Fetch-Mode": "cors",
+        "Sec-Fetch-Site": "same-site",
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
+        "x-ms-client-request-id": "278480c0-c9d8-466d-8c3e-77173cb85c2f",
+        "x-ms-useragent": "azsdk-js-data-tables/13.1.2 core-rest-pipeline/1.9.1 OS/Win32",
+        "x-ms-version": "2019-02-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,X-Content-Type-Options,Cache-Control,ETag,Content-Type,Content-Length,Date,Transfer-Encoding",
+        "Cache-Control": "no-cache",
+        "Content-Type": "application/json; odata=minimalmetadata; streaming=true; charset=utf-8",
+        "Date": "Thu, 14 Jul 2022 22:53:53 GMT",
+        "ETag": "W/\u0022datetime\u00272022-07-14T22%3A53%3A53.837539Z\u0027\u0022",
+        "Server": [
+          "Windows-Azure-Table/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "278480c0-c9d8-466d-8c3e-77173cb85c2f",
+        "x-ms-request-id": "0b62bf6a-8002-0019-53d4-97ef01000000",
+        "x-ms-version": "2019-02-02"
+      },
+      "ResponseBody": {
+        "odata.metadata": "https://fakeaccountname.table.core.windows.net/$metadata#batchTableTestbrowser/@Element",
+        "odata.etag": "W/\u0022datetime\u00272022-07-14T22%3A53%3A53.837539Z\u0027\u0022",
+        "PartitionKey": "batchTest",
+        "RowKey": "2",
+        "Timestamp": "2022-07-14T22:53:53.837539Z",
+        "name": "updated"
+      }
+    },
+    {
+      "RequestUri": "https://fakeaccountname.table.core.windows.net/batchTableTestbrowser(PartitionKey=\u0027batchTest\u0027,RowKey=\u00273\u0027)?st=2021-08-03T08:52:15Z\u0026spr=https\u0026sig=fakesigval",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json;odata=minimalmetadata",
+        "Accept-Encoding": "gzip, deflate, br",
+        "Accept-Language": "en-GB",
+        "dataserviceversion": "3.0",
+        "Referer": "http://localhost:9876/",
+        "sec-ch-ua": "",
+        "sec-ch-ua-mobile": "?0",
+        "sec-ch-ua-platform": "",
+        "Sec-Fetch-Dest": "empty",
+        "Sec-Fetch-Mode": "cors",
+        "Sec-Fetch-Site": "same-site",
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
+        "x-ms-client-request-id": "098bfa32-b43e-45f5-91db-736d3f224f32",
+        "x-ms-useragent": "azsdk-js-data-tables/13.1.2 core-rest-pipeline/1.9.1 OS/Win32",
+        "x-ms-version": "2019-02-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,X-Content-Type-Options,Cache-Control,ETag,Content-Type,Content-Length,Date,Transfer-Encoding",
+        "Cache-Control": "no-cache",
+        "Content-Type": "application/json; odata=minimalmetadata; streaming=true; charset=utf-8",
+        "Date": "Thu, 14 Jul 2022 22:53:54 GMT",
+        "ETag": "W/\u0022datetime\u00272022-07-14T22%3A53%3A53.837539Z\u0027\u0022",
+        "Server": [
+          "Windows-Azure-Table/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "098bfa32-b43e-45f5-91db-736d3f224f32",
+        "x-ms-request-id": "0b62bf77-8002-0019-5ed4-97ef01000000",
+        "x-ms-version": "2019-02-02"
+      },
+      "ResponseBody": {
+        "odata.metadata": "https://fakeaccountname.table.core.windows.net/$metadata#batchTableTestbrowser/@Element",
+        "odata.etag": "W/\u0022datetime\u00272022-07-14T22%3A53%3A53.837539Z\u0027\u0022",
+        "PartitionKey": "batchTest",
+        "RowKey": "3",
+        "Timestamp": "2022-07-14T22:53:53.837539Z",
+        "name": "updated"
+      }
+    },
+    {
+      "RequestUri": "https://fakeaccountname.table.core.windows.net/$batch?st=2021-08-03T08:52:15Z\u0026spr=https\u0026sig=fakesigval",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip, deflate, br",
+        "Accept-Language": "en-GB",
+        "Content-Length": "1345",
+        "Content-Type": "multipart/mixed; boundary=batch_fakeId",
+        "dataserviceversion": "3.0;",
+        "maxdataserviceversion": "3.0;NetFx",
+        "Referer": "http://localhost:9876/",
+        "sec-ch-ua": "",
+        "sec-ch-ua-mobile": "?0",
+        "sec-ch-ua-platform": "",
+        "Sec-Fetch-Dest": "empty",
+        "Sec-Fetch-Mode": "cors",
+        "Sec-Fetch-Site": "same-site",
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
+        "x-ms-client-request-id": "1d41285f-fc29-4d69-9d7a-2a1d237466bb",
+        "x-ms-useragent": "azsdk-js-data-tables/13.1.2 core-rest-pipeline/1.9.1 OS/Win32",
+        "x-ms-version": "2019-02-02"
+      },
+      "RequestBody": "LS1iYXRjaF9mYWtlSWQNCmNvbnRlbnQtdHlwZTogbXVsdGlwYXJ0L21peGVkOyBib3VuZGFyeT1jaGFuZ2VzZXRfZmFrZUlkDQoNCg0KLS1jaGFuZ2VzZXRfZmFrZUlkDQpjb250ZW50LXR5cGU6IGFwcGxpY2F0aW9uL2h0dHANCmNvbnRlbnQtdHJhbnNmZXItZW5jb2Rpbmc6IGJpbmFyeQ0KDQpQVVQgaHR0cHM6Ly9mYWtlYWNjb3VudG5hbWUudGFibGUuY29yZS53aW5kb3dzLm5ldC9iYXRjaFRhYmxlVGVzdGJyb3dzZXIoUGFydGl0aW9uS2V5PSdiYXRjaFRlc3QnLFJvd0tleT0nMScpIEhUVFAvMS4xDQpDb250ZW50LVR5cGU6IGFwcGxpY2F0aW9uL2pzb24NCkRhdGFTZXJ2aWNlVmVyc2lvbjogMy4wDQpBY2NlcHQ6IGFwcGxpY2F0aW9uL2pzb24NCklmLU1hdGNoOiBXLyJkYXRldGltZScyMDIyLTA3LTE0VDIyJTNBNTMlM0E1My44Mzc1MzlaJyINCg0KDQp7IlBhcnRpdGlvbktleSI6ImJhdGNoVGVzdCIsIlJvd0tleSI6IjEiLCJuYW1lIjoidXBkYXRlZCJ9DQotLWNoYW5nZXNldF9mYWtlSWQNCmNvbnRlbnQtdHlwZTogYXBwbGljYXRpb24vaHR0cA0KY29udGVudC10cmFuc2Zlci1lbmNvZGluZzogYmluYXJ5DQoNClBVVCBodHRwczovL2Zha2VhY2NvdW50bmFtZS50YWJsZS5jb3JlLndpbmRvd3MubmV0L2JhdGNoVGFibGVUZXN0YnJvd3NlcihQYXJ0aXRpb25LZXk9J2JhdGNoVGVzdCcsUm93S2V5PScyJykgSFRUUC8xLjENCkNvbnRlbnQtVHlwZTogYXBwbGljYXRpb24vanNvbg0KRGF0YVNlcnZpY2VWZXJzaW9uOiAzLjANCkFjY2VwdDogYXBwbGljYXRpb24vanNvbg0KSWYtTWF0Y2g6IFcvImRhdGV0aW1lJzIwMjItMDctMTRUMjIlM0E1MyUzQTUzLjgzNzUzOVonIg0KDQoNCnsiUGFydGl0aW9uS2V5IjoiYmF0Y2hUZXN0IiwiUm93S2V5IjoiMiIsIm5hbWUiOiJ1cGRhdGVkIn0NCi0tY2hhbmdlc2V0X2Zha2VJZA0KY29udGVudC10eXBlOiBhcHBsaWNhdGlvbi9odHRwDQpjb250ZW50LXRyYW5zZmVyLWVuY29kaW5nOiBiaW5hcnkNCg0KUFVUIGh0dHBzOi8vZmFrZWFjY291bnRuYW1lLnRhYmxlLmNvcmUud2luZG93cy5uZXQvYmF0Y2hUYWJsZVRlc3Ricm93c2VyKFBhcnRpdGlvbktleT0nYmF0Y2hUZXN0JyxSb3dLZXk9JzMnKSBIVFRQLzEuMQ0KQ29udGVudC1UeXBlOiBhcHBsaWNhdGlvbi9qc29uDQpEYXRhU2VydmljZVZlcnNpb246IDMuMA0KQWNjZXB0OiBhcHBsaWNhdGlvbi9qc29uDQpJZi1NYXRjaDogVy8iZGF0ZXRpbWUnMjAyMi0wNy0xNFQyMiUzQTUzJTNBNTMuODM3NTM5WiciDQoNCg0KeyJQYXJ0aXRpb25LZXkiOiJiYXRjaFRlc3QiLCJSb3dLZXkiOiIzIiwibmFtZSI6InVwZGF0ZWQifQ0KLS1jaGFuZ2VzZXRfZmFrZUlkLS0NCi0tYmF0Y2hfZmFrZUlkLS0NCg==",
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Type": "multipart/mixed; boundary=batchresponse_31616cd9-c3ad-439c-bc08-0ef36e2ba25e",
+        "Date": "Thu, 14 Jul 2022 22:53:54 GMT",
+        "Server": [
+          "Windows-Azure-Table/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "1d41285f-fc29-4d69-9d7a-2a1d237466bb",
+        "x-ms-request-id": "0b62bf84-8002-0019-69d4-97ef01000000",
+        "x-ms-version": "2019-02-02"
+      },
+      "ResponseBody": "LS1iYXRjaHJlc3BvbnNlXzMxNjE2Y2Q5LWMzYWQtNDM5Yy1iYzA4LTBlZjM2ZTJiYTI1ZQ0KQ29udGVudC1UeXBlOiBtdWx0aXBhcnQvbWl4ZWQ7IGJvdW5kYXJ5PWNoYW5nZXNldHJlc3BvbnNlXzQ1M2VjY2M0LTk0ZGYtNDc5NC05ZDFjLTRhN2U1MjlkZjMzMg0KDQotLWNoYW5nZXNldHJlc3BvbnNlXzQ1M2VjY2M0LTk0ZGYtNDc5NC05ZDFjLTRhN2U1MjlkZjMzMg0KQ29udGVudC1UeXBlOiBhcHBsaWNhdGlvbi9odHRwDQpDb250ZW50LVRyYW5zZmVyLUVuY29kaW5nOiBiaW5hcnkNCg0KSFRUUC8xLjEgMjA0IE5vIENvbnRlbnQNClgtQ29udGVudC1UeXBlLU9wdGlvbnM6IG5vc25pZmYNCkNhY2hlLUNvbnRyb2w6IG5vLWNhY2hlDQpEYXRhU2VydmljZVZlcnNpb246IDEuMDsNCkVUYWc6IFcvImRhdGV0aW1lJzIwMjItMDctMTRUMjIlM0E1MyUzQTU0Ljg3NDk0MzRaJyINCg0KDQotLWNoYW5nZXNldHJlc3BvbnNlXzQ1M2VjY2M0LTk0ZGYtNDc5NC05ZDFjLTRhN2U1MjlkZjMzMg0KQ29udGVudC1UeXBlOiBhcHBsaWNhdGlvbi9odHRwDQpDb250ZW50LVRyYW5zZmVyLUVuY29kaW5nOiBiaW5hcnkNCg0KSFRUUC8xLjEgMjA0IE5vIENvbnRlbnQNClgtQ29udGVudC1UeXBlLU9wdGlvbnM6IG5vc25pZmYNCkNhY2hlLUNvbnRyb2w6IG5vLWNhY2hlDQpEYXRhU2VydmljZVZlcnNpb246IDEuMDsNCkVUYWc6IFcvImRhdGV0aW1lJzIwMjItMDctMTRUMjIlM0E1MyUzQTU0Ljg3NDk0MzRaJyINCg0KDQotLWNoYW5nZXNldHJlc3BvbnNlXzQ1M2VjY2M0LTk0ZGYtNDc5NC05ZDFjLTRhN2U1MjlkZjMzMg0KQ29udGVudC1UeXBlOiBhcHBsaWNhdGlvbi9odHRwDQpDb250ZW50LVRyYW5zZmVyLUVuY29kaW5nOiBiaW5hcnkNCg0KSFRUUC8xLjEgMjA0IE5vIENvbnRlbnQNClgtQ29udGVudC1UeXBlLU9wdGlvbnM6IG5vc25pZmYNCkNhY2hlLUNvbnRyb2w6IG5vLWNhY2hlDQpEYXRhU2VydmljZVZlcnNpb246IDEuMDsNCkVUYWc6IFcvImRhdGV0aW1lJzIwMjItMDctMTRUMjIlM0E1MyUzQTU0Ljg3NTk0MjVaJyINCg0KDQotLWNoYW5nZXNldHJlc3BvbnNlXzQ1M2VjY2M0LTk0ZGYtNDc5NC05ZDFjLTRhN2U1MjlkZjMzMi0tDQotLWJhdGNocmVzcG9uc2VfMzE2MTZjZDktYzNhZC00MzljLWJjMDgtMGVmMzZlMmJhMjVlLS0NCg=="
+    },
+    {
+      "RequestUri": "https://fakeaccountname.table.core.windows.net/batchTableTestbrowser()?st=2021-08-03T08:52:15Z\u0026spr=https\u0026sig=fakesigval\u0026$filter=PartitionKey%20eq%20%27batchTest%27",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json;odata=minimalmetadata",
+        "Accept-Encoding": "gzip, deflate, br",
+        "Accept-Language": "en-GB",
+        "dataserviceversion": "3.0",
+        "Referer": "http://localhost:9876/",
+        "sec-ch-ua": "",
+        "sec-ch-ua-mobile": "?0",
+        "sec-ch-ua-platform": "",
+        "Sec-Fetch-Dest": "empty",
+        "Sec-Fetch-Mode": "cors",
+        "Sec-Fetch-Site": "same-site",
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
+        "x-ms-client-request-id": "706f1d18-eccf-4b14-b49f-d6133af92e2a",
+        "x-ms-useragent": "azsdk-js-data-tables/13.1.2 core-rest-pipeline/1.9.1 OS/Win32",
+        "x-ms-version": "2019-02-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,X-Content-Type-Options,Cache-Control,Content-Type,Content-Length,Date,Transfer-Encoding",
+        "Cache-Control": "no-cache",
+        "Content-Type": "application/json; odata=minimalmetadata; streaming=true; charset=utf-8",
+        "Date": "Thu, 14 Jul 2022 22:53:54 GMT",
+        "Server": [
+          "Windows-Azure-Table/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "706f1d18-eccf-4b14-b49f-d6133af92e2a",
+        "x-ms-request-id": "0b62bf89-8002-0019-6dd4-97ef01000000",
+        "x-ms-version": "2019-02-02"
+      },
+      "ResponseBody": {
+        "odata.metadata": "https://fakeaccountname.table.core.windows.net/$metadata#batchTableTestbrowser",
+        "value": [
+          {
+            "odata.etag": "W/\u0022datetime\u00272022-07-14T22%3A53%3A54.8749434Z\u0027\u0022",
+            "PartitionKey": "batchTest",
+            "RowKey": "1",
+            "Timestamp": "2022-07-14T22:53:54.8749434Z",
+            "name": "updated"
+          },
+          {
+            "odata.etag": "W/\u0022datetime\u00272022-07-14T22%3A53%3A54.8749434Z\u0027\u0022",
+            "PartitionKey": "batchTest",
+            "RowKey": "2",
+            "Timestamp": "2022-07-14T22:53:54.8749434Z",
+            "name": "updated"
+          },
+          {
+            "odata.etag": "W/\u0022datetime\u00272022-07-14T22%3A53%3A54.8759425Z\u0027\u0022",
+            "PartitionKey": "batchTest",
+            "RowKey": "3",
+            "Timestamp": "2022-07-14T22:53:54.8759425Z",
+            "name": "updated"
+          }
+        ]
+      }
+    }
+  ],
+  "Variables": {}
+}

--- a/sdk/tables/data-tables/recordings/node/batch_operations/recording_should_send_a_set_of_update_batch_operations_with_options.json
+++ b/sdk/tables/data-tables/recordings/node/batch_operations/recording_should_send_a_set_of_update_batch_operations_with_options.json
@@ -1,0 +1,210 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://fakeaccountname.table.core.windows.net/batchTableTestnode(PartitionKey=\u0027batchTest\u0027,RowKey=\u00271\u0027)?st=2021-08-03T08:52:15Z\u0026spr=https\u0026sig=fakesigval",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json;odata=minimalmetadata",
+        "Accept-Encoding": "gzip,deflate",
+        "DataServiceVersion": "3.0",
+        "User-Agent": "azsdk-js-data-tables/13.1.2 core-rest-pipeline/1.9.1 Node/v16.13.2 OS/(x64-Windows_NT-10.0.22000)",
+        "x-ms-client-request-id": "b74898d8-d5e4-408e-819a-3092bec975ab",
+        "x-ms-version": "2019-02-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,X-Content-Type-Options,Cache-Control,ETag,Content-Type,Content-Length,Date,Transfer-Encoding",
+        "Cache-Control": "no-cache",
+        "Content-Type": "application/json; odata=minimalmetadata; streaming=true; charset=utf-8",
+        "Date": "Thu, 14 Jul 2022 22:53:40 GMT",
+        "ETag": "W/\u0022datetime\u00272022-07-14T22%3A53%3A41.0768595Z\u0027\u0022",
+        "Server": [
+          "Windows-Azure-Table/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "b74898d8-d5e4-408e-819a-3092bec975ab",
+        "x-ms-request-id": "48e130b7-f002-0061-17d4-974cf9000000",
+        "x-ms-version": "2019-02-02"
+      },
+      "ResponseBody": {
+        "odata.metadata": "https://fakeaccountname.table.core.windows.net/$metadata#batchTableTestnode/@Element",
+        "odata.etag": "W/\u0022datetime\u00272022-07-14T22%3A53%3A41.0768595Z\u0027\u0022",
+        "PartitionKey": "batchTest",
+        "RowKey": "1",
+        "Timestamp": "2022-07-14T22:53:41.0768595Z",
+        "name": "updated"
+      }
+    },
+    {
+      "RequestUri": "https://fakeaccountname.table.core.windows.net/batchTableTestnode(PartitionKey=\u0027batchTest\u0027,RowKey=\u00272\u0027)?st=2021-08-03T08:52:15Z\u0026spr=https\u0026sig=fakesigval",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json;odata=minimalmetadata",
+        "Accept-Encoding": "gzip,deflate",
+        "DataServiceVersion": "3.0",
+        "User-Agent": "azsdk-js-data-tables/13.1.2 core-rest-pipeline/1.9.1 Node/v16.13.2 OS/(x64-Windows_NT-10.0.22000)",
+        "x-ms-client-request-id": "795b10f5-7ffa-476c-b46d-da14eb2a85f3",
+        "x-ms-version": "2019-02-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,X-Content-Type-Options,Cache-Control,ETag,Content-Type,Content-Length,Date,Transfer-Encoding",
+        "Cache-Control": "no-cache",
+        "Content-Type": "application/json; odata=minimalmetadata; streaming=true; charset=utf-8",
+        "Date": "Thu, 14 Jul 2022 22:53:40 GMT",
+        "ETag": "W/\u0022datetime\u00272022-07-14T22%3A53%3A41.0768595Z\u0027\u0022",
+        "Server": [
+          "Windows-Azure-Table/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "795b10f5-7ffa-476c-b46d-da14eb2a85f3",
+        "x-ms-request-id": "48e130c3-f002-0061-23d4-974cf9000000",
+        "x-ms-version": "2019-02-02"
+      },
+      "ResponseBody": {
+        "odata.metadata": "https://fakeaccountname.table.core.windows.net/$metadata#batchTableTestnode/@Element",
+        "odata.etag": "W/\u0022datetime\u00272022-07-14T22%3A53%3A41.0768595Z\u0027\u0022",
+        "PartitionKey": "batchTest",
+        "RowKey": "2",
+        "Timestamp": "2022-07-14T22:53:41.0768595Z",
+        "name": "updated"
+      }
+    },
+    {
+      "RequestUri": "https://fakeaccountname.table.core.windows.net/batchTableTestnode(PartitionKey=\u0027batchTest\u0027,RowKey=\u00273\u0027)?st=2021-08-03T08:52:15Z\u0026spr=https\u0026sig=fakesigval",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json;odata=minimalmetadata",
+        "Accept-Encoding": "gzip,deflate",
+        "DataServiceVersion": "3.0",
+        "User-Agent": "azsdk-js-data-tables/13.1.2 core-rest-pipeline/1.9.1 Node/v16.13.2 OS/(x64-Windows_NT-10.0.22000)",
+        "x-ms-client-request-id": "75327880-d141-4a61-b41e-f733bbcd0abf",
+        "x-ms-version": "2019-02-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,X-Content-Type-Options,Cache-Control,ETag,Content-Type,Content-Length,Date,Transfer-Encoding",
+        "Cache-Control": "no-cache",
+        "Content-Type": "application/json; odata=minimalmetadata; streaming=true; charset=utf-8",
+        "Date": "Thu, 14 Jul 2022 22:53:41 GMT",
+        "ETag": "W/\u0022datetime\u00272022-07-14T22%3A53%3A41.0768595Z\u0027\u0022",
+        "Server": [
+          "Windows-Azure-Table/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "75327880-d141-4a61-b41e-f733bbcd0abf",
+        "x-ms-request-id": "48e130d0-f002-0061-30d4-974cf9000000",
+        "x-ms-version": "2019-02-02"
+      },
+      "ResponseBody": {
+        "odata.metadata": "https://fakeaccountname.table.core.windows.net/$metadata#batchTableTestnode/@Element",
+        "odata.etag": "W/\u0022datetime\u00272022-07-14T22%3A53%3A41.0768595Z\u0027\u0022",
+        "PartitionKey": "batchTest",
+        "RowKey": "3",
+        "Timestamp": "2022-07-14T22:53:41.0768595Z",
+        "name": "updated"
+      }
+    },
+    {
+      "RequestUri": "https://fakeaccountname.table.core.windows.net/$batch?st=2021-08-03T08:52:15Z\u0026spr=https\u0026sig=fakesigval",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip,deflate",
+        "Content-Length": "1339",
+        "Content-Type": "multipart/mixed; boundary=batch_fakeId",
+        "DataServiceVersion": "3.0;",
+        "MaxDataServiceVersion": "3.0;NetFx",
+        "User-Agent": "azsdk-js-data-tables/13.1.2 core-rest-pipeline/1.9.1 Node/v16.13.2 OS/(x64-Windows_NT-10.0.22000)",
+        "x-ms-client-request-id": "a2f76be9-7c13-4f85-a499-b1435c5aa02b",
+        "x-ms-version": "2019-02-02"
+      },
+      "RequestBody": "LS1iYXRjaF9mYWtlSWQNCmNvbnRlbnQtdHlwZTogbXVsdGlwYXJ0L21peGVkOyBib3VuZGFyeT1jaGFuZ2VzZXRfZmFrZUlkDQoNCg0KLS1jaGFuZ2VzZXRfZmFrZUlkDQpjb250ZW50LXR5cGU6IGFwcGxpY2F0aW9uL2h0dHANCmNvbnRlbnQtdHJhbnNmZXItZW5jb2Rpbmc6IGJpbmFyeQ0KDQpQVVQgaHR0cHM6Ly9mYWtlYWNjb3VudG5hbWUudGFibGUuY29yZS53aW5kb3dzLm5ldC9iYXRjaFRhYmxlVGVzdG5vZGUoUGFydGl0aW9uS2V5PSdiYXRjaFRlc3QnLFJvd0tleT0nMScpIEhUVFAvMS4xDQpDb250ZW50LVR5cGU6IGFwcGxpY2F0aW9uL2pzb24NCkRhdGFTZXJ2aWNlVmVyc2lvbjogMy4wDQpBY2NlcHQ6IGFwcGxpY2F0aW9uL2pzb24NCklmLU1hdGNoOiBXLyJkYXRldGltZScyMDIyLTA3LTE0VDIyJTNBNTMlM0E0MS4wNzY4NTk1WiciDQoNCg0KeyJQYXJ0aXRpb25LZXkiOiJiYXRjaFRlc3QiLCJSb3dLZXkiOiIxIiwibmFtZSI6InVwZGF0ZWQifQ0KLS1jaGFuZ2VzZXRfZmFrZUlkDQpjb250ZW50LXR5cGU6IGFwcGxpY2F0aW9uL2h0dHANCmNvbnRlbnQtdHJhbnNmZXItZW5jb2Rpbmc6IGJpbmFyeQ0KDQpQVVQgaHR0cHM6Ly9mYWtlYWNjb3VudG5hbWUudGFibGUuY29yZS53aW5kb3dzLm5ldC9iYXRjaFRhYmxlVGVzdG5vZGUoUGFydGl0aW9uS2V5PSdiYXRjaFRlc3QnLFJvd0tleT0nMicpIEhUVFAvMS4xDQpDb250ZW50LVR5cGU6IGFwcGxpY2F0aW9uL2pzb24NCkRhdGFTZXJ2aWNlVmVyc2lvbjogMy4wDQpBY2NlcHQ6IGFwcGxpY2F0aW9uL2pzb24NCklmLU1hdGNoOiBXLyJkYXRldGltZScyMDIyLTA3LTE0VDIyJTNBNTMlM0E0MS4wNzY4NTk1WiciDQoNCg0KeyJQYXJ0aXRpb25LZXkiOiJiYXRjaFRlc3QiLCJSb3dLZXkiOiIyIiwibmFtZSI6InVwZGF0ZWQifQ0KLS1jaGFuZ2VzZXRfZmFrZUlkDQpjb250ZW50LXR5cGU6IGFwcGxpY2F0aW9uL2h0dHANCmNvbnRlbnQtdHJhbnNmZXItZW5jb2Rpbmc6IGJpbmFyeQ0KDQpQVVQgaHR0cHM6Ly9mYWtlYWNjb3VudG5hbWUudGFibGUuY29yZS53aW5kb3dzLm5ldC9iYXRjaFRhYmxlVGVzdG5vZGUoUGFydGl0aW9uS2V5PSdiYXRjaFRlc3QnLFJvd0tleT0nMycpIEhUVFAvMS4xDQpDb250ZW50LVR5cGU6IGFwcGxpY2F0aW9uL2pzb24NCkRhdGFTZXJ2aWNlVmVyc2lvbjogMy4wDQpBY2NlcHQ6IGFwcGxpY2F0aW9uL2pzb24NCklmLU1hdGNoOiBXLyJkYXRldGltZScyMDIyLTA3LTE0VDIyJTNBNTMlM0E0MS4wNzY4NTk1WiciDQoNCg0KeyJQYXJ0aXRpb25LZXkiOiJiYXRjaFRlc3QiLCJSb3dLZXkiOiIzIiwibmFtZSI6InVwZGF0ZWQifQ0KLS1jaGFuZ2VzZXRfZmFrZUlkLS0NCi0tYmF0Y2hfZmFrZUlkLS0NCg==",
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Type": "multipart/mixed; boundary=batchresponse_92e26cde-e07e-4ce9-9161-64022bc46e9c",
+        "Date": "Thu, 14 Jul 2022 22:53:41 GMT",
+        "Server": [
+          "Windows-Azure-Table/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "a2f76be9-7c13-4f85-a499-b1435c5aa02b",
+        "x-ms-request-id": "48e130d5-f002-0061-35d4-974cf9000000",
+        "x-ms-version": "2019-02-02"
+      },
+      "ResponseBody": "LS1iYXRjaHJlc3BvbnNlXzkyZTI2Y2RlLWUwN2UtNGNlOS05MTYxLTY0MDIyYmM0NmU5Yw0KQ29udGVudC1UeXBlOiBtdWx0aXBhcnQvbWl4ZWQ7IGJvdW5kYXJ5PWNoYW5nZXNldHJlc3BvbnNlXzRmYzJjOWI1LTJlZTYtNDBlMS04Y2YyLTU3ZGE2YTEwYzJiYQ0KDQotLWNoYW5nZXNldHJlc3BvbnNlXzRmYzJjOWI1LTJlZTYtNDBlMS04Y2YyLTU3ZGE2YTEwYzJiYQ0KQ29udGVudC1UeXBlOiBhcHBsaWNhdGlvbi9odHRwDQpDb250ZW50LVRyYW5zZmVyLUVuY29kaW5nOiBiaW5hcnkNCg0KSFRUUC8xLjEgMjA0IE5vIENvbnRlbnQNClgtQ29udGVudC1UeXBlLU9wdGlvbnM6IG5vc25pZmYNCkNhY2hlLUNvbnRyb2w6IG5vLWNhY2hlDQpEYXRhU2VydmljZVZlcnNpb246IDEuMDsNCkVUYWc6IFcvImRhdGV0aW1lJzIwMjItMDctMTRUMjIlM0E1MyUzQTQyLjAyMzMxNjZaJyINCg0KDQotLWNoYW5nZXNldHJlc3BvbnNlXzRmYzJjOWI1LTJlZTYtNDBlMS04Y2YyLTU3ZGE2YTEwYzJiYQ0KQ29udGVudC1UeXBlOiBhcHBsaWNhdGlvbi9odHRwDQpDb250ZW50LVRyYW5zZmVyLUVuY29kaW5nOiBiaW5hcnkNCg0KSFRUUC8xLjEgMjA0IE5vIENvbnRlbnQNClgtQ29udGVudC1UeXBlLU9wdGlvbnM6IG5vc25pZmYNCkNhY2hlLUNvbnRyb2w6IG5vLWNhY2hlDQpEYXRhU2VydmljZVZlcnNpb246IDEuMDsNCkVUYWc6IFcvImRhdGV0aW1lJzIwMjItMDctMTRUMjIlM0E1MyUzQTQyLjAyMzMxNjZaJyINCg0KDQotLWNoYW5nZXNldHJlc3BvbnNlXzRmYzJjOWI1LTJlZTYtNDBlMS04Y2YyLTU3ZGE2YTEwYzJiYQ0KQ29udGVudC1UeXBlOiBhcHBsaWNhdGlvbi9odHRwDQpDb250ZW50LVRyYW5zZmVyLUVuY29kaW5nOiBiaW5hcnkNCg0KSFRUUC8xLjEgMjA0IE5vIENvbnRlbnQNClgtQ29udGVudC1UeXBlLU9wdGlvbnM6IG5vc25pZmYNCkNhY2hlLUNvbnRyb2w6IG5vLWNhY2hlDQpEYXRhU2VydmljZVZlcnNpb246IDEuMDsNCkVUYWc6IFcvImRhdGV0aW1lJzIwMjItMDctMTRUMjIlM0E1MyUzQTQyLjAyMzMxNjZaJyINCg0KDQotLWNoYW5nZXNldHJlc3BvbnNlXzRmYzJjOWI1LTJlZTYtNDBlMS04Y2YyLTU3ZGE2YTEwYzJiYS0tDQotLWJhdGNocmVzcG9uc2VfOTJlMjZjZGUtZTA3ZS00Y2U5LTkxNjEtNjQwMjJiYzQ2ZTljLS0NCg=="
+    },
+    {
+      "RequestUri": "https://fakeaccountname.table.core.windows.net/batchTableTestnode()?st=2021-08-03T08:52:15Z\u0026spr=https\u0026sig=fakesigval\u0026$filter=PartitionKey%20eq%20%27batchTest%27",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json;odata=minimalmetadata",
+        "Accept-Encoding": "gzip,deflate",
+        "DataServiceVersion": "3.0",
+        "User-Agent": "azsdk-js-data-tables/13.1.2 core-rest-pipeline/1.9.1 Node/v16.13.2 OS/(x64-Windows_NT-10.0.22000)",
+        "x-ms-client-request-id": "4de0ce3e-6771-4f64-b0ec-d78816df318d",
+        "x-ms-version": "2019-02-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,X-Content-Type-Options,Cache-Control,Content-Type,Content-Length,Date,Transfer-Encoding",
+        "Cache-Control": "no-cache",
+        "Content-Type": "application/json; odata=minimalmetadata; streaming=true; charset=utf-8",
+        "Date": "Thu, 14 Jul 2022 22:53:41 GMT",
+        "Server": [
+          "Windows-Azure-Table/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "4de0ce3e-6771-4f64-b0ec-d78816df318d",
+        "x-ms-request-id": "48e130e2-f002-0061-41d4-974cf9000000",
+        "x-ms-version": "2019-02-02"
+      },
+      "ResponseBody": {
+        "odata.metadata": "https://fakeaccountname.table.core.windows.net/$metadata#batchTableTestnode",
+        "value": [
+          {
+            "odata.etag": "W/\u0022datetime\u00272022-07-14T22%3A53%3A42.0233166Z\u0027\u0022",
+            "PartitionKey": "batchTest",
+            "RowKey": "1",
+            "Timestamp": "2022-07-14T22:53:42.0233166Z",
+            "name": "updated"
+          },
+          {
+            "odata.etag": "W/\u0022datetime\u00272022-07-14T22%3A53%3A42.0233166Z\u0027\u0022",
+            "PartitionKey": "batchTest",
+            "RowKey": "2",
+            "Timestamp": "2022-07-14T22:53:42.0233166Z",
+            "name": "updated"
+          },
+          {
+            "odata.etag": "W/\u0022datetime\u00272022-07-14T22%3A53%3A42.0233166Z\u0027\u0022",
+            "PartitionKey": "batchTest",
+            "RowKey": "3",
+            "Timestamp": "2022-07-14T22:53:42.0233166Z",
+            "name": "updated"
+          }
+        ]
+      }
+    }
+  ],
+  "Variables": {}
+}

--- a/sdk/tables/data-tables/review/data-tables.api.md
+++ b/sdk/tables/data-tables/review/data-tables.api.md
@@ -416,7 +416,7 @@ export class TableTransaction {
     actions: TransactionAction[];
     createEntity<T extends object = Record<string, unknown>>(entity: TableEntity<T>): void;
     deleteEntity(partitionKey: string, rowKey: string): void;
-    updateEntity<T extends object = Record<string, unknown>>(entity: TableEntity<T>, updateMode?: UpdateMode): void;
+    updateEntity<T extends object = Record<string, unknown>>(entity: TableEntity<T>, updateMode?: UpdateMode, updateOptions?: UpdateTableEntityOptions): void;
     upsertEntity<T extends object = Record<string, unknown>>(entity: TableEntity<T>, updateMode?: UpdateMode): void;
 }
 
@@ -447,7 +447,7 @@ export interface TableUpdateEntityHeaders {
 export type TransactionAction = CreateDeleteEntityAction | UpdateEntityAction;
 
 // @public
-export type UpdateEntityAction = ["update" | "upsert", TableEntity] | ["update" | "upsert", TableEntity, "Merge" | "Replace"];
+export type UpdateEntityAction = ["update" | "upsert", TableEntity] | ["update" | "upsert", TableEntity, "Merge" | "Replace"] | ["update" | "upsert", TableEntity, "Merge" | "Replace", UpdateTableEntityOptions | undefined];
 
 // @public
 export type UpdateEntityResponse = TableUpdateEntityHeaders;

--- a/sdk/tables/data-tables/src/TableClient.ts
+++ b/sdk/tables/data-tables/src/TableClient.ts
@@ -879,7 +879,7 @@ export class TableClient {
     }
 
     for (const item of actions) {
-      const [action, entity, updateMode = "Merge"] = item;
+      const [action, entity, updateMode = "Merge", updateOptions] = item;
       switch (action) {
         case "create":
           this.transactionClient.createEntity(entity);
@@ -888,7 +888,7 @@ export class TableClient {
           this.transactionClient.deleteEntity(entity.partitionKey, entity.rowKey);
           break;
         case "update":
-          this.transactionClient.updateEntity(entity, updateMode);
+          this.transactionClient.updateEntity(entity, updateMode, updateOptions);
           break;
         case "upsert":
           this.transactionClient.upsertEntity(entity, updateMode);

--- a/sdk/tables/data-tables/src/TableTransaction.ts
+++ b/sdk/tables/data-tables/src/TableTransaction.ts
@@ -77,6 +77,7 @@ export class TableTransaction {
    * Adds an update action to the transaction
    * @param entity - entity to update
    * @param updateMode - update mode
+   * @param options - options for the update operation
    */
   updateEntity<T extends object = Record<string, unknown>>(
     entity: TableEntity<T>,

--- a/sdk/tables/data-tables/src/TableTransaction.ts
+++ b/sdk/tables/data-tables/src/TableTransaction.ts
@@ -80,9 +80,10 @@ export class TableTransaction {
    */
   updateEntity<T extends object = Record<string, unknown>>(
     entity: TableEntity<T>,
-    updateMode: UpdateMode = "Merge"
+    updateMode: UpdateMode = "Merge",
+    updateOptions?: UpdateTableEntityOptions
   ): void {
-    this.actions.push(["update", entity, updateMode]);
+    this.actions.push(["update", entity, updateMode, updateOptions]);
   }
 
   /**

--- a/sdk/tables/data-tables/src/models.ts
+++ b/sdk/tables/data-tables/src/models.ts
@@ -14,7 +14,8 @@ export type CreateDeleteEntityAction = ["create" | "delete", TableEntity];
  */
 export type UpdateEntityAction =
   | ["update" | "upsert", TableEntity]
-  | ["update" | "upsert", TableEntity, "Merge" | "Replace"];
+  | ["update" | "upsert", TableEntity, "Merge" | "Replace"]
+  | ["update" | "upsert", TableEntity, "Merge" | "Replace", UpdateTableEntityOptions | undefined];
 
 /**
  * Represents the union of all the available transactional actions


### PR DESCRIPTION
Currently, you cannot submit an ifMatch parameter when adding an updateEntity() command to a transaction like you can to the tableClient.updateEntity(). This PR adds the ability to pass an update option to transaction.updateEntity().

### Packages impacted by this PR

@azure/data-tables

### Issues associated with this PR

none

### Describe the problem that is addressed by this PR

Adds the currently missing ability to call transaction.updateEntity() with update options so the submitTransaction() will send a ifMatch header for the update.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?

---

### Are there test cases added in this PR? _(If not, why?)_

Yes

### Provide a list of related PRs _(if any)_

None

### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [ ] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
