### PR TITLE
Downgrade core-http version

### DIFF
--- a/sdk/digitaltwins/digital-twins-core/package.json
+++ b/sdk/digitaltwins/digital-twins-core/package.json
@@ -64,7 +64,7 @@
     "url": "https://github.com/Azure/azure-sdk-for-js/issues"
   },
   "dependencies": {
-    "@azure/core-http": "^2.2.6",
+    "@azure/core-http": "^2.2.5",
     "@azure/core-paging": "^1.1.1",
     "@azure/core-tracing": "^1.0.0",
     "@azure/logger": "^1.0.0",


### PR DESCRIPTION
### Packages impacted by this PR
@ azure/core-http

### Issues associated with this PR
The package version needs to be downgraded since 2.2.6 is not publicly available as of yet.

### Describe the problem that is addressed by this PR
In order to release SDK version, the core-http version needs to be downgraded.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?
N/A

### Are there test cases added in this PR? _(If not, why?)_
N/A

### Provide a list of related PRs _(if any)_
N/A

### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_
N/A

### Checklists
- [ ] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
