### PR TITLE
@azure/communication-common - remove a local copy of isNode

### DIFF
--- a/sdk/communication/communication-common/package.json
+++ b/sdk/communication/communication-common/package.json
@@ -66,6 +66,7 @@
     "@azure/core-auth": "^1.3.0",
     "@azure/core-rest-pipeline": "^1.3.2",
     "@azure/core-tracing": "1.0.0-preview.13",
+    "@azure/core-util": "^1.0.0",
     "events": "^3.0.0",
     "jwt-decode": "^3.1.2",
     "tslib": "^2.2.0"

--- a/sdk/communication/communication-common/src/credential/communicationAccessKeyCredentialPolicy.ts
+++ b/sdk/communication/communication-common/src/credential/communicationAccessKeyCredentialPolicy.ts
@@ -9,7 +9,7 @@ import {
 } from "@azure/core-rest-pipeline";
 import { shaHMAC, shaHash } from "./cryptoUtils";
 import { KeyCredential } from "@azure/core-auth";
-import { isNode } from "./isNode";
+import { isNode } from "@azure/core-util";
 
 /**
  * CommunicationKeyCredentialPolicy provides a means of signing requests made through

--- a/sdk/communication/communication-common/src/credential/isNode.browser.ts
+++ b/sdk/communication/communication-common/src/credential/isNode.browser.ts
@@ -1,7 +1,0 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT license.
-
-/**
- * A constant that indicates whether the environment the code is running is Node.JS.
- */
-export const isNode = false;

--- a/sdk/communication/communication-common/src/credential/isNode.ts
+++ b/sdk/communication/communication-common/src/credential/isNode.ts
@@ -1,8 +1,0 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT license.
-
-/**
- * A constant that indicates whether the environment the code is running is Node.JS.
- */
-export const isNode =
-  typeof process !== "undefined" && Boolean(process.version) && Boolean(process.versions?.node);

--- a/sdk/communication/communication-common/test/communicationKeyCredentialPolicy.spec.ts
+++ b/sdk/communication/communication-common/test/communicationKeyCredentialPolicy.spec.ts
@@ -11,7 +11,7 @@ import {
 import { KeyCredential } from "@azure/core-auth";
 import { assert } from "chai";
 import { createCommunicationAccessKeyCredentialPolicy } from "../src/credential/communicationAccessKeyCredentialPolicy";
-import { isNode } from "../src/credential/isNode";
+import { isNode } from "@azure/core-util";
 
 describe("CommunicationKeyCredentialPolicy", () => {
   it("signs the request", async () => {

--- a/sdk/communication/communication-common/test/communicationTokenCredential.spec.ts
+++ b/sdk/communication/communication-common/test/communicationTokenCredential.spec.ts
@@ -5,7 +5,7 @@ import { assert, use } from "chai";
 import { AbortSignal } from "@azure/abort-controller";
 import { AzureCommunicationTokenCredential } from "../src/azureCommunicationTokenCredential";
 import chaiAsPromised from "chai-as-promised";
-import { isNode } from "../src/credential/isNode";
+import { isNode } from "@azure/core-util";
 import sinon from "sinon";
 
 use(chaiAsPromised);


### PR DESCRIPTION
### Packages impacted by this PR
- @azure/communication-common

### Issues associated with this PR
- https://skype.visualstudio.com/SPOOL/_workitems/edit/2762212

### Describe the problem that is addressed by this PR
- Addressing technical debt
- We planned to remove the local copy of isNode once a stable version of @azure/core-util is released
- The local copy was created during the migration to Azure Core v2 ([here](https://github.com/Azure/autorest.typescript/wiki/%60core-http%60-dependency-migration-to-%60core-client%60-%60core-rest-pipeline%60#other-changes-to-consider-when-migrating-to-core-v2))


### Provide a list of related PRs
- https://github.com/Azure/azure-sdk-for-js/pull/21352 

