### PR TITLE
[ServiceBus] Add `identifier` property to `ServiceBusClient`

### DIFF
--- a/sdk/servicebus/service-bus/CHANGELOG.md
+++ b/sdk/servicebus/service-bus/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Features Added
 
+- Add Client Identifier support [tracking issue: #21902](https://github.com/Azure/azure-sdk-for-js/issues/21902)
+
 ### Breaking Changes
 
 ### Bugs Fixed

--- a/sdk/servicebus/service-bus/review/service-bus.api.md
+++ b/sdk/servicebus/service-bus/review/service-bus.api.md
@@ -335,11 +335,13 @@ export class ServiceBusClient {
     createRuleManager(topicName: string, subscriptionName: string): ServiceBusRuleManager;
     createSender(queueOrTopicName: string): ServiceBusSender;
     fullyQualifiedNamespace: string;
+    identifier: string;
 }
 
 // @public
 export interface ServiceBusClientOptions {
     customEndpointAddress?: string;
+    identifier?: string;
     retryOptions?: RetryOptions;
     userAgentOptions?: UserAgentPolicyOptions;
     webSocketOptions?: WebSocketOptions;

--- a/sdk/servicebus/service-bus/src/constructorHelpers.ts
+++ b/sdk/servicebus/service-bus/src/constructorHelpers.ts
@@ -41,6 +41,10 @@ import {
  */
 export interface ServiceBusClientOptions {
   /**
+   * ID to identify this client. This can be used to correlate logs and exceptions.
+   */
+  identifier?: string;
+  /**
    * A custom endpoint to use when connecting to the Service Bus service.
    * This can be useful when your network does not allow connecting to the
    * standard Azure Service Bus endpoint address, but does allow connecting

--- a/sdk/servicebus/service-bus/src/core/batchingReceiver.ts
+++ b/sdk/servicebus/service-bus/src/core/batchingReceiver.ts
@@ -150,13 +150,13 @@ export class BatchingReceiver extends MessageReceiver {
   }
 
   static create(
-    id: string,
+    clientId: string,
     context: ConnectionContext,
     entityPath: string,
     options: ReceiveOptions
   ): BatchingReceiver {
     throwErrorIfConnectionClosed(context);
-    const bReceiver = new BatchingReceiver(id, context, entityPath, options);
+    const bReceiver = new BatchingReceiver(clientId, context, entityPath, options);
     context.messageReceivers[bReceiver.name] = bReceiver;
     return bReceiver;
   }

--- a/sdk/servicebus/service-bus/src/core/batchingReceiver.ts
+++ b/sdk/servicebus/service-bus/src/core/batchingReceiver.ts
@@ -35,8 +35,13 @@ export class BatchingReceiver extends MessageReceiver {
    * @param connectionContext - The client entity context.
    * @param options - Options for how you'd like to connect.
    */
-  constructor(connectionContext: ConnectionContext, entityPath: string, options: ReceiveOptions) {
-    super(connectionContext, entityPath, "batching", options);
+  constructor(
+    clientId: string,
+    connectionContext: ConnectionContext,
+    entityPath: string,
+    options: ReceiveOptions
+  ) {
+    super(clientId, connectionContext, entityPath, "batching", options);
 
     this._batchingReceiverLite = new BatchingReceiverLite(
       connectionContext,
@@ -145,12 +150,13 @@ export class BatchingReceiver extends MessageReceiver {
   }
 
   static create(
+    id: string,
     context: ConnectionContext,
     entityPath: string,
     options: ReceiveOptions
   ): BatchingReceiver {
     throwErrorIfConnectionClosed(context);
-    const bReceiver = new BatchingReceiver(context, entityPath, options);
+    const bReceiver = new BatchingReceiver(id, context, entityPath, options);
     context.messageReceivers[bReceiver.name] = bReceiver;
     return bReceiver;
   }

--- a/sdk/servicebus/service-bus/src/core/messageReceiver.ts
+++ b/sdk/servicebus/service-bus/src/core/messageReceiver.ts
@@ -133,6 +133,7 @@ export abstract class MessageReceiver extends LinkEntity<Receiver> {
   protected _lockRenewer: LockRenewer | undefined;
 
   constructor(
+    private clientId: string,
     context: ConnectionContext,
     entityPath: string,
     receiverType: ReceiverType,
@@ -165,6 +166,7 @@ export abstract class MessageReceiver extends LinkEntity<Receiver> {
       {
         address: this.address,
       },
+      this.clientId,
       {
         onSettled: (context: EventContext) => {
           return onMessageSettled(this.logPrefix, context.delivery, this._deliveryDispositionMap);

--- a/sdk/servicebus/service-bus/src/core/messageSender.ts
+++ b/sdk/servicebus/service-bus/src/core/messageSender.ts
@@ -64,7 +64,7 @@ export class MessageSender extends LinkEntity<AwaitableSender> {
   private _retryOptions: RetryOptions;
 
   constructor(
-    private id: string,
+    private clientId: string,
     connectionContext: ConnectionContext,
     entityPath: string,
     retryOptions: RetryOptions
@@ -140,7 +140,7 @@ export class MessageSender extends LinkEntity<AwaitableSender> {
       target: {
         address: this.address,
       },
-      source: this.id,
+      source: this.clientId,
       onError: this._onAmqpError,
       onClose: this._onAmqpClose,
       onSessionError: this._onSessionError,

--- a/sdk/servicebus/service-bus/src/core/messageSender.ts
+++ b/sdk/servicebus/service-bus/src/core/messageSender.ts
@@ -64,6 +64,7 @@ export class MessageSender extends LinkEntity<AwaitableSender> {
   private _retryOptions: RetryOptions;
 
   constructor(
+    private id: string,
     connectionContext: ConnectionContext,
     entityPath: string,
     retryOptions: RetryOptions
@@ -139,6 +140,7 @@ export class MessageSender extends LinkEntity<AwaitableSender> {
       target: {
         address: this.address,
       },
+      source: this.id,
       onError: this._onAmqpError,
       onClose: this._onAmqpClose,
       onSessionError: this._onSessionError,
@@ -455,13 +457,14 @@ export class MessageSender extends LinkEntity<AwaitableSender> {
   }
 
   static create(
+    clientId: string,
     context: ConnectionContext,
     entityPath: string,
     retryOptions: RetryOptions
   ): MessageSender {
     throwErrorIfConnectionClosed(context);
 
-    const sbSender = new MessageSender(context, entityPath, retryOptions);
+    const sbSender = new MessageSender(clientId, context, entityPath, retryOptions);
     context.senders[sbSender.name] = sbSender;
     return sbSender;
   }

--- a/sdk/servicebus/service-bus/src/core/shared.ts
+++ b/sdk/servicebus/service-bus/src/core/shared.ts
@@ -85,6 +85,7 @@ export function createReceiverOptions(
   name: string,
   receiveMode: ReceiveMode,
   source: Source,
+  target: string,
   handlers: ReceiverHandlers
 ): ReceiverOptions {
   const rcvrOptions: ReceiverOptions = {
@@ -97,6 +98,7 @@ export function createReceiverOptions(
     // receiveAndDelete -> settled (1), peekLock -> unsettled (0)
     snd_settle_mode: receiveMode === "receiveAndDelete" ? 1 : 0,
     source,
+    target,
     credit_window: 0,
     ...handlers,
   };

--- a/sdk/servicebus/service-bus/src/core/shared.ts
+++ b/sdk/servicebus/service-bus/src/core/shared.ts
@@ -5,6 +5,7 @@ import { Delivery, ReceiverOptions, Source } from "rhea-promise";
 import { translateServiceBusError } from "../serviceBusError";
 import { receiverLogger } from "../log";
 import { ReceiveMode } from "../models";
+import { Constants } from "@azure/core-amqp";
 
 /**
  * @internal
@@ -85,7 +86,7 @@ export function createReceiverOptions(
   name: string,
   receiveMode: ReceiveMode,
   source: Source,
-  target: string,
+  clientId: string,
   handlers: ReceiverHandlers
 ): ReceiverOptions {
   const rcvrOptions: ReceiverOptions = {
@@ -98,8 +99,9 @@ export function createReceiverOptions(
     // receiveAndDelete -> settled (1), peekLock -> unsettled (0)
     snd_settle_mode: receiveMode === "receiveAndDelete" ? 1 : 0,
     source,
-    target,
+    target: clientId,
     credit_window: 0,
+    properties: { [Constants.receiverIdentifierName]: clientId },
     ...handlers,
   };
 

--- a/sdk/servicebus/service-bus/src/core/streamingReceiver.ts
+++ b/sdk/servicebus/service-bus/src/core/streamingReceiver.ts
@@ -129,11 +129,17 @@ export class StreamingReceiver extends MessageReceiver {
   /**
    * Instantiate a new Streaming receiver for receiving messages with handlers.
    *
+   * @param clientId - the client id
    * @param connectionContext - The client entity context.
    * @param options - Options for how you'd like to connect.
    */
-  constructor(connectionContext: ConnectionContext, entityPath: string, options: ReceiveOptions) {
-    super(connectionContext, entityPath, "streaming", options);
+  constructor(
+    clientId: string,
+    connectionContext: ConnectionContext,
+    entityPath: string,
+    options: ReceiveOptions
+  ) {
+    super(clientId, connectionContext, entityPath, "streaming", options);
 
     if (typeof options?.maxConcurrentCalls === "number" && options?.maxConcurrentCalls > 0) {
       this.maxConcurrentCalls = options.maxConcurrentCalls;

--- a/sdk/servicebus/service-bus/src/receivers/receiver.ts
+++ b/sdk/servicebus/service-bus/src/receivers/receiver.ts
@@ -291,6 +291,7 @@ export class ServiceBusReceiverImpl implements ServiceBusReceiver {
    * @throws Error if the underlying connection is closed.
    */
   constructor(
+    private clientId: string,
     private _context: ConnectionContext,
     public entityPath: string,
     public receiveMode: "peekLock" | "receiveAndDelete",
@@ -507,7 +508,7 @@ export class ServiceBusReceiverImpl implements ServiceBusReceiver {
 
     this._streamingReceiver =
       this._streamingReceiver ??
-      new StreamingReceiver(this._context, this.entityPath, {
+      new StreamingReceiver(this.clientId, this._context, this.entityPath, {
         ...options,
         receiveMode: this.receiveMode,
         retryOptions: this._retryOptions,
@@ -650,7 +651,7 @@ export class ServiceBusReceiverImpl implements ServiceBusReceiver {
     entityPath: string,
     options: ReceiveOptions
   ): BatchingReceiver {
-    return BatchingReceiver.create(context, entityPath, options);
+    return BatchingReceiver.create(this.clientId, context, entityPath, options);
   }
 
   /**

--- a/sdk/servicebus/service-bus/src/sender.ts
+++ b/sdk/servicebus/service-bus/src/sender.ts
@@ -157,13 +157,14 @@ export class ServiceBusSenderImpl implements ServiceBusSender {
    * @throws Error if the underlying connection is closed.
    */
   constructor(
+    clientId: string,
     private _context: ConnectionContext,
     private _entityPath: string,
     retryOptions: RetryOptions = {}
   ) {
     throwErrorIfConnectionClosed(_context);
     this.entityPath = _entityPath;
-    this._sender = MessageSender.create(this._context, _entityPath, retryOptions);
+    this._sender = MessageSender.create(clientId, this._context, _entityPath, retryOptions);
     this._retryOptions = retryOptions;
   }
 

--- a/sdk/servicebus/service-bus/src/session/messageSession.ts
+++ b/sdk/servicebus/service-bus/src/session/messageSession.ts
@@ -258,9 +258,9 @@ export class MessageSession extends LinkEntity<Receiver> {
   /**
    * Creates a new AMQP receiver under a new AMQP session.
    */
-  private async _init(abortSignal?: AbortSignalLike): Promise<void> {
+  private async _init(clientId: string, abortSignal?: AbortSignalLike): Promise<void> {
     try {
-      const options = this._createMessageSessionOptions();
+      const options = this._createMessageSessionOptions(clientId);
       await this.initLink(options, abortSignal);
 
       if (this.link == null) {
@@ -327,7 +327,7 @@ export class MessageSession extends LinkEntity<Receiver> {
   /**
    * Creates the options that need to be specified while creating an AMQP receiver link.
    */
-  private _createMessageSessionOptions(): ReceiverOptions {
+  private _createMessageSessionOptions(clientId: string): ReceiverOptions {
     const rcvrOptions: ReceiverOptions = createReceiverOptions(
       this.name,
       this.receiveMode,
@@ -335,6 +335,7 @@ export class MessageSession extends LinkEntity<Receiver> {
         address: this.address,
         filter: { [Constants.sessionFilterName]: this.sessionId },
       },
+      clientId,
       {
         onClose: (context) =>
           this._onAmqpClose(context).catch(() => {
@@ -924,6 +925,7 @@ export class MessageSession extends LinkEntity<Receiver> {
    * @param options - Options that can be provided while creating the MessageSession.
    */
   static async create(
+    clientId: string,
     context: ConnectionContext,
     entityPath: string,
     sessionId: string | undefined,
@@ -931,7 +933,7 @@ export class MessageSession extends LinkEntity<Receiver> {
   ): Promise<MessageSession> {
     throwErrorIfConnectionClosed(context);
     const messageSession = new MessageSession(context, entityPath, sessionId, options);
-    await messageSession._init(options?.abortSignal);
+    await messageSession._init(clientId, options?.abortSignal);
     return messageSession;
   }
 

--- a/sdk/servicebus/service-bus/test/internal/retries.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/retries.spec.ts
@@ -347,6 +347,7 @@ describe("Retries - Receive methods", () => {
     } else {
       // Mocking batchingReceiver.receive to throw the error and fail
       const batchingReceiver = BatchingReceiver.create(
+        "serviceBusClientId",
         (receiver as any)._context,
         "dummyEntityPath",
         {

--- a/sdk/servicebus/service-bus/test/internal/unit/abortSignal.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/unit/abortSignal.spec.ts
@@ -244,7 +244,6 @@ describe("AbortSignal", () => {
 
       const sender = new MessageSender(
         "serviceBusClientId",
-
         createConnectionContextForTests({
           onCreateAwaitableSenderCalled: () => {
             /** Nothing to do here */
@@ -274,7 +273,6 @@ describe("AbortSignal", () => {
 
       const sender = new MessageSender(
         "serviceBusClientId",
-
         createConnectionContextForTests({
           onCreateAwaitableSenderCalled: () => {
             isAborted = true;
@@ -303,7 +301,6 @@ describe("AbortSignal", () => {
     it("...before first async call", async () => {
       const messageReceiver = new StreamingReceiver(
         "serviceBusClientId",
-
         createConnectionContextForTests(),
         "fakeEntityPath",
         defaultOptions
@@ -324,7 +321,6 @@ describe("AbortSignal", () => {
     it("...after negotiateClaim", async () => {
       const messageReceiver = new StreamingReceiver(
         "serviceBusClientId",
-
         createConnectionContextForTests(),
         "fakeEntityPath",
         defaultOptions
@@ -433,7 +429,6 @@ describe("AbortSignal", () => {
     it("Receiver.subscribe", async () => {
       const receiver = new ServiceBusReceiverImpl(
         "serviceBusClientId",
-
         createConnectionContextForTests(),
         "entityPath",
         "peekLock",

--- a/sdk/servicebus/service-bus/test/internal/unit/abortSignal.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/unit/abortSignal.spec.ts
@@ -57,7 +57,12 @@ describe("AbortSignal", () => {
     });
 
     it("AbortSignal is plumbed through all send operations", async () => {
-      const sender = new MessageSender(connectionContext, "fakeEntityPath", {});
+      const sender = new MessageSender(
+        "serviceBusClientId",
+        connectionContext,
+        "fakeEntityPath",
+        {}
+      );
       closeables.push(sender);
 
       let passedInOptions: OperationOptionsBase | undefined;
@@ -85,7 +90,9 @@ describe("AbortSignal", () => {
     });
 
     it("_trySend with an already aborted AbortSignal", async () => {
-      const sender = new MessageSender(connectionContext, "fakeEntityPath", { timeoutInMs: 1 });
+      const sender = new MessageSender("serviceBusClientId", connectionContext, "fakeEntityPath", {
+        timeoutInMs: 1,
+      });
       closeables.push(sender);
 
       sender["open"] = async () => {
@@ -112,7 +119,7 @@ describe("AbortSignal", () => {
     });
 
     it("_trySend when the timer expires", async () => {
-      const sender = new MessageSender(connectionContext, "fakeEntityPath", {
+      const sender = new MessageSender("serviceBusClientId", connectionContext, "fakeEntityPath", {
         timeoutInMs: 1,
       });
       closeables.push(sender);
@@ -158,7 +165,7 @@ describe("AbortSignal", () => {
     });
 
     it("_trySend passes abortSignal to awaitable sender", async () => {
-      const sender = new MessageSender(connectionContext, "fakeEntityPath", {
+      const sender = new MessageSender("serviceBusClientId", connectionContext, "fakeEntityPath", {
         timeoutInMs: 1,
       });
       closeables.push(sender);
@@ -192,7 +199,12 @@ describe("AbortSignal", () => {
 
   describe("MessageSender.open() aborts after...", () => {
     it("...beforeLock", async () => {
-      const sender = new MessageSender(createConnectionContextForTests(), "fakeEntityPath", {});
+      const sender = new MessageSender(
+        "serviceBusClientId",
+        createConnectionContextForTests(),
+        "fakeEntityPath",
+        {}
+      );
       closeables.push(sender);
 
       const abortSignal = createCountdownAbortSignal(1);
@@ -207,7 +219,12 @@ describe("AbortSignal", () => {
     });
 
     it("...afterLock", async () => {
-      const sender = new MessageSender(createConnectionContextForTests(), "fakeEntityPath", {});
+      const sender = new MessageSender(
+        "serviceBusClientId",
+        createConnectionContextForTests(),
+        "fakeEntityPath",
+        {}
+      );
       closeables.push(sender);
 
       const abortSignal = createCountdownAbortSignal(2);
@@ -226,6 +243,8 @@ describe("AbortSignal", () => {
       const taggedAbortSignal = createAbortSignalForTest(() => isAborted);
 
       const sender = new MessageSender(
+        "serviceBusClientId",
+
         createConnectionContextForTests({
           onCreateAwaitableSenderCalled: () => {
             /** Nothing to do here */
@@ -254,6 +273,8 @@ describe("AbortSignal", () => {
       const taggedAbortSignal = createAbortSignalForTest(() => isAborted);
 
       const sender = new MessageSender(
+        "serviceBusClientId",
+
         createConnectionContextForTests({
           onCreateAwaitableSenderCalled: () => {
             isAborted = true;
@@ -281,6 +302,8 @@ describe("AbortSignal", () => {
   describe("MessageReceiver.open() aborts after...", () => {
     it("...before first async call", async () => {
       const messageReceiver = new StreamingReceiver(
+        "serviceBusClientId",
+
         createConnectionContextForTests(),
         "fakeEntityPath",
         defaultOptions
@@ -300,6 +323,8 @@ describe("AbortSignal", () => {
 
     it("...after negotiateClaim", async () => {
       const messageReceiver = new StreamingReceiver(
+        "serviceBusClientId",
+
         createConnectionContextForTests(),
         "fakeEntityPath",
         defaultOptions
@@ -331,7 +356,12 @@ describe("AbortSignal", () => {
           isAborted = true;
         },
       });
-      const messageReceiver = new StreamingReceiver(fakeContext, "fakeEntityPath", defaultOptions);
+      const messageReceiver = new StreamingReceiver(
+        "serviceBusClientId",
+        fakeContext,
+        "fakeEntityPath",
+        defaultOptions
+      );
       closeables.push(messageReceiver);
 
       messageReceiver["_negotiateClaim"] = async () => {
@@ -357,10 +387,16 @@ describe("AbortSignal", () => {
     it("SessionReceiver.subscribe", async () => {
       const connectionContext = createConnectionContextForTestsWithSessionId();
 
-      const messageSession = await MessageSession.create(connectionContext, "entityPath", "hello", {
-        retryOptions: undefined,
-        skipParsingBodyAsJson: false,
-      });
+      const messageSession = await MessageSession.create(
+        "serviceBusClientId",
+        connectionContext,
+        "entityPath",
+        "hello",
+        {
+          retryOptions: undefined,
+          skipParsingBodyAsJson: false,
+        }
+      );
 
       const session = new ServiceBusSessionReceiverImpl(
         messageSession,
@@ -396,6 +432,8 @@ describe("AbortSignal", () => {
 
     it("Receiver.subscribe", async () => {
       const receiver = new ServiceBusReceiverImpl(
+        "serviceBusClientId",
+
         createConnectionContextForTests(),
         "entityPath",
         "peekLock",

--- a/sdk/servicebus/service-bus/test/internal/unit/batchingReceiver.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/unit/batchingReceiver.spec.ts
@@ -51,7 +51,6 @@ describe("BatchingReceiver unit tests", () => {
       const origAbortSignal = createAbortSignalForTest();
       const receiver = new ServiceBusReceiverImpl(
         "serviceBusClientId",
-
         createConnectionContextForTests(),
         "fakeEntityPath",
         "peekLock",
@@ -205,7 +204,6 @@ describe("BatchingReceiver unit tests", () => {
       it("1. We received 'max messages'", async () => {
         const batchingReceiver = new BatchingReceiver(
           "serviceBusClientId",
-
           createConnectionContextForTests(),
           "dummyEntityPath",
           {
@@ -240,7 +238,6 @@ describe("BatchingReceiver unit tests", () => {
       it("2. We've waited 'max wait time'", async () => {
         const receiver = new BatchingReceiver(
           "serviceBusClientId",
-
           createConnectionContextForTests(),
           "dummyEntityPath",
           {
@@ -275,7 +272,6 @@ describe("BatchingReceiver unit tests", () => {
         async () => {
           const batchingReceiver = new BatchingReceiver(
             "serviceBusClientId",
-
             createConnectionContextForTests(),
             "dummyEntityPath",
             {
@@ -326,7 +322,6 @@ describe("BatchingReceiver unit tests", () => {
       (lockMode === "receiveAndDelete" ? it : it.skip)(`3b. (without idle timeout)`, async () => {
         const batchingReceiver = new BatchingReceiver(
           "serviceBusClientId",
-
           createConnectionContextForTests(),
           "dummyEntityPath",
           {
@@ -383,7 +378,6 @@ describe("BatchingReceiver unit tests", () => {
         async () => {
           const batchingReceiver = new BatchingReceiver(
             "serviceBusClientId",
-
             createConnectionContextForTests(),
             "dummyEntityPath",
             {

--- a/sdk/servicebus/service-bus/test/internal/unit/batchingReceiver.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/unit/batchingReceiver.spec.ts
@@ -50,6 +50,8 @@ describe("BatchingReceiver unit tests", () => {
     it("is plumbed into BatchingReceiver from ServiceBusReceiverImpl", async () => {
       const origAbortSignal = createAbortSignalForTest();
       const receiver = new ServiceBusReceiverImpl(
+        "serviceBusClientId",
+
         createConnectionContextForTests(),
         "fakeEntityPath",
         "peekLock",
@@ -85,11 +87,16 @@ describe("BatchingReceiver unit tests", () => {
       const abortController = new AbortController();
       abortController.abort();
 
-      const receiver = new BatchingReceiver(createConnectionContextForTests(), "fakeEntityPath", {
-        receiveMode: "peekLock",
-        lockRenewer: undefined,
-        skipParsingBodyAsJson: false,
-      });
+      const receiver = new BatchingReceiver(
+        "serviceBusClientId",
+        createConnectionContextForTests(),
+        "fakeEntityPath",
+        {
+          receiveMode: "peekLock",
+          lockRenewer: undefined,
+          skipParsingBodyAsJson: false,
+        }
+      );
 
       try {
         await receiver.receive(1, 60 * 1000, 60 * 1000, {
@@ -105,11 +112,16 @@ describe("BatchingReceiver unit tests", () => {
     it("abortSignal while receive is in process", async () => {
       const abortController = new AbortController();
 
-      const receiver = new BatchingReceiver(createConnectionContextForTests(), "fakeEntityPath", {
-        receiveMode: "peekLock",
-        lockRenewer: undefined,
-        skipParsingBodyAsJson: false,
-      });
+      const receiver = new BatchingReceiver(
+        "serviceBusClientId",
+        createConnectionContextForTests(),
+        "fakeEntityPath",
+        {
+          receiveMode: "peekLock",
+          lockRenewer: undefined,
+          skipParsingBodyAsJson: false,
+        }
+      );
       closeables.push(receiver);
 
       const listeners = new Set<string>();
@@ -192,6 +204,8 @@ describe("BatchingReceiver unit tests", () => {
 
       it("1. We received 'max messages'", async () => {
         const batchingReceiver = new BatchingReceiver(
+          "serviceBusClientId",
+
           createConnectionContextForTests(),
           "dummyEntityPath",
           {
@@ -225,6 +239,8 @@ describe("BatchingReceiver unit tests", () => {
       // because otherwise it'd be one of the others.
       it("2. We've waited 'max wait time'", async () => {
         const receiver = new BatchingReceiver(
+          "serviceBusClientId",
+
           createConnectionContextForTests(),
           "dummyEntityPath",
           {
@@ -258,6 +274,8 @@ describe("BatchingReceiver unit tests", () => {
         `3a. (with idle timeout) We've received 1 message and _now_ have exceeded 'max wait time past first message'`,
         async () => {
           const batchingReceiver = new BatchingReceiver(
+            "serviceBusClientId",
+
             createConnectionContextForTests(),
             "dummyEntityPath",
             {
@@ -307,6 +325,8 @@ describe("BatchingReceiver unit tests", () => {
       // When we eliminate that bug we can remove this test in favor of the idle timeout test above.
       (lockMode === "receiveAndDelete" ? it : it.skip)(`3b. (without idle timeout)`, async () => {
         const batchingReceiver = new BatchingReceiver(
+          "serviceBusClientId",
+
           createConnectionContextForTests(),
           "dummyEntityPath",
           {
@@ -362,6 +382,8 @@ describe("BatchingReceiver unit tests", () => {
         "4. sanity check that we're using getRemainingWaitTimeInMs",
         async () => {
           const batchingReceiver = new BatchingReceiver(
+            "serviceBusClientId",
+
             createConnectionContextForTests(),
             "dummyEntityPath",
             {

--- a/sdk/servicebus/service-bus/test/internal/unit/linkentity.unittest.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/unit/linkentity.unittest.spec.ts
@@ -344,13 +344,18 @@ describe("LinkEntity unit tests", () => {
 
   describe("cache cleanup", () => {
     it("batchingreceiver", () => {
-      const batchingReceiver = new BatchingReceiver(connectionContext, "entityPath", {
-        abortSignal: undefined,
-        lockRenewer: undefined,
-        receiveMode: "receiveAndDelete",
-        skipParsingBodyAsJson: false,
-        tracingOptions: {},
-      });
+      const batchingReceiver = new BatchingReceiver(
+        "serviceBusClientId",
+        connectionContext,
+        "entityPath",
+        {
+          abortSignal: undefined,
+          lockRenewer: undefined,
+          receiveMode: "receiveAndDelete",
+          skipParsingBodyAsJson: false,
+          tracingOptions: {},
+        }
+      );
 
       initCachedLinks(batchingReceiver.name);
 
@@ -368,13 +373,18 @@ describe("LinkEntity unit tests", () => {
     });
 
     it("streamingreceiver", () => {
-      const streamingReceiver = new StreamingReceiver(connectionContext, "entityPath", {
-        abortSignal: undefined,
-        lockRenewer: undefined,
-        receiveMode: "receiveAndDelete",
-        skipParsingBodyAsJson: false,
-        tracingOptions: {},
-      });
+      const streamingReceiver = new StreamingReceiver(
+        "serviceBusClientId",
+        connectionContext,
+        "entityPath",
+        {
+          abortSignal: undefined,
+          lockRenewer: undefined,
+          receiveMode: "receiveAndDelete",
+          skipParsingBodyAsJson: false,
+          tracingOptions: {},
+        }
+      );
 
       initCachedLinks(streamingReceiver.name);
 
@@ -392,7 +402,7 @@ describe("LinkEntity unit tests", () => {
     });
 
     it("sender", () => {
-      const sender = new MessageSender(connectionContext, "entityPath", {});
+      const sender = new MessageSender("serviceBusClientId", connectionContext, "entityPath", {});
 
       initCachedLinks(sender.name);
 

--- a/sdk/servicebus/service-bus/test/internal/unit/messageSender.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/unit/messageSender.spec.ts
@@ -16,7 +16,6 @@ describe("MessageSender unit tests", () => {
 
     const messageSender = new MessageSender(
       "serviceBusClientId",
-
       createConnectionContextForTests(),
       "entityPath",
       retryOptions
@@ -66,7 +65,6 @@ describe("MessageSender unit tests", () => {
 
     const messageSender = new MessageSender(
       "serviceBusClientId",
-
       createConnectionContextForTests(),
       "entityPath",
       retryOptions

--- a/sdk/servicebus/service-bus/test/internal/unit/messageSender.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/unit/messageSender.spec.ts
@@ -15,6 +15,8 @@ describe("MessageSender unit tests", () => {
     };
 
     const messageSender = new MessageSender(
+      "serviceBusClientId",
+
       createConnectionContextForTests(),
       "entityPath",
       retryOptions
@@ -63,6 +65,8 @@ describe("MessageSender unit tests", () => {
     };
 
     const messageSender = new MessageSender(
+      "serviceBusClientId",
+
       createConnectionContextForTests(),
       "entityPath",
       retryOptions

--- a/sdk/servicebus/service-bus/test/internal/unit/messageSession.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/unit/messageSession.spec.ts
@@ -360,6 +360,8 @@ describe("Message session unit tests", () => {
 
     beforeEach(async () => {
       messageSession = await MessageSession.create(
+        "serviceBusClientId",
+
         createConnectionContextForTestsWithSessionId("session id"),
         "entity path",
         "session id",

--- a/sdk/servicebus/service-bus/test/internal/unit/messageSession.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/unit/messageSession.spec.ts
@@ -361,7 +361,6 @@ describe("Message session unit tests", () => {
     beforeEach(async () => {
       messageSession = await MessageSession.create(
         "serviceBusClientId",
-
         createConnectionContextForTestsWithSessionId("session id"),
         "entity path",
         "session id",

--- a/sdk/servicebus/service-bus/test/internal/unit/receiver.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/unit/receiver.spec.ts
@@ -27,6 +27,8 @@ describe("Receiver unit tests", () => {
   describe("init() and close() interactions", () => {
     it("close() called just after init() but before the next step", async () => {
       const batchingReceiver = new BatchingReceiver(
+        "serviceBusClientId",
+
         createConnectionContextForTests(),
         "fakeEntityPath",
         {
@@ -55,6 +57,8 @@ describe("Receiver unit tests", () => {
 
     it("message receiver init() bails out early if object is closed()", async () => {
       const messageReceiver2 = new StreamingReceiver(
+        "serviceBusClientId",
+
         createConnectionContextForTests(),
         "fakeEntityPath",
         {
@@ -98,6 +102,8 @@ describe("Receiver unit tests", () => {
 
     it("can't subscribe while another subscribe is active", async () => {
       receiverImpl = new ServiceBusReceiverImpl(
+        "serviceBusClientId",
+
         createConnectionContextForTests(),
         "fakeEntityPath",
         "peekLock",
@@ -131,6 +137,8 @@ describe("Receiver unit tests", () => {
       let closeWasCalled = false;
 
       receiverImpl = new ServiceBusReceiverImpl(
+        "serviceBusClientId",
+
         createConnectionContextForTests({
           onCreateReceiverCalled: (receiver) => {
             (receiver as any).close = () => {
@@ -169,6 +177,8 @@ describe("Receiver unit tests", () => {
 
     it("can re-subscribe after previous subscription is aborted", async () => {
       receiverImpl = new ServiceBusReceiverImpl(
+        "serviceBusClientId",
+
         createConnectionContextForTests(),
         "fakeEntityPath",
         "peekLock",
@@ -213,6 +223,8 @@ describe("Receiver unit tests", () => {
   describe("getMessageIterator", () => {
     it("abortSignal is passed through (receiver)", async () => {
       const impl = new ServiceBusReceiverImpl(
+        "serviceBusClientId",
+
         createConnectionContextForTests(),
         "entity path",
         "peekLock",
@@ -239,6 +251,8 @@ describe("Receiver unit tests", () => {
     it("abortSignal is passed through (session receiver)", async () => {
       const connectionContext = createConnectionContextForTestsWithSessionId();
       const messageSession = await MessageSession.create(
+        "serviceBusClientId",
+
         connectionContext,
         "entity path",
         undefined,
@@ -283,7 +297,14 @@ describe("Receiver unit tests", () => {
 
     it("create() with an existing _streamingReceiver", async () => {
       const context = createConnectionContextForTests();
-      impl = new ServiceBusReceiverImpl(context, "entity path", "peekLock", 1, false);
+      impl = new ServiceBusReceiverImpl(
+        "serviceBusClientId",
+        context,
+        "entity path",
+        "peekLock",
+        1,
+        false
+      );
 
       const existingStreamingReceiver = createStreamingReceiver("entityPath");
       const subscribeStub = sinon.spy(existingStreamingReceiver, "subscribe");
@@ -310,7 +331,14 @@ describe("Receiver unit tests", () => {
     it("create() with an existing receiver and that receiver is NOT open()", async () => {
       const context = createConnectionContextForTests();
 
-      impl = new ServiceBusReceiverImpl(context, "entity path", "peekLock", 1, false);
+      impl = new ServiceBusReceiverImpl(
+        "serviceBusClientId",
+        context,
+        "entity path",
+        "peekLock",
+        1,
+        false
+      );
 
       await subscribeAndWaitForInitialize(impl);
 

--- a/sdk/servicebus/service-bus/test/internal/unit/receiver.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/unit/receiver.spec.ts
@@ -22,13 +22,31 @@ import { ServiceBusSessionReceiverImpl } from "../../../src/receivers/sessionRec
 import { MessageSession } from "../../../src/session/messageSession";
 import sinon from "sinon";
 import { assertThrows } from "../../public/utils/testUtils";
+import { Constants } from "@azure/core-amqp";
 
 describe("Receiver unit tests", () => {
+  it("Receiver should set target in created receiver options", () => {
+    const batchingReceiver = new BatchingReceiver(
+      "serviceBusClientId",
+      createConnectionContextForTests(),
+      "fakeEntityPath",
+      {
+        lockRenewer: undefined,
+        receiveMode: "peekLock",
+        skipParsingBodyAsJson: false,
+      }
+    );
+    const options = batchingReceiver["_createReceiverOptions"](false, {});
+    assert.equal(options.target, "serviceBusClientId");
+    assert.deepStrictEqual(options.properties, {
+      [Constants.receiverIdentifierName]: "serviceBusClientId",
+    });
+  });
+
   describe("init() and close() interactions", () => {
     it("close() called just after init() but before the next step", async () => {
       const batchingReceiver = new BatchingReceiver(
         "serviceBusClientId",
-
         createConnectionContextForTests(),
         "fakeEntityPath",
         {
@@ -58,7 +76,6 @@ describe("Receiver unit tests", () => {
     it("message receiver init() bails out early if object is closed()", async () => {
       const messageReceiver2 = new StreamingReceiver(
         "serviceBusClientId",
-
         createConnectionContextForTests(),
         "fakeEntityPath",
         {
@@ -103,7 +120,6 @@ describe("Receiver unit tests", () => {
     it("can't subscribe while another subscribe is active", async () => {
       receiverImpl = new ServiceBusReceiverImpl(
         "serviceBusClientId",
-
         createConnectionContextForTests(),
         "fakeEntityPath",
         "peekLock",
@@ -138,7 +154,6 @@ describe("Receiver unit tests", () => {
 
       receiverImpl = new ServiceBusReceiverImpl(
         "serviceBusClientId",
-
         createConnectionContextForTests({
           onCreateReceiverCalled: (receiver) => {
             (receiver as any).close = () => {
@@ -178,7 +193,6 @@ describe("Receiver unit tests", () => {
     it("can re-subscribe after previous subscription is aborted", async () => {
       receiverImpl = new ServiceBusReceiverImpl(
         "serviceBusClientId",
-
         createConnectionContextForTests(),
         "fakeEntityPath",
         "peekLock",
@@ -224,7 +238,6 @@ describe("Receiver unit tests", () => {
     it("abortSignal is passed through (receiver)", async () => {
       const impl = new ServiceBusReceiverImpl(
         "serviceBusClientId",
-
         createConnectionContextForTests(),
         "entity path",
         "peekLock",
@@ -252,7 +265,6 @@ describe("Receiver unit tests", () => {
       const connectionContext = createConnectionContextForTestsWithSessionId();
       const messageSession = await MessageSession.create(
         "serviceBusClientId",
-
         connectionContext,
         "entity path",
         undefined,

--- a/sdk/servicebus/service-bus/test/internal/unit/sender.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/unit/sender.spec.ts
@@ -119,4 +119,9 @@ describe("sender unit tests", () => {
       }
     });
   });
+
+  it("should set source in created sender options", () => {
+    const options = sender["_sender"]["_createSenderOptions"]();
+    assert.equal(options.source, "serviceBusClientId");
+  });
 });

--- a/sdk/servicebus/service-bus/test/internal/unit/sender.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/unit/sender.spec.ts
@@ -29,7 +29,7 @@ describe("Sender helper unit tests", () => {
 
 describe("sender unit tests", () => {
   const fakeContext = createConnectionContextForTests();
-  const sender = new ServiceBusSenderImpl(fakeContext, "fakeEntityPath");
+  const sender = new ServiceBusSenderImpl("serviceBusClientId", fakeContext, "fakeEntityPath");
   sender["_sender"].createBatch = async () => {
     return new ServiceBusMessageBatchImpl(fakeContext, 100);
   };

--- a/sdk/servicebus/service-bus/test/internal/unit/serviceBusReceiverUnitTests.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/unit/serviceBusReceiverUnitTests.spec.ts
@@ -14,6 +14,8 @@ describe("ServiceBusReceiver unit tests", () => {
 
   beforeEach(() => {
     receiver = new ServiceBusReceiverImpl(
+      "serviceBusClientId",
+
       createConnectionContextForTests(),
       "entityPath",
       "peekLock",

--- a/sdk/servicebus/service-bus/test/internal/unit/unittestUtils.ts
+++ b/sdk/servicebus/service-bus/test/internal/unit/unittestUtils.ts
@@ -291,7 +291,12 @@ export function addTestStreamingReceiver(): (
       };
     }
 
-    const streamingReceiver = new StreamingReceiver(connectionContext, entityPath, options);
+    const streamingReceiver = new StreamingReceiver(
+      "serviceBusClientId",
+      connectionContext,
+      entityPath,
+      options
+    );
     closeables.push(streamingReceiver);
     return streamingReceiver;
   }


### PR DESCRIPTION
Its main purpose is to help correlate client logs and errors. It can be specified when creating instances of `ServiceBusClient` via optional `ServiceBusClientOptions.identifier`. If not specified, a unique one will be generated.

### Packages impacted by this PR

`@azure/service-bus`

### Issues associated with this PR
#21902

### Describe the problem that is addressed by this PR

When creating one of the Service Bus client types, it can be useful for a host application to be able to uniquely identify the client instance. The Service Bus service also supports setting the identifier of an AMQP link, which it will associate with some error messages to make it easier to correlate errors with a given client instance.

- [ ] TODO: add tests