### PR TITLE
Use the right var for package info

### DIFF
--- a/eng/scripts/docs/Docs-ToC.ps1
+++ b/eng/scripts/docs/Docs-ToC.ps1
@@ -78,13 +78,13 @@ function Get-javascript-PackageLevelReadme($packageMetadata)
 function Get-javascript-DocsMsTocData($packageMetadata, $docRepoLocation) {
   $packageLevelReadmeName = GetPackageReadmeName -packageMetadata $packageMetadata
   $packageTocHeader = $packageMetadata.Package
-  if ($clientPackage.DisplayName) {
-    $packageTocHeader = $clientPackage.DisplayName
+  if ($packageMetadata.DisplayName) {
+    $packageTocHeader = $packageMetadata.DisplayName
   }
   $output = [PSCustomObject]@{
     PackageLevelReadmeHref = "~/docs-ref-services/{moniker}/$packageLevelReadmeName-readme.md"
     PackageTocHeader       = $packageTocHeader
-    TocChildren            = @($clientPackage.Package)
+    TocChildren            = @($packageMetadata.Package)
   }
 
   return $output


### PR DESCRIPTION
### Packages impacted by this PR


### Issues associated with this PR


### Describe the problem that is addressed by this PR
The review site is not correctly showing the right display. 

https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1718787&view=results
### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [ ] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
