### PR TITLE
[core-client] bump dependency `core-auth` version to `^1.4.0`

### DIFF
--- a/sdk/core/core-client/package.json
+++ b/sdk/core/core-client/package.json
@@ -69,7 +69,7 @@
   "prettier": "@azure/eslint-plugin-azure-sdk/prettier.json",
   "dependencies": {
     "@azure/abort-controller": "^1.0.0",
-    "@azure/core-auth": "^1.3.0",
+    "@azure/core-auth": "^1.4.0",
     "@azure/core-rest-pipeline": "^1.5.0",
     "@azure/core-tracing": "^1.0.0",
     "@azure/core-util": "^1.0.0",


### PR DESCRIPTION
for the new `claims` property `GetTokenOptions`.