### PR TITLE
[communication-common] Handle unknown additional properties when deserializing identifier REST model

### DIFF
--- a/sdk/communication/communication-common/CHANGELOG.md
+++ b/sdk/communication/communication-common/CHANGELOG.md
@@ -7,6 +7,10 @@
 - Added `getIdentifierRawId` and `createIdentifierFromRawId` to translate between a `CommunicationIdentifier` and its underlying canonical rawId representation. Developers can now use the rawId as an encoded format for identifiers to store in their databases or as stable keys in general.
 - Always include `rawId` when serializing identifiers to wire format.
 
+### Bugs Fixed
+
+- Made internal `CommunicationIdentifierSerializer` resilient to unknown additional response properties.
+
 ## 2.0.0 (2022-03-08)
 
 ### Features Added

--- a/sdk/communication/communication-common/src/identifierModelSerializer.ts
+++ b/sdk/communication/communication-common/src/identifierModelSerializer.ts
@@ -95,7 +95,7 @@ const assertNotNullOrUndefined = <
 };
 
 const assertMaximumOneNestedModel = (identifier: SerializedCommunicationIdentifier): void => {
-  let presentProperties = [];
+  const presentProperties: string[] = [];
   if (identifier.communicationUser !== undefined) {
     presentProperties.push("communicationUser");
   }

--- a/sdk/communication/communication-common/src/identifierModelSerializer.ts
+++ b/sdk/communication/communication-common/src/identifierModelSerializer.ts
@@ -95,10 +95,20 @@ const assertNotNullOrUndefined = <
 };
 
 const assertMaximumOneNestedModel = (identifier: SerializedCommunicationIdentifier): void => {
-  const { rawId: _rawId, ...props } = identifier;
-  const keys = Object.keys(props);
-  if (keys.length > 1) {
-    throw new Error(`Only one of the properties in ${JSON.stringify(keys)} should be present.`);
+  let presentProperties = [];
+  if (identifier.communicationUser !== undefined) {
+    presentProperties.push("communicationUser");
+  }
+  if (identifier.microsoftTeamsUser !== undefined) {
+    presentProperties.push("microsoftTeamsUser");
+  }
+  if (identifier.phoneNumber !== undefined) {
+    presentProperties.push("phoneNumber");
+  }
+  if (presentProperties.length > 1) {
+    throw new Error(
+      `Only one of the properties in ${JSON.stringify(presentProperties)} should be present.`
+    );
   }
 };
 

--- a/sdk/communication/communication-common/test/identifierModelSerializer.spec.ts
+++ b/sdk/communication/communication-common/test/identifierModelSerializer.spec.ts
@@ -40,10 +40,9 @@ const assertThrowsMissingProperty = <
 const assertThrowsTooManyProperties = (
   serializedIdentifier: SerializedCommunicationIdentifier
 ): void => {
-  const { rawId: _rawId, ...props } = serializedIdentifier;
   assert.throws(() => {
     deserializeCommunicationIdentifier(serializedIdentifier);
-  }, `Only one of the properties in ${JSON.stringify(Object.keys(props))} should be present.`);
+  }, /^Only one of the properties in \[[\w\,\"\s]+\] should be present.$/);
 };
 
 describe("Identifier model serializer", () => {
@@ -155,6 +154,19 @@ describe("Identifier model serializer", () => {
           id: "8:acs:37691ec4-57fb-4c0f-ae31-32791610cb14_37691ec4-57fb-4c0f-ae31-32791610cb14",
         },
       },
+      {
+        kind: "communicationUser",
+        communicationUserId:
+          "8:acs:37691ec4-57fb-4c0f-ae31-32791610cb14_37691ec4-57fb-4c0f-ae31-32791610cb14",
+      }
+    );
+    assertDeserialize(
+      {
+        kind: "communicationUser",
+        communicationUser: {
+          id: "8:acs:37691ec4-57fb-4c0f-ae31-32791610cb14_37691ec4-57fb-4c0f-ae31-32791610cb14",
+        },
+      } as any,
       {
         kind: "communicationUser",
         communicationUserId:

--- a/sdk/communication/communication-common/test/identifierModelSerializer.spec.ts
+++ b/sdk/communication/communication-common/test/identifierModelSerializer.spec.ts
@@ -174,6 +174,19 @@ describe("Identifier model serializer", () => {
       }
     );
     assertDeserialize(
+      {
+        someFutureProperty: "fooBar",
+        communicationUser: {
+          id: "8:acs:37691ec4-57fb-4c0f-ae31-32791610cb14_37691ec4-57fb-4c0f-ae31-32791610cb14",
+        },
+      } as any,
+      {
+        kind: "communicationUser",
+        communicationUserId:
+          "8:acs:37691ec4-57fb-4c0f-ae31-32791610cb14_37691ec4-57fb-4c0f-ae31-32791610cb14",
+      }
+    );
+    assertDeserialize(
       { phoneNumber: { value: "+1234555000" }, rawId: "4:+1234555000" },
       { kind: "phoneNumber", phoneNumber: "+1234555000", rawId: "4:+1234555000" }
     );

--- a/sdk/communication/communication-common/test/identifierModelSerializer.spec.ts
+++ b/sdk/communication/communication-common/test/identifierModelSerializer.spec.ts
@@ -42,7 +42,7 @@ const assertThrowsTooManyProperties = (
 ): void => {
   assert.throws(() => {
     deserializeCommunicationIdentifier(serializedIdentifier);
-  }, /^Only one of the properties in \[[\w\,\"\s]+\] should be present.$/);
+  }, /^Only one of the properties in \[[\w,"\s]+\] should be present.$/);
 };
 
 describe("Identifier model serializer", () => {


### PR DESCRIPTION
### Packages impacted by this PR
communication-common and its downstream dependencies

### Issues associated with this PR


### Describe the problem that is addressed by this PR
Needed to be able to handle the new stable version of `CommunicationIdentifierModel`, see swagger: https://github.com/Azure/azure-rest-api-specs/pull/19675

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?

This PR aligns the logic with C# and Java and checks that at most one of the known properties is part of the payload. Alternatively, the existing JS pattern could have been altered to exclude `kind` from the check. But handling new additional properties without failure seemed better than risking not to throw when encountering a malformed service response.

### Are there test cases added in this PR? _(If not, why?)_

Yes.

### Provide a list of related PRs _(if any)_

https://github.com/Azure/azure-rest-api-specs/pull/19675

### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [ ] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
