### PR TITLE
[Microsoft.DigitalTwins] Revert fixing typo after SDK review

### DIFF
--- a/sdk/digitaltwins/digital-twins-core/CHANGELOG.md
+++ b/sdk/digitaltwins/digital-twins-core/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Release History
 
-## 1.1.0 (2022-05-31)
+## 1.1.0 (2022-07-19)
 
-- GA Release
+### Features Added
+
+- Added support for twin and component metadata property `$lastUpdateTime`, signifying the date and time a twin or component was last updated.
 
 ## 1.1.0-beta.1 (2022-04-04)
 

--- a/sdk/digitaltwins/digital-twins-core/review/digital-twins-core.api.md
+++ b/sdk/digitaltwins/digital-twins-core/review/digital-twins-core.api.md
@@ -86,9 +86,7 @@ export type DigitalTwinsAddResponse = DigitalTwinsAddHeaders & {
 export class DigitalTwinsClient {
     constructor(endpointUrl: string, credential: TokenCredential, options?: DigitalTwinsClientOptions);
     createModels(dtdlModels: any[], options?: OperationOptions): Promise<DigitalTwinModelsAddResponse>;
-    // @deprecated (undocumented)
-    decomissionModel: (modelId: string, options?: OperationOptions) => Promise<RestResponse>;
-    decommissionModel(modelId: string, options?: OperationOptions): Promise<RestResponse>;
+    decomissionModel: (modelId: string, options?: OperationOptions): Promise<RestResponse>;
     deleteDigitalTwin(digitalTwinId: string, options?: DigitalTwinsDeleteOptionalParams): Promise<RestResponse>;
     deleteEventRoute(eventRouteId: string, options?: OperationOptions): Promise<RestResponse>;
     deleteModel(modelId: string, options?: OperationOptions): Promise<RestResponse>;

--- a/sdk/digitaltwins/digital-twins-core/review/digital-twins-core.api.md
+++ b/sdk/digitaltwins/digital-twins-core/review/digital-twins-core.api.md
@@ -86,7 +86,7 @@ export type DigitalTwinsAddResponse = DigitalTwinsAddHeaders & {
 export class DigitalTwinsClient {
     constructor(endpointUrl: string, credential: TokenCredential, options?: DigitalTwinsClientOptions);
     createModels(dtdlModels: any[], options?: OperationOptions): Promise<DigitalTwinModelsAddResponse>;
-    decomissionModel: (modelId: string, options?: OperationOptions): Promise<RestResponse>;
+    decomissionModel(modelId: string, options?: OperationOptions): Promise<RestResponse>;
     deleteDigitalTwin(digitalTwinId: string, options?: DigitalTwinsDeleteOptionalParams): Promise<RestResponse>;
     deleteEventRoute(eventRouteId: string, options?: OperationOptions): Promise<RestResponse>;
     deleteModel(modelId: string, options?: OperationOptions): Promise<RestResponse>;

--- a/sdk/digitaltwins/digital-twins-core/src/digitalTwinsClient.ts
+++ b/sdk/digitaltwins/digital-twins-core/src/digitalTwinsClient.ts
@@ -753,22 +753,17 @@ export class DigitalTwinsClient {
    * @returns The http response.
    *
    */
-  public decommissionModel(modelId: string, options: OperationOptions = {}): Promise<RestResponse> {
+  public decomissionModel(modelId: string, options: OperationOptions = {}): Promise<RestResponse> {
     const jsonPatch = [{ op: "replace", path: "/decommissioned", value: true }];
 
     return tracingClient.withSpan(
-      "DigitalTwinsClient.decommissionModel",
+      "DigitalTwinsClient.decomissionModel",
       options,
       async (updatedOptions) => {
         return this.client.digitalTwinModels.update(modelId, jsonPatch, updatedOptions);
       }
     );
   }
-
-  /**
-   * @deprecated Please use {@link DigitalTwinsClient.decommissionModel} instead.
-   */
-  public decomissionModel = this.decommissionModel;
 
   /**
    * Delete a model.


### PR DESCRIPTION
### Packages impacted by this PR


### Issues associated with this PR


### Describe the problem that is addressed by this PR

During the SDK review of 1.1.0, it was determined that the change fixing a typo in a function (decomissionModel) should be reverted, since it was deemed confusing to have both side by side.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [ ] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
