### PR TITLE
[core-lro] Clean-up logging

### DIFF
--- a/sdk/core/core-lro/CHANGELOG.md
+++ b/sdk/core/core-lro/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Other Changes
 
 - Support LROs with GET as the initial request method.
+- Better logging support for the operation and the poller.
 
 ## 2.3.0-beta.1 (2022-05-18)
 

--- a/sdk/core/core-lro/src/lroEngine/models.ts
+++ b/sdk/core/core-lro/src/lroEngine/models.ts
@@ -94,8 +94,6 @@ export interface LroInfo {
  * Type of a polling operation state that can actually be resumed.
  */
 export type ResumablePollOperationState<T> = PollOperationState<T> & {
-  /** The response received when initiating the LRO */
-  initialRawResponse?: RawResponse;
   /** The LRO configuration */
   config?: LroInfo;
   /** @deprecated use state.config.pollingUrl instead */

--- a/sdk/core/core-lro/src/lroEngine/operation.ts
+++ b/sdk/core/core-lro/src/lroEngine/operation.ts
@@ -107,7 +107,6 @@ export class GenericPollOperation<TResult, TState extends PollOperationState<TRe
         this.pollerConfig!,
         this.getLroStatusFromResponse
       );
-      logger.verbose(`LRO: polling response: ${JSON.stringify(currentState.rawResponse)}`);
       if (currentState.done) {
         state.result = buildResult({
           response: currentState.flatResponse,
@@ -126,7 +125,6 @@ export class GenericPollOperation<TResult, TState extends PollOperationState<TRe
       }
       lastResponse = currentState;
     }
-    logger.verbose(`LRO: current state: ${JSON.stringify(state)}`);
     if (lastResponse) {
       this.updateState?.(state, lastResponse?.rawResponse);
     } else {

--- a/sdk/core/core-lro/test/engine.spec.ts
+++ b/sdk/core/core-lro/test/engine.spec.ts
@@ -1963,7 +1963,6 @@ describe("Lro Engine", function () {
         }
       });
       await poller.pollUntilDone();
-      assert.ok(state.initialRawResponse);
     });
   });
 
@@ -2069,7 +2068,6 @@ describe("Lro Engine", function () {
         processResult: (result: unknown, state: any) => {
           const serializedState = JSON.stringify({ state: state });
           assert.equal(serializedState, poller.toString());
-          assert.ok(state.initialRawResponse);
           assert.ok(state.pollingURL);
           assert.ok(state.config.pollingUrl);
           assert.equal((result as any).id, "100");
@@ -2092,7 +2090,6 @@ describe("Lro Engine", function () {
         processResult: (result: unknown, state: any) => {
           const serializedState = JSON.stringify({ state: state });
           assert.equal(serializedState, poller.toString());
-          assert.ok(state.initialRawResponse);
           assert.equal((result as any).id, "100");
           return { ...(result as any), id: "200" };
         },


### PR DESCRIPTION
### Packages impacted by this PR
@azure/core-lro

### Issues associated with this PR
N/A

### Describe the problem that is addressed by this PR
The lroEngine was logging raw responses without sanitization, a bad practice at best and a security vulnerability at worst.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?
The customer should rely on core-client logging for information about the responses so the operation and polling statuses are logged instead of raw responses. See a sample of the cleaned-up log in [log.txt](https://github.com/Azure/azure-sdk-for-js/files/9127914/log.txt)

### Are there test cases added in this PR? _(If not, why?)_
N/A

### Provide a list of related PRs _(if any)_
N/A

### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
