### PR TITLE
[storage-blob] Escape path like dotnet for storage blob names (exclude path separator from encoding)

### DIFF
--- a/sdk/storage/storage-blob/recordings/browsers/blob_versioning/recording_list_blobs_include_versions.json
+++ b/sdk/storage/storage-blob/recordings/browsers/blob_versioning/recording_list_blobs_include_versions.json
@@ -1,161 +1,161 @@
 {
-  "recordings": [
-    {
-      "method": "PUT",
-      "url": "https://fakestorageaccount.blob.core.windows.net/container159218749276106537",
-      "query": {
-        "restype": "container"
-      },
-      "requestBody": null,
-      "status": 201,
-      "response": "",
-      "responseHeaders": {
-        "content-length": "0",
-        "date": "Mon, 15 Jun 2020 02:18:12 GMT",
-        "etag": "\"0x8D810D25B259EA2\"",
-        "last-modified": "Mon, 15 Jun 2020 02:18:13 GMT",
-        "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "981467ee-dfac-4265-a6bc-084558bfae9c",
-        "x-ms-request-id": "b4a3f506-001e-0029-5cbb-4273d4000000",
-        "x-ms-version": "2019-12-12"
-      }
-    },
-    {
-      "method": "PUT",
-      "url": "https://fakestorageaccount.blob.core.windows.net/container159218749276106537/blob159218749332805006",
-      "query": {},
-      "requestBody": "Hello World",
-      "status": 201,
-      "response": "",
-      "responseHeaders": {
-        "content-length": "0",
-        "content-md5": "sQqNsWTgdUEFt6mb5y4/5Q==",
-        "date": "Mon, 15 Jun 2020 02:18:13 GMT",
-        "etag": "\"0x8D810D25B7C52E1\"",
-        "last-modified": "Mon, 15 Jun 2020 02:18:13 GMT",
-        "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "7b26de92-6fbf-4b7e-8dc8-db1979b1d21d",
-        "x-ms-content-crc64": "YeJLfssylmU=",
-        "x-ms-request-id": "b4a3f59d-001e-0029-6abb-4273d4000000",
-        "x-ms-request-server-encrypted": "true",
-        "x-ms-version": "2019-12-12",
-        "x-ms-version-id": "2020-06-15T02:18:13.6976097Z"
-      }
-    },
-    {
-      "method": "PUT",
-      "url": "https://fakestorageaccount.blob.core.windows.net/container159218749276106537/blob159218749332805006",
-      "query": {},
-      "requestBody": "",
-      "status": 201,
-      "response": "",
-      "responseHeaders": {
-        "content-length": "0",
-        "content-md5": "1B2M2Y8AsgTpgAmY7PhCfg==",
-        "date": "Mon, 15 Jun 2020 02:18:13 GMT",
-        "etag": "\"0x8D810D25BA89AF6\"",
-        "last-modified": "Mon, 15 Jun 2020 02:18:13 GMT",
-        "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "a38402d3-d14e-4e02-ad5e-ad7b083833e2",
-        "x-ms-content-crc64": "AAAAAAAAAAA=",
-        "x-ms-request-id": "b4a3f61c-001e-0029-5ebb-4273d4000000",
-        "x-ms-request-server-encrypted": "true",
-        "x-ms-version": "2019-12-12",
-        "x-ms-version-id": "2020-06-15T02:18:13.9888134Z"
-      }
-    },
-    {
-      "method": "PUT",
-      "url": "https://fakestorageaccount.blob.core.windows.net/container159218749276106537/blockblob%2F0159218749418603936",
-      "query": {},
-      "requestBody": "",
-      "status": 201,
-      "response": "",
-      "responseHeaders": {
-        "content-length": "0",
-        "content-md5": "1B2M2Y8AsgTpgAmY7PhCfg==",
-        "date": "Mon, 15 Jun 2020 02:18:14 GMT",
-        "etag": "\"0x8D810D25BFF080F\"",
-        "last-modified": "Mon, 15 Jun 2020 02:18:14 GMT",
-        "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "99691821-93f6-4c61-97b3-0f2cbf5c1946",
-        "x-ms-content-crc64": "AAAAAAAAAAA=",
-        "x-ms-request-id": "b4a3f727-001e-0029-4cbb-4273d4000000",
-        "x-ms-request-server-encrypted": "true",
-        "x-ms-version": "2019-12-12",
-        "x-ms-version-id": "2020-06-15T02:18:14.5542159Z"
-      }
-    },
-    {
-      "method": "PUT",
-      "url": "https://fakestorageaccount.blob.core.windows.net/container159218749276106537/blockblob%2F1159218749475303359",
-      "query": {},
-      "requestBody": "",
-      "status": 201,
-      "response": "",
-      "responseHeaders": {
-        "content-length": "0",
-        "content-md5": "1B2M2Y8AsgTpgAmY7PhCfg==",
-        "date": "Mon, 15 Jun 2020 02:18:14 GMT",
-        "etag": "\"0x8D810D25C559C40\"",
-        "last-modified": "Mon, 15 Jun 2020 02:18:15 GMT",
-        "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "d141a683-a945-4dd6-9c9f-cdb80ce3be5d",
-        "x-ms-content-crc64": "AAAAAAAAAAA=",
-        "x-ms-request-id": "b4a3f83f-001e-0029-5ebb-4273d4000000",
-        "x-ms-request-server-encrypted": "true",
-        "x-ms-version": "2019-12-12",
-        "x-ms-version-id": "2020-06-15T02:18:15.1216192Z"
-      }
-    },
-    {
-      "method": "GET",
-      "url": "https://fakestorageaccount.blob.core.windows.net/container159218749276106537",
-      "query": {
-        "include": "versions",
-        "restype": "container",
-        "comp": "list"
-      },
-      "requestBody": null,
-      "status": 200,
-      "response": "<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults ServiceEndpoint=\"https://fakestorageaccount.blob.core.windows.net/\" ContainerName=\"container159218749276106537\"><Blobs><Blob><Name>blob159218749332805006</Name><VersionId>2020-06-15T02:18:13.6976097Z</VersionId><Properties><Creation-Time>Mon, 15 Jun 2020 02:18:13 GMT</Creation-Time><Last-Modified>Mon, 15 Jun 2020 02:18:13 GMT</Last-Modified><Etag>0x8D810D25B7C52E1</Etag><Content-Length>11</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>sQqNsWTgdUEFt6mb5y4/5Q==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><ServerEncrypted>true</ServerEncrypted></Properties><OrMetadata /></Blob><Blob><Name>blob159218749332805006</Name><VersionId>2020-06-15T02:18:13.9888134Z</VersionId><IsCurrentVersion>true</IsCurrentVersion><Properties><Creation-Time>Mon, 15 Jun 2020 02:18:13 GMT</Creation-Time><Last-Modified>Mon, 15 Jun 2020 02:18:13 GMT</Last-Modified><Etag>0x8D810D25BA89AF6</Etag><Content-Length>0</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>1B2M2Y8AsgTpgAmY7PhCfg==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties><OrMetadata /></Blob><Blob><Name>blockblob/0159218749418603936</Name><VersionId>2020-06-15T02:18:14.5542159Z</VersionId><IsCurrentVersion>true</IsCurrentVersion><Properties><Creation-Time>Mon, 15 Jun 2020 02:18:14 GMT</Creation-Time><Last-Modified>Mon, 15 Jun 2020 02:18:14 GMT</Last-Modified><Etag>0x8D810D25BFF080F</Etag><Content-Length>0</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>1B2M2Y8AsgTpgAmY7PhCfg==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties><OrMetadata /></Blob><Blob><Name>blockblob/1159218749475303359</Name><VersionId>2020-06-15T02:18:15.1216192Z</VersionId><IsCurrentVersion>true</IsCurrentVersion><Properties><Creation-Time>Mon, 15 Jun 2020 02:18:15 GMT</Creation-Time><Last-Modified>Mon, 15 Jun 2020 02:18:15 GMT</Last-Modified><Etag>0x8D810D25C559C40</Etag><Content-Length>0</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>1B2M2Y8AsgTpgAmY7PhCfg==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties><OrMetadata /></Blob></Blobs><NextMarker /></EnumerationResults>",
-      "responseHeaders": {
-        "content-type": "application/xml",
-        "date": "Mon, 15 Jun 2020 02:18:15 GMT",
-        "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "transfer-encoding": "chunked",
-        "x-ms-client-request-id": "bc3727f8-656a-4563-b563-d9458dfdc370",
-        "x-ms-request-id": "b4a3f961-001e-0029-77bb-4273d4000000",
-        "x-ms-version": "2019-12-12"
-      }
-    },
-    {
-      "method": "DELETE",
-      "url": "https://fakestorageaccount.blob.core.windows.net/container159218749276106537",
-      "query": {
-        "restype": "container"
-      },
-      "requestBody": null,
-      "status": 202,
-      "response": "",
-      "responseHeaders": {
-        "content-length": "0",
-        "date": "Mon, 15 Jun 2020 02:18:16 GMT",
-        "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "eccaa938-0e08-4d39-8680-4e3e07bdf35b",
-        "x-ms-request-id": "b4a3fae0-001e-0029-6cbb-4273d4000000",
-        "x-ms-version": "2019-12-12"
-      }
-    }
-  ],
-  "uniqueTestInfo": {
-    "uniqueName": {
-      "container": "container159218749276106537",
-      "blob": "blob159218749332805006",
-      "blockblob/0": "blockblob/0159218749418603936",
-      "blockblob/1": "blockblob/1159218749475303359"
-    },
-    "newDate": {}
+ "recordings": [
+  {
+   "method": "PUT",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container166374975723905121",
+   "query": {
+    "restype": "container"
+   },
+   "requestBody": null,
+   "status": 201,
+   "response": "",
+   "responseHeaders": {
+    "content-length": "0",
+    "date": "Wed, 21 Sep 2022 08:42:38 GMT",
+    "etag": "\"0x8DA9BAD3CFE103E\"",
+    "last-modified": "Wed, 21 Sep 2022 08:42:38 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "79a3fef8-4b4c-4fdb-a2ab-29254a7724b2",
+    "x-ms-request-id": "e9748018-701e-005d-2c96-cdee3d000000",
+    "x-ms-version": "2021-08-06"
+   }
   },
-  "hash": "b08eb17f72d430f08657866c2038c7fc"
+  {
+   "method": "PUT",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container166374975723905121/blob166374975796809737",
+   "query": {},
+   "requestBody": "Hello World",
+   "status": 201,
+   "response": "",
+   "responseHeaders": {
+    "content-length": "0",
+    "content-md5": "sQqNsWTgdUEFt6mb5y4/5Q==",
+    "date": "Wed, 21 Sep 2022 08:42:38 GMT",
+    "etag": "\"0x8DA9BAD3D1D39EE\"",
+    "last-modified": "Wed, 21 Sep 2022 08:42:38 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "936e6dd5-9e81-4ef5-b6ce-ab469ffa1788",
+    "x-ms-content-crc64": "YeJLfssylmU=",
+    "x-ms-request-id": "e9748062-701e-005d-4c96-cdee3d000000",
+    "x-ms-request-server-encrypted": "true",
+    "x-ms-version": "2021-08-06",
+    "x-ms-version-id": "2022-09-21T08:42:38.3319534Z"
+   }
+  },
+  {
+   "method": "PUT",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container166374975723905121/blob166374975796809737",
+   "query": {},
+   "requestBody": "",
+   "status": 201,
+   "response": "",
+   "responseHeaders": {
+    "content-length": "0",
+    "content-md5": "1B2M2Y8AsgTpgAmY7PhCfg==",
+    "date": "Wed, 21 Sep 2022 08:42:38 GMT",
+    "etag": "\"0x8DA9BAD3D2D3CFC\"",
+    "last-modified": "Wed, 21 Sep 2022 08:42:38 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "58d77613-7863-4e35-a259-7d085975747d",
+    "x-ms-content-crc64": "AAAAAAAAAAA=",
+    "x-ms-request-id": "e9748096-701e-005d-6296-cdee3d000000",
+    "x-ms-request-server-encrypted": "true",
+    "x-ms-version": "2021-08-06",
+    "x-ms-version-id": "2022-09-21T08:42:38.4378892Z"
+   }
+  },
+  {
+   "method": "PUT",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container166374975723905121/blockblob/0166374975827606101",
+   "query": {},
+   "requestBody": "",
+   "status": 201,
+   "response": "",
+   "responseHeaders": {
+    "content-length": "0",
+    "content-md5": "1B2M2Y8AsgTpgAmY7PhCfg==",
+    "date": "Wed, 21 Sep 2022 08:42:38 GMT",
+    "etag": "\"0x8DA9BAD3D4C31D3\"",
+    "last-modified": "Wed, 21 Sep 2022 08:42:38 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "a5ad1c67-5472-4988-b752-822d2c3a8fb1",
+    "x-ms-content-crc64": "AAAAAAAAAAA=",
+    "x-ms-request-id": "e9748108-701e-005d-1296-cdee3d000000",
+    "x-ms-request-server-encrypted": "true",
+    "x-ms-version": "2021-08-06",
+    "x-ms-version-id": "2022-09-21T08:42:38.6397651Z"
+   }
+  },
+  {
+   "method": "PUT",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container166374975723905121/blockblob/1166374975847602159",
+   "query": {},
+   "requestBody": "",
+   "status": 201,
+   "response": "",
+   "responseHeaders": {
+    "content-length": "0",
+    "content-md5": "1B2M2Y8AsgTpgAmY7PhCfg==",
+    "date": "Wed, 21 Sep 2022 08:42:38 GMT",
+    "etag": "\"0x8DA9BAD3D6A8A86\"",
+    "last-modified": "Wed, 21 Sep 2022 08:42:38 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "e5063213-471d-4b37-97be-b0f1f6099e4b",
+    "x-ms-content-crc64": "AAAAAAAAAAA=",
+    "x-ms-request-id": "e9748158-701e-005d-3896-cdee3d000000",
+    "x-ms-request-server-encrypted": "true",
+    "x-ms-version": "2021-08-06",
+    "x-ms-version-id": "2022-09-21T08:42:38.8386438Z"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container166374975723905121",
+   "query": {
+    "comp": "list",
+    "restype": "container",
+    "include": "versions"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults ServiceEndpoint=\"https://fakestorageaccount.blob.core.windows.net/\" ContainerName=\"container166374975723905121\"><Blobs><Blob><Name>blob166374975796809737</Name><VersionId>2022-09-21T08:42:38.3319534Z</VersionId><Properties><Creation-Time>Wed, 21 Sep 2022 08:42:38 GMT</Creation-Time><Last-Modified>Wed, 21 Sep 2022 08:42:38 GMT</Last-Modified><Etag>0x8DA9BAD3D1D39EE</Etag><Content-Length>11</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>sQqNsWTgdUEFt6mb5y4/5Q==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><ServerEncrypted>true</ServerEncrypted></Properties><OrMetadata /></Blob><Blob><Name>blob166374975796809737</Name><VersionId>2022-09-21T08:42:38.4378892Z</VersionId><IsCurrentVersion>true</IsCurrentVersion><Properties><Creation-Time>Wed, 21 Sep 2022 08:42:38 GMT</Creation-Time><Last-Modified>Wed, 21 Sep 2022 08:42:38 GMT</Last-Modified><Etag>0x8DA9BAD3D2D3CFC</Etag><Content-Length>0</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>1B2M2Y8AsgTpgAmY7PhCfg==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties><OrMetadata /></Blob><Blob><Name>blockblob/0166374975827606101</Name><VersionId>2022-09-21T08:42:38.6397651Z</VersionId><IsCurrentVersion>true</IsCurrentVersion><Properties><Creation-Time>Wed, 21 Sep 2022 08:42:38 GMT</Creation-Time><Last-Modified>Wed, 21 Sep 2022 08:42:38 GMT</Last-Modified><Etag>0x8DA9BAD3D4C31D3</Etag><Content-Length>0</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>1B2M2Y8AsgTpgAmY7PhCfg==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties><OrMetadata /></Blob><Blob><Name>blockblob/1166374975847602159</Name><VersionId>2022-09-21T08:42:38.8386438Z</VersionId><IsCurrentVersion>true</IsCurrentVersion><Properties><Creation-Time>Wed, 21 Sep 2022 08:42:38 GMT</Creation-Time><Last-Modified>Wed, 21 Sep 2022 08:42:38 GMT</Last-Modified><Etag>0x8DA9BAD3D6A8A86</Etag><Content-Length>0</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>1B2M2Y8AsgTpgAmY7PhCfg==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties><OrMetadata /></Blob></Blobs><NextMarker /></EnumerationResults>",
+   "responseHeaders": {
+    "content-type": "application/xml",
+    "date": "Wed, 21 Sep 2022 08:42:38 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "transfer-encoding": "chunked",
+    "x-ms-client-request-id": "c3864fc5-23bb-4bdf-b256-54ebd640f346",
+    "x-ms-request-id": "e97481ca-701e-005d-7296-cdee3d000000",
+    "x-ms-version": "2021-08-06"
+   }
+  },
+  {
+   "method": "DELETE",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container166374975723905121",
+   "query": {
+    "restype": "container"
+   },
+   "requestBody": null,
+   "status": 202,
+   "response": "",
+   "responseHeaders": {
+    "content-length": "0",
+    "date": "Wed, 21 Sep 2022 08:42:39 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "5b1655fd-1ff6-48db-bd90-14a4f050b618",
+    "x-ms-request-id": "e97483a0-701e-005d-5196-cdee3d000000",
+    "x-ms-version": "2021-08-06"
+   }
+  }
+ ],
+ "uniqueTestInfo": {
+  "uniqueName": {
+   "container": "container166374975723905121",
+   "blob": "blob166374975796809737",
+   "blockblob/0": "blockblob/0166374975827606101",
+   "blockblob/1": "blockblob/1166374975847602159"
+  },
+  "newDate": {}
+ },
+ "hash": "f0f783aeb3fd70fa35d870f4f3db5b80"
 }

--- a/sdk/storage/storage-blob/recordings/browsers/containerclient/recording_listblobflat_with_blobs_encrypted_with_cpk.json
+++ b/sdk/storage/storage-blob/recordings/browsers/containerclient/recording_listblobflat_with_blobs_encrypted_with_cpk.json
@@ -2,7 +2,7 @@
  "recordings": [
   {
    "method": "PUT",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container157003457573408060",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container166375027827100032",
    "query": {
     "restype": "container"
    },
@@ -10,86 +10,88 @@
    "status": 201,
    "response": "",
    "responseHeaders": {
-    "date": "Wed, 02 Oct 2019 16:42:55 GMT",
-    "last-modified": "Wed, 02 Oct 2019 16:42:55 GMT",
+    "content-length": "0",
+    "date": "Wed, 21 Sep 2022 08:51:17 GMT",
+    "etag": "\"0x8DA9BAE733B7E3D\"",
+    "last-modified": "Wed, 21 Sep 2022 08:51:18 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-    "etag": "\"0x8D7475793407985\"",
-    "x-ms-request-id": "215f5e5a-201e-0080-0440-7993dc000000",
-    "x-ms-version": "2019-02-02",
-    "x-ms-client-request-id": "9d34848d-a94b-44a9-b06d-59cd4f5b297f",
-    "content-length": "0"
+    "x-ms-client-request-id": "e9b2eb80-d169-48e3-80a2-044858500d6e",
+    "x-ms-request-id": "8e8ada83-501e-005a-2a97-cd825e000000",
+    "x-ms-version": "2021-08-06"
    }
   },
   {
    "method": "PUT",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container157003457573408060/blockblob%2F0157003457580306272",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container166375027827100032/blockblob/0166375027846609403",
    "query": {},
    "requestBody": "",
    "status": 201,
    "response": "",
    "responseHeaders": {
-    "x-ms-content-crc64": "AAAAAAAAAAA=",
-    "date": "Wed, 02 Oct 2019 16:42:55 GMT",
-    "x-ms-encryption-key-sha256": "3QFFFpRA5+XANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=",
-    "last-modified": "Wed, 02 Oct 2019 16:42:55 GMT",
-    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-    "content-md5": "1B2M2Y8AsgTpgAmY7PhCfg==",
-    "x-ms-request-server-encrypted": "true",
-    "x-ms-request-id": "215f5ea2-201e-0080-3f40-7993dc000000",
-    "x-ms-version": "2019-02-02",
-    "x-ms-client-request-id": "7ec92a58-6546-4807-bb3b-add2bb04fb5d",
     "content-length": "0",
-    "etag": "\"0x8D74757934AC8F9\""
+    "content-md5": "1B2M2Y8AsgTpgAmY7PhCfg==",
+    "date": "Wed, 21 Sep 2022 08:51:18 GMT",
+    "etag": "\"0x8DA9BAE735B37A0\"",
+    "last-modified": "Wed, 21 Sep 2022 08:51:18 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "ffb357a3-ce37-4314-9eb8-ba0501db0e58",
+    "x-ms-content-crc64": "AAAAAAAAAAA=",
+    "x-ms-encryption-key-sha256": "3QFFFpRA5+XANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=",
+    "x-ms-request-id": "8e8ada9c-501e-005a-3c97-cd825e000000",
+    "x-ms-request-server-encrypted": "true",
+    "x-ms-version": "2021-08-06",
+    "x-ms-version-id": "2022-09-21T08:51:18.8319136Z"
    }
   },
   {
    "method": "PUT",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container157003457573408060/blockblob%2F1157003457587303899",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container166375027827100032/blockblob/1166375027867207323",
    "query": {},
    "requestBody": "",
    "status": 201,
    "response": "",
    "responseHeaders": {
-    "x-ms-content-crc64": "AAAAAAAAAAA=",
-    "date": "Wed, 02 Oct 2019 16:42:55 GMT",
-    "x-ms-encryption-key-sha256": "3QFFFpRA5+XANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=",
-    "last-modified": "Wed, 02 Oct 2019 16:42:55 GMT",
-    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-    "content-md5": "1B2M2Y8AsgTpgAmY7PhCfg==",
-    "x-ms-request-server-encrypted": "true",
-    "x-ms-request-id": "215f5edf-201e-0080-7440-7993dc000000",
-    "x-ms-version": "2019-02-02",
-    "x-ms-client-request-id": "79fcdea2-ab33-48f9-bffd-3771d621e35c",
     "content-length": "0",
-    "etag": "\"0x8D747579355C81E\""
+    "content-md5": "1B2M2Y8AsgTpgAmY7PhCfg==",
+    "date": "Wed, 21 Sep 2022 08:51:18 GMT",
+    "etag": "\"0x8DA9BAE737AEFA5\"",
+    "last-modified": "Wed, 21 Sep 2022 08:51:19 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "d1b7cd78-cb26-4f0e-84c4-797a591eec7b",
+    "x-ms-content-crc64": "AAAAAAAAAAA=",
+    "x-ms-encryption-key-sha256": "3QFFFpRA5+XANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=",
+    "x-ms-request-id": "8e8adab6-501e-005a-5497-cd825e000000",
+    "x-ms-request-server-encrypted": "true",
+    "x-ms-version": "2021-08-06",
+    "x-ms-version-id": "2022-09-21T08:51:19.0407855Z"
    }
   },
   {
    "method": "GET",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container157003457573408060",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container166375027827100032",
    "query": {
     "comp": "list",
-    "include": "copy,deleted,metadata,snapshots,uncommittedblobs",
-    "maxresults": "1",
     "prefix": "blockblob",
-    "restype": "container"
+    "maxresults": "1",
+    "restype": "container",
+    "include": "copy,deleted,metadata,snapshots,uncommittedblobs"
    },
    "requestBody": null,
    "status": 200,
-   "response": "<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults ServiceEndpoint=\"https://fakestorageaccount.blob.core.windows.net/\" ContainerName=\"container157003457573408060\"><Prefix>blockblob</Prefix><MaxResults>1</MaxResults><Blobs><Blob><Name>blockblob/0157003457580306272</Name><Properties><Creation-Time>Wed, 02 Oct 2019 16:42:55 GMT</Creation-Time><Last-Modified>Wed, 02 Oct 2019 16:42:55 GMT</Last-Modified><Etag>0x8D74757934AC8F9</Etag><Content-Length>0</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64>AAAAAAAAAAA=</Content-CRC64><Content-MD5>1B2M2Y8AsgTpgAmY7PhCfg==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Cool</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted><CustomerProvidedKeySha256>3QFFFpRA5+XANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=</CustomerProvidedKeySha256><TagCount>0</TagCount></Properties><Metadata Encrypted=\"true\" /></Blob></Blobs><NextMarker>2!100!MDAwMDI5IWJsb2NrYmxvYi8xMTU3MDAzNDU3NTg3MzAzODk5ITAwMDAyOCE5OTk5LTEyLTMxVDIzOjU5OjU5Ljk5OTk5OTlaIQ--</NextMarker></EnumerationResults>",
+   "response": "<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults ServiceEndpoint=\"https://fakestorageaccount.blob.core.windows.net/\" ContainerName=\"container166375027827100032\"><Prefix>blockblob</Prefix><MaxResults>1</MaxResults><Blobs><Blob><Name>blockblob/0166375027846609403</Name><VersionId>2022-09-21T08:51:18.8319136Z</VersionId><IsCurrentVersion>true</IsCurrentVersion><Properties><Creation-Time>Wed, 21 Sep 2022 08:51:18 GMT</Creation-Time><Last-Modified>Wed, 21 Sep 2022 08:51:18 GMT</Last-Modified><Etag>0x8DA9BAE735B37A0</Etag><Content-Length>0</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>1B2M2Y8AsgTpgAmY7PhCfg==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted><CustomerProvidedKeySha256>3QFFFpRA5+XANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=</CustomerProvidedKeySha256></Properties><Metadata Encrypted=\"true\" /><OrMetadata /></Blob></Blobs><NextMarker>2!100!MDAwMDI5IWJsb2NrYmxvYi8xMTY2Mzc1MDI3ODY3MjA3MzIzITAwMDAyOCE5OTk5LTEyLTMxVDIzOjU5OjU5Ljk5OTk5OTlaIQ--</NextMarker></EnumerationResults>",
    "responseHeaders": {
-    "date": "Wed, 02 Oct 2019 16:42:55 GMT",
+    "content-type": "application/xml",
+    "date": "Wed, 21 Sep 2022 08:51:18 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
     "transfer-encoding": "chunked",
-    "content-type": "application/xml",
-    "x-ms-request-id": "215f5f0b-201e-0080-1a40-7993dc000000",
-    "x-ms-version": "2019-02-02",
-    "x-ms-client-request-id": "14e98336-b64a-4a35-98b8-e74bc631d5a7"
+    "x-ms-client-request-id": "e35271b4-19f6-467d-a1e1-d6af1ae31397",
+    "x-ms-request-id": "8e8adad6-501e-005a-7197-cd825e000000",
+    "x-ms-version": "2021-08-06"
    }
   },
   {
    "method": "DELETE",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container157003457573408060",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container166375027827100032",
    "query": {
     "restype": "container"
    },
@@ -97,18 +99,22 @@
    "status": 202,
    "response": "",
    "responseHeaders": {
-    "date": "Wed, 02 Oct 2019 16:42:55 GMT",
+    "content-length": "0",
+    "date": "Wed, 21 Sep 2022 08:51:18 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-    "x-ms-request-id": "215f5f35-201e-0080-4440-7993dc000000",
-    "x-ms-version": "2019-02-02",
-    "x-ms-client-request-id": "8616ee01-df28-481b-9729-7719ebc0641c",
-    "content-length": "0"
+    "x-ms-client-request-id": "0f8ff843-4d82-4d81-9f6f-eab0d872aebc",
+    "x-ms-request-id": "8e8adaf9-501e-005a-1197-cd825e000000",
+    "x-ms-version": "2021-08-06"
    }
   }
  ],
  "uniqueTestInfo": {
-  "container": "container157003457573408060",
-  "blockblob/0": "blockblob/0157003457580306272",
-  "blockblob/1": "blockblob/1157003457587303899"
- }
+  "uniqueName": {
+   "container": "container166375027827100032",
+   "blockblob/0": "blockblob/0166375027846609403",
+   "blockblob/1": "blockblob/1166375027867207323"
+  },
+  "newDate": {}
+ },
+ "hash": "d7b272289cea339515d8419113d8e8cf"
 }

--- a/sdk/storage/storage-blob/recordings/browsers/containerclient/recording_listblobsbyhierarchy_with_all_parameters_configured.json
+++ b/sdk/storage/storage-blob/recordings/browsers/containerclient/recording_listblobsbyhierarchy_with_all_parameters_configured.json
@@ -2,7 +2,7 @@
  "recordings": [
   {
    "method": "PUT",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container157003458010701514",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container166374976976201775",
    "query": {
     "restype": "container"
    },
@@ -10,168 +10,170 @@
    "status": 201,
    "response": "",
    "responseHeaders": {
-    "date": "Wed, 02 Oct 2019 16:42:59 GMT",
-    "last-modified": "Wed, 02 Oct 2019 16:42:59 GMT",
+    "content-length": "0",
+    "date": "Wed, 21 Sep 2022 08:42:50 GMT",
+    "etag": "\"0x8DA9BAD442412F8\"",
+    "last-modified": "Wed, 21 Sep 2022 08:42:50 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-    "etag": "\"0x8D7475795DBC4EB\"",
-    "x-ms-request-id": "215f6cde-201e-0080-5540-7993dc000000",
-    "x-ms-version": "2019-02-02",
-    "x-ms-client-request-id": "3572a3df-40e5-4bc9-a5eb-0e8246c87122",
-    "content-length": "0"
+    "x-ms-client-request-id": "5d403943-73ef-47df-94b6-3ff6a3d0ffff",
+    "x-ms-request-id": "e9749d61-701e-005d-3796-cdee3d000000",
+    "x-ms-version": "2021-08-06"
    }
   },
   {
    "method": "PUT",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container157003458010701514/blockblob0%2F0157003458017609146",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container166374976976201775/blockblob0/0166374976995801101",
    "query": {},
    "requestBody": "",
    "status": 201,
    "response": "",
    "responseHeaders": {
-    "x-ms-content-crc64": "AAAAAAAAAAA=",
-    "date": "Wed, 02 Oct 2019 16:42:59 GMT",
-    "last-modified": "Wed, 02 Oct 2019 16:42:59 GMT",
-    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "content-length": "0",
     "content-md5": "1B2M2Y8AsgTpgAmY7PhCfg==",
-    "etag": "\"0x8D7475795E63672\"",
-    "x-ms-request-id": "215f6d0e-201e-0080-7e40-7993dc000000",
-    "x-ms-version": "2019-02-02",
-    "x-ms-client-request-id": "ca0bc59b-6a94-4da9-a7bb-b812a16c3c14",
+    "date": "Wed, 21 Sep 2022 08:42:50 GMT",
+    "etag": "\"0x8DA9BAD44423F94\"",
+    "last-modified": "Wed, 21 Sep 2022 08:42:50 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "e6882c98-efaa-4748-a66a-5b45aa490ec9",
+    "x-ms-content-crc64": "AAAAAAAAAAA=",
+    "x-ms-request-id": "e9749d97-701e-005d-6396-cdee3d000000",
     "x-ms-request-server-encrypted": "true",
-    "content-length": "0"
+    "x-ms-version": "2021-08-06",
+    "x-ms-version-id": "2022-09-21T08:42:50.3196318Z"
    }
   },
   {
    "method": "PUT",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container157003458010701514/blockblob1%2F1157003458024906759",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container166374976976201775/blockblob1/1166374977015400735",
    "query": {},
    "requestBody": "",
    "status": 201,
    "response": "",
    "responseHeaders": {
-    "x-ms-content-crc64": "AAAAAAAAAAA=",
-    "date": "Wed, 02 Oct 2019 16:42:59 GMT",
-    "last-modified": "Wed, 02 Oct 2019 16:42:59 GMT",
-    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "content-length": "0",
     "content-md5": "1B2M2Y8AsgTpgAmY7PhCfg==",
-    "etag": "\"0x8D7475795F10E72\"",
-    "x-ms-request-id": "215f6d47-201e-0080-3040-7993dc000000",
-    "x-ms-version": "2019-02-02",
-    "x-ms-client-request-id": "8f60a7da-d880-4f05-a690-69736dc5cf5a",
+    "date": "Wed, 21 Sep 2022 08:42:50 GMT",
+    "etag": "\"0x8DA9BAD44604A33\"",
+    "last-modified": "Wed, 21 Sep 2022 08:42:50 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "67837abd-8c98-463a-8fa5-0bec67707359",
+    "x-ms-content-crc64": "AAAAAAAAAAA=",
+    "x-ms-request-id": "e9749dcb-701e-005d-0e96-cdee3d000000",
     "x-ms-request-server-encrypted": "true",
-    "content-length": "0"
+    "x-ms-version": "2021-08-06",
+    "x-ms-version-id": "2022-09-21T08:42:50.5155123Z"
    }
   },
   {
    "method": "GET",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container157003458010701514",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container166374976976201775",
    "query": {
     "comp": "list",
-    "delimiter": "/",
-    "include": "copy,deleted,metadata,uncommittedblobs",
+    "prefix": "blockblob",
     "maxresults": "1",
-    "prefix": "blockblob",
-    "restype": "container"
+    "restype": "container",
+    "include": "copy,deleted,metadata,uncommittedblobs",
+    "delimiter": "/"
    },
    "requestBody": null,
    "status": 200,
-   "response": "<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults ServiceEndpoint=\"https://fakestorageaccount.blob.core.windows.net/\" ContainerName=\"container157003458010701514\"><Prefix>blockblob</Prefix><MaxResults>1</MaxResults><Delimiter>/</Delimiter><Blobs><BlobPrefix><Name>blockblob0/</Name></BlobPrefix></Blobs><NextMarker>2!100!MDAwMDMwIWJsb2NrYmxvYjEvMTE1NzAwMzQ1ODAyNDkwNjc1OSEwMDAwMjghOTk5OS0xMi0zMVQyMzo1OTo1OS45OTk5OTk5WiE-</NextMarker></EnumerationResults>",
+   "response": "<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults ServiceEndpoint=\"https://fakestorageaccount.blob.core.windows.net/\" ContainerName=\"container166374976976201775\"><Prefix>blockblob</Prefix><MaxResults>1</MaxResults><Delimiter>/</Delimiter><Blobs><BlobPrefix><Name>blockblob0/</Name></BlobPrefix></Blobs><NextMarker>2!100!MDAwMDMwIWJsb2NrYmxvYjEvMTE2NjM3NDk3NzAxNTQwMDczNSEwMDAwMjghOTk5OS0xMi0zMVQyMzo1OTo1OS45OTk5OTk5WiE-</NextMarker></EnumerationResults>",
    "responseHeaders": {
-    "date": "Wed, 02 Oct 2019 16:42:59 GMT",
+    "content-type": "application/xml",
+    "date": "Wed, 21 Sep 2022 08:42:50 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
     "transfer-encoding": "chunked",
-    "content-type": "application/xml",
-    "x-ms-request-id": "215f6d89-201e-0080-6e40-7993dc000000",
-    "x-ms-version": "2019-02-02",
-    "x-ms-client-request-id": "540c723b-a9ad-4679-a8a1-49e88f3139cc"
+    "x-ms-client-request-id": "594486db-9d2f-4f6d-bea3-38d5046ca480",
+    "x-ms-request-id": "e9749dfc-701e-005d-3996-cdee3d000000",
+    "x-ms-version": "2021-08-06"
    }
   },
   {
    "method": "GET",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container157003458010701514",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container166374976976201775",
    "query": {
     "comp": "list",
-    "delimiter": "/",
-    "include": "copy,deleted,metadata,uncommittedblobs",
-    "marker": "2!100!MDAwMDMwIWJsb2NrYmxvYjEvMTE1NzAwMzQ1ODAyNDkwNjc1OSEwMDAwMjghOTk5OS0xMi0zMVQyMzo1OTo1OS45OTk5OTk5WiE-",
-    "maxresults": "2",
     "prefix": "blockblob",
-    "restype": "container"
+    "marker": "2!100!MDAwMDMwIWJsb2NrYmxvYjEvMTE2NjM3NDk3NzAxNTQwMDczNSEwMDAwMjghOTk5OS0xMi0zMVQyMzo1OTo1OS45OTk5OTk5WiE-",
+    "maxresults": "2",
+    "restype": "container",
+    "include": "copy,deleted,metadata,uncommittedblobs",
+    "delimiter": "/"
    },
    "requestBody": null,
    "status": 200,
-   "response": "<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults ServiceEndpoint=\"https://fakestorageaccount.blob.core.windows.net/\" ContainerName=\"container157003458010701514\"><Prefix>blockblob</Prefix><Marker>2!100!MDAwMDMwIWJsb2NrYmxvYjEvMTE1NzAwMzQ1ODAyNDkwNjc1OSEwMDAwMjghOTk5OS0xMi0zMVQyMzo1OTo1OS45OTk5OTk5WiE-</Marker><MaxResults>2</MaxResults><Delimiter>/</Delimiter><Blobs><BlobPrefix><Name>blockblob1/</Name></BlobPrefix></Blobs><NextMarker /></EnumerationResults>",
+   "response": "<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults ServiceEndpoint=\"https://fakestorageaccount.blob.core.windows.net/\" ContainerName=\"container166374976976201775\"><Prefix>blockblob</Prefix><Marker>2!100!MDAwMDMwIWJsb2NrYmxvYjEvMTE2NjM3NDk3NzAxNTQwMDczNSEwMDAwMjghOTk5OS0xMi0zMVQyMzo1OTo1OS45OTk5OTk5WiE-</Marker><MaxResults>2</MaxResults><Delimiter>/</Delimiter><Blobs><BlobPrefix><Name>blockblob1/</Name></BlobPrefix></Blobs><NextMarker /></EnumerationResults>",
    "responseHeaders": {
-    "date": "Wed, 02 Oct 2019 16:42:59 GMT",
+    "content-type": "application/xml",
+    "date": "Wed, 21 Sep 2022 08:42:50 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
     "transfer-encoding": "chunked",
-    "content-type": "application/xml",
-    "x-ms-request-id": "215f6dd2-201e-0080-3140-7993dc000000",
-    "x-ms-version": "2019-02-02",
-    "x-ms-client-request-id": "6117025e-a1bc-4cff-ad81-173c51426cb4"
+    "x-ms-client-request-id": "2dea6548-0746-423b-93de-a8dfd0bd4def",
+    "x-ms-request-id": "e9749e3c-701e-005d-6e96-cdee3d000000",
+    "x-ms-version": "2021-08-06"
    }
   },
   {
    "method": "GET",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container157003458010701514",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container166374976976201775",
    "query": {
     "comp": "list",
-    "delimiter": "/",
-    "include": "copy,deleted,metadata,uncommittedblobs",
-    "maxresults": "2",
     "prefix": "blockblob0/",
-    "restype": "container"
+    "maxresults": "2",
+    "restype": "container",
+    "include": "copy,deleted,metadata,uncommittedblobs",
+    "delimiter": "/"
    },
    "requestBody": null,
    "status": 200,
-   "response": "<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults ServiceEndpoint=\"https://fakestorageaccount.blob.core.windows.net/\" ContainerName=\"container157003458010701514\"><Prefix>blockblob0/</Prefix><MaxResults>2</MaxResults><Delimiter>/</Delimiter><Blobs><Blob><Name>blockblob0/0157003458017609146</Name><Properties><Creation-Time>Wed, 02 Oct 2019 16:42:59 GMT</Creation-Time><Last-Modified>Wed, 02 Oct 2019 16:42:59 GMT</Last-Modified><Etag>0x8D7475795E63672</Etag><Content-Length>0</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64>AAAAAAAAAAA=</Content-CRC64><Content-MD5>1B2M2Y8AsgTpgAmY7PhCfg==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Cool</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted><TagCount>0</TagCount></Properties><Metadata><keya>a</keya><keyb>c</keyb></Metadata></Blob></Blobs><NextMarker /></EnumerationResults>",
+   "response": "<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults ServiceEndpoint=\"https://fakestorageaccount.blob.core.windows.net/\" ContainerName=\"container166374976976201775\"><Prefix>blockblob0/</Prefix><MaxResults>2</MaxResults><Delimiter>/</Delimiter><Blobs><Blob><Name>blockblob0/0166374976995801101</Name><VersionId>2022-09-21T08:42:50.3196318Z</VersionId><IsCurrentVersion>true</IsCurrentVersion><Properties><Creation-Time>Wed, 21 Sep 2022 08:42:50 GMT</Creation-Time><Last-Modified>Wed, 21 Sep 2022 08:42:50 GMT</Last-Modified><Etag>0x8DA9BAD44423F94</Etag><Content-Length>0</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>1B2M2Y8AsgTpgAmY7PhCfg==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties><Metadata><keya>a</keya><keyb>c</keyb></Metadata><OrMetadata /></Blob></Blobs><NextMarker /></EnumerationResults>",
    "responseHeaders": {
-    "date": "Wed, 02 Oct 2019 16:43:00 GMT",
+    "content-type": "application/xml",
+    "date": "Wed, 21 Sep 2022 08:42:50 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
     "transfer-encoding": "chunked",
-    "content-type": "application/xml",
-    "x-ms-request-id": "215f6e15-201e-0080-6c40-7993dc000000",
-    "x-ms-version": "2019-02-02",
-    "x-ms-client-request-id": "a40f75e8-105e-412b-ab35-85340e85885c"
+    "x-ms-client-request-id": "058fb017-f92e-4896-a48e-d2c7c4210e68",
+    "x-ms-request-id": "e9749e8e-701e-005d-3696-cdee3d000000",
+    "x-ms-version": "2021-08-06"
    }
   },
   {
    "method": "DELETE",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container157003458010701514/blockblob0%2F0157003458017609146",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container166374976976201775/blockblob0/0166374976995801101",
    "query": {},
    "requestBody": null,
    "status": 202,
    "response": "",
    "responseHeaders": {
-    "date": "Wed, 02 Oct 2019 16:43:00 GMT",
+    "content-length": "0",
+    "date": "Wed, 21 Sep 2022 08:42:51 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "191534e2-5228-4cf4-9d5a-062eb875c406",
     "x-ms-delete-type-permanent": "false",
-    "x-ms-request-id": "215f6e45-201e-0080-1940-7993dc000000",
-    "x-ms-version": "2019-02-02",
-    "x-ms-client-request-id": "8a548341-25cf-431e-99d7-aee4f19aa0b2",
-    "content-length": "0"
+    "x-ms-request-id": "e9749eeb-701e-005d-0596-cdee3d000000",
+    "x-ms-version": "2021-08-06"
    }
   },
   {
    "method": "DELETE",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container157003458010701514/blockblob1%2F1157003458024906759",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container166374976976201775/blockblob1/1166374977015400735",
    "query": {},
    "requestBody": null,
    "status": 202,
    "response": "",
    "responseHeaders": {
-    "date": "Wed, 02 Oct 2019 16:43:00 GMT",
+    "content-length": "0",
+    "date": "Wed, 21 Sep 2022 08:42:51 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "c80b8b7d-b862-4820-a3af-79854fc870c8",
     "x-ms-delete-type-permanent": "false",
-    "x-ms-request-id": "215f6e86-201e-0080-5340-7993dc000000",
-    "x-ms-version": "2019-02-02",
-    "x-ms-client-request-id": "053a66e2-dcfb-4995-8cff-d1b7bb3bd925",
-    "content-length": "0"
+    "x-ms-request-id": "e9749f21-701e-005d-3496-cdee3d000000",
+    "x-ms-version": "2021-08-06"
    }
   },
   {
    "method": "DELETE",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container157003458010701514",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container166374976976201775",
    "query": {
     "restype": "container"
    },
@@ -179,18 +181,22 @@
    "status": 202,
    "response": "",
    "responseHeaders": {
-    "date": "Wed, 02 Oct 2019 16:43:00 GMT",
+    "content-length": "0",
+    "date": "Wed, 21 Sep 2022 08:42:51 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-    "x-ms-request-id": "215f6eb8-201e-0080-0440-7993dc000000",
-    "x-ms-version": "2019-02-02",
-    "x-ms-client-request-id": "3041b93b-b862-4c30-89f2-447d73952ded",
-    "content-length": "0"
+    "x-ms-client-request-id": "07a1bc17-3d8b-4f20-b28f-be8b78966ebd",
+    "x-ms-request-id": "e9749f50-701e-005d-5e96-cdee3d000000",
+    "x-ms-version": "2021-08-06"
    }
   }
  ],
  "uniqueTestInfo": {
-  "container": "container157003458010701514",
-  "blockblob0/0": "blockblob0/0157003458017609146",
-  "blockblob1/1": "blockblob1/1157003458024906759"
- }
+  "uniqueName": {
+   "container": "container166374976976201775",
+   "blockblob0/0": "blockblob0/0166374976995801101",
+   "blockblob1/1": "blockblob1/1166374977015400735"
+  },
+  "newDate": {}
+ },
+ "hash": "a7b298b47f08c30e856e6c06e9f5572b"
 }

--- a/sdk/storage/storage-blob/recordings/browsers/containerclient/recording_listblobsbyhierarchy_with_default_parameters.json
+++ b/sdk/storage/storage-blob/recordings/browsers/containerclient/recording_listblobsbyhierarchy_with_default_parameters.json
@@ -2,7 +2,7 @@
  "recordings": [
   {
    "method": "PUT",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container163764842213702136",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container166374976432208679",
    "query": {
     "restype": "container"
    },
@@ -10,70 +10,85 @@
    "status": 201,
    "response": "",
    "responseHeaders": {
-    "etag": "\"0x8D9AE49549EC21F\"",
-    "last-modified": "Tue, 23 Nov 2021 06:20:22 GMT",
-    "x-ms-client-request-id": "a94d643e-54ec-4626-bca5-e6ffa499cb73",
-    "x-ms-request-id": "e9cb1e45-701e-0001-4432-e02f85000000",
-    "x-ms-version": "2021-02-12"
+    "content-length": "0",
+    "date": "Wed, 21 Sep 2022 08:42:44 GMT",
+    "etag": "\"0x8DA9BAD40E5DBEF\"",
+    "last-modified": "Wed, 21 Sep 2022 08:42:44 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "f32ed586-4fde-410e-8007-ebbe0aa6becb",
+    "x-ms-request-id": "e9749456-701e-005d-4b96-cdee3d000000",
+    "x-ms-version": "2021-08-06"
    }
   },
   {
    "method": "PUT",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container163764842213702136/blockblob0%2F0163764842260905408",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container166374976432208679/blockblob0/0166374976451709060",
    "query": {},
    "requestBody": "",
    "status": 201,
    "response": "",
    "responseHeaders": {
+    "content-length": "0",
     "content-md5": "1B2M2Y8AsgTpgAmY7PhCfg==",
-    "etag": "\"0x8D9AE4954E7D574\"",
-    "last-modified": "Tue, 23 Nov 2021 06:20:22 GMT",
-    "x-ms-client-request-id": "591c0776-3de5-455e-ac38-a3b4131a558f",
+    "date": "Wed, 21 Sep 2022 08:42:44 GMT",
+    "etag": "\"0x8DA9BAD41039C02\"",
+    "last-modified": "Wed, 21 Sep 2022 08:42:44 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "1a981ada-6c24-4362-b9c6-ece3e46f0a25",
     "x-ms-content-crc64": "AAAAAAAAAAA=",
-    "x-ms-request-id": "e9cb1e48-701e-0001-4632-e02f85000000",
-    "x-ms-request-server-encrypted": "false",
-    "x-ms-version": "2021-02-12"
+    "x-ms-request-id": "e97494b4-701e-005d-0996-cdee3d000000",
+    "x-ms-request-server-encrypted": "true",
+    "x-ms-version": "2021-08-06",
+    "x-ms-version-id": "2022-09-21T08:42:44.8759569Z"
    }
   },
   {
    "method": "PUT",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container163764842213702136/blockblob1%2F1163764842308205053",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container166374976432208679/blockblob1/1166374976471006753",
    "query": {},
    "requestBody": "",
    "status": 201,
    "response": "",
    "responseHeaders": {
+    "content-length": "0",
     "content-md5": "1B2M2Y8AsgTpgAmY7PhCfg==",
-    "etag": "\"0x8D9AE49552F8C9D\"",
-    "last-modified": "Tue, 23 Nov 2021 06:20:23 GMT",
-    "x-ms-client-request-id": "50bd0767-8cb4-48d6-8378-cfd2030f1e2e",
+    "date": "Wed, 21 Sep 2022 08:42:44 GMT",
+    "etag": "\"0x8DA9BAD41215890\"",
+    "last-modified": "Wed, 21 Sep 2022 08:42:45 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "c72f5873-e000-4184-b857-30721aa43670",
     "x-ms-content-crc64": "AAAAAAAAAAA=",
-    "x-ms-request-id": "e9cb1e57-701e-0001-5532-e02f85000000",
-    "x-ms-request-server-encrypted": "false",
-    "x-ms-version": "2021-02-12"
+    "x-ms-request-id": "e9749519-701e-005d-5796-cdee3d000000",
+    "x-ms-request-server-encrypted": "true",
+    "x-ms-version": "2021-08-06",
+    "x-ms-version-id": "2022-09-21T08:42:45.0698384Z"
    }
   },
   {
    "method": "PUT",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container163764842213702136/blockblob2%2F2163764842355204991",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container166374976432208679/blockblob2/2166374976490407997",
    "query": {},
    "requestBody": "",
    "status": 201,
    "response": "",
    "responseHeaders": {
+    "content-length": "0",
     "content-md5": "1B2M2Y8AsgTpgAmY7PhCfg==",
-    "etag": "\"0x8D9AE49557792C0\"",
-    "last-modified": "Tue, 23 Nov 2021 06:20:23 GMT",
-    "x-ms-client-request-id": "6803f169-89c9-4aa4-a806-06d97ff8aa8d",
+    "date": "Wed, 21 Sep 2022 08:42:45 GMT",
+    "etag": "\"0x8DA9BAD413F1515\"",
+    "last-modified": "Wed, 21 Sep 2022 08:42:45 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "d80ab957-e866-4a5a-a7fa-adf0b874b495",
     "x-ms-content-crc64": "AAAAAAAAAAA=",
-    "x-ms-request-id": "e9cb1e5d-701e-0001-5b32-e02f85000000",
-    "x-ms-request-server-encrypted": "false",
-    "x-ms-version": "2021-02-12"
+    "x-ms-request-id": "e974958f-701e-005d-2c96-cdee3d000000",
+    "x-ms-request-server-encrypted": "true",
+    "x-ms-version": "2021-08-06",
+    "x-ms-version-id": "2022-09-21T08:42:45.2647189Z"
    }
   },
   {
    "method": "GET",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container163764842213702136",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container166374976432208679",
    "query": {
     "comp": "list",
     "restype": "container",
@@ -81,59 +96,71 @@
    },
    "requestBody": null,
    "status": 200,
-   "response": "<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults ServiceEndpoint=\"https://fakestorageaccount.blob.core.windows.net/\" ContainerName=\"container163764842213702136\"><Delimiter>/</Delimiter><Blobs><BlobPrefix><Name>blockblob0/</Name></BlobPrefix><BlobPrefix><Name>blockblob1/</Name></BlobPrefix><BlobPrefix><Name>blockblob2/</Name></BlobPrefix></Blobs><NextMarker /></EnumerationResults>",
+   "response": "<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults ServiceEndpoint=\"https://fakestorageaccount.blob.core.windows.net/\" ContainerName=\"container166374976432208679\"><Delimiter>/</Delimiter><Blobs><BlobPrefix><Name>blockblob0/</Name></BlobPrefix><BlobPrefix><Name>blockblob1/</Name></BlobPrefix><BlobPrefix><Name>blockblob2/</Name></BlobPrefix></Blobs><NextMarker /></EnumerationResults>",
    "responseHeaders": {
     "content-type": "application/xml",
-    "x-ms-client-request-id": "57f97752-b5fb-4c60-96f1-ee2912ecbec0",
-    "x-ms-request-id": "e9cb1e5f-701e-0001-5d32-e02f85000000",
-    "x-ms-version": "2021-02-12"
+    "date": "Wed, 21 Sep 2022 08:42:45 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "transfer-encoding": "chunked",
+    "x-ms-client-request-id": "6ebd5fe8-df5e-4626-9ee9-9911fd7a0494",
+    "x-ms-request-id": "e97495f3-701e-005d-7196-cdee3d000000",
+    "x-ms-version": "2021-08-06"
    }
   },
   {
    "method": "DELETE",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container163764842213702136/blockblob0%2F0163764842260905408",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container166374976432208679/blockblob0/0166374976451709060",
    "query": {},
    "requestBody": null,
    "status": 202,
    "response": "",
    "responseHeaders": {
-    "x-ms-client-request-id": "281795a4-5cd1-4f36-aee9-320efadb5813",
+    "content-length": "0",
+    "date": "Wed, 21 Sep 2022 08:42:45 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "fd2fd6df-68ce-4f0d-a8be-c3901dd44c82",
     "x-ms-delete-type-permanent": "false",
-    "x-ms-request-id": "e9cb1e68-701e-0001-6532-e02f85000000",
-    "x-ms-version": "2021-02-12"
+    "x-ms-request-id": "e974965c-701e-005d-4696-cdee3d000000",
+    "x-ms-version": "2021-08-06"
    }
   },
   {
    "method": "DELETE",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container163764842213702136/blockblob1%2F1163764842308205053",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container166374976432208679/blockblob1/1166374976471006753",
    "query": {},
    "requestBody": null,
    "status": 202,
    "response": "",
    "responseHeaders": {
-    "x-ms-client-request-id": "0c3b7610-8837-4e6a-8657-d7e27013a0a0",
+    "content-length": "0",
+    "date": "Wed, 21 Sep 2022 08:42:45 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "20a69926-9c94-429f-bf48-fc42fd46f9dc",
     "x-ms-delete-type-permanent": "false",
-    "x-ms-request-id": "e9cb1e77-701e-0001-7432-e02f85000000",
-    "x-ms-version": "2021-02-12"
+    "x-ms-request-id": "e97496d6-701e-005d-1896-cdee3d000000",
+    "x-ms-version": "2021-08-06"
    }
   },
   {
    "method": "DELETE",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container163764842213702136/blockblob2%2F2163764842355204991",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container166374976432208679/blockblob2/2166374976490407997",
    "query": {},
    "requestBody": null,
    "status": 202,
    "response": "",
    "responseHeaders": {
-    "x-ms-client-request-id": "b4387e38-6e5e-4731-9ce6-9c8a245e3923",
+    "content-length": "0",
+    "date": "Wed, 21 Sep 2022 08:42:45 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "31756577-2f5c-403e-ad07-7fc76ba8e315",
     "x-ms-delete-type-permanent": "false",
-    "x-ms-request-id": "e9cb1e79-701e-0001-7632-e02f85000000",
-    "x-ms-version": "2021-02-12"
+    "x-ms-request-id": "e9749732-701e-005d-5896-cdee3d000000",
+    "x-ms-version": "2021-08-06"
    }
   },
   {
    "method": "DELETE",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container163764842213702136",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container166374976432208679",
    "query": {
     "restype": "container"
    },
@@ -141,20 +168,23 @@
    "status": 202,
    "response": "",
    "responseHeaders": {
-    "x-ms-client-request-id": "851f29aa-f913-4404-8c50-223c6dd4ed1d",
-    "x-ms-request-id": "e9cb1e7b-701e-0001-7832-e02f85000000",
-    "x-ms-version": "2021-02-12"
+    "content-length": "0",
+    "date": "Wed, 21 Sep 2022 08:42:46 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "fbfa398a-66c4-4a5d-b386-62b820407d37",
+    "x-ms-request-id": "e97497ab-701e-005d-4296-cdee3d000000",
+    "x-ms-version": "2021-08-06"
    }
   }
  ],
  "uniqueTestInfo": {
   "uniqueName": {
-   "container": "container163764842213702136",
-   "blockblob0/0": "blockblob0/0163764842260905408",
-   "blockblob1/1": "blockblob1/1163764842308205053",
-   "blockblob2/2": "blockblob2/2163764842355204991"
+   "container": "container166374976432208679",
+   "blockblob0/0": "blockblob0/0166374976451709060",
+   "blockblob1/1": "blockblob1/1166374976471006753",
+   "blockblob2/2": "blockblob2/2166374976490407997"
   },
   "newDate": {}
  },
- "hash": "14ddd8852b53ca5367b094b88486574c"
+ "hash": "5a5694e73d4a6a85a1e1ad0d467c7afc"
 }

--- a/sdk/storage/storage-blob/recordings/browsers/containerclient/recording_listblobsbyhierarchy_with_default_parameters__null_prefix_shouldnt_throw_error.json
+++ b/sdk/storage/storage-blob/recordings/browsers/containerclient/recording_listblobsbyhierarchy_with_default_parameters__null_prefix_shouldnt_throw_error.json
@@ -2,7 +2,7 @@
  "recordings": [
   {
    "method": "PUT",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container157437903424901660",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container166374976798505394",
    "query": {
     "restype": "container"
    },
@@ -11,18 +11,18 @@
    "response": "",
    "responseHeaders": {
     "content-length": "0",
-    "date": "Thu, 21 Nov 2019 23:30:33 GMT",
-    "etag": "\"0x8D76EDACE8F9C23\"",
-    "last-modified": "Thu, 21 Nov 2019 23:30:34 GMT",
+    "date": "Wed, 21 Sep 2022 08:42:48 GMT",
+    "etag": "\"0x8DA9BAD4314ED69\"",
+    "last-modified": "Wed, 21 Sep 2022 08:42:48 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-    "x-ms-client-request-id": "1cad425b-ea38-4e5e-a5ea-a74900832c02",
-    "x-ms-request-id": "49f12c1e-b01e-007d-25c3-a00e7c000000",
-    "x-ms-version": "2019-02-02"
+    "x-ms-client-request-id": "0f9501d4-dce4-4227-8fce-35bfa6ef250c",
+    "x-ms-request-id": "e9749ab7-701e-005d-7096-cdee3d000000",
+    "x-ms-version": "2021-08-06"
    }
   },
   {
    "method": "PUT",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container157437903424901660/blockblob0%2F0157437903440404286",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container166374976798505394/blockblob0/0166374976818202816",
    "query": {},
    "requestBody": "",
    "status": 201,
@@ -30,20 +30,21 @@
    "responseHeaders": {
     "content-length": "0",
     "content-md5": "1B2M2Y8AsgTpgAmY7PhCfg==",
-    "date": "Thu, 21 Nov 2019 23:30:33 GMT",
-    "etag": "\"0x8D76EDACE95FD0A\"",
-    "last-modified": "Thu, 21 Nov 2019 23:30:34 GMT",
+    "date": "Wed, 21 Sep 2022 08:42:48 GMT",
+    "etag": "\"0x8DA9BAD43336AEB\"",
+    "last-modified": "Wed, 21 Sep 2022 08:42:48 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-    "x-ms-client-request-id": "4d6a460d-c2fc-4861-a570-9a1decef4368",
+    "x-ms-client-request-id": "400f401c-eb91-4295-9061-3d3f4b1e0b18",
     "x-ms-content-crc64": "AAAAAAAAAAA=",
-    "x-ms-request-id": "49f12c34-b01e-007d-3ac3-a00e7c000000",
+    "x-ms-request-id": "e9749ae2-701e-005d-1696-cdee3d000000",
     "x-ms-request-server-encrypted": "true",
-    "x-ms-version": "2019-02-02"
+    "x-ms-version": "2021-08-06",
+    "x-ms-version-id": "2022-09-21T08:42:48.5437163Z"
    }
   },
   {
    "method": "PUT",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container157437903424901660/blockblob1%2F1157437903443802324",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container166374976798505394/blockblob1/1166374976837904028",
    "query": {},
    "requestBody": "",
    "status": 201,
@@ -51,20 +52,21 @@
    "responseHeaders": {
     "content-length": "0",
     "content-md5": "1B2M2Y8AsgTpgAmY7PhCfg==",
-    "date": "Thu, 21 Nov 2019 23:30:33 GMT",
-    "etag": "\"0x8D76EDACE9A91BE\"",
-    "last-modified": "Thu, 21 Nov 2019 23:30:34 GMT",
+    "date": "Wed, 21 Sep 2022 08:42:48 GMT",
+    "etag": "\"0x8DA9BAD43517588\"",
+    "last-modified": "Wed, 21 Sep 2022 08:42:48 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-    "x-ms-client-request-id": "68ba52c2-69d9-4769-83b2-0f9903925681",
+    "x-ms-client-request-id": "53657f92-74ec-46ea-a332-99be4977e2f4",
     "x-ms-content-crc64": "AAAAAAAAAAA=",
-    "x-ms-request-id": "49f12c42-b01e-007d-46c3-a00e7c000000",
+    "x-ms-request-id": "e9749b16-701e-005d-4896-cdee3d000000",
     "x-ms-request-server-encrypted": "true",
-    "x-ms-version": "2019-02-02"
+    "x-ms-version": "2021-08-06",
+    "x-ms-version-id": "2022-09-21T08:42:48.7405960Z"
    }
   },
   {
    "method": "PUT",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container157437903424901660/blockblob2%2F2157437903446606468",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container166374976798505394/blockblob2/2166374976858207400",
    "query": {},
    "requestBody": "",
    "status": 201,
@@ -72,92 +74,93 @@
    "responseHeaders": {
     "content-length": "0",
     "content-md5": "1B2M2Y8AsgTpgAmY7PhCfg==",
-    "date": "Thu, 21 Nov 2019 23:30:33 GMT",
-    "etag": "\"0x8D76EDACE9E8A16\"",
-    "last-modified": "Thu, 21 Nov 2019 23:30:34 GMT",
+    "date": "Wed, 21 Sep 2022 08:42:48 GMT",
+    "etag": "\"0x8DA9BAD436FF544\"",
+    "last-modified": "Wed, 21 Sep 2022 08:42:48 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-    "x-ms-client-request-id": "57588f8f-2bd1-4fa8-bf42-89a88b0a2990",
+    "x-ms-client-request-id": "0f905553-3a6c-403d-8bc1-a91144c8d2a3",
     "x-ms-content-crc64": "AAAAAAAAAAA=",
-    "x-ms-request-id": "49f12c55-b01e-007d-57c3-a00e7c000000",
+    "x-ms-request-id": "e9749b4f-701e-005d-7d96-cdee3d000000",
     "x-ms-request-server-encrypted": "true",
-    "x-ms-version": "2019-02-02"
+    "x-ms-version": "2021-08-06",
+    "x-ms-version-id": "2022-09-21T08:42:48.9404740Z"
    }
   },
   {
    "method": "GET",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container157437903424901660",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container166374976798505394",
    "query": {
-    "delimiter": "/",
+    "comp": "list",
     "restype": "container",
-    "comp": "list"
+    "delimiter": "/"
    },
    "requestBody": null,
    "status": 200,
-   "response": "<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults ServiceEndpoint=\"https://fakestorageaccount.blob.core.windows.net/\" ContainerName=\"container157437903424901660\"><Delimiter>/</Delimiter><Blobs><BlobPrefix><Name>blockblob0/</Name></BlobPrefix><BlobPrefix><Name>blockblob1/</Name></BlobPrefix><BlobPrefix><Name>blockblob2/</Name></BlobPrefix></Blobs><NextMarker /></EnumerationResults>",
+   "response": "<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults ServiceEndpoint=\"https://fakestorageaccount.blob.core.windows.net/\" ContainerName=\"container166374976798505394\"><Delimiter>/</Delimiter><Blobs><BlobPrefix><Name>blockblob0/</Name></BlobPrefix><BlobPrefix><Name>blockblob1/</Name></BlobPrefix><BlobPrefix><Name>blockblob2/</Name></BlobPrefix></Blobs><NextMarker /></EnumerationResults>",
    "responseHeaders": {
     "content-type": "application/xml",
-    "date": "Thu, 21 Nov 2019 23:30:33 GMT",
+    "date": "Wed, 21 Sep 2022 08:42:49 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
     "transfer-encoding": "chunked",
-    "x-ms-client-request-id": "fe34ce56-c544-45ad-8b8f-34b65a8d8417",
-    "x-ms-request-id": "49f12c5e-b01e-007d-5dc3-a00e7c000000",
-    "x-ms-version": "2019-02-02"
+    "x-ms-client-request-id": "cf78d92b-7897-47ee-b967-a4a021306fc1",
+    "x-ms-request-id": "e9749ba7-701e-005d-4e96-cdee3d000000",
+    "x-ms-version": "2021-08-06"
    }
   },
   {
    "method": "DELETE",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container157437903424901660/blockblob0%2F0157437903440404286",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container166374976798505394/blockblob0/0166374976818202816",
    "query": {},
    "requestBody": null,
    "status": 202,
    "response": "",
    "responseHeaders": {
     "content-length": "0",
-    "date": "Thu, 21 Nov 2019 23:30:33 GMT",
+    "date": "Wed, 21 Sep 2022 08:42:49 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-    "x-ms-client-request-id": "adef9319-3c7e-4436-bf18-8a60a486a5e1",
-    "x-ms-delete-type-permanent": "true",
-    "x-ms-request-id": "49f12c6a-b01e-007d-68c3-a00e7c000000",
-    "x-ms-version": "2019-02-02"
+    "x-ms-client-request-id": "3432da15-1978-4a6d-ace8-1a15a94e34fa",
+    "x-ms-delete-type-permanent": "false",
+    "x-ms-request-id": "e9749c12-701e-005d-2a96-cdee3d000000",
+    "x-ms-version": "2021-08-06"
    }
   },
   {
    "method": "DELETE",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container157437903424901660/blockblob1%2F1157437903443802324",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container166374976798505394/blockblob1/1166374976837904028",
    "query": {},
    "requestBody": null,
    "status": 202,
    "response": "",
    "responseHeaders": {
     "content-length": "0",
-    "date": "Thu, 21 Nov 2019 23:30:33 GMT",
+    "date": "Wed, 21 Sep 2022 08:42:49 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-    "x-ms-client-request-id": "e617afb3-8819-45b0-9ac7-d0fb9195c24c",
-    "x-ms-delete-type-permanent": "true",
-    "x-ms-request-id": "49f12c85-b01e-007d-01c3-a00e7c000000",
-    "x-ms-version": "2019-02-02"
+    "x-ms-client-request-id": "76b19854-e3aa-4014-acb6-f06358c2bdd9",
+    "x-ms-delete-type-permanent": "false",
+    "x-ms-request-id": "e9749c77-701e-005d-0396-cdee3d000000",
+    "x-ms-version": "2021-08-06"
    }
   },
   {
    "method": "DELETE",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container157437903424901660/blockblob2%2F2157437903446606468",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container166374976798505394/blockblob2/2166374976858207400",
    "query": {},
    "requestBody": null,
    "status": 202,
    "response": "",
    "responseHeaders": {
     "content-length": "0",
-    "date": "Thu, 21 Nov 2019 23:30:33 GMT",
+    "date": "Wed, 21 Sep 2022 08:42:49 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-    "x-ms-client-request-id": "317292b5-e80d-4ad8-8712-1f5e2708a384",
-    "x-ms-delete-type-permanent": "true",
-    "x-ms-request-id": "49f12cbb-b01e-007d-32c3-a00e7c000000",
-    "x-ms-version": "2019-02-02"
+    "x-ms-client-request-id": "2541260e-e830-4e9e-906b-543068281cc3",
+    "x-ms-delete-type-permanent": "false",
+    "x-ms-request-id": "e9749c9d-701e-005d-2696-cdee3d000000",
+    "x-ms-version": "2021-08-06"
    }
   },
   {
    "method": "DELETE",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container157437903424901660",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container166374976798505394",
    "query": {
     "restype": "container"
    },
@@ -166,21 +169,22 @@
    "response": "",
    "responseHeaders": {
     "content-length": "0",
-    "date": "Thu, 21 Nov 2019 23:30:33 GMT",
+    "date": "Wed, 21 Sep 2022 08:42:49 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-    "x-ms-client-request-id": "efd3b0c8-068d-4801-8fec-01a148501e7d",
-    "x-ms-request-id": "49f12cd1-b01e-007d-46c3-a00e7c000000",
-    "x-ms-version": "2019-02-02"
+    "x-ms-client-request-id": "2f104036-e6e0-4574-a8f9-0b0fa897a6b8",
+    "x-ms-request-id": "e9749cfd-701e-005d-5c96-cdee3d000000",
+    "x-ms-version": "2021-08-06"
    }
   }
  ],
  "uniqueTestInfo": {
   "uniqueName": {
-   "container": "container157437903424901660",
-   "blockblob0/0": "blockblob0/0157437903440404286",
-   "blockblob1/1": "blockblob1/1157437903443802324",
-   "blockblob2/2": "blockblob2/2157437903446606468"
+   "container": "container166374976798505394",
+   "blockblob0/0": "blockblob0/0166374976818202816",
+   "blockblob1/1": "blockblob1/1166374976837904028",
+   "blockblob2/2": "blockblob2/2166374976858207400"
   },
   "newDate": {}
- }
+ },
+ "hash": "2e69df699514ec2d9a4102dcbf6ae87c"
 }

--- a/sdk/storage/storage-blob/recordings/browsers/containerclient/recording_listblobsbyhierarchy_with_special_chars.json
+++ b/sdk/storage/storage-blob/recordings/browsers/containerclient/recording_listblobsbyhierarchy_with_special_chars.json
@@ -2,7 +2,7 @@
  "recordings": [
   {
    "method": "PUT",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container163841192304309777",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container166374976611207775",
    "query": {
     "restype": "container"
    },
@@ -11,18 +11,18 @@
    "response": "",
    "responseHeaders": {
     "content-length": "0",
-    "date": "Thu, 02 Dec 2021 02:25:23 GMT",
-    "etag": "\"0x8D9B53AFECF3584\"",
-    "last-modified": "Thu, 02 Dec 2021 02:25:23 GMT",
+    "date": "Wed, 21 Sep 2022 08:42:46 GMT",
+    "etag": "\"0x8DA9BAD41F72400\"",
+    "last-modified": "Wed, 21 Sep 2022 08:42:46 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-    "x-ms-client-request-id": "4f485325-6bf7-4430-aa88-bd9bb5862cb8",
-    "x-ms-request-id": "d0cb577d-201e-0022-5923-e721a6000000",
-    "x-ms-version": "2021-02-12"
+    "x-ms-client-request-id": "c8a5e2b6-6a23-40e8-a361-de13d95bbdfe",
+    "x-ms-request-id": "e97497f6-701e-005d-0396-cdee3d000000",
+    "x-ms-version": "2021-08-06"
    }
   },
   {
    "method": "PUT",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container163841192304309777/first_dir%EF%BF%BF%2Ffile%EF%BF%BF.blob",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container166374976611207775/first_dir%EF%BF%BF/file%EF%BF%BF.blob",
    "query": {},
    "requestBody": "",
    "status": 201,
@@ -30,20 +30,21 @@
    "responseHeaders": {
     "content-length": "0",
     "content-md5": "1B2M2Y8AsgTpgAmY7PhCfg==",
-    "date": "Thu, 02 Dec 2021 02:25:23 GMT",
-    "etag": "\"0x8D9B53AFEF09DBA\"",
-    "last-modified": "Thu, 02 Dec 2021 02:25:23 GMT",
+    "date": "Wed, 21 Sep 2022 08:42:46 GMT",
+    "etag": "\"0x8DA9BAD42157D70\"",
+    "last-modified": "Wed, 21 Sep 2022 08:42:46 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-    "x-ms-client-request-id": "4d8a7f59-d952-44e0-8420-0f8d86de189b",
+    "x-ms-client-request-id": "6d5f2cff-4790-4489-812e-54cbac380f2d",
     "x-ms-content-crc64": "AAAAAAAAAAA=",
-    "x-ms-request-id": "d0cb579f-201e-0022-6c23-e721a6000000",
+    "x-ms-request-id": "e9749833-701e-005d-3796-cdee3d000000",
     "x-ms-request-server-encrypted": "true",
-    "x-ms-version": "2021-02-12"
+    "x-ms-version": "2021-08-06",
+    "x-ms-version-id": "2022-09-21T08:42:46.6698608Z"
    }
   },
   {
    "method": "PUT",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container163841192304309777/second_dir%EF%BF%BF%2Ffile%EF%BF%BF.blob",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container166374976611207775/second_dir%EF%BF%BF/file%EF%BF%BF.blob",
    "query": {},
    "requestBody": "",
    "status": 201,
@@ -51,20 +52,21 @@
    "responseHeaders": {
     "content-length": "0",
     "content-md5": "1B2M2Y8AsgTpgAmY7PhCfg==",
-    "date": "Thu, 02 Dec 2021 02:25:23 GMT",
-    "etag": "\"0x8D9B53AFF10CB29\"",
-    "last-modified": "Thu, 02 Dec 2021 02:25:24 GMT",
+    "date": "Wed, 21 Sep 2022 08:42:46 GMT",
+    "etag": "\"0x8DA9BAD42342435\"",
+    "last-modified": "Wed, 21 Sep 2022 08:42:46 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-    "x-ms-client-request-id": "d22b9d70-23fb-4c08-9714-96d358ee6dcf",
+    "x-ms-client-request-id": "793ff680-addd-40c6-989f-42c7e5fe18f5",
     "x-ms-content-crc64": "AAAAAAAAAAA=",
-    "x-ms-request-id": "d0cb57d9-201e-0022-2423-e721a6000000",
+    "x-ms-request-id": "e9749875-701e-005d-7196-cdee3d000000",
     "x-ms-request-server-encrypted": "true",
-    "x-ms-version": "2021-02-12"
+    "x-ms-version": "2021-08-06",
+    "x-ms-version-id": "2022-09-21T08:42:46.8707381Z"
    }
   },
   {
    "method": "PUT",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container163841192304309777/normal_dir%2Ffile%EF%BF%BF.blob",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container166374976611207775/normal_dir/file%EF%BF%BF.blob",
    "query": {},
    "requestBody": "",
    "status": 201,
@@ -72,20 +74,21 @@
    "responseHeaders": {
     "content-length": "0",
     "content-md5": "1B2M2Y8AsgTpgAmY7PhCfg==",
-    "date": "Thu, 02 Dec 2021 02:25:23 GMT",
-    "etag": "\"0x8D9B53AFF2F7229\"",
-    "last-modified": "Thu, 02 Dec 2021 02:25:24 GMT",
+    "date": "Wed, 21 Sep 2022 08:42:46 GMT",
+    "etag": "\"0x8DA9BAD425192AC\"",
+    "last-modified": "Wed, 21 Sep 2022 08:42:47 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-    "x-ms-client-request-id": "f4530d21-542e-447d-8807-33a483cac174",
+    "x-ms-client-request-id": "23eda320-3f13-4aff-a76a-0a88d65eab96",
     "x-ms-content-crc64": "AAAAAAAAAAA=",
-    "x-ms-request-id": "d0cb5804-201e-0022-4723-e721a6000000",
+    "x-ms-request-id": "e97498ae-701e-005d-2896-cdee3d000000",
     "x-ms-request-server-encrypted": "true",
-    "x-ms-version": "2021-02-12"
+    "x-ms-version": "2021-08-06",
+    "x-ms-version-id": "2022-09-21T08:42:47.0636204Z"
    }
   },
   {
    "method": "PUT",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container163841192304309777/first_file%EF%BF%BF.blob",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container166374976611207775/first_file%EF%BF%BF.blob",
    "query": {},
    "requestBody": "",
    "status": 201,
@@ -93,20 +96,21 @@
    "responseHeaders": {
     "content-length": "0",
     "content-md5": "1B2M2Y8AsgTpgAmY7PhCfg==",
-    "date": "Thu, 02 Dec 2021 02:25:24 GMT",
-    "etag": "\"0x8D9B53AFF4E192E\"",
-    "last-modified": "Thu, 02 Dec 2021 02:25:24 GMT",
+    "date": "Wed, 21 Sep 2022 08:42:47 GMT",
+    "etag": "\"0x8DA9BAD426F9D4A\"",
+    "last-modified": "Wed, 21 Sep 2022 08:42:47 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-    "x-ms-client-request-id": "34ec32c7-8f7c-42be-9365-32613defd4e9",
+    "x-ms-client-request-id": "4fa2ded0-c1dc-47db-9af6-0a77bbbf6609",
     "x-ms-content-crc64": "AAAAAAAAAAA=",
-    "x-ms-request-id": "d0cb5826-201e-0022-6523-e721a6000000",
+    "x-ms-request-id": "e97498f5-701e-005d-6b96-cdee3d000000",
     "x-ms-request-server-encrypted": "true",
-    "x-ms-version": "2021-02-12"
+    "x-ms-version": "2021-08-06",
+    "x-ms-version-id": "2022-09-21T08:42:47.2605002Z"
    }
   },
   {
    "method": "PUT",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container163841192304309777/second_file%EF%BF%BF.blob",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container166374976611207775/second_file%EF%BF%BF.blob",
    "query": {},
    "requestBody": "",
    "status": 201,
@@ -114,20 +118,21 @@
    "responseHeaders": {
     "content-length": "0",
     "content-md5": "1B2M2Y8AsgTpgAmY7PhCfg==",
-    "date": "Thu, 02 Dec 2021 02:25:24 GMT",
-    "etag": "\"0x8D9B53AFF6CC033\"",
-    "last-modified": "Thu, 02 Dec 2021 02:25:24 GMT",
+    "date": "Wed, 21 Sep 2022 08:42:47 GMT",
+    "etag": "\"0x8DA9BAD428D80E0\"",
+    "last-modified": "Wed, 21 Sep 2022 08:42:47 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-    "x-ms-client-request-id": "010e3efb-2b8b-4ca8-95ce-53f7a83f84a0",
+    "x-ms-client-request-id": "592df47a-ff11-4cb6-974b-0ce2d6b1c350",
     "x-ms-content-crc64": "AAAAAAAAAAA=",
-    "x-ms-request-id": "d0cb5842-201e-0022-0123-e721a6000000",
+    "x-ms-request-id": "e9749928-701e-005d-1296-cdee3d000000",
     "x-ms-request-server-encrypted": "true",
-    "x-ms-version": "2021-02-12"
+    "x-ms-version": "2021-08-06",
+    "x-ms-version-id": "2022-09-21T08:42:47.4563808Z"
    }
   },
   {
    "method": "PUT",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container163841192304309777/NormalBlob",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container166374976611207775/NormalBlob",
    "query": {},
    "requestBody": "",
    "status": 201,
@@ -135,20 +140,21 @@
    "responseHeaders": {
     "content-length": "0",
     "content-md5": "1B2M2Y8AsgTpgAmY7PhCfg==",
-    "date": "Thu, 02 Dec 2021 02:25:24 GMT",
-    "etag": "\"0x8D9B53AFF8BDC5C\"",
-    "last-modified": "Thu, 02 Dec 2021 02:25:24 GMT",
+    "date": "Wed, 21 Sep 2022 08:42:47 GMT",
+    "etag": "\"0x8DA9BAD42AAC849\"",
+    "last-modified": "Wed, 21 Sep 2022 08:42:47 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-    "x-ms-client-request-id": "fdfa6f0a-15a4-40db-b9dd-3b81ad37081d",
+    "x-ms-client-request-id": "bdca0b43-0130-4e5e-b9d4-1ead6f09463a",
     "x-ms-content-crc64": "AAAAAAAAAAA=",
-    "x-ms-request-id": "d0cb5865-201e-0022-2123-e721a6000000",
+    "x-ms-request-id": "e9749962-701e-005d-3f96-cdee3d000000",
     "x-ms-request-server-encrypted": "true",
-    "x-ms-version": "2021-02-12"
+    "x-ms-version": "2021-08-06",
+    "x-ms-version-id": "2022-09-21T08:42:47.6482633Z"
    }
   },
   {
    "method": "GET",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container163841192304309777",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container166374976611207775",
    "query": {
     "comp": "list",
     "restype": "container",
@@ -156,20 +162,20 @@
    },
    "requestBody": null,
    "status": 200,
-   "response": "<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults ServiceEndpoint=\"https://fakestorageaccount.blob.core.windows.net/\" ContainerName=\"container163841192304309777\"><Delimiter>/</Delimiter><Blobs><Blob><Name>NormalBlob</Name><Properties><Creation-Time>Thu, 02 Dec 2021 02:25:24 GMT</Creation-Time><Last-Modified>Thu, 02 Dec 2021 02:25:24 GMT</Last-Modified><Etag>0x8D9B53AFF8BDC5C</Etag><Content-Length>0</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>1B2M2Y8AsgTpgAmY7PhCfg==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties><OrMetadata /></Blob><BlobPrefix><Name Encoded=\"true\">first_dir%EF%BF%BF%2F</Name></BlobPrefix><Blob><Name Encoded=\"true\">first_file%EF%BF%BF.blob</Name><Properties><Creation-Time>Thu, 02 Dec 2021 02:25:24 GMT</Creation-Time><Last-Modified>Thu, 02 Dec 2021 02:25:24 GMT</Last-Modified><Etag>0x8D9B53AFF4E192E</Etag><Content-Length>0</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>1B2M2Y8AsgTpgAmY7PhCfg==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties><OrMetadata /></Blob><BlobPrefix><Name>normal_dir/</Name></BlobPrefix><BlobPrefix><Name Encoded=\"true\">second_dir%EF%BF%BF%2F</Name></BlobPrefix><Blob><Name Encoded=\"true\">second_file%EF%BF%BF.blob</Name><Properties><Creation-Time>Thu, 02 Dec 2021 02:25:24 GMT</Creation-Time><Last-Modified>Thu, 02 Dec 2021 02:25:24 GMT</Last-Modified><Etag>0x8D9B53AFF6CC033</Etag><Content-Length>0</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>1B2M2Y8AsgTpgAmY7PhCfg==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties><OrMetadata /></Blob></Blobs><NextMarker /></EnumerationResults>",
+   "response": "<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults ServiceEndpoint=\"https://fakestorageaccount.blob.core.windows.net/\" ContainerName=\"container166374976611207775\"><Delimiter>/</Delimiter><Blobs><Blob><Name>NormalBlob</Name><VersionId>2022-09-21T08:42:47.6482633Z</VersionId><IsCurrentVersion>true</IsCurrentVersion><Properties><Creation-Time>Wed, 21 Sep 2022 08:42:47 GMT</Creation-Time><Last-Modified>Wed, 21 Sep 2022 08:42:47 GMT</Last-Modified><Etag>0x8DA9BAD42AAC849</Etag><Content-Length>0</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>1B2M2Y8AsgTpgAmY7PhCfg==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties><OrMetadata /></Blob><BlobPrefix><Name Encoded=\"true\">first_dir%EF%BF%BF%2F</Name></BlobPrefix><Blob><Name Encoded=\"true\">first_file%EF%BF%BF.blob</Name><VersionId>2022-09-21T08:42:47.2605002Z</VersionId><IsCurrentVersion>true</IsCurrentVersion><Properties><Creation-Time>Wed, 21 Sep 2022 08:42:47 GMT</Creation-Time><Last-Modified>Wed, 21 Sep 2022 08:42:47 GMT</Last-Modified><Etag>0x8DA9BAD426F9D4A</Etag><Content-Length>0</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>1B2M2Y8AsgTpgAmY7PhCfg==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties><OrMetadata /></Blob><BlobPrefix><Name>normal_dir/</Name></BlobPrefix><BlobPrefix><Name Encoded=\"true\">second_dir%EF%BF%BF%2F</Name></BlobPrefix><Blob><Name Encoded=\"true\">second_file%EF%BF%BF.blob</Name><VersionId>2022-09-21T08:42:47.4563808Z</VersionId><IsCurrentVersion>true</IsCurrentVersion><Properties><Creation-Time>Wed, 21 Sep 2022 08:42:47 GMT</Creation-Time><Last-Modified>Wed, 21 Sep 2022 08:42:47 GMT</Last-Modified><Etag>0x8DA9BAD428D80E0</Etag><Content-Length>0</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>1B2M2Y8AsgTpgAmY7PhCfg==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties><OrMetadata /></Blob></Blobs><NextMarker /></EnumerationResults>",
    "responseHeaders": {
     "content-type": "application/xml",
-    "date": "Thu, 02 Dec 2021 02:25:24 GMT",
+    "date": "Wed, 21 Sep 2022 08:42:47 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
     "transfer-encoding": "chunked",
-    "x-ms-client-request-id": "24b28dcf-0ca2-4382-9266-c0f1bde477eb",
-    "x-ms-request-id": "d0cb5882-201e-0022-3823-e721a6000000",
-    "x-ms-version": "2021-02-12"
+    "x-ms-client-request-id": "d204a3ce-dfbf-460a-af1e-f9e008d2035c",
+    "x-ms-request-id": "e97499b7-701e-005d-0f96-cdee3d000000",
+    "x-ms-version": "2021-08-06"
    }
   },
   {
    "method": "DELETE",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container163841192304309777",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container166374976611207775",
    "query": {
     "restype": "container"
    },
@@ -178,19 +184,19 @@
    "response": "",
    "responseHeaders": {
     "content-length": "0",
-    "date": "Thu, 02 Dec 2021 02:25:25 GMT",
+    "date": "Wed, 21 Sep 2022 08:42:48 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-    "x-ms-client-request-id": "afa14b93-6fc7-4a27-9285-09cd18803459",
-    "x-ms-request-id": "d0cb5893-201e-0022-4523-e721a6000000",
-    "x-ms-version": "2021-02-12"
+    "x-ms-client-request-id": "f33b240a-3cad-497c-84df-705e038e65a2",
+    "x-ms-request-id": "e9749a3f-701e-005d-0696-cdee3d000000",
+    "x-ms-version": "2021-08-06"
    }
   }
  ],
  "uniqueTestInfo": {
   "uniqueName": {
-   "container": "container163841192304309777"
+   "container": "container166374976611207775"
   },
   "newDate": {}
  },
- "hash": "db6913ea25412bd89dc3495c620e140b"
+ "hash": "e96ca4b9bcb482c036ceca1f4c460de9"
 }

--- a/sdk/storage/storage-blob/recordings/browsers/containerclient/recording_listblobsflat_to_list_uncommitted_blobs.json
+++ b/sdk/storage/storage-blob/recordings/browsers/containerclient/recording_listblobsflat_to_list_uncommitted_blobs.json
@@ -2,7 +2,7 @@
  "recordings": [
   {
    "method": "PUT",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container165103944890400416",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container166374841402003383",
    "query": {
     "restype": "container"
    },
@@ -11,18 +11,18 @@
    "response": "",
    "responseHeaders": {
     "content-length": "0",
-    "date": "Wed, 27 Apr 2022 06:04:09 GMT",
-    "etag": "\"0x8DA2813BEE21D4B\"",
-    "last-modified": "Wed, 27 Apr 2022 06:04:09 GMT",
+    "date": "Wed, 21 Sep 2022 08:20:14 GMT",
+    "etag": "\"0x8DA9BAA1C64F520\"",
+    "last-modified": "Wed, 21 Sep 2022 08:20:14 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-    "x-ms-client-request-id": "e94ec7f3-5531-4975-89aa-9a4a40034679",
-    "x-ms-request-id": "bfdd03f0-a01e-0008-4dfc-599638000000",
-    "x-ms-version": "2021-06-08"
+    "x-ms-client-request-id": "57632f12-2356-4b9f-8eef-90a80622620b",
+    "x-ms-request-id": "e45fdde6-601e-0041-3a92-cdbc5d000000",
+    "x-ms-version": "2021-08-06"
    }
   },
   {
    "method": "PUT",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container165103944890400416/blockblob%2F0165103944952005154",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container166374841402003383/blockblob/0166374841477908907",
    "query": {
     "comp": "block",
     "blockid": "MQ=="
@@ -32,18 +32,18 @@
    "response": "",
    "responseHeaders": {
     "content-length": "0",
-    "date": "Wed, 27 Apr 2022 06:04:09 GMT",
+    "date": "Wed, 21 Sep 2022 08:20:14 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-    "x-ms-client-request-id": "9ace2a73-94f9-4b3b-8ebb-c765808b7cd8",
+    "x-ms-client-request-id": "a68a1f71-82fc-4a7b-99e4-2bc5abe7bde9",
     "x-ms-content-crc64": "7YooR2vuA24=",
-    "x-ms-request-id": "bfdd0453-a01e-0008-1dfc-599638000000",
+    "x-ms-request-id": "e45fde38-601e-0041-0392-cdbc5d000000",
     "x-ms-request-server-encrypted": "true",
-    "x-ms-version": "2021-06-08"
+    "x-ms-version": "2021-08-06"
    }
   },
   {
    "method": "PUT",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container165103944890400416/blockblob%2F1165103944976106409",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container166374841402003383/blockblob/1166374841498303797",
    "query": {
     "comp": "block",
     "blockid": "MQ=="
@@ -53,18 +53,18 @@
    "response": "",
    "responseHeaders": {
     "content-length": "0",
-    "date": "Wed, 27 Apr 2022 06:04:09 GMT",
+    "date": "Wed, 21 Sep 2022 08:20:14 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-    "x-ms-client-request-id": "dca1145b-9f75-487c-9f14-c8da96f8e9ba",
+    "x-ms-client-request-id": "1fba04ef-bb07-47db-97c4-a04aac894052",
     "x-ms-content-crc64": "7YooR2vuA24=",
-    "x-ms-request-id": "bfdd0510-a01e-0008-40fc-599638000000",
+    "x-ms-request-id": "e45fde80-601e-0041-4692-cdbc5d000000",
     "x-ms-request-server-encrypted": "true",
-    "x-ms-version": "2021-06-08"
+    "x-ms-version": "2021-08-06"
    }
   },
   {
    "method": "PUT",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container165103944890400416/blockblob%2F2165103944997502460",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container166374841402003383/blockblob/2166374841518604239",
    "query": {
     "comp": "block",
     "blockid": "MQ=="
@@ -74,18 +74,18 @@
    "response": "",
    "responseHeaders": {
     "content-length": "0",
-    "date": "Wed, 27 Apr 2022 06:04:10 GMT",
+    "date": "Wed, 21 Sep 2022 08:20:15 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-    "x-ms-client-request-id": "8baa378e-c472-4322-8b4f-373f220e4537",
+    "x-ms-client-request-id": "f569721c-1480-4ee1-9367-b3319b7f19e6",
     "x-ms-content-crc64": "7YooR2vuA24=",
-    "x-ms-request-id": "bfdd05ac-a01e-0008-47fc-599638000000",
+    "x-ms-request-id": "e45fdec1-601e-0041-7f92-cdbc5d000000",
     "x-ms-request-server-encrypted": "true",
-    "x-ms-version": "2021-06-08"
+    "x-ms-version": "2021-08-06"
    }
   },
   {
    "method": "GET",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container165103944890400416",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container166374841402003383",
    "query": {
     "comp": "list",
     "restype": "container",
@@ -93,71 +93,71 @@
    },
    "requestBody": null,
    "status": 200,
-   "response": "<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults ServiceEndpoint=\"https://fakestorageaccount.blob.core.windows.net/\" ContainerName=\"container165103944890400416\"><Blobs><Blob><Name>blockblob/0165103944952005154</Name><Properties><Content-Length>0</Content-Length><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>false</ServerEncrypted></Properties><OrMetadata /></Blob><Blob><Name>blockblob/1165103944976106409</Name><Properties><Content-Length>0</Content-Length><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>false</ServerEncrypted></Properties><OrMetadata /></Blob><Blob><Name>blockblob/2165103944997502460</Name><Properties><Content-Length>0</Content-Length><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>false</ServerEncrypted></Properties><OrMetadata /></Blob></Blobs><NextMarker /></EnumerationResults>",
+   "response": "<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults ServiceEndpoint=\"https://fakestorageaccount.blob.core.windows.net/\" ContainerName=\"container166374841402003383\"><Blobs><Blob><Name>blockblob/0166374841477908907</Name><Properties><Content-Length>0</Content-Length><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>false</ServerEncrypted></Properties><OrMetadata /></Blob><Blob><Name>blockblob/1166374841498303797</Name><Properties><Content-Length>0</Content-Length><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>false</ServerEncrypted></Properties><OrMetadata /></Blob><Blob><Name>blockblob/2166374841518604239</Name><Properties><Content-Length>0</Content-Length><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>false</ServerEncrypted></Properties><OrMetadata /></Blob></Blobs><NextMarker /></EnumerationResults>",
    "responseHeaders": {
     "content-type": "application/xml",
-    "date": "Wed, 27 Apr 2022 06:04:10 GMT",
+    "date": "Wed, 21 Sep 2022 08:20:15 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
     "transfer-encoding": "chunked",
-    "x-ms-client-request-id": "4daa741c-2969-4c03-a632-639559326f79",
-    "x-ms-request-id": "bfdd0651-a01e-0008-5bfc-599638000000",
-    "x-ms-version": "2021-06-08"
+    "x-ms-client-request-id": "c3084991-f9b9-48e0-95d9-d47ee0b38810",
+    "x-ms-request-id": "e45fdf0b-601e-0041-4192-cdbc5d000000",
+    "x-ms-version": "2021-08-06"
    }
   },
   {
    "method": "DELETE",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container165103944890400416/blockblob%2F0165103944952005154",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container166374841402003383/blockblob/0166374841477908907",
    "query": {},
    "requestBody": null,
    "status": 202,
    "response": "",
    "responseHeaders": {
     "content-length": "0",
-    "date": "Wed, 27 Apr 2022 06:04:10 GMT",
+    "date": "Wed, 21 Sep 2022 08:20:15 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-    "x-ms-client-request-id": "78b0b3ee-00af-4d0e-8734-92fd9acaa4c1",
+    "x-ms-client-request-id": "2fa0a861-9590-412f-a549-35a185bed5b9",
     "x-ms-delete-type-permanent": "false",
-    "x-ms-request-id": "bfdd06f2-a01e-0008-65fc-599638000000",
-    "x-ms-version": "2021-06-08"
+    "x-ms-request-id": "e45fdf4f-601e-0041-8092-cdbc5d000000",
+    "x-ms-version": "2021-08-06"
    }
   },
   {
    "method": "DELETE",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container165103944890400416/blockblob%2F1165103944976106409",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container166374841402003383/blockblob/1166374841498303797",
    "query": {},
    "requestBody": null,
    "status": 202,
    "response": "",
    "responseHeaders": {
     "content-length": "0",
-    "date": "Wed, 27 Apr 2022 06:04:10 GMT",
+    "date": "Wed, 21 Sep 2022 08:20:15 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-    "x-ms-client-request-id": "9d8c4857-71c5-41c5-a9e7-e329a350a0d2",
+    "x-ms-client-request-id": "8f5069a8-f96b-4429-913d-8c877e2c841a",
     "x-ms-delete-type-permanent": "false",
-    "x-ms-request-id": "bfdd07af-a01e-0008-0bfc-599638000000",
-    "x-ms-version": "2021-06-08"
+    "x-ms-request-id": "e45fdf92-601e-0041-3e92-cdbc5d000000",
+    "x-ms-version": "2021-08-06"
    }
   },
   {
    "method": "DELETE",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container165103944890400416/blockblob%2F2165103944997502460",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container166374841402003383/blockblob/2166374841518604239",
    "query": {},
    "requestBody": null,
    "status": 202,
    "response": "",
    "responseHeaders": {
     "content-length": "0",
-    "date": "Wed, 27 Apr 2022 06:04:10 GMT",
+    "date": "Wed, 21 Sep 2022 08:20:15 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-    "x-ms-client-request-id": "ca321333-d30d-47fa-86d7-0b19ed16c0c4",
+    "x-ms-client-request-id": "7821ab91-4785-4c72-8290-b99bc6834f85",
     "x-ms-delete-type-permanent": "false",
-    "x-ms-request-id": "bfdd0843-a01e-0008-13fc-599638000000",
-    "x-ms-version": "2021-06-08"
+    "x-ms-request-id": "e45fdfc9-601e-0041-7192-cdbc5d000000",
+    "x-ms-version": "2021-08-06"
    }
   },
   {
    "method": "DELETE",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container165103944890400416",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container166374841402003383",
    "query": {
     "restype": "container"
    },
@@ -166,22 +166,22 @@
    "response": "",
    "responseHeaders": {
     "content-length": "0",
-    "date": "Wed, 27 Apr 2022 06:04:11 GMT",
+    "date": "Wed, 21 Sep 2022 08:20:16 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-    "x-ms-client-request-id": "9bc1d805-b0bd-4df4-8ab2-cdb686788720",
-    "x-ms-request-id": "bfdd08d2-a01e-0008-12fc-599638000000",
-    "x-ms-version": "2021-06-08"
+    "x-ms-client-request-id": "442e54d4-fd67-45fb-a7fe-069c20f6becf",
+    "x-ms-request-id": "e45fe002-601e-0041-2892-cdbc5d000000",
+    "x-ms-version": "2021-08-06"
    }
   }
  ],
  "uniqueTestInfo": {
   "uniqueName": {
-   "container": "container165103944890400416",
-   "blockblob/0": "blockblob/0165103944952005154",
-   "blockblob/1": "blockblob/1165103944976106409",
-   "blockblob/2": "blockblob/2165103944997502460"
+   "container": "container166374841402003383",
+   "blockblob/0": "blockblob/0166374841477908907",
+   "blockblob/1": "blockblob/1166374841498303797",
+   "blockblob/2": "blockblob/2166374841518604239"
   },
   "newDate": {}
  },
- "hash": "f0f7f6b136ec13f3e4d13efee8b68fa5"
+ "hash": "47a27d734b8a8ac617d38b06c3ce3c9b"
 }

--- a/sdk/storage/storage-blob/recordings/browsers/containerclient/recording_listblobsflat_with_all_parameters_configured.json
+++ b/sdk/storage/storage-blob/recordings/browsers/containerclient/recording_listblobsflat_with_all_parameters_configured.json
@@ -2,7 +2,7 @@
  "recordings": [
   {
    "method": "PUT",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container157003457515007119",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container166375027664805620",
    "query": {
     "restype": "container"
    },
@@ -10,142 +10,144 @@
    "status": 201,
    "response": "",
    "responseHeaders": {
-    "date": "Wed, 02 Oct 2019 16:42:54 GMT",
-    "last-modified": "Wed, 02 Oct 2019 16:42:54 GMT",
+    "content-length": "0",
+    "date": "Wed, 21 Sep 2022 08:51:16 GMT",
+    "etag": "\"0x8DA9BAE72444A3A\"",
+    "last-modified": "Wed, 21 Sep 2022 08:51:17 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-    "etag": "\"0x8D7475792E76E3F\"",
-    "x-ms-request-id": "215f5cab-201e-0080-0640-7993dc000000",
-    "x-ms-version": "2019-02-02",
-    "x-ms-client-request-id": "83583039-625f-43b9-bb3a-6adc9262db0f",
-    "content-length": "0"
+    "x-ms-client-request-id": "650315a9-fa9d-4b5a-a819-5abae6c68709",
+    "x-ms-request-id": "8e8ad999-501e-005a-7997-cd825e000000",
+    "x-ms-version": "2021-08-06"
    }
   },
   {
    "method": "PUT",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container157003457515007119/blockblob%2F0157003457523503844",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container166375027664805620/blockblob/0166375027684404209",
    "query": {},
    "requestBody": "",
    "status": 201,
    "response": "",
    "responseHeaders": {
-    "x-ms-content-crc64": "AAAAAAAAAAA=",
-    "date": "Wed, 02 Oct 2019 16:42:54 GMT",
-    "last-modified": "Wed, 02 Oct 2019 16:42:54 GMT",
-    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "content-length": "0",
     "content-md5": "1B2M2Y8AsgTpgAmY7PhCfg==",
-    "etag": "\"0x8D7475792F43004\"",
-    "x-ms-request-id": "215f5ce4-201e-0080-3640-7993dc000000",
-    "x-ms-version": "2019-02-02",
-    "x-ms-client-request-id": "10680334-b538-44f1-9b6c-c19a5d39e5f0",
+    "date": "Wed, 21 Sep 2022 08:51:16 GMT",
+    "etag": "\"0x8DA9BAE726760EF\"",
+    "last-modified": "Wed, 21 Sep 2022 08:51:17 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "cdb0f80b-6d51-4951-9630-3c71a96234a2",
+    "x-ms-content-crc64": "AAAAAAAAAAA=",
+    "x-ms-request-id": "8e8ad9b0-501e-005a-0b97-cd825e000000",
     "x-ms-request-server-encrypted": "true",
-    "content-length": "0"
+    "x-ms-version": "2021-08-06",
+    "x-ms-version-id": "2022-09-21T08:51:17.2348921Z"
    }
   },
   {
    "method": "PUT",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container157003457515007119/blockblob%2F1157003457530507553",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container166375027664805620/blockblob/1166375027707402071",
    "query": {},
    "requestBody": "",
    "status": 201,
    "response": "",
    "responseHeaders": {
-    "x-ms-content-crc64": "AAAAAAAAAAA=",
-    "date": "Wed, 02 Oct 2019 16:42:54 GMT",
-    "last-modified": "Wed, 02 Oct 2019 16:42:55 GMT",
-    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "content-length": "0",
     "content-md5": "1B2M2Y8AsgTpgAmY7PhCfg==",
-    "etag": "\"0x8D7475792FEE0E4\"",
-    "x-ms-request-id": "215f5d21-201e-0080-6a40-7993dc000000",
-    "x-ms-version": "2019-02-02",
-    "x-ms-client-request-id": "7bf016ad-5694-4eea-b469-7e031990708b",
+    "date": "Wed, 21 Sep 2022 08:51:16 GMT",
+    "etag": "\"0x8DA9BAE72854480\"",
+    "last-modified": "Wed, 21 Sep 2022 08:51:17 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "68d779a7-e41c-4699-adb2-48fd31a156bf",
+    "x-ms-content-crc64": "AAAAAAAAAAA=",
+    "x-ms-request-id": "8e8ad9cc-501e-005a-2297-cd825e000000",
     "x-ms-request-server-encrypted": "true",
-    "content-length": "0"
+    "x-ms-version": "2021-08-06",
+    "x-ms-version-id": "2022-09-21T08:51:17.4297728Z"
    }
   },
   {
    "method": "GET",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container157003457515007119",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container166375027664805620",
    "query": {
     "comp": "list",
-    "include": "copy,deleted,metadata,snapshots,uncommittedblobs",
+    "prefix": "blockblob",
     "maxresults": "1",
-    "prefix": "blockblob",
-    "restype": "container"
+    "restype": "container",
+    "include": "copy,deleted,metadata,snapshots,uncommittedblobs"
    },
    "requestBody": null,
    "status": 200,
-   "response": "<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults ServiceEndpoint=\"https://fakestorageaccount.blob.core.windows.net/\" ContainerName=\"container157003457515007119\"><Prefix>blockblob</Prefix><MaxResults>1</MaxResults><Blobs><Blob><Name>blockblob/0157003457523503844</Name><Properties><Creation-Time>Wed, 02 Oct 2019 16:42:54 GMT</Creation-Time><Last-Modified>Wed, 02 Oct 2019 16:42:54 GMT</Last-Modified><Etag>0x8D7475792F43004</Etag><Content-Length>0</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64>AAAAAAAAAAA=</Content-CRC64><Content-MD5>1B2M2Y8AsgTpgAmY7PhCfg==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Cool</AccessTier><AccessTierChangeTime>Wed, 02 Oct 2019 16:42:54 GMT</AccessTierChangeTime><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted><TagCount>0</TagCount></Properties><Metadata><keya>a</keya><keyb>c</keyb></Metadata></Blob></Blobs><NextMarker>2!100!MDAwMDI5IWJsb2NrYmxvYi8xMTU3MDAzNDU3NTMwNTA3NTUzITAwMDAyOCE5OTk5LTEyLTMxVDIzOjU5OjU5Ljk5OTk5OTlaIQ--</NextMarker></EnumerationResults>",
+   "response": "<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults ServiceEndpoint=\"https://fakestorageaccount.blob.core.windows.net/\" ContainerName=\"container166375027664805620\"><Prefix>blockblob</Prefix><MaxResults>1</MaxResults><Blobs><Blob><Name>blockblob/0166375027684404209</Name><VersionId>2022-09-21T08:51:17.2348921Z</VersionId><IsCurrentVersion>true</IsCurrentVersion><Properties><Creation-Time>Wed, 21 Sep 2022 08:51:17 GMT</Creation-Time><Last-Modified>Wed, 21 Sep 2022 08:51:17 GMT</Last-Modified><Etag>0x8DA9BAE726760EF</Etag><Content-Length>0</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>1B2M2Y8AsgTpgAmY7PhCfg==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Cool</AccessTier><AccessTierChangeTime>Wed, 21 Sep 2022 08:51:17 GMT</AccessTierChangeTime><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties><Metadata><keya>a</keya><keyb>c</keyb></Metadata><OrMetadata /></Blob></Blobs><NextMarker>2!100!MDAwMDI5IWJsb2NrYmxvYi8xMTY2Mzc1MDI3NzA3NDAyMDcxITAwMDAyOCE5OTk5LTEyLTMxVDIzOjU5OjU5Ljk5OTk5OTlaIQ--</NextMarker></EnumerationResults>",
    "responseHeaders": {
-    "date": "Wed, 02 Oct 2019 16:42:54 GMT",
+    "content-type": "application/xml",
+    "date": "Wed, 21 Sep 2022 08:51:16 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
     "transfer-encoding": "chunked",
-    "content-type": "application/xml",
-    "x-ms-request-id": "215f5d56-201e-0080-1b40-7993dc000000",
-    "x-ms-version": "2019-02-02",
-    "x-ms-client-request-id": "58e7379e-cd31-4ec8-92c4-efc61fdf69ec"
+    "x-ms-client-request-id": "be17ff92-7670-4b2f-9a7e-5a58c92312a9",
+    "x-ms-request-id": "8e8ad9eb-501e-005a-3e97-cd825e000000",
+    "x-ms-version": "2021-08-06"
    }
   },
   {
    "method": "GET",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container157003457515007119",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container166375027664805620",
    "query": {
     "comp": "list",
-    "include": "copy,deleted,metadata,snapshots,uncommittedblobs",
-    "marker": "2!100!MDAwMDI5IWJsb2NrYmxvYi8xMTU3MDAzNDU3NTMwNTA3NTUzITAwMDAyOCE5OTk5LTEyLTMxVDIzOjU5OjU5Ljk5OTk5OTlaIQ--",
-    "maxresults": "2",
     "prefix": "blockblob",
-    "restype": "container"
+    "marker": "2!100!MDAwMDI5IWJsb2NrYmxvYi8xMTY2Mzc1MDI3NzA3NDAyMDcxITAwMDAyOCE5OTk5LTEyLTMxVDIzOjU5OjU5Ljk5OTk5OTlaIQ--",
+    "maxresults": "2",
+    "restype": "container",
+    "include": "copy,deleted,metadata,snapshots,uncommittedblobs"
    },
    "requestBody": null,
    "status": 200,
-   "response": "<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults ServiceEndpoint=\"https://fakestorageaccount.blob.core.windows.net/\" ContainerName=\"container157003457515007119\"><Prefix>blockblob</Prefix><Marker>2!100!MDAwMDI5IWJsb2NrYmxvYi8xMTU3MDAzNDU3NTMwNTA3NTUzITAwMDAyOCE5OTk5LTEyLTMxVDIzOjU5OjU5Ljk5OTk5OTlaIQ--</Marker><MaxResults>2</MaxResults><Blobs><Blob><Name>blockblob/1157003457530507553</Name><Properties><Creation-Time>Wed, 02 Oct 2019 16:42:55 GMT</Creation-Time><Last-Modified>Wed, 02 Oct 2019 16:42:55 GMT</Last-Modified><Etag>0x8D7475792FEE0E4</Etag><Content-Length>0</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64>AAAAAAAAAAA=</Content-CRC64><Content-MD5>1B2M2Y8AsgTpgAmY7PhCfg==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Cool</AccessTier><AccessTierChangeTime>Wed, 02 Oct 2019 16:42:55 GMT</AccessTierChangeTime><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted><TagCount>0</TagCount></Properties><Metadata><keya>a</keya><keyb>c</keyb></Metadata></Blob></Blobs><NextMarker /></EnumerationResults>",
+   "response": "<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults ServiceEndpoint=\"https://fakestorageaccount.blob.core.windows.net/\" ContainerName=\"container166375027664805620\"><Prefix>blockblob</Prefix><Marker>2!100!MDAwMDI5IWJsb2NrYmxvYi8xMTY2Mzc1MDI3NzA3NDAyMDcxITAwMDAyOCE5OTk5LTEyLTMxVDIzOjU5OjU5Ljk5OTk5OTlaIQ--</Marker><MaxResults>2</MaxResults><Blobs><Blob><Name>blockblob/1166375027707402071</Name><VersionId>2022-09-21T08:51:17.4297728Z</VersionId><IsCurrentVersion>true</IsCurrentVersion><Properties><Creation-Time>Wed, 21 Sep 2022 08:51:17 GMT</Creation-Time><Last-Modified>Wed, 21 Sep 2022 08:51:17 GMT</Last-Modified><Etag>0x8DA9BAE72854480</Etag><Content-Length>0</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>1B2M2Y8AsgTpgAmY7PhCfg==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Cool</AccessTier><AccessTierChangeTime>Wed, 21 Sep 2022 08:51:17 GMT</AccessTierChangeTime><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties><Metadata><keya>a</keya><keyb>c</keyb></Metadata><OrMetadata /></Blob></Blobs><NextMarker /></EnumerationResults>",
    "responseHeaders": {
-    "date": "Wed, 02 Oct 2019 16:42:55 GMT",
+    "content-type": "application/xml",
+    "date": "Wed, 21 Sep 2022 08:51:17 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
     "transfer-encoding": "chunked",
-    "content-type": "application/xml",
-    "x-ms-request-id": "215f5d85-201e-0080-4640-7993dc000000",
-    "x-ms-version": "2019-02-02",
-    "x-ms-client-request-id": "09e4fba1-ea55-4b8a-a887-2da0bb3f7de4"
+    "x-ms-client-request-id": "3c5e88a4-5264-4c7e-b0f2-81e055f99aa6",
+    "x-ms-request-id": "8e8ada05-501e-005a-5497-cd825e000000",
+    "x-ms-version": "2021-08-06"
    }
   },
   {
    "method": "DELETE",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container157003457515007119/blockblob%2F0157003457523503844",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container166375027664805620/blockblob/0166375027684404209",
    "query": {},
    "requestBody": null,
    "status": 202,
    "response": "",
    "responseHeaders": {
-    "date": "Wed, 02 Oct 2019 16:42:55 GMT",
+    "content-length": "0",
+    "date": "Wed, 21 Sep 2022 08:51:17 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "84e1523d-f0bd-4839-bd74-db6c6d4bddbf",
     "x-ms-delete-type-permanent": "false",
-    "x-ms-request-id": "215f5dcb-201e-0080-0340-7993dc000000",
-    "x-ms-version": "2019-02-02",
-    "x-ms-client-request-id": "e99b50d0-d70d-4a4e-9a1f-ab0927285647",
-    "content-length": "0"
+    "x-ms-request-id": "8e8ada14-501e-005a-6297-cd825e000000",
+    "x-ms-version": "2021-08-06"
    }
   },
   {
    "method": "DELETE",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container157003457515007119/blockblob%2F1157003457530507553",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container166375027664805620/blockblob/1166375027707402071",
    "query": {},
    "requestBody": null,
    "status": 202,
    "response": "",
    "responseHeaders": {
-    "date": "Wed, 02 Oct 2019 16:42:55 GMT",
+    "content-length": "0",
+    "date": "Wed, 21 Sep 2022 08:51:17 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "91cebd98-8cae-4cd3-8f0d-ca8439318518",
     "x-ms-delete-type-permanent": "false",
-    "x-ms-request-id": "215f5df9-201e-0080-2c40-7993dc000000",
-    "x-ms-version": "2019-02-02",
-    "x-ms-client-request-id": "4f5d4771-58d9-4bb9-a4b5-dc2f315052ff",
-    "content-length": "0"
+    "x-ms-request-id": "8e8ada2e-501e-005a-7a97-cd825e000000",
+    "x-ms-version": "2021-08-06"
    }
   },
   {
    "method": "DELETE",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container157003457515007119",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container166375027664805620",
    "query": {
     "restype": "container"
    },
@@ -153,18 +155,22 @@
    "status": 202,
    "response": "",
    "responseHeaders": {
-    "date": "Wed, 02 Oct 2019 16:42:55 GMT",
+    "content-length": "0",
+    "date": "Wed, 21 Sep 2022 08:51:17 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-    "x-ms-request-id": "215f5e2c-201e-0080-5940-7993dc000000",
-    "x-ms-version": "2019-02-02",
-    "x-ms-client-request-id": "4c6e8306-a978-4e73-abba-a835019ffbb0",
-    "content-length": "0"
+    "x-ms-client-request-id": "6e2da207-aeb2-41cd-a037-ef5919656fb6",
+    "x-ms-request-id": "8e8ada5d-501e-005a-1197-cd825e000000",
+    "x-ms-version": "2021-08-06"
    }
   }
  ],
  "uniqueTestInfo": {
-  "container": "container157003457515007119",
-  "blockblob/0": "blockblob/0157003457523503844",
-  "blockblob/1": "blockblob/1157003457530507553"
- }
+  "uniqueName": {
+   "container": "container166375027664805620",
+   "blockblob/0": "blockblob/0166375027684404209",
+   "blockblob/1": "blockblob/1166375027707402071"
+  },
+  "newDate": {}
+ },
+ "hash": "93f9c00b7e9bace67c31c26c02331591"
 }

--- a/sdk/storage/storage-blob/recordings/browsers/containerclient/recording_listblobsflat_with_default_parameters.json
+++ b/sdk/storage/storage-blob/recordings/browsers/containerclient/recording_listblobsflat_with_default_parameters.json
@@ -2,7 +2,7 @@
  "recordings": [
   {
    "method": "PUT",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container163764841401705164",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container166374823504300249",
    "query": {
     "restype": "container"
    },
@@ -10,129 +10,156 @@
    "status": 201,
    "response": "",
    "responseHeaders": {
-    "etag": "\"0x8D9AE4950873BF4\"",
-    "last-modified": "Tue, 23 Nov 2021 06:20:15 GMT",
-    "x-ms-client-request-id": "dbe5fd62-bd86-4627-aefd-e7a3b26cdc42",
-    "x-ms-request-id": "e9cb1dd6-701e-0001-5a32-e02f85000000",
-    "x-ms-version": "2021-02-12"
+    "content-length": "0",
+    "date": "Wed, 21 Sep 2022 08:17:15 GMT",
+    "etag": "\"0x8DA9BA9B1B485F9\"",
+    "last-modified": "Wed, 21 Sep 2022 08:17:15 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "69300eba-2e2e-4fa3-b977-1473db173b25",
+    "x-ms-request-id": "74fd9df0-901e-006a-5e92-cd3c91000000",
+    "x-ms-version": "2021-08-06"
    }
   },
   {
    "method": "PUT",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container163764841401705164/blockblob%2F0163764841574609662",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container166374823504300249/blockblob/0166374823578106369",
    "query": {},
    "requestBody": "",
    "status": 201,
    "response": "",
    "responseHeaders": {
+    "content-length": "0",
     "content-md5": "1B2M2Y8AsgTpgAmY7PhCfg==",
-    "etag": "\"0x8D9AE4950D11500\"",
-    "last-modified": "Tue, 23 Nov 2021 06:20:16 GMT",
-    "x-ms-client-request-id": "9d323f8e-59ec-49f1-b814-75e343e1e8dc",
+    "date": "Wed, 21 Sep 2022 08:17:15 GMT",
+    "etag": "\"0x8DA9BA9B1D55BC0\"",
+    "last-modified": "Wed, 21 Sep 2022 08:17:16 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "83b3ad4b-f026-45b7-87ce-6019f470cf2d",
     "x-ms-content-crc64": "AAAAAAAAAAA=",
-    "x-ms-request-id": "e9cb1ddd-701e-0001-6032-e02f85000000",
-    "x-ms-request-server-encrypted": "false",
-    "x-ms-version": "2021-02-12"
+    "x-ms-request-id": "74fd9e5b-901e-006a-1d92-cd3c91000000",
+    "x-ms-request-server-encrypted": "true",
+    "x-ms-version": "2021-08-06",
+    "x-ms-version-id": "2022-09-21T08:17:16.1674688Z"
    }
   },
   {
    "method": "PUT",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container163764841401705164/blockblob%2F1163764841622702101",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container166374823504300249/blockblob/1166374823598605779",
    "query": {},
    "requestBody": "",
    "status": 201,
    "response": "",
    "responseHeaders": {
+    "content-length": "0",
     "content-md5": "1B2M2Y8AsgTpgAmY7PhCfg==",
-    "etag": "\"0x8D9AE495119B6CB\"",
-    "last-modified": "Tue, 23 Nov 2021 06:20:16 GMT",
-    "x-ms-client-request-id": "d540aacd-9e7a-49ae-a925-c4679d314675",
+    "date": "Wed, 21 Sep 2022 08:17:16 GMT",
+    "etag": "\"0x8DA9BA9B1F38D69\"",
+    "last-modified": "Wed, 21 Sep 2022 08:17:16 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "6fe037ce-616e-48e2-b604-ac97e4bd1f06",
     "x-ms-content-crc64": "AAAAAAAAAAA=",
-    "x-ms-request-id": "e9cb1de9-701e-0001-6c32-e02f85000000",
-    "x-ms-request-server-encrypted": "false",
-    "x-ms-version": "2021-02-12"
+    "x-ms-request-id": "74fd9e78-901e-006a-3792-cd3c91000000",
+    "x-ms-request-server-encrypted": "true",
+    "x-ms-version": "2021-08-06",
+    "x-ms-version-id": "2022-09-21T08:17:16.3653481Z"
    }
   },
   {
    "method": "PUT",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container163764841401705164/blockblob%2F2163764841672607543",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container166374823504300249/blockblob/2166374823618701256",
    "query": {},
    "requestBody": "",
    "status": 201,
    "response": "",
    "responseHeaders": {
+    "content-length": "0",
     "content-md5": "1B2M2Y8AsgTpgAmY7PhCfg==",
-    "etag": "\"0x8D9AE4951669E53\"",
-    "last-modified": "Tue, 23 Nov 2021 06:20:17 GMT",
-    "x-ms-client-request-id": "d64045e1-f8aa-4572-8764-6b90ff623631",
+    "date": "Wed, 21 Sep 2022 08:17:16 GMT",
+    "etag": "\"0x8DA9BA9B212A941\"",
+    "last-modified": "Wed, 21 Sep 2022 08:17:16 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "8fec9d2b-d3e2-497c-9fb4-9088b0fddfb6",
     "x-ms-content-crc64": "AAAAAAAAAAA=",
-    "x-ms-request-id": "e9cb1df1-701e-0001-7432-e02f85000000",
-    "x-ms-request-server-encrypted": "false",
-    "x-ms-version": "2021-02-12"
+    "x-ms-request-id": "74fd9ea4-901e-006a-5b92-cd3c91000000",
+    "x-ms-request-server-encrypted": "true",
+    "x-ms-version": "2021-08-06",
+    "x-ms-version-id": "2022-09-21T08:17:16.5692225Z"
    }
   },
   {
    "method": "GET",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container163764841401705164",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container166374823504300249",
    "query": {
     "comp": "list",
     "restype": "container"
    },
    "requestBody": null,
    "status": 200,
-   "response": "<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults ServiceEndpoint=\"https://fakestorageaccount.blob.core.windows.net/\" ContainerName=\"container163764841401705164\"><Blobs><Blob><Name>blockblob/0163764841574609662</Name><Properties><Creation-Time>Tue, 23 Nov 2021 06:20:16 GMT</Creation-Time><Last-Modified>Tue, 23 Nov 2021 06:20:16 GMT</Last-Modified><Etag>0x8D9AE4950D11500</Etag><Content-Length>0</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>1B2M2Y8AsgTpgAmY7PhCfg==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>false</ServerEncrypted></Properties><OrMetadata /></Blob><Blob><Name>blockblob/1163764841622702101</Name><Properties><Creation-Time>Tue, 23 Nov 2021 06:20:16 GMT</Creation-Time><Last-Modified>Tue, 23 Nov 2021 06:20:16 GMT</Last-Modified><Etag>0x8D9AE495119B6CB</Etag><Content-Length>0</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>1B2M2Y8AsgTpgAmY7PhCfg==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>false</ServerEncrypted></Properties><OrMetadata /></Blob><Blob><Name>blockblob/2163764841672607543</Name><Properties><Creation-Time>Tue, 23 Nov 2021 06:20:17 GMT</Creation-Time><Last-Modified>Tue, 23 Nov 2021 06:20:17 GMT</Last-Modified><Etag>0x8D9AE4951669E53</Etag><Content-Length>0</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>1B2M2Y8AsgTpgAmY7PhCfg==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>false</ServerEncrypted></Properties><OrMetadata /></Blob></Blobs><NextMarker /></EnumerationResults>",
+   "response": "<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults ServiceEndpoint=\"https://fakestorageaccount.blob.core.windows.net/\" ContainerName=\"container166374823504300249\"><Blobs><Blob><Name>blockblob/0166374823578106369</Name><VersionId>2022-09-21T08:17:16.1674688Z</VersionId><IsCurrentVersion>true</IsCurrentVersion><Properties><Creation-Time>Wed, 21 Sep 2022 08:17:16 GMT</Creation-Time><Last-Modified>Wed, 21 Sep 2022 08:17:16 GMT</Last-Modified><Etag>0x8DA9BA9B1D55BC0</Etag><Content-Length>0</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>1B2M2Y8AsgTpgAmY7PhCfg==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties><OrMetadata /></Blob><Blob><Name>blockblob/1166374823598605779</Name><VersionId>2022-09-21T08:17:16.3653481Z</VersionId><IsCurrentVersion>true</IsCurrentVersion><Properties><Creation-Time>Wed, 21 Sep 2022 08:17:16 GMT</Creation-Time><Last-Modified>Wed, 21 Sep 2022 08:17:16 GMT</Last-Modified><Etag>0x8DA9BA9B1F38D69</Etag><Content-Length>0</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>1B2M2Y8AsgTpgAmY7PhCfg==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties><OrMetadata /></Blob><Blob><Name>blockblob/2166374823618701256</Name><VersionId>2022-09-21T08:17:16.5692225Z</VersionId><IsCurrentVersion>true</IsCurrentVersion><Properties><Creation-Time>Wed, 21 Sep 2022 08:17:16 GMT</Creation-Time><Last-Modified>Wed, 21 Sep 2022 08:17:16 GMT</Last-Modified><Etag>0x8DA9BA9B212A941</Etag><Content-Length>0</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>1B2M2Y8AsgTpgAmY7PhCfg==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties><OrMetadata /></Blob></Blobs><NextMarker /></EnumerationResults>",
    "responseHeaders": {
     "content-type": "application/xml",
-    "x-ms-client-request-id": "4108b06a-b2f8-4168-9d05-73386c5baff2",
-    "x-ms-request-id": "e9cb1df3-701e-0001-7632-e02f85000000",
-    "x-ms-version": "2021-02-12"
+    "date": "Wed, 21 Sep 2022 08:17:16 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "transfer-encoding": "chunked",
+    "x-ms-client-request-id": "7944ea65-70d8-4859-937c-5550eb998f35",
+    "x-ms-request-id": "74fd9ecd-901e-006a-7992-cd3c91000000",
+    "x-ms-version": "2021-08-06"
    }
   },
   {
    "method": "DELETE",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container163764841401705164/blockblob%2F0163764841574609662",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container166374823504300249/blockblob/0166374823578106369",
    "query": {},
    "requestBody": null,
    "status": 202,
    "response": "",
    "responseHeaders": {
-    "x-ms-client-request-id": "1ba81079-8a52-4f93-8cd2-89736cb1f97e",
+    "content-length": "0",
+    "date": "Wed, 21 Sep 2022 08:17:16 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "52f7a3d8-db8f-45d8-b992-e49ce19c18da",
     "x-ms-delete-type-permanent": "false",
-    "x-ms-request-id": "e9cb1dff-701e-0001-0232-e02f85000000",
-    "x-ms-version": "2021-02-12"
+    "x-ms-request-id": "74fd9f23-901e-006a-3f92-cd3c91000000",
+    "x-ms-version": "2021-08-06"
    }
   },
   {
    "method": "DELETE",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container163764841401705164/blockblob%2F1163764841622702101",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container166374823504300249/blockblob/1166374823598605779",
    "query": {},
    "requestBody": null,
    "status": 202,
    "response": "",
    "responseHeaders": {
-    "x-ms-client-request-id": "4462a5c5-189e-4eb9-9143-c09d591813f9",
+    "content-length": "0",
+    "date": "Wed, 21 Sep 2022 08:17:17 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "b02cd65b-565d-4212-97b3-f0017c5e04ca",
     "x-ms-delete-type-permanent": "false",
-    "x-ms-request-id": "e9cb1e0b-701e-0001-0d32-e02f85000000",
-    "x-ms-version": "2021-02-12"
+    "x-ms-request-id": "74fd9f4a-901e-006a-6392-cd3c91000000",
+    "x-ms-version": "2021-08-06"
    }
   },
   {
    "method": "DELETE",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container163764841401705164/blockblob%2F2163764841672607543",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container166374823504300249/blockblob/2166374823618701256",
    "query": {},
    "requestBody": null,
    "status": 202,
    "response": "",
    "responseHeaders": {
-    "x-ms-client-request-id": "491f2604-2c4e-4806-8880-3dfd9e6440c5",
+    "content-length": "0",
+    "date": "Wed, 21 Sep 2022 08:17:17 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "19833a86-d1e7-41a0-8739-e116790c0300",
     "x-ms-delete-type-permanent": "false",
-    "x-ms-request-id": "e9cb1e0d-701e-0001-0f32-e02f85000000",
-    "x-ms-version": "2021-02-12"
+    "x-ms-request-id": "74fd9f67-901e-006a-7b92-cd3c91000000",
+    "x-ms-version": "2021-08-06"
    }
   },
   {
    "method": "DELETE",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container163764841401705164",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container166374823504300249",
    "query": {
     "restype": "container"
    },
@@ -140,20 +167,23 @@
    "status": 202,
    "response": "",
    "responseHeaders": {
-    "x-ms-client-request-id": "cc218ea0-94d9-43e8-be02-412f7cf6bb20",
-    "x-ms-request-id": "e9cb1e12-701e-0001-1432-e02f85000000",
-    "x-ms-version": "2021-02-12"
+    "content-length": "0",
+    "date": "Wed, 21 Sep 2022 08:17:17 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "bb0cd9fe-cb79-4fa7-9da5-5283e93d8851",
+    "x-ms-request-id": "74fd9f8e-901e-006a-1f92-cd3c91000000",
+    "x-ms-version": "2021-08-06"
    }
   }
  ],
  "uniqueTestInfo": {
   "uniqueName": {
-   "container": "container163764841401705164",
-   "blockblob/0": "blockblob/0163764841574609662",
-   "blockblob/1": "blockblob/1163764841622702101",
-   "blockblob/2": "blockblob/2163764841672607543"
+   "container": "container166374823504300249",
+   "blockblob/0": "blockblob/0166374823578106369",
+   "blockblob/1": "blockblob/1166374823598605779",
+   "blockblob/2": "blockblob/2166374823618701256"
   },
   "newDate": {}
  },
- "hash": "0f944e98863a215eb39673f7ff3bc263"
+ "hash": "28c25d94529d4f5ef41872ff9788c0e7"
 }

--- a/sdk/storage/storage-blob/recordings/browsers/containerclient/recording_listblobsflat_with_default_parameters__null_prefix_shouldnt_throw_error.json
+++ b/sdk/storage/storage-blob/recordings/browsers/containerclient/recording_listblobsflat_with_default_parameters__null_prefix_shouldnt_throw_error.json
@@ -2,7 +2,7 @@
  "recordings": [
   {
    "method": "PUT",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container157437876614103982",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container166375027414904832",
    "query": {
     "restype": "container"
    },
@@ -11,18 +11,18 @@
    "response": "",
    "responseHeaders": {
     "content-length": "0",
-    "date": "Thu, 21 Nov 2019 23:26:05 GMT",
-    "etag": "\"0x8D76EDA2EB8B14F\"",
-    "last-modified": "Thu, 21 Nov 2019 23:26:06 GMT",
+    "date": "Wed, 21 Sep 2022 08:51:14 GMT",
+    "etag": "\"0x8DA9BAE7119158C\"",
+    "last-modified": "Wed, 21 Sep 2022 08:51:15 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-    "x-ms-client-request-id": "482bee37-5c9d-4985-bdca-1b9cbe2ccc87",
-    "x-ms-request-id": "4c1a0726-901e-008e-52c3-a0a9e9000000",
-    "x-ms-version": "2019-02-02"
+    "x-ms-client-request-id": "364523ec-3bb4-4c11-94c9-d00e0356bf5e",
+    "x-ms-request-id": "8e8ad878-501e-005a-2197-cd825e000000",
+    "x-ms-version": "2021-08-06"
    }
   },
   {
    "method": "PUT",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container157437876614103982/blockblob%2F0157437876623205406",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container166375027414904832/blockblob/0166375027489400816",
    "query": {},
    "requestBody": "",
    "status": 201,
@@ -30,20 +30,21 @@
    "responseHeaders": {
     "content-length": "0",
     "content-md5": "1B2M2Y8AsgTpgAmY7PhCfg==",
-    "date": "Thu, 21 Nov 2019 23:26:05 GMT",
-    "etag": "\"0x8D76EDA2EBF7F4C\"",
-    "last-modified": "Thu, 21 Nov 2019 23:26:06 GMT",
+    "date": "Wed, 21 Sep 2022 08:51:14 GMT",
+    "etag": "\"0x8DA9BAE713A0CB5\"",
+    "last-modified": "Wed, 21 Sep 2022 08:51:15 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-    "x-ms-client-request-id": "69755180-6140-4e81-980b-e0f93786971e",
+    "x-ms-client-request-id": "9183b2f3-7c12-4096-aee4-06238d1306c3",
     "x-ms-content-crc64": "AAAAAAAAAAA=",
-    "x-ms-request-id": "4c1a0738-901e-008e-63c3-a0a9e9000000",
+    "x-ms-request-id": "8e8ad89a-501e-005a-3c97-cd825e000000",
     "x-ms-request-server-encrypted": "true",
-    "x-ms-version": "2019-02-02"
+    "x-ms-version": "2021-08-06",
+    "x-ms-version-id": "2022-09-21T08:51:15.2591029Z"
    }
   },
   {
    "method": "PUT",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container157437876614103982/blockblob%2F1157437876627208350",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container166375027414904832/blockblob/1166375027510008225",
    "query": {},
    "requestBody": "",
    "status": 201,
@@ -51,20 +52,21 @@
    "responseHeaders": {
     "content-length": "0",
     "content-md5": "1B2M2Y8AsgTpgAmY7PhCfg==",
-    "date": "Thu, 21 Nov 2019 23:26:05 GMT",
-    "etag": "\"0x8D76EDA2EC3ECE6\"",
-    "last-modified": "Thu, 21 Nov 2019 23:26:06 GMT",
+    "date": "Wed, 21 Sep 2022 08:51:14 GMT",
+    "etag": "\"0x8DA9BAE71588C6C\"",
+    "last-modified": "Wed, 21 Sep 2022 08:51:15 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-    "x-ms-client-request-id": "23d99293-ea30-44ea-9423-ab1e02b0b0e8",
+    "x-ms-client-request-id": "6f5d34af-0b59-4553-bc07-25f266630fdb",
     "x-ms-content-crc64": "AAAAAAAAAAA=",
-    "x-ms-request-id": "4c1a0744-901e-008e-6fc3-a0a9e9000000",
+    "x-ms-request-id": "8e8ad8c5-501e-005a-5797-cd825e000000",
     "x-ms-request-server-encrypted": "true",
-    "x-ms-version": "2019-02-02"
+    "x-ms-version": "2021-08-06",
+    "x-ms-version-id": "2022-09-21T08:51:15.4589804Z"
    }
   },
   {
    "method": "PUT",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container157437876614103982/blockblob%2F2157437876630002519",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container166375027414904832/blockblob/2166375027530104709",
    "query": {},
    "requestBody": "",
    "status": 201,
@@ -72,91 +74,92 @@
    "responseHeaders": {
     "content-length": "0",
     "content-md5": "1B2M2Y8AsgTpgAmY7PhCfg==",
-    "date": "Thu, 21 Nov 2019 23:26:06 GMT",
-    "etag": "\"0x8D76EDA2ECE4F0A\"",
-    "last-modified": "Thu, 21 Nov 2019 23:26:06 GMT",
+    "date": "Wed, 21 Sep 2022 08:51:14 GMT",
+    "etag": "\"0x8DA9BAE71770C24\"",
+    "last-modified": "Wed, 21 Sep 2022 08:51:15 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-    "x-ms-client-request-id": "0e68149c-4902-45a1-b288-9996cc57e5d3",
+    "x-ms-client-request-id": "1e2e156d-ff56-40cf-b211-c768595a8327",
     "x-ms-content-crc64": "AAAAAAAAAAA=",
-    "x-ms-request-id": "4c1a075c-901e-008e-06c3-a0a9e9000000",
+    "x-ms-request-id": "8e8ad8e7-501e-005a-7797-cd825e000000",
     "x-ms-request-server-encrypted": "true",
-    "x-ms-version": "2019-02-02"
+    "x-ms-version": "2021-08-06",
+    "x-ms-version-id": "2022-09-21T08:51:15.6588580Z"
    }
   },
   {
    "method": "GET",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container157437876614103982",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container166375027414904832",
    "query": {
-    "restype": "container",
-    "comp": "list"
+    "comp": "list",
+    "restype": "container"
    },
    "requestBody": null,
    "status": 200,
-   "response": "<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults ServiceEndpoint=\"https://fakestorageaccount.blob.core.windows.net/\" ContainerName=\"container157437876614103982\"><Blobs><Blob><Name>blockblob/0157437876623205406</Name><Properties><Creation-Time>Thu, 21 Nov 2019 23:26:06 GMT</Creation-Time><Last-Modified>Thu, 21 Nov 2019 23:26:06 GMT</Last-Modified><Etag>0x8D76EDA2EBF7F4C</Etag><Content-Length>0</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>1B2M2Y8AsgTpgAmY7PhCfg==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties></Blob><Blob><Name>blockblob/1157437876627208350</Name><Properties><Creation-Time>Thu, 21 Nov 2019 23:26:06 GMT</Creation-Time><Last-Modified>Thu, 21 Nov 2019 23:26:06 GMT</Last-Modified><Etag>0x8D76EDA2EC3ECE6</Etag><Content-Length>0</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>1B2M2Y8AsgTpgAmY7PhCfg==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties></Blob><Blob><Name>blockblob/2157437876630002519</Name><Properties><Creation-Time>Thu, 21 Nov 2019 23:26:06 GMT</Creation-Time><Last-Modified>Thu, 21 Nov 2019 23:26:06 GMT</Last-Modified><Etag>0x8D76EDA2ECE4F0A</Etag><Content-Length>0</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>1B2M2Y8AsgTpgAmY7PhCfg==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties></Blob></Blobs><NextMarker /></EnumerationResults>",
+   "response": "<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults ServiceEndpoint=\"https://fakestorageaccount.blob.core.windows.net/\" ContainerName=\"container166375027414904832\"><Blobs><Blob><Name>blockblob/0166375027489400816</Name><VersionId>2022-09-21T08:51:15.2591029Z</VersionId><IsCurrentVersion>true</IsCurrentVersion><Properties><Creation-Time>Wed, 21 Sep 2022 08:51:15 GMT</Creation-Time><Last-Modified>Wed, 21 Sep 2022 08:51:15 GMT</Last-Modified><Etag>0x8DA9BAE713A0CB5</Etag><Content-Length>0</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>1B2M2Y8AsgTpgAmY7PhCfg==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties><OrMetadata /></Blob><Blob><Name>blockblob/1166375027510008225</Name><VersionId>2022-09-21T08:51:15.4589804Z</VersionId><IsCurrentVersion>true</IsCurrentVersion><Properties><Creation-Time>Wed, 21 Sep 2022 08:51:15 GMT</Creation-Time><Last-Modified>Wed, 21 Sep 2022 08:51:15 GMT</Last-Modified><Etag>0x8DA9BAE71588C6C</Etag><Content-Length>0</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>1B2M2Y8AsgTpgAmY7PhCfg==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties><OrMetadata /></Blob><Blob><Name>blockblob/2166375027530104709</Name><VersionId>2022-09-21T08:51:15.6588580Z</VersionId><IsCurrentVersion>true</IsCurrentVersion><Properties><Creation-Time>Wed, 21 Sep 2022 08:51:15 GMT</Creation-Time><Last-Modified>Wed, 21 Sep 2022 08:51:15 GMT</Last-Modified><Etag>0x8DA9BAE71770C24</Etag><Content-Length>0</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>1B2M2Y8AsgTpgAmY7PhCfg==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties><OrMetadata /></Blob></Blobs><NextMarker /></EnumerationResults>",
    "responseHeaders": {
     "content-type": "application/xml",
-    "date": "Thu, 21 Nov 2019 23:26:06 GMT",
+    "date": "Wed, 21 Sep 2022 08:51:15 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
     "transfer-encoding": "chunked",
-    "x-ms-client-request-id": "f640c561-c366-4472-acf2-067874977dfd",
-    "x-ms-request-id": "4c1a076b-901e-008e-12c3-a0a9e9000000",
-    "x-ms-version": "2019-02-02"
+    "x-ms-client-request-id": "7db51cc9-97fd-4a1b-bf03-5b14dca0b78e",
+    "x-ms-request-id": "8e8ad8f5-501e-005a-0597-cd825e000000",
+    "x-ms-version": "2021-08-06"
    }
   },
   {
    "method": "DELETE",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container157437876614103982/blockblob%2F0157437876623205406",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container166375027414904832/blockblob/0166375027489400816",
    "query": {},
    "requestBody": null,
    "status": 202,
    "response": "",
    "responseHeaders": {
     "content-length": "0",
-    "date": "Thu, 21 Nov 2019 23:26:06 GMT",
+    "date": "Wed, 21 Sep 2022 08:51:15 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-    "x-ms-client-request-id": "fdf1d591-791b-4fe3-ad6b-3c0b6cb3d181",
-    "x-ms-delete-type-permanent": "true",
-    "x-ms-request-id": "4c1a0773-901e-008e-1ac3-a0a9e9000000",
-    "x-ms-version": "2019-02-02"
+    "x-ms-client-request-id": "72adcac8-7598-4dcc-9840-b1bdec14c8a8",
+    "x-ms-delete-type-permanent": "false",
+    "x-ms-request-id": "8e8ad916-501e-005a-2197-cd825e000000",
+    "x-ms-version": "2021-08-06"
    }
   },
   {
    "method": "DELETE",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container157437876614103982/blockblob%2F1157437876627208350",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container166375027414904832/blockblob/1166375027510008225",
    "query": {},
    "requestBody": null,
    "status": 202,
    "response": "",
    "responseHeaders": {
     "content-length": "0",
-    "date": "Thu, 21 Nov 2019 23:26:06 GMT",
+    "date": "Wed, 21 Sep 2022 08:51:15 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-    "x-ms-client-request-id": "41d2dbe2-c09b-45ae-9cfa-eaed79b7ff94",
-    "x-ms-delete-type-permanent": "true",
-    "x-ms-request-id": "4c1a0788-901e-008e-2ac3-a0a9e9000000",
-    "x-ms-version": "2019-02-02"
+    "x-ms-client-request-id": "b0e30e89-50ab-4cf8-a059-37a3673b1f52",
+    "x-ms-delete-type-permanent": "false",
+    "x-ms-request-id": "8e8ad92c-501e-005a-3297-cd825e000000",
+    "x-ms-version": "2021-08-06"
    }
   },
   {
    "method": "DELETE",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container157437876614103982/blockblob%2F2157437876630002519",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container166375027414904832/blockblob/2166375027530104709",
    "query": {},
    "requestBody": null,
    "status": 202,
    "response": "",
    "responseHeaders": {
     "content-length": "0",
-    "date": "Thu, 21 Nov 2019 23:26:06 GMT",
+    "date": "Wed, 21 Sep 2022 08:51:15 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-    "x-ms-client-request-id": "3361b856-c5c5-4aa9-86c0-36aa49648a84",
-    "x-ms-delete-type-permanent": "true",
-    "x-ms-request-id": "4c1a0794-901e-008e-34c3-a0a9e9000000",
-    "x-ms-version": "2019-02-02"
+    "x-ms-client-request-id": "7993dadd-d3e3-41f4-a718-dee888fb369a",
+    "x-ms-delete-type-permanent": "false",
+    "x-ms-request-id": "8e8ad967-501e-005a-4f97-cd825e000000",
+    "x-ms-version": "2021-08-06"
    }
   },
   {
    "method": "DELETE",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container157437876614103982",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container166375027414904832",
    "query": {
     "restype": "container"
    },
@@ -165,21 +168,22 @@
    "response": "",
    "responseHeaders": {
     "content-length": "0",
-    "date": "Thu, 21 Nov 2019 23:26:06 GMT",
+    "date": "Wed, 21 Sep 2022 08:51:16 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-    "x-ms-client-request-id": "f56a3b55-525f-4c75-8238-2e5f20e6b7c1",
-    "x-ms-request-id": "4c1a079d-901e-008e-3dc3-a0a9e9000000",
-    "x-ms-version": "2019-02-02"
+    "x-ms-client-request-id": "47998cce-27f6-4107-9a60-286741831487",
+    "x-ms-request-id": "8e8ad97d-501e-005a-6197-cd825e000000",
+    "x-ms-version": "2021-08-06"
    }
   }
  ],
  "uniqueTestInfo": {
   "uniqueName": {
-   "container": "container157437876614103982",
-   "blockblob/0": "blockblob/0157437876623205406",
-   "blockblob/1": "blockblob/1157437876627208350",
-   "blockblob/2": "blockblob/2157437876630002519"
+   "container": "container166375027414904832",
+   "blockblob/0": "blockblob/0166375027489400816",
+   "blockblob/1": "blockblob/1166375027510008225",
+   "blockblob/2": "blockblob/2166375027530104709"
   },
   "newDate": {}
- }
+ },
+ "hash": "c5f14b9d454c10acfb5d7159d1192756"
 }

--- a/sdk/storage/storage-blob/recordings/browsers/containerclient/recording_listblobsflat_with_special_chars.json
+++ b/sdk/storage/storage-blob/recordings/browsers/containerclient/recording_listblobsflat_with_special_chars.json
@@ -2,7 +2,7 @@
  "recordings": [
   {
    "method": "PUT",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container163764841978802417",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container166374841641208247",
    "query": {
     "restype": "container"
    },
@@ -10,65 +10,61 @@
    "status": 201,
    "response": "",
    "responseHeaders": {
-    "etag": "\"0x8D9AE49533804A7\"",
-    "last-modified": "Tue, 23 Nov 2021 06:20:20 GMT",
-    "x-ms-client-request-id": "de20f9c0-0c88-4530-b0b6-f70de5582ca8",
-    "x-ms-request-id": "e9cb1e25-701e-0001-2732-e02f85000000",
-    "x-ms-version": "2021-02-12"
+    "content-length": "0",
+    "date": "Wed, 21 Sep 2022 08:20:16 GMT",
+    "etag": "\"0x8DA9BAA1D7E2B16\"",
+    "last-modified": "Wed, 21 Sep 2022 08:20:16 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "8e41bdac-4ccb-4115-bc3c-c150764d75c9",
+    "x-ms-request-id": "e45fe0b1-601e-0041-6e92-cdbc5d000000",
+    "x-ms-version": "2021-08-06"
    }
   },
   {
    "method": "PUT",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container163764841978802417/dir1%2Fdir2%2Ffile%EF%BF%BF.blob",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container166374841641208247/dir1/dir2/file%EF%BF%BF.blob",
    "query": {},
    "requestBody": "",
    "status": 201,
    "response": "",
    "responseHeaders": {
+    "content-length": "0",
     "content-md5": "1B2M2Y8AsgTpgAmY7PhCfg==",
-    "etag": "\"0x8D9AE495380F7F0\"",
-    "last-modified": "Tue, 23 Nov 2021 06:20:20 GMT",
-    "x-ms-client-request-id": "db3a20a5-e9af-45af-8e63-63a8eb41703a",
+    "date": "Wed, 21 Sep 2022 08:20:16 GMT",
+    "etag": "\"0x8DA9BAA1D9D438A\"",
+    "last-modified": "Wed, 21 Sep 2022 08:20:16 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "6b9ef4d6-4a3a-4a7a-942f-62d7082982a3",
     "x-ms-content-crc64": "AAAAAAAAAAA=",
-    "x-ms-request-id": "e9cb1e28-701e-0001-2932-e02f85000000",
-    "x-ms-request-server-encrypted": "false",
-    "x-ms-version": "2021-02-12"
+    "x-ms-request-id": "e45fe0ee-601e-0041-2692-cdbc5d000000",
+    "x-ms-request-server-encrypted": "true",
+    "x-ms-version": "2021-08-06",
+    "x-ms-version-id": "2022-09-21T08:20:16.9937802Z"
    }
   },
   {
    "method": "GET",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container163764841978802417",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container166374841641208247",
    "query": {
     "comp": "list",
     "restype": "container"
    },
    "requestBody": null,
    "status": 200,
-   "response": "<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults ServiceEndpoint=\"https://fakestorageaccount.blob.core.windows.net/\" ContainerName=\"container163764841978802417\"><Blobs><Blob><Name Encoded=\"true\">dir1%2Fdir2%2Ffile%EF%BF%BF.blob</Name><Properties><Creation-Time>Tue, 23 Nov 2021 06:20:20 GMT</Creation-Time><Last-Modified>Tue, 23 Nov 2021 06:20:20 GMT</Last-Modified><Etag>0x8D9AE495380F7F0</Etag><Content-Length>0</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>1B2M2Y8AsgTpgAmY7PhCfg==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>false</ServerEncrypted></Properties><OrMetadata /></Blob></Blobs><NextMarker /></EnumerationResults>",
+   "response": "<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults ServiceEndpoint=\"https://fakestorageaccount.blob.core.windows.net/\" ContainerName=\"container166374841641208247\"><Blobs><Blob><Name Encoded=\"true\">dir1%2Fdir2%2Ffile%EF%BF%BF.blob</Name><VersionId>2022-09-21T08:20:16.9937802Z</VersionId><IsCurrentVersion>true</IsCurrentVersion><Properties><Creation-Time>Wed, 21 Sep 2022 08:20:16 GMT</Creation-Time><Last-Modified>Wed, 21 Sep 2022 08:20:16 GMT</Last-Modified><Etag>0x8DA9BAA1D9D438A</Etag><Content-Length>0</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>1B2M2Y8AsgTpgAmY7PhCfg==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties><OrMetadata /></Blob></Blobs><NextMarker /></EnumerationResults>",
    "responseHeaders": {
     "content-type": "application/xml",
-    "x-ms-client-request-id": "2b99562b-47a9-4a9e-9f6b-239384e3b781",
-    "x-ms-request-id": "e9cb1e2b-701e-0001-2c32-e02f85000000",
-    "x-ms-version": "2021-02-12"
+    "date": "Wed, 21 Sep 2022 08:20:16 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "transfer-encoding": "chunked",
+    "x-ms-client-request-id": "8f05efcd-fa5d-42ec-b614-a394eda56f09",
+    "x-ms-request-id": "e45fe12e-601e-0041-4892-cdbc5d000000",
+    "x-ms-version": "2021-08-06"
    }
   },
   {
    "method": "DELETE",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container163764841978802417/dir1%2Fdir2%2Ffile%EF%BF%BF.blob",
-   "query": {},
-   "requestBody": null,
-   "status": 202,
-   "response": "",
-   "responseHeaders": {
-    "x-ms-client-request-id": "3fb609fc-29fa-4347-9273-daea61354087",
-    "x-ms-delete-type-permanent": "false",
-    "x-ms-request-id": "e9cb1e35-701e-0001-3632-e02f85000000",
-    "x-ms-version": "2021-02-12"
-   }
-  },
-  {
-   "method": "DELETE",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container163764841978802417",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container166374841641208247",
    "query": {
     "restype": "container"
    },
@@ -76,17 +72,20 @@
    "status": 202,
    "response": "",
    "responseHeaders": {
-    "x-ms-client-request-id": "414efdd5-b380-401e-b6d2-3eba09bf16f5",
-    "x-ms-request-id": "e9cb1e43-701e-0001-4232-e02f85000000",
-    "x-ms-version": "2021-02-12"
+    "content-length": "0",
+    "date": "Wed, 21 Sep 2022 08:20:17 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "0d61a082-b31c-4bfb-85c0-43caf678b72b",
+    "x-ms-request-id": "e45fe14b-601e-0041-6292-cdbc5d000000",
+    "x-ms-version": "2021-08-06"
    }
   }
  ],
  "uniqueTestInfo": {
   "uniqueName": {
-   "container": "container163764841978802417"
+   "container": "container166374841641208247"
   },
   "newDate": {}
  },
- "hash": "1f7a3ccbe20a845e20145edc511395c5"
+ "hash": "9c81a85039e283401454fdcd70fc979d"
 }

--- a/sdk/storage/storage-blob/recordings/browsers/containerclient/recording_verify_pagedasynciterableiterator_for_listblobsbyhierarchy.json
+++ b/sdk/storage/storage-blob/recordings/browsers/containerclient/recording_verify_pagedasynciterableiterator_for_listblobsbyhierarchy.json
@@ -2,7 +2,7 @@
  "recordings": [
   {
    "method": "PUT",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container157003458074707000",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container166375028297000813",
    "query": {
     "restype": "container"
    },
@@ -10,269 +10,275 @@
    "status": 201,
    "response": "",
    "responseHeaders": {
-    "date": "Wed, 02 Oct 2019 16:43:00 GMT",
-    "last-modified": "Wed, 02 Oct 2019 16:43:00 GMT",
+    "content-length": "0",
+    "date": "Wed, 21 Sep 2022 08:51:22 GMT",
+    "etag": "\"0x8DA9BAE760901F0\"",
+    "last-modified": "Wed, 21 Sep 2022 08:51:23 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-    "etag": "\"0x8D74757963D5D95\"",
-    "x-ms-request-id": "215f6ef5-201e-0080-4040-7993dc000000",
-    "x-ms-version": "2019-02-02",
-    "x-ms-client-request-id": "e6652012-3da5-49be-bee3-a5e3a690eca8",
-    "content-length": "0"
+    "x-ms-client-request-id": "16f0ddce-0fac-41db-83eb-190db88444d3",
+    "x-ms-request-id": "8e8adcb4-501e-005a-2297-cd825e000000",
+    "x-ms-version": "2021-08-06"
    }
   },
   {
    "method": "PUT",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container157003458074707000/prefix157003458081805678%2Fblockblob1570034580818008160",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container166375028297000813/prefix166375028316700634/blockblob1663750283167030590",
    "query": {},
    "requestBody": "",
    "status": 201,
    "response": "",
    "responseHeaders": {
-    "x-ms-content-crc64": "AAAAAAAAAAA=",
-    "date": "Wed, 02 Oct 2019 16:43:00 GMT",
-    "last-modified": "Wed, 02 Oct 2019 16:43:00 GMT",
-    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "content-length": "0",
     "content-md5": "1B2M2Y8AsgTpgAmY7PhCfg==",
-    "etag": "\"0x8D7475796486AEC\"",
-    "x-ms-request-id": "215f6f16-201e-0080-5d40-7993dc000000",
-    "x-ms-version": "2019-02-02",
-    "x-ms-client-request-id": "b40c725f-f04a-4e46-9e15-f647258371e4",
+    "date": "Wed, 21 Sep 2022 08:51:22 GMT",
+    "etag": "\"0x8DA9BAE7626B89C\"",
+    "last-modified": "Wed, 21 Sep 2022 08:51:23 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "74e04658-0a5a-4a4d-825c-f7ad0e26241d",
+    "x-ms-content-crc64": "AAAAAAAAAAA=",
+    "x-ms-request-id": "8e8adcd1-501e-005a-3b97-cd825e000000",
     "x-ms-request-server-encrypted": "true",
-    "content-length": "0"
+    "x-ms-version": "2021-08-06",
+    "x-ms-version-id": "2022-09-21T08:51:23.5210396Z"
    }
   },
   {
    "method": "PUT",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container157003458074707000/prefix157003458081805678%2Fblockblob1570034580818008161",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container166375028297000813/prefix166375028316700634/blockblob1663750283167030591",
    "query": {},
    "requestBody": "",
    "status": 201,
    "response": "",
    "responseHeaders": {
-    "x-ms-content-crc64": "AAAAAAAAAAA=",
-    "date": "Wed, 02 Oct 2019 16:43:00 GMT",
-    "last-modified": "Wed, 02 Oct 2019 16:43:00 GMT",
-    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "content-length": "0",
     "content-md5": "1B2M2Y8AsgTpgAmY7PhCfg==",
-    "etag": "\"0x8D7475796531BDA\"",
-    "x-ms-request-id": "215f6f42-201e-0080-0540-7993dc000000",
-    "x-ms-version": "2019-02-02",
-    "x-ms-client-request-id": "fc53a291-c0ba-4585-9bb8-a722ef390c44",
+    "date": "Wed, 21 Sep 2022 08:51:23 GMT",
+    "etag": "\"0x8DA9BAE76444E19\"",
+    "last-modified": "Wed, 21 Sep 2022 08:51:23 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "e1fb634c-06d3-45b5-8086-675673cd581f",
+    "x-ms-content-crc64": "AAAAAAAAAAA=",
+    "x-ms-request-id": "8e8adce2-501e-005a-4a97-cd825e000000",
     "x-ms-request-server-encrypted": "true",
-    "content-length": "0"
+    "x-ms-version": "2021-08-06",
+    "x-ms-version-id": "2022-09-21T08:51:23.7149209Z"
    }
   },
   {
    "method": "PUT",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container157003458074707000/prefix157003458081805678%2Fblockblob1570034580818008162",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container166375028297000813/prefix166375028316700634/blockblob1663750283167030592",
    "query": {},
    "requestBody": "",
    "status": 201,
    "response": "",
    "responseHeaders": {
-    "x-ms-content-crc64": "AAAAAAAAAAA=",
-    "date": "Wed, 02 Oct 2019 16:43:00 GMT",
-    "last-modified": "Wed, 02 Oct 2019 16:43:00 GMT",
-    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "content-length": "0",
     "content-md5": "1B2M2Y8AsgTpgAmY7PhCfg==",
-    "etag": "\"0x8D74757965DCCBF\"",
-    "x-ms-request-id": "215f6f6d-201e-0080-2a40-7993dc000000",
-    "x-ms-version": "2019-02-02",
-    "x-ms-client-request-id": "f700b164-aede-4a63-ba08-fcc123ab94ec",
+    "date": "Wed, 21 Sep 2022 08:51:23 GMT",
+    "etag": "\"0x8DA9BAE766258B5\"",
+    "last-modified": "Wed, 21 Sep 2022 08:51:23 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "5e8c9bdd-e7bc-4c2e-9a48-5a7541dc42db",
+    "x-ms-content-crc64": "AAAAAAAAAAA=",
+    "x-ms-request-id": "8e8adcf9-501e-005a-5d97-cd825e000000",
     "x-ms-request-server-encrypted": "true",
-    "content-length": "0"
+    "x-ms-version": "2021-08-06",
+    "x-ms-version-id": "2022-09-21T08:51:23.9127997Z"
    }
   },
   {
    "method": "PUT",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container157003458074707000/prefix157003458081805678%2Fblockblob1570034580818008163",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container166375028297000813/prefix166375028316700634/blockblob1663750283167030593",
    "query": {},
    "requestBody": "",
    "status": 201,
    "response": "",
    "responseHeaders": {
-    "x-ms-content-crc64": "AAAAAAAAAAA=",
-    "date": "Wed, 02 Oct 2019 16:43:00 GMT",
-    "last-modified": "Wed, 02 Oct 2019 16:43:00 GMT",
-    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "content-length": "0",
     "content-md5": "1B2M2Y8AsgTpgAmY7PhCfg==",
-    "etag": "\"0x8D7475796687DA8\"",
-    "x-ms-request-id": "215f6f98-201e-0080-5440-7993dc000000",
-    "x-ms-version": "2019-02-02",
-    "x-ms-client-request-id": "a667bd3f-6631-4d25-91f2-ca9bddf19b8b",
+    "date": "Wed, 21 Sep 2022 08:51:23 GMT",
+    "etag": "\"0x8DA9BAE76808A55\"",
+    "last-modified": "Wed, 21 Sep 2022 08:51:24 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "7278f1cd-c999-4fff-b609-d247473523b4",
+    "x-ms-content-crc64": "AAAAAAAAAAA=",
+    "x-ms-request-id": "8e8add0f-501e-005a-7397-cd825e000000",
     "x-ms-request-server-encrypted": "true",
-    "content-length": "0"
+    "x-ms-version": "2021-08-06",
+    "x-ms-version-id": "2022-09-21T08:51:24.1096789Z"
    }
   },
   {
    "method": "PUT",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container157003458074707000/prefix157003458081805678%2Fblockblob1570034580818008164",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container166375028297000813/prefix166375028316700634/blockblob1663750283167030594",
    "query": {},
    "requestBody": "",
    "status": 201,
    "response": "",
    "responseHeaders": {
-    "x-ms-content-crc64": "AAAAAAAAAAA=",
-    "date": "Wed, 02 Oct 2019 16:43:00 GMT",
-    "last-modified": "Wed, 02 Oct 2019 16:43:00 GMT",
-    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "content-length": "0",
     "content-md5": "1B2M2Y8AsgTpgAmY7PhCfg==",
-    "etag": "\"0x8D7475796737CC4\"",
-    "x-ms-request-id": "215f6fcc-201e-0080-0240-7993dc000000",
-    "x-ms-version": "2019-02-02",
-    "x-ms-client-request-id": "be440062-464f-4857-8d72-54e9c0948dfd",
+    "date": "Wed, 21 Sep 2022 08:51:23 GMT",
+    "etag": "\"0x8DA9BAE769EBBFD\"",
+    "last-modified": "Wed, 21 Sep 2022 08:51:24 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "50b1d2f1-ae48-4962-bffe-bedab8d6ee70",
+    "x-ms-content-crc64": "AAAAAAAAAAA=",
+    "x-ms-request-id": "8e8add24-501e-005a-0697-cd825e000000",
     "x-ms-request-server-encrypted": "true",
-    "content-length": "0"
+    "x-ms-version": "2021-08-06",
+    "x-ms-version-id": "2022-09-21T08:51:24.3075581Z"
    }
   },
   {
    "method": "PUT",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container157003458074707000/prefix157003458081805678%2Fblockblob1570034580818008165",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container166375028297000813/prefix166375028316700634/blockblob1663750283167030595",
    "query": {},
    "requestBody": "",
    "status": 201,
    "response": "",
    "responseHeaders": {
-    "x-ms-content-crc64": "AAAAAAAAAAA=",
-    "date": "Wed, 02 Oct 2019 16:43:00 GMT",
-    "last-modified": "Wed, 02 Oct 2019 16:43:00 GMT",
-    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "content-length": "0",
     "content-md5": "1B2M2Y8AsgTpgAmY7PhCfg==",
-    "etag": "\"0x8D74757968029F4\"",
-    "x-ms-request-id": "215f700f-201e-0080-4140-7993dc000000",
-    "x-ms-version": "2019-02-02",
-    "x-ms-client-request-id": "9cb6e48c-9b7f-4227-be8f-738a50394f44",
+    "date": "Wed, 21 Sep 2022 08:51:23 GMT",
+    "etag": "\"0x8DA9BAE76BCC692\"",
+    "last-modified": "Wed, 21 Sep 2022 08:51:24 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "32eb1810-5381-4df3-b322-7bc911b9ca86",
+    "x-ms-content-crc64": "AAAAAAAAAAA=",
+    "x-ms-request-id": "8e8add40-501e-005a-1397-cd825e000000",
     "x-ms-request-server-encrypted": "true",
-    "content-length": "0"
+    "x-ms-version": "2021-08-06",
+    "x-ms-version-id": "2022-09-21T08:51:24.5044370Z"
    }
   },
   {
    "method": "GET",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container157003458074707000",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container166375028297000813",
    "query": {
     "comp": "list",
-    "delimiter": "/",
+    "restype": "container",
     "include": "metadata",
-    "restype": "container"
+    "delimiter": "/"
    },
    "requestBody": null,
    "status": 200,
-   "response": "<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults ServiceEndpoint=\"https://fakestorageaccount.blob.core.windows.net/\" ContainerName=\"container157003458074707000\"><Delimiter>/</Delimiter><Blobs><BlobPrefix><Name>prefix157003458081805678/</Name></BlobPrefix></Blobs><NextMarker /></EnumerationResults>",
+   "response": "<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults ServiceEndpoint=\"https://fakestorageaccount.blob.core.windows.net/\" ContainerName=\"container166375028297000813\"><Delimiter>/</Delimiter><Blobs><BlobPrefix><Name>prefix166375028316700634/</Name></BlobPrefix></Blobs><NextMarker /></EnumerationResults>",
    "responseHeaders": {
-    "date": "Wed, 02 Oct 2019 16:43:00 GMT",
+    "content-type": "application/xml",
+    "date": "Wed, 21 Sep 2022 08:51:24 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
     "transfer-encoding": "chunked",
-    "content-type": "application/xml",
-    "x-ms-request-id": "215f7065-201e-0080-1440-7993dc000000",
-    "x-ms-version": "2019-02-02",
-    "x-ms-client-request-id": "95d22f3c-497f-443b-b0bb-2266dc05135c"
+    "x-ms-client-request-id": "511ff73c-c63a-4804-aa05-33704b84ff5f",
+    "x-ms-request-id": "8e8add4d-501e-005a-1f97-cd825e000000",
+    "x-ms-version": "2021-08-06"
    }
   },
   {
    "method": "DELETE",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container157003458074707000/prefix157003458081805678%2Fblockblob1570034580818008160",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container166375028297000813/prefix166375028316700634/blockblob1663750283167030590",
    "query": {},
    "requestBody": null,
    "status": 202,
    "response": "",
    "responseHeaders": {
-    "date": "Wed, 02 Oct 2019 16:43:00 GMT",
+    "content-length": "0",
+    "date": "Wed, 21 Sep 2022 08:51:24 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "ca47955c-9802-422a-af3e-44deef26f547",
     "x-ms-delete-type-permanent": "false",
-    "x-ms-request-id": "215f70ad-201e-0080-5440-7993dc000000",
-    "x-ms-version": "2019-02-02",
-    "x-ms-client-request-id": "da58644d-d1f0-4b0b-b77a-21bcd9451df3",
-    "content-length": "0"
+    "x-ms-request-id": "8e8add64-501e-005a-3397-cd825e000000",
+    "x-ms-version": "2021-08-06"
    }
   },
   {
    "method": "DELETE",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container157003458074707000/prefix157003458081805678%2Fblockblob1570034580818008161",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container166375028297000813/prefix166375028316700634/blockblob1663750283167030591",
    "query": {},
    "requestBody": null,
    "status": 202,
    "response": "",
    "responseHeaders": {
-    "date": "Wed, 02 Oct 2019 16:43:01 GMT",
+    "content-length": "0",
+    "date": "Wed, 21 Sep 2022 08:51:24 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "e2d38b14-0e03-48fb-a209-911444481844",
     "x-ms-delete-type-permanent": "false",
-    "x-ms-request-id": "215f70fa-201e-0080-1c40-7993dc000000",
-    "x-ms-version": "2019-02-02",
-    "x-ms-client-request-id": "363509c9-b473-459f-a082-2732007ab309",
-    "content-length": "0"
+    "x-ms-request-id": "8e8add77-501e-005a-4697-cd825e000000",
+    "x-ms-version": "2021-08-06"
    }
   },
   {
    "method": "DELETE",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container157003458074707000/prefix157003458081805678%2Fblockblob1570034580818008162",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container166375028297000813/prefix166375028316700634/blockblob1663750283167030592",
    "query": {},
    "requestBody": null,
    "status": 202,
    "response": "",
    "responseHeaders": {
-    "date": "Wed, 02 Oct 2019 16:43:01 GMT",
+    "content-length": "0",
+    "date": "Wed, 21 Sep 2022 08:51:24 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "5d23bdef-cccf-49f4-b4ea-9a69a74c5570",
     "x-ms-delete-type-permanent": "false",
-    "x-ms-request-id": "215f7141-201e-0080-5940-7993dc000000",
-    "x-ms-version": "2019-02-02",
-    "x-ms-client-request-id": "f57edf9a-39d3-4d40-b181-9610d6a3c398",
-    "content-length": "0"
+    "x-ms-request-id": "8e8add80-501e-005a-4f97-cd825e000000",
+    "x-ms-version": "2021-08-06"
    }
   },
   {
    "method": "DELETE",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container157003458074707000/prefix157003458081805678%2Fblockblob1570034580818008163",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container166375028297000813/prefix166375028316700634/blockblob1663750283167030593",
    "query": {},
    "requestBody": null,
    "status": 202,
    "response": "",
    "responseHeaders": {
-    "date": "Wed, 02 Oct 2019 16:43:01 GMT",
+    "content-length": "0",
+    "date": "Wed, 21 Sep 2022 08:51:24 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "619847c0-b740-46fa-998c-6cd195c1e590",
     "x-ms-delete-type-permanent": "false",
-    "x-ms-request-id": "215f7184-201e-0080-1140-7993dc000000",
-    "x-ms-version": "2019-02-02",
-    "x-ms-client-request-id": "474cf0c3-1a97-4221-862b-416c4a744291",
-    "content-length": "0"
+    "x-ms-request-id": "8e8add8e-501e-005a-5c97-cd825e000000",
+    "x-ms-version": "2021-08-06"
    }
   },
   {
    "method": "DELETE",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container157003458074707000/prefix157003458081805678%2Fblockblob1570034580818008164",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container166375028297000813/prefix166375028316700634/blockblob1663750283167030594",
    "query": {},
    "requestBody": null,
    "status": 202,
    "response": "",
    "responseHeaders": {
-    "date": "Wed, 02 Oct 2019 16:43:01 GMT",
+    "content-length": "0",
+    "date": "Wed, 21 Sep 2022 08:51:25 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "cad43ff5-de44-4202-8d0c-fa359059586b",
     "x-ms-delete-type-permanent": "false",
-    "x-ms-request-id": "215f71d2-201e-0080-4c40-7993dc000000",
-    "x-ms-version": "2019-02-02",
-    "x-ms-client-request-id": "0ebf0af9-6c4a-4723-a133-6d4efe87f6e0",
-    "content-length": "0"
+    "x-ms-request-id": "8e8add9a-501e-005a-6797-cd825e000000",
+    "x-ms-version": "2021-08-06"
    }
   },
   {
    "method": "DELETE",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container157003458074707000/prefix157003458081805678%2Fblockblob1570034580818008165",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container166375028297000813/prefix166375028316700634/blockblob1663750283167030595",
    "query": {},
    "requestBody": null,
    "status": 202,
    "response": "",
    "responseHeaders": {
-    "date": "Wed, 02 Oct 2019 16:43:01 GMT",
+    "content-length": "0",
+    "date": "Wed, 21 Sep 2022 08:51:25 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "ea72e44b-9744-48fa-b4cf-878ece2432b8",
     "x-ms-delete-type-permanent": "false",
-    "x-ms-request-id": "215f722a-201e-0080-0b40-7993dc000000",
-    "x-ms-version": "2019-02-02",
-    "x-ms-client-request-id": "06e6fbee-ea23-426a-b7b3-437f58d04f02",
-    "content-length": "0"
+    "x-ms-request-id": "8e8adda6-501e-005a-7197-cd825e000000",
+    "x-ms-version": "2021-08-06"
    }
   },
   {
    "method": "DELETE",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container157003458074707000",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container166375028297000813",
    "query": {
     "restype": "container"
    },
@@ -280,18 +286,22 @@
    "status": 202,
    "response": "",
    "responseHeaders": {
-    "date": "Wed, 02 Oct 2019 16:43:01 GMT",
+    "content-length": "0",
+    "date": "Wed, 21 Sep 2022 08:51:25 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-    "x-ms-request-id": "215f728d-201e-0080-5c40-7993dc000000",
-    "x-ms-version": "2019-02-02",
-    "x-ms-client-request-id": "46ebf930-71b7-413e-a6ed-27b421320d8f",
-    "content-length": "0"
+    "x-ms-client-request-id": "4094894b-49b7-450e-9b1a-5a55e32cd9d4",
+    "x-ms-request-id": "8e8addb4-501e-005a-7e97-cd825e000000",
+    "x-ms-version": "2021-08-06"
    }
   }
  ],
  "uniqueTestInfo": {
-  "container": "container157003458074707000",
-  "prefix": "prefix157003458081805678",
-  "blockblob": "blockblob157003458081800816"
- }
+  "uniqueName": {
+   "container": "container166375028297000813",
+   "prefix": "prefix166375028316700634",
+   "blockblob": "blockblob166375028316703059"
+  },
+  "newDate": {}
+ },
+ "hash": "c2f7d07d9e4626087a13abba22923d59"
 }

--- a/sdk/storage/storage-blob/recordings/browsers/containerclient/recording_verify_pagedasynciterableiterator_for_listblobsflat.json
+++ b/sdk/storage/storage-blob/recordings/browsers/containerclient/recording_verify_pagedasynciterableiterator_for_listblobsflat.json
@@ -2,7 +2,7 @@
  "recordings": [
   {
    "method": "PUT",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container157003457608807406",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container166375027929903842",
    "query": {
     "restype": "container"
    },
@@ -10,193 +10,197 @@
    "status": 201,
    "response": "",
    "responseHeaders": {
-    "date": "Wed, 02 Oct 2019 16:42:55 GMT",
-    "last-modified": "Wed, 02 Oct 2019 16:42:55 GMT",
+    "content-length": "0",
+    "date": "Wed, 21 Sep 2022 08:51:18 GMT",
+    "etag": "\"0x8DA9BAE73D86A82\"",
+    "last-modified": "Wed, 21 Sep 2022 08:51:19 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-    "etag": "\"0x8D74757937663D1\"",
-    "x-ms-request-id": "215f5f72-201e-0080-7b40-7993dc000000",
-    "x-ms-version": "2019-02-02",
-    "x-ms-client-request-id": "aded3142-30dd-4cdb-8e6f-ee562769182e",
-    "content-length": "0"
+    "x-ms-client-request-id": "91b4b8c0-79d0-4dea-ad43-baceff8005a3",
+    "x-ms-request-id": "8e8adb0e-501e-005a-2497-cd825e000000",
+    "x-ms-version": "2021-08-06"
    }
   },
   {
    "method": "PUT",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container157003457608807406/blockblob%2F0157003457615909489",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container166375027929903842/blockblob/0166375027949406362",
    "query": {},
    "requestBody": "",
    "status": 201,
    "response": "",
    "responseHeaders": {
-    "x-ms-content-crc64": "AAAAAAAAAAA=",
-    "date": "Wed, 02 Oct 2019 16:42:55 GMT",
-    "last-modified": "Wed, 02 Oct 2019 16:42:55 GMT",
-    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "content-length": "0",
     "content-md5": "1B2M2Y8AsgTpgAmY7PhCfg==",
-    "etag": "\"0x8D747579381281B\"",
-    "x-ms-request-id": "215f5fb7-201e-0080-3840-7993dc000000",
-    "x-ms-version": "2019-02-02",
-    "x-ms-client-request-id": "7539a109-077d-44a8-84de-13d595a16a9d",
+    "date": "Wed, 21 Sep 2022 08:51:19 GMT",
+    "etag": "\"0x8DA9BAE73F674E4\"",
+    "last-modified": "Wed, 21 Sep 2022 08:51:19 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "dc6d51ff-b723-44fa-8a51-73a46babf967",
+    "x-ms-content-crc64": "AAAAAAAAAAA=",
+    "x-ms-request-id": "8e8adb21-501e-005a-3697-cd825e000000",
     "x-ms-request-server-encrypted": "true",
-    "content-length": "0"
+    "x-ms-version": "2021-08-06",
+    "x-ms-version-id": "2022-09-21T08:51:19.8492900Z"
    }
   },
   {
    "method": "PUT",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container157003457608807406/blockblob%2F1157003457623003136",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container166375027929903842/blockblob/1166375027968900069",
    "query": {},
    "requestBody": "",
    "status": 201,
    "response": "",
    "responseHeaders": {
-    "x-ms-content-crc64": "AAAAAAAAAAA=",
-    "date": "Wed, 02 Oct 2019 16:42:55 GMT",
-    "last-modified": "Wed, 02 Oct 2019 16:42:55 GMT",
-    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "content-length": "0",
     "content-md5": "1B2M2Y8AsgTpgAmY7PhCfg==",
-    "etag": "\"0x8D74757938BD90D\"",
-    "x-ms-request-id": "215f5ff5-201e-0080-7440-7993dc000000",
-    "x-ms-version": "2019-02-02",
-    "x-ms-client-request-id": "9a46168e-06ab-4e55-8e14-6b32fcc9b17a",
+    "date": "Wed, 21 Sep 2022 08:51:19 GMT",
+    "etag": "\"0x8DA9BAE74147F7D\"",
+    "last-modified": "Wed, 21 Sep 2022 08:51:20 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "007cdbad-803d-4417-bcfe-4e2ff3a1ac0c",
+    "x-ms-content-crc64": "AAAAAAAAAAA=",
+    "x-ms-request-id": "8e8adb39-501e-005a-4d97-cd825e000000",
     "x-ms-request-server-encrypted": "true",
-    "content-length": "0"
+    "x-ms-version": "2021-08-06",
+    "x-ms-version-id": "2022-09-21T08:51:20.0461693Z"
    }
   },
   {
    "method": "PUT",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container157003457608807406/blockblob%2F2157003457629904315",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container166375027929903842/blockblob/2166375027988406788",
    "query": {},
    "requestBody": "",
    "status": 201,
    "response": "",
    "responseHeaders": {
-    "x-ms-content-crc64": "AAAAAAAAAAA=",
-    "date": "Wed, 02 Oct 2019 16:42:55 GMT",
-    "last-modified": "Wed, 02 Oct 2019 16:42:56 GMT",
-    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "content-length": "0",
     "content-md5": "1B2M2Y8AsgTpgAmY7PhCfg==",
-    "etag": "\"0x8D747579396B109\"",
-    "x-ms-request-id": "215f6033-201e-0080-2d40-7993dc000000",
-    "x-ms-version": "2019-02-02",
-    "x-ms-client-request-id": "ffcaead9-6e36-4c35-8103-b67458046165",
+    "date": "Wed, 21 Sep 2022 08:51:19 GMT",
+    "etag": "\"0x8DA9BAE743214F6\"",
+    "last-modified": "Wed, 21 Sep 2022 08:51:20 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "168df985-32fe-468f-bf17-81298f506f9c",
+    "x-ms-content-crc64": "AAAAAAAAAAA=",
+    "x-ms-request-id": "8e8adb57-501e-005a-6897-cd825e000000",
     "x-ms-request-server-encrypted": "true",
-    "content-length": "0"
+    "x-ms-version": "2021-08-06",
+    "x-ms-version-id": "2022-09-21T08:51:20.2400502Z"
    }
   },
   {
    "method": "PUT",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container157003457608807406/blockblob%2F3157003457638107205",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container166375027929903842/blockblob/3166375028007902582",
    "query": {},
    "requestBody": "",
    "status": 201,
    "response": "",
    "responseHeaders": {
-    "x-ms-content-crc64": "AAAAAAAAAAA=",
-    "date": "Wed, 02 Oct 2019 16:42:55 GMT",
-    "last-modified": "Wed, 02 Oct 2019 16:42:56 GMT",
-    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "content-length": "0",
     "content-md5": "1B2M2Y8AsgTpgAmY7PhCfg==",
-    "etag": "\"0x8D7475793A3AC6B\"",
-    "x-ms-request-id": "215f6087-201e-0080-7840-7993dc000000",
-    "x-ms-version": "2019-02-02",
-    "x-ms-client-request-id": "9f871262-49bb-4c69-b092-a14d2351ecd8",
+    "date": "Wed, 21 Sep 2022 08:51:19 GMT",
+    "etag": "\"0x8DA9BAE744FD17C\"",
+    "last-modified": "Wed, 21 Sep 2022 08:51:20 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "c91fe73b-a37c-4927-a93f-79a1aaadcc31",
+    "x-ms-content-crc64": "AAAAAAAAAAA=",
+    "x-ms-request-id": "8e8adb63-501e-005a-7397-cd825e000000",
     "x-ms-request-server-encrypted": "true",
-    "content-length": "0"
+    "x-ms-version": "2021-08-06",
+    "x-ms-version-id": "2022-09-21T08:51:20.4349308Z"
    }
   },
   {
    "method": "GET",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container157003457608807406",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container166375027929903842",
    "query": {
     "comp": "list",
-    "include": "copy,deleted,metadata,snapshots,uncommittedblobs",
     "prefix": "blockblob",
-    "restype": "container"
+    "restype": "container",
+    "include": "copy,deleted,metadata,snapshots,uncommittedblobs"
    },
    "requestBody": null,
    "status": 200,
-   "response": "<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults ServiceEndpoint=\"https://fakestorageaccount.blob.core.windows.net/\" ContainerName=\"container157003457608807406\"><Prefix>blockblob</Prefix><Blobs><Blob><Name>blockblob/0157003457615909489</Name><Properties><Creation-Time>Wed, 02 Oct 2019 16:42:55 GMT</Creation-Time><Last-Modified>Wed, 02 Oct 2019 16:42:55 GMT</Last-Modified><Etag>0x8D747579381281B</Etag><Content-Length>0</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64>AAAAAAAAAAA=</Content-CRC64><Content-MD5>1B2M2Y8AsgTpgAmY7PhCfg==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Cool</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted><TagCount>0</TagCount></Properties><Metadata><keya>a</keya><keyb>c</keyb></Metadata></Blob><Blob><Name>blockblob/1157003457623003136</Name><Properties><Creation-Time>Wed, 02 Oct 2019 16:42:55 GMT</Creation-Time><Last-Modified>Wed, 02 Oct 2019 16:42:55 GMT</Last-Modified><Etag>0x8D74757938BD90D</Etag><Content-Length>0</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64>AAAAAAAAAAA=</Content-CRC64><Content-MD5>1B2M2Y8AsgTpgAmY7PhCfg==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Cool</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted><TagCount>0</TagCount></Properties><Metadata><keya>a</keya><keyb>c</keyb></Metadata></Blob><Blob><Name>blockblob/2157003457629904315</Name><Properties><Creation-Time>Wed, 02 Oct 2019 16:42:56 GMT</Creation-Time><Last-Modified>Wed, 02 Oct 2019 16:42:56 GMT</Last-Modified><Etag>0x8D747579396B109</Etag><Content-Length>0</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64>AAAAAAAAAAA=</Content-CRC64><Content-MD5>1B2M2Y8AsgTpgAmY7PhCfg==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Cool</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted><TagCount>0</TagCount></Properties><Metadata><keya>a</keya><keyb>c</keyb></Metadata></Blob><Blob><Name>blockblob/3157003457638107205</Name><Properties><Creation-Time>Wed, 02 Oct 2019 16:42:56 GMT</Creation-Time><Last-Modified>Wed, 02 Oct 2019 16:42:56 GMT</Last-Modified><Etag>0x8D7475793A3AC6B</Etag><Content-Length>0</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64>AAAAAAAAAAA=</Content-CRC64><Content-MD5>1B2M2Y8AsgTpgAmY7PhCfg==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Cool</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted><TagCount>0</TagCount></Properties><Metadata><keya>a</keya><keyb>c</keyb></Metadata></Blob></Blobs><NextMarker /></EnumerationResults>",
+   "response": "<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults ServiceEndpoint=\"https://fakestorageaccount.blob.core.windows.net/\" ContainerName=\"container166375027929903842\"><Prefix>blockblob</Prefix><Blobs><Blob><Name>blockblob/0166375027949406362</Name><VersionId>2022-09-21T08:51:19.8492900Z</VersionId><IsCurrentVersion>true</IsCurrentVersion><Properties><Creation-Time>Wed, 21 Sep 2022 08:51:19 GMT</Creation-Time><Last-Modified>Wed, 21 Sep 2022 08:51:19 GMT</Last-Modified><Etag>0x8DA9BAE73F674E4</Etag><Content-Length>0</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>1B2M2Y8AsgTpgAmY7PhCfg==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties><Metadata><keya>a</keya><keyb>c</keyb></Metadata><OrMetadata /></Blob><Blob><Name>blockblob/1166375027968900069</Name><VersionId>2022-09-21T08:51:20.0461693Z</VersionId><IsCurrentVersion>true</IsCurrentVersion><Properties><Creation-Time>Wed, 21 Sep 2022 08:51:20 GMT</Creation-Time><Last-Modified>Wed, 21 Sep 2022 08:51:20 GMT</Last-Modified><Etag>0x8DA9BAE74147F7D</Etag><Content-Length>0</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>1B2M2Y8AsgTpgAmY7PhCfg==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties><Metadata><keya>a</keya><keyb>c</keyb></Metadata><OrMetadata /></Blob><Blob><Name>blockblob/2166375027988406788</Name><VersionId>2022-09-21T08:51:20.2400502Z</VersionId><IsCurrentVersion>true</IsCurrentVersion><Properties><Creation-Time>Wed, 21 Sep 2022 08:51:20 GMT</Creation-Time><Last-Modified>Wed, 21 Sep 2022 08:51:20 GMT</Last-Modified><Etag>0x8DA9BAE743214F6</Etag><Content-Length>0</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>1B2M2Y8AsgTpgAmY7PhCfg==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties><Metadata><keya>a</keya><keyb>c</keyb></Metadata><OrMetadata /></Blob><Blob><Name>blockblob/3166375028007902582</Name><VersionId>2022-09-21T08:51:20.4349308Z</VersionId><IsCurrentVersion>true</IsCurrentVersion><Properties><Creation-Time>Wed, 21 Sep 2022 08:51:20 GMT</Creation-Time><Last-Modified>Wed, 21 Sep 2022 08:51:20 GMT</Last-Modified><Etag>0x8DA9BAE744FD17C</Etag><Content-Length>0</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>1B2M2Y8AsgTpgAmY7PhCfg==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties><Metadata><keya>a</keya><keyb>c</keyb></Metadata><OrMetadata /></Blob></Blobs><NextMarker /></EnumerationResults>",
    "responseHeaders": {
-    "date": "Wed, 02 Oct 2019 16:42:56 GMT",
+    "content-type": "application/xml",
+    "date": "Wed, 21 Sep 2022 08:51:19 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
     "transfer-encoding": "chunked",
-    "content-type": "application/xml",
-    "x-ms-request-id": "215f60bd-201e-0080-2c40-7993dc000000",
-    "x-ms-version": "2019-02-02",
-    "x-ms-client-request-id": "e0f2de29-c898-4acd-9d3f-d194241a0132"
+    "x-ms-client-request-id": "0adb2c2c-fde4-4c0f-a1f9-d66b5d5c7b5f",
+    "x-ms-request-id": "8e8adb7c-501e-005a-0c97-cd825e000000",
+    "x-ms-version": "2021-08-06"
    }
   },
   {
    "method": "DELETE",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container157003457608807406/blockblob%2F0157003457615909489",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container166375027929903842/blockblob/0166375027949406362",
    "query": {},
    "requestBody": null,
    "status": 202,
    "response": "",
    "responseHeaders": {
-    "date": "Wed, 02 Oct 2019 16:42:56 GMT",
+    "content-length": "0",
+    "date": "Wed, 21 Sep 2022 08:51:20 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "49282e0f-614e-4945-a6f6-080a5db3494b",
     "x-ms-delete-type-permanent": "false",
-    "x-ms-request-id": "215f6127-201e-0080-0740-7993dc000000",
-    "x-ms-version": "2019-02-02",
-    "x-ms-client-request-id": "7f6c3fc4-002e-4ac0-ba59-20e803ce2f9b",
-    "content-length": "0"
+    "x-ms-request-id": "8e8adba2-501e-005a-2c97-cd825e000000",
+    "x-ms-version": "2021-08-06"
    }
   },
   {
    "method": "DELETE",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container157003457608807406/blockblob%2F1157003457623003136",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container166375027929903842/blockblob/1166375027968900069",
    "query": {},
    "requestBody": null,
    "status": 202,
    "response": "",
    "responseHeaders": {
-    "date": "Wed, 02 Oct 2019 16:42:56 GMT",
+    "content-length": "0",
+    "date": "Wed, 21 Sep 2022 08:51:20 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "35670929-cfab-40c0-a7b0-f7866a528fa9",
     "x-ms-delete-type-permanent": "false",
-    "x-ms-request-id": "215f615b-201e-0080-3540-7993dc000000",
-    "x-ms-version": "2019-02-02",
-    "x-ms-client-request-id": "7bc404b8-37d1-497a-a9f3-1268af6c8bbd",
-    "content-length": "0"
+    "x-ms-request-id": "8e8adbb9-501e-005a-4097-cd825e000000",
+    "x-ms-version": "2021-08-06"
    }
   },
   {
    "method": "DELETE",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container157003457608807406/blockblob%2F2157003457629904315",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container166375027929903842/blockblob/2166375027988406788",
    "query": {},
    "requestBody": null,
    "status": 202,
    "response": "",
    "responseHeaders": {
-    "date": "Wed, 02 Oct 2019 16:42:56 GMT",
+    "content-length": "0",
+    "date": "Wed, 21 Sep 2022 08:51:20 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "7d5efc6e-012f-4053-99fc-68737b8fb2d5",
     "x-ms-delete-type-permanent": "false",
-    "x-ms-request-id": "215f619f-201e-0080-6740-7993dc000000",
-    "x-ms-version": "2019-02-02",
-    "x-ms-client-request-id": "47c34ed4-c525-40e0-a175-d89af06cf08c",
-    "content-length": "0"
+    "x-ms-request-id": "8e8adbe4-501e-005a-6997-cd825e000000",
+    "x-ms-version": "2021-08-06"
    }
   },
   {
    "method": "DELETE",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container157003457608807406/blockblob%2F3157003457638107205",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container166375027929903842/blockblob/3166375028007902582",
    "query": {},
    "requestBody": null,
    "status": 202,
    "response": "",
    "responseHeaders": {
-    "date": "Wed, 02 Oct 2019 16:42:56 GMT",
+    "content-length": "0",
+    "date": "Wed, 21 Sep 2022 08:51:20 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "eb69c03f-2774-4d0e-b543-f108b418e4c9",
     "x-ms-delete-type-permanent": "false",
-    "x-ms-request-id": "215f61e8-201e-0080-2240-7993dc000000",
-    "x-ms-version": "2019-02-02",
-    "x-ms-client-request-id": "0e38efa5-e609-46f4-8b40-301036964e56",
-    "content-length": "0"
+    "x-ms-request-id": "8e8adbed-501e-005a-7197-cd825e000000",
+    "x-ms-version": "2021-08-06"
    }
   },
   {
    "method": "DELETE",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container157003457608807406",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container166375027929903842",
    "query": {
     "restype": "container"
    },
@@ -204,20 +208,24 @@
    "status": 202,
    "response": "",
    "responseHeaders": {
-    "date": "Wed, 02 Oct 2019 16:42:56 GMT",
+    "content-length": "0",
+    "date": "Wed, 21 Sep 2022 08:51:21 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-    "x-ms-request-id": "215f6231-201e-0080-6240-7993dc000000",
-    "x-ms-version": "2019-02-02",
-    "x-ms-client-request-id": "4650d590-a669-4236-bc86-bdeee4706d6f",
-    "content-length": "0"
+    "x-ms-client-request-id": "c50c10f5-be35-48a6-be3f-628af2225da5",
+    "x-ms-request-id": "8e8adc04-501e-005a-0797-cd825e000000",
+    "x-ms-version": "2021-08-06"
    }
   }
  ],
  "uniqueTestInfo": {
-  "container": "container157003457608807406",
-  "blockblob/0": "blockblob/0157003457615909489",
-  "blockblob/1": "blockblob/1157003457623003136",
-  "blockblob/2": "blockblob/2157003457629904315",
-  "blockblob/3": "blockblob/3157003457638107205"
- }
+  "uniqueName": {
+   "container": "container166375027929903842",
+   "blockblob/0": "blockblob/0166375027949406362",
+   "blockblob/1": "blockblob/1166375027968900069",
+   "blockblob/2": "blockblob/2166375027988406788",
+   "blockblob/3": "blockblob/3166375028007902582"
+  },
+  "newDate": {}
+ },
+ "hash": "64a3807dc127970ebfcd359f377f8d08"
 }

--- a/sdk/storage/storage-blob/recordings/browsers/containerclient/recording_verify_pagedasynciterableiteratorbypage__continuationtoken_for_listblobsflat.json
+++ b/sdk/storage/storage-blob/recordings/browsers/containerclient/recording_verify_pagedasynciterableiteratorbypage__continuationtoken_for_listblobsflat.json
@@ -2,7 +2,7 @@
  "recordings": [
   {
    "method": "PUT",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container157003457848202538",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container166374976176003018",
    "query": {
     "restype": "container"
    },
@@ -10,218 +10,222 @@
    "status": 201,
    "response": "",
    "responseHeaders": {
-    "date": "Wed, 02 Oct 2019 16:42:58 GMT",
-    "last-modified": "Wed, 02 Oct 2019 16:42:58 GMT",
+    "content-length": "0",
+    "date": "Wed, 21 Sep 2022 08:42:42 GMT",
+    "etag": "\"0x8DA9BAD3F5EB1C5\"",
+    "last-modified": "Wed, 21 Sep 2022 08:42:42 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-    "etag": "\"0x8D7475794E3E1B1\"",
-    "x-ms-request-id": "215f688e-201e-0080-2d40-7993dc000000",
-    "x-ms-version": "2019-02-02",
-    "x-ms-client-request-id": "fb9382e2-b966-42ed-b038-4dd2b15dc4a3",
-    "content-length": "0"
+    "x-ms-client-request-id": "8b48d9b4-1353-43e9-b2a3-3f56ff2407b7",
+    "x-ms-request-id": "e9748a08-701e-005d-4b96-cdee3d000000",
+    "x-ms-version": "2021-08-06"
    }
   },
   {
    "method": "PUT",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container157003457848202538/blockblob%2F0157003457855208109",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container166374976176003018/blockblob/0166374976195204876",
    "query": {},
    "requestBody": "",
    "status": 201,
    "response": "",
    "responseHeaders": {
-    "x-ms-content-crc64": "AAAAAAAAAAA=",
-    "date": "Wed, 02 Oct 2019 16:42:58 GMT",
-    "last-modified": "Wed, 02 Oct 2019 16:42:58 GMT",
-    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "content-length": "0",
     "content-md5": "1B2M2Y8AsgTpgAmY7PhCfg==",
-    "etag": "\"0x8D7475794EE2E1A\"",
-    "x-ms-request-id": "215f68d1-201e-0080-6040-7993dc000000",
-    "x-ms-version": "2019-02-02",
-    "x-ms-client-request-id": "261d12e7-b688-4f56-9178-7f1f1da91a5b",
+    "date": "Wed, 21 Sep 2022 08:42:42 GMT",
+    "etag": "\"0x8DA9BAD3F7C4ED3\"",
+    "last-modified": "Wed, 21 Sep 2022 08:42:42 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "74492960-e467-4911-96d5-df8c3c6199aa",
+    "x-ms-content-crc64": "AAAAAAAAAAA=",
+    "x-ms-request-id": "e9748a74-701e-005d-7c96-cdee3d000000",
     "x-ms-request-server-encrypted": "true",
-    "content-length": "0"
+    "x-ms-version": "2021-08-06",
+    "x-ms-version-id": "2022-09-21T08:42:42.3115227Z"
    }
   },
   {
    "method": "PUT",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container157003457848202538/blockblob%2F1157003457862302552",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container166374976176003018/blockblob/1166374976214507106",
    "query": {},
    "requestBody": "",
    "status": 201,
    "response": "",
    "responseHeaders": {
-    "x-ms-content-crc64": "AAAAAAAAAAA=",
-    "date": "Wed, 02 Oct 2019 16:42:58 GMT",
-    "last-modified": "Wed, 02 Oct 2019 16:42:58 GMT",
-    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "content-length": "0",
     "content-md5": "1B2M2Y8AsgTpgAmY7PhCfg==",
-    "etag": "\"0x8D7475794F90623\"",
-    "x-ms-request-id": "215f690a-201e-0080-0c40-7993dc000000",
-    "x-ms-version": "2019-02-02",
-    "x-ms-client-request-id": "e30eb802-40f4-4179-a20c-2f57a554dbb6",
+    "date": "Wed, 21 Sep 2022 08:42:42 GMT",
+    "etag": "\"0x8DA9BAD3F999640\"",
+    "last-modified": "Wed, 21 Sep 2022 08:42:42 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "eb9b8487-5ee7-4472-9612-11fe05ac1e72",
+    "x-ms-content-crc64": "AAAAAAAAAAA=",
+    "x-ms-request-id": "e9748ac6-701e-005d-2696-cdee3d000000",
     "x-ms-request-server-encrypted": "true",
-    "content-length": "0"
+    "x-ms-version": "2021-08-06",
+    "x-ms-version-id": "2022-09-21T08:42:42.5024064Z"
    }
   },
   {
    "method": "PUT",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container157003457848202538/blockblob%2F2157003457869306593",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container166374976176003018/blockblob/2166374976233804487",
    "query": {},
    "requestBody": "",
    "status": 201,
    "response": "",
    "responseHeaders": {
-    "x-ms-content-crc64": "AAAAAAAAAAA=",
-    "date": "Wed, 02 Oct 2019 16:42:58 GMT",
-    "last-modified": "Wed, 02 Oct 2019 16:42:58 GMT",
-    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "content-length": "0",
     "content-md5": "1B2M2Y8AsgTpgAmY7PhCfg==",
-    "etag": "\"0x8D7475795047A7F\"",
-    "x-ms-request-id": "215f694b-201e-0080-3f40-7993dc000000",
-    "x-ms-version": "2019-02-02",
-    "x-ms-client-request-id": "9879eead-249c-4d98-9ad4-5793ff212061",
+    "date": "Wed, 21 Sep 2022 08:42:42 GMT",
+    "etag": "\"0x8DA9BAD3FB83D07\"",
+    "last-modified": "Wed, 21 Sep 2022 08:42:42 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "7290b96d-b183-4b74-a054-60444ee31168",
+    "x-ms-content-crc64": "AAAAAAAAAAA=",
+    "x-ms-request-id": "e9748b97-701e-005d-0996-cdee3d000000",
     "x-ms-request-server-encrypted": "true",
-    "content-length": "0"
+    "x-ms-version": "2021-08-06",
+    "x-ms-version-id": "2022-09-21T08:42:42.7032839Z"
    }
   },
   {
    "method": "PUT",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container157003457848202538/blockblob%2F3157003457877105266",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container166374976176003018/blockblob/3166374976253808420",
    "query": {},
    "requestBody": "",
    "status": 201,
    "response": "",
    "responseHeaders": {
-    "x-ms-content-crc64": "AAAAAAAAAAA=",
-    "date": "Wed, 02 Oct 2019 16:42:58 GMT",
-    "last-modified": "Wed, 02 Oct 2019 16:42:58 GMT",
-    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "content-length": "0",
     "content-md5": "1B2M2Y8AsgTpgAmY7PhCfg==",
-    "etag": "\"0x8D74757950FC7CE\"",
-    "x-ms-request-id": "215f6989-201e-0080-6f40-7993dc000000",
-    "x-ms-version": "2019-02-02",
-    "x-ms-client-request-id": "c2e244f7-fcf0-4813-9504-fb0ba15bd13e",
+    "date": "Wed, 21 Sep 2022 08:42:42 GMT",
+    "etag": "\"0x8DA9BAD3FD5F98F\"",
+    "last-modified": "Wed, 21 Sep 2022 08:42:42 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "7abba723-3478-4b2f-86d4-99c2456d7bcc",
+    "x-ms-content-crc64": "AAAAAAAAAAA=",
+    "x-ms-request-id": "e9748d11-701e-005d-3696-cdee3d000000",
     "x-ms-request-server-encrypted": "true",
-    "content-length": "0"
+    "x-ms-version": "2021-08-06",
+    "x-ms-version-id": "2022-09-21T08:42:42.8981647Z"
    }
   },
   {
    "method": "GET",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container157003457848202538",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container166374976176003018",
    "query": {
     "comp": "list",
-    "include": "copy,deleted,metadata,snapshots,uncommittedblobs",
-    "maxresults": "2",
     "prefix": "blockblob",
-    "restype": "container"
+    "maxresults": "2",
+    "restype": "container",
+    "include": "copy,deleted,metadata,snapshots,uncommittedblobs"
    },
    "requestBody": null,
    "status": 200,
-   "response": "<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults ServiceEndpoint=\"https://fakestorageaccount.blob.core.windows.net/\" ContainerName=\"container157003457848202538\"><Prefix>blockblob</Prefix><MaxResults>2</MaxResults><Blobs><Blob><Name>blockblob/0157003457855208109</Name><Properties><Creation-Time>Wed, 02 Oct 2019 16:42:58 GMT</Creation-Time><Last-Modified>Wed, 02 Oct 2019 16:42:58 GMT</Last-Modified><Etag>0x8D7475794EE2E1A</Etag><Content-Length>0</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64>AAAAAAAAAAA=</Content-CRC64><Content-MD5>1B2M2Y8AsgTpgAmY7PhCfg==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Cool</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted><TagCount>0</TagCount></Properties><Metadata><keya>a</keya><keyb>c</keyb></Metadata></Blob><Blob><Name>blockblob/1157003457862302552</Name><Properties><Creation-Time>Wed, 02 Oct 2019 16:42:58 GMT</Creation-Time><Last-Modified>Wed, 02 Oct 2019 16:42:58 GMT</Last-Modified><Etag>0x8D7475794F90623</Etag><Content-Length>0</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64>AAAAAAAAAAA=</Content-CRC64><Content-MD5>1B2M2Y8AsgTpgAmY7PhCfg==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Cool</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted><TagCount>0</TagCount></Properties><Metadata><keya>a</keya><keyb>c</keyb></Metadata></Blob></Blobs><NextMarker>2!100!MDAwMDI5IWJsb2NrYmxvYi8yMTU3MDAzNDU3ODY5MzA2NTkzITAwMDAyOCE5OTk5LTEyLTMxVDIzOjU5OjU5Ljk5OTk5OTlaIQ--</NextMarker></EnumerationResults>",
+   "response": "<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults ServiceEndpoint=\"https://fakestorageaccount.blob.core.windows.net/\" ContainerName=\"container166374976176003018\"><Prefix>blockblob</Prefix><MaxResults>2</MaxResults><Blobs><Blob><Name>blockblob/0166374976195204876</Name><VersionId>2022-09-21T08:42:42.3115227Z</VersionId><IsCurrentVersion>true</IsCurrentVersion><Properties><Creation-Time>Wed, 21 Sep 2022 08:42:42 GMT</Creation-Time><Last-Modified>Wed, 21 Sep 2022 08:42:42 GMT</Last-Modified><Etag>0x8DA9BAD3F7C4ED3</Etag><Content-Length>0</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>1B2M2Y8AsgTpgAmY7PhCfg==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties><Metadata><keya>a</keya><keyb>c</keyb></Metadata><OrMetadata /></Blob><Blob><Name>blockblob/1166374976214507106</Name><VersionId>2022-09-21T08:42:42.5024064Z</VersionId><IsCurrentVersion>true</IsCurrentVersion><Properties><Creation-Time>Wed, 21 Sep 2022 08:42:42 GMT</Creation-Time><Last-Modified>Wed, 21 Sep 2022 08:42:42 GMT</Last-Modified><Etag>0x8DA9BAD3F999640</Etag><Content-Length>0</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>1B2M2Y8AsgTpgAmY7PhCfg==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties><Metadata><keya>a</keya><keyb>c</keyb></Metadata><OrMetadata /></Blob></Blobs><NextMarker>2!100!MDAwMDI5IWJsb2NrYmxvYi8yMTY2Mzc0OTc2MjMzODA0NDg3ITAwMDAyOCE5OTk5LTEyLTMxVDIzOjU5OjU5Ljk5OTk5OTlaIQ--</NextMarker></EnumerationResults>",
    "responseHeaders": {
-    "date": "Wed, 02 Oct 2019 16:42:58 GMT",
+    "content-type": "application/xml",
+    "date": "Wed, 21 Sep 2022 08:42:43 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
     "transfer-encoding": "chunked",
-    "content-type": "application/xml",
-    "x-ms-request-id": "215f69dc-201e-0080-3440-7993dc000000",
-    "x-ms-version": "2019-02-02",
-    "x-ms-client-request-id": "5ff81dcd-c1a3-417a-be4d-8cc1a51e5cff"
+    "x-ms-client-request-id": "0b8cbbda-9f0e-40f7-b771-35756ad9e089",
+    "x-ms-request-id": "e9748ebc-701e-005d-0496-cdee3d000000",
+    "x-ms-version": "2021-08-06"
    }
   },
   {
    "method": "GET",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container157003457848202538",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container166374976176003018",
    "query": {
     "comp": "list",
-    "include": "copy,deleted,metadata,snapshots,uncommittedblobs",
-    "marker": "2!100!MDAwMDI5IWJsb2NrYmxvYi8yMTU3MDAzNDU3ODY5MzA2NTkzITAwMDAyOCE5OTk5LTEyLTMxVDIzOjU5OjU5Ljk5OTk5OTlaIQ--",
-    "maxresults": "2",
     "prefix": "blockblob",
-    "restype": "container"
+    "marker": "2!100!MDAwMDI5IWJsb2NrYmxvYi8yMTY2Mzc0OTc2MjMzODA0NDg3ITAwMDAyOCE5OTk5LTEyLTMxVDIzOjU5OjU5Ljk5OTk5OTlaIQ--",
+    "maxresults": "2",
+    "restype": "container",
+    "include": "copy,deleted,metadata,snapshots,uncommittedblobs"
    },
    "requestBody": null,
    "status": 200,
-   "response": "<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults ServiceEndpoint=\"https://fakestorageaccount.blob.core.windows.net/\" ContainerName=\"container157003457848202538\"><Prefix>blockblob</Prefix><Marker>2!100!MDAwMDI5IWJsb2NrYmxvYi8yMTU3MDAzNDU3ODY5MzA2NTkzITAwMDAyOCE5OTk5LTEyLTMxVDIzOjU5OjU5Ljk5OTk5OTlaIQ--</Marker><MaxResults>2</MaxResults><Blobs><Blob><Name>blockblob/2157003457869306593</Name><Properties><Creation-Time>Wed, 02 Oct 2019 16:42:58 GMT</Creation-Time><Last-Modified>Wed, 02 Oct 2019 16:42:58 GMT</Last-Modified><Etag>0x8D7475795047A7F</Etag><Content-Length>0</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64>AAAAAAAAAAA=</Content-CRC64><Content-MD5>1B2M2Y8AsgTpgAmY7PhCfg==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Cool</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted><TagCount>0</TagCount></Properties><Metadata><keya>a</keya><keyb>c</keyb></Metadata></Blob><Blob><Name>blockblob/3157003457877105266</Name><Properties><Creation-Time>Wed, 02 Oct 2019 16:42:58 GMT</Creation-Time><Last-Modified>Wed, 02 Oct 2019 16:42:58 GMT</Last-Modified><Etag>0x8D74757950FC7CE</Etag><Content-Length>0</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64>AAAAAAAAAAA=</Content-CRC64><Content-MD5>1B2M2Y8AsgTpgAmY7PhCfg==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Cool</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted><TagCount>0</TagCount></Properties><Metadata><keya>a</keya><keyb>c</keyb></Metadata></Blob></Blobs><NextMarker /></EnumerationResults>",
+   "response": "<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults ServiceEndpoint=\"https://fakestorageaccount.blob.core.windows.net/\" ContainerName=\"container166374976176003018\"><Prefix>blockblob</Prefix><Marker>2!100!MDAwMDI5IWJsb2NrYmxvYi8yMTY2Mzc0OTc2MjMzODA0NDg3ITAwMDAyOCE5OTk5LTEyLTMxVDIzOjU5OjU5Ljk5OTk5OTlaIQ--</Marker><MaxResults>2</MaxResults><Blobs><Blob><Name>blockblob/2166374976233804487</Name><VersionId>2022-09-21T08:42:42.7032839Z</VersionId><IsCurrentVersion>true</IsCurrentVersion><Properties><Creation-Time>Wed, 21 Sep 2022 08:42:42 GMT</Creation-Time><Last-Modified>Wed, 21 Sep 2022 08:42:42 GMT</Last-Modified><Etag>0x8DA9BAD3FB83D07</Etag><Content-Length>0</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>1B2M2Y8AsgTpgAmY7PhCfg==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties><Metadata><keya>a</keya><keyb>c</keyb></Metadata><OrMetadata /></Blob><Blob><Name>blockblob/3166374976253808420</Name><VersionId>2022-09-21T08:42:42.8981647Z</VersionId><IsCurrentVersion>true</IsCurrentVersion><Properties><Creation-Time>Wed, 21 Sep 2022 08:42:42 GMT</Creation-Time><Last-Modified>Wed, 21 Sep 2022 08:42:42 GMT</Last-Modified><Etag>0x8DA9BAD3FD5F98F</Etag><Content-Length>0</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>1B2M2Y8AsgTpgAmY7PhCfg==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties><Metadata><keya>a</keya><keyb>c</keyb></Metadata><OrMetadata /></Blob></Blobs><NextMarker /></EnumerationResults>",
    "responseHeaders": {
-    "date": "Wed, 02 Oct 2019 16:42:58 GMT",
+    "content-type": "application/xml",
+    "date": "Wed, 21 Sep 2022 08:42:43 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
     "transfer-encoding": "chunked",
-    "content-type": "application/xml",
-    "x-ms-request-id": "215f6a0e-201e-0080-5e40-7993dc000000",
-    "x-ms-version": "2019-02-02",
-    "x-ms-client-request-id": "bb19caa8-f8f6-48c6-a71f-ac2def009bab"
+    "x-ms-client-request-id": "fe20c3d1-c281-4d8a-90b4-6a6c8cd28c7e",
+    "x-ms-request-id": "e9749074-701e-005d-4696-cdee3d000000",
+    "x-ms-version": "2021-08-06"
    }
   },
   {
    "method": "DELETE",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container157003457848202538/blockblob%2F0157003457855208109",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container166374976176003018/blockblob/0166374976195204876",
    "query": {},
    "requestBody": null,
    "status": 202,
    "response": "",
    "responseHeaders": {
-    "date": "Wed, 02 Oct 2019 16:42:58 GMT",
+    "content-length": "0",
+    "date": "Wed, 21 Sep 2022 08:42:43 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "4718550f-f0fb-4073-a50f-a7d5d8638e1f",
     "x-ms-delete-type-permanent": "false",
-    "x-ms-request-id": "215f6a33-201e-0080-7d40-7993dc000000",
-    "x-ms-version": "2019-02-02",
-    "x-ms-client-request-id": "e47bfad4-128b-4c67-a132-178480f3013c",
-    "content-length": "0"
+    "x-ms-request-id": "e9749146-701e-005d-4096-cdee3d000000",
+    "x-ms-version": "2021-08-06"
    }
   },
   {
    "method": "DELETE",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container157003457848202538/blockblob%2F1157003457862302552",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container166374976176003018/blockblob/1166374976214507106",
    "query": {},
    "requestBody": null,
    "status": 202,
    "response": "",
    "responseHeaders": {
-    "date": "Wed, 02 Oct 2019 16:42:58 GMT",
+    "content-length": "0",
+    "date": "Wed, 21 Sep 2022 08:42:43 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "5825b9dd-29f3-476a-b9d2-9a3b5e30da26",
     "x-ms-delete-type-permanent": "false",
-    "x-ms-request-id": "215f6a6d-201e-0080-2f40-7993dc000000",
-    "x-ms-version": "2019-02-02",
-    "x-ms-client-request-id": "1f1ff6d0-ec7b-4ad5-8a14-2a35e1535259",
-    "content-length": "0"
+    "x-ms-request-id": "e97491bb-701e-005d-0c96-cdee3d000000",
+    "x-ms-version": "2021-08-06"
    }
   },
   {
    "method": "DELETE",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container157003457848202538/blockblob%2F2157003457869306593",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container166374976176003018/blockblob/2166374976233804487",
    "query": {},
    "requestBody": null,
    "status": 202,
    "response": "",
    "responseHeaders": {
-    "date": "Wed, 02 Oct 2019 16:42:58 GMT",
+    "content-length": "0",
+    "date": "Wed, 21 Sep 2022 08:42:43 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "9d3fec4b-5574-416d-8673-87d1f1623a4f",
     "x-ms-delete-type-permanent": "false",
-    "x-ms-request-id": "215f6a8e-201e-0080-4d40-7993dc000000",
-    "x-ms-version": "2019-02-02",
-    "x-ms-client-request-id": "3bd2e633-97ed-414b-8c51-90ab136bbc90",
-    "content-length": "0"
+    "x-ms-request-id": "e974924f-701e-005d-7296-cdee3d000000",
+    "x-ms-version": "2021-08-06"
    }
   },
   {
    "method": "DELETE",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container157003457848202538/blockblob%2F3157003457877105266",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container166374976176003018/blockblob/3166374976253808420",
    "query": {},
    "requestBody": null,
    "status": 202,
    "response": "",
    "responseHeaders": {
-    "date": "Wed, 02 Oct 2019 16:42:58 GMT",
+    "content-length": "0",
+    "date": "Wed, 21 Sep 2022 08:42:44 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "193e7981-1cd9-462b-b2d7-7520ed6fbf77",
     "x-ms-delete-type-permanent": "false",
-    "x-ms-request-id": "215f6ab1-201e-0080-6d40-7993dc000000",
-    "x-ms-version": "2019-02-02",
-    "x-ms-client-request-id": "8b827896-72cc-41e2-931e-6aaf9d3da620",
-    "content-length": "0"
+    "x-ms-request-id": "e9749309-701e-005d-7196-cdee3d000000",
+    "x-ms-version": "2021-08-06"
    }
   },
   {
    "method": "DELETE",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container157003457848202538",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container166374976176003018",
    "query": {
     "restype": "container"
    },
@@ -229,20 +233,24 @@
    "status": 202,
    "response": "",
    "responseHeaders": {
-    "date": "Wed, 02 Oct 2019 16:42:58 GMT",
+    "content-length": "0",
+    "date": "Wed, 21 Sep 2022 08:42:44 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-    "x-ms-request-id": "215f6acf-201e-0080-0640-7993dc000000",
-    "x-ms-version": "2019-02-02",
-    "x-ms-client-request-id": "812f5590-e58c-4582-a3c8-6e2d0a884df3",
-    "content-length": "0"
+    "x-ms-client-request-id": "c3c436e3-af32-416b-af55-aa0e9f363ef1",
+    "x-ms-request-id": "e974939b-701e-005d-5396-cdee3d000000",
+    "x-ms-version": "2021-08-06"
    }
   }
  ],
  "uniqueTestInfo": {
-  "container": "container157003457848202538",
-  "blockblob/0": "blockblob/0157003457855208109",
-  "blockblob/1": "blockblob/1157003457862302552",
-  "blockblob/2": "blockblob/2157003457869306593",
-  "blockblob/3": "blockblob/3157003457877105266"
- }
+  "uniqueName": {
+   "container": "container166374976176003018",
+   "blockblob/0": "blockblob/0166374976195204876",
+   "blockblob/1": "blockblob/1166374976214507106",
+   "blockblob/2": "blockblob/2166374976233804487",
+   "blockblob/3": "blockblob/3166374976253808420"
+  },
+  "newDate": {}
+ },
+ "hash": "105e0035ecd81e4e0d5e1e044a126892"
 }

--- a/sdk/storage/storage-blob/recordings/browsers/containerclient/recording_verify_pagedasynciterableiteratorbypage_for_listblobsflat.json
+++ b/sdk/storage/storage-blob/recordings/browsers/containerclient/recording_verify_pagedasynciterableiteratorbypage_for_listblobsflat.json
@@ -2,7 +2,7 @@
  "recordings": [
   {
    "method": "PUT",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container157003457763605198",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container166374975918703135",
    "query": {
     "restype": "container"
    },
@@ -10,218 +10,222 @@
    "status": 201,
    "response": "",
    "responseHeaders": {
-    "date": "Wed, 02 Oct 2019 16:42:57 GMT",
-    "last-modified": "Wed, 02 Oct 2019 16:42:57 GMT",
+    "content-length": "0",
+    "date": "Wed, 21 Sep 2022 08:42:39 GMT",
+    "etag": "\"0x8DA9BAD3DD62832\"",
+    "last-modified": "Wed, 21 Sep 2022 08:42:39 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-    "etag": "\"0x8D747579463BCD6\"",
-    "x-ms-request-id": "215f6550-201e-0080-0e40-7993dc000000",
-    "x-ms-version": "2019-02-02",
-    "x-ms-client-request-id": "9a54fb27-f693-43aa-a975-070f7df75730",
-    "content-length": "0"
+    "x-ms-client-request-id": "fc5bf21c-5d57-44b7-ac15-aee074c05ad7",
+    "x-ms-request-id": "e9748424-701e-005d-1196-cdee3d000000",
+    "x-ms-version": "2021-08-06"
    }
   },
   {
    "method": "PUT",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container157003457763605198/blockblob%2F0157003457771700045",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container166374975918703135/blockblob/0166374975938207269",
    "query": {},
    "requestBody": "",
    "status": 201,
    "response": "",
    "responseHeaders": {
-    "x-ms-content-crc64": "AAAAAAAAAAA=",
-    "date": "Wed, 02 Oct 2019 16:42:57 GMT",
-    "last-modified": "Wed, 02 Oct 2019 16:42:57 GMT",
-    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "content-length": "0",
     "content-md5": "1B2M2Y8AsgTpgAmY7PhCfg==",
-    "etag": "\"0x8D74757946EA6A6\"",
-    "x-ms-request-id": "215f658f-201e-0080-3d40-7993dc000000",
-    "x-ms-version": "2019-02-02",
-    "x-ms-client-request-id": "7a6c8f34-266e-4bd9-a183-749602e3f7ed",
+    "date": "Wed, 21 Sep 2022 08:42:39 GMT",
+    "etag": "\"0x8DA9BAD3DF4DA95\"",
+    "last-modified": "Wed, 21 Sep 2022 08:42:39 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "4068ceda-47bf-4b20-9af4-b6e99c55c999",
+    "x-ms-content-crc64": "AAAAAAAAAAA=",
+    "x-ms-request-id": "e9748495-701e-005d-4596-cdee3d000000",
     "x-ms-request-server-encrypted": "true",
-    "content-length": "0"
+    "x-ms-version": "2021-08-06",
+    "x-ms-version-id": "2022-09-21T08:42:39.7450901Z"
    }
   },
   {
    "method": "PUT",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container157003457763605198/blockblob%2F1157003457778609531",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container166374975918703135/blockblob/1166374975957906215",
    "query": {},
    "requestBody": "",
    "status": 201,
    "response": "",
    "responseHeaders": {
-    "x-ms-content-crc64": "AAAAAAAAAAA=",
-    "date": "Wed, 02 Oct 2019 16:42:57 GMT",
-    "last-modified": "Wed, 02 Oct 2019 16:42:57 GMT",
-    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "content-length": "0",
     "content-md5": "1B2M2Y8AsgTpgAmY7PhCfg==",
-    "etag": "\"0x8D747579479A5C1\"",
-    "x-ms-request-id": "215f65d0-201e-0080-6f40-7993dc000000",
-    "x-ms-version": "2019-02-02",
-    "x-ms-client-request-id": "4924c6a4-f1b7-4b8d-bda6-c97643f8763d",
+    "date": "Wed, 21 Sep 2022 08:42:39 GMT",
+    "etag": "\"0x8DA9BAD3E12490B\"",
+    "last-modified": "Wed, 21 Sep 2022 08:42:39 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "1559aa35-2426-421e-b2d7-9135654d2cd2",
+    "x-ms-content-crc64": "AAAAAAAAAAA=",
+    "x-ms-request-id": "e9748514-701e-005d-0196-cdee3d000000",
     "x-ms-request-server-encrypted": "true",
-    "content-length": "0"
+    "x-ms-version": "2021-08-06",
+    "x-ms-version-id": "2022-09-21T08:42:39.9379723Z"
    }
   },
   {
    "method": "PUT",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container157003457763605198/blockblob%2F2157003457786009376",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container166374975918703135/blockblob/2166374975977406930",
    "query": {},
    "requestBody": "",
    "status": 201,
    "response": "",
    "responseHeaders": {
-    "x-ms-content-crc64": "AAAAAAAAAAA=",
-    "date": "Wed, 02 Oct 2019 16:42:57 GMT",
-    "last-modified": "Wed, 02 Oct 2019 16:42:57 GMT",
-    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "content-length": "0",
     "content-md5": "1B2M2Y8AsgTpgAmY7PhCfg==",
-    "etag": "\"0x8D74757948456B9\"",
-    "x-ms-request-id": "215f661e-201e-0080-2c40-7993dc000000",
-    "x-ms-version": "2019-02-02",
-    "x-ms-client-request-id": "141a985b-d37c-49b3-a206-2ced46249ee6",
+    "date": "Wed, 21 Sep 2022 08:42:40 GMT",
+    "etag": "\"0x8DA9BAD3E307AB2\"",
+    "last-modified": "Wed, 21 Sep 2022 08:42:40 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "26a0fe1a-1e7d-4382-bf5a-d97ad0885fa2",
+    "x-ms-content-crc64": "AAAAAAAAAAA=",
+    "x-ms-request-id": "e974859d-701e-005d-4296-cdee3d000000",
     "x-ms-request-server-encrypted": "true",
-    "content-length": "0"
+    "x-ms-version": "2021-08-06",
+    "x-ms-version-id": "2022-09-21T08:42:40.1358514Z"
    }
   },
   {
    "method": "PUT",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container157003457763605198/blockblob%2F3157003457793003398",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container166374975918703135/blockblob/3166374975997004170",
    "query": {},
    "requestBody": "",
    "status": 201,
    "response": "",
    "responseHeaders": {
-    "x-ms-content-crc64": "AAAAAAAAAAA=",
-    "date": "Wed, 02 Oct 2019 16:42:57 GMT",
-    "last-modified": "Wed, 02 Oct 2019 16:42:57 GMT",
-    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "content-length": "0",
     "content-md5": "1B2M2Y8AsgTpgAmY7PhCfg==",
-    "etag": "\"0x8D74757948F7CE2\"",
-    "x-ms-request-id": "215f6677-201e-0080-7840-7993dc000000",
-    "x-ms-version": "2019-02-02",
-    "x-ms-client-request-id": "1f757ccd-8700-4186-807e-82f5b1cf20fc",
+    "date": "Wed, 21 Sep 2022 08:42:40 GMT",
+    "etag": "\"0x8DA9BAD3E4E5E46\"",
+    "last-modified": "Wed, 21 Sep 2022 08:42:40 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "28b1c96a-705e-4835-9ec8-e6630aee0485",
+    "x-ms-content-crc64": "AAAAAAAAAAA=",
+    "x-ms-request-id": "e9748609-701e-005d-6f96-cdee3d000000",
     "x-ms-request-server-encrypted": "true",
-    "content-length": "0"
+    "x-ms-version": "2021-08-06",
+    "x-ms-version-id": "2022-09-21T08:42:40.3317318Z"
    }
   },
   {
    "method": "GET",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container157003457763605198",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container166374975918703135",
    "query": {
     "comp": "list",
-    "include": "copy,deleted,metadata,snapshots,uncommittedblobs",
-    "maxresults": "2",
     "prefix": "blockblob",
-    "restype": "container"
+    "maxresults": "2",
+    "restype": "container",
+    "include": "copy,deleted,metadata,snapshots,uncommittedblobs"
    },
    "requestBody": null,
    "status": 200,
-   "response": "<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults ServiceEndpoint=\"https://fakestorageaccount.blob.core.windows.net/\" ContainerName=\"container157003457763605198\"><Prefix>blockblob</Prefix><MaxResults>2</MaxResults><Blobs><Blob><Name>blockblob/0157003457771700045</Name><Properties><Creation-Time>Wed, 02 Oct 2019 16:42:57 GMT</Creation-Time><Last-Modified>Wed, 02 Oct 2019 16:42:57 GMT</Last-Modified><Etag>0x8D74757946EA6A6</Etag><Content-Length>0</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64>AAAAAAAAAAA=</Content-CRC64><Content-MD5>1B2M2Y8AsgTpgAmY7PhCfg==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Cool</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted><TagCount>0</TagCount></Properties><Metadata><keya>a</keya><keyb>c</keyb></Metadata></Blob><Blob><Name>blockblob/1157003457778609531</Name><Properties><Creation-Time>Wed, 02 Oct 2019 16:42:57 GMT</Creation-Time><Last-Modified>Wed, 02 Oct 2019 16:42:57 GMT</Last-Modified><Etag>0x8D747579479A5C1</Etag><Content-Length>0</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64>AAAAAAAAAAA=</Content-CRC64><Content-MD5>1B2M2Y8AsgTpgAmY7PhCfg==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Cool</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted><TagCount>0</TagCount></Properties><Metadata><keya>a</keya><keyb>c</keyb></Metadata></Blob></Blobs><NextMarker>2!100!MDAwMDI5IWJsb2NrYmxvYi8yMTU3MDAzNDU3Nzg2MDA5Mzc2ITAwMDAyOCE5OTk5LTEyLTMxVDIzOjU5OjU5Ljk5OTk5OTlaIQ--</NextMarker></EnumerationResults>",
+   "response": "<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults ServiceEndpoint=\"https://fakestorageaccount.blob.core.windows.net/\" ContainerName=\"container166374975918703135\"><Prefix>blockblob</Prefix><MaxResults>2</MaxResults><Blobs><Blob><Name>blockblob/0166374975938207269</Name><VersionId>2022-09-21T08:42:39.7450901Z</VersionId><IsCurrentVersion>true</IsCurrentVersion><Properties><Creation-Time>Wed, 21 Sep 2022 08:42:39 GMT</Creation-Time><Last-Modified>Wed, 21 Sep 2022 08:42:39 GMT</Last-Modified><Etag>0x8DA9BAD3DF4DA95</Etag><Content-Length>0</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>1B2M2Y8AsgTpgAmY7PhCfg==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties><Metadata><keya>a</keya><keyb>c</keyb></Metadata><OrMetadata /></Blob><Blob><Name>blockblob/1166374975957906215</Name><VersionId>2022-09-21T08:42:39.9379723Z</VersionId><IsCurrentVersion>true</IsCurrentVersion><Properties><Creation-Time>Wed, 21 Sep 2022 08:42:39 GMT</Creation-Time><Last-Modified>Wed, 21 Sep 2022 08:42:39 GMT</Last-Modified><Etag>0x8DA9BAD3E12490B</Etag><Content-Length>0</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>1B2M2Y8AsgTpgAmY7PhCfg==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties><Metadata><keya>a</keya><keyb>c</keyb></Metadata><OrMetadata /></Blob></Blobs><NextMarker>2!100!MDAwMDI5IWJsb2NrYmxvYi8yMTY2Mzc0OTc1OTc3NDA2OTMwITAwMDAyOCE5OTk5LTEyLTMxVDIzOjU5OjU5Ljk5OTk5OTlaIQ--</NextMarker></EnumerationResults>",
    "responseHeaders": {
-    "date": "Wed, 02 Oct 2019 16:42:57 GMT",
+    "content-type": "application/xml",
+    "date": "Wed, 21 Sep 2022 08:42:40 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
     "transfer-encoding": "chunked",
-    "content-type": "application/xml",
-    "x-ms-request-id": "215f66c3-201e-0080-3540-7993dc000000",
-    "x-ms-version": "2019-02-02",
-    "x-ms-client-request-id": "c35a2f2b-0578-4113-99f5-e6e4fa1c83d8"
+    "x-ms-client-request-id": "39583454-60fc-4ef2-8d88-2df21137f5e0",
+    "x-ms-request-id": "e974867a-701e-005d-1e96-cdee3d000000",
+    "x-ms-version": "2021-08-06"
    }
   },
   {
    "method": "GET",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container157003457763605198",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container166374975918703135",
    "query": {
     "comp": "list",
-    "include": "copy,deleted,metadata,snapshots,uncommittedblobs",
-    "marker": "2!100!MDAwMDI5IWJsb2NrYmxvYi8yMTU3MDAzNDU3Nzg2MDA5Mzc2ITAwMDAyOCE5OTk5LTEyLTMxVDIzOjU5OjU5Ljk5OTk5OTlaIQ--",
-    "maxresults": "2",
     "prefix": "blockblob",
-    "restype": "container"
+    "marker": "2!100!MDAwMDI5IWJsb2NrYmxvYi8yMTY2Mzc0OTc1OTc3NDA2OTMwITAwMDAyOCE5OTk5LTEyLTMxVDIzOjU5OjU5Ljk5OTk5OTlaIQ--",
+    "maxresults": "2",
+    "restype": "container",
+    "include": "copy,deleted,metadata,snapshots,uncommittedblobs"
    },
    "requestBody": null,
    "status": 200,
-   "response": "<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults ServiceEndpoint=\"https://fakestorageaccount.blob.core.windows.net/\" ContainerName=\"container157003457763605198\"><Prefix>blockblob</Prefix><Marker>2!100!MDAwMDI5IWJsb2NrYmxvYi8yMTU3MDAzNDU3Nzg2MDA5Mzc2ITAwMDAyOCE5OTk5LTEyLTMxVDIzOjU5OjU5Ljk5OTk5OTlaIQ--</Marker><MaxResults>2</MaxResults><Blobs><Blob><Name>blockblob/2157003457786009376</Name><Properties><Creation-Time>Wed, 02 Oct 2019 16:42:57 GMT</Creation-Time><Last-Modified>Wed, 02 Oct 2019 16:42:57 GMT</Last-Modified><Etag>0x8D74757948456B9</Etag><Content-Length>0</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64>AAAAAAAAAAA=</Content-CRC64><Content-MD5>1B2M2Y8AsgTpgAmY7PhCfg==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Cool</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted><TagCount>0</TagCount></Properties><Metadata><keya>a</keya><keyb>c</keyb></Metadata></Blob><Blob><Name>blockblob/3157003457793003398</Name><Properties><Creation-Time>Wed, 02 Oct 2019 16:42:57 GMT</Creation-Time><Last-Modified>Wed, 02 Oct 2019 16:42:57 GMT</Last-Modified><Etag>0x8D74757948F7CE2</Etag><Content-Length>0</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64>AAAAAAAAAAA=</Content-CRC64><Content-MD5>1B2M2Y8AsgTpgAmY7PhCfg==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Cool</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted><TagCount>0</TagCount></Properties><Metadata><keya>a</keya><keyb>c</keyb></Metadata></Blob></Blobs><NextMarker /></EnumerationResults>",
+   "response": "<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults ServiceEndpoint=\"https://fakestorageaccount.blob.core.windows.net/\" ContainerName=\"container166374975918703135\"><Prefix>blockblob</Prefix><Marker>2!100!MDAwMDI5IWJsb2NrYmxvYi8yMTY2Mzc0OTc1OTc3NDA2OTMwITAwMDAyOCE5OTk5LTEyLTMxVDIzOjU5OjU5Ljk5OTk5OTlaIQ--</Marker><MaxResults>2</MaxResults><Blobs><Blob><Name>blockblob/2166374975977406930</Name><VersionId>2022-09-21T08:42:40.1358514Z</VersionId><IsCurrentVersion>true</IsCurrentVersion><Properties><Creation-Time>Wed, 21 Sep 2022 08:42:40 GMT</Creation-Time><Last-Modified>Wed, 21 Sep 2022 08:42:40 GMT</Last-Modified><Etag>0x8DA9BAD3E307AB2</Etag><Content-Length>0</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>1B2M2Y8AsgTpgAmY7PhCfg==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties><Metadata><keya>a</keya><keyb>c</keyb></Metadata><OrMetadata /></Blob><Blob><Name>blockblob/3166374975997004170</Name><VersionId>2022-09-21T08:42:40.3317318Z</VersionId><IsCurrentVersion>true</IsCurrentVersion><Properties><Creation-Time>Wed, 21 Sep 2022 08:42:40 GMT</Creation-Time><Last-Modified>Wed, 21 Sep 2022 08:42:40 GMT</Last-Modified><Etag>0x8DA9BAD3E4E5E46</Etag><Content-Length>0</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>1B2M2Y8AsgTpgAmY7PhCfg==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties><Metadata><keya>a</keya><keyb>c</keyb></Metadata><OrMetadata /></Blob></Blobs><NextMarker /></EnumerationResults>",
    "responseHeaders": {
-    "date": "Wed, 02 Oct 2019 16:42:57 GMT",
+    "content-type": "application/xml",
+    "date": "Wed, 21 Sep 2022 08:42:40 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
     "transfer-encoding": "chunked",
-    "content-type": "application/xml",
-    "x-ms-request-id": "215f6711-201e-0080-7440-7993dc000000",
-    "x-ms-version": "2019-02-02",
-    "x-ms-client-request-id": "df180765-0a42-44dd-ac4b-25d05d103956"
+    "x-ms-client-request-id": "c8477116-4aad-4135-8ffa-51536878a9e1",
+    "x-ms-request-id": "e9748749-701e-005d-7296-cdee3d000000",
+    "x-ms-version": "2021-08-06"
    }
   },
   {
    "method": "DELETE",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container157003457763605198/blockblob%2F0157003457771700045",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container166374975918703135/blockblob/0166374975938207269",
    "query": {},
    "requestBody": null,
    "status": 202,
    "response": "",
    "responseHeaders": {
-    "date": "Wed, 02 Oct 2019 16:42:57 GMT",
+    "content-length": "0",
+    "date": "Wed, 21 Sep 2022 08:42:40 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "5f708c10-ed87-4830-8226-051b0172be3a",
     "x-ms-delete-type-permanent": "false",
-    "x-ms-request-id": "215f6752-201e-0080-2a40-7993dc000000",
-    "x-ms-version": "2019-02-02",
-    "x-ms-client-request-id": "48462d73-82ae-4de8-bc7c-72ccffae6498",
-    "content-length": "0"
+    "x-ms-request-id": "e9748826-701e-005d-6696-cdee3d000000",
+    "x-ms-version": "2021-08-06"
    }
   },
   {
    "method": "DELETE",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container157003457763605198/blockblob%2F1157003457778609531",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container166374975918703135/blockblob/1166374975957906215",
    "query": {},
    "requestBody": null,
    "status": 202,
    "response": "",
    "responseHeaders": {
-    "date": "Wed, 02 Oct 2019 16:42:57 GMT",
+    "content-length": "0",
+    "date": "Wed, 21 Sep 2022 08:42:41 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "18b20feb-03a1-4de0-8814-2ede95044d18",
     "x-ms-delete-type-permanent": "false",
-    "x-ms-request-id": "215f6792-201e-0080-5e40-7993dc000000",
-    "x-ms-version": "2019-02-02",
-    "x-ms-client-request-id": "5ae8c65b-0ada-4f0e-9818-32521d55b09e",
-    "content-length": "0"
+    "x-ms-request-id": "e9748875-701e-005d-0d96-cdee3d000000",
+    "x-ms-version": "2021-08-06"
    }
   },
   {
    "method": "DELETE",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container157003457763605198/blockblob%2F2157003457786009376",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container166374975918703135/blockblob/2166374975977406930",
    "query": {},
    "requestBody": null,
    "status": 202,
    "response": "",
    "responseHeaders": {
-    "date": "Wed, 02 Oct 2019 16:42:57 GMT",
+    "content-length": "0",
+    "date": "Wed, 21 Sep 2022 08:42:41 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "b1d204cd-262f-41de-ab43-1d591d5ac2fb",
     "x-ms-delete-type-permanent": "false",
-    "x-ms-request-id": "215f67d3-201e-0080-1440-7993dc000000",
-    "x-ms-version": "2019-02-02",
-    "x-ms-client-request-id": "4cc86e2b-20f6-4722-9fde-1a089ae76405",
-    "content-length": "0"
+    "x-ms-request-id": "e97488bc-701e-005d-3196-cdee3d000000",
+    "x-ms-version": "2021-08-06"
    }
   },
   {
    "method": "DELETE",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container157003457763605198/blockblob%2F3157003457793003398",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container166374975918703135/blockblob/3166374975997004170",
    "query": {},
    "requestBody": null,
    "status": 202,
    "response": "",
    "responseHeaders": {
-    "date": "Wed, 02 Oct 2019 16:42:57 GMT",
+    "content-length": "0",
+    "date": "Wed, 21 Sep 2022 08:42:41 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "4b54bbf2-7067-4570-98e4-fe371f03bc6f",
     "x-ms-delete-type-permanent": "false",
-    "x-ms-request-id": "215f680b-201e-0080-4140-7993dc000000",
-    "x-ms-version": "2019-02-02",
-    "x-ms-client-request-id": "6d7fe09c-b4f8-4ef5-8427-512b5cc904b6",
-    "content-length": "0"
+    "x-ms-request-id": "e974891f-701e-005d-5f96-cdee3d000000",
+    "x-ms-version": "2021-08-06"
    }
   },
   {
    "method": "DELETE",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container157003457763605198",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container166374975918703135",
    "query": {
     "restype": "container"
    },
@@ -229,20 +233,24 @@
    "status": 202,
    "response": "",
    "responseHeaders": {
-    "date": "Wed, 02 Oct 2019 16:42:58 GMT",
+    "content-length": "0",
+    "date": "Wed, 21 Sep 2022 08:42:41 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-    "x-ms-request-id": "215f6851-201e-0080-7d40-7993dc000000",
-    "x-ms-version": "2019-02-02",
-    "x-ms-client-request-id": "aa632711-02cf-4f62-8122-d8173b864a6a",
-    "content-length": "0"
+    "x-ms-client-request-id": "4a944c43-da04-4ead-b879-64cad6c64d8b",
+    "x-ms-request-id": "e9748977-701e-005d-0896-cdee3d000000",
+    "x-ms-version": "2021-08-06"
    }
   }
  ],
  "uniqueTestInfo": {
-  "container": "container157003457763605198",
-  "blockblob/0": "blockblob/0157003457771700045",
-  "blockblob/1": "blockblob/1157003457778609531",
-  "blockblob/2": "blockblob/2157003457786009376",
-  "blockblob/3": "blockblob/3157003457793003398"
- }
+  "uniqueName": {
+   "container": "container166374975918703135",
+   "blockblob/0": "blockblob/0166374975938207269",
+   "blockblob/1": "blockblob/1166374975957906215",
+   "blockblob/2": "blockblob/2166374975977406930",
+   "blockblob/3": "blockblob/3166374975997004170"
+  },
+  "newDate": {}
+ },
+ "hash": "38157886e11cd02ddd4912e407afc92a"
 }

--- a/sdk/storage/storage-blob/recordings/browsers/containerclient/recording_verify_pagedasynciterableiteratorgenerator_next_syntax_for_listblobsflat.json
+++ b/sdk/storage/storage-blob/recordings/browsers/containerclient/recording_verify_pagedasynciterableiteratorgenerator_next_syntax_for_listblobsflat.json
@@ -2,7 +2,7 @@
  "recordings": [
   {
    "method": "PUT",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container157003457695306096",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container166375028157003192",
    "query": {
     "restype": "container"
    },
@@ -10,117 +10,119 @@
    "status": 201,
    "response": "",
    "responseHeaders": {
-    "date": "Wed, 02 Oct 2019 16:42:56 GMT",
-    "last-modified": "Wed, 02 Oct 2019 16:42:56 GMT",
+    "content-length": "0",
+    "date": "Wed, 21 Sep 2022 08:51:21 GMT",
+    "etag": "\"0x8DA9BAE75330CA7\"",
+    "last-modified": "Wed, 21 Sep 2022 08:51:21 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-    "etag": "\"0x8D7475793FF15FC\"",
-    "x-ms-request-id": "215f6294-201e-0080-3940-7993dc000000",
-    "x-ms-version": "2019-02-02",
-    "x-ms-client-request-id": "c4ef4e40-0af7-4d3c-91ad-70afad788929",
-    "content-length": "0"
+    "x-ms-client-request-id": "3ba08e84-285a-4104-b4fc-b7ff6f8a9365",
+    "x-ms-request-id": "8e8adc21-501e-005a-2197-cd825e000000",
+    "x-ms-version": "2021-08-06"
    }
   },
   {
    "method": "PUT",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container157003457695306096/blockblob%2F0157003457705308272",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container166375028157003192/blockblob/0166375028176607971",
    "query": {},
    "requestBody": "",
    "status": 201,
    "response": "",
    "responseHeaders": {
-    "x-ms-content-crc64": "AAAAAAAAAAA=",
-    "date": "Wed, 02 Oct 2019 16:42:56 GMT",
-    "last-modified": "Wed, 02 Oct 2019 16:42:56 GMT",
-    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "content-length": "0",
     "content-md5": "1B2M2Y8AsgTpgAmY7PhCfg==",
-    "etag": "\"0x8D747579409642D\"",
-    "x-ms-request-id": "215f62ec-201e-0080-0340-7993dc000000",
-    "x-ms-version": "2019-02-02",
-    "x-ms-client-request-id": "a0912db3-6dc5-4d9e-b2f7-f05d2e2e119d",
+    "date": "Wed, 21 Sep 2022 08:51:21 GMT",
+    "etag": "\"0x8DA9BAE755161A6\"",
+    "last-modified": "Wed, 21 Sep 2022 08:51:22 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "7b7ee44b-1559-444e-94e5-1eac2ed5e3bd",
+    "x-ms-content-crc64": "AAAAAAAAAAA=",
+    "x-ms-request-id": "8e8adc46-501e-005a-4097-cd825e000000",
     "x-ms-request-server-encrypted": "true",
-    "content-length": "0"
+    "x-ms-version": "2021-08-06",
+    "x-ms-version-id": "2022-09-21T08:51:22.1228966Z"
    }
   },
   {
    "method": "PUT",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container157003457695306096/blockblob%2F1157003457712100768",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container166375028157003192/blockblob/1166375028196304514",
    "query": {},
    "requestBody": "",
    "status": 201,
    "response": "",
    "responseHeaders": {
-    "x-ms-content-crc64": "AAAAAAAAAAA=",
-    "date": "Wed, 02 Oct 2019 16:42:56 GMT",
-    "last-modified": "Wed, 02 Oct 2019 16:42:56 GMT",
-    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "content-length": "0",
     "content-md5": "1B2M2Y8AsgTpgAmY7PhCfg==",
-    "etag": "\"0x8D747579413C6E9\"",
-    "x-ms-request-id": "215f6334-201e-0080-4340-7993dc000000",
-    "x-ms-version": "2019-02-02",
-    "x-ms-client-request-id": "16ca661d-6517-45b7-8a31-a23628ebce32",
+    "date": "Wed, 21 Sep 2022 08:51:21 GMT",
+    "etag": "\"0x8DA9BAE756F934A\"",
+    "last-modified": "Wed, 21 Sep 2022 08:51:22 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "f622a657-55d6-4bc1-8e64-48b53b4d245b",
+    "x-ms-content-crc64": "AAAAAAAAAAA=",
+    "x-ms-request-id": "8e8adc58-501e-005a-4f97-cd825e000000",
     "x-ms-request-server-encrypted": "true",
-    "content-length": "0"
+    "x-ms-version": "2021-08-06",
+    "x-ms-version-id": "2022-09-21T08:51:22.3207754Z"
    }
   },
   {
    "method": "GET",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container157003457695306096",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container166375028157003192",
    "query": {
     "comp": "list",
-    "include": "copy,deleted,metadata,snapshots,uncommittedblobs",
     "prefix": "blockblob",
-    "restype": "container"
+    "restype": "container",
+    "include": "copy,deleted,metadata,snapshots,uncommittedblobs"
    },
    "requestBody": null,
    "status": 200,
-   "response": "<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults ServiceEndpoint=\"https://fakestorageaccount.blob.core.windows.net/\" ContainerName=\"container157003457695306096\"><Prefix>blockblob</Prefix><Blobs><Blob><Name>blockblob/0157003457705308272</Name><Properties><Creation-Time>Wed, 02 Oct 2019 16:42:56 GMT</Creation-Time><Last-Modified>Wed, 02 Oct 2019 16:42:56 GMT</Last-Modified><Etag>0x8D747579409642D</Etag><Content-Length>0</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64>AAAAAAAAAAA=</Content-CRC64><Content-MD5>1B2M2Y8AsgTpgAmY7PhCfg==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Cool</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted><TagCount>0</TagCount></Properties><Metadata><keya>a</keya><keyb>c</keyb></Metadata></Blob><Blob><Name>blockblob/1157003457712100768</Name><Properties><Creation-Time>Wed, 02 Oct 2019 16:42:56 GMT</Creation-Time><Last-Modified>Wed, 02 Oct 2019 16:42:56 GMT</Last-Modified><Etag>0x8D747579413C6E9</Etag><Content-Length>0</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64>AAAAAAAAAAA=</Content-CRC64><Content-MD5>1B2M2Y8AsgTpgAmY7PhCfg==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Cool</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted><TagCount>0</TagCount></Properties><Metadata><keya>a</keya><keyb>c</keyb></Metadata></Blob></Blobs><NextMarker /></EnumerationResults>",
+   "response": "<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults ServiceEndpoint=\"https://fakestorageaccount.blob.core.windows.net/\" ContainerName=\"container166375028157003192\"><Prefix>blockblob</Prefix><Blobs><Blob><Name>blockblob/0166375028176607971</Name><VersionId>2022-09-21T08:51:22.1228966Z</VersionId><IsCurrentVersion>true</IsCurrentVersion><Properties><Creation-Time>Wed, 21 Sep 2022 08:51:22 GMT</Creation-Time><Last-Modified>Wed, 21 Sep 2022 08:51:22 GMT</Last-Modified><Etag>0x8DA9BAE755161A6</Etag><Content-Length>0</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>1B2M2Y8AsgTpgAmY7PhCfg==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties><Metadata><keya>a</keya><keyb>c</keyb></Metadata><OrMetadata /></Blob><Blob><Name>blockblob/1166375028196304514</Name><VersionId>2022-09-21T08:51:22.3207754Z</VersionId><IsCurrentVersion>true</IsCurrentVersion><Properties><Creation-Time>Wed, 21 Sep 2022 08:51:22 GMT</Creation-Time><Last-Modified>Wed, 21 Sep 2022 08:51:22 GMT</Last-Modified><Etag>0x8DA9BAE756F934A</Etag><Content-Length>0</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>1B2M2Y8AsgTpgAmY7PhCfg==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties><Metadata><keya>a</keya><keyb>c</keyb></Metadata><OrMetadata /></Blob></Blobs><NextMarker /></EnumerationResults>",
    "responseHeaders": {
-    "date": "Wed, 02 Oct 2019 16:42:56 GMT",
+    "content-type": "application/xml",
+    "date": "Wed, 21 Sep 2022 08:51:21 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
     "transfer-encoding": "chunked",
-    "content-type": "application/xml",
-    "x-ms-request-id": "215f639c-201e-0080-1940-7993dc000000",
-    "x-ms-version": "2019-02-02",
-    "x-ms-client-request-id": "7cb9a9f7-4ad9-484e-b58f-0d7e0025c96b"
+    "x-ms-client-request-id": "18ad7cbe-f3e0-44d6-8961-385fefbe2f3b",
+    "x-ms-request-id": "8e8adc63-501e-005a-5897-cd825e000000",
+    "x-ms-version": "2021-08-06"
    }
   },
   {
    "method": "DELETE",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container157003457695306096/blockblob%2F0157003457705308272",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container166375028157003192/blockblob/0166375028176607971",
    "query": {},
    "requestBody": null,
    "status": 202,
    "response": "",
    "responseHeaders": {
-    "date": "Wed, 02 Oct 2019 16:42:56 GMT",
+    "content-length": "0",
+    "date": "Wed, 21 Sep 2022 08:51:22 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "8cc84f59-4851-4290-9e25-5a82369f93b8",
     "x-ms-delete-type-permanent": "false",
-    "x-ms-request-id": "215f63d4-201e-0080-4a40-7993dc000000",
-    "x-ms-version": "2019-02-02",
-    "x-ms-client-request-id": "261b9f60-8aee-4393-a0a1-3d1a4b6b7bdc",
-    "content-length": "0"
+    "x-ms-request-id": "8e8adc70-501e-005a-6597-cd825e000000",
+    "x-ms-version": "2021-08-06"
    }
   },
   {
    "method": "DELETE",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container157003457695306096/blockblob%2F1157003457712100768",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container166375028157003192/blockblob/1166375028196304514",
    "query": {},
    "requestBody": null,
    "status": 202,
    "response": "",
    "responseHeaders": {
-    "date": "Wed, 02 Oct 2019 16:42:56 GMT",
+    "content-length": "0",
+    "date": "Wed, 21 Sep 2022 08:51:22 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "d5e56b38-c4e1-4aa8-b390-acce5330fcf9",
     "x-ms-delete-type-permanent": "false",
-    "x-ms-request-id": "215f6410-201e-0080-7b40-7993dc000000",
-    "x-ms-version": "2019-02-02",
-    "x-ms-client-request-id": "3c628ad4-2612-4083-9cef-07c1af31768f",
-    "content-length": "0"
+    "x-ms-request-id": "8e8adc8c-501e-005a-7f97-cd825e000000",
+    "x-ms-version": "2021-08-06"
    }
   },
   {
    "method": "DELETE",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container157003457695306096",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container166375028157003192",
    "query": {
     "restype": "container"
    },
@@ -128,18 +130,22 @@
    "status": 202,
    "response": "",
    "responseHeaders": {
-    "date": "Wed, 02 Oct 2019 16:42:57 GMT",
+    "content-length": "0",
+    "date": "Wed, 21 Sep 2022 08:51:22 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-    "x-ms-request-id": "215f6463-201e-0080-4840-7993dc000000",
-    "x-ms-version": "2019-02-02",
-    "x-ms-client-request-id": "9dc5c7cd-f17a-472f-8783-a2ed6543d337",
-    "content-length": "0"
+    "x-ms-client-request-id": "a3c7fca8-ab22-4218-8237-8f349200fada",
+    "x-ms-request-id": "8e8adca2-501e-005a-1297-cd825e000000",
+    "x-ms-version": "2021-08-06"
    }
   }
  ],
  "uniqueTestInfo": {
-  "container": "container157003457695306096",
-  "blockblob/0": "blockblob/0157003457705308272",
-  "blockblob/1": "blockblob/1157003457712100768"
- }
+  "uniqueName": {
+   "container": "container166375028157003192",
+   "blockblob/0": "blockblob/0166375028176607971",
+   "blockblob/1": "blockblob/1166375028196304514"
+  },
+  "newDate": {}
+ },
+ "hash": "f9aa1bbc65464d3b93d1688e08c6cfae"
 }

--- a/sdk/storage/storage-blob/recordings/browsers/special_naming_tests/recording_should_work_with_special_blob_name_arabic.json
+++ b/sdk/storage/storage-blob/recordings/browsers/special_naming_tests/recording_should_work_with_special_blob_name_arabic.json
@@ -2,7 +2,7 @@
  "recordings": [
   {
    "method": "PUT",
-   "url": "https://fakestorageaccount.blob.core.windows.net/1container-with-dash158018570842509818",
+   "url": "https://fakestorageaccount.blob.core.windows.net/1container-with-dash166375028892201088",
    "query": {
     "restype": "container"
    },
@@ -11,18 +11,18 @@
    "response": "",
    "responseHeaders": {
     "content-length": "0",
-    "date": "Tue, 28 Jan 2020 04:28:28 GMT",
-    "etag": "\"0x8D7A3AA861235E8\"",
-    "last-modified": "Tue, 28 Jan 2020 04:28:28 GMT",
+    "date": "Wed, 21 Sep 2022 08:51:28 GMT",
+    "etag": "\"0x8DA9BAE7994D7A9\"",
+    "last-modified": "Wed, 21 Sep 2022 08:51:29 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-    "x-ms-client-request-id": "e04c1195-d673-47ef-8bb8-d96b515a36dc",
-    "x-ms-request-id": "2bd8b03c-401e-0017-7193-d5a69f000000",
-    "x-ms-version": "2019-02-02"
+    "x-ms-client-request-id": "6e6d4df7-bc78-4e5c-a071-ae8fb8c7dfa6",
+    "x-ms-request-id": "8e8adee0-501e-005a-0397-cd825e000000",
+    "x-ms-version": "2021-08-06"
    }
   },
   {
    "method": "PUT",
-   "url": "https://fakestorageaccount.blob.core.windows.net/1container-with-dash158018570842509818/%D8%B9%D8%B1%D8%A8%D9%8A%2F%D8%B9%D8%B1%D8%A8%D9%89158018570859108609",
+   "url": "https://fakestorageaccount.blob.core.windows.net/1container-with-dash166375028892201088/%D8%B9%D8%B1%D8%A8%D9%8A/%D8%B9%D8%B1%D8%A8%D9%89166375028911705728",
    "query": {},
    "requestBody": "A",
    "status": 201,
@@ -30,20 +30,21 @@
    "responseHeaders": {
     "content-length": "0",
     "content-md5": "f8VicOenD6gaWTW3Lqy+KQ==",
-    "date": "Tue, 28 Jan 2020 04:28:28 GMT",
-    "etag": "\"0x8D7A3AA862BE66C\"",
-    "last-modified": "Tue, 28 Jan 2020 04:28:28 GMT",
+    "date": "Wed, 21 Sep 2022 08:51:28 GMT",
+    "etag": "\"0x8DA9BAE79B3BD95\"",
+    "last-modified": "Wed, 21 Sep 2022 08:51:29 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-    "x-ms-client-request-id": "81d64e34-45f0-4e9a-9eee-3987fd5ace12",
+    "x-ms-client-request-id": "ce6f4b99-17cc-409c-8c7b-fb7855963960",
     "x-ms-content-crc64": "PiO3pTJ67n0=",
-    "x-ms-request-id": "2bd8b069-401e-0017-1a93-d5a69f000000",
+    "x-ms-request-id": "8e8adef4-501e-005a-1497-cd825e000000",
     "x-ms-request-server-encrypted": "true",
-    "x-ms-version": "2019-02-02"
+    "x-ms-version": "2021-08-06",
+    "x-ms-version-id": "2022-09-21T08:51:29.4783893Z"
    }
   },
   {
    "method": "HEAD",
-   "url": "https://fakestorageaccount.blob.core.windows.net/1container-with-dash158018570842509818/%D8%B9%D8%B1%D8%A8%D9%8A%2F%D8%B9%D8%B1%D8%A8%D9%89158018570859108609",
+   "url": "https://fakestorageaccount.blob.core.windows.net/1container-with-dash166375028892201088/%D8%B9%D8%B1%D8%A8%D9%8A/%D8%B9%D8%B1%D8%A8%D9%89166375028911705728",
    "query": {},
    "requestBody": null,
    "status": 200,
@@ -53,46 +54,48 @@
     "content-length": "1",
     "content-md5": "f8VicOenD6gaWTW3Lqy+KQ==",
     "content-type": "application/octet-stream",
-    "date": "Tue, 28 Jan 2020 04:28:28 GMT",
-    "etag": "\"0x8D7A3AA862BE66C\"",
-    "last-modified": "Tue, 28 Jan 2020 04:28:28 GMT",
+    "date": "Wed, 21 Sep 2022 08:51:28 GMT",
+    "etag": "\"0x8DA9BAE79B3BD95\"",
+    "last-modified": "Wed, 21 Sep 2022 08:51:29 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-    "x-ms-access-tier": "Cool",
+    "x-ms-access-tier": "Hot",
     "x-ms-access-tier-inferred": "true",
     "x-ms-blob-type": "BlockBlob",
-    "x-ms-client-request-id": "414e47f3-047d-4377-827d-1f9509712061",
-    "x-ms-creation-time": "Tue, 28 Jan 2020 04:28:28 GMT",
+    "x-ms-client-request-id": "a4c53372-3edf-4d2e-a105-7c6acc107d75",
+    "x-ms-creation-time": "Wed, 21 Sep 2022 08:51:29 GMT",
+    "x-ms-is-current-version": "true",
     "x-ms-lease-state": "available",
     "x-ms-lease-status": "unlocked",
-    "x-ms-request-id": "2bd8b09a-401e-0017-4b93-d5a69f000000",
+    "x-ms-request-id": "8e8adeff-501e-005a-1e97-cd825e000000",
     "x-ms-server-encrypted": "true",
-    "x-ms-version": "2019-02-02"
+    "x-ms-version": "2021-08-06",
+    "x-ms-version-id": "2022-09-21T08:51:29.4783893Z"
    }
   },
   {
    "method": "GET",
-   "url": "https://fakestorageaccount.blob.core.windows.net/1container-with-dash158018570842509818",
+   "url": "https://fakestorageaccount.blob.core.windows.net/1container-with-dash166375028892201088",
    "query": {
-    "prefix": "عربي/عربى158018570859108609",
-    "restype": "container",
-    "comp": "list"
+    "comp": "list",
+    "prefix": "عربي/عربى166375028911705728",
+    "restype": "container"
    },
    "requestBody": null,
    "status": 200,
-   "response": "<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults ServiceEndpoint=\"https://fakestorageaccount.blob.core.windows.net/\" ContainerName=\"1container-with-dash158018570842509818\"><Prefix>عربي/عربى158018570859108609</Prefix><Blobs><Blob><Name>عربي/عربى158018570859108609</Name><Properties><Creation-Time>Tue, 28 Jan 2020 04:28:28 GMT</Creation-Time><Last-Modified>Tue, 28 Jan 2020 04:28:28 GMT</Last-Modified><Etag>0x8D7A3AA862BE66C</Etag><Content-Length>1</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>f8VicOenD6gaWTW3Lqy+KQ==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Cool</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties></Blob></Blobs><NextMarker /></EnumerationResults>",
+   "response": "<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults ServiceEndpoint=\"https://fakestorageaccount.blob.core.windows.net/\" ContainerName=\"1container-with-dash166375028892201088\"><Prefix>عربي/عربى166375028911705728</Prefix><Blobs><Blob><Name>عربي/عربى166375028911705728</Name><VersionId>2022-09-21T08:51:29.4783893Z</VersionId><IsCurrentVersion>true</IsCurrentVersion><Properties><Creation-Time>Wed, 21 Sep 2022 08:51:29 GMT</Creation-Time><Last-Modified>Wed, 21 Sep 2022 08:51:29 GMT</Last-Modified><Etag>0x8DA9BAE79B3BD95</Etag><Content-Length>1</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>f8VicOenD6gaWTW3Lqy+KQ==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties><OrMetadata /></Blob></Blobs><NextMarker /></EnumerationResults>",
    "responseHeaders": {
     "content-type": "application/xml",
-    "date": "Tue, 28 Jan 2020 04:28:28 GMT",
+    "date": "Wed, 21 Sep 2022 08:51:29 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
     "transfer-encoding": "chunked",
-    "x-ms-client-request-id": "d88ac7dc-738e-4212-9bc0-2a65230ad1c2",
-    "x-ms-request-id": "2bd8b0ce-401e-0017-7b93-d5a69f000000",
-    "x-ms-version": "2019-02-02"
+    "x-ms-client-request-id": "60eca3a6-d2a4-41ea-a3c9-36baabcc7e3d",
+    "x-ms-request-id": "8e8adf13-501e-005a-3297-cd825e000000",
+    "x-ms-version": "2021-08-06"
    }
   },
   {
    "method": "DELETE",
-   "url": "https://fakestorageaccount.blob.core.windows.net/1container-with-dash158018570842509818",
+   "url": "https://fakestorageaccount.blob.core.windows.net/1container-with-dash166375028892201088",
    "query": {
     "restype": "container"
    },
@@ -101,19 +104,20 @@
    "response": "",
    "responseHeaders": {
     "content-length": "0",
-    "date": "Tue, 28 Jan 2020 04:28:29 GMT",
+    "date": "Wed, 21 Sep 2022 08:51:29 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-    "x-ms-client-request-id": "f8937a39-e130-4c6a-9b8a-08806c8ac8a7",
-    "x-ms-request-id": "2bd8b0fa-401e-0017-2593-d5a69f000000",
-    "x-ms-version": "2019-02-02"
+    "x-ms-client-request-id": "9440545c-8c39-469b-85c1-849f8c45dfeb",
+    "x-ms-request-id": "8e8adf37-501e-005a-5497-cd825e000000",
+    "x-ms-version": "2021-08-06"
    }
   }
  ],
  "uniqueTestInfo": {
   "uniqueName": {
-   "1container-with-dash": "1container-with-dash158018570842509818",
-   "عربي/عربى": "عربي/عربى158018570859108609"
+   "1container-with-dash": "1container-with-dash166375028892201088",
+   "عربي/عربى": "عربي/عربى166375028911705728"
   },
   "newDate": {}
- }
+ },
+ "hash": "51248f066d727d5a171f9d336c0c62c8"
 }

--- a/sdk/storage/storage-blob/recordings/browsers/special_naming_tests/recording_should_work_with_special_blob_name_characters.json
+++ b/sdk/storage/storage-blob/recordings/browsers/special_naming_tests/recording_should_work_with_special_blob_name_characters.json
@@ -2,7 +2,7 @@
  "recordings": [
   {
    "method": "PUT",
-   "url": "https://fakestorageaccount.blob.core.windows.net/1container-with-dash158018570326800067",
+   "url": "https://fakestorageaccount.blob.core.windows.net/1container-with-dash166375028793109713",
    "query": {
     "restype": "container"
    },
@@ -11,18 +11,18 @@
    "response": "",
    "responseHeaders": {
     "content-length": "0",
-    "date": "Tue, 28 Jan 2020 04:28:23 GMT",
-    "etag": "\"0x8D7A3AA82FFAD38\"",
-    "last-modified": "Tue, 28 Jan 2020 04:28:23 GMT",
+    "date": "Wed, 21 Sep 2022 08:51:27 GMT",
+    "etag": "\"0x8DA9BAE78FDDDF2\"",
+    "last-modified": "Wed, 21 Sep 2022 08:51:28 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-    "x-ms-client-request-id": "1f84a971-f700-4ea4-8726-48ed03043c44",
-    "x-ms-request-id": "2bd8a9cb-401e-0017-7993-d5a69f000000",
-    "x-ms-version": "2019-02-02"
+    "x-ms-client-request-id": "6dd527f2-2254-4c89-abe0-081978e37cd1",
+    "x-ms-request-id": "8e8ade85-501e-005a-3297-cd825e000000",
+    "x-ms-version": "2021-08-06"
    }
   },
   {
    "method": "PUT",
-   "url": "https://fakestorageaccount.blob.core.windows.net/1container-with-dash158018570326800067/%E6%B1%89%E5%AD%97.%20special%20~!%40%23%24%25%5E%26*()_%2B%601234567890-%3D%7B%7D%7C%5B%5D%5C%3A%22%3B%27%3C%3E%3F%2C%2F%27158018570343700073",
+   "url": "https://fakestorageaccount.blob.core.windows.net/1container-with-dash166375028793109713/%E6%B1%89%E5%AD%97.%20special%20~!%40%23%24%25%5E%26*()_%2B%601234567890-%3D%7B%7D%7C%5B%5D%5C%3A%22%3B%27%3C%3E%3F%2C/%27166375028812909943",
    "query": {},
    "requestBody": "A",
    "status": 201,
@@ -30,20 +30,21 @@
    "responseHeaders": {
     "content-length": "0",
     "content-md5": "f8VicOenD6gaWTW3Lqy+KQ==",
-    "date": "Tue, 28 Jan 2020 04:28:23 GMT",
-    "etag": "\"0x8D7A3AA831A97A5\"",
-    "last-modified": "Tue, 28 Jan 2020 04:28:23 GMT",
+    "date": "Wed, 21 Sep 2022 08:51:27 GMT",
+    "etag": "\"0x8DA9BAE791C293C\"",
+    "last-modified": "Wed, 21 Sep 2022 08:51:28 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-    "x-ms-client-request-id": "0697a179-a59b-4b10-8540-2c61c2295fe4",
+    "x-ms-client-request-id": "284ceb22-a931-4fd2-95e2-85b24d3b9fd7",
     "x-ms-content-crc64": "PiO3pTJ67n0=",
-    "x-ms-request-id": "2bd8a9fb-401e-0017-2693-d5a69f000000",
+    "x-ms-request-id": "8e8ade97-501e-005a-4397-cd825e000000",
     "x-ms-request-server-encrypted": "true",
-    "x-ms-version": "2019-02-02"
+    "x-ms-version": "2021-08-06",
+    "x-ms-version-id": "2022-09-21T08:51:28.4849980Z"
    }
   },
   {
    "method": "HEAD",
-   "url": "https://fakestorageaccount.blob.core.windows.net/1container-with-dash158018570326800067/%E6%B1%89%E5%AD%97.%20special%20~!%40%23%24%25%5E%26*()_%2B%601234567890-%3D%7B%7D%7C%5B%5D%5C%3A%22%3B%27%3C%3E%3F%2C%2F%27158018570343700073",
+   "url": "https://fakestorageaccount.blob.core.windows.net/1container-with-dash166375028793109713/%E6%B1%89%E5%AD%97.%20special%20~!%40%23%24%25%5E%26*()_%2B%601234567890-%3D%7B%7D%7C%5B%5D%5C%3A%22%3B%27%3C%3E%3F%2C/%27166375028812909943",
    "query": {},
    "requestBody": null,
    "status": 200,
@@ -53,46 +54,48 @@
     "content-length": "1",
     "content-md5": "f8VicOenD6gaWTW3Lqy+KQ==",
     "content-type": "application/octet-stream",
-    "date": "Tue, 28 Jan 2020 04:28:23 GMT",
-    "etag": "\"0x8D7A3AA831A97A5\"",
-    "last-modified": "Tue, 28 Jan 2020 04:28:23 GMT",
+    "date": "Wed, 21 Sep 2022 08:51:27 GMT",
+    "etag": "\"0x8DA9BAE791C293C\"",
+    "last-modified": "Wed, 21 Sep 2022 08:51:28 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-    "x-ms-access-tier": "Cool",
+    "x-ms-access-tier": "Hot",
     "x-ms-access-tier-inferred": "true",
     "x-ms-blob-type": "BlockBlob",
-    "x-ms-client-request-id": "0e0ea3c9-0493-42cc-b335-008db2fe9d5f",
-    "x-ms-creation-time": "Tue, 28 Jan 2020 04:28:23 GMT",
+    "x-ms-client-request-id": "bd59b8d1-bb27-49d6-91ed-e458025259ed",
+    "x-ms-creation-time": "Wed, 21 Sep 2022 08:51:28 GMT",
+    "x-ms-is-current-version": "true",
     "x-ms-lease-state": "available",
     "x-ms-lease-status": "unlocked",
-    "x-ms-request-id": "2bd8aa36-401e-0017-5d93-d5a69f000000",
+    "x-ms-request-id": "8e8ade9d-501e-005a-4997-cd825e000000",
     "x-ms-server-encrypted": "true",
-    "x-ms-version": "2019-02-02"
+    "x-ms-version": "2021-08-06",
+    "x-ms-version-id": "2022-09-21T08:51:28.4849980Z"
    }
   },
   {
    "method": "GET",
-   "url": "https://fakestorageaccount.blob.core.windows.net/1container-with-dash158018570326800067",
+   "url": "https://fakestorageaccount.blob.core.windows.net/1container-with-dash166375028793109713",
    "query": {
-    "prefix": "汉字. special ~!@#$%^&*()_+`1234567890-={}|[]/:\";'<>?,/'158018570343700073",
-    "restype": "container",
-    "comp": "list"
+    "comp": "list",
+    "prefix": "汉字. special ~!@#$%^&*()_+`1234567890-={}|[]/:\";'<>?,/'166375028812909943",
+    "restype": "container"
    },
    "requestBody": null,
    "status": 200,
-   "response": "<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults ServiceEndpoint=\"https://fakestorageaccount.blob.core.windows.net/\" ContainerName=\"1container-with-dash158018570326800067\"><Prefix>汉字. special ~!@#$%^&amp;*()_+`1234567890-={}|[]/:\";'&lt;&gt;?,/'158018570343700073</Prefix><Blobs><Blob><Name>汉字. special ~!@#$%^&amp;*()_+`1234567890-={}|[]/:\";'&lt;&gt;?,/'158018570343700073</Name><Properties><Creation-Time>Tue, 28 Jan 2020 04:28:23 GMT</Creation-Time><Last-Modified>Tue, 28 Jan 2020 04:28:23 GMT</Last-Modified><Etag>0x8D7A3AA831A97A5</Etag><Content-Length>1</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>f8VicOenD6gaWTW3Lqy+KQ==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Cool</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties></Blob></Blobs><NextMarker /></EnumerationResults>",
+   "response": "<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults ServiceEndpoint=\"https://fakestorageaccount.blob.core.windows.net/\" ContainerName=\"1container-with-dash166375028793109713\"><Prefix>汉字. special ~!@#$%^&amp;*()_+`1234567890-={}|[]/:\";'&lt;&gt;?,/'166375028812909943</Prefix><Blobs><Blob><Name>汉字. special ~!@#$%^&amp;*()_+`1234567890-={}|[]/:\";'&lt;&gt;?,/'166375028812909943</Name><VersionId>2022-09-21T08:51:28.4849980Z</VersionId><IsCurrentVersion>true</IsCurrentVersion><Properties><Creation-Time>Wed, 21 Sep 2022 08:51:28 GMT</Creation-Time><Last-Modified>Wed, 21 Sep 2022 08:51:28 GMT</Last-Modified><Etag>0x8DA9BAE791C293C</Etag><Content-Length>1</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>f8VicOenD6gaWTW3Lqy+KQ==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties><OrMetadata /></Blob></Blobs><NextMarker /></EnumerationResults>",
    "responseHeaders": {
     "content-type": "application/xml",
-    "date": "Tue, 28 Jan 2020 04:28:23 GMT",
+    "date": "Wed, 21 Sep 2022 08:51:28 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
     "transfer-encoding": "chunked",
-    "x-ms-client-request-id": "4d9f1246-b3fe-4a55-9960-6ec3f429f336",
-    "x-ms-request-id": "2bd8aa75-401e-0017-1593-d5a69f000000",
-    "x-ms-version": "2019-02-02"
+    "x-ms-client-request-id": "6eadbeec-f630-4602-bb7b-8e33012d485f",
+    "x-ms-request-id": "8e8adeb0-501e-005a-5897-cd825e000000",
+    "x-ms-version": "2021-08-06"
    }
   },
   {
    "method": "DELETE",
-   "url": "https://fakestorageaccount.blob.core.windows.net/1container-with-dash158018570326800067",
+   "url": "https://fakestorageaccount.blob.core.windows.net/1container-with-dash166375028793109713",
    "query": {
     "restype": "container"
    },
@@ -101,19 +104,20 @@
    "response": "",
    "responseHeaders": {
     "content-length": "0",
-    "date": "Tue, 28 Jan 2020 04:28:24 GMT",
+    "date": "Wed, 21 Sep 2022 08:51:28 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-    "x-ms-client-request-id": "8c22284c-c10b-4a8d-aa99-657604b85538",
-    "x-ms-request-id": "2bd8aaba-401e-0017-5893-d5a69f000000",
-    "x-ms-version": "2019-02-02"
+    "x-ms-client-request-id": "3934c615-4823-4cbd-afd4-001e2981f499",
+    "x-ms-request-id": "8e8adecb-501e-005a-6e97-cd825e000000",
+    "x-ms-version": "2021-08-06"
    }
   }
  ],
  "uniqueTestInfo": {
   "uniqueName": {
-   "1container-with-dash": "1container-with-dash158018570326800067",
-   "汉字. special ~!@#$%^&*()_+`1234567890-={}|[]\\:\";'<>?,/'": "汉字. special ~!@#$%^&*()_+`1234567890-={}|[]\\:\";'<>?,/'158018570343700073"
+   "1container-with-dash": "1container-with-dash166375028793109713",
+   "汉字. special ~!@#$%^&*()_+`1234567890-={}|[]\\:\";'<>?,/'": "汉字. special ~!@#$%^&*()_+`1234567890-={}|[]\\:\";'<>?,/'166375028812909943"
   },
   "newDate": {}
- }
+ },
+ "hash": "5faaa4222c965b0af8b3a7b521afa8c9"
 }

--- a/sdk/storage/storage-blob/recordings/browsers/special_naming_tests/recording_should_work_with_special_blob_name_japanese.json
+++ b/sdk/storage/storage-blob/recordings/browsers/special_naming_tests/recording_should_work_with_special_blob_name_japanese.json
@@ -2,7 +2,7 @@
  "recordings": [
   {
    "method": "PUT",
-   "url": "https://fakestorageaccount.blob.core.windows.net/1container-with-dash158018571097709674",
+   "url": "https://fakestorageaccount.blob.core.windows.net/1container-with-dash166375028992405795",
    "query": {
     "restype": "container"
    },
@@ -11,18 +11,18 @@
    "response": "",
    "responseHeaders": {
     "content-length": "0",
-    "date": "Tue, 28 Jan 2020 04:28:31 GMT",
-    "etag": "\"0x8D7A3AA8797E389\"",
-    "last-modified": "Tue, 28 Jan 2020 04:28:31 GMT",
+    "date": "Wed, 21 Sep 2022 08:51:29 GMT",
+    "etag": "\"0x8DA9BAE7A2DCCE0\"",
+    "last-modified": "Wed, 21 Sep 2022 08:51:30 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-    "x-ms-client-request-id": "79a51ff7-8a10-4dbe-a73a-e9b4fd43385c",
-    "x-ms-request-id": "2bd8b351-401e-0017-5093-d5a69f000000",
-    "x-ms-version": "2019-02-02"
+    "x-ms-client-request-id": "e9faf288-6460-463e-bc4a-d92e5ab1b9b4",
+    "x-ms-request-id": "8e8adf4f-501e-005a-6a97-cd825e000000",
+    "x-ms-version": "2021-08-06"
    }
   },
   {
    "method": "PUT",
-   "url": "https://fakestorageaccount.blob.core.windows.net/1container-with-dash158018571097709674/%E3%81%AB%E3%81%A3%E3%81%BD%E3%82%93%E3%81%94%2F%E3%81%AB%E3%81%BB%E3%82%93%E3%81%94158018571114601805",
+   "url": "https://fakestorageaccount.blob.core.windows.net/1container-with-dash166375028992405795/%E3%81%AB%E3%81%A3%E3%81%BD%E3%82%93%E3%81%94/%E3%81%AB%E3%81%BB%E3%82%93%E3%81%94166375029012005244",
    "query": {},
    "requestBody": "A",
    "status": 201,
@@ -30,20 +30,21 @@
    "responseHeaders": {
     "content-length": "0",
     "content-md5": "f8VicOenD6gaWTW3Lqy+KQ==",
-    "date": "Tue, 28 Jan 2020 04:28:31 GMT",
-    "etag": "\"0x8D7A3AA87B1E1C2\"",
-    "last-modified": "Tue, 28 Jan 2020 04:28:31 GMT",
+    "date": "Wed, 21 Sep 2022 08:51:29 GMT",
+    "etag": "\"0x8DA9BAE7A4C3C2A\"",
+    "last-modified": "Wed, 21 Sep 2022 08:51:30 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-    "x-ms-client-request-id": "c36b49db-eeef-4369-9dff-0dab15288d7b",
+    "x-ms-client-request-id": "a7c1674c-b98f-4cd3-abb9-e7d1366b287b",
     "x-ms-content-crc64": "PiO3pTJ67n0=",
-    "x-ms-request-id": "2bd8b393-401e-0017-0c93-d5a69f000000",
+    "x-ms-request-id": "8e8adf69-501e-005a-0297-cd825e000000",
     "x-ms-request-server-encrypted": "true",
-    "x-ms-version": "2019-02-02"
+    "x-ms-version": "2021-08-06",
+    "x-ms-version-id": "2022-09-21T08:51:30.4777770Z"
    }
   },
   {
    "method": "HEAD",
-   "url": "https://fakestorageaccount.blob.core.windows.net/1container-with-dash158018571097709674/%E3%81%AB%E3%81%A3%E3%81%BD%E3%82%93%E3%81%94%2F%E3%81%AB%E3%81%BB%E3%82%93%E3%81%94158018571114601805",
+   "url": "https://fakestorageaccount.blob.core.windows.net/1container-with-dash166375028992405795/%E3%81%AB%E3%81%A3%E3%81%BD%E3%82%93%E3%81%94/%E3%81%AB%E3%81%BB%E3%82%93%E3%81%94166375029012005244",
    "query": {},
    "requestBody": null,
    "status": 200,
@@ -53,46 +54,48 @@
     "content-length": "1",
     "content-md5": "f8VicOenD6gaWTW3Lqy+KQ==",
     "content-type": "application/octet-stream",
-    "date": "Tue, 28 Jan 2020 04:28:31 GMT",
-    "etag": "\"0x8D7A3AA87B1E1C2\"",
-    "last-modified": "Tue, 28 Jan 2020 04:28:31 GMT",
+    "date": "Wed, 21 Sep 2022 08:51:29 GMT",
+    "etag": "\"0x8DA9BAE7A4C3C2A\"",
+    "last-modified": "Wed, 21 Sep 2022 08:51:30 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-    "x-ms-access-tier": "Cool",
+    "x-ms-access-tier": "Hot",
     "x-ms-access-tier-inferred": "true",
     "x-ms-blob-type": "BlockBlob",
-    "x-ms-client-request-id": "8f9a427c-615a-4cb2-ae4d-feb24b8cebeb",
-    "x-ms-creation-time": "Tue, 28 Jan 2020 04:28:31 GMT",
+    "x-ms-client-request-id": "5432dd1d-a187-46f5-be52-f9a21fd68c2f",
+    "x-ms-creation-time": "Wed, 21 Sep 2022 08:51:30 GMT",
+    "x-ms-is-current-version": "true",
     "x-ms-lease-state": "available",
     "x-ms-lease-status": "unlocked",
-    "x-ms-request-id": "2bd8b3d1-401e-0017-4793-d5a69f000000",
+    "x-ms-request-id": "8e8adf7c-501e-005a-1297-cd825e000000",
     "x-ms-server-encrypted": "true",
-    "x-ms-version": "2019-02-02"
+    "x-ms-version": "2021-08-06",
+    "x-ms-version-id": "2022-09-21T08:51:30.4777770Z"
    }
   },
   {
    "method": "GET",
-   "url": "https://fakestorageaccount.blob.core.windows.net/1container-with-dash158018571097709674",
+   "url": "https://fakestorageaccount.blob.core.windows.net/1container-with-dash166375028992405795",
    "query": {
-    "prefix": "にっぽんご/にほんご158018571114601805",
-    "restype": "container",
-    "comp": "list"
+    "comp": "list",
+    "prefix": "にっぽんご/にほんご166375029012005244",
+    "restype": "container"
    },
    "requestBody": null,
    "status": 200,
-   "response": "<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults ServiceEndpoint=\"https://fakestorageaccount.blob.core.windows.net/\" ContainerName=\"1container-with-dash158018571097709674\"><Prefix>にっぽんご/にほんご158018571114601805</Prefix><Blobs><Blob><Name>にっぽんご/にほんご158018571114601805</Name><Properties><Creation-Time>Tue, 28 Jan 2020 04:28:31 GMT</Creation-Time><Last-Modified>Tue, 28 Jan 2020 04:28:31 GMT</Last-Modified><Etag>0x8D7A3AA87B1E1C2</Etag><Content-Length>1</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>f8VicOenD6gaWTW3Lqy+KQ==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Cool</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties></Blob></Blobs><NextMarker /></EnumerationResults>",
+   "response": "<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults ServiceEndpoint=\"https://fakestorageaccount.blob.core.windows.net/\" ContainerName=\"1container-with-dash166375028992405795\"><Prefix>にっぽんご/にほんご166375029012005244</Prefix><Blobs><Blob><Name>にっぽんご/にほんご166375029012005244</Name><VersionId>2022-09-21T08:51:30.4777770Z</VersionId><IsCurrentVersion>true</IsCurrentVersion><Properties><Creation-Time>Wed, 21 Sep 2022 08:51:30 GMT</Creation-Time><Last-Modified>Wed, 21 Sep 2022 08:51:30 GMT</Last-Modified><Etag>0x8DA9BAE7A4C3C2A</Etag><Content-Length>1</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>f8VicOenD6gaWTW3Lqy+KQ==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties><OrMetadata /></Blob></Blobs><NextMarker /></EnumerationResults>",
    "responseHeaders": {
     "content-type": "application/xml",
-    "date": "Tue, 28 Jan 2020 04:28:31 GMT",
+    "date": "Wed, 21 Sep 2022 08:51:30 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
     "transfer-encoding": "chunked",
-    "x-ms-client-request-id": "d51d13a2-f3a1-4010-98b2-d0ebe2315960",
-    "x-ms-request-id": "2bd8b404-401e-0017-7793-d5a69f000000",
-    "x-ms-version": "2019-02-02"
+    "x-ms-client-request-id": "7871239a-2235-4438-9911-d51684f3d9fe",
+    "x-ms-request-id": "8e8adf92-501e-005a-2497-cd825e000000",
+    "x-ms-version": "2021-08-06"
    }
   },
   {
    "method": "DELETE",
-   "url": "https://fakestorageaccount.blob.core.windows.net/1container-with-dash158018571097709674",
+   "url": "https://fakestorageaccount.blob.core.windows.net/1container-with-dash166375028992405795",
    "query": {
     "restype": "container"
    },
@@ -101,19 +104,20 @@
    "response": "",
    "responseHeaders": {
     "content-length": "0",
-    "date": "Tue, 28 Jan 2020 04:28:31 GMT",
+    "date": "Wed, 21 Sep 2022 08:51:30 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-    "x-ms-client-request-id": "b4291379-b158-417b-bd83-9cadbf85ee22",
-    "x-ms-request-id": "2bd8b445-401e-0017-3593-d5a69f000000",
-    "x-ms-version": "2019-02-02"
+    "x-ms-client-request-id": "f76edaba-2223-407f-b355-7af5e5e970fb",
+    "x-ms-request-id": "8e8adfa7-501e-005a-3897-cd825e000000",
+    "x-ms-version": "2021-08-06"
    }
   }
  ],
  "uniqueTestInfo": {
   "uniqueName": {
-   "1container-with-dash": "1container-with-dash158018571097709674",
-   "にっぽんご/にほんご": "にっぽんご/にほんご158018571114601805"
+   "1container-with-dash": "1container-with-dash166375028992405795",
+   "にっぽんご/にほんご": "にっぽんご/にほんご166375029012005244"
   },
   "newDate": {}
- }
+ },
+ "hash": "f72bc2889f5c1b7912a6d49d3f8a6514"
 }

--- a/sdk/storage/storage-blob/recordings/browsers/special_naming_tests/recording_should_work_with_special_blob_names_chinese_characters.json
+++ b/sdk/storage/storage-blob/recordings/browsers/special_naming_tests/recording_should_work_with_special_blob_names_chinese_characters.json
@@ -2,7 +2,7 @@
  "recordings": [
   {
    "method": "PUT",
-   "url": "https://fakestorageaccount.blob.core.windows.net/1container-with-dash158018570157704787",
+   "url": "https://fakestorageaccount.blob.core.windows.net/1container-with-dash166375028694704805",
    "query": {
     "restype": "container"
    },
@@ -11,18 +11,18 @@
    "response": "",
    "responseHeaders": {
     "content-length": "0",
-    "date": "Tue, 28 Jan 2020 04:28:21 GMT",
-    "etag": "\"0x8D7A3AA81FD7810\"",
-    "last-modified": "Tue, 28 Jan 2020 04:28:21 GMT",
+    "date": "Wed, 21 Sep 2022 08:51:26 GMT",
+    "etag": "\"0x8DA9BAE7867F589\"",
+    "last-modified": "Wed, 21 Sep 2022 08:51:27 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-    "x-ms-client-request-id": "aff7d1c9-9889-4812-9b31-d2366f810438",
-    "x-ms-request-id": "2bd8a75b-401e-0017-5693-d5a69f000000",
-    "x-ms-version": "2019-02-02"
+    "x-ms-client-request-id": "6a6a585a-7cb4-43e8-9926-b52935f0755b",
+    "x-ms-request-id": "8e8ade25-501e-005a-5e97-cd825e000000",
+    "x-ms-version": "2021-08-06"
    }
   },
   {
    "method": "PUT",
-   "url": "https://fakestorageaccount.blob.core.windows.net/1container-with-dash158018570157704787/%2F%2F%2F%2FUpper%2Fblob%2Fempty%20%2Fanother%20%E6%B1%89%E5%AD%97158018570174805777",
+   "url": "https://fakestorageaccount.blob.core.windows.net/1container-with-dash166375028694704805/////Upper/blob/empty%20/another%20%E6%B1%89%E5%AD%97166375028714508822",
    "query": {},
    "requestBody": "A",
    "status": 201,
@@ -30,20 +30,21 @@
    "responseHeaders": {
     "content-length": "0",
     "content-md5": "f8VicOenD6gaWTW3Lqy+KQ==",
-    "date": "Tue, 28 Jan 2020 04:28:21 GMT",
-    "etag": "\"0x8D7A3AA8217C649\"",
-    "last-modified": "Tue, 28 Jan 2020 04:28:21 GMT",
+    "date": "Wed, 21 Sep 2022 08:51:26 GMT",
+    "etag": "\"0x8DA9BAE7885F43B\"",
+    "last-modified": "Wed, 21 Sep 2022 08:51:27 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-    "x-ms-client-request-id": "5367485d-23d3-4014-bde1-00675261c784",
+    "x-ms-client-request-id": "73e44760-e985-4d59-b5ba-5b136eba85d1",
     "x-ms-content-crc64": "PiO3pTJ67n0=",
-    "x-ms-request-id": "2bd8a7a5-401e-0017-1493-d5a69f000000",
+    "x-ms-request-id": "8e8ade36-501e-005a-6c97-cd825e000000",
     "x-ms-request-server-encrypted": "true",
-    "x-ms-version": "2019-02-02"
+    "x-ms-version": "2021-08-06",
+    "x-ms-version-id": "2022-09-21T08:51:27.5006011Z"
    }
   },
   {
    "method": "HEAD",
-   "url": "https://fakestorageaccount.blob.core.windows.net/1container-with-dash158018570157704787/%2F%2F%2F%2FUpper%2Fblob%2Fempty%20%2Fanother%20%E6%B1%89%E5%AD%97158018570174805777",
+   "url": "https://fakestorageaccount.blob.core.windows.net/1container-with-dash166375028694704805/////Upper/blob/empty%20/another%20%E6%B1%89%E5%AD%97166375028714508822",
    "query": {},
    "requestBody": null,
    "status": 200,
@@ -53,46 +54,48 @@
     "content-length": "1",
     "content-md5": "f8VicOenD6gaWTW3Lqy+KQ==",
     "content-type": "application/octet-stream",
-    "date": "Tue, 28 Jan 2020 04:28:21 GMT",
-    "etag": "\"0x8D7A3AA8217C649\"",
-    "last-modified": "Tue, 28 Jan 2020 04:28:21 GMT",
+    "date": "Wed, 21 Sep 2022 08:51:27 GMT",
+    "etag": "\"0x8DA9BAE7885F43B\"",
+    "last-modified": "Wed, 21 Sep 2022 08:51:27 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-    "x-ms-access-tier": "Cool",
+    "x-ms-access-tier": "Hot",
     "x-ms-access-tier-inferred": "true",
     "x-ms-blob-type": "BlockBlob",
-    "x-ms-client-request-id": "a320a3fb-6921-443a-a02b-e51b1fb7940a",
-    "x-ms-creation-time": "Tue, 28 Jan 2020 04:28:21 GMT",
+    "x-ms-client-request-id": "10e8c986-a2c0-4b20-b345-3e724e6c7682",
+    "x-ms-creation-time": "Wed, 21 Sep 2022 08:51:27 GMT",
+    "x-ms-is-current-version": "true",
     "x-ms-lease-state": "available",
     "x-ms-lease-status": "unlocked",
-    "x-ms-request-id": "2bd8a7df-401e-0017-4a93-d5a69f000000",
+    "x-ms-request-id": "8e8ade4d-501e-005a-7f97-cd825e000000",
     "x-ms-server-encrypted": "true",
-    "x-ms-version": "2019-02-02"
+    "x-ms-version": "2021-08-06",
+    "x-ms-version-id": "2022-09-21T08:51:27.5006011Z"
    }
   },
   {
    "method": "GET",
-   "url": "https://fakestorageaccount.blob.core.windows.net/1container-with-dash158018570157704787",
+   "url": "https://fakestorageaccount.blob.core.windows.net/1container-with-dash166375028694704805",
    "query": {
-    "prefix": "////Upper/blob/empty /another 汉字158018570174805777",
-    "restype": "container",
-    "comp": "list"
+    "comp": "list",
+    "prefix": "////Upper/blob/empty /another 汉字166375028714508822",
+    "restype": "container"
    },
    "requestBody": null,
    "status": 200,
-   "response": "<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults ServiceEndpoint=\"https://fakestorageaccount.blob.core.windows.net/\" ContainerName=\"1container-with-dash158018570157704787\"><Prefix>////Upper/blob/empty /another 汉字158018570174805777</Prefix><Blobs><Blob><Name>////Upper/blob/empty /another 汉字158018570174805777</Name><Properties><Creation-Time>Tue, 28 Jan 2020 04:28:21 GMT</Creation-Time><Last-Modified>Tue, 28 Jan 2020 04:28:21 GMT</Last-Modified><Etag>0x8D7A3AA8217C649</Etag><Content-Length>1</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>f8VicOenD6gaWTW3Lqy+KQ==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Cool</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties></Blob></Blobs><NextMarker /></EnumerationResults>",
+   "response": "<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults ServiceEndpoint=\"https://fakestorageaccount.blob.core.windows.net/\" ContainerName=\"1container-with-dash166375028694704805\"><Prefix>////Upper/blob/empty /another 汉字166375028714508822</Prefix><Blobs><Blob><Name>////Upper/blob/empty /another 汉字166375028714508822</Name><VersionId>2022-09-21T08:51:27.5006011Z</VersionId><IsCurrentVersion>true</IsCurrentVersion><Properties><Creation-Time>Wed, 21 Sep 2022 08:51:27 GMT</Creation-Time><Last-Modified>Wed, 21 Sep 2022 08:51:27 GMT</Last-Modified><Etag>0x8DA9BAE7885F43B</Etag><Content-Length>1</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>f8VicOenD6gaWTW3Lqy+KQ==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties><OrMetadata /></Blob></Blobs><NextMarker /></EnumerationResults>",
    "responseHeaders": {
     "content-type": "application/xml",
-    "date": "Tue, 28 Jan 2020 04:28:22 GMT",
+    "date": "Wed, 21 Sep 2022 08:51:27 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
     "transfer-encoding": "chunked",
-    "x-ms-client-request-id": "f3b90f16-ff93-43ab-94c5-a77e0ef8cda0",
-    "x-ms-request-id": "2bd8a818-401e-0017-7893-d5a69f000000",
-    "x-ms-version": "2019-02-02"
+    "x-ms-client-request-id": "6115255a-a632-473d-8814-465522f8e93a",
+    "x-ms-request-id": "8e8ade61-501e-005a-0e97-cd825e000000",
+    "x-ms-version": "2021-08-06"
    }
   },
   {
    "method": "DELETE",
-   "url": "https://fakestorageaccount.blob.core.windows.net/1container-with-dash158018570157704787",
+   "url": "https://fakestorageaccount.blob.core.windows.net/1container-with-dash166375028694704805",
    "query": {
     "restype": "container"
    },
@@ -101,19 +104,20 @@
    "response": "",
    "responseHeaders": {
     "content-length": "0",
-    "date": "Tue, 28 Jan 2020 04:28:22 GMT",
+    "date": "Wed, 21 Sep 2022 08:51:27 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-    "x-ms-client-request-id": "b5921fc5-a5ea-488e-aac1-19d76c2e02a8",
-    "x-ms-request-id": "2bd8a841-401e-0017-1f93-d5a69f000000",
-    "x-ms-version": "2019-02-02"
+    "x-ms-client-request-id": "aeb6fa3d-6cb4-46f7-8b2f-4ee8ce1ce78e",
+    "x-ms-request-id": "8e8ade7a-501e-005a-2797-cd825e000000",
+    "x-ms-version": "2021-08-06"
    }
   }
  ],
  "uniqueTestInfo": {
   "uniqueName": {
-   "1container-with-dash": "1container-with-dash158018570157704787",
-   "////Upper/blob/empty /another 汉字": "////Upper/blob/empty /another 汉字158018570174805777"
+   "1container-with-dash": "1container-with-dash166375028694704805",
+   "////Upper/blob/empty /another 汉字": "////Upper/blob/empty /another 汉字166375028714508822"
   },
   "newDate": {}
- }
+ },
+ "hash": "f56ee88ff3e885144482720e0a3cb8bf"
 }

--- a/sdk/storage/storage-blob/recordings/browsers/special_naming_tests/recording_should_work_with_special_container_and_blob_names_uppercase.json
+++ b/sdk/storage/storage-blob/recordings/browsers/special_naming_tests/recording_should_work_with_special_container_and_blob_names_uppercase.json
@@ -2,7 +2,7 @@
  "recordings": [
   {
    "method": "PUT",
-   "url": "https://fakestorageaccount.blob.core.windows.net/1container-with-dash158018569986501506",
+   "url": "https://fakestorageaccount.blob.core.windows.net/1container-with-dash166374977153608235",
    "query": {
     "restype": "container"
    },
@@ -11,18 +11,18 @@
    "response": "",
    "responseHeaders": {
     "content-length": "0",
-    "date": "Tue, 28 Jan 2020 04:28:19 GMT",
-    "etag": "\"0x8D7A3AA80F8830B\"",
-    "last-modified": "Tue, 28 Jan 2020 04:28:19 GMT",
+    "date": "Wed, 21 Sep 2022 08:42:51 GMT",
+    "etag": "\"0x8DA9BAD4532C361\"",
+    "last-modified": "Wed, 21 Sep 2022 08:42:51 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-    "x-ms-client-request-id": "45ae6fac-86c5-446a-9a7b-39755431cdae",
-    "x-ms-request-id": "2bd8a4c5-401e-0017-2993-d5a69f000000",
-    "x-ms-version": "2019-02-02"
+    "x-ms-client-request-id": "bc836b78-9bbb-4325-82b7-b5ebfa71a235",
+    "x-ms-request-id": "e9749f89-701e-005d-1396-cdee3d000000",
+    "x-ms-version": "2021-08-06"
    }
   },
   {
    "method": "PUT",
-   "url": "https://fakestorageaccount.blob.core.windows.net/1container-with-dash158018569986501506/%2F%2F%2F%2FUpper%2Fblob%2Fempty%20%2Fanother158018570003803411",
+   "url": "https://fakestorageaccount.blob.core.windows.net/1container-with-dash166374977153608235/////Upper/blob/empty%20/another166374977173001820",
    "query": {},
    "requestBody": "A",
    "status": 201,
@@ -30,20 +30,21 @@
    "responseHeaders": {
     "content-length": "0",
     "content-md5": "f8VicOenD6gaWTW3Lqy+KQ==",
-    "date": "Tue, 28 Jan 2020 04:28:20 GMT",
-    "etag": "\"0x8D7A3AA8113200E\"",
-    "last-modified": "Tue, 28 Jan 2020 04:28:20 GMT",
+    "date": "Wed, 21 Sep 2022 08:42:51 GMT",
+    "etag": "\"0x8DA9BAD45509F20\"",
+    "last-modified": "Wed, 21 Sep 2022 08:42:52 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-    "x-ms-client-request-id": "b73c88ab-5f6e-4371-9769-08c9f89ffa2b",
+    "x-ms-client-request-id": "60e4ac21-2470-4d52-9741-701c5f538f2a",
     "x-ms-content-crc64": "PiO3pTJ67n0=",
-    "x-ms-request-id": "2bd8a513-401e-0017-7093-d5a69f000000",
+    "x-ms-request-id": "e9749fd4-701e-005d-5c96-cdee3d000000",
     "x-ms-request-server-encrypted": "true",
-    "x-ms-version": "2019-02-02"
+    "x-ms-version": "2021-08-06",
+    "x-ms-version-id": "2022-09-21T08:42:52.0905504Z"
    }
   },
   {
    "method": "HEAD",
-   "url": "https://fakestorageaccount.blob.core.windows.net/1container-with-dash158018569986501506/%2F%2F%2F%2FUpper%2Fblob%2Fempty%20%2Fanother158018570003803411",
+   "url": "https://fakestorageaccount.blob.core.windows.net/1container-with-dash166374977153608235/////Upper/blob/empty%20/another166374977173001820",
    "query": {},
    "requestBody": null,
    "status": 200,
@@ -53,46 +54,48 @@
     "content-length": "1",
     "content-md5": "f8VicOenD6gaWTW3Lqy+KQ==",
     "content-type": "application/octet-stream",
-    "date": "Tue, 28 Jan 2020 04:28:20 GMT",
-    "etag": "\"0x8D7A3AA8113200E\"",
-    "last-modified": "Tue, 28 Jan 2020 04:28:20 GMT",
+    "date": "Wed, 21 Sep 2022 08:42:52 GMT",
+    "etag": "\"0x8DA9BAD45509F20\"",
+    "last-modified": "Wed, 21 Sep 2022 08:42:52 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-    "x-ms-access-tier": "Cool",
+    "x-ms-access-tier": "Hot",
     "x-ms-access-tier-inferred": "true",
     "x-ms-blob-type": "BlockBlob",
-    "x-ms-client-request-id": "89f3d489-d280-4922-8622-08b2404e762e",
-    "x-ms-creation-time": "Tue, 28 Jan 2020 04:28:20 GMT",
+    "x-ms-client-request-id": "f64c186f-e23c-410d-a969-287da185f37b",
+    "x-ms-creation-time": "Wed, 21 Sep 2022 08:42:52 GMT",
+    "x-ms-is-current-version": "true",
     "x-ms-lease-state": "available",
     "x-ms-lease-status": "unlocked",
-    "x-ms-request-id": "2bd8a541-401e-0017-1c93-d5a69f000000",
+    "x-ms-request-id": "e974a011-701e-005d-1496-cdee3d000000",
     "x-ms-server-encrypted": "true",
-    "x-ms-version": "2019-02-02"
+    "x-ms-version": "2021-08-06",
+    "x-ms-version-id": "2022-09-21T08:42:52.0905504Z"
    }
   },
   {
    "method": "GET",
-   "url": "https://fakestorageaccount.blob.core.windows.net/1container-with-dash158018569986501506",
+   "url": "https://fakestorageaccount.blob.core.windows.net/1container-with-dash166374977153608235",
    "query": {
-    "prefix": "////Upper/blob/empty /another158018570003803411",
-    "restype": "container",
-    "comp": "list"
+    "comp": "list",
+    "prefix": "////Upper/blob/empty /another166374977173001820",
+    "restype": "container"
    },
    "requestBody": null,
    "status": 200,
-   "response": "<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults ServiceEndpoint=\"https://fakestorageaccount.blob.core.windows.net/\" ContainerName=\"1container-with-dash158018569986501506\"><Prefix>////Upper/blob/empty /another158018570003803411</Prefix><Blobs><Blob><Name>////Upper/blob/empty /another158018570003803411</Name><Properties><Creation-Time>Tue, 28 Jan 2020 04:28:20 GMT</Creation-Time><Last-Modified>Tue, 28 Jan 2020 04:28:20 GMT</Last-Modified><Etag>0x8D7A3AA8113200E</Etag><Content-Length>1</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>f8VicOenD6gaWTW3Lqy+KQ==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Cool</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties></Blob></Blobs><NextMarker /></EnumerationResults>",
+   "response": "<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults ServiceEndpoint=\"https://fakestorageaccount.blob.core.windows.net/\" ContainerName=\"1container-with-dash166374977153608235\"><Prefix>////Upper/blob/empty /another166374977173001820</Prefix><Blobs><Blob><Name>////Upper/blob/empty /another166374977173001820</Name><VersionId>2022-09-21T08:42:52.0905504Z</VersionId><IsCurrentVersion>true</IsCurrentVersion><Properties><Creation-Time>Wed, 21 Sep 2022 08:42:52 GMT</Creation-Time><Last-Modified>Wed, 21 Sep 2022 08:42:52 GMT</Last-Modified><Etag>0x8DA9BAD45509F20</Etag><Content-Length>1</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>f8VicOenD6gaWTW3Lqy+KQ==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties><OrMetadata /></Blob></Blobs><NextMarker /></EnumerationResults>",
    "responseHeaders": {
     "content-type": "application/xml",
-    "date": "Tue, 28 Jan 2020 04:28:20 GMT",
+    "date": "Wed, 21 Sep 2022 08:42:52 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
     "transfer-encoding": "chunked",
-    "x-ms-client-request-id": "e0d05742-85d9-41dd-b958-f0a7fbfdf5bf",
-    "x-ms-request-id": "2bd8a58b-401e-0017-4f93-d5a69f000000",
-    "x-ms-version": "2019-02-02"
+    "x-ms-client-request-id": "bbdfe041-bcb4-49be-a00d-cb636df5067a",
+    "x-ms-request-id": "e974a049-701e-005d-4796-cdee3d000000",
+    "x-ms-version": "2021-08-06"
    }
   },
   {
    "method": "DELETE",
-   "url": "https://fakestorageaccount.blob.core.windows.net/1container-with-dash158018569986501506",
+   "url": "https://fakestorageaccount.blob.core.windows.net/1container-with-dash166374977153608235",
    "query": {
     "restype": "container"
    },
@@ -101,19 +104,20 @@
    "response": "",
    "responseHeaders": {
     "content-length": "0",
-    "date": "Tue, 28 Jan 2020 04:28:20 GMT",
+    "date": "Wed, 21 Sep 2022 08:42:52 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-    "x-ms-client-request-id": "3e841f16-9f3e-4a85-9a45-7861cc937b9d",
-    "x-ms-request-id": "2bd8a5d5-401e-0017-0793-d5a69f000000",
-    "x-ms-version": "2019-02-02"
+    "x-ms-client-request-id": "13e56168-13fa-43ef-9366-ed1695bcae7a",
+    "x-ms-request-id": "e974a072-701e-005d-6d96-cdee3d000000",
+    "x-ms-version": "2021-08-06"
    }
   }
  ],
  "uniqueTestInfo": {
   "uniqueName": {
-   "1container-with-dash": "1container-with-dash158018569986501506",
-   "////Upper/blob/empty /another": "////Upper/blob/empty /another158018570003803411"
+   "1container-with-dash": "1container-with-dash166374977153608235",
+   "////Upper/blob/empty /another": "////Upper/blob/empty /another166374977173001820"
   },
   "newDate": {}
- }
+ },
+ "hash": "540c9ca11128b012b9794fdd5864eb4e"
 }

--- a/sdk/storage/storage-blob/recordings/browsers/special_naming_tests/recording_should_work_with_special_container_and_blob_names_with_.json
+++ b/sdk/storage/storage-blob/recordings/browsers/special_naming_tests/recording_should_work_with_special_container_and_blob_names_with_.json
@@ -2,7 +2,7 @@
  "recordings": [
   {
    "method": "PUT",
-   "url": "https://fakestorageaccount.blob.core.windows.net/1container-with-dash158018569815206823",
+   "url": "https://fakestorageaccount.blob.core.windows.net/1container-with-dash166375028595804505",
    "query": {
     "restype": "container"
    },
@@ -11,18 +11,18 @@
    "response": "",
    "responseHeaders": {
     "content-length": "0",
-    "date": "Tue, 28 Jan 2020 04:28:18 GMT",
-    "etag": "\"0x8D7A3AA7FF33F99\"",
-    "last-modified": "Tue, 28 Jan 2020 04:28:18 GMT",
+    "date": "Wed, 21 Sep 2022 08:51:25 GMT",
+    "etag": "\"0x8DA9BAE77D086B5\"",
+    "last-modified": "Wed, 21 Sep 2022 08:51:26 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-    "x-ms-client-request-id": "ef0ca5bc-c881-4cb6-981e-f139c6f7d203",
-    "x-ms-request-id": "2bd8a27e-401e-0017-0293-d5a69f000000",
-    "x-ms-version": "2019-02-02"
+    "x-ms-client-request-id": "a690b289-8335-418d-b773-0dde1ebd234b",
+    "x-ms-request-id": "8e8addc9-501e-005a-1297-cd825e000000",
+    "x-ms-version": "2021-08-06"
    }
   },
   {
    "method": "PUT",
-   "url": "https://fakestorageaccount.blob.core.windows.net/1container-with-dash158018569815206823/%2F%2F%2F%2Fblob%2Fempty%20%2Fanother158018569832304159",
+   "url": "https://fakestorageaccount.blob.core.windows.net/1container-with-dash166375028595804505/////blob/empty%20/another166375028615306811",
    "query": {},
    "requestBody": "A",
    "status": 201,
@@ -30,20 +30,21 @@
    "responseHeaders": {
     "content-length": "0",
     "content-md5": "f8VicOenD6gaWTW3Lqy+KQ==",
-    "date": "Tue, 28 Jan 2020 04:28:18 GMT",
-    "etag": "\"0x8D7A3AA800D8F50\"",
-    "last-modified": "Tue, 28 Jan 2020 04:28:18 GMT",
+    "date": "Wed, 21 Sep 2022 08:51:25 GMT",
+    "etag": "\"0x8DA9BAE77EEFC0A\"",
+    "last-modified": "Wed, 21 Sep 2022 08:51:26 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-    "x-ms-client-request-id": "aaa13270-52e6-46c1-8469-94c5ef900b0d",
+    "x-ms-client-request-id": "24c93d5f-e646-42ae-abfc-443094657a84",
     "x-ms-content-crc64": "PiO3pTJ67n0=",
-    "x-ms-request-id": "2bd8a2c2-401e-0017-4393-d5a69f000000",
+    "x-ms-request-id": "8e8addd5-501e-005a-1b97-cd825e000000",
     "x-ms-request-server-encrypted": "true",
-    "x-ms-version": "2019-02-02"
+    "x-ms-version": "2021-08-06",
+    "x-ms-version-id": "2022-09-21T08:51:26.5112074Z"
    }
   },
   {
    "method": "HEAD",
-   "url": "https://fakestorageaccount.blob.core.windows.net/1container-with-dash158018569815206823/%2F%2F%2F%2Fblob%2Fempty%20%2Fanother158018569832304159",
+   "url": "https://fakestorageaccount.blob.core.windows.net/1container-with-dash166375028595804505/////blob/empty%20/another166375028615306811",
    "query": {},
    "requestBody": null,
    "status": 200,
@@ -53,46 +54,48 @@
     "content-length": "1",
     "content-md5": "f8VicOenD6gaWTW3Lqy+KQ==",
     "content-type": "application/octet-stream",
-    "date": "Tue, 28 Jan 2020 04:28:18 GMT",
-    "etag": "\"0x8D7A3AA800D8F50\"",
-    "last-modified": "Tue, 28 Jan 2020 04:28:18 GMT",
+    "date": "Wed, 21 Sep 2022 08:51:26 GMT",
+    "etag": "\"0x8DA9BAE77EEFC0A\"",
+    "last-modified": "Wed, 21 Sep 2022 08:51:26 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-    "x-ms-access-tier": "Cool",
+    "x-ms-access-tier": "Hot",
     "x-ms-access-tier-inferred": "true",
     "x-ms-blob-type": "BlockBlob",
-    "x-ms-client-request-id": "390ada83-5eb8-4efc-8f3a-4a96b4ccdebc",
-    "x-ms-creation-time": "Tue, 28 Jan 2020 04:28:18 GMT",
+    "x-ms-client-request-id": "9f2f7b1a-e439-4d83-be5c-73cefaece3e5",
+    "x-ms-creation-time": "Wed, 21 Sep 2022 08:51:26 GMT",
+    "x-ms-is-current-version": "true",
     "x-ms-lease-state": "available",
     "x-ms-lease-status": "unlocked",
-    "x-ms-request-id": "2bd8a2fb-401e-0017-7993-d5a69f000000",
+    "x-ms-request-id": "8e8adde9-501e-005a-2c97-cd825e000000",
     "x-ms-server-encrypted": "true",
-    "x-ms-version": "2019-02-02"
+    "x-ms-version": "2021-08-06",
+    "x-ms-version-id": "2022-09-21T08:51:26.5112074Z"
    }
   },
   {
    "method": "GET",
-   "url": "https://fakestorageaccount.blob.core.windows.net/1container-with-dash158018569815206823",
+   "url": "https://fakestorageaccount.blob.core.windows.net/1container-with-dash166375028595804505",
    "query": {
-    "prefix": "////blob/empty /another158018569832304159",
-    "restype": "container",
-    "comp": "list"
+    "comp": "list",
+    "prefix": "////blob/empty /another166375028615306811",
+    "restype": "container"
    },
    "requestBody": null,
    "status": 200,
-   "response": "<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults ServiceEndpoint=\"https://fakestorageaccount.blob.core.windows.net/\" ContainerName=\"1container-with-dash158018569815206823\"><Prefix>////blob/empty /another158018569832304159</Prefix><Blobs><Blob><Name>////blob/empty /another158018569832304159</Name><Properties><Creation-Time>Tue, 28 Jan 2020 04:28:18 GMT</Creation-Time><Last-Modified>Tue, 28 Jan 2020 04:28:18 GMT</Last-Modified><Etag>0x8D7A3AA800D8F50</Etag><Content-Length>1</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>f8VicOenD6gaWTW3Lqy+KQ==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Cool</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties></Blob></Blobs><NextMarker /></EnumerationResults>",
+   "response": "<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults ServiceEndpoint=\"https://fakestorageaccount.blob.core.windows.net/\" ContainerName=\"1container-with-dash166375028595804505\"><Prefix>////blob/empty /another166375028615306811</Prefix><Blobs><Blob><Name>////blob/empty /another166375028615306811</Name><VersionId>2022-09-21T08:51:26.5112074Z</VersionId><IsCurrentVersion>true</IsCurrentVersion><Properties><Creation-Time>Wed, 21 Sep 2022 08:51:26 GMT</Creation-Time><Last-Modified>Wed, 21 Sep 2022 08:51:26 GMT</Last-Modified><Etag>0x8DA9BAE77EEFC0A</Etag><Content-Length>1</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>f8VicOenD6gaWTW3Lqy+KQ==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties><OrMetadata /></Blob></Blobs><NextMarker /></EnumerationResults>",
    "responseHeaders": {
     "content-type": "application/xml",
-    "date": "Tue, 28 Jan 2020 04:28:18 GMT",
+    "date": "Wed, 21 Sep 2022 08:51:26 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
     "transfer-encoding": "chunked",
-    "x-ms-client-request-id": "a8d85064-0486-42ab-9ff6-f9ee0fcdb168",
-    "x-ms-request-id": "2bd8a330-401e-0017-2b93-d5a69f000000",
-    "x-ms-version": "2019-02-02"
+    "x-ms-client-request-id": "893a030f-3253-438a-9e96-d6257fcd4519",
+    "x-ms-request-id": "8e8addfc-501e-005a-3c97-cd825e000000",
+    "x-ms-version": "2021-08-06"
    }
   },
   {
    "method": "DELETE",
-   "url": "https://fakestorageaccount.blob.core.windows.net/1container-with-dash158018569815206823",
+   "url": "https://fakestorageaccount.blob.core.windows.net/1container-with-dash166375028595804505",
    "query": {
     "restype": "container"
    },
@@ -101,19 +104,20 @@
    "response": "",
    "responseHeaders": {
     "content-length": "0",
-    "date": "Tue, 28 Jan 2020 04:28:18 GMT",
+    "date": "Wed, 21 Sep 2022 08:51:26 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-    "x-ms-client-request-id": "98f2d66a-b122-471e-8470-e73c14371719",
-    "x-ms-request-id": "2bd8a36a-401e-0017-6393-d5a69f000000",
-    "x-ms-version": "2019-02-02"
+    "x-ms-client-request-id": "b5e99af8-5be7-4f86-9825-761d44cd63c4",
+    "x-ms-request-id": "8e8ade10-501e-005a-4c97-cd825e000000",
+    "x-ms-version": "2021-08-06"
    }
   }
  ],
  "uniqueTestInfo": {
   "uniqueName": {
-   "1container-with-dash": "1container-with-dash158018569815206823",
-   "////blob/empty /another": "////blob/empty /another158018569832304159"
+   "1container-with-dash": "1container-with-dash166375028595804505",
+   "////blob/empty /another": "////blob/empty /another166375028615306811"
   },
   "newDate": {}
- }
+ },
+ "hash": "c57dc20404ab00a147f645a66d381409"
 }

--- a/sdk/storage/storage-blob/recordings/node/blob_versioning/recording_list_blobs_include_versions.js
+++ b/sdk/storage/storage-blob/recordings/node/blob_versioning/recording_list_blobs_include_versions.js
@@ -1,151 +1,151 @@
 let nock = require('nock');
 
-module.exports.hash = "d1f04813bc3b3c180b3c151592797721";
+module.exports.hash = "7154a4d9a0b712caa81a682435862b6d";
 
-module.exports.testInfo = {"uniqueName":{"container":"container159218739798401048","blob":"blob159218739827103012","blockblob/0":"blockblob/0159218739885105753","blockblob/1":"blockblob/1159218739914105458"},"newDate":{}}
+module.exports.testInfo = {"uniqueName":{"container":"container165899993672202712","blob":"blob165899993735509030","blockblob/0":"blockblob/0165899993758208152","blockblob/1":"blockblob/1165899993768600784"},"newDate":{}}
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container159218739798401048')
+  .put('/container165899993672202712')
   .query(true)
   .reply(201, "", [
   'Content-Length',
   '0',
   'Last-Modified',
-  'Mon, 15 Jun 2020 02:16:38 GMT',
+  'Thu, 28 Jul 2022 09:18:57 GMT',
   'ETag',
-  '"0x8D810D2227D5AF2"',
+  '"0x8DA707A334A3AE1"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'd8031b57-501e-0069-2cbb-4274ec000000',
+  '196f4bd0-901e-0055-4c63-a2f432000000',
   'x-ms-client-request-id',
-  'c73c5674-452e-4456-abb4-66680c7d4d31',
+  'a14e67b1-236e-4874-b025-e721f644391d',
   'x-ms-version',
-  '2019-12-12',
+  '2021-08-06',
   'Date',
-  'Mon, 15 Jun 2020 02:16:37 GMT'
+  'Thu, 28 Jul 2022 09:18:57 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container159218739798401048/blob159218739827103012', "Hello World")
+  .put('/container165899993672202712/blob165899993735509030', "Hello World")
   .reply(201, "", [
   'Content-Length',
   '0',
   'Content-MD5',
   'sQqNsWTgdUEFt6mb5y4/5Q==',
   'Last-Modified',
-  'Mon, 15 Jun 2020 02:16:38 GMT',
+  'Thu, 28 Jul 2022 09:18:57 GMT',
   'ETag',
-  '"0x8D810D222A9BCEB"',
+  '"0x8DA707A335F6195"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'd8031c45-501e-0069-01bb-4274ec000000',
+  '196f4bea-901e-0055-6163-a2f432000000',
   'x-ms-client-request-id',
-  '81d7cd13-761d-4765-a333-368aaf9df399',
+  'cdaef129-e1d3-418f-865c-ba89886fb8fb',
   'x-ms-version',
-  '2019-12-12',
+  '2021-08-06',
   'x-ms-content-crc64',
   'YeJLfssylmU=',
   'x-ms-request-server-encrypted',
   'true',
   'x-ms-version-id',
-  '2020-06-15T02:16:38.3651051Z',
+  '2022-07-28T09:18:57.6556437Z',
   'Date',
-  'Mon, 15 Jun 2020 02:16:37 GMT'
+  'Thu, 28 Jul 2022 09:18:57 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container159218739798401048/blob159218739827103012')
+  .put('/container165899993672202712/blob165899993735509030')
   .reply(201, "", [
   'Content-Length',
   '0',
   'Content-MD5',
   '1B2M2Y8AsgTpgAmY7PhCfg==',
   'Last-Modified',
-  'Mon, 15 Jun 2020 02:16:38 GMT',
+  'Thu, 28 Jul 2022 09:18:57 GMT',
   'ETag',
-  '"0x8D810D222D5B6DE"',
+  '"0x8DA707A337027E2"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'd8031cef-501e-0069-21bb-4274ec000000',
+  '196f4bf4-901e-0055-6963-a2f432000000',
   'x-ms-client-request-id',
-  'e2acb811-e53e-4bd9-8da4-83297a145aec',
+  '9e4bc27f-6048-4b21-a775-b78755c42a71',
   'x-ms-version',
-  '2019-12-12',
+  '2021-08-06',
   'x-ms-content-crc64',
   'AAAAAAAAAAA=',
   'x-ms-request-server-encrypted',
   'true',
   'x-ms-version-id',
-  '2020-06-15T02:16:38.6543086Z',
+  '2022-07-28T09:18:57.7665778Z',
   'Date',
-  'Mon, 15 Jun 2020 02:16:38 GMT'
+  'Thu, 28 Jul 2022 09:18:57 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container159218739798401048/blockblob%2F0159218739885105753')
+  .put('/container165899993672202712/blockblob/0165899993758208152')
   .reply(201, "", [
   'Content-Length',
   '0',
   'Content-MD5',
   '1B2M2Y8AsgTpgAmY7PhCfg==',
   'Last-Modified',
-  'Mon, 15 Jun 2020 02:16:38 GMT',
+  'Thu, 28 Jul 2022 09:18:57 GMT',
   'ETag',
-  '"0x8D810D22301FEFB"',
+  '"0x8DA707A33802AF3"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'd8031d87-501e-0069-34bb-4274ec000000',
+  '196f4c0a-901e-0055-7963-a2f432000000',
   'x-ms-client-request-id',
-  'c7c727f2-b2d5-45a2-b36b-546271b1cc1c',
+  '0fba4118-845b-4968-a65b-97d03e30c6c9',
   'x-ms-version',
-  '2019-12-12',
+  '2021-08-06',
   'x-ms-content-crc64',
   'AAAAAAAAAAA=',
   'x-ms-request-server-encrypted',
   'true',
   'x-ms-version-id',
-  '2020-06-15T02:16:38.9445138Z',
+  '2022-07-28T09:18:57.8705139Z',
   'Date',
-  'Mon, 15 Jun 2020 02:16:38 GMT'
+  'Thu, 28 Jul 2022 09:18:57 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container159218739798401048/blockblob%2F1159218739914105458')
+  .put('/container165899993672202712/blockblob/1165899993768600784')
   .reply(201, "", [
   'Content-Length',
   '0',
   'Content-MD5',
   '1B2M2Y8AsgTpgAmY7PhCfg==',
   'Last-Modified',
-  'Mon, 15 Jun 2020 02:16:39 GMT',
+  'Thu, 28 Jul 2022 09:18:57 GMT',
   'ETag',
-  '"0x8D810D2232E6E34"',
+  '"0x8DA707A338FE001"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'd8031e9c-501e-0069-34bb-4274ec000000',
+  '196f4c10-901e-0055-7f63-a2f432000000',
   'x-ms-client-request-id',
-  '43c1fe8d-fa95-456d-9d61-7df78090cb32',
+  'd5420d25-6c5f-4c2e-b48b-5daad3f06913',
   'x-ms-version',
-  '2019-12-12',
+  '2021-08-06',
   'x-ms-content-crc64',
   'AAAAAAAAAAA=',
   'x-ms-request-server-encrypted',
   'true',
   'x-ms-version-id',
-  '2020-06-15T02:16:39.2357186Z',
+  '2022-07-28T09:18:57.9744509Z',
   'Date',
-  'Mon, 15 Jun 2020 02:16:38 GMT'
+  'Thu, 28 Jul 2022 09:18:57 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .get('/container159218739798401048')
+  .get('/container165899993672202712')
   .query(true)
-  .reply(200, "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults ServiceEndpoint=\"https://fakestorageaccount.blob.core.windows.net/\" ContainerName=\"container159218739798401048\"><Blobs><Blob><Name>blob159218739827103012</Name><VersionId>2020-06-15T02:16:38.3651051Z</VersionId><Properties><Creation-Time>Mon, 15 Jun 2020 02:16:38 GMT</Creation-Time><Last-Modified>Mon, 15 Jun 2020 02:16:38 GMT</Last-Modified><Etag>0x8D810D222A9BCEB</Etag><Content-Length>11</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>sQqNsWTgdUEFt6mb5y4/5Q==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><ServerEncrypted>true</ServerEncrypted></Properties><OrMetadata /></Blob><Blob><Name>blob159218739827103012</Name><VersionId>2020-06-15T02:16:38.6543086Z</VersionId><IsCurrentVersion>true</IsCurrentVersion><Properties><Creation-Time>Mon, 15 Jun 2020 02:16:38 GMT</Creation-Time><Last-Modified>Mon, 15 Jun 2020 02:16:38 GMT</Last-Modified><Etag>0x8D810D222D5B6DE</Etag><Content-Length>0</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>1B2M2Y8AsgTpgAmY7PhCfg==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties><OrMetadata /></Blob><Blob><Name>blockblob/0159218739885105753</Name><VersionId>2020-06-15T02:16:38.9445138Z</VersionId><IsCurrentVersion>true</IsCurrentVersion><Properties><Creation-Time>Mon, 15 Jun 2020 02:16:38 GMT</Creation-Time><Last-Modified>Mon, 15 Jun 2020 02:16:38 GMT</Last-Modified><Etag>0x8D810D22301FEFB</Etag><Content-Length>0</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>1B2M2Y8AsgTpgAmY7PhCfg==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties><OrMetadata /></Blob><Blob><Name>blockblob/1159218739914105458</Name><VersionId>2020-06-15T02:16:39.2357186Z</VersionId><IsCurrentVersion>true</IsCurrentVersion><Properties><Creation-Time>Mon, 15 Jun 2020 02:16:39 GMT</Creation-Time><Last-Modified>Mon, 15 Jun 2020 02:16:39 GMT</Last-Modified><Etag>0x8D810D2232E6E34</Etag><Content-Length>0</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>1B2M2Y8AsgTpgAmY7PhCfg==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties><OrMetadata /></Blob></Blobs><NextMarker /></EnumerationResults>", [
+  .reply(200, "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults ServiceEndpoint=\"https://fakestorageaccount.blob.core.windows.net/\" ContainerName=\"container165899993672202712\"><Blobs><Blob><Name>blob165899993735509030</Name><VersionId>2022-07-28T09:18:57.6556437Z</VersionId><Properties><Creation-Time>Thu, 28 Jul 2022 09:18:57 GMT</Creation-Time><Last-Modified>Thu, 28 Jul 2022 09:18:57 GMT</Last-Modified><Etag>0x8DA707A335F6195</Etag><Content-Length>11</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>sQqNsWTgdUEFt6mb5y4/5Q==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><ServerEncrypted>true</ServerEncrypted></Properties><OrMetadata /></Blob><Blob><Name>blob165899993735509030</Name><VersionId>2022-07-28T09:18:57.7665778Z</VersionId><IsCurrentVersion>true</IsCurrentVersion><Properties><Creation-Time>Thu, 28 Jul 2022 09:18:57 GMT</Creation-Time><Last-Modified>Thu, 28 Jul 2022 09:18:57 GMT</Last-Modified><Etag>0x8DA707A337027E2</Etag><Content-Length>0</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>1B2M2Y8AsgTpgAmY7PhCfg==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties><OrMetadata /></Blob><Blob><Name>blockblob/0165899993758208152</Name><VersionId>2022-07-28T09:18:57.8705139Z</VersionId><IsCurrentVersion>true</IsCurrentVersion><Properties><Creation-Time>Thu, 28 Jul 2022 09:18:57 GMT</Creation-Time><Last-Modified>Thu, 28 Jul 2022 09:18:57 GMT</Last-Modified><Etag>0x8DA707A33802AF3</Etag><Content-Length>0</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>1B2M2Y8AsgTpgAmY7PhCfg==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties><OrMetadata /></Blob><Blob><Name>blockblob/1165899993768600784</Name><VersionId>2022-07-28T09:18:57.9744509Z</VersionId><IsCurrentVersion>true</IsCurrentVersion><Properties><Creation-Time>Thu, 28 Jul 2022 09:18:57 GMT</Creation-Time><Last-Modified>Thu, 28 Jul 2022 09:18:57 GMT</Last-Modified><Etag>0x8DA707A338FE001</Etag><Content-Length>0</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>1B2M2Y8AsgTpgAmY7PhCfg==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties><OrMetadata /></Blob></Blobs><NextMarker /></EnumerationResults>", [
   'Transfer-Encoding',
   'chunked',
   'Content-Type',
@@ -153,21 +153,21 @@ nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParam
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'd8031f6c-501e-0069-7dbb-4274ec000000',
+  '196f4c2c-901e-0055-1863-a2f432000000',
   'x-ms-client-request-id',
-  '83b3063d-0c0e-42ee-8557-46870a3bfe7b',
+  '9d2e2115-577c-42f7-ba40-f741935985b1',
   'x-ms-version',
-  '2019-12-12',
+  '2021-08-06',
   'Access-Control-Expose-Headers',
   'x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,Content-Type,Content-Length,Date,Transfer-Encoding',
   'Access-Control-Allow-Origin',
   '*',
   'Date',
-  'Mon, 15 Jun 2020 02:16:38 GMT'
+  'Thu, 28 Jul 2022 09:18:57 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .delete('/container159218739798401048')
+  .delete('/container165899993672202712')
   .query(true)
   .reply(202, "", [
   'Content-Length',
@@ -175,11 +175,11 @@ nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParam
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'd80320f8-501e-0069-7dbb-4274ec000000',
+  '196f4c4e-901e-0055-3463-a2f432000000',
   'x-ms-client-request-id',
-  'cd5154a5-eeb2-4f78-8f41-6faccf2069f4',
+  '599a815c-83da-423b-b8fd-e907d02419a1',
   'x-ms-version',
-  '2019-12-12',
+  '2021-08-06',
   'Date',
-  'Mon, 15 Jun 2020 02:16:39 GMT'
+  'Thu, 28 Jul 2022 09:18:57 GMT'
 ]);

--- a/sdk/storage/storage-blob/recordings/node/containerclient/recording_listblobflat_with_blobs_encrypted_with_cpk.js
+++ b/sdk/storage/storage-blob/recordings/node/containerclient/recording_listblobflat_with_blobs_encrypted_with_cpk.js
@@ -1,46 +1,50 @@
 let nock = require('nock');
 
-module.exports.testInfo = {"container":"container156816841663509039","blockblob/0":"blockblob/0156816841706709570","blockblob/1":"blockblob/1156816841749007099"}
+module.exports.hash = "c0abfb4bb1863a076c1e5ac109a4cc7b";
+
+module.exports.testInfo = {"uniqueName":{"container":"container165899957948908427","blockblob/0":"blockblob/0165899957958904339","blockblob/1":"blockblob/1165899957970106437"},"newDate":{}}
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container156816841663509039')
+  .put('/container165899957948908427')
   .query(true)
-  .reply(201, "", [ 'Content-Length',
+  .reply(201, "", [
+  'Content-Length',
   '0',
   'Last-Modified',
-  'Wed, 11 Sep 2019 02:20:16 GMT',
+  'Thu, 28 Jul 2022 09:12:59 GMT',
   'ETag',
-  '"0x8D7365E962340DD"',
+  '"0x8DA70795E0DB561"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'eba07377-d01e-003b-0547-6824a2000000',
+  'a85ba603-d01e-0054-1662-a2abee000000',
   'x-ms-client-request-id',
-  '2c67ac45-d268-436d-b591-5ff9af3edd31',
+  '909f294c-6d36-44a2-8c84-f55f8663f1f4',
   'x-ms-version',
-  '2019-02-02',
+  '2021-08-06',
   'Date',
-  'Wed, 11 Sep 2019 02:20:16 GMT' ]);
-
+  'Thu, 28 Jul 2022 09:12:59 GMT'
+]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container156816841663509039/blockblob%2F0156816841706709570')
-  .reply(201, "", [ 'Content-Length',
+  .put('/container165899957948908427/blockblob/0165899957958904339')
+  .reply(201, "", [
+  'Content-Length',
   '0',
   'Content-MD5',
   '1B2M2Y8AsgTpgAmY7PhCfg==',
   'Last-Modified',
-  'Wed, 11 Sep 2019 02:20:17 GMT',
+  'Thu, 28 Jul 2022 09:12:59 GMT',
   'ETag',
-  '"0x8D7365E966406CF"',
+  '"0x8DA70795E20853E"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'd971de22-501e-004c-4547-68a1e3000000',
+  'a85ba617-d01e-0054-2562-a2abee000000',
   'x-ms-client-request-id',
-  '592bd15c-82b0-4e76-8dab-ad8fd26e1f89',
+  'd9643a74-a082-487b-8833-85dc03c2e4e0',
   'x-ms-version',
-  '2019-02-02',
+  '2021-08-06',
   'x-ms-content-crc64',
   'AAAAAAAAAAA=',
   'x-ms-request-server-encrypted',
@@ -48,27 +52,28 @@ nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParam
   'x-ms-encryption-key-sha256',
   '3QFFFpRA5+XANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=',
   'Date',
-  'Wed, 11 Sep 2019 02:20:17 GMT' ]);
-
+  'Thu, 28 Jul 2022 09:12:59 GMT'
+]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container156816841663509039/blockblob%2F1156816841749007099')
-  .reply(201, "", [ 'Content-Length',
+  .put('/container165899957948908427/blockblob/1165899957970106437')
+  .reply(201, "", [
+  'Content-Length',
   '0',
   'Content-MD5',
   '1B2M2Y8AsgTpgAmY7PhCfg==',
   'Last-Modified',
-  'Wed, 11 Sep 2019 02:20:17 GMT',
+  'Thu, 28 Jul 2022 09:12:59 GMT',
   'ETag',
-  '"0x8D7365E96A2C8DD"',
+  '"0x8DA70795E2FEC18"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '84b83954-401e-0017-4647-68a69f000000',
+  'a85ba62c-d01e-0054-3362-a2abee000000',
   'x-ms-client-request-id',
-  'c02720f6-1cc7-4715-ac3c-c3c57af6c608',
+  '40cf7708-6af1-4b76-909b-58de46efc6ea',
   'x-ms-version',
-  '2019-02-02',
+  '2021-08-06',
   'x-ms-content-crc64',
   'AAAAAAAAAAA=',
   'x-ms-request-server-encrypted',
@@ -76,45 +81,47 @@ nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParam
   'x-ms-encryption-key-sha256',
   '3QFFFpRA5+XANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=',
   'Date',
-  'Wed, 11 Sep 2019 02:20:17 GMT' ]);
-
+  'Thu, 28 Jul 2022 09:12:59 GMT'
+]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .get('/container156816841663509039')
+  .get('/container165899957948908427')
   .query(true)
-  .reply(200, "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults ServiceEndpoint=\"https://fakestorageaccount.blob.core.windows.net/\" ContainerName=\"container156816841663509039\"><Prefix>blockblob</Prefix><MaxResults>1</MaxResults><Blobs><Blob><Name>blockblob/0156816841706709570</Name><Properties><Creation-Time>Wed, 11 Sep 2019 02:20:17 GMT</Creation-Time><Last-Modified>Wed, 11 Sep 2019 02:20:17 GMT</Last-Modified><Etag>0x8D7365E966406CF</Etag><Content-Length>0</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64>AAAAAAAAAAA=</Content-CRC64><Content-MD5>1B2M2Y8AsgTpgAmY7PhCfg==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Cool</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted><CustomerProvidedKeySha256>3QFFFpRA5+XANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=</CustomerProvidedKeySha256><TagCount>0</TagCount></Properties><Metadata Encrypted=\"true\" /></Blob></Blobs><NextMarker>2!100!MDAwMDI5IWJsb2NrYmxvYi8xMTU2ODE2ODQxNzQ5MDA3MDk5ITAwMDAyOCE5OTk5LTEyLTMxVDIzOjU5OjU5Ljk5OTk5OTlaIQ--</NextMarker></EnumerationResults>", [ 'Transfer-Encoding',
+  .reply(200, "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults ServiceEndpoint=\"https://fakestorageaccount.blob.core.windows.net/\" ContainerName=\"container165899957948908427\"><Prefix>blockblob</Prefix><MaxResults>1</MaxResults><Blobs><Blob><Name>blockblob/0165899957958904339</Name><Properties><Creation-Time>Thu, 28 Jul 2022 09:12:59 GMT</Creation-Time><Last-Modified>Thu, 28 Jul 2022 09:12:59 GMT</Last-Modified><Etag>0x8DA70795E20853E</Etag><Content-Length>0</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>1B2M2Y8AsgTpgAmY7PhCfg==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted><CustomerProvidedKeySha256>3QFFFpRA5+XANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=</CustomerProvidedKeySha256></Properties><Metadata Encrypted=\"true\" /><OrMetadata /></Blob></Blobs><NextMarker>2!100!MDAwMDI5IWJsb2NrYmxvYi8xMTY1ODk5OTU3OTcwMTA2NDM3ITAwMDAyOCE5OTk5LTEyLTMxVDIzOjU5OjU5Ljk5OTk5OTlaIQ--</NextMarker></EnumerationResults>", [
+  'Transfer-Encoding',
   'chunked',
   'Content-Type',
   'application/xml',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '1b9f246c-e01e-0033-4e47-683fd1000000',
+  'a85ba642-d01e-0054-4662-a2abee000000',
   'x-ms-client-request-id',
-  'c2d37219-3e45-48f8-83b5-5bca5519f92a',
+  '8a7f82e8-b99b-454a-bb56-a8bf7f8e6e11',
   'x-ms-version',
-  '2019-02-02',
+  '2021-08-06',
   'Access-Control-Expose-Headers',
   'x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,Content-Type,Content-Length,Date,Transfer-Encoding',
   'Access-Control-Allow-Origin',
   '*',
   'Date',
-  'Wed, 11 Sep 2019 02:20:17 GMT' ]);
-
+  'Thu, 28 Jul 2022 09:12:59 GMT'
+]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .delete('/container156816841663509039')
+  .delete('/container165899957948908427')
   .query(true)
-  .reply(202, "", [ 'Content-Length',
+  .reply(202, "", [
+  'Content-Length',
   '0',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '18369a8f-b01e-004d-5b47-68a01e000000',
+  'a85ba651-d01e-0054-5362-a2abee000000',
   'x-ms-client-request-id',
-  'f4d74832-a37b-4bef-909e-82daf3567900',
+  'fd28b201-6898-4449-a39e-16672e084475',
   'x-ms-version',
-  '2019-02-02',
+  '2021-08-06',
   'Date',
-  'Wed, 11 Sep 2019 02:20:17 GMT' ]);
-
+  'Thu, 28 Jul 2022 09:12:59 GMT'
+]);

--- a/sdk/storage/storage-blob/recordings/node/containerclient/recording_listblobsbyhierarchy_with_all_parameters_configured.js
+++ b/sdk/storage/storage-blob/recordings/node/containerclient/recording_listblobsbyhierarchy_with_all_parameters_configured.js
@@ -1,198 +1,209 @@
 let nock = require('nock');
 
-module.exports.testInfo = {"container":"container156816843966500638","blockblob0/0":"blockblob0/0156816844007405924","blockblob1/1":"blockblob1/1156816844049104742"}
+module.exports.hash = "a38363b365a0cc53487de4a5ec6d1f00";
+
+module.exports.testInfo = {"uniqueName":{"container":"container165899894160306171","blockblob0/0":"blockblob0/0165899894171800583","blockblob1/1":"blockblob1/1165899894182108673"},"newDate":{}}
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container156816843966500638')
+  .put('/container165899894160306171')
   .query(true)
-  .reply(201, "", [ 'Content-Length',
+  .reply(201, "", [
+  'Content-Length',
   '0',
   'Last-Modified',
-  'Wed, 11 Sep 2019 02:20:40 GMT',
+  'Thu, 28 Jul 2022 09:02:21 GMT',
   'ETag',
-  '"0x8D7365EA3DA1E1D"',
+  '"0x8DA7077E1D6E5F1"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '8bb88531-601e-000b-0647-687e88000000',
+  '3078df00-301e-0011-0460-a27e0d000000',
   'x-ms-client-request-id',
-  '09bf00ac-448b-4f29-bdf8-415e70dfab4b',
+  '3b0fc8db-a84a-486b-bb7b-6dd93668fad1',
   'x-ms-version',
-  '2019-02-02',
+  '2021-08-06',
   'Date',
-  'Wed, 11 Sep 2019 02:20:39 GMT' ]);
-
+  'Thu, 28 Jul 2022 09:02:21 GMT'
+]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container156816843966500638/blockblob0%2F0156816844007405924')
-  .reply(201, "", [ 'Content-Length',
+  .put('/container165899894160306171/blockblob0/0165899894171800583')
+  .reply(201, "", [
+  'Content-Length',
   '0',
   'Content-MD5',
   '1B2M2Y8AsgTpgAmY7PhCfg==',
   'Last-Modified',
-  'Wed, 11 Sep 2019 02:20:40 GMT',
+  'Thu, 28 Jul 2022 09:02:22 GMT',
   'ETag',
-  '"0x8D7365EA41882E1"',
+  '"0x8DA7077E1EAC23F"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '52e8293d-801e-0028-5a47-681143000000',
+  '3078df16-301e-0011-1460-a27e0d000000',
   'x-ms-client-request-id',
-  '48382c3d-e317-4406-8c36-27ba4b344045',
+  '891c8882-d385-42a6-abaf-6d4406dd8733',
   'x-ms-version',
-  '2019-02-02',
+  '2021-08-06',
   'x-ms-content-crc64',
   'AAAAAAAAAAA=',
   'x-ms-request-server-encrypted',
   'true',
   'Date',
-  'Wed, 11 Sep 2019 02:20:39 GMT' ]);
-
+  'Thu, 28 Jul 2022 09:02:21 GMT'
+]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container156816843966500638/blockblob1%2F1156816844049104742')
-  .reply(201, "", [ 'Content-Length',
+  .put('/container165899894160306171/blockblob1/1165899894182108673')
+  .reply(201, "", [
+  'Content-Length',
   '0',
   'Content-MD5',
   '1B2M2Y8AsgTpgAmY7PhCfg==',
   'Last-Modified',
-  'Wed, 11 Sep 2019 02:20:40 GMT',
+  'Thu, 28 Jul 2022 09:02:22 GMT',
   'ETag',
-  '"0x8D7365EA4580858"',
+  '"0x8DA7077E1FA5034"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '51442922-301e-0031-3547-683d2b000000',
+  '3078df3b-301e-0011-3360-a27e0d000000',
   'x-ms-client-request-id',
-  'cad702bf-791a-49cf-8386-b07f0218df8c',
+  'f16258e6-7f28-4354-9359-59b10b6e2b0d',
   'x-ms-version',
-  '2019-02-02',
+  '2021-08-06',
   'x-ms-content-crc64',
   'AAAAAAAAAAA=',
   'x-ms-request-server-encrypted',
   'true',
   'Date',
-  'Wed, 11 Sep 2019 02:20:40 GMT' ]);
-
+  'Thu, 28 Jul 2022 09:02:21 GMT'
+]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .get('/container156816843966500638')
+  .get('/container165899894160306171')
   .query(true)
-  .reply(200, "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults ServiceEndpoint=\"https://fakestorageaccount.blob.core.windows.net/\" ContainerName=\"container156816843966500638\"><Prefix>blockblob</Prefix><MaxResults>1</MaxResults><Delimiter>/</Delimiter><Blobs><BlobPrefix><Name>blockblob0/</Name></BlobPrefix></Blobs><NextMarker>2!100!MDAwMDMwIWJsb2NrYmxvYjEvMTE1NjgxNjg0NDA0OTEwNDc0MiEwMDAwMjghOTk5OS0xMi0zMVQyMzo1OTo1OS45OTk5OTk5WiE-</NextMarker></EnumerationResults>", [ 'Transfer-Encoding',
+  .reply(200, "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults ServiceEndpoint=\"https://fakestorageaccount.blob.core.windows.net/\" ContainerName=\"container165899894160306171\"><Prefix>blockblob</Prefix><MaxResults>1</MaxResults><Delimiter>/</Delimiter><Blobs><BlobPrefix><Name>blockblob0/</Name></BlobPrefix></Blobs><NextMarker>2!100!MDAwMDMwIWJsb2NrYmxvYjEvMTE2NTg5OTg5NDE4MjEwODY3MyEwMDAwMjghOTk5OS0xMi0zMVQyMzo1OTo1OS45OTk5OTk5WiE-</NextMarker></EnumerationResults>", [
+  'Transfer-Encoding',
   'chunked',
   'Content-Type',
   'application/xml',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '1b9f3db5-e01e-0033-6d47-683fd1000000',
+  '3078df58-301e-0011-4d60-a27e0d000000',
   'x-ms-client-request-id',
-  '6e9cfc5d-6cc7-4e8f-917d-00b85d5b6799',
+  '34c08b63-0b11-4567-82b9-abdd6fe69e86',
   'x-ms-version',
-  '2019-02-02',
+  '2021-08-06',
   'Access-Control-Expose-Headers',
   'x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,Content-Type,Content-Length,Date,Transfer-Encoding',
   'Access-Control-Allow-Origin',
   '*',
   'Date',
-  'Wed, 11 Sep 2019 02:20:40 GMT' ]);
-
+  'Thu, 28 Jul 2022 09:02:21 GMT'
+]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .get('/container156816843966500638')
+  .get('/container165899894160306171')
   .query(true)
-  .reply(200, "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults ServiceEndpoint=\"https://fakestorageaccount.blob.core.windows.net/\" ContainerName=\"container156816843966500638\"><Prefix>blockblob</Prefix><Marker>2!100!MDAwMDMwIWJsb2NrYmxvYjEvMTE1NjgxNjg0NDA0OTEwNDc0MiEwMDAwMjghOTk5OS0xMi0zMVQyMzo1OTo1OS45OTk5OTk5WiE-</Marker><MaxResults>2</MaxResults><Delimiter>/</Delimiter><Blobs><BlobPrefix><Name>blockblob1/</Name></BlobPrefix></Blobs><NextMarker /></EnumerationResults>", [ 'Transfer-Encoding',
+  .reply(200, "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults ServiceEndpoint=\"https://fakestorageaccount.blob.core.windows.net/\" ContainerName=\"container165899894160306171\"><Prefix>blockblob</Prefix><Marker>2!100!MDAwMDMwIWJsb2NrYmxvYjEvMTE2NTg5OTg5NDE4MjEwODY3MyEwMDAwMjghOTk5OS0xMi0zMVQyMzo1OTo1OS45OTk5OTk5WiE-</Marker><MaxResults>2</MaxResults><Delimiter>/</Delimiter><Blobs><BlobPrefix><Name>blockblob1/</Name></BlobPrefix></Blobs><NextMarker /></EnumerationResults>", [
+  'Transfer-Encoding',
   'chunked',
   'Content-Type',
   'application/xml',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '155ace9f-c01e-0006-1347-689184000000',
+  '3078df78-301e-0011-6860-a27e0d000000',
   'x-ms-client-request-id',
-  'ab36f359-296d-4e7f-b8ce-725ea4e62aac',
+  'd48b01f4-1ecf-4bb5-b680-45d31685c532',
   'x-ms-version',
-  '2019-02-02',
+  '2021-08-06',
   'Access-Control-Expose-Headers',
   'x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,Content-Type,Content-Length,Date,Transfer-Encoding',
   'Access-Control-Allow-Origin',
   '*',
   'Date',
-  'Wed, 11 Sep 2019 02:20:40 GMT' ]);
-
+  'Thu, 28 Jul 2022 09:02:21 GMT'
+]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .get('/container156816843966500638')
+  .get('/container165899894160306171')
   .query(true)
-  .reply(200, "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults ServiceEndpoint=\"https://fakestorageaccount.blob.core.windows.net/\" ContainerName=\"container156816843966500638\"><Prefix>blockblob0/</Prefix><MaxResults>2</MaxResults><Delimiter>/</Delimiter><Blobs><Blob><Name>blockblob0/0156816844007405924</Name><Properties><Creation-Time>Wed, 11 Sep 2019 02:20:40 GMT</Creation-Time><Last-Modified>Wed, 11 Sep 2019 02:20:40 GMT</Last-Modified><Etag>0x8D7365EA41882E1</Etag><Content-Length>0</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64>AAAAAAAAAAA=</Content-CRC64><Content-MD5>1B2M2Y8AsgTpgAmY7PhCfg==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Cool</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted><TagCount>0</TagCount></Properties><Metadata><keya>a</keya><keyb>c</keyb></Metadata></Blob></Blobs><NextMarker /></EnumerationResults>", [ 'Transfer-Encoding',
+  .reply(200, "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults ServiceEndpoint=\"https://fakestorageaccount.blob.core.windows.net/\" ContainerName=\"container165899894160306171\"><Prefix>blockblob0/</Prefix><MaxResults>2</MaxResults><Delimiter>/</Delimiter><Blobs><Blob><Name>blockblob0/0165899894171800583</Name><Properties><Creation-Time>Thu, 28 Jul 2022 09:02:22 GMT</Creation-Time><Last-Modified>Thu, 28 Jul 2022 09:02:22 GMT</Last-Modified><Etag>0x8DA7077E1EAC23F</Etag><Content-Length>0</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>1B2M2Y8AsgTpgAmY7PhCfg==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties><Metadata><keya>a</keya><keyb>c</keyb></Metadata><OrMetadata /></Blob></Blobs><NextMarker /></EnumerationResults>", [
+  'Transfer-Encoding',
   'chunked',
   'Content-Type',
   'application/xml',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '25d6838c-101e-002d-4e47-68e53c000000',
+  '3078df8d-301e-0011-7960-a27e0d000000',
   'x-ms-client-request-id',
-  '9ae60243-94b9-4fa2-b890-38e662f83e75',
+  '1c07638d-ae59-4a56-b4ae-58a603b7fc04',
   'x-ms-version',
-  '2019-02-02',
+  '2021-08-06',
   'Access-Control-Expose-Headers',
   'x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,Content-Type,Content-Length,Date,Transfer-Encoding',
   'Access-Control-Allow-Origin',
   '*',
   'Date',
-  'Wed, 11 Sep 2019 02:20:41 GMT' ]);
-
+  'Thu, 28 Jul 2022 09:02:21 GMT'
+]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .delete('/container156816843966500638/blockblob0%2F0156816844007405924')
-  .reply(202, "", [ 'Content-Length',
+  .delete('/container165899894160306171/blockblob0/0165899894171800583')
+  .reply(202, "", [
+  'Content-Length',
   '0',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '027028fe-201e-0043-6c47-684c15000000',
+  '3078df9d-301e-0011-0860-a27e0d000000',
   'x-ms-client-request-id',
-  'e456faf1-2793-4dfc-8517-f7076642ea88',
+  '16c722b9-27e7-455d-8eaf-616cbe999a70',
   'x-ms-version',
-  '2019-02-02',
+  '2021-08-06',
   'x-ms-delete-type-permanent',
   'false',
   'Date',
-  'Wed, 11 Sep 2019 02:20:41 GMT' ]);
-
+  'Thu, 28 Jul 2022 09:02:21 GMT'
+]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .delete('/container156816843966500638/blockblob1%2F1156816844049104742')
-  .reply(202, "", [ 'Content-Length',
+  .delete('/container165899894160306171/blockblob1/1165899894182108673')
+  .reply(202, "", [
+  'Content-Length',
   '0',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'a0441bef-701e-0050-2c47-6879f4000000',
+  '3078dfb2-301e-0011-1b60-a27e0d000000',
   'x-ms-client-request-id',
-  'c244825c-d512-4285-8c3b-1bdaea8c79c2',
+  '1fbdeea3-e77d-4247-8af8-d68582834a80',
   'x-ms-version',
-  '2019-02-02',
+  '2021-08-06',
   'x-ms-delete-type-permanent',
   'false',
   'Date',
-  'Wed, 11 Sep 2019 02:20:42 GMT' ]);
-
+  'Thu, 28 Jul 2022 09:02:21 GMT'
+]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .delete('/container156816843966500638')
+  .delete('/container165899894160306171')
   .query(true)
-  .reply(202, "", [ 'Content-Length',
+  .reply(202, "", [
+  'Content-Length',
   '0',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'bc0ae31a-901e-003c-4d47-68d227000000',
+  '3078dfc9-301e-0011-2f60-a27e0d000000',
   'x-ms-client-request-id',
-  'bf130253-543d-4322-966c-530c8bccad8d',
+  'af419589-621c-4705-85d2-691ab00e5de4',
   'x-ms-version',
-  '2019-02-02',
+  '2021-08-06',
   'Date',
-  'Wed, 11 Sep 2019 02:20:42 GMT' ]);
-
+  'Thu, 28 Jul 2022 09:02:21 GMT'
+]);

--- a/sdk/storage/storage-blob/recordings/node/containerclient/recording_listblobsbyhierarchy_with_default_parameters.js
+++ b/sdk/storage/storage-blob/recordings/node/containerclient/recording_listblobsbyhierarchy_with_default_parameters.js
@@ -1,189 +1,207 @@
 let nock = require('nock');
 
-module.exports.hash = "9d93248e467ebd9afc3028d08238e416";
+module.exports.hash = "b4ac1f32fc6815294b334efcae0ce744";
 
-module.exports.testInfo = {"uniqueName":{"container":"container163764847399101586","blockblob0/0":"blockblob0/0163764847423307029","blockblob1/1":"blockblob1/1163764847448100326","blockblob2/2":"blockblob2/2163764847472702491"},"newDate":{}}
+module.exports.testInfo = {"uniqueName":{"container":"container165899958434206247","blockblob0/0":"blockblob0/0165899958444305388","blockblob1/1":"blockblob1/1165899958454303662","blockblob2/2":"blockblob2/2165899958464306196"},"newDate":{}}
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container163764847399101586')
+  .put('/container165899958434206247')
   .query(true)
   .reply(201, "", [
-  'Transfer-Encoding',
-  'chunked',
+  'Content-Length',
+  '0',
   'Last-Modified',
-  'Tue, 23 Nov 2021 06:21:14 GMT',
+  'Thu, 28 Jul 2022 09:13:04 GMT',
   'ETag',
-  '"0x8D9AE4973646AA4"',
+  '"0x8DA707960F23FAE"',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'e179331b-501e-0003-1a32-e07981000000',
+  'a85ba9af-d01e-0054-0e62-a2abee000000',
   'x-ms-client-request-id',
-  '9f12c0a1-9c79-434c-b8c2-ab438e6774c9',
+  'cf6d95d8-23a2-48de-8a88-d20cb7940507',
   'x-ms-version',
-  '2021-02-12',
+  '2021-08-06',
   'Date',
-  'Tue, 23 Nov 2021 06:21:13 GMT'
+  'Thu, 28 Jul 2022 09:13:04 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container163764847399101586/blockblob0%2F0163764847423307029')
+  .put('/container165899958434206247/blockblob0/0165899958444305388')
   .reply(201, "", [
-  'Transfer-Encoding',
-  'chunked',
+  'Content-Length',
+  '0',
   'Content-MD5',
   '1B2M2Y8AsgTpgAmY7PhCfg==',
   'Last-Modified',
-  'Tue, 23 Nov 2021 06:21:14 GMT',
+  'Thu, 28 Jul 2022 09:13:04 GMT',
   'ETag',
-  '"0x8D9AE49738A875C"',
+  '"0x8DA7079610331A6"',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'e179331d-501e-0003-1b32-e07981000000',
+  'a85ba9be-d01e-0054-1a62-a2abee000000',
   'x-ms-client-request-id',
-  '80f0d7bc-5df0-440d-ba25-2572bac7ba4b',
+  '084e2b38-72c2-4b65-980d-65136e6d3bd0',
   'x-ms-version',
-  '2021-02-12',
+  '2021-08-06',
   'x-ms-content-crc64',
   'AAAAAAAAAAA=',
   'x-ms-request-server-encrypted',
-  'false',
+  'true',
   'Date',
-  'Tue, 23 Nov 2021 06:21:13 GMT'
+  'Thu, 28 Jul 2022 09:13:04 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container163764847399101586/blockblob1%2F1163764847448100326')
+  .put('/container165899958434206247/blockblob1/1165899958454303662')
   .reply(201, "", [
-  'Transfer-Encoding',
-  'chunked',
+  'Content-Length',
+  '0',
   'Content-MD5',
   '1B2M2Y8AsgTpgAmY7PhCfg==',
   'Last-Modified',
-  'Tue, 23 Nov 2021 06:21:14 GMT',
+  'Thu, 28 Jul 2022 09:13:04 GMT',
   'ETag',
-  '"0x8D9AE4973B012D2"',
+  '"0x8DA707961129880"',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'e1793320-501e-0003-1e32-e07981000000',
+  'a85ba9d1-d01e-0054-2962-a2abee000000',
   'x-ms-client-request-id',
-  'd9a2f408-61d7-476c-8e58-325e03952606',
+  'fa65e99b-fbc9-4436-b266-99a296aa2c39',
   'x-ms-version',
-  '2021-02-12',
+  '2021-08-06',
   'x-ms-content-crc64',
   'AAAAAAAAAAA=',
   'x-ms-request-server-encrypted',
-  'false',
+  'true',
   'Date',
-  'Tue, 23 Nov 2021 06:21:13 GMT'
+  'Thu, 28 Jul 2022 09:13:04 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container163764847399101586/blockblob2%2F2163764847472702491')
+  .put('/container165899958434206247/blockblob2/2165899958464306196')
   .reply(201, "", [
-  'Transfer-Encoding',
-  'chunked',
+  'Content-Length',
+  '0',
   'Content-MD5',
   '1B2M2Y8AsgTpgAmY7PhCfg==',
   'Last-Modified',
-  'Tue, 23 Nov 2021 06:21:14 GMT',
+  'Thu, 28 Jul 2022 09:13:04 GMT',
   'ETag',
-  '"0x8D9AE4973D59A3D"',
+  '"0x8DA70796121FF60"',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'e1793321-501e-0003-1f32-e07981000000',
+  'a85ba9de-d01e-0054-3362-a2abee000000',
   'x-ms-client-request-id',
-  'fccb47f9-858a-4289-b2df-3c6d8e748c54',
+  '4d60f109-409a-486e-a0cd-2b9eb9ceb6a5',
   'x-ms-version',
-  '2021-02-12',
+  '2021-08-06',
   'x-ms-content-crc64',
   'AAAAAAAAAAA=',
   'x-ms-request-server-encrypted',
-  'false',
+  'true',
   'Date',
-  'Tue, 23 Nov 2021 06:21:14 GMT'
+  'Thu, 28 Jul 2022 09:13:04 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .get('/container163764847399101586')
+  .get('/container165899958434206247')
   .query(true)
-  .reply(200, "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults ServiceEndpoint=\"https://fakestorageaccount.blob.core.windows.net/\" ContainerName=\"container163764847399101586\"><Delimiter>/</Delimiter><Blobs><BlobPrefix><Name>blockblob0/</Name></BlobPrefix><BlobPrefix><Name>blockblob1/</Name></BlobPrefix><BlobPrefix><Name>blockblob2/</Name></BlobPrefix></Blobs><NextMarker /></EnumerationResults>", [
+  .reply(200, "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults ServiceEndpoint=\"https://fakestorageaccount.blob.core.windows.net/\" ContainerName=\"container165899958434206247\"><Delimiter>/</Delimiter><Blobs><BlobPrefix><Name>blockblob0/</Name></BlobPrefix><BlobPrefix><Name>blockblob1/</Name></BlobPrefix><BlobPrefix><Name>blockblob2/</Name></BlobPrefix></Blobs><NextMarker /></EnumerationResults>", [
   'Transfer-Encoding',
   'chunked',
   'Content-Type',
   'application/xml',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'e1793322-501e-0003-2032-e07981000000',
+  'a85ba9eb-d01e-0054-3d62-a2abee000000',
   'x-ms-client-request-id',
-  '6ffec78e-aa12-430a-bf13-727b98abcfc7',
+  '79d7b0e9-2fe8-4edc-88a7-c93ae7cd1418',
   'x-ms-version',
-  '2021-02-12',
+  '2021-08-06',
   'Access-Control-Expose-Headers',
-  'x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,Content-Type',
+  'x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,Content-Type,Content-Length,Date,Transfer-Encoding',
   'Access-Control-Allow-Origin',
   '*',
   'Date',
-  'Tue, 23 Nov 2021 06:21:14 GMT'
+  'Thu, 28 Jul 2022 09:13:04 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .delete('/container163764847399101586/blockblob0%2F0163764847423307029')
+  .delete('/container165899958434206247/blockblob0/0165899958444305388')
   .reply(202, "", [
-  'Transfer-Encoding',
-  'chunked',
+  'Content-Length',
+  '0',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'e1793323-501e-0003-2132-e07981000000',
+  'a85baa15-d01e-0054-6262-a2abee000000',
   'x-ms-client-request-id',
-  '92e23781-9cca-43d1-ae20-3c5e28d74ec2',
+  'ba3aad4e-566e-4cfa-9236-5589b8724a6d',
   'x-ms-version',
-  '2021-02-12',
+  '2021-08-06',
   'x-ms-delete-type-permanent',
   'false',
   'Date',
-  'Tue, 23 Nov 2021 06:21:14 GMT'
+  'Thu, 28 Jul 2022 09:13:04 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .delete('/container163764847399101586/blockblob1%2F1163764847448100326')
+  .delete('/container165899958434206247/blockblob1/1165899958454303662')
   .reply(202, "", [
-  'Transfer-Encoding',
-  'chunked',
+  'Content-Length',
+  '0',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'e1793324-501e-0003-2232-e07981000000',
+  'a85baa31-d01e-0054-7962-a2abee000000',
   'x-ms-client-request-id',
-  '7a3d8d27-c8aa-439f-bf34-4509b3553703',
+  'b754ecc5-1c9b-4c79-84e0-64f97db0bd1f',
   'x-ms-version',
-  '2021-02-12',
+  '2021-08-06',
   'x-ms-delete-type-permanent',
   'false',
   'Date',
-  'Tue, 23 Nov 2021 06:21:14 GMT'
+  'Thu, 28 Jul 2022 09:13:04 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .delete('/container163764847399101586/blockblob2%2F2163764847472702491')
+  .delete('/container165899958434206247/blockblob2/2165899958464306196')
   .reply(202, "", [
-  'Transfer-Encoding',
-  'chunked',
+  'Content-Length',
+  '0',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'e1793325-501e-0003-2332-e07981000000',
+  'a85baa40-d01e-0054-0362-a2abee000000',
   'x-ms-client-request-id',
-  'e738ff4d-71b6-4621-9192-5e993e01b1b3',
+  '39951eee-5ba0-4e5b-9b03-9289bfb1d3ae',
   'x-ms-version',
-  '2021-02-12',
+  '2021-08-06',
   'x-ms-delete-type-permanent',
   'false',
   'Date',
-  'Tue, 23 Nov 2021 06:21:15 GMT'
+  'Thu, 28 Jul 2022 09:13:05 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .delete('/container163764847399101586')
+  .delete('/container165899958434206247')
   .query(true)
   .reply(202, "", [
-  'Transfer-Encoding',
-  'chunked',
+  'Content-Length',
+  '0',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'e1793326-501e-0003-2432-e07981000000',
+  'a85baa4a-d01e-0054-0c62-a2abee000000',
   'x-ms-client-request-id',
-  'f15f9405-9ad8-49cf-bd7d-8099bc66fb6d',
+  '84e47932-8b1a-4b59-bbdb-f36c9e0339f1',
   'x-ms-version',
-  '2021-02-12',
+  '2021-08-06',
   'Date',
-  'Tue, 23 Nov 2021 06:21:15 GMT'
+  'Thu, 28 Jul 2022 09:13:05 GMT'
 ]);

--- a/sdk/storage/storage-blob/recordings/node/containerclient/recording_listblobsbyhierarchy_with_default_parameters__null_prefix_shouldnt_throw_error.js
+++ b/sdk/storage/storage-blob/recordings/node/containerclient/recording_listblobsbyhierarchy_with_default_parameters__null_prefix_shouldnt_throw_error.js
@@ -1,114 +1,116 @@
 let nock = require('nock');
 
-module.exports.testInfo = {"uniqueName":{"container":"container157437901329105668","blockblob0/0":"blockblob0/0157437901349001178","blockblob1/1":"blockblob1/1157437901356906306","blockblob2/2":"blockblob2/2157437901363800911"},"newDate":{}}
+module.exports.hash = "459c714894a351a8ab3c6563d11587ee";
+
+module.exports.testInfo = {"uniqueName":{"container":"container165899894008503348","blockblob0/0":"blockblob0/0165899894075903133","blockblob1/1":"blockblob1/1165899894086909632","blockblob2/2":"blockblob2/2165899894097200555"},"newDate":{}}
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container157437901329105668')
+  .put('/container165899894008503348')
   .query(true)
   .reply(201, "", [
   'Content-Length',
   '0',
   'Last-Modified',
-  'Thu, 21 Nov 2019 23:30:13 GMT',
+  'Thu, 28 Jul 2022 09:02:20 GMT',
   'ETag',
-  '"0x8D76EDAC215506B"',
+  '"0x8DA7077E1454229"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'f00de0c1-801e-003b-71c3-a03afb000000',
+  '3078dde4-301e-0011-1160-a27e0d000000',
   'x-ms-client-request-id',
-  '37d3c082-9de9-47fa-85ee-9d3b8af493cc',
+  '178847dd-d728-4378-a979-b92159522023',
   'x-ms-version',
-  '2019-02-02',
+  '2021-08-06',
   'Date',
-  'Thu, 21 Nov 2019 23:30:13 GMT'
+  'Thu, 28 Jul 2022 09:02:20 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container157437901329105668/blockblob0%2F0157437901349001178')
+  .put('/container165899894008503348/blockblob0/0165899894075903133')
   .reply(201, "", [
   'Content-Length',
   '0',
   'Content-MD5',
   '1B2M2Y8AsgTpgAmY7PhCfg==',
   'Last-Modified',
-  'Thu, 21 Nov 2019 23:30:13 GMT',
+  'Thu, 28 Jul 2022 09:02:21 GMT',
   'ETag',
-  '"0x8D76EDAC2255E58"',
+  '"0x8DA7077E1594725"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '0c489a01-f01e-006c-12c3-a094c8000000',
+  '3078de08-301e-0011-2d60-a27e0d000000',
   'x-ms-client-request-id',
-  '0b61bbe6-c083-472d-8e53-76538bdcbffd',
+  '158123c8-9caa-490e-bcb6-fae89a49765d',
   'x-ms-version',
-  '2019-02-02',
+  '2021-08-06',
   'x-ms-content-crc64',
   'AAAAAAAAAAA=',
   'x-ms-request-server-encrypted',
   'true',
   'Date',
-  'Thu, 21 Nov 2019 23:30:13 GMT'
+  'Thu, 28 Jul 2022 09:02:20 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container157437901329105668/blockblob1%2F1157437901356906306')
+  .put('/container165899894008503348/blockblob1/1165899894086909632')
   .reply(201, "", [
   'Content-Length',
   '0',
   'Content-MD5',
   '1B2M2Y8AsgTpgAmY7PhCfg==',
   'Last-Modified',
-  'Thu, 21 Nov 2019 23:30:13 GMT',
+  'Thu, 28 Jul 2022 09:02:21 GMT',
   'ETag',
-  '"0x8D76EDAC23035B9"',
+  '"0x8DA7077E1692327"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '891d4fa6-901e-0037-45c3-a0adf3000000',
+  '3078de44-301e-0011-6360-a27e0d000000',
   'x-ms-client-request-id',
-  '970cb04c-770c-4040-874f-59c5ed18707e',
+  'f1fb7962-5012-4596-b66e-7705dc207306',
   'x-ms-version',
-  '2019-02-02',
+  '2021-08-06',
   'x-ms-content-crc64',
   'AAAAAAAAAAA=',
   'x-ms-request-server-encrypted',
   'true',
   'Date',
-  'Thu, 21 Nov 2019 23:30:13 GMT'
+  'Thu, 28 Jul 2022 09:02:20 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container157437901329105668/blockblob2%2F2157437901363800911')
+  .put('/container165899894008503348/blockblob2/2165899894097200555')
   .reply(201, "", [
   'Content-Length',
   '0',
   'Content-MD5',
   '1B2M2Y8AsgTpgAmY7PhCfg==',
   'Last-Modified',
-  'Thu, 21 Nov 2019 23:30:13 GMT',
+  'Thu, 28 Jul 2022 09:02:21 GMT',
   'ETag',
-  '"0x8D76EDAC23A2294"',
+  '"0x8DA7077E178D82E"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '932da7ca-b01e-0030-29c3-a0c190000000',
+  '3078de68-301e-0011-0160-a27e0d000000',
   'x-ms-client-request-id',
-  'e440873d-5f21-44d7-ba7d-c1a774988fc6',
+  'c6808a70-d3d8-41d4-9979-df4ae93db987',
   'x-ms-version',
-  '2019-02-02',
+  '2021-08-06',
   'x-ms-content-crc64',
   'AAAAAAAAAAA=',
   'x-ms-request-server-encrypted',
   'true',
   'Date',
-  'Thu, 21 Nov 2019 23:30:13 GMT'
+  'Thu, 28 Jul 2022 09:02:20 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .get('/container157437901329105668')
+  .get('/container165899894008503348')
   .query(true)
-  .reply(200, "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults ServiceEndpoint=\"https://fakestorageaccount.blob.core.windows.net/\" ContainerName=\"container157437901329105668\"><Delimiter>/</Delimiter><Blobs><BlobPrefix><Name>blockblob0/</Name></BlobPrefix><BlobPrefix><Name>blockblob1/</Name></BlobPrefix><BlobPrefix><Name>blockblob2/</Name></BlobPrefix></Blobs><NextMarker /></EnumerationResults>", [
+  .reply(200, "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults ServiceEndpoint=\"https://fakestorageaccount.blob.core.windows.net/\" ContainerName=\"container165899894008503348\"><Delimiter>/</Delimiter><Blobs><BlobPrefix><Name>blockblob0/</Name></BlobPrefix><BlobPrefix><Name>blockblob1/</Name></BlobPrefix><BlobPrefix><Name>blockblob2/</Name></BlobPrefix></Blobs><NextMarker /></EnumerationResults>", [
   'Transfer-Encoding',
   'chunked',
   'Content-Type',
@@ -116,78 +118,78 @@ nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParam
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'f00de1cd-801e-003b-70c3-a03afb000000',
+  '3078de84-301e-0011-1960-a27e0d000000',
   'x-ms-client-request-id',
-  'e0961356-621c-49db-b4c4-f5f0783fb3cc',
+  '9c27dab3-bb7c-451a-8b15-8f862d7be29b',
   'x-ms-version',
-  '2019-02-02',
+  '2021-08-06',
   'Access-Control-Expose-Headers',
   'x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,Content-Type,Content-Length,Date,Transfer-Encoding',
   'Access-Control-Allow-Origin',
   '*',
   'Date',
-  'Thu, 21 Nov 2019 23:30:13 GMT'
+  'Thu, 28 Jul 2022 09:02:20 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .delete('/container157437901329105668/blockblob0%2F0157437901349001178')
+  .delete('/container165899894008503348/blockblob0/0165899894075903133')
   .reply(202, "", [
   'Content-Length',
   '0',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '38b6e803-401e-0024-52c3-a089ff000000',
+  '3078de9e-301e-0011-3060-a27e0d000000',
   'x-ms-client-request-id',
-  'cd66f784-3a62-47a1-8fb2-1531f1845984',
+  '944f9469-f9bd-4e13-af1f-13e355afd9a5',
   'x-ms-version',
-  '2019-02-02',
+  '2021-08-06',
   'x-ms-delete-type-permanent',
-  'true',
+  'false',
   'Date',
-  'Thu, 21 Nov 2019 23:30:12 GMT'
+  'Thu, 28 Jul 2022 09:02:20 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .delete('/container157437901329105668/blockblob1%2F1157437901356906306')
+  .delete('/container165899894008503348/blockblob1/1165899894086909632')
   .reply(202, "", [
   'Content-Length',
   '0',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '4e42f1c4-201e-0022-4fc3-a0ba40000000',
+  '3078deb4-301e-0011-4560-a27e0d000000',
   'x-ms-client-request-id',
-  '7c3e3c97-bf55-4965-9f80-3a32985c3dcb',
+  '92f7938d-ef30-4fa9-8fe1-be137c6036ea',
   'x-ms-version',
-  '2019-02-02',
+  '2021-08-06',
   'x-ms-delete-type-permanent',
-  'true',
+  'false',
   'Date',
-  'Thu, 21 Nov 2019 23:30:13 GMT'
+  'Thu, 28 Jul 2022 09:02:20 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .delete('/container157437901329105668/blockblob2%2F2157437901363800911')
+  .delete('/container165899894008503348/blockblob2/2165899894097200555')
   .reply(202, "", [
   'Content-Length',
   '0',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '5423ea3b-401e-008d-70c3-a0488d000000',
+  '3078decc-301e-0011-5a60-a27e0d000000',
   'x-ms-client-request-id',
-  '6d9f943d-de96-437b-b44e-9946004156a2',
+  '6ccd411f-7647-46da-8430-fd988da23f92',
   'x-ms-version',
-  '2019-02-02',
+  '2021-08-06',
   'x-ms-delete-type-permanent',
-  'true',
+  'false',
   'Date',
-  'Thu, 21 Nov 2019 23:30:13 GMT'
+  'Thu, 28 Jul 2022 09:02:20 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .delete('/container157437901329105668')
+  .delete('/container165899894008503348')
   .query(true)
   .reply(202, "", [
   'Content-Length',
@@ -195,11 +197,11 @@ nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParam
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'f00de26f-801e-003b-08c3-a03afb000000',
+  '3078deeb-301e-0011-7360-a27e0d000000',
   'x-ms-client-request-id',
-  'c1f83a73-52cc-40af-8458-e25f03a9cd30',
+  '8a78ffc4-eb54-4571-a57c-778556d462e9',
   'x-ms-version',
-  '2019-02-02',
+  '2021-08-06',
   'Date',
-  'Thu, 21 Nov 2019 23:30:13 GMT'
+  'Thu, 28 Jul 2022 09:02:20 GMT'
 ]);

--- a/sdk/storage/storage-blob/recordings/node/containerclient/recording_listblobsbyhierarchy_with_special_chars.js
+++ b/sdk/storage/storage-blob/recordings/node/containerclient/recording_listblobsbyhierarchy_with_special_chars.js
@@ -1,197 +1,197 @@
 let nock = require('nock');
 
-module.exports.hash = "762865f4930297f2a92be2425d081f11";
+module.exports.hash = "b963543250830298b2efb9ad6c02c436";
 
-module.exports.testInfo = {"uniqueName":{"container":"container163841191727006884"},"newDate":{}}
+module.exports.testInfo = {"uniqueName":{"container":"container165899958524406447"},"newDate":{}}
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container163841191727006884')
+  .put('/container165899958524406447')
   .query(true)
   .reply(201, "", [
   'Content-Length',
   '0',
   'Last-Modified',
-  'Thu, 02 Dec 2021 02:25:18 GMT',
+  'Thu, 28 Jul 2022 09:13:05 GMT',
   'ETag',
-  '"0x8D9B53AFB6A4DCA"',
+  '"0x8DA7079617BCDC4"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '5597be56-f01e-0031-6d23-e705aa000000',
+  'a85baa59-d01e-0054-1962-a2abee000000',
   'x-ms-client-request-id',
-  'd127e1ac-c392-4bb6-8410-bfa896b510de',
+  '48a2fadc-19f5-4844-85eb-6a65ce9d8b33',
   'x-ms-version',
-  '2021-02-12',
+  '2021-08-06',
   'Date',
-  'Thu, 02 Dec 2021 02:25:17 GMT'
+  'Thu, 28 Jul 2022 09:13:05 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container163841191727006884/first_dir%EF%BF%BF%2Ffile%EF%BF%BF.blob')
+  .put('/container165899958524406447/first_dir%EF%BF%BF/file%EF%BF%BF.blob')
   .reply(201, "", [
   'Content-Length',
   '0',
   'Content-MD5',
   '1B2M2Y8AsgTpgAmY7PhCfg==',
   'Last-Modified',
-  'Thu, 02 Dec 2021 02:25:18 GMT',
+  'Thu, 28 Jul 2022 09:13:05 GMT',
   'ETag',
-  '"0x8D9B53AFB803C6E"',
+  '"0x8DA7079618D0C1A"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '5597be80-f01e-0031-1323-e705aa000000',
+  'a85baa79-d01e-0054-3462-a2abee000000',
   'x-ms-client-request-id',
-  '0db9977a-e26e-4524-b56f-f967e0a6da60',
+  'dd4d50e1-07dc-4d25-b4d2-4832e6543e83',
   'x-ms-version',
-  '2021-02-12',
+  '2021-08-06',
   'x-ms-content-crc64',
   'AAAAAAAAAAA=',
   'x-ms-request-server-encrypted',
   'true',
   'Date',
-  'Thu, 02 Dec 2021 02:25:17 GMT'
+  'Thu, 28 Jul 2022 09:13:05 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container163841191727006884/second_dir%EF%BF%BF%2Ffile%EF%BF%BF.blob')
+  .put('/container165899958524406447/second_dir%EF%BF%BF/file%EF%BF%BF.blob')
   .reply(201, "", [
   'Content-Length',
   '0',
   'Content-MD5',
   '1B2M2Y8AsgTpgAmY7PhCfg==',
   'Last-Modified',
-  'Thu, 02 Dec 2021 02:25:18 GMT',
+  'Thu, 28 Jul 2022 09:13:05 GMT',
   'ETag',
-  '"0x8D9B53AFB9102D0"',
+  '"0x8DA7079619C24E0"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '5597be93-f01e-0031-2223-e705aa000000',
+  'a85baa8e-d01e-0054-4762-a2abee000000',
   'x-ms-client-request-id',
-  '53533a13-0e1b-4a8d-ac17-398caf011c01',
+  'a846305a-881a-4d56-9ea4-afbeec88348d',
   'x-ms-version',
-  '2021-02-12',
+  '2021-08-06',
   'x-ms-content-crc64',
   'AAAAAAAAAAA=',
   'x-ms-request-server-encrypted',
   'true',
   'Date',
-  'Thu, 02 Dec 2021 02:25:18 GMT'
+  'Thu, 28 Jul 2022 09:13:05 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container163841191727006884/normal_dir%2Ffile%EF%BF%BF.blob')
+  .put('/container165899958524406447/normal_dir/file%EF%BF%BF.blob')
   .reply(201, "", [
   'Content-Length',
   '0',
   'Content-MD5',
   '1B2M2Y8AsgTpgAmY7PhCfg==',
   'Last-Modified',
-  'Thu, 02 Dec 2021 02:25:18 GMT',
+  'Thu, 28 Jul 2022 09:13:05 GMT',
   'ETag',
-  '"0x8D9B53AFBA1F03F"',
+  '"0x8DA707961AB64B6"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '5597bea6-f01e-0031-3423-e705aa000000',
+  'a85baa9d-d01e-0054-5462-a2abee000000',
   'x-ms-client-request-id',
-  '194f9cb9-b0c7-4ea5-be45-2aafcd1448f2',
+  '2dff1c10-57ff-4b35-9832-fb73b3e61319',
   'x-ms-version',
-  '2021-02-12',
+  '2021-08-06',
   'x-ms-content-crc64',
   'AAAAAAAAAAA=',
   'x-ms-request-server-encrypted',
   'true',
   'Date',
-  'Thu, 02 Dec 2021 02:25:18 GMT'
+  'Thu, 28 Jul 2022 09:13:05 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container163841191727006884/first_file%EF%BF%BF.blob')
+  .put('/container165899958524406447/first_file%EF%BF%BF.blob')
   .reply(201, "", [
   'Content-Length',
   '0',
   'Content-MD5',
   '1B2M2Y8AsgTpgAmY7PhCfg==',
   'Last-Modified',
-  'Thu, 02 Dec 2021 02:25:18 GMT',
+  'Thu, 28 Jul 2022 09:13:05 GMT',
   'ETag',
-  '"0x8D9B53AFBB379D5"',
+  '"0x8DA707961BAA47A"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '5597beb0-f01e-0031-3e23-e705aa000000',
+  'a85baaa4-d01e-0054-5b62-a2abee000000',
   'x-ms-client-request-id',
-  '731dc9eb-cea5-4ee0-9f2f-72886a47dda4',
+  '12b33149-ab61-4f68-8e3e-ad27e1edc7e9',
   'x-ms-version',
-  '2021-02-12',
+  '2021-08-06',
   'x-ms-content-crc64',
   'AAAAAAAAAAA=',
   'x-ms-request-server-encrypted',
   'true',
   'Date',
-  'Thu, 02 Dec 2021 02:25:18 GMT'
+  'Thu, 28 Jul 2022 09:13:05 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container163841191727006884/second_file%EF%BF%BF.blob')
+  .put('/container165899958524406447/second_file%EF%BF%BF.blob')
   .reply(201, "", [
   'Content-Length',
   '0',
   'Content-MD5',
   '1B2M2Y8AsgTpgAmY7PhCfg==',
   'Last-Modified',
-  'Thu, 02 Dec 2021 02:25:18 GMT',
+  'Thu, 28 Jul 2022 09:13:06 GMT',
   'ETag',
-  '"0x8D9B53AFBC4403C"',
+  '"0x8DA707961C9E44C"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '5597bec1-f01e-0031-4b23-e705aa000000',
+  'a85baab7-d01e-0054-6762-a2abee000000',
   'x-ms-client-request-id',
-  'de8404d6-0581-4b8e-8cc8-1afcbf7be92e',
+  '1d9d22d9-f164-4d31-baa0-2540eb52d4d0',
   'x-ms-version',
-  '2021-02-12',
+  '2021-08-06',
   'x-ms-content-crc64',
   'AAAAAAAAAAA=',
   'x-ms-request-server-encrypted',
   'true',
   'Date',
-  'Thu, 02 Dec 2021 02:25:18 GMT'
+  'Thu, 28 Jul 2022 09:13:05 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container163841191727006884/NormalBlob')
+  .put('/container165899958524406447/NormalBlob')
   .reply(201, "", [
   'Content-Length',
   '0',
   'Content-MD5',
   '1B2M2Y8AsgTpgAmY7PhCfg==',
   'Last-Modified',
-  'Thu, 02 Dec 2021 02:25:18 GMT',
+  'Thu, 28 Jul 2022 09:13:06 GMT',
   'ETag',
-  '"0x8D9B53AFBD52DA5"',
+  '"0x8DA707961D8FD16"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '5597bec8-f01e-0031-5123-e705aa000000',
+  'a85baada-d01e-0054-0562-a2abee000000',
   'x-ms-client-request-id',
-  '8a098e8c-9c2d-4575-b9f3-334e8005f3c3',
+  'c16ecf75-022c-43f7-a3ac-ccfe6a5e6b35',
   'x-ms-version',
-  '2021-02-12',
+  '2021-08-06',
   'x-ms-content-crc64',
   'AAAAAAAAAAA=',
   'x-ms-request-server-encrypted',
   'true',
   'Date',
-  'Thu, 02 Dec 2021 02:25:18 GMT'
+  'Thu, 28 Jul 2022 09:13:05 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .get('/container163841191727006884')
+  .get('/container165899958524406447')
   .query(true)
-  .reply(200, "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults ServiceEndpoint=\"https://fakestorageaccount.blob.core.windows.net/\" ContainerName=\"container163841191727006884\"><Delimiter>/</Delimiter><Blobs><Blob><Name>NormalBlob</Name><Properties><Creation-Time>Thu, 02 Dec 2021 02:25:18 GMT</Creation-Time><Last-Modified>Thu, 02 Dec 2021 02:25:18 GMT</Last-Modified><Etag>0x8D9B53AFBD52DA5</Etag><Content-Length>0</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>1B2M2Y8AsgTpgAmY7PhCfg==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties><OrMetadata /></Blob><BlobPrefix><Name Encoded=\"true\">first_dir%EF%BF%BF%2F</Name></BlobPrefix><Blob><Name Encoded=\"true\">first_file%EF%BF%BF.blob</Name><Properties><Creation-Time>Thu, 02 Dec 2021 02:25:18 GMT</Creation-Time><Last-Modified>Thu, 02 Dec 2021 02:25:18 GMT</Last-Modified><Etag>0x8D9B53AFBB379D5</Etag><Content-Length>0</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>1B2M2Y8AsgTpgAmY7PhCfg==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties><OrMetadata /></Blob><BlobPrefix><Name>normal_dir/</Name></BlobPrefix><BlobPrefix><Name Encoded=\"true\">second_dir%EF%BF%BF%2F</Name></BlobPrefix><Blob><Name Encoded=\"true\">second_file%EF%BF%BF.blob</Name><Properties><Creation-Time>Thu, 02 Dec 2021 02:25:18 GMT</Creation-Time><Last-Modified>Thu, 02 Dec 2021 02:25:18 GMT</Last-Modified><Etag>0x8D9B53AFBC4403C</Etag><Content-Length>0</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>1B2M2Y8AsgTpgAmY7PhCfg==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties><OrMetadata /></Blob></Blobs><NextMarker /></EnumerationResults>", [
+  .reply(200, "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults ServiceEndpoint=\"https://fakestorageaccount.blob.core.windows.net/\" ContainerName=\"container165899958524406447\"><Delimiter>/</Delimiter><Blobs><Blob><Name>NormalBlob</Name><Properties><Creation-Time>Thu, 28 Jul 2022 09:13:06 GMT</Creation-Time><Last-Modified>Thu, 28 Jul 2022 09:13:06 GMT</Last-Modified><Etag>0x8DA707961D8FD16</Etag><Content-Length>0</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>1B2M2Y8AsgTpgAmY7PhCfg==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties><OrMetadata /></Blob><BlobPrefix><Name Encoded=\"true\">first_dir%EF%BF%BF%2F</Name></BlobPrefix><Blob><Name Encoded=\"true\">first_file%EF%BF%BF.blob</Name><Properties><Creation-Time>Thu, 28 Jul 2022 09:13:05 GMT</Creation-Time><Last-Modified>Thu, 28 Jul 2022 09:13:05 GMT</Last-Modified><Etag>0x8DA707961BAA47A</Etag><Content-Length>0</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>1B2M2Y8AsgTpgAmY7PhCfg==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties><OrMetadata /></Blob><BlobPrefix><Name>normal_dir/</Name></BlobPrefix><BlobPrefix><Name Encoded=\"true\">second_dir%EF%BF%BF%2F</Name></BlobPrefix><Blob><Name Encoded=\"true\">second_file%EF%BF%BF.blob</Name><Properties><Creation-Time>Thu, 28 Jul 2022 09:13:06 GMT</Creation-Time><Last-Modified>Thu, 28 Jul 2022 09:13:06 GMT</Last-Modified><Etag>0x8DA707961C9E44C</Etag><Content-Length>0</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>1B2M2Y8AsgTpgAmY7PhCfg==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties><OrMetadata /></Blob></Blobs><NextMarker /></EnumerationResults>", [
   'Transfer-Encoding',
   'chunked',
   'Content-Type',
@@ -199,21 +199,21 @@ nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParam
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '5597bed1-f01e-0031-5923-e705aa000000',
+  'a85baaed-d01e-0054-1762-a2abee000000',
   'x-ms-client-request-id',
-  '3344c12c-211d-4c7a-b1a4-852b4512b16c',
+  '763fbb6a-5978-4fdc-9e96-03c8cf4a452d',
   'x-ms-version',
-  '2021-02-12',
+  '2021-08-06',
   'Access-Control-Expose-Headers',
   'x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,Content-Type,Content-Length,Date,Transfer-Encoding',
   'Access-Control-Allow-Origin',
   '*',
   'Date',
-  'Thu, 02 Dec 2021 02:25:18 GMT'
+  'Thu, 28 Jul 2022 09:13:05 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .delete('/container163841191727006884')
+  .delete('/container165899958524406447')
   .query(true)
   .reply(202, "", [
   'Content-Length',
@@ -221,11 +221,11 @@ nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParam
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '5597bee2-f01e-0031-6a23-e705aa000000',
+  'a85bab10-d01e-0054-3162-a2abee000000',
   'x-ms-client-request-id',
-  '456e173a-0527-4587-a333-6f1effa8c492',
+  '2384999e-473e-4fcd-bdc4-18720321361f',
   'x-ms-version',
-  '2021-02-12',
+  '2021-08-06',
   'Date',
-  'Thu, 02 Dec 2021 02:25:18 GMT'
+  'Thu, 28 Jul 2022 09:13:06 GMT'
 ]);

--- a/sdk/storage/storage-blob/recordings/node/containerclient/recording_listblobsflat_to_list_uncommitted_blobs.js
+++ b/sdk/storage/storage-blob/recordings/node/containerclient/recording_listblobsflat_to_list_uncommitted_blobs.js
@@ -1,33 +1,33 @@
 let nock = require('nock');
 
-module.exports.hash = "bd55f9cc77d519a3e3c2fc810b4a330b";
+module.exports.hash = "924ceb7744182fd8020e80c1a0decc4c";
 
-module.exports.testInfo = {"uniqueName":{"container":"container165103876256802377","blockblob/0":"blockblob/0165103876393906476","blockblob/1":"blockblob/1165103876422301699","blockblob/2":"blockblob/2165103876450106623"},"newDate":{}}
+module.exports.testInfo = {"uniqueName":{"container":"container165899957636104377","blockblob/0":"blockblob/0165899957646301168","blockblob/1":"blockblob/1165899957656403743","blockblob/2":"blockblob/2165899957666400181"},"newDate":{}}
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container165103876256802377')
+  .put('/container165899957636104377')
   .query(true)
   .reply(201, "", [
   'Content-Length',
   '0',
   'Last-Modified',
-  'Wed, 27 Apr 2022 05:52:44 GMT',
+  'Thu, 28 Jul 2022 09:12:56 GMT',
   'ETag',
-  '"0x8DA2812262DFA00"',
+  '"0x8DA70795C308920"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'bdb2c98d-d01e-006a-56fb-5902ea000000',
+  'a85ba3c1-d01e-0054-4f62-a2abee000000',
   'x-ms-client-request-id',
-  '33c522c5-510c-45d9-a434-3078fb189548',
+  '5d0e30e8-c5eb-49ad-8f59-478304fd4337',
   'x-ms-version',
-  '2021-06-08',
+  '2021-08-06',
   'Date',
-  'Wed, 27 Apr 2022 05:52:43 GMT'
+  'Thu, 28 Jul 2022 09:12:56 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container165103876256802377/blockblob%2F0165103876393906476', "Hello")
+  .put('/container165899957636104377/blockblob/0165899957646301168', "Hello")
   .query(true)
   .reply(201, "", [
   'Content-Length',
@@ -35,21 +35,21 @@ nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParam
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'bdb2ca83-d01e-006a-36fb-5902ea000000',
+  'a85ba3d3-d01e-0054-5d62-a2abee000000',
   'x-ms-client-request-id',
-  'd91c3b97-7498-4a2d-b904-b7310f0c4ae8',
+  '8d3a5041-bb41-4879-a4a0-8aceaf89002b',
   'x-ms-version',
-  '2021-06-08',
+  '2021-08-06',
   'x-ms-content-crc64',
   '7YooR2vuA24=',
   'x-ms-request-server-encrypted',
   'true',
   'Date',
-  'Wed, 27 Apr 2022 05:52:43 GMT'
+  'Thu, 28 Jul 2022 09:12:56 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container165103876256802377/blockblob%2F1165103876422301699', "Hello")
+  .put('/container165899957636104377/blockblob/1165899957656403743', "Hello")
   .query(true)
   .reply(201, "", [
   'Content-Length',
@@ -57,21 +57,21 @@ nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParam
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'bdb2cb2f-d01e-006a-5bfb-5902ea000000',
+  'a85ba3f1-d01e-0054-7162-a2abee000000',
   'x-ms-client-request-id',
-  'ef618368-d052-4a05-9bf9-480cefb85ff4',
+  'c64776bc-642b-4a75-bdb7-3f6f9422e7d9',
   'x-ms-version',
-  '2021-06-08',
+  '2021-08-06',
   'x-ms-content-crc64',
   '7YooR2vuA24=',
   'x-ms-request-server-encrypted',
   'true',
   'Date',
-  'Wed, 27 Apr 2022 05:52:43 GMT'
+  'Thu, 28 Jul 2022 09:12:56 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container165103876256802377/blockblob%2F2165103876450106623', "Hello")
+  .put('/container165899957636104377/blockblob/2165899957666400181', "Hello")
   .query(true)
   .reply(201, "", [
   'Content-Length',
@@ -79,23 +79,23 @@ nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParam
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'bdb2cbb8-d01e-006a-4efb-5902ea000000',
+  'a85ba3ff-d01e-0054-7f62-a2abee000000',
   'x-ms-client-request-id',
-  '7448c9e7-d9c9-4f29-83ca-ce683e5eec3f',
+  'bc2dd8f3-8f63-4ea6-82c5-4569cf5b61cf',
   'x-ms-version',
-  '2021-06-08',
+  '2021-08-06',
   'x-ms-content-crc64',
   '7YooR2vuA24=',
   'x-ms-request-server-encrypted',
   'true',
   'Date',
-  'Wed, 27 Apr 2022 05:52:44 GMT'
+  'Thu, 28 Jul 2022 09:12:56 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .get('/container165103876256802377')
+  .get('/container165899957636104377')
   .query(true)
-  .reply(200, "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults ServiceEndpoint=\"https://fakestorageaccount.blob.core.windows.net/\" ContainerName=\"container165103876256802377\"><Blobs><Blob><Name>blockblob/0165103876393906476</Name><Properties><Content-Length>0</Content-Length><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>false</ServerEncrypted></Properties><OrMetadata /></Blob><Blob><Name>blockblob/1165103876422301699</Name><Properties><Content-Length>0</Content-Length><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>false</ServerEncrypted></Properties><OrMetadata /></Blob><Blob><Name>blockblob/2165103876450106623</Name><Properties><Content-Length>0</Content-Length><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>false</ServerEncrypted></Properties><OrMetadata /></Blob></Blobs><NextMarker /></EnumerationResults>", [
+  .reply(200, "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults ServiceEndpoint=\"https://fakestorageaccount.blob.core.windows.net/\" ContainerName=\"container165899957636104377\"><Blobs><Blob><Name>blockblob/0165899957646301168</Name><Properties><Content-Length>0</Content-Length><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>false</ServerEncrypted></Properties><OrMetadata /></Blob><Blob><Name>blockblob/1165899957656403743</Name><Properties><Content-Length>0</Content-Length><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>false</ServerEncrypted></Properties><OrMetadata /></Blob><Blob><Name>blockblob/2165899957666400181</Name><Properties><Content-Length>0</Content-Length><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>false</ServerEncrypted></Properties><OrMetadata /></Blob></Blobs><NextMarker /></EnumerationResults>", [
   'Transfer-Encoding',
   'chunked',
   'Content-Type',
@@ -103,74 +103,78 @@ nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParam
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'bdb2cc56-d01e-006a-4ffb-5902ea000000',
+  'a85ba414-d01e-0054-1062-a2abee000000',
   'x-ms-client-request-id',
-  'f2862285-55b0-4daa-9138-c9b3be1a7215',
+  'ee15b9a6-a156-4402-8a11-4dd29ac34727',
   'x-ms-version',
-  '2021-06-08',
+  '2021-08-06',
+  'Access-Control-Expose-Headers',
+  'x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,Content-Type,Content-Length,Date,Transfer-Encoding',
+  'Access-Control-Allow-Origin',
+  '*',
   'Date',
-  'Wed, 27 Apr 2022 05:52:44 GMT'
+  'Thu, 28 Jul 2022 09:12:56 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .delete('/container165103876256802377/blockblob%2F0165103876393906476')
+  .delete('/container165899957636104377/blockblob/0165899957646301168')
   .reply(202, "", [
   'Content-Length',
   '0',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'bdb2ccbc-d01e-006a-29fb-5902ea000000',
+  'a85ba43e-d01e-0054-3462-a2abee000000',
   'x-ms-client-request-id',
-  '420c9573-4623-4c9d-90f4-861110de9476',
+  '7e0c76f5-f176-4d28-b310-0f81777d9a60',
   'x-ms-version',
-  '2021-06-08',
+  '2021-08-06',
   'x-ms-delete-type-permanent',
   'false',
   'Date',
-  'Wed, 27 Apr 2022 05:52:44 GMT'
+  'Thu, 28 Jul 2022 09:12:56 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .delete('/container165103876256802377/blockblob%2F1165103876422301699')
+  .delete('/container165899957636104377/blockblob/1165899957656403743')
   .reply(202, "", [
   'Content-Length',
   '0',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'bdb2cd2a-d01e-006a-0dfb-5902ea000000',
+  'a85ba451-d01e-0054-4362-a2abee000000',
   'x-ms-client-request-id',
-  '4e42dc70-4a56-4adc-b634-98772a05fd94',
+  'fd7b57a2-b88c-42ab-a2d0-f301250837aa',
   'x-ms-version',
-  '2021-06-08',
+  '2021-08-06',
   'x-ms-delete-type-permanent',
   'false',
   'Date',
-  'Wed, 27 Apr 2022 05:52:44 GMT'
+  'Thu, 28 Jul 2022 09:12:56 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .delete('/container165103876256802377/blockblob%2F2165103876450106623')
+  .delete('/container165899957636104377/blockblob/2165899957666400181')
   .reply(202, "", [
   'Content-Length',
   '0',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'bdb2cdba-d01e-006a-0ffb-5902ea000000',
+  'a85ba467-d01e-0054-5462-a2abee000000',
   'x-ms-client-request-id',
-  '0ede6cca-d190-46e7-ae09-3e33b5b89473',
+  'e4482dc6-8bd0-4cb6-9068-958f6343b8d0',
   'x-ms-version',
-  '2021-06-08',
+  '2021-08-06',
   'x-ms-delete-type-permanent',
   'false',
   'Date',
-  'Wed, 27 Apr 2022 05:52:45 GMT'
+  'Thu, 28 Jul 2022 09:12:57 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .delete('/container165103876256802377')
+  .delete('/container165899957636104377')
   .query(true)
   .reply(202, "", [
   'Content-Length',
@@ -178,11 +182,11 @@ nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParam
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'bdb2ce3f-d01e-006a-7ffb-5902ea000000',
+  'a85ba477-d01e-0054-6262-a2abee000000',
   'x-ms-client-request-id',
-  '05869850-6094-494a-a621-2a36a39534c0',
+  '11400bb4-d725-4d7b-bfe4-10a7a6440c9d',
   'x-ms-version',
-  '2021-06-08',
+  '2021-08-06',
   'Date',
-  'Wed, 27 Apr 2022 05:52:45 GMT'
+  'Thu, 28 Jul 2022 09:12:57 GMT'
 ]);

--- a/sdk/storage/storage-blob/recordings/node/containerclient/recording_listblobsflat_with_all_parameters_configured.js
+++ b/sdk/storage/storage-blob/recordings/node/containerclient/recording_listblobsflat_with_all_parameters_configured.js
@@ -1,175 +1,185 @@
 let nock = require('nock');
 
-module.exports.testInfo = {"container":"container156816841337309636","blockblob/0":"blockblob/0156816841378203245","blockblob/1":"blockblob/1156816841418501759"}
+module.exports.hash = "22ffc2ddfc1499ef04837c558cd7e802";
+
+module.exports.testInfo = {"uniqueName":{"container":"container165899957868602749","blockblob/0":"blockblob/0165899957878603067","blockblob/1":"blockblob/1165899957888904643"},"newDate":{}}
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container156816841337309636')
+  .put('/container165899957868602749')
   .query(true)
-  .reply(201, "", [ 'Content-Length',
+  .reply(201, "", [
+  'Content-Length',
   '0',
   'Last-Modified',
-  'Wed, 11 Sep 2019 02:20:13 GMT',
+  'Thu, 28 Jul 2022 09:12:58 GMT',
   'ETag',
-  '"0x8D7365E942E6C28"',
+  '"0x8DA70795D934031"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'ed16f1b4-f01e-0005-3d47-689283000000',
+  'a85ba564-d01e-0054-2262-a2abee000000',
   'x-ms-client-request-id',
-  '9e3a1856-46bd-443b-8ea6-7f422d4b79e8',
+  'c5e6fee1-74e3-498a-9d0d-6b81ad95718f',
   'x-ms-version',
-  '2019-02-02',
+  '2021-08-06',
   'Date',
-  'Wed, 11 Sep 2019 02:20:13 GMT' ]);
-
+  'Thu, 28 Jul 2022 09:12:58 GMT'
+]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container156816841337309636/blockblob%2F0156816841378203245')
-  .reply(201, "", [ 'Content-Length',
+  .put('/container165899957868602749/blockblob/0165899957878603067')
+  .reply(201, "", [
+  'Content-Length',
   '0',
   'Content-MD5',
   '1B2M2Y8AsgTpgAmY7PhCfg==',
   'Last-Modified',
-  'Wed, 11 Sep 2019 02:20:14 GMT',
+  'Thu, 28 Jul 2022 09:12:59 GMT',
   'ETag',
-  '"0x8D7365E946C21A6"',
+  '"0x8DA70795DA46451"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '87aedcb7-201e-006a-1847-683a57000000',
+  'a85ba57b-d01e-0054-3662-a2abee000000',
   'x-ms-client-request-id',
-  '2e215dd6-6b85-43d6-9c86-93a8cf884179',
+  '80006244-29f4-4128-bbd7-6dc07eefac85',
   'x-ms-version',
-  '2019-02-02',
+  '2021-08-06',
   'x-ms-content-crc64',
   'AAAAAAAAAAA=',
   'x-ms-request-server-encrypted',
   'true',
   'Date',
-  'Wed, 11 Sep 2019 02:20:13 GMT' ]);
-
+  'Thu, 28 Jul 2022 09:12:58 GMT'
+]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container156816841337309636/blockblob%2F1156816841418501759')
-  .reply(201, "", [ 'Content-Length',
+  .put('/container165899957868602749/blockblob/1165899957888904643')
+  .reply(201, "", [
+  'Content-Length',
   '0',
   'Content-MD5',
   '1B2M2Y8AsgTpgAmY7PhCfg==',
   'Last-Modified',
-  'Wed, 11 Sep 2019 02:20:14 GMT',
+  'Thu, 28 Jul 2022 09:12:59 GMT',
   'ETag',
-  '"0x8D7365E94A9F921"',
+  '"0x8DA70795DB3CB1D"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'cb602abf-401e-001c-0847-68beeb000000',
+  'a85ba594-d01e-0054-4c62-a2abee000000',
   'x-ms-client-request-id',
-  '5802f198-d615-4c4f-aa40-2dfeab7bc822',
+  '90600723-d6e6-45c6-bb6e-fafacaa2cec9',
   'x-ms-version',
-  '2019-02-02',
+  '2021-08-06',
   'x-ms-content-crc64',
   'AAAAAAAAAAA=',
   'x-ms-request-server-encrypted',
   'true',
   'Date',
-  'Wed, 11 Sep 2019 02:20:14 GMT' ]);
-
+  'Thu, 28 Jul 2022 09:12:58 GMT'
+]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .get('/container156816841337309636')
+  .get('/container165899957868602749')
   .query(true)
-  .reply(200, "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults ServiceEndpoint=\"https://fakestorageaccount.blob.core.windows.net/\" ContainerName=\"container156816841337309636\"><Prefix>blockblob</Prefix><MaxResults>1</MaxResults><Blobs><Blob><Name>blockblob/0156816841378203245</Name><Properties><Creation-Time>Wed, 11 Sep 2019 02:20:14 GMT</Creation-Time><Last-Modified>Wed, 11 Sep 2019 02:20:14 GMT</Last-Modified><Etag>0x8D7365E946C21A6</Etag><Content-Length>0</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64>AAAAAAAAAAA=</Content-CRC64><Content-MD5>1B2M2Y8AsgTpgAmY7PhCfg==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Cool</AccessTier><AccessTierChangeTime>Wed, 11 Sep 2019 02:20:14 GMT</AccessTierChangeTime><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted><TagCount>0</TagCount></Properties><Metadata><keya>a</keya><keyb>c</keyb></Metadata></Blob></Blobs><NextMarker>2!100!MDAwMDI5IWJsb2NrYmxvYi8xMTU2ODE2ODQxNDE4NTAxNzU5ITAwMDAyOCE5OTk5LTEyLTMxVDIzOjU5OjU5Ljk5OTk5OTlaIQ--</NextMarker></EnumerationResults>", [ 'Transfer-Encoding',
+  .reply(200, "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults ServiceEndpoint=\"https://fakestorageaccount.blob.core.windows.net/\" ContainerName=\"container165899957868602749\"><Prefix>blockblob</Prefix><MaxResults>1</MaxResults><Blobs><Blob><Name>blockblob/0165899957878603067</Name><Properties><Creation-Time>Thu, 28 Jul 2022 09:12:59 GMT</Creation-Time><Last-Modified>Thu, 28 Jul 2022 09:12:59 GMT</Last-Modified><Etag>0x8DA70795DA46451</Etag><Content-Length>0</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>1B2M2Y8AsgTpgAmY7PhCfg==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Cool</AccessTier><AccessTierChangeTime>Thu, 28 Jul 2022 09:12:59 GMT</AccessTierChangeTime><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties><Metadata><keya>a</keya><keyb>c</keyb></Metadata><OrMetadata /></Blob></Blobs><NextMarker>2!100!MDAwMDI5IWJsb2NrYmxvYi8xMTY1ODk5OTU3ODg4OTA0NjQzITAwMDAyOCE5OTk5LTEyLTMxVDIzOjU5OjU5Ljk5OTk5OTlaIQ--</NextMarker></EnumerationResults>", [
+  'Transfer-Encoding',
   'chunked',
   'Content-Type',
   'application/xml',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '84b8359a-401e-0017-4247-68a69f000000',
+  'a85ba5a6-d01e-0054-5962-a2abee000000',
   'x-ms-client-request-id',
-  '2b1facbf-c6df-4fb6-aa06-7daa635a38cd',
+  'd80ef4b7-b21a-40dd-ba8a-1bcf56022c88',
   'x-ms-version',
-  '2019-02-02',
+  '2021-08-06',
   'Access-Control-Expose-Headers',
   'x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,Content-Type,Content-Length,Date,Transfer-Encoding',
   'Access-Control-Allow-Origin',
   '*',
   'Date',
-  'Wed, 11 Sep 2019 02:20:14 GMT' ]);
-
+  'Thu, 28 Jul 2022 09:12:58 GMT'
+]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .get('/container156816841337309636')
+  .get('/container165899957868602749')
   .query(true)
-  .reply(200, "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults ServiceEndpoint=\"https://fakestorageaccount.blob.core.windows.net/\" ContainerName=\"container156816841337309636\"><Prefix>blockblob</Prefix><Marker>2!100!MDAwMDI5IWJsb2NrYmxvYi8xMTU2ODE2ODQxNDE4NTAxNzU5ITAwMDAyOCE5OTk5LTEyLTMxVDIzOjU5OjU5Ljk5OTk5OTlaIQ--</Marker><MaxResults>2</MaxResults><Blobs><Blob><Name>blockblob/1156816841418501759</Name><Properties><Creation-Time>Wed, 11 Sep 2019 02:20:14 GMT</Creation-Time><Last-Modified>Wed, 11 Sep 2019 02:20:14 GMT</Last-Modified><Etag>0x8D7365E94A9F921</Etag><Content-Length>0</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64>AAAAAAAAAAA=</Content-CRC64><Content-MD5>1B2M2Y8AsgTpgAmY7PhCfg==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Cool</AccessTier><AccessTierChangeTime>Wed, 11 Sep 2019 02:20:14 GMT</AccessTierChangeTime><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted><TagCount>0</TagCount></Properties><Metadata><keya>a</keya><keyb>c</keyb></Metadata></Blob></Blobs><NextMarker /></EnumerationResults>", [ 'Transfer-Encoding',
+  .reply(200, "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults ServiceEndpoint=\"https://fakestorageaccount.blob.core.windows.net/\" ContainerName=\"container165899957868602749\"><Prefix>blockblob</Prefix><Marker>2!100!MDAwMDI5IWJsb2NrYmxvYi8xMTY1ODk5OTU3ODg4OTA0NjQzITAwMDAyOCE5OTk5LTEyLTMxVDIzOjU5OjU5Ljk5OTk5OTlaIQ--</Marker><MaxResults>2</MaxResults><Blobs><Blob><Name>blockblob/1165899957888904643</Name><Properties><Creation-Time>Thu, 28 Jul 2022 09:12:59 GMT</Creation-Time><Last-Modified>Thu, 28 Jul 2022 09:12:59 GMT</Last-Modified><Etag>0x8DA70795DB3CB1D</Etag><Content-Length>0</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>1B2M2Y8AsgTpgAmY7PhCfg==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Cool</AccessTier><AccessTierChangeTime>Thu, 28 Jul 2022 09:12:59 GMT</AccessTierChangeTime><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties><Metadata><keya>a</keya><keyb>c</keyb></Metadata><OrMetadata /></Blob></Blobs><NextMarker /></EnumerationResults>", [
+  'Transfer-Encoding',
   'chunked',
   'Content-Type',
   'application/xml',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'd898b587-f01e-0063-0b47-6820d9000000',
+  'a85ba5b3-d01e-0054-6462-a2abee000000',
   'x-ms-client-request-id',
-  '5003c4bd-fdfe-401e-b7dc-9747b280ae37',
+  '5b442949-39f7-4cf8-a9a8-8e17d57e489e',
   'x-ms-version',
-  '2019-02-02',
+  '2021-08-06',
   'Access-Control-Expose-Headers',
   'x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,Content-Type,Content-Length,Date,Transfer-Encoding',
   'Access-Control-Allow-Origin',
   '*',
   'Date',
-  'Wed, 11 Sep 2019 02:20:15 GMT' ]);
-
+  'Thu, 28 Jul 2022 09:12:59 GMT'
+]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .delete('/container156816841337309636/blockblob%2F0156816841378203245')
-  .reply(202, "", [ 'Content-Length',
+  .delete('/container165899957868602749/blockblob/0165899957878603067')
+  .reply(202, "", [
+  'Content-Length',
   '0',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '5b164f1a-501e-0065-3847-68d7a1000000',
+  'a85ba5c3-d01e-0054-7262-a2abee000000',
   'x-ms-client-request-id',
-  '051aaeaf-b3b4-4806-88a5-95ad748da478',
+  '8413a19a-a33e-41bf-ac3b-cf99a14364bd',
   'x-ms-version',
-  '2019-02-02',
+  '2021-08-06',
   'x-ms-delete-type-permanent',
   'false',
   'Date',
-  'Wed, 11 Sep 2019 02:20:15 GMT' ]);
-
+  'Thu, 28 Jul 2022 09:12:59 GMT'
+]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .delete('/container156816841337309636/blockblob%2F1156816841418501759')
-  .reply(202, "", [ 'Content-Length',
+  .delete('/container165899957868602749/blockblob/1165899957888904643')
+  .reply(202, "", [
+  'Content-Length',
   '0',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '1da18e6d-c01e-002f-6147-68e7c6000000',
+  'a85ba5df-d01e-0054-7b62-a2abee000000',
   'x-ms-client-request-id',
-  '755b0b21-2b71-4780-8ca5-c69c56a71a1a',
+  '5450a763-1d85-4ae4-a473-c060586692e0',
   'x-ms-version',
-  '2019-02-02',
+  '2021-08-06',
   'x-ms-delete-type-permanent',
   'false',
   'Date',
-  'Wed, 11 Sep 2019 02:20:15 GMT' ]);
-
+  'Thu, 28 Jul 2022 09:12:59 GMT'
+]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .delete('/container156816841337309636')
+  .delete('/container165899957868602749')
   .query(true)
-  .reply(202, "", [ 'Content-Length',
+  .reply(202, "", [
+  'Content-Length',
   '0',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'd898b721-f01e-0063-0747-6820d9000000',
+  'a85ba5f4-d01e-0054-0a62-a2abee000000',
   'x-ms-client-request-id',
-  '0cb4a92e-5c54-4a2e-baba-f8212954ea3b',
+  '5b6f1c8f-303f-4cbb-a48f-55dca2fd5e4d',
   'x-ms-version',
-  '2019-02-02',
+  '2021-08-06',
   'Date',
-  'Wed, 11 Sep 2019 02:20:16 GMT' ]);
-
+  'Thu, 28 Jul 2022 09:12:59 GMT'
+]);

--- a/sdk/storage/storage-blob/recordings/node/containerclient/recording_listblobsflat_with_default_parameters.js
+++ b/sdk/storage/storage-blob/recordings/node/containerclient/recording_listblobsflat_with_default_parameters.js
@@ -1,189 +1,207 @@
 let nock = require('nock');
 
-module.exports.hash = "418d2dead90d038009be0c18a35991ca";
+module.exports.hash = "82e37fc06c0e5cb904a539632ac1c032";
 
-module.exports.testInfo = {"uniqueName":{"container":"container163764846946300799","blockblob/0":"blockblob/0163764847049508913","blockblob/1":"blockblob/1163764847075404687","blockblob/2":"blockblob/2163764847100203486"},"newDate":{}}
+module.exports.testInfo = {"uniqueName":{"container":"container165899957535605677","blockblob/0":"blockblob/0165899957545808816","blockblob/1":"blockblob/1165899957556007079","blockblob/2":"blockblob/2165899957566002598"},"newDate":{}}
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container163764846946300799')
+  .put('/container165899957535605677')
   .query(true)
   .reply(201, "", [
-  'Transfer-Encoding',
-  'chunked',
+  'Content-Length',
+  '0',
   'Last-Modified',
-  'Tue, 23 Nov 2021 06:21:10 GMT',
+  'Thu, 28 Jul 2022 09:12:55 GMT',
   'ETag',
-  '"0x8D9AE497125C49D"',
+  '"0x8DA70795B976CEB"',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'e1793304-501e-0003-0932-e07981000000',
+  'a85ba30f-d01e-0054-3b62-a2abee000000',
   'x-ms-client-request-id',
-  'fd371097-dcb9-49e8-a9be-8aa50e328a16',
+  'ff49ef5d-c1b5-4b3c-8949-769b73673425',
   'x-ms-version',
-  '2021-02-12',
+  '2021-08-06',
   'Date',
-  'Tue, 23 Nov 2021 06:21:10 GMT'
+  'Thu, 28 Jul 2022 09:12:55 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container163764846946300799/blockblob%2F0163764847049508913')
+  .put('/container165899957535605677/blockblob/0165899957545808816')
   .reply(201, "", [
-  'Transfer-Encoding',
-  'chunked',
+  'Content-Length',
+  '0',
   'Content-MD5',
   '1B2M2Y8AsgTpgAmY7PhCfg==',
   'Last-Modified',
-  'Tue, 23 Nov 2021 06:21:10 GMT',
+  'Thu, 28 Jul 2022 09:12:55 GMT',
   'ETag',
-  '"0x8D9AE497151AE92"',
+  '"0x8DA70795BA89795"',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'e1793307-501e-0003-0a32-e07981000000',
+  'a85ba31b-d01e-0054-4462-a2abee000000',
   'x-ms-client-request-id',
-  'c5711044-3c51-4a51-9cc9-fbfad8129867',
+  '9f912fda-6b82-4515-87ee-9369618225ba',
   'x-ms-version',
-  '2021-02-12',
+  '2021-08-06',
   'x-ms-content-crc64',
   'AAAAAAAAAAA=',
   'x-ms-request-server-encrypted',
-  'false',
+  'true',
   'Date',
-  'Tue, 23 Nov 2021 06:21:10 GMT'
+  'Thu, 28 Jul 2022 09:12:55 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container163764846946300799/blockblob%2F1163764847075404687')
+  .put('/container165899957535605677/blockblob/1165899957556007079')
   .reply(201, "", [
-  'Transfer-Encoding',
-  'chunked',
+  'Content-Length',
+  '0',
   'Content-MD5',
   '1B2M2Y8AsgTpgAmY7PhCfg==',
   'Last-Modified',
-  'Tue, 23 Nov 2021 06:21:10 GMT',
+  'Thu, 28 Jul 2022 09:12:55 GMT',
   'ETag',
-  '"0x8D9AE497177AD2B"',
+  '"0x8DA70795BB7FE6C"',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'e1793308-501e-0003-0b32-e07981000000',
+  'a85ba330-d01e-0054-5562-a2abee000000',
   'x-ms-client-request-id',
-  '23405c1c-5b44-4206-8c6c-d733ffb4eb43',
+  'e5c57608-539f-46b6-b62f-d6ba0c21e889',
   'x-ms-version',
-  '2021-02-12',
+  '2021-08-06',
   'x-ms-content-crc64',
   'AAAAAAAAAAA=',
   'x-ms-request-server-encrypted',
-  'false',
+  'true',
   'Date',
-  'Tue, 23 Nov 2021 06:21:10 GMT'
+  'Thu, 28 Jul 2022 09:12:55 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container163764846946300799/blockblob%2F2163764847100203486')
+  .put('/container165899957535605677/blockblob/2165899957566002598')
   .reply(201, "", [
-  'Transfer-Encoding',
-  'chunked',
+  'Content-Length',
+  '0',
   'Content-MD5',
   '1B2M2Y8AsgTpgAmY7PhCfg==',
   'Last-Modified',
-  'Tue, 23 Nov 2021 06:21:11 GMT',
+  'Thu, 28 Jul 2022 09:12:55 GMT',
   'ETag',
-  '"0x8D9AE49719DD2AC"',
+  '"0x8DA70795BC73E33"',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'e1793309-501e-0003-0c32-e07981000000',
+  'a85ba33d-d01e-0054-5f62-a2abee000000',
   'x-ms-client-request-id',
-  '60f2adc1-251e-4270-a22a-8f694963d3a3',
+  'ec934c84-96f8-49a7-adbc-9e62d0e3e250',
   'x-ms-version',
-  '2021-02-12',
+  '2021-08-06',
   'x-ms-content-crc64',
   'AAAAAAAAAAA=',
   'x-ms-request-server-encrypted',
-  'false',
+  'true',
   'Date',
-  'Tue, 23 Nov 2021 06:21:10 GMT'
+  'Thu, 28 Jul 2022 09:12:55 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .get('/container163764846946300799')
+  .get('/container165899957535605677')
   .query(true)
-  .reply(200, "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults ServiceEndpoint=\"https://fakestorageaccount.blob.core.windows.net/\" ContainerName=\"container163764846946300799\"><Blobs><Blob><Name>blockblob/0163764847049508913</Name><Properties><Creation-Time>Tue, 23 Nov 2021 06:21:10 GMT</Creation-Time><Last-Modified>Tue, 23 Nov 2021 06:21:10 GMT</Last-Modified><Etag>0x8D9AE497151AE92</Etag><Content-Length>0</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>1B2M2Y8AsgTpgAmY7PhCfg==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>false</ServerEncrypted></Properties><OrMetadata /></Blob><Blob><Name>blockblob/1163764847075404687</Name><Properties><Creation-Time>Tue, 23 Nov 2021 06:21:10 GMT</Creation-Time><Last-Modified>Tue, 23 Nov 2021 06:21:10 GMT</Last-Modified><Etag>0x8D9AE497177AD2B</Etag><Content-Length>0</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>1B2M2Y8AsgTpgAmY7PhCfg==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>false</ServerEncrypted></Properties><OrMetadata /></Blob><Blob><Name>blockblob/2163764847100203486</Name><Properties><Creation-Time>Tue, 23 Nov 2021 06:21:11 GMT</Creation-Time><Last-Modified>Tue, 23 Nov 2021 06:21:11 GMT</Last-Modified><Etag>0x8D9AE49719DD2AC</Etag><Content-Length>0</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>1B2M2Y8AsgTpgAmY7PhCfg==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>false</ServerEncrypted></Properties><OrMetadata /></Blob></Blobs><NextMarker /></EnumerationResults>", [
+  .reply(200, "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults ServiceEndpoint=\"https://fakestorageaccount.blob.core.windows.net/\" ContainerName=\"container165899957535605677\"><Blobs><Blob><Name>blockblob/0165899957545808816</Name><Properties><Creation-Time>Thu, 28 Jul 2022 09:12:55 GMT</Creation-Time><Last-Modified>Thu, 28 Jul 2022 09:12:55 GMT</Last-Modified><Etag>0x8DA70795BA89795</Etag><Content-Length>0</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>1B2M2Y8AsgTpgAmY7PhCfg==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties><OrMetadata /></Blob><Blob><Name>blockblob/1165899957556007079</Name><Properties><Creation-Time>Thu, 28 Jul 2022 09:12:55 GMT</Creation-Time><Last-Modified>Thu, 28 Jul 2022 09:12:55 GMT</Last-Modified><Etag>0x8DA70795BB7FE6C</Etag><Content-Length>0</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>1B2M2Y8AsgTpgAmY7PhCfg==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties><OrMetadata /></Blob><Blob><Name>blockblob/2165899957566002598</Name><Properties><Creation-Time>Thu, 28 Jul 2022 09:12:55 GMT</Creation-Time><Last-Modified>Thu, 28 Jul 2022 09:12:55 GMT</Last-Modified><Etag>0x8DA70795BC73E33</Etag><Content-Length>0</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>1B2M2Y8AsgTpgAmY7PhCfg==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties><OrMetadata /></Blob></Blobs><NextMarker /></EnumerationResults>", [
   'Transfer-Encoding',
   'chunked',
   'Content-Type',
   'application/xml',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'e179330a-501e-0003-0d32-e07981000000',
+  'a85ba351-d01e-0054-6d62-a2abee000000',
   'x-ms-client-request-id',
-  '43868828-52de-402c-8a2e-627a75ae8de5',
+  '6e2c0236-b00d-4311-8a8c-7b0d0662d64b',
   'x-ms-version',
-  '2021-02-12',
+  '2021-08-06',
   'Access-Control-Expose-Headers',
-  'x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,Content-Type',
+  'x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,Content-Type,Content-Length,Date,Transfer-Encoding',
   'Access-Control-Allow-Origin',
   '*',
   'Date',
-  'Tue, 23 Nov 2021 06:21:11 GMT'
+  'Thu, 28 Jul 2022 09:12:55 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .delete('/container163764846946300799/blockblob%2F0163764847049508913')
+  .delete('/container165899957535605677/blockblob/0165899957545808816')
   .reply(202, "", [
-  'Transfer-Encoding',
-  'chunked',
+  'Content-Length',
+  '0',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'e179330d-501e-0003-0e32-e07981000000',
+  'a85ba381-d01e-0054-1762-a2abee000000',
   'x-ms-client-request-id',
-  '81dd1865-3b8c-4297-9287-1d0b04342fb4',
+  '0eb56818-d561-40e5-bb8f-58382ddd2244',
   'x-ms-version',
-  '2021-02-12',
+  '2021-08-06',
   'x-ms-delete-type-permanent',
   'false',
   'Date',
-  'Tue, 23 Nov 2021 06:21:11 GMT'
+  'Thu, 28 Jul 2022 09:12:55 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .delete('/container163764846946300799/blockblob%2F1163764847075404687')
+  .delete('/container165899957535605677/blockblob/1165899957556007079')
   .reply(202, "", [
-  'Transfer-Encoding',
-  'chunked',
+  'Content-Length',
+  '0',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'e179330e-501e-0003-0f32-e07981000000',
+  'a85ba38a-d01e-0054-2062-a2abee000000',
   'x-ms-client-request-id',
-  '9c0ce74a-1979-41be-a363-26f59092a8a3',
+  '4fa72564-a914-4c69-90e6-73790d5daa29',
   'x-ms-version',
-  '2021-02-12',
+  '2021-08-06',
   'x-ms-delete-type-permanent',
   'false',
   'Date',
-  'Tue, 23 Nov 2021 06:21:11 GMT'
+  'Thu, 28 Jul 2022 09:12:56 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .delete('/container163764846946300799/blockblob%2F2163764847100203486')
+  .delete('/container165899957535605677/blockblob/2165899957566002598')
   .reply(202, "", [
-  'Transfer-Encoding',
-  'chunked',
+  'Content-Length',
+  '0',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'e1793310-501e-0003-1132-e07981000000',
+  'a85ba39c-d01e-0054-2f62-a2abee000000',
   'x-ms-client-request-id',
-  'fe31cc23-9e3b-4d41-bbd0-e1ed36d2625d',
+  'd35a37b7-4e9b-466e-bb69-a25b7b429ab3',
   'x-ms-version',
-  '2021-02-12',
+  '2021-08-06',
   'x-ms-delete-type-permanent',
   'false',
   'Date',
-  'Tue, 23 Nov 2021 06:21:11 GMT'
+  'Thu, 28 Jul 2022 09:12:56 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .delete('/container163764846946300799')
+  .delete('/container165899957535605677')
   .query(true)
   .reply(202, "", [
-  'Transfer-Encoding',
-  'chunked',
+  'Content-Length',
+  '0',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'e1793311-501e-0003-1232-e07981000000',
+  'a85ba3b0-d01e-0054-3f62-a2abee000000',
   'x-ms-client-request-id',
-  '2007b266-137b-40f9-ae7e-d3f79d8197b5',
+  'df43b102-02bd-430a-ba63-e7c28746c967',
   'x-ms-version',
-  '2021-02-12',
+  '2021-08-06',
   'Date',
-  'Tue, 23 Nov 2021 06:21:12 GMT'
+  'Thu, 28 Jul 2022 09:12:56 GMT'
 ]);

--- a/sdk/storage/storage-blob/recordings/node/containerclient/recording_listblobsflat_with_default_parameters__null_prefix_shouldnt_throw_error.js
+++ b/sdk/storage/storage-blob/recordings/node/containerclient/recording_listblobsflat_with_default_parameters__null_prefix_shouldnt_throw_error.js
@@ -1,114 +1,116 @@
 let nock = require('nock');
 
-module.exports.testInfo = {"uniqueName":{"container":"container157437874225702943","blockblob/0":"blockblob/0157437874232102547","blockblob/1":"blockblob/1157437874236908002","blockblob/2":"blockblob/2157437874241604499"},"newDate":{}}
+module.exports.hash = "ce0618bc744df5dbe9b85eeb8e82b442";
+
+module.exports.testInfo = {"uniqueName":{"container":"container165899957767901075","blockblob/0":"blockblob/0165899957777908237","blockblob/1":"blockblob/1165899957788005419","blockblob/2":"blockblob/2165899957798003222"},"newDate":{}}
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container157437874225702943')
+  .put('/container165899957767901075')
   .query(true)
   .reply(201, "", [
   'Content-Length',
   '0',
   'Last-Modified',
-  'Thu, 21 Nov 2019 23:25:42 GMT',
+  'Thu, 28 Jul 2022 09:12:57 GMT',
   'ETag',
-  '"0x8D76EDA2078A923"',
+  '"0x8DA70795CF987D9"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'c85d40f6-e01e-0060-76c2-a003c0000000',
+  'a85ba4b8-d01e-0054-1962-a2abee000000',
   'x-ms-client-request-id',
-  '780f4cae-b47d-45e9-9fe1-a54a3f4c14ee',
+  '1c068638-e311-44ba-bb7f-0d0fd62d39ab',
   'x-ms-version',
-  '2019-02-02',
+  '2021-08-06',
   'Date',
-  'Thu, 21 Nov 2019 23:25:41 GMT'
+  'Thu, 28 Jul 2022 09:12:57 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container157437874225702943/blockblob%2F0157437874232102547')
+  .put('/container165899957767901075/blockblob/0165899957777908237')
   .reply(201, "", [
   'Content-Length',
   '0',
   'Content-MD5',
   '1B2M2Y8AsgTpgAmY7PhCfg==',
   'Last-Modified',
-  'Thu, 21 Nov 2019 23:25:42 GMT',
+  'Thu, 28 Jul 2022 09:12:58 GMT',
   'ETag',
-  '"0x8D76EDA2080CE80"',
+  '"0x8DA70795D0AADEA"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '0e4084ef-801e-0049-5bc2-a03db4000000',
+  'a85ba4cd-d01e-0054-2862-a2abee000000',
   'x-ms-client-request-id',
-  '3736550d-0869-4b81-8e15-321c8fe7ac9e',
+  '17676732-950d-4879-bd28-44fa20be3c4b',
   'x-ms-version',
-  '2019-02-02',
+  '2021-08-06',
   'x-ms-content-crc64',
   'AAAAAAAAAAA=',
   'x-ms-request-server-encrypted',
   'true',
   'Date',
-  'Thu, 21 Nov 2019 23:25:41 GMT'
+  'Thu, 28 Jul 2022 09:12:57 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container157437874225702943/blockblob%2F1157437874236908002')
+  .put('/container165899957767901075/blockblob/1165899957788005419')
   .reply(201, "", [
   'Content-Length',
   '0',
   'Content-MD5',
   '1B2M2Y8AsgTpgAmY7PhCfg==',
   'Last-Modified',
-  'Thu, 21 Nov 2019 23:25:42 GMT',
+  'Thu, 28 Jul 2022 09:12:58 GMT',
   'ETag',
-  '"0x8D76EDA2087D4A8"',
+  '"0x8DA70795D19EDB3"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '96d703b7-b01e-0099-15c2-a000e2000000',
+  'a85ba4f8-d01e-0054-4c62-a2abee000000',
   'x-ms-client-request-id',
-  'c177489f-5701-4f56-a1c9-0e66aafc6e51',
+  'd6ae15a3-cb52-457e-9b33-e9139d6963cc',
   'x-ms-version',
-  '2019-02-02',
+  '2021-08-06',
   'x-ms-content-crc64',
   'AAAAAAAAAAA=',
   'x-ms-request-server-encrypted',
   'true',
   'Date',
-  'Thu, 21 Nov 2019 23:25:41 GMT'
+  'Thu, 28 Jul 2022 09:12:57 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container157437874225702943/blockblob%2F2157437874241604499')
+  .put('/container165899957767901075/blockblob/2165899957798003222')
   .reply(201, "", [
   'Content-Length',
   '0',
   'Content-MD5',
   '1B2M2Y8AsgTpgAmY7PhCfg==',
   'Last-Modified',
-  'Thu, 21 Nov 2019 23:25:42 GMT',
+  'Thu, 28 Jul 2022 09:12:58 GMT',
   'ETag',
-  '"0x8D76EDA208F28FE"',
+  '"0x8DA70795D292D81"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '382d2a6e-d01e-006b-5bc2-a0f8ab000000',
+  'a85ba509-d01e-0054-5b62-a2abee000000',
   'x-ms-client-request-id',
-  '8b276f9a-f6aa-49ec-b93c-731b093194e4',
+  '283b9007-cfaf-4faa-8f45-8874ff280705',
   'x-ms-version',
-  '2019-02-02',
+  '2021-08-06',
   'x-ms-content-crc64',
   'AAAAAAAAAAA=',
   'x-ms-request-server-encrypted',
   'true',
   'Date',
-  'Thu, 21 Nov 2019 23:25:42 GMT'
+  'Thu, 28 Jul 2022 09:12:57 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .get('/container157437874225702943')
+  .get('/container165899957767901075')
   .query(true)
-  .reply(200, "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults ServiceEndpoint=\"https://fakestorageaccount.blob.core.windows.net/\" ContainerName=\"container157437874225702943\"><Blobs><Blob><Name>blockblob/0157437874232102547</Name><Properties><Creation-Time>Thu, 21 Nov 2019 23:25:42 GMT</Creation-Time><Last-Modified>Thu, 21 Nov 2019 23:25:42 GMT</Last-Modified><Etag>0x8D76EDA2080CE80</Etag><Content-Length>0</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>1B2M2Y8AsgTpgAmY7PhCfg==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties></Blob><Blob><Name>blockblob/1157437874236908002</Name><Properties><Creation-Time>Thu, 21 Nov 2019 23:25:42 GMT</Creation-Time><Last-Modified>Thu, 21 Nov 2019 23:25:42 GMT</Last-Modified><Etag>0x8D76EDA2087D4A8</Etag><Content-Length>0</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>1B2M2Y8AsgTpgAmY7PhCfg==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties></Blob><Blob><Name>blockblob/2157437874241604499</Name><Properties><Creation-Time>Thu, 21 Nov 2019 23:25:42 GMT</Creation-Time><Last-Modified>Thu, 21 Nov 2019 23:25:42 GMT</Last-Modified><Etag>0x8D76EDA208F28FE</Etag><Content-Length>0</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>1B2M2Y8AsgTpgAmY7PhCfg==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties></Blob></Blobs><NextMarker /></EnumerationResults>", [
+  .reply(200, "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults ServiceEndpoint=\"https://fakestorageaccount.blob.core.windows.net/\" ContainerName=\"container165899957767901075\"><Blobs><Blob><Name>blockblob/0165899957777908237</Name><Properties><Creation-Time>Thu, 28 Jul 2022 09:12:58 GMT</Creation-Time><Last-Modified>Thu, 28 Jul 2022 09:12:58 GMT</Last-Modified><Etag>0x8DA70795D0AADEA</Etag><Content-Length>0</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>1B2M2Y8AsgTpgAmY7PhCfg==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties><OrMetadata /></Blob><Blob><Name>blockblob/1165899957788005419</Name><Properties><Creation-Time>Thu, 28 Jul 2022 09:12:58 GMT</Creation-Time><Last-Modified>Thu, 28 Jul 2022 09:12:58 GMT</Last-Modified><Etag>0x8DA70795D19EDB3</Etag><Content-Length>0</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>1B2M2Y8AsgTpgAmY7PhCfg==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties><OrMetadata /></Blob><Blob><Name>blockblob/2165899957798003222</Name><Properties><Creation-Time>Thu, 28 Jul 2022 09:12:58 GMT</Creation-Time><Last-Modified>Thu, 28 Jul 2022 09:12:58 GMT</Last-Modified><Etag>0x8DA70795D292D81</Etag><Content-Length>0</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>1B2M2Y8AsgTpgAmY7PhCfg==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties><OrMetadata /></Blob></Blobs><NextMarker /></EnumerationResults>", [
   'Transfer-Encoding',
   'chunked',
   'Content-Type',
@@ -116,78 +118,78 @@ nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParam
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'c85d415a-e01e-0060-51c2-a003c0000000',
+  'a85ba51b-d01e-0054-6962-a2abee000000',
   'x-ms-client-request-id',
-  'c3093927-242c-4306-9fd2-c3624d67b28c',
+  '2c51e615-3a02-4f31-868b-18dc5097a786',
   'x-ms-version',
-  '2019-02-02',
+  '2021-08-06',
   'Access-Control-Expose-Headers',
   'x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,Content-Type,Content-Length,Date,Transfer-Encoding',
   'Access-Control-Allow-Origin',
   '*',
   'Date',
-  'Thu, 21 Nov 2019 23:25:41 GMT'
+  'Thu, 28 Jul 2022 09:12:58 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .delete('/container157437874225702943/blockblob%2F0157437874232102547')
+  .delete('/container165899957767901075/blockblob/0165899957777908237')
   .reply(202, "", [
   'Content-Length',
   '0',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '39740b8f-601e-001c-2dc2-a02d3f000000',
+  'a85ba537-d01e-0054-7e62-a2abee000000',
   'x-ms-client-request-id',
-  '66d96529-a145-4aab-a767-05cb6bd0dc16',
+  'ac3e5986-3476-4a8b-8471-a1de3a94a63d',
   'x-ms-version',
-  '2019-02-02',
+  '2021-08-06',
   'x-ms-delete-type-permanent',
-  'true',
+  'false',
   'Date',
-  'Thu, 21 Nov 2019 23:25:42 GMT'
+  'Thu, 28 Jul 2022 09:12:58 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .delete('/container157437874225702943/blockblob%2F1157437874236908002')
+  .delete('/container165899957767901075/blockblob/1165899957788005419')
   .reply(202, "", [
   'Content-Length',
   '0',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '8919fcf4-901e-0037-6ac2-a0adf3000000',
+  'a85ba543-d01e-0054-0762-a2abee000000',
   'x-ms-client-request-id',
-  '07ae2b8c-1bf2-47fc-8fa7-25b7bf33c511',
+  'e457b177-92ff-4789-a1a3-807f0a0b09c7',
   'x-ms-version',
-  '2019-02-02',
+  '2021-08-06',
   'x-ms-delete-type-permanent',
-  'true',
+  'false',
   'Date',
-  'Thu, 21 Nov 2019 23:25:41 GMT'
+  'Thu, 28 Jul 2022 09:12:58 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .delete('/container157437874225702943/blockblob%2F2157437874241604499')
+  .delete('/container165899957767901075/blockblob/2165899957798003222')
   .reply(202, "", [
   'Content-Length',
   '0',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'f00aa8bb-801e-003b-4ec2-a03afb000000',
+  'a85ba54e-d01e-0054-1062-a2abee000000',
   'x-ms-client-request-id',
-  'c6cc1b0f-2c32-4bb6-81b0-816b3bde3472',
+  '2a5619a9-bdaf-4631-a65e-40871122c386',
   'x-ms-version',
-  '2019-02-02',
+  '2021-08-06',
   'x-ms-delete-type-permanent',
-  'true',
+  'false',
   'Date',
-  'Thu, 21 Nov 2019 23:25:42 GMT'
+  'Thu, 28 Jul 2022 09:12:58 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .delete('/container157437874225702943')
+  .delete('/container165899957767901075')
   .query(true)
   .reply(202, "", [
   'Content-Length',
@@ -195,11 +197,11 @@ nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParam
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'c85d41b5-e01e-0060-2ac2-a003c0000000',
+  'a85ba55c-d01e-0054-1b62-a2abee000000',
   'x-ms-client-request-id',
-  '742e10b9-d2da-4422-b388-75e9fd6ed8fd',
+  '337c5bac-5f47-46f6-b72f-9d95c3c91d96',
   'x-ms-version',
-  '2019-02-02',
+  '2021-08-06',
   'Date',
-  'Thu, 21 Nov 2019 23:25:41 GMT'
+  'Thu, 28 Jul 2022 09:12:58 GMT'
 ]);

--- a/sdk/storage/storage-blob/recordings/node/containerclient/recording_listblobsflat_with_special_chars.js
+++ b/sdk/storage/storage-blob/recordings/node/containerclient/recording_listblobsflat_with_special_chars.js
@@ -1,105 +1,96 @@
 let nock = require('nock');
 
-module.exports.hash = "f8306cff267e3c7a75e734f991cfcd79";
+module.exports.hash = "9f20ad398583e168e35c37a3044acb80";
 
-module.exports.testInfo = {"uniqueName":{"container":"container163764847274901088"},"newDate":{}}
+module.exports.testInfo = {"uniqueName":{"container":"container165899957727208203"},"newDate":{}}
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container163764847274901088')
+  .put('/container165899957727208203')
   .query(true)
   .reply(201, "", [
-  'Transfer-Encoding',
-  'chunked',
+  'Content-Length',
+  '0',
   'Last-Modified',
-  'Tue, 23 Nov 2021 06:21:12 GMT',
+  'Thu, 28 Jul 2022 09:12:57 GMT',
   'ETag',
-  '"0x8D9AE4972A81FE8"',
+  '"0x8DA70795CBB4F86"',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'e1793313-501e-0003-1432-e07981000000',
+  'a85ba488-d01e-0054-7062-a2abee000000',
   'x-ms-client-request-id',
-  '90542033-dd83-4e5a-a9db-fa4c35513c18',
+  'd64c6a89-61ee-46d8-b1f3-7a5967ecca2f',
   'x-ms-version',
-  '2021-02-12',
+  '2021-08-06',
   'Date',
-  'Tue, 23 Nov 2021 06:21:12 GMT'
+  'Thu, 28 Jul 2022 09:12:57 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container163764847274901088/dir1%2Fdir2%2Ffile%EF%BF%BF.blob')
+  .put('/container165899957727208203/dir1/dir2/file%EF%BF%BF.blob')
   .reply(201, "", [
-  'Transfer-Encoding',
-  'chunked',
+  'Content-Length',
+  '0',
   'Content-MD5',
   '1B2M2Y8AsgTpgAmY7PhCfg==',
   'Last-Modified',
-  'Tue, 23 Nov 2021 06:21:13 GMT',
+  'Thu, 28 Jul 2022 09:12:57 GMT',
   'ETag',
-  '"0x8D9AE4972CEB190"',
+  '"0x8DA70795CCC9D67"',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'e1793317-501e-0003-1632-e07981000000',
+  'a85ba490-d01e-0054-7662-a2abee000000',
   'x-ms-client-request-id',
-  '615f5558-c221-437e-a318-2444d6dc4ace',
+  'ca21a362-2aec-4178-b726-6390faf018bc',
   'x-ms-version',
-  '2021-02-12',
+  '2021-08-06',
   'x-ms-content-crc64',
   'AAAAAAAAAAA=',
   'x-ms-request-server-encrypted',
-  'false',
+  'true',
   'Date',
-  'Tue, 23 Nov 2021 06:21:12 GMT'
+  'Thu, 28 Jul 2022 09:12:57 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .get('/container163764847274901088')
+  .get('/container165899957727208203')
   .query(true)
-  .reply(200, "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults ServiceEndpoint=\"https://fakestorageaccount.blob.core.windows.net/\" ContainerName=\"container163764847274901088\"><Blobs><Blob><Name Encoded=\"true\">dir1%2Fdir2%2Ffile%EF%BF%BF.blob</Name><Properties><Creation-Time>Tue, 23 Nov 2021 06:21:13 GMT</Creation-Time><Last-Modified>Tue, 23 Nov 2021 06:21:13 GMT</Last-Modified><Etag>0x8D9AE4972CEB190</Etag><Content-Length>0</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>1B2M2Y8AsgTpgAmY7PhCfg==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>false</ServerEncrypted></Properties><OrMetadata /></Blob></Blobs><NextMarker /></EnumerationResults>", [
+  .reply(200, "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults ServiceEndpoint=\"https://fakestorageaccount.blob.core.windows.net/\" ContainerName=\"container165899957727208203\"><Blobs><Blob><Name Encoded=\"true\">dir1%2Fdir2%2Ffile%EF%BF%BF.blob</Name><Properties><Creation-Time>Thu, 28 Jul 2022 09:12:57 GMT</Creation-Time><Last-Modified>Thu, 28 Jul 2022 09:12:57 GMT</Last-Modified><Etag>0x8DA70795CCC9D67</Etag><Content-Length>0</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>1B2M2Y8AsgTpgAmY7PhCfg==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties><OrMetadata /></Blob></Blobs><NextMarker /></EnumerationResults>", [
   'Transfer-Encoding',
   'chunked',
   'Content-Type',
   'application/xml',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'e1793318-501e-0003-1732-e07981000000',
+  'a85ba49e-d01e-0054-0262-a2abee000000',
   'x-ms-client-request-id',
-  '4a87dac8-66b1-47b5-8f0c-a44e34ebaf57',
+  '2b3f47a7-7dfb-4a39-917c-bac7d30d97a6',
   'x-ms-version',
-  '2021-02-12',
+  '2021-08-06',
   'Access-Control-Expose-Headers',
-  'x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,Content-Type',
+  'x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,Content-Type,Content-Length,Date,Transfer-Encoding',
   'Access-Control-Allow-Origin',
   '*',
   'Date',
-  'Tue, 23 Nov 2021 06:21:12 GMT'
+  'Thu, 28 Jul 2022 09:12:57 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .delete('/container163764847274901088/dir1%2Fdir2%2Ffile%EF%BF%BF.blob')
-  .reply(202, "", [
-  'Transfer-Encoding',
-  'chunked',
-  'x-ms-request-id',
-  'e1793319-501e-0003-1832-e07981000000',
-  'x-ms-client-request-id',
-  '85207475-3c90-47c6-9c2b-cae32742a960',
-  'x-ms-version',
-  '2021-02-12',
-  'x-ms-delete-type-permanent',
-  'false',
-  'Date',
-  'Tue, 23 Nov 2021 06:21:13 GMT'
-]);
-
-nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .delete('/container163764847274901088')
+  .delete('/container165899957727208203')
   .query(true)
   .reply(202, "", [
-  'Transfer-Encoding',
-  'chunked',
+  'Content-Length',
+  '0',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'e179331a-501e-0003-1932-e07981000000',
+  'a85ba4aa-d01e-0054-0d62-a2abee000000',
   'x-ms-client-request-id',
-  '195e4cd0-3e67-49a5-b8f7-c15fd4229d03',
+  '97478e8c-2a1e-4ff8-91b9-f09ae1a8901d',
   'x-ms-version',
-  '2021-02-12',
+  '2021-08-06',
   'Date',
-  'Tue, 23 Nov 2021 06:21:13 GMT'
+  'Thu, 28 Jul 2022 09:12:57 GMT'
 ]);

--- a/sdk/storage/storage-blob/recordings/node/containerclient/recording_verify_pagedasynciterableiterator_for_listblobsbyhierarchy.js
+++ b/sdk/storage/storage-blob/recordings/node/containerclient/recording_verify_pagedasynciterableiterator_for_listblobsbyhierarchy.js
@@ -1,328 +1,345 @@
 let nock = require('nock');
 
-module.exports.testInfo = {"container":"container156816844333804365","prefix":"prefix156816844373806414","blockblob":"blockblob156816844373803610"}
+module.exports.hash = "9bcd40c1a2055bfce716b674002134bd";
+
+module.exports.testInfo = {"uniqueName":{"container":"container165899894254306183","prefix":"prefix165899894264506999","blockblob":"blockblob165899894264506235"},"newDate":{}}
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container156816844333804365')
+  .put('/container165899894254306183')
   .query(true)
-  .reply(201, "", [ 'Content-Length',
+  .reply(201, "", [
+  'Content-Length',
   '0',
   'Last-Modified',
-  'Wed, 11 Sep 2019 02:20:43 GMT',
+  'Thu, 28 Jul 2022 09:02:22 GMT',
   'ETag',
-  '"0x8D7365EA60965A8"',
+  '"0x8DA7077E266672B"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '02702a8f-201e-0043-5147-684c15000000',
+  '3078dff2-301e-0011-5160-a27e0d000000',
   'x-ms-client-request-id',
-  'd2886241-5106-4412-94c7-4ca0afe71b5e',
+  'f9d64235-d94a-4050-a0ec-52e612e76606',
   'x-ms-version',
-  '2019-02-02',
+  '2021-08-06',
   'Date',
-  'Wed, 11 Sep 2019 02:20:42 GMT' ]);
-
+  'Thu, 28 Jul 2022 09:02:21 GMT'
+]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container156816844333804365/prefix156816844373806414%2Fblockblob1568168443738036100')
-  .reply(201, "", [ 'Content-Length',
+  .put('/container165899894254306183/prefix165899894264506999/blockblob1658998942645062350')
+  .reply(201, "", [
+  'Content-Length',
   '0',
   'Content-MD5',
   '1B2M2Y8AsgTpgAmY7PhCfg==',
   'Last-Modified',
-  'Wed, 11 Sep 2019 02:20:44 GMT',
+  'Thu, 28 Jul 2022 09:02:22 GMT',
   'ETag',
-  '"0x8D7365EA647126B"',
+  '"0x8DA7077E2784662"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'fbec9b2e-701e-001f-5447-68bdec000000',
+  '3078e009-301e-0011-6460-a27e0d000000',
   'x-ms-client-request-id',
-  '349244cd-421a-4d06-ba67-1a21d9770b67',
+  '438856b7-1ce6-4f37-8499-18739b09abcd',
   'x-ms-version',
-  '2019-02-02',
+  '2021-08-06',
   'x-ms-content-crc64',
   'AAAAAAAAAAA=',
   'x-ms-request-server-encrypted',
   'true',
   'Date',
-  'Wed, 11 Sep 2019 02:20:43 GMT' ]);
-
+  'Thu, 28 Jul 2022 09:02:22 GMT'
+]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container156816844333804365/prefix156816844373806414%2Fblockblob1568168443738036101')
-  .reply(201, "", [ 'Content-Length',
+  .put('/container165899894254306183/prefix165899894264506999/blockblob1658998942645062351')
+  .reply(201, "", [
+  'Content-Length',
   '0',
   'Content-MD5',
   '1B2M2Y8AsgTpgAmY7PhCfg==',
   'Last-Modified',
-  'Wed, 11 Sep 2019 02:20:44 GMT',
+  'Thu, 28 Jul 2022 09:02:23 GMT',
   'ETag',
-  '"0x8D7365EA6862280"',
+  '"0x8DA7077E287FB6E"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'af570aed-501e-0008-2047-687d8f000000',
+  '3078e018-301e-0011-6f60-a27e0d000000',
   'x-ms-client-request-id',
-  '18d695a9-a068-4540-b92f-3bb87f532c1b',
+  '023d90cf-d043-4b26-b549-1c93ee836e63',
   'x-ms-version',
-  '2019-02-02',
+  '2021-08-06',
   'x-ms-content-crc64',
   'AAAAAAAAAAA=',
   'x-ms-request-server-encrypted',
   'true',
   'Date',
-  'Wed, 11 Sep 2019 02:20:43 GMT' ]);
-
+  'Thu, 28 Jul 2022 09:02:22 GMT'
+]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container156816844333804365/prefix156816844373806414%2Fblockblob1568168443738036102')
-  .reply(201, "", [ 'Content-Length',
+  .put('/container165899894254306183/prefix165899894264506999/blockblob1658998942645062352')
+  .reply(201, "", [
+  'Content-Length',
   '0',
   'Content-MD5',
   '1B2M2Y8AsgTpgAmY7PhCfg==',
   'Last-Modified',
-  'Wed, 11 Sep 2019 02:20:44 GMT',
+  'Thu, 28 Jul 2022 09:02:23 GMT',
   'ETag',
-  '"0x8D7365EA6C3F9F7"',
+  '"0x8DA7077E2978962"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'fbec9bd3-701e-001f-7247-68bdec000000',
+  '3078e046-301e-0011-1a60-a27e0d000000',
   'x-ms-client-request-id',
-  '6e043626-a86f-429d-a404-7ef44a67de66',
+  '49ebaf03-61f2-4336-a40a-b149a87c4004',
   'x-ms-version',
-  '2019-02-02',
+  '2021-08-06',
   'x-ms-content-crc64',
   'AAAAAAAAAAA=',
   'x-ms-request-server-encrypted',
   'true',
   'Date',
-  'Wed, 11 Sep 2019 02:20:44 GMT' ]);
-
+  'Thu, 28 Jul 2022 09:02:22 GMT'
+]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container156816844333804365/prefix156816844373806414%2Fblockblob1568168443738036103')
-  .reply(201, "", [ 'Content-Length',
+  .put('/container165899894254306183/prefix165899894264506999/blockblob1658998942645062353')
+  .reply(201, "", [
+  'Content-Length',
   '0',
   'Content-MD5',
   '1B2M2Y8AsgTpgAmY7PhCfg==',
   'Last-Modified',
-  'Wed, 11 Sep 2019 02:20:45 GMT',
+  'Thu, 28 Jul 2022 09:02:23 GMT',
   'ETag',
-  '"0x8D7365EA702BC01"',
+  '"0x8DA7077E2A71754"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '816dbbb2-c01e-006b-2d47-683baa000000',
+  '3078e079-301e-0011-4260-a27e0d000000',
   'x-ms-client-request-id',
-  '6305dbae-a1cd-4280-865b-c29ff8a6573a',
+  'e2889222-ddf9-4d21-828c-c7f37093e048',
   'x-ms-version',
-  '2019-02-02',
+  '2021-08-06',
   'x-ms-content-crc64',
   'AAAAAAAAAAA=',
   'x-ms-request-server-encrypted',
   'true',
   'Date',
-  'Wed, 11 Sep 2019 02:20:44 GMT' ]);
-
+  'Thu, 28 Jul 2022 09:02:22 GMT'
+]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container156816844333804365/prefix156816844373806414%2Fblockblob1568168443738036104')
-  .reply(201, "", [ 'Content-Length',
+  .put('/container165899894254306183/prefix165899894264506999/blockblob1658998942645062354')
+  .reply(201, "", [
+  'Content-Length',
   '0',
   'Content-MD5',
   '1B2M2Y8AsgTpgAmY7PhCfg==',
   'Last-Modified',
-  'Wed, 11 Sep 2019 02:20:45 GMT',
+  'Thu, 28 Jul 2022 09:02:23 GMT',
   'ETag',
-  '"0x8D7365EA74108C0"',
+  '"0x8DA7077E2B6A54A"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '0ec2f4c9-601e-004f-2947-68a2e4000000',
+  '3078e094-301e-0011-5b60-a27e0d000000',
   'x-ms-client-request-id',
-  'bf6bb28a-e989-4b11-ac07-a2dd06cc48e0',
+  'ccd972c5-5f20-4fd5-95cd-5c45ff32ebf9',
   'x-ms-version',
-  '2019-02-02',
+  '2021-08-06',
   'x-ms-content-crc64',
   'AAAAAAAAAAA=',
   'x-ms-request-server-encrypted',
   'true',
   'Date',
-  'Wed, 11 Sep 2019 02:20:45 GMT' ]);
-
+  'Thu, 28 Jul 2022 09:02:22 GMT'
+]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container156816844333804365/prefix156816844373806414%2Fblockblob1568168443738036105')
-  .reply(201, "", [ 'Content-Length',
+  .put('/container165899894254306183/prefix165899894264506999/blockblob1658998942645062355')
+  .reply(201, "", [
+  'Content-Length',
   '0',
   'Content-MD5',
   '1B2M2Y8AsgTpgAmY7PhCfg==',
   'Last-Modified',
-  'Wed, 11 Sep 2019 02:20:46 GMT',
+  'Thu, 28 Jul 2022 09:02:23 GMT',
   'ETag',
-  '"0x8D7365EA77FA3AD"',
+  '"0x8DA7077E2C63344"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'b36c9db9-801e-0023-3447-680937000000',
+  '3078e0ae-301e-0011-7360-a27e0d000000',
   'x-ms-client-request-id',
-  '73960d6a-4e06-4d1d-8858-5a1af14b681b',
+  '912c2339-a06f-43ac-b6f2-624aa1e0c09e',
   'x-ms-version',
-  '2019-02-02',
+  '2021-08-06',
   'x-ms-content-crc64',
   'AAAAAAAAAAA=',
   'x-ms-request-server-encrypted',
   'true',
   'Date',
-  'Wed, 11 Sep 2019 02:20:45 GMT' ]);
-
+  'Thu, 28 Jul 2022 09:02:22 GMT'
+]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .get('/container156816844333804365')
+  .get('/container165899894254306183')
   .query(true)
-  .reply(200, "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults ServiceEndpoint=\"https://fakestorageaccount.blob.core.windows.net/\" ContainerName=\"container156816844333804365\"><Delimiter>/</Delimiter><Blobs><BlobPrefix><Name>prefix156816844373806414/</Name></BlobPrefix></Blobs><NextMarker /></EnumerationResults>", [ 'Transfer-Encoding',
+  .reply(200, "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults ServiceEndpoint=\"https://fakestorageaccount.blob.core.windows.net/\" ContainerName=\"container165899894254306183\"><Delimiter>/</Delimiter><Blobs><BlobPrefix><Name>prefix165899894264506999/</Name></BlobPrefix></Blobs><NextMarker /></EnumerationResults>", [
+  'Transfer-Encoding',
   'chunked',
   'Content-Type',
   'application/xml',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '331d0ccd-c01e-000d-2247-6889f0000000',
+  '3078e0d0-301e-0011-0560-a27e0d000000',
   'x-ms-client-request-id',
-  'c13e4d7b-8c59-4be0-a2d2-2e113f332619',
+  '1974700c-fefe-4313-9b45-fb509afd5290',
   'x-ms-version',
-  '2019-02-02',
+  '2021-08-06',
   'Access-Control-Expose-Headers',
   'x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,Content-Type,Content-Length,Date,Transfer-Encoding',
   'Access-Control-Allow-Origin',
   '*',
   'Date',
-  'Wed, 11 Sep 2019 02:20:46 GMT' ]);
-
+  'Thu, 28 Jul 2022 09:02:22 GMT'
+]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .delete('/container156816844333804365/prefix156816844373806414%2Fblockblob1568168443738036100')
-  .reply(202, "", [ 'Content-Length',
+  .delete('/container165899894254306183/prefix165899894264506999/blockblob1658998942645062350')
+  .reply(202, "", [
+  'Content-Length',
   '0',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '64827821-e01e-005e-7947-6895ff000000',
+  '3078e0f3-301e-0011-2460-a27e0d000000',
   'x-ms-client-request-id',
-  'b9c9fb7d-c09e-496f-9819-2a471fd98011',
+  '77ed682a-30d3-4841-9ab6-6f5bf8ae1478',
   'x-ms-version',
-  '2019-02-02',
+  '2021-08-06',
   'x-ms-delete-type-permanent',
   'false',
   'Date',
-  'Wed, 11 Sep 2019 02:20:46 GMT' ]);
-
+  'Thu, 28 Jul 2022 09:02:22 GMT'
+]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .delete('/container156816844333804365/prefix156816844373806414%2Fblockblob1568168443738036101')
-  .reply(202, "", [ 'Content-Length',
+  .delete('/container165899894254306183/prefix165899894264506999/blockblob1658998942645062351')
+  .reply(202, "", [
+  'Content-Length',
   '0',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '7ae57981-801e-0067-3847-68d55b000000',
+  '3078e116-301e-0011-4460-a27e0d000000',
   'x-ms-client-request-id',
-  'ce1ce5bd-ea99-4c11-8c1e-ff4e1ab63a1f',
+  '607190e7-b5b1-4bf1-9d6b-207c4351c150',
   'x-ms-version',
-  '2019-02-02',
+  '2021-08-06',
   'x-ms-delete-type-permanent',
   'false',
   'Date',
-  'Wed, 11 Sep 2019 02:20:46 GMT' ]);
-
+  'Thu, 28 Jul 2022 09:02:22 GMT'
+]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .delete('/container156816844333804365/prefix156816844373806414%2Fblockblob1568168443738036102')
-  .reply(202, "", [ 'Content-Length',
+  .delete('/container165899894254306183/prefix165899894264506999/blockblob1658998942645062352')
+  .reply(202, "", [
+  'Content-Length',
   '0',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '7a357e03-301e-003a-6b47-68255f000000',
+  '3078e133-301e-0011-5e60-a27e0d000000',
   'x-ms-client-request-id',
-  'eb5197d4-c51f-4252-9699-0e71c18ba80c',
+  'a6fd6112-7f7e-4fad-8dda-d197444a9a71',
   'x-ms-version',
-  '2019-02-02',
+  '2021-08-06',
   'x-ms-delete-type-permanent',
   'false',
   'Date',
-  'Wed, 11 Sep 2019 02:20:47 GMT' ]);
-
+  'Thu, 28 Jul 2022 09:02:23 GMT'
+]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .delete('/container156816844333804365/prefix156816844373806414%2Fblockblob1568168443738036103')
-  .reply(202, "", [ 'Content-Length',
+  .delete('/container165899894254306183/prefix165899894264506999/blockblob1658998942645062353')
+  .reply(202, "", [
+  'Content-Length',
   '0',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'df1895a1-401e-0058-5d47-686287000000',
+  '3078e14b-301e-0011-7560-a27e0d000000',
   'x-ms-client-request-id',
-  '3126aa18-c139-4ba1-9d9d-ddc53df22655',
+  'df86c634-ca87-4a92-ba22-909dfda4f7d6',
   'x-ms-version',
-  '2019-02-02',
+  '2021-08-06',
   'x-ms-delete-type-permanent',
   'false',
   'Date',
-  'Wed, 11 Sep 2019 02:20:47 GMT' ]);
-
+  'Thu, 28 Jul 2022 09:02:23 GMT'
+]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .delete('/container156816844333804365/prefix156816844373806414%2Fblockblob1568168443738036104')
-  .reply(202, "", [ 'Content-Length',
+  .delete('/container165899894254306183/prefix165899894264506999/blockblob1658998942645062354')
+  .reply(202, "", [
+  'Content-Length',
   '0',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'dd4b2748-901e-0037-6547-68ca53000000',
+  '3078e163-301e-0011-0960-a27e0d000000',
   'x-ms-client-request-id',
-  'd7fc6b31-f567-4a5c-a98f-c789df8c02cc',
+  'd44bfcf1-467b-40dd-b472-a9a8a6f530d5',
   'x-ms-version',
-  '2019-02-02',
+  '2021-08-06',
   'x-ms-delete-type-permanent',
   'false',
   'Date',
-  'Wed, 11 Sep 2019 02:20:48 GMT' ]);
-
+  'Thu, 28 Jul 2022 09:02:23 GMT'
+]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .delete('/container156816844333804365/prefix156816844373806414%2Fblockblob1568168443738036105')
-  .reply(202, "", [ 'Content-Length',
+  .delete('/container165899894254306183/prefix165899894264506999/blockblob1658998942645062355')
+  .reply(202, "", [
+  'Content-Length',
   '0',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '585ef535-101e-0026-6d47-68fd48000000',
+  '3078e186-301e-0011-2a60-a27e0d000000',
   'x-ms-client-request-id',
-  '4d2b67c7-649b-4fc6-93f9-9ff8950037ec',
+  '0df58572-f000-40bf-90e4-402c6eb8af7e',
   'x-ms-version',
-  '2019-02-02',
+  '2021-08-06',
   'x-ms-delete-type-permanent',
   'false',
   'Date',
-  'Wed, 11 Sep 2019 02:20:48 GMT' ]);
-
+  'Thu, 28 Jul 2022 09:02:23 GMT'
+]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .delete('/container156816844333804365')
+  .delete('/container165899894254306183')
   .query(true)
-  .reply(202, "", [ 'Content-Length',
+  .reply(202, "", [
+  'Content-Length',
   '0',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'b36ca3dc-801e-0023-5c47-680937000000',
+  '3078e1a2-301e-0011-4060-a27e0d000000',
   'x-ms-client-request-id',
-  'cc810e4b-fb1a-4110-b674-8c2b5efa4f12',
+  '473b7e16-672b-4a60-8477-f2e7a235a176',
   'x-ms-version',
-  '2019-02-02',
+  '2021-08-06',
   'Date',
-  'Wed, 11 Sep 2019 02:20:49 GMT' ]);
-
+  'Thu, 28 Jul 2022 09:02:23 GMT'
+]);

--- a/sdk/storage/storage-blob/recordings/node/containerclient/recording_verify_pagedasynciterableiterator_for_listblobsflat.js
+++ b/sdk/storage/storage-blob/recordings/node/containerclient/recording_verify_pagedasynciterableiterator_for_listblobsflat.js
@@ -1,240 +1,253 @@
 let nock = require('nock');
 
-module.exports.testInfo = {"container":"container156816841871804388","blockblob/0":"blockblob/0156816841913503521","blockblob/1":"blockblob/1156816841954203116","blockblob/2":"blockblob/2156816841994509703","blockblob/3":"blockblob/3156816842037809796"}
+module.exports.hash = "af687eb54a0abcf04e0e25ac64183f35";
+
+module.exports.testInfo = {"uniqueName":{"container":"container165899958000501368","blockblob/0":"blockblob/0165899958010605045","blockblob/1":"blockblob/1165899958020702340","blockblob/2":"blockblob/2165899958030703387","blockblob/3":"blockblob/3165899958040708968"},"newDate":{}}
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container156816841871804388')
+  .put('/container165899958000501368')
   .query(true)
-  .reply(201, "", [ 'Content-Length',
+  .reply(201, "", [
+  'Content-Length',
   '0',
   'Last-Modified',
-  'Wed, 11 Sep 2019 02:20:19 GMT',
+  'Thu, 28 Jul 2022 09:13:00 GMT',
   'ETag',
-  '"0x8D7365E975E28FC"',
+  '"0x8DA70795E5C8D04"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '478dd161-701e-0014-4147-68a598000000',
+  'a85ba660-d01e-0054-5f62-a2abee000000',
   'x-ms-client-request-id',
-  '768e1073-7a45-4c9a-bb9e-5ae9fef5a784',
+  'c6ac4293-47e7-4420-832c-321e3e2683cd',
   'x-ms-version',
-  '2019-02-02',
+  '2021-08-06',
   'Date',
-  'Wed, 11 Sep 2019 02:20:19 GMT' ]);
-
+  'Thu, 28 Jul 2022 09:12:59 GMT'
+]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container156816841871804388/blockblob%2F0156816841913503521')
-  .reply(201, "", [ 'Content-Length',
+  .put('/container165899958000501368/blockblob/0165899958010605045')
+  .reply(201, "", [
+  'Content-Length',
   '0',
   'Content-MD5',
   '1B2M2Y8AsgTpgAmY7PhCfg==',
   'Last-Modified',
-  'Wed, 11 Sep 2019 02:20:19 GMT',
+  'Thu, 28 Jul 2022 09:13:00 GMT',
   'ETag',
-  '"0x8D7365E979D5B9C"',
+  '"0x8DA70795E6DAE7F"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '9a012e33-701e-005b-2c47-686180000000',
+  'a85ba672-d01e-0054-6d62-a2abee000000',
   'x-ms-client-request-id',
-  'c0597e4b-1404-43a4-b142-256084d23a33',
+  '6210bb11-f458-4a02-8d18-5617d2ba2122',
   'x-ms-version',
-  '2019-02-02',
+  '2021-08-06',
   'x-ms-content-crc64',
   'AAAAAAAAAAA=',
   'x-ms-request-server-encrypted',
   'true',
   'Date',
-  'Wed, 11 Sep 2019 02:20:18 GMT' ]);
-
+  'Thu, 28 Jul 2022 09:13:00 GMT'
+]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container156816841871804388/blockblob%2F1156816841954203116')
-  .reply(201, "", [ 'Content-Length',
+  .put('/container165899958000501368/blockblob/1165899958020702340')
+  .reply(201, "", [
+  'Content-Length',
   '0',
   'Content-MD5',
   '1B2M2Y8AsgTpgAmY7PhCfg==',
   'Last-Modified',
-  'Wed, 11 Sep 2019 02:20:19 GMT',
+  'Thu, 28 Jul 2022 09:13:00 GMT',
   'ETag',
-  '"0x8D7365E97DAE4E9"',
+  '"0x8DA70795E7CEE51"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'eba07760-d01e-003b-3247-6824a2000000',
+  'a85ba684-d01e-0054-7c62-a2abee000000',
   'x-ms-client-request-id',
-  '18304bf2-7fa5-42c2-8a8e-60b0e5424147',
+  '0b16216e-806b-482a-9d06-c1dfa5eb68a0',
   'x-ms-version',
-  '2019-02-02',
+  '2021-08-06',
   'x-ms-content-crc64',
   'AAAAAAAAAAA=',
   'x-ms-request-server-encrypted',
   'true',
   'Date',
-  'Wed, 11 Sep 2019 02:20:19 GMT' ]);
-
+  'Thu, 28 Jul 2022 09:13:00 GMT'
+]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container156816841871804388/blockblob%2F2156816841994509703')
-  .reply(201, "", [ 'Content-Length',
+  .put('/container165899958000501368/blockblob/2165899958030703387')
+  .reply(201, "", [
+  'Content-Length',
   '0',
   'Content-MD5',
   '1B2M2Y8AsgTpgAmY7PhCfg==',
   'Last-Modified',
-  'Wed, 11 Sep 2019 02:20:20 GMT',
+  'Thu, 28 Jul 2022 09:13:00 GMT',
   'ETag',
-  '"0x8D7365E9819A6EF"',
+  '"0x8DA70795E8C2E22"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '63d0d698-601e-0000-1347-6866fc000000',
+  'a85ba693-d01e-0054-0962-a2abee000000',
   'x-ms-client-request-id',
-  '35849ee4-b6a7-4f96-a7bb-7f4a255b67cf',
+  'ef4b715c-3f77-4b11-b9d0-edbe3c2fcd6b',
   'x-ms-version',
-  '2019-02-02',
+  '2021-08-06',
   'x-ms-content-crc64',
   'AAAAAAAAAAA=',
   'x-ms-request-server-encrypted',
   'true',
   'Date',
-  'Wed, 11 Sep 2019 02:20:19 GMT' ]);
-
+  'Thu, 28 Jul 2022 09:13:00 GMT'
+]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container156816841871804388/blockblob%2F3156816842037809796')
-  .reply(201, "", [ 'Content-Length',
+  .put('/container165899958000501368/blockblob/3165899958040708968')
+  .reply(201, "", [
+  'Content-Length',
   '0',
   'Content-MD5',
   '1B2M2Y8AsgTpgAmY7PhCfg==',
   'Last-Modified',
-  'Wed, 11 Sep 2019 02:20:20 GMT',
+  'Thu, 28 Jul 2022 09:13:00 GMT',
   'ETag',
-  '"0x8D7365E985B76BE"',
+  '"0x8DA70795E9B6DEA"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '155aaf9f-c01e-0006-3d47-689184000000',
+  'a85ba6a3-d01e-0054-1662-a2abee000000',
   'x-ms-client-request-id',
-  'a293b439-a3ca-4796-b547-b45380811fce',
+  'eb5e0c64-4398-4d3d-841f-747157893090',
   'x-ms-version',
-  '2019-02-02',
+  '2021-08-06',
   'x-ms-content-crc64',
   'AAAAAAAAAAA=',
   'x-ms-request-server-encrypted',
   'true',
   'Date',
-  'Wed, 11 Sep 2019 02:20:20 GMT' ]);
-
+  'Thu, 28 Jul 2022 09:13:00 GMT'
+]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .get('/container156816841871804388')
+  .get('/container165899958000501368')
   .query(true)
-  .reply(200, "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults ServiceEndpoint=\"https://fakestorageaccount.blob.core.windows.net/\" ContainerName=\"container156816841871804388\"><Prefix>blockblob</Prefix><Blobs><Blob><Name>blockblob/0156816841913503521</Name><Properties><Creation-Time>Wed, 11 Sep 2019 02:20:19 GMT</Creation-Time><Last-Modified>Wed, 11 Sep 2019 02:20:19 GMT</Last-Modified><Etag>0x8D7365E979D5B9C</Etag><Content-Length>0</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64>AAAAAAAAAAA=</Content-CRC64><Content-MD5>1B2M2Y8AsgTpgAmY7PhCfg==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Cool</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted><TagCount>0</TagCount></Properties><Metadata><keya>a</keya><keyb>c</keyb></Metadata></Blob><Blob><Name>blockblob/1156816841954203116</Name><Properties><Creation-Time>Wed, 11 Sep 2019 02:20:19 GMT</Creation-Time><Last-Modified>Wed, 11 Sep 2019 02:20:19 GMT</Last-Modified><Etag>0x8D7365E97DAE4E9</Etag><Content-Length>0</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64>AAAAAAAAAAA=</Content-CRC64><Content-MD5>1B2M2Y8AsgTpgAmY7PhCfg==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Cool</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted><TagCount>0</TagCount></Properties><Metadata><keya>a</keya><keyb>c</keyb></Metadata></Blob><Blob><Name>blockblob/2156816841994509703</Name><Properties><Creation-Time>Wed, 11 Sep 2019 02:20:20 GMT</Creation-Time><Last-Modified>Wed, 11 Sep 2019 02:20:20 GMT</Last-Modified><Etag>0x8D7365E9819A6EF</Etag><Content-Length>0</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64>AAAAAAAAAAA=</Content-CRC64><Content-MD5>1B2M2Y8AsgTpgAmY7PhCfg==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Cool</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted><TagCount>0</TagCount></Properties><Metadata><keya>a</keya><keyb>c</keyb></Metadata></Blob><Blob><Name>blockblob/3156816842037809796</Name><Properties><Creation-Time>Wed, 11 Sep 2019 02:20:20 GMT</Creation-Time><Last-Modified>Wed, 11 Sep 2019 02:20:20 GMT</Last-Modified><Etag>0x8D7365E985B76BE</Etag><Content-Length>0</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64>AAAAAAAAAAA=</Content-CRC64><Content-MD5>1B2M2Y8AsgTpgAmY7PhCfg==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Cool</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted><TagCount>0</TagCount></Properties><Metadata><keya>a</keya><keyb>c</keyb></Metadata></Blob></Blobs><NextMarker /></EnumerationResults>", [ 'Transfer-Encoding',
+  .reply(200, "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults ServiceEndpoint=\"https://fakestorageaccount.blob.core.windows.net/\" ContainerName=\"container165899958000501368\"><Prefix>blockblob</Prefix><Blobs><Blob><Name>blockblob/0165899958010605045</Name><Properties><Creation-Time>Thu, 28 Jul 2022 09:13:00 GMT</Creation-Time><Last-Modified>Thu, 28 Jul 2022 09:13:00 GMT</Last-Modified><Etag>0x8DA70795E6DAE7F</Etag><Content-Length>0</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>1B2M2Y8AsgTpgAmY7PhCfg==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties><Metadata><keya>a</keya><keyb>c</keyb></Metadata><OrMetadata /></Blob><Blob><Name>blockblob/1165899958020702340</Name><Properties><Creation-Time>Thu, 28 Jul 2022 09:13:00 GMT</Creation-Time><Last-Modified>Thu, 28 Jul 2022 09:13:00 GMT</Last-Modified><Etag>0x8DA70795E7CEE51</Etag><Content-Length>0</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>1B2M2Y8AsgTpgAmY7PhCfg==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties><Metadata><keya>a</keya><keyb>c</keyb></Metadata><OrMetadata /></Blob><Blob><Name>blockblob/2165899958030703387</Name><Properties><Creation-Time>Thu, 28 Jul 2022 09:13:00 GMT</Creation-Time><Last-Modified>Thu, 28 Jul 2022 09:13:00 GMT</Last-Modified><Etag>0x8DA70795E8C2E22</Etag><Content-Length>0</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>1B2M2Y8AsgTpgAmY7PhCfg==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties><Metadata><keya>a</keya><keyb>c</keyb></Metadata><OrMetadata /></Blob><Blob><Name>blockblob/3165899958040708968</Name><Properties><Creation-Time>Thu, 28 Jul 2022 09:13:00 GMT</Creation-Time><Last-Modified>Thu, 28 Jul 2022 09:13:00 GMT</Last-Modified><Etag>0x8DA70795E9B6DEA</Etag><Content-Length>0</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>1B2M2Y8AsgTpgAmY7PhCfg==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties><Metadata><keya>a</keya><keyb>c</keyb></Metadata><OrMetadata /></Blob></Blobs><NextMarker /></EnumerationResults>", [
+  'Transfer-Encoding',
   'chunked',
   'Content-Type',
   'application/xml',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '679772d7-b01e-0064-3147-68d65c000000',
+  'a85ba6b3-d01e-0054-2362-a2abee000000',
   'x-ms-client-request-id',
-  '41e7cd78-ceb5-4e96-9e17-027cefbd5294',
+  '1f951b55-cc76-4eb5-8f07-cc7304395ab3',
   'x-ms-version',
-  '2019-02-02',
+  '2021-08-06',
   'Access-Control-Expose-Headers',
   'x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,Content-Type,Content-Length,Date,Transfer-Encoding',
   'Access-Control-Allow-Origin',
   '*',
   'Date',
-  'Wed, 11 Sep 2019 02:20:20 GMT' ]);
-
+  'Thu, 28 Jul 2022 09:13:00 GMT'
+]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .delete('/container156816841871804388/blockblob%2F0156816841913503521')
-  .reply(202, "", [ 'Content-Length',
+  .delete('/container165899958000501368/blockblob/0165899958010605045')
+  .reply(202, "", [
+  'Content-Length',
   '0',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '9bf88c94-501e-0047-3e47-68b997000000',
+  'a85ba6e7-d01e-0054-4c62-a2abee000000',
   'x-ms-client-request-id',
-  'a0ce4e98-9007-4b1d-b93f-62fb21e75414',
+  'de33ed7c-abf3-44af-98a7-ae20c10e9f11',
   'x-ms-version',
-  '2019-02-02',
+  '2021-08-06',
   'x-ms-delete-type-permanent',
   'false',
   'Date',
-  'Wed, 11 Sep 2019 02:20:21 GMT' ]);
-
+  'Thu, 28 Jul 2022 09:13:00 GMT'
+]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .delete('/container156816841871804388/blockblob%2F1156816841954203116')
-  .reply(202, "", [ 'Content-Length',
+  .delete('/container165899958000501368/blockblob/1165899958020702340')
+  .reply(202, "", [
+  'Content-Length',
   '0',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '63d0d8a3-601e-0000-3f47-6866fc000000',
+  'a85ba6f6-d01e-0054-5b62-a2abee000000',
   'x-ms-client-request-id',
-  '7c1555a0-dc70-4ee4-9f3e-ef8657ad369f',
+  'aff04d63-0385-42bf-a6ca-e73211097d40',
   'x-ms-version',
-  '2019-02-02',
+  '2021-08-06',
   'x-ms-delete-type-permanent',
   'false',
   'Date',
-  'Wed, 11 Sep 2019 02:20:21 GMT' ]);
-
+  'Thu, 28 Jul 2022 09:13:00 GMT'
+]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .delete('/container156816841871804388/blockblob%2F2156816841994509703')
-  .reply(202, "", [ 'Content-Length',
+  .delete('/container165899958000501368/blockblob/2165899958030703387')
+  .reply(202, "", [
+  'Content-Length',
   '0',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '96e2ad12-201e-0061-0647-682223000000',
+  'a85ba710-d01e-0054-6f62-a2abee000000',
   'x-ms-client-request-id',
-  'aaa5fe7b-784e-4981-95a7-be6aa76e5a13',
+  '89c7ad04-a9c8-411d-9d72-dd7cc7e75fb8',
   'x-ms-version',
-  '2019-02-02',
+  '2021-08-06',
   'x-ms-delete-type-permanent',
   'false',
   'Date',
-  'Wed, 11 Sep 2019 02:20:22 GMT' ]);
-
+  'Thu, 28 Jul 2022 09:13:00 GMT'
+]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .delete('/container156816841871804388/blockblob%2F3156816842037809796')
-  .reply(202, "", [ 'Content-Length',
+  .delete('/container165899958000501368/blockblob/3165899958040708968')
+  .reply(202, "", [
+  'Content-Length',
   '0',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '331cf7d4-c01e-000d-5b47-6889f0000000',
+  'a85ba721-d01e-0054-7962-a2abee000000',
   'x-ms-client-request-id',
-  '6841a2b4-c8bc-45d0-aafd-ec049cecca75',
+  '6bd1c255-06f2-42d3-95c6-069bb54568d9',
   'x-ms-version',
-  '2019-02-02',
+  '2021-08-06',
   'x-ms-delete-type-permanent',
   'false',
   'Date',
-  'Wed, 11 Sep 2019 02:20:22 GMT' ]);
-
+  'Thu, 28 Jul 2022 09:13:00 GMT'
+]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .delete('/container156816841871804388')
+  .delete('/container165899958000501368')
   .query(true)
-  .reply(202, "", [ 'Content-Length',
+  .reply(202, "", [
+  'Content-Length',
   '0',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'f40a99f4-a01e-001d-6247-68bf16000000',
+  'a85ba734-d01e-0054-0762-a2abee000000',
   'x-ms-client-request-id',
-  '1230fc21-8e2d-46ef-8785-8bf40aaf4a6f',
+  '0a9b4f88-bd3d-404f-899b-725162527295',
   'x-ms-version',
-  '2019-02-02',
+  '2021-08-06',
   'Date',
-  'Wed, 11 Sep 2019 02:20:22 GMT' ]);
-
+  'Thu, 28 Jul 2022 09:13:01 GMT'
+]);

--- a/sdk/storage/storage-blob/recordings/node/containerclient/recording_verify_pagedasynciterableiteratorbypage__continuationtoken_for_listblobsflat.js
+++ b/sdk/storage/storage-blob/recordings/node/containerclient/recording_verify_pagedasynciterableiteratorbypage__continuationtoken_for_listblobsflat.js
@@ -1,263 +1,277 @@
 let nock = require('nock');
 
-module.exports.testInfo = {"container":"container156816843115309572","blockblob/0":"blockblob/0156816843155707479","blockblob/1":"blockblob/1156816843196107646","blockblob/2":"blockblob/2156816843237903195","blockblob/3":"blockblob/3156816843278400263"}
+module.exports.hash = "d2e965fc0af8133d396f97d80424c92c";
+
+module.exports.testInfo = {"uniqueName":{"container":"container165899958312700315","blockblob/0":"blockblob/0165899958322909411","blockblob/1":"blockblob/1165899958334304678","blockblob/2":"blockblob/2165899958344404742","blockblob/3":"blockblob/3165899958354401508"},"newDate":{}}
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container156816843115309572')
+  .put('/container165899958312700315')
   .query(true)
-  .reply(201, "", [ 'Content-Length',
+  .reply(201, "", [
+  'Content-Length',
   '0',
   'Last-Modified',
-  'Wed, 11 Sep 2019 02:20:31 GMT',
+  'Thu, 28 Jul 2022 09:13:03 GMT',
   'ETag',
-  '"0x8D7365E9EC6ACAD"',
+  '"0x8DA707960391D14"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'a4570533-f01e-0041-2847-684eef000000',
+  'a85ba8b0-d01e-0054-3562-a2abee000000',
   'x-ms-client-request-id',
-  'f26ad67c-69ef-4298-8393-afd8a30269dc',
+  'ad14efb0-66f0-4a07-a215-60d9774de31d',
   'x-ms-version',
-  '2019-02-02',
+  '2021-08-06',
   'Date',
-  'Wed, 11 Sep 2019 02:20:30 GMT' ]);
-
+  'Thu, 28 Jul 2022 09:13:03 GMT'
+]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container156816843115309572/blockblob%2F0156816843155707479')
-  .reply(201, "", [ 'Content-Length',
+  .put('/container165899958312700315/blockblob/0165899958322909411')
+  .reply(201, "", [
+  'Content-Length',
   '0',
   'Content-MD5',
   '1B2M2Y8AsgTpgAmY7PhCfg==',
   'Last-Modified',
-  'Wed, 11 Sep 2019 02:20:31 GMT',
+  'Thu, 28 Jul 2022 09:13:03 GMT',
   'ETag',
-  '"0x8D7365E9F044F04"',
+  '"0x8DA7079604A387F"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'c7e036d6-501e-002a-0847-6813b9000000',
+  'a85ba8bf-d01e-0054-4362-a2abee000000',
   'x-ms-client-request-id',
-  '02d5b9b3-608a-4082-9438-6c3389927bc9',
+  'c6ccc2bd-a0a1-4b51-b3d9-5048270154e1',
   'x-ms-version',
-  '2019-02-02',
+  '2021-08-06',
   'x-ms-content-crc64',
   'AAAAAAAAAAA=',
   'x-ms-request-server-encrypted',
   'true',
   'Date',
-  'Wed, 11 Sep 2019 02:20:31 GMT' ]);
-
+  'Thu, 28 Jul 2022 09:13:03 GMT'
+]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container156816843115309572/blockblob%2F1156816843196107646')
-  .reply(201, "", [ 'Content-Length',
+  .put('/container165899958312700315/blockblob/1165899958334304678')
+  .reply(201, "", [
+  'Content-Length',
   '0',
   'Content-MD5',
   '1B2M2Y8AsgTpgAmY7PhCfg==',
   'Last-Modified',
-  'Wed, 11 Sep 2019 02:20:32 GMT',
+  'Thu, 28 Jul 2022 09:13:03 GMT',
   'ETag',
-  '"0x8D7365E9F4422B2"',
+  '"0x8DA7079605B9ACE"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '87aefc07-201e-006a-3747-683a57000000',
+  'a85ba8cf-d01e-0054-5062-a2abee000000',
   'x-ms-client-request-id',
-  'd7696baf-21cc-4e3c-9c17-2f0c658bb5e7',
+  '12cd6d9c-dc6e-4d1d-ab81-efc52c05a2de',
   'x-ms-version',
-  '2019-02-02',
+  '2021-08-06',
   'x-ms-content-crc64',
   'AAAAAAAAAAA=',
   'x-ms-request-server-encrypted',
   'true',
   'Date',
-  'Wed, 11 Sep 2019 02:20:31 GMT' ]);
-
+  'Thu, 28 Jul 2022 09:13:03 GMT'
+]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container156816843115309572/blockblob%2F2156816843237903195')
-  .reply(201, "", [ 'Content-Length',
+  .put('/container165899958312700315/blockblob/2165899958344404742')
+  .reply(201, "", [
+  'Content-Length',
   '0',
   'Content-MD5',
   '1B2M2Y8AsgTpgAmY7PhCfg==',
   'Last-Modified',
-  'Wed, 11 Sep 2019 02:20:32 GMT',
+  'Thu, 28 Jul 2022 09:13:03 GMT',
   'ETag',
-  '"0x8D7365E9F81FA29"',
+  '"0x8DA7079606ADA9D"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '331d0141-c01e-000d-3147-6889f0000000',
+  'a85ba8db-d01e-0054-5a62-a2abee000000',
   'x-ms-client-request-id',
-  '52827ff4-dfe9-483a-8cf7-4e0d8963e5ef',
+  '72a8e7fb-da89-4e73-bc0e-7eda4668dec8',
   'x-ms-version',
-  '2019-02-02',
+  '2021-08-06',
   'x-ms-content-crc64',
   'AAAAAAAAAAA=',
   'x-ms-request-server-encrypted',
   'true',
   'Date',
-  'Wed, 11 Sep 2019 02:20:32 GMT' ]);
-
+  'Thu, 28 Jul 2022 09:13:03 GMT'
+]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container156816843115309572/blockblob%2F3156816843278400263')
-  .reply(201, "", [ 'Content-Length',
+  .put('/container165899958312700315/blockblob/3165899958354401508')
+  .reply(201, "", [
+  'Content-Length',
   '0',
   'Content-MD5',
   '1B2M2Y8AsgTpgAmY7PhCfg==',
   'Last-Modified',
-  'Wed, 11 Sep 2019 02:20:33 GMT',
+  'Thu, 28 Jul 2022 09:13:03 GMT',
   'ETag',
-  '"0x8D7365E9FBF836E"',
+  '"0x8DA7079607A1A6F"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '5b16626f-501e-0065-6647-68d7a1000000',
+  'a85ba8ec-d01e-0054-6862-a2abee000000',
   'x-ms-client-request-id',
-  '6e4cd5c3-6f37-4875-bf2c-0ac1d364807e',
+  '90cea3df-4ce6-462d-88b6-b35fcaca0e58',
   'x-ms-version',
-  '2019-02-02',
+  '2021-08-06',
   'x-ms-content-crc64',
   'AAAAAAAAAAA=',
   'x-ms-request-server-encrypted',
   'true',
   'Date',
-  'Wed, 11 Sep 2019 02:20:32 GMT' ]);
-
+  'Thu, 28 Jul 2022 09:13:03 GMT'
+]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .get('/container156816843115309572')
+  .get('/container165899958312700315')
   .query(true)
-  .reply(200, "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults ServiceEndpoint=\"https://fakestorageaccount.blob.core.windows.net/\" ContainerName=\"container156816843115309572\"><Prefix>blockblob</Prefix><MaxResults>2</MaxResults><Blobs><Blob><Name>blockblob/0156816843155707479</Name><Properties><Creation-Time>Wed, 11 Sep 2019 02:20:31 GMT</Creation-Time><Last-Modified>Wed, 11 Sep 2019 02:20:31 GMT</Last-Modified><Etag>0x8D7365E9F044F04</Etag><Content-Length>0</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64>AAAAAAAAAAA=</Content-CRC64><Content-MD5>1B2M2Y8AsgTpgAmY7PhCfg==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Cool</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted><TagCount>0</TagCount></Properties><Metadata><keya>a</keya><keyb>c</keyb></Metadata></Blob><Blob><Name>blockblob/1156816843196107646</Name><Properties><Creation-Time>Wed, 11 Sep 2019 02:20:32 GMT</Creation-Time><Last-Modified>Wed, 11 Sep 2019 02:20:32 GMT</Last-Modified><Etag>0x8D7365E9F4422B2</Etag><Content-Length>0</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64>AAAAAAAAAAA=</Content-CRC64><Content-MD5>1B2M2Y8AsgTpgAmY7PhCfg==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Cool</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted><TagCount>0</TagCount></Properties><Metadata><keya>a</keya><keyb>c</keyb></Metadata></Blob></Blobs><NextMarker>2!100!MDAwMDI5IWJsb2NrYmxvYi8yMTU2ODE2ODQzMjM3OTAzMTk1ITAwMDAyOCE5OTk5LTEyLTMxVDIzOjU5OjU5Ljk5OTk5OTlaIQ--</NextMarker></EnumerationResults>", [ 'Transfer-Encoding',
+  .reply(200, "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults ServiceEndpoint=\"https://fakestorageaccount.blob.core.windows.net/\" ContainerName=\"container165899958312700315\"><Prefix>blockblob</Prefix><MaxResults>2</MaxResults><Blobs><Blob><Name>blockblob/0165899958322909411</Name><Properties><Creation-Time>Thu, 28 Jul 2022 09:13:03 GMT</Creation-Time><Last-Modified>Thu, 28 Jul 2022 09:13:03 GMT</Last-Modified><Etag>0x8DA7079604A387F</Etag><Content-Length>0</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>1B2M2Y8AsgTpgAmY7PhCfg==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties><Metadata><keya>a</keya><keyb>c</keyb></Metadata><OrMetadata /></Blob><Blob><Name>blockblob/1165899958334304678</Name><Properties><Creation-Time>Thu, 28 Jul 2022 09:13:03 GMT</Creation-Time><Last-Modified>Thu, 28 Jul 2022 09:13:03 GMT</Last-Modified><Etag>0x8DA7079605B9ACE</Etag><Content-Length>0</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>1B2M2Y8AsgTpgAmY7PhCfg==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties><Metadata><keya>a</keya><keyb>c</keyb></Metadata><OrMetadata /></Blob></Blobs><NextMarker>2!100!MDAwMDI5IWJsb2NrYmxvYi8yMTY1ODk5OTU4MzQ0NDA0NzQyITAwMDAyOCE5OTk5LTEyLTMxVDIzOjU5OjU5Ljk5OTk5OTlaIQ--</NextMarker></EnumerationResults>", [
+  'Transfer-Encoding',
   'chunked',
   'Content-Type',
   'application/xml',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '05569103-a01e-0059-7547-68637a000000',
+  'a85ba904-d01e-0054-7d62-a2abee000000',
   'x-ms-client-request-id',
-  '95d9979f-0746-4997-88d3-12cd7e1b7fad',
+  'e8d0d31e-d06a-46cd-bfbf-0e7fef4ba6d9',
   'x-ms-version',
-  '2019-02-02',
+  '2021-08-06',
   'Access-Control-Expose-Headers',
   'x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,Content-Type,Content-Length,Date,Transfer-Encoding',
   'Access-Control-Allow-Origin',
   '*',
   'Date',
-  'Wed, 11 Sep 2019 02:20:33 GMT' ]);
-
+  'Thu, 28 Jul 2022 09:13:03 GMT'
+]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .get('/container156816843115309572')
+  .get('/container165899958312700315')
   .query(true)
-  .reply(200, "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults ServiceEndpoint=\"https://fakestorageaccount.blob.core.windows.net/\" ContainerName=\"container156816843115309572\"><Prefix>blockblob</Prefix><Marker>2!100!MDAwMDI5IWJsb2NrYmxvYi8yMTU2ODE2ODQzMjM3OTAzMTk1ITAwMDAyOCE5OTk5LTEyLTMxVDIzOjU5OjU5Ljk5OTk5OTlaIQ--</Marker><MaxResults>2</MaxResults><Blobs><Blob><Name>blockblob/2156816843237903195</Name><Properties><Creation-Time>Wed, 11 Sep 2019 02:20:32 GMT</Creation-Time><Last-Modified>Wed, 11 Sep 2019 02:20:32 GMT</Last-Modified><Etag>0x8D7365E9F81FA29</Etag><Content-Length>0</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64>AAAAAAAAAAA=</Content-CRC64><Content-MD5>1B2M2Y8AsgTpgAmY7PhCfg==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Cool</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted><TagCount>0</TagCount></Properties><Metadata><keya>a</keya><keyb>c</keyb></Metadata></Blob><Blob><Name>blockblob/3156816843278400263</Name><Properties><Creation-Time>Wed, 11 Sep 2019 02:20:33 GMT</Creation-Time><Last-Modified>Wed, 11 Sep 2019 02:20:33 GMT</Last-Modified><Etag>0x8D7365E9FBF836E</Etag><Content-Length>0</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64>AAAAAAAAAAA=</Content-CRC64><Content-MD5>1B2M2Y8AsgTpgAmY7PhCfg==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Cool</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted><TagCount>0</TagCount></Properties><Metadata><keya>a</keya><keyb>c</keyb></Metadata></Blob></Blobs><NextMarker /></EnumerationResults>", [ 'Transfer-Encoding',
+  .reply(200, "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults ServiceEndpoint=\"https://fakestorageaccount.blob.core.windows.net/\" ContainerName=\"container165899958312700315\"><Prefix>blockblob</Prefix><Marker>2!100!MDAwMDI5IWJsb2NrYmxvYi8yMTY1ODk5OTU4MzQ0NDA0NzQyITAwMDAyOCE5OTk5LTEyLTMxVDIzOjU5OjU5Ljk5OTk5OTlaIQ--</Marker><MaxResults>2</MaxResults><Blobs><Blob><Name>blockblob/2165899958344404742</Name><Properties><Creation-Time>Thu, 28 Jul 2022 09:13:03 GMT</Creation-Time><Last-Modified>Thu, 28 Jul 2022 09:13:03 GMT</Last-Modified><Etag>0x8DA7079606ADA9D</Etag><Content-Length>0</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>1B2M2Y8AsgTpgAmY7PhCfg==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties><Metadata><keya>a</keya><keyb>c</keyb></Metadata><OrMetadata /></Blob><Blob><Name>blockblob/3165899958354401508</Name><Properties><Creation-Time>Thu, 28 Jul 2022 09:13:03 GMT</Creation-Time><Last-Modified>Thu, 28 Jul 2022 09:13:03 GMT</Last-Modified><Etag>0x8DA7079607A1A6F</Etag><Content-Length>0</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>1B2M2Y8AsgTpgAmY7PhCfg==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties><Metadata><keya>a</keya><keyb>c</keyb></Metadata><OrMetadata /></Blob></Blobs><NextMarker /></EnumerationResults>", [
+  'Transfer-Encoding',
   'chunked',
   'Content-Type',
   'application/xml',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '51442098-301e-0031-5247-683d2b000000',
+  'a85ba91a-d01e-0054-0e62-a2abee000000',
   'x-ms-client-request-id',
-  'cf941745-8ebd-4358-8e93-d115d989531e',
+  '86f84cc1-7d22-4af0-a53a-d4b3e8dcc39d',
   'x-ms-version',
-  '2019-02-02',
+  '2021-08-06',
   'Access-Control-Expose-Headers',
   'x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,Content-Type,Content-Length,Date,Transfer-Encoding',
   'Access-Control-Allow-Origin',
   '*',
   'Date',
-  'Wed, 11 Sep 2019 02:20:33 GMT' ]);
-
+  'Thu, 28 Jul 2022 09:13:03 GMT'
+]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .delete('/container156816843115309572/blockblob%2F0156816843155707479')
-  .reply(202, "", [ 'Content-Length',
+  .delete('/container165899958312700315/blockblob/0165899958322909411')
+  .reply(202, "", [
+  'Content-Length',
   '0',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'ed17140e-f01e-0005-0b47-689283000000',
+  'a85ba943-d01e-0054-2f62-a2abee000000',
   'x-ms-client-request-id',
-  '0d807082-8ff5-4b5b-8d20-e314433d20d9',
+  'fea8df3d-eb03-45a2-b2ec-ac2d904e7c93',
   'x-ms-version',
-  '2019-02-02',
+  '2021-08-06',
   'x-ms-delete-type-permanent',
   'false',
   'Date',
-  'Wed, 11 Sep 2019 02:20:34 GMT' ]);
-
+  'Thu, 28 Jul 2022 09:13:03 GMT'
+]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .delete('/container156816843115309572/blockblob%2F1156816843196107646')
-  .reply(202, "", [ 'Content-Length',
+  .delete('/container165899958312700315/blockblob/1165899958334304678')
+  .reply(202, "", [
+  'Content-Length',
   '0',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'fbec91e4-701e-001f-2d47-68bdec000000',
+  'a85ba954-d01e-0054-3f62-a2abee000000',
   'x-ms-client-request-id',
-  'c4f59e72-2c98-4638-aa9e-67dd68cfd90a',
+  'b9f78f78-8498-4290-9c93-84f076e5ed96',
   'x-ms-version',
-  '2019-02-02',
+  '2021-08-06',
   'x-ms-delete-type-permanent',
   'false',
   'Date',
-  'Wed, 11 Sep 2019 02:20:33 GMT' ]);
-
+  'Thu, 28 Jul 2022 09:13:03 GMT'
+]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .delete('/container156816843115309572/blockblob%2F2156816843237903195')
-  .reply(202, "", [ 'Content-Length',
+  .delete('/container165899958312700315/blockblob/2165899958344404742')
+  .reply(202, "", [
+  'Content-Length',
   '0',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'df188348-401e-0058-4847-686287000000',
+  'a85ba961-d01e-0054-4962-a2abee000000',
   'x-ms-client-request-id',
-  '62f925b7-e9a4-4c25-ac7c-25acf297b493',
+  'f27c1e18-f164-499e-9120-cdd13b442b74',
   'x-ms-version',
-  '2019-02-02',
+  '2021-08-06',
   'x-ms-delete-type-permanent',
   'false',
   'Date',
-  'Wed, 11 Sep 2019 02:20:34 GMT' ]);
-
+  'Thu, 28 Jul 2022 09:13:04 GMT'
+]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .delete('/container156816843115309572/blockblob%2F3156816843278400263')
-  .reply(202, "", [ 'Content-Length',
+  .delete('/container165899958312700315/blockblob/3165899958354401508')
+  .reply(202, "", [
+  'Content-Length',
   '0',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'd53a4865-001e-0032-7d47-683e2c000000',
+  'a85ba972-d01e-0054-5762-a2abee000000',
   'x-ms-client-request-id',
-  '2e309e77-c801-43d2-8434-c29ae68ff9dd',
+  '7855ad86-24c4-4133-af3e-030e7f1a748b',
   'x-ms-version',
-  '2019-02-02',
+  '2021-08-06',
   'x-ms-delete-type-permanent',
   'false',
   'Date',
-  'Wed, 11 Sep 2019 02:20:35 GMT' ]);
-
+  'Thu, 28 Jul 2022 09:13:04 GMT'
+]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .delete('/container156816843115309572')
+  .delete('/container165899958312700315')
   .query(true)
-  .reply(202, "", [ 'Content-Length',
+  .reply(202, "", [
+  'Content-Length',
   '0',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '5b637c71-801e-0001-0d47-686701000000',
+  'a85ba98d-d01e-0054-7162-a2abee000000',
   'x-ms-client-request-id',
-  'e54a3c3a-e10b-4902-835e-f7f3270ae02a',
+  'ef3b8a45-cf16-435f-8b27-5071095f4143',
   'x-ms-version',
-  '2019-02-02',
+  '2021-08-06',
   'Date',
-  'Wed, 11 Sep 2019 02:20:35 GMT' ]);
-
+  'Thu, 28 Jul 2022 09:13:04 GMT'
+]);

--- a/sdk/storage/storage-blob/recordings/node/containerclient/recording_verify_pagedasynciterableiteratorbypage_for_listblobsflat.js
+++ b/sdk/storage/storage-blob/recordings/node/containerclient/recording_verify_pagedasynciterableiteratorbypage_for_listblobsflat.js
@@ -1,263 +1,277 @@
 let nock = require('nock');
 
-module.exports.testInfo = {"container":"container156816842621809153","blockblob/0":"blockblob/0156816842663305054","blockblob/1":"blockblob/1156816842705901696","blockblob/2":"blockblob/2156816842746700476","blockblob/3":"blockblob/3156816842787904640"}
+module.exports.hash = "81c720dab55f3a3dc42b7200cf704a30";
+
+module.exports.testInfo = {"uniqueName":{"container":"container165899958191608257","blockblob/0":"blockblob/0165899958201707219","blockblob/1":"blockblob/1165899958211702673","blockblob/2":"blockblob/2165899958221809911","blockblob/3":"blockblob/3165899958232109818"},"newDate":{}}
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container156816842621809153')
+  .put('/container165899958191608257')
   .query(true)
-  .reply(201, "", [ 'Content-Length',
+  .reply(201, "", [
+  'Content-Length',
   '0',
   'Last-Modified',
-  'Wed, 11 Sep 2019 02:20:26 GMT',
+  'Thu, 28 Jul 2022 09:13:02 GMT',
   'ETag',
-  '"0x8D7365E9BD74520"',
+  '"0x8DA70795F80218A"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '1ab4e5ca-a01e-003f-7347-68d120000000',
+  'a85ba7cd-d01e-0054-0162-a2abee000000',
   'x-ms-client-request-id',
-  '280416b1-4209-43f3-ae62-ce02ff2bc053',
+  'e36333aa-8e6e-4edf-a0fc-7d933da57b00',
   'x-ms-version',
-  '2019-02-02',
+  '2021-08-06',
   'Date',
-  'Wed, 11 Sep 2019 02:20:25 GMT' ]);
-
+  'Thu, 28 Jul 2022 09:13:01 GMT'
+]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container156816842621809153/blockblob%2F0156816842663305054')
-  .reply(201, "", [ 'Content-Length',
+  .put('/container165899958191608257/blockblob/0165899958201707219')
+  .reply(201, "", [
+  'Content-Length',
   '0',
   'Content-MD5',
   '1B2M2Y8AsgTpgAmY7PhCfg==',
   'Last-Modified',
-  'Wed, 11 Sep 2019 02:20:26 GMT',
+  'Thu, 28 Jul 2022 09:13:02 GMT',
   'ETag',
-  '"0x8D7365E9C184112"',
+  '"0x8DA70795F911843"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'ea8df559-701e-003d-3047-68d3da000000',
+  'a85ba7e7-d01e-0054-1462-a2abee000000',
   'x-ms-client-request-id',
-  '50e66912-ffe6-4401-85bb-79960ab46e3d',
+  'b0cb51c9-7ecd-4539-b8f0-166eb5b0ffbc',
   'x-ms-version',
-  '2019-02-02',
+  '2021-08-06',
   'x-ms-content-crc64',
   'AAAAAAAAAAA=',
   'x-ms-request-server-encrypted',
   'true',
   'Date',
-  'Wed, 11 Sep 2019 02:20:26 GMT' ]);
-
+  'Thu, 28 Jul 2022 09:13:02 GMT'
+]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container156816842621809153/blockblob%2F1156816842705901696')
-  .reply(201, "", [ 'Content-Length',
+  .put('/container165899958191608257/blockblob/1165899958211702673')
+  .reply(201, "", [
+  'Content-Length',
   '0',
   'Content-MD5',
   '1B2M2Y8AsgTpgAmY7PhCfg==',
   'Last-Modified',
-  'Wed, 11 Sep 2019 02:20:27 GMT',
+  'Thu, 28 Jul 2022 09:13:02 GMT',
   'ETag',
-  '"0x8D7365E9C568DCC"',
+  '"0x8DA70795FA07F15"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'af56f065-501e-0008-4d47-687d8f000000',
+  'a85ba7f8-d01e-0054-2462-a2abee000000',
   'x-ms-client-request-id',
-  '09fc200c-f69e-4101-8311-51b9fee057b1',
+  'ee18cd4d-87e9-48fa-88d1-c1b3c5a7ea8f',
   'x-ms-version',
-  '2019-02-02',
+  '2021-08-06',
   'x-ms-content-crc64',
   'AAAAAAAAAAA=',
   'x-ms-request-server-encrypted',
   'true',
   'Date',
-  'Wed, 11 Sep 2019 02:20:26 GMT' ]);
-
+  'Thu, 28 Jul 2022 09:13:02 GMT'
+]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container156816842621809153/blockblob%2F2156816842746700476')
-  .reply(201, "", [ 'Content-Length',
+  .put('/container165899958191608257/blockblob/2165899958221809911')
+  .reply(201, "", [
+  'Content-Length',
   '0',
   'Content-MD5',
   '1B2M2Y8AsgTpgAmY7PhCfg==',
   'Last-Modified',
-  'Wed, 11 Sep 2019 02:20:27 GMT',
+  'Thu, 28 Jul 2022 09:13:02 GMT',
   'ETag',
-  '"0x8D7365E9C9528BD"',
+  '"0x8DA70795FB00CFB"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'a04407de-701e-0050-3d47-6879f4000000',
+  'a85ba808-d01e-0054-3062-a2abee000000',
   'x-ms-client-request-id',
-  '8ab38b56-0eec-4700-bc15-470675a171f3',
+  'fb72c217-95a2-483c-9574-34c5117ba26a',
   'x-ms-version',
-  '2019-02-02',
+  '2021-08-06',
   'x-ms-content-crc64',
   'AAAAAAAAAAA=',
   'x-ms-request-server-encrypted',
   'true',
   'Date',
-  'Wed, 11 Sep 2019 02:20:27 GMT' ]);
-
+  'Thu, 28 Jul 2022 09:13:02 GMT'
+]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container156816842621809153/blockblob%2F3156816842787904640')
-  .reply(201, "", [ 'Content-Length',
+  .put('/container165899958191608257/blockblob/3165899958232109818')
+  .reply(201, "", [
+  'Content-Length',
   '0',
   'Content-MD5',
   '1B2M2Y8AsgTpgAmY7PhCfg==',
   'Last-Modified',
-  'Wed, 11 Sep 2019 02:20:28 GMT',
+  'Thu, 28 Jul 2022 09:13:02 GMT',
   'ETag',
-  '"0x8D7365E9CD3274D"',
+  '"0x8DA70795FBFC1F1"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'a9ac723e-a01e-0016-0847-68a762000000',
+  'a85ba80f-d01e-0054-3762-a2abee000000',
   'x-ms-client-request-id',
-  '2af46ec7-859b-435c-a1be-43068a838a32',
+  'efe09aca-660e-47d5-9aa8-23072d2a5470',
   'x-ms-version',
-  '2019-02-02',
+  '2021-08-06',
   'x-ms-content-crc64',
   'AAAAAAAAAAA=',
   'x-ms-request-server-encrypted',
   'true',
   'Date',
-  'Wed, 11 Sep 2019 02:20:27 GMT' ]);
-
+  'Thu, 28 Jul 2022 09:13:02 GMT'
+]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .get('/container156816842621809153')
+  .get('/container165899958191608257')
   .query(true)
-  .reply(200, "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults ServiceEndpoint=\"https://fakestorageaccount.blob.core.windows.net/\" ContainerName=\"container156816842621809153\"><Prefix>blockblob</Prefix><MaxResults>2</MaxResults><Blobs><Blob><Name>blockblob/0156816842663305054</Name><Properties><Creation-Time>Wed, 11 Sep 2019 02:20:26 GMT</Creation-Time><Last-Modified>Wed, 11 Sep 2019 02:20:26 GMT</Last-Modified><Etag>0x8D7365E9C184112</Etag><Content-Length>0</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64>AAAAAAAAAAA=</Content-CRC64><Content-MD5>1B2M2Y8AsgTpgAmY7PhCfg==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Cool</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted><TagCount>0</TagCount></Properties><Metadata><keya>a</keya><keyb>c</keyb></Metadata></Blob><Blob><Name>blockblob/1156816842705901696</Name><Properties><Creation-Time>Wed, 11 Sep 2019 02:20:27 GMT</Creation-Time><Last-Modified>Wed, 11 Sep 2019 02:20:27 GMT</Last-Modified><Etag>0x8D7365E9C568DCC</Etag><Content-Length>0</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64>AAAAAAAAAAA=</Content-CRC64><Content-MD5>1B2M2Y8AsgTpgAmY7PhCfg==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Cool</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted><TagCount>0</TagCount></Properties><Metadata><keya>a</keya><keyb>c</keyb></Metadata></Blob></Blobs><NextMarker>2!100!MDAwMDI5IWJsb2NrYmxvYi8yMTU2ODE2ODQyNzQ2NzAwNDc2ITAwMDAyOCE5OTk5LTEyLTMxVDIzOjU5OjU5Ljk5OTk5OTlaIQ--</NextMarker></EnumerationResults>", [ 'Transfer-Encoding',
+  .reply(200, "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults ServiceEndpoint=\"https://fakestorageaccount.blob.core.windows.net/\" ContainerName=\"container165899958191608257\"><Prefix>blockblob</Prefix><MaxResults>2</MaxResults><Blobs><Blob><Name>blockblob/0165899958201707219</Name><Properties><Creation-Time>Thu, 28 Jul 2022 09:13:02 GMT</Creation-Time><Last-Modified>Thu, 28 Jul 2022 09:13:02 GMT</Last-Modified><Etag>0x8DA70795F911843</Etag><Content-Length>0</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>1B2M2Y8AsgTpgAmY7PhCfg==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties><Metadata><keya>a</keya><keyb>c</keyb></Metadata><OrMetadata /></Blob><Blob><Name>blockblob/1165899958211702673</Name><Properties><Creation-Time>Thu, 28 Jul 2022 09:13:02 GMT</Creation-Time><Last-Modified>Thu, 28 Jul 2022 09:13:02 GMT</Last-Modified><Etag>0x8DA70795FA07F15</Etag><Content-Length>0</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>1B2M2Y8AsgTpgAmY7PhCfg==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties><Metadata><keya>a</keya><keyb>c</keyb></Metadata><OrMetadata /></Blob></Blobs><NextMarker>2!100!MDAwMDI5IWJsb2NrYmxvYi8yMTY1ODk5OTU4MjIxODA5OTExITAwMDAyOCE5OTk5LTEyLTMxVDIzOjU5OjU5Ljk5OTk5OTlaIQ--</NextMarker></EnumerationResults>", [
+  'Transfer-Encoding',
   'chunked',
   'Content-Type',
   'application/xml',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '5b905556-e01e-001a-3b47-684993000000',
+  'a85ba81f-d01e-0054-4562-a2abee000000',
   'x-ms-client-request-id',
-  '24dad3b1-2752-4dd2-8e87-d89800707bf0',
+  'e064915c-bc03-4621-9d94-bcdc8d528385',
   'x-ms-version',
-  '2019-02-02',
+  '2021-08-06',
   'Access-Control-Expose-Headers',
   'x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,Content-Type,Content-Length,Date,Transfer-Encoding',
   'Access-Control-Allow-Origin',
   '*',
   'Date',
-  'Wed, 11 Sep 2019 02:20:28 GMT' ]);
-
+  'Thu, 28 Jul 2022 09:13:02 GMT'
+]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .get('/container156816842621809153')
+  .get('/container165899958191608257')
   .query(true)
-  .reply(200, "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults ServiceEndpoint=\"https://fakestorageaccount.blob.core.windows.net/\" ContainerName=\"container156816842621809153\"><Prefix>blockblob</Prefix><Marker>2!100!MDAwMDI5IWJsb2NrYmxvYi8yMTU2ODE2ODQyNzQ2NzAwNDc2ITAwMDAyOCE5OTk5LTEyLTMxVDIzOjU5OjU5Ljk5OTk5OTlaIQ--</Marker><MaxResults>2</MaxResults><Blobs><Blob><Name>blockblob/2156816842746700476</Name><Properties><Creation-Time>Wed, 11 Sep 2019 02:20:27 GMT</Creation-Time><Last-Modified>Wed, 11 Sep 2019 02:20:27 GMT</Last-Modified><Etag>0x8D7365E9C9528BD</Etag><Content-Length>0</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64>AAAAAAAAAAA=</Content-CRC64><Content-MD5>1B2M2Y8AsgTpgAmY7PhCfg==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Cool</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted><TagCount>0</TagCount></Properties><Metadata><keya>a</keya><keyb>c</keyb></Metadata></Blob><Blob><Name>blockblob/3156816842787904640</Name><Properties><Creation-Time>Wed, 11 Sep 2019 02:20:28 GMT</Creation-Time><Last-Modified>Wed, 11 Sep 2019 02:20:28 GMT</Last-Modified><Etag>0x8D7365E9CD3274D</Etag><Content-Length>0</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64>AAAAAAAAAAA=</Content-CRC64><Content-MD5>1B2M2Y8AsgTpgAmY7PhCfg==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Cool</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted><TagCount>0</TagCount></Properties><Metadata><keya>a</keya><keyb>c</keyb></Metadata></Blob></Blobs><NextMarker /></EnumerationResults>", [ 'Transfer-Encoding',
+  .reply(200, "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults ServiceEndpoint=\"https://fakestorageaccount.blob.core.windows.net/\" ContainerName=\"container165899958191608257\"><Prefix>blockblob</Prefix><Marker>2!100!MDAwMDI5IWJsb2NrYmxvYi8yMTY1ODk5OTU4MjIxODA5OTExITAwMDAyOCE5OTk5LTEyLTMxVDIzOjU5OjU5Ljk5OTk5OTlaIQ--</Marker><MaxResults>2</MaxResults><Blobs><Blob><Name>blockblob/2165899958221809911</Name><Properties><Creation-Time>Thu, 28 Jul 2022 09:13:02 GMT</Creation-Time><Last-Modified>Thu, 28 Jul 2022 09:13:02 GMT</Last-Modified><Etag>0x8DA70795FB00CFB</Etag><Content-Length>0</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>1B2M2Y8AsgTpgAmY7PhCfg==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties><Metadata><keya>a</keya><keyb>c</keyb></Metadata><OrMetadata /></Blob><Blob><Name>blockblob/3165899958232109818</Name><Properties><Creation-Time>Thu, 28 Jul 2022 09:13:02 GMT</Creation-Time><Last-Modified>Thu, 28 Jul 2022 09:13:02 GMT</Last-Modified><Etag>0x8DA70795FBFC1F1</Etag><Content-Length>0</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>1B2M2Y8AsgTpgAmY7PhCfg==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties><Metadata><keya>a</keya><keyb>c</keyb></Metadata><OrMetadata /></Blob></Blobs><NextMarker /></EnumerationResults>", [
+  'Transfer-Encoding',
   'chunked',
   'Content-Type',
   'application/xml',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '02701781-201e-0043-5547-684c15000000',
+  'a85ba830-d01e-0054-5162-a2abee000000',
   'x-ms-client-request-id',
-  'dd03b4e5-305b-4e5f-8aa5-95101f5a548d',
+  '1d26f3ab-bad2-4bd6-89a6-4e36c955abb7',
   'x-ms-version',
-  '2019-02-02',
+  '2021-08-06',
   'Access-Control-Expose-Headers',
   'x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,Content-Type,Content-Length,Date,Transfer-Encoding',
   'Access-Control-Allow-Origin',
   '*',
   'Date',
-  'Wed, 11 Sep 2019 02:20:28 GMT' ]);
-
+  'Thu, 28 Jul 2022 09:13:02 GMT'
+]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .delete('/container156816842621809153/blockblob%2F0156816842663305054')
-  .reply(202, "", [ 'Content-Length',
+  .delete('/container165899958191608257/blockblob/0165899958201707219')
+  .reply(202, "", [
+  'Content-Length',
   '0',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'f1957d5e-301e-0057-2a47-688f71000000',
+  'a85ba846-d01e-0054-6362-a2abee000000',
   'x-ms-client-request-id',
-  '9de97af8-d6de-4b1b-a4f7-b7d1fc21125d',
+  'f3600208-6854-40f0-9f08-cdc407c35faa',
   'x-ms-version',
-  '2019-02-02',
+  '2021-08-06',
   'x-ms-delete-type-permanent',
   'false',
   'Date',
-  'Wed, 11 Sep 2019 02:20:29 GMT' ]);
-
+  'Thu, 28 Jul 2022 09:13:02 GMT'
+]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .delete('/container156816842621809153/blockblob%2F1156816842705901696')
-  .reply(202, "", [ 'Content-Length',
+  .delete('/container165899958191608257/blockblob/1165899958211702673')
+  .reply(202, "", [
+  'Content-Length',
   '0',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'd1804461-801e-000a-6f47-687f75000000',
+  'a85ba85a-d01e-0054-7462-a2abee000000',
   'x-ms-client-request-id',
-  '6063bd7e-1a9d-4811-bc83-3c96de56bd5c',
+  'f2b95078-e46c-476b-9b05-794ccc86045a',
   'x-ms-version',
-  '2019-02-02',
+  '2021-08-06',
   'x-ms-delete-type-permanent',
   'false',
   'Date',
-  'Wed, 11 Sep 2019 02:20:29 GMT' ]);
-
+  'Thu, 28 Jul 2022 09:13:02 GMT'
+]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .delete('/container156816842621809153/blockblob%2F2156816842746700476')
-  .reply(202, "", [ 'Content-Length',
+  .delete('/container165899958191608257/blockblob/2165899958221809911')
+  .reply(202, "", [
+  'Content-Length',
   '0',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '8b506656-b01e-0002-2647-686406000000',
+  'a85ba878-d01e-0054-0a62-a2abee000000',
   'x-ms-client-request-id',
-  '7b1f67be-c9a4-4dee-b597-1010fa713b61',
+  'e1824421-baec-42ec-adfb-279dcbc66355',
   'x-ms-version',
-  '2019-02-02',
+  '2021-08-06',
   'x-ms-delete-type-permanent',
   'false',
   'Date',
-  'Wed, 11 Sep 2019 02:20:29 GMT' ]);
-
+  'Thu, 28 Jul 2022 09:13:02 GMT'
+]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .delete('/container156816842621809153/blockblob%2F3156816842787904640')
-  .reply(202, "", [ 'Content-Length',
+  .delete('/container165899958191608257/blockblob/3165899958232109818')
+  .reply(202, "", [
+  'Content-Length',
   '0',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '3cabbdd0-101e-004b-5247-685766000000',
+  'a85ba88d-d01e-0054-1c62-a2abee000000',
   'x-ms-client-request-id',
-  'c15d9d72-5285-4d5f-ba53-71a5d973c9a7',
+  'b105be7e-916d-46e7-aa26-737603afaa9b',
   'x-ms-version',
-  '2019-02-02',
+  '2021-08-06',
   'x-ms-delete-type-permanent',
   'false',
   'Date',
-  'Wed, 11 Sep 2019 02:20:30 GMT' ]);
-
+  'Thu, 28 Jul 2022 09:13:02 GMT'
+]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .delete('/container156816842621809153')
+  .delete('/container165899958191608257')
   .query(true)
-  .reply(202, "", [ 'Content-Length',
+  .reply(202, "", [
+  'Content-Length',
   '0',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '7ae569db-801e-0067-6447-68d55b000000',
+  'a85ba899-d01e-0054-2562-a2abee000000',
   'x-ms-client-request-id',
-  '60ec1a50-5f90-425e-896b-79f4adf2c388',
+  '443c6f40-c66b-4fc7-87ae-37438cc6a729',
   'x-ms-version',
-  '2019-02-02',
+  '2021-08-06',
   'Date',
-  'Wed, 11 Sep 2019 02:20:30 GMT' ]);
-
+  'Thu, 28 Jul 2022 09:13:03 GMT'
+]);

--- a/sdk/storage/storage-blob/recordings/node/containerclient/recording_verify_pagedasynciterableiteratorgenerator_next_syntax_for_listblobsflat.js
+++ b/sdk/storage/storage-blob/recordings/node/containerclient/recording_verify_pagedasynciterableiteratorgenerator_next_syntax_for_listblobsflat.js
@@ -1,152 +1,161 @@
 let nock = require('nock');
 
-module.exports.testInfo = {"container":"container156816842336800192","blockblob/0":"blockblob/0156816842377804523","blockblob/1":"blockblob/1156816842418401929"}
+module.exports.hash = "d7034bb7c19d2d43c9e42f4e0f94fea4";
+
+module.exports.testInfo = {"uniqueName":{"container":"container165899958120905912","blockblob/0":"blockblob/0165899958131106963","blockblob/1":"blockblob/1165899958141106074"},"newDate":{}}
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container156816842336800192')
+  .put('/container165899958120905912')
   .query(true)
-  .reply(201, "", [ 'Content-Length',
+  .reply(201, "", [
+  'Content-Length',
   '0',
   'Last-Modified',
-  'Wed, 11 Sep 2019 02:20:23 GMT',
+  'Thu, 28 Jul 2022 09:13:01 GMT',
   'ETag',
-  '"0x8D7365E9A235D3E"',
+  '"0x8DA70795F14503F"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'dd4afdec-901e-0037-6f47-68ca53000000',
+  'a85ba743-d01e-0054-1562-a2abee000000',
   'x-ms-client-request-id',
-  'a3f3f4c3-14bc-4d82-b1bc-7cddee6e9dca',
+  'f92d0d08-47ee-4836-8c87-a61726472ff9',
   'x-ms-version',
-  '2019-02-02',
+  '2021-08-06',
   'Date',
-  'Wed, 11 Sep 2019 02:20:23 GMT' ]);
-
+  'Thu, 28 Jul 2022 09:13:01 GMT'
+]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container156816842336800192/blockblob%2F0156816842377804523')
-  .reply(201, "", [ 'Content-Length',
+  .put('/container165899958120905912/blockblob/0165899958131106963')
+  .reply(201, "", [
+  'Content-Length',
   '0',
   'Content-MD5',
   '1B2M2Y8AsgTpgAmY7PhCfg==',
   'Last-Modified',
-  'Wed, 11 Sep 2019 02:20:24 GMT',
+  'Thu, 28 Jul 2022 09:13:01 GMT',
   'ETag',
-  '"0x8D7365E9A61B670"',
+  '"0x8DA70795F256F62"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '331cf92e-c01e-000d-1c47-6889f0000000',
+  'a85ba75b-d01e-0054-2562-a2abee000000',
   'x-ms-client-request-id',
-  '33f43f4f-04fa-4257-92a7-f6d72accf0fe',
+  '6854bfd1-f054-4838-88ea-db2c555053ad',
   'x-ms-version',
-  '2019-02-02',
+  '2021-08-06',
   'x-ms-content-crc64',
   'AAAAAAAAAAA=',
   'x-ms-request-server-encrypted',
   'true',
   'Date',
-  'Wed, 11 Sep 2019 02:20:23 GMT' ]);
-
+  'Thu, 28 Jul 2022 09:13:01 GMT'
+]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container156816842336800192/blockblob%2F1156816842418401929')
-  .reply(201, "", [ 'Content-Length',
+  .put('/container165899958120905912/blockblob/1165899958141106074')
+  .reply(201, "", [
+  'Content-Length',
   '0',
   'Content-MD5',
   '1B2M2Y8AsgTpgAmY7PhCfg==',
   'Last-Modified',
-  'Wed, 11 Sep 2019 02:20:24 GMT',
+  'Thu, 28 Jul 2022 09:13:01 GMT',
   'ETag',
-  '"0x8D7365E9AA13BE7"',
+  '"0x8DA70795F34D634"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '9a0133f0-701e-005b-3747-686180000000',
+  'a85ba76c-d01e-0054-3462-a2abee000000',
   'x-ms-client-request-id',
-  'd47e596c-130e-4d39-b7ba-0557d8b5aeef',
+  'c0071121-b251-4a70-af40-3d3b26ca9214',
   'x-ms-version',
-  '2019-02-02',
+  '2021-08-06',
   'x-ms-content-crc64',
   'AAAAAAAAAAA=',
   'x-ms-request-server-encrypted',
   'true',
   'Date',
-  'Wed, 11 Sep 2019 02:20:23 GMT' ]);
-
+  'Thu, 28 Jul 2022 09:13:01 GMT'
+]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .get('/container156816842336800192')
+  .get('/container165899958120905912')
   .query(true)
-  .reply(200, "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults ServiceEndpoint=\"https://fakestorageaccount.blob.core.windows.net/\" ContainerName=\"container156816842336800192\"><Prefix>blockblob</Prefix><Blobs><Blob><Name>blockblob/0156816842377804523</Name><Properties><Creation-Time>Wed, 11 Sep 2019 02:20:24 GMT</Creation-Time><Last-Modified>Wed, 11 Sep 2019 02:20:24 GMT</Last-Modified><Etag>0x8D7365E9A61B670</Etag><Content-Length>0</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64>AAAAAAAAAAA=</Content-CRC64><Content-MD5>1B2M2Y8AsgTpgAmY7PhCfg==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Cool</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted><TagCount>0</TagCount></Properties><Metadata><keya>a</keya><keyb>c</keyb></Metadata></Blob><Blob><Name>blockblob/1156816842418401929</Name><Properties><Creation-Time>Wed, 11 Sep 2019 02:20:24 GMT</Creation-Time><Last-Modified>Wed, 11 Sep 2019 02:20:24 GMT</Last-Modified><Etag>0x8D7365E9AA13BE7</Etag><Content-Length>0</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64>AAAAAAAAAAA=</Content-CRC64><Content-MD5>1B2M2Y8AsgTpgAmY7PhCfg==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Cool</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted><TagCount>0</TagCount></Properties><Metadata><keya>a</keya><keyb>c</keyb></Metadata></Blob></Blobs><NextMarker /></EnumerationResults>", [ 'Transfer-Encoding',
+  .reply(200, "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults ServiceEndpoint=\"https://fakestorageaccount.blob.core.windows.net/\" ContainerName=\"container165899958120905912\"><Prefix>blockblob</Prefix><Blobs><Blob><Name>blockblob/0165899958131106963</Name><Properties><Creation-Time>Thu, 28 Jul 2022 09:13:01 GMT</Creation-Time><Last-Modified>Thu, 28 Jul 2022 09:13:01 GMT</Last-Modified><Etag>0x8DA70795F256F62</Etag><Content-Length>0</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>1B2M2Y8AsgTpgAmY7PhCfg==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties><Metadata><keya>a</keya><keyb>c</keyb></Metadata><OrMetadata /></Blob><Blob><Name>blockblob/1165899958141106074</Name><Properties><Creation-Time>Thu, 28 Jul 2022 09:13:01 GMT</Creation-Time><Last-Modified>Thu, 28 Jul 2022 09:13:01 GMT</Last-Modified><Etag>0x8DA70795F34D634</Etag><Content-Length>0</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>1B2M2Y8AsgTpgAmY7PhCfg==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties><Metadata><keya>a</keya><keyb>c</keyb></Metadata><OrMetadata /></Blob></Blobs><NextMarker /></EnumerationResults>", [
+  'Transfer-Encoding',
   'chunked',
   'Content-Type',
   'application/xml',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'cb603ca2-401e-001c-5547-68beeb000000',
+  'a85ba777-d01e-0054-3c62-a2abee000000',
   'x-ms-client-request-id',
-  'ff4bf5e8-f992-4f4a-b69c-d07d3e434dc3',
+  'e6f2fce5-449c-4359-b288-a0bb00727a93',
   'x-ms-version',
-  '2019-02-02',
+  '2021-08-06',
   'Access-Control-Expose-Headers',
   'x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,Content-Type,Content-Length,Date,Transfer-Encoding',
   'Access-Control-Allow-Origin',
   '*',
   'Date',
-  'Wed, 11 Sep 2019 02:20:24 GMT' ]);
-
+  'Thu, 28 Jul 2022 09:13:01 GMT'
+]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .delete('/container156816842336800192/blockblob%2F0156816842377804523')
-  .reply(202, "", [ 'Content-Length',
+  .delete('/container165899958120905912/blockblob/0165899958131106963')
+  .reply(202, "", [
+  'Content-Length',
   '0',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'a04404d8-701e-0050-7747-6879f4000000',
+  'a85ba781-d01e-0054-4562-a2abee000000',
   'x-ms-client-request-id',
-  '3db47ce0-f658-406e-815a-c03a442530a3',
+  'd7cc22ff-7033-43db-a639-1f4cd0b2647e',
   'x-ms-version',
-  '2019-02-02',
+  '2021-08-06',
   'x-ms-delete-type-permanent',
   'false',
   'Date',
-  'Wed, 11 Sep 2019 02:20:24 GMT' ]);
-
+  'Thu, 28 Jul 2022 09:13:01 GMT'
+]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .delete('/container156816842336800192/blockblob%2F1156816842418401929')
-  .reply(202, "", [ 'Content-Length',
+  .delete('/container165899958120905912/blockblob/1165899958141106074')
+  .reply(202, "", [
+  'Content-Length',
   '0',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '4744da5c-301e-0013-3c47-68531d000000',
+  'a85ba791-d01e-0054-5262-a2abee000000',
   'x-ms-client-request-id',
-  '7e2c0368-a0b1-47c2-9be5-0204e4c3c16f',
+  'a14566ff-771f-4cb6-85a1-ba51c8a6dc63',
   'x-ms-version',
-  '2019-02-02',
+  '2021-08-06',
   'x-ms-delete-type-permanent',
   'false',
   'Date',
-  'Wed, 11 Sep 2019 02:20:25 GMT' ]);
-
+  'Thu, 28 Jul 2022 09:13:01 GMT'
+]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .delete('/container156816842336800192')
+  .delete('/container165899958120905912')
   .query(true)
-  .reply(202, "", [ 'Content-Length',
+  .reply(202, "", [
+  'Content-Length',
   '0',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '25d66948-101e-002d-2d47-68e53c000000',
+  'a85ba7b5-d01e-0054-6f62-a2abee000000',
   'x-ms-client-request-id',
-  '73f1e550-553a-4f29-a0bf-eae92b2e3600',
+  '9c067e3f-d67e-44ee-8875-4938ab213e6a',
   'x-ms-version',
-  '2019-02-02',
+  '2021-08-06',
   'Date',
-  'Wed, 11 Sep 2019 02:20:25 GMT' ]);
-
+  'Thu, 28 Jul 2022 09:13:01 GMT'
+]);

--- a/sdk/storage/storage-blob/recordings/node/shared_access_signature_sas_generation_nodejs_only/recording_blobclientgeneratesasurl_should_work_for_blob_with_special_namings.js
+++ b/sdk/storage/storage-blob/recordings/node/shared_access_signature_sas_generation_nodejs_only/recording_blobclientgeneratesasurl_should_work_for_blob_with_special_namings.js
@@ -1,58 +1,56 @@
 let nock = require('nock');
 
-module.exports.hash = "810db80746f4a77cac08867f6e6bcdf9";
+module.exports.hash = "2296a89d66d851b541c90ffcc755d3b9";
 
-module.exports.testInfo = {"uniqueName":{"container-with-dash":"container-with-dash160639564825600073","////Upper/blob/empty /another 汉字 ру́сский язы́к ру́сский язы́к عربي/عربى にっぽんご/にほんご . special ~!@#$%^&*()_+`1234567890-={}|[]\\:\";'<>?,/'+%2F'%25%":"////Upper/blob/empty /another 汉字 ру́сский язы́к ру́сский язы́к عربي/عربى にっぽんご/にほんご . special ~!@#$%^&*()_+`1234567890-={}|[]\\:\";'<>?,/'+%2F'%25%160639564966207887"},"newDate":{"tmr":"2020-11-26T13:00:48.254Z"}}
+module.exports.testInfo = {"uniqueName":{"container-with-dash":"container-with-dash165899712377500176","////Upper/blob/empty /another 汉字 ру́сский язы́к ру́сский язы́к عربي/عربى にっぽんご/にほんご . special ~!@#$%^&*()_+`1234567890-={}|[]\\:\";'<>?,/'+%2F'%25%":"////Upper/blob/empty /another 汉字 ру́сский язы́к ру́сский язы́к عربي/عربى にっぽんご/にほんご . special ~!@#$%^&*()_+`1234567890-={}|[]\\:\";'<>?,/'+%2F'%25%165899712387906364"},"newDate":{"tmr":"2022-07-28T08:32:03.775Z"}}
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container-with-dash160639564825600073')
+  .put('/container-with-dash165899712377500176')
   .query(true)
   .reply(201, "", [
   'Content-Length',
   '0',
   'Last-Modified',
-  'Thu, 26 Nov 2020 13:00:49 GMT',
+  'Thu, 28 Jul 2022 08:32:04 GMT',
   'ETag',
-  '"0x8D8920B4C475195"',
+  '"0x8DA7073A654BB65"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '187851c0-e01e-002b-3df4-c3d531000000',
+  '56907736-201e-0032-4c5c-a2e4ce000000',
   'x-ms-client-request-id',
-  '1b054201-f23b-49c4-8b24-485009c9470d',
+  '7f48e7ca-6674-4589-a5d5-9b8f1d8f63a9',
   'x-ms-version',
-  '2020-02-10',
+  '2021-08-06',
   'Date',
-  'Thu, 26 Nov 2020 13:00:48 GMT'
+  'Thu, 28 Jul 2022 08:32:03 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container-with-dash160639564825600073/%2F%2F%2F%2FUpper%2Fblob%2Fempty%20%2Fanother%20%E6%B1%89%E5%AD%97%20%D1%80%D1%83%CC%81%D1%81%D1%81%D0%BA%D0%B8%D0%B9%20%D1%8F%D0%B7%D1%8B%CC%81%D0%BA%20%D1%80%D1%83%CC%81%D1%81%D1%81%D0%BA%D0%B8%D0%B9%20%D1%8F%D0%B7%D1%8B%CC%81%D0%BA%20%D8%B9%D8%B1%D8%A8%D9%8A%2F%D8%B9%D8%B1%D8%A8%D9%89%20%E3%81%AB%E3%81%A3%E3%81%BD%E3%82%93%E3%81%94%2F%E3%81%AB%E3%81%BB%E3%82%93%E3%81%94%20.%20special%20~!%40%23%24%25%5E%26*()_%2B%601234567890-%3D%7B%7D%7C%5B%5D%5C%3A%22%3B%27%3C%3E%3F%2C%2F%27%2B%252F%27%2525%25160639564966207887')
+  .put('/container-with-dash165899712377500176/////Upper/blob/empty%20/another%20%E6%B1%89%E5%AD%97%20%D1%80%D1%83%CC%81%D1%81%D1%81%D0%BA%D0%B8%D0%B9%20%D1%8F%D0%B7%D1%8B%CC%81%D0%BA%20%D1%80%D1%83%CC%81%D1%81%D1%81%D0%BA%D0%B8%D0%B9%20%D1%8F%D0%B7%D1%8B%CC%81%D0%BA%20%D8%B9%D8%B1%D8%A8%D9%8A/%D8%B9%D8%B1%D8%A8%D9%89%20%E3%81%AB%E3%81%A3%E3%81%BD%E3%82%93%E3%81%94/%E3%81%AB%E3%81%BB%E3%82%93%E3%81%94%20.%20special%20~!%40%23%24%25%5E%26*()_%2B%601234567890-%3D%7B%7D%7C%5B%5D%5C%3A%22%3B%27%3C%3E%3F%2C/%27%2B%252F%27%2525%25165899712387906364')
   .reply(201, "", [
   'Content-Length',
   '0',
   'Last-Modified',
-  'Thu, 26 Nov 2020 13:00:49 GMT',
+  'Thu, 28 Jul 2022 08:32:04 GMT',
   'ETag',
-  '"0x8D8920B4C79A092"',
+  '"0x8DA7073A666C06E"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '1878522e-e01e-002b-19f4-c3d531000000',
+  '56907774-201e-0032-055c-a2e4ce000000',
   'x-ms-client-request-id',
-  '186f27de-6c86-4b7b-94b9-78fe0f1cc351',
+  '2d04735d-2dc3-4341-8181-14a755140057',
   'x-ms-version',
-  '2020-02-10',
+  '2021-08-06',
   'x-ms-request-server-encrypted',
   'true',
-  'x-ms-version-id',
-  '2020-11-26T13:00:49.8260114Z',
   'Date',
-  'Thu, 26 Nov 2020 13:00:48 GMT'
+  'Thu, 28 Jul 2022 08:32:04 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .head('/container-with-dash160639564825600073/%2F%2F%2F%2FUpper%2Fblob%2Fempty%20%2Fanother%20%E6%B1%89%E5%AD%97%20%D1%80%D1%83%CC%81%D1%81%D1%81%D0%BA%D0%B8%D0%B9%20%D1%8F%D0%B7%D1%8B%CC%81%D0%BA%20%D1%80%D1%83%CC%81%D1%81%D1%81%D0%BA%D0%B8%D0%B9%20%D1%8F%D0%B7%D1%8B%CC%81%D0%BA%20%D8%B9%D8%B1%D8%A8%D9%8A%2F%D8%B9%D8%B1%D8%A8%D9%89%20%E3%81%AB%E3%81%A3%E3%81%BD%E3%82%93%E3%81%94%2F%E3%81%AB%E3%81%BB%E3%82%93%E3%81%94%20.%20special%20~!%40%23%24%25%5E%26*()_%2B%601234567890-%3D%7B%7D%7C%5B%5D%5C%3A%22%3B%27%3C%3E%3F%2C%2F%27%2B%252F%27%2525%25160639564966207887')
+  .head('/container-with-dash165899712377500176/////Upper/blob/empty%20/another%20%E6%B1%89%E5%AD%97%20%D1%80%D1%83%CC%81%D1%81%D1%81%D0%BA%D0%B8%D0%B9%20%D1%8F%D0%B7%D1%8B%CC%81%D0%BA%20%D1%80%D1%83%CC%81%D1%81%D1%81%D0%BA%D0%B8%D0%B9%20%D1%8F%D0%B7%D1%8B%CC%81%D0%BA%20%D8%B9%D8%B1%D8%A8%D9%8A/%D8%B9%D8%B1%D8%A8%D9%89%20%E3%81%AB%E3%81%A3%E3%81%BD%E3%82%93%E3%81%94/%E3%81%AB%E3%81%BB%E3%82%93%E3%81%94%20.%20special%20~!%40%23%24%25%5E%26*()_%2B%601234567890-%3D%7B%7D%7C%5B%5D%5C%3A%22%3B%27%3C%3E%3F%2C/%27%2B%252F%27%2525%25165899712387906364')
   .query(true)
   .reply(200, "", [
   'Content-Length',
@@ -60,25 +58,21 @@ nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParam
   'Content-Type',
   'application/octet-stream',
   'Last-Modified',
-  'Thu, 26 Nov 2020 13:00:49 GMT',
+  'Thu, 28 Jul 2022 08:32:04 GMT',
   'Accept-Ranges',
   'bytes',
   'ETag',
-  '"0x8D8920B4C79A092"',
+  '"0x8DA7073A666C06E"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '187852a0-e01e-002b-7df4-c3d531000000',
+  '5690778d-201e-0032-1b5c-a2e4ce000000',
   'x-ms-client-request-id',
-  '47554349-2855-4267-858f-bb2bea14df32',
+  '96ff70a7-f64f-4c51-a80c-2823fdd9dc86',
   'x-ms-version',
-  '2020-02-10',
-  'x-ms-version-id',
-  '2020-11-26T13:00:49.8260114Z',
-  'x-ms-is-current-version',
-  'true',
+  '2021-08-06',
   'x-ms-creation-time',
-  'Thu, 26 Nov 2020 13:00:49 GMT',
+  'Thu, 28 Jul 2022 08:32:04 GMT',
   'x-ms-lease-status',
   'unlocked',
   'x-ms-lease-state',
@@ -90,15 +84,15 @@ nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParam
   'x-ms-server-encrypted',
   'true',
   'Access-Control-Expose-Headers',
-  'x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,x-ms-version-id,x-ms-is-current-version,Content-Type,Last-Modified,ETag,x-ms-creation-time,x-ms-lease-status,x-ms-lease-state,x-ms-blob-type,x-ms-blob-sequence-number,x-ms-server-encrypted,Accept-Ranges,Content-Length,Date,Transfer-Encoding',
+  'x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,Content-Type,Last-Modified,ETag,x-ms-creation-time,x-ms-lease-status,x-ms-lease-state,x-ms-blob-type,x-ms-blob-sequence-number,x-ms-server-encrypted,Accept-Ranges,Content-Length,Date,Transfer-Encoding',
   'Access-Control-Allow-Origin',
   '*',
   'Date',
-  'Thu, 26 Nov 2020 13:00:49 GMT'
+  'Thu, 28 Jul 2022 08:32:04 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .delete('/container-with-dash160639564825600073')
+  .delete('/container-with-dash165899712377500176')
   .query(true)
   .reply(202, "", [
   'Content-Length',
@@ -106,11 +100,11 @@ nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParam
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '187852ea-e01e-002b-3df4-c3d531000000',
+  '569077b1-201e-0032-3a5c-a2e4ce000000',
   'x-ms-client-request-id',
-  '038bb07d-c67a-406d-a5ee-3e0726eaa379',
+  'ebebf8de-a295-462a-9ae5-cc88b6737dc8',
   'x-ms-version',
-  '2020-02-10',
+  '2021-08-06',
   'Date',
-  'Thu, 26 Nov 2020 13:00:49 GMT'
+  'Thu, 28 Jul 2022 08:32:04 GMT'
 ]);

--- a/sdk/storage/storage-blob/recordings/node/shared_access_signature_sas_generation_nodejs_only/recording_generateblobsasqueryparameters_should_work_for_blob_with_special_namings.js
+++ b/sdk/storage/storage-blob/recordings/node/shared_access_signature_sas_generation_nodejs_only/recording_generateblobsasqueryparameters_should_work_for_blob_with_special_namings.js
@@ -1,54 +1,59 @@
 let nock = require('nock');
 
-module.exports.testInfo = {"now":"2019-09-11T02:25:44.764Z","tmr":"2019-09-11T02:25:44.764Z","container-with-dash":"container-with-dash156816874476402005","////Upper/blob/empty /another 汉字 ру́сский язы́к ру́сский язы́к عربي/عربى にっぽんご/にほんご . special ~!@#$%^&*()_+`1234567890-={}|[]\\:\";'<>?,/'":"////Upper/blob/empty /another 汉字 ру́сский язы́к ру́сский язы́к عربي/عربى にっぽんご/にほんご . special ~!@#$%^&*()_+`1234567890-={}|[]\\:\";'<>?,/'156816874518504593"}
+module.exports.hash = "84c54831694ae9a2dada1c3679c10ac6";
+
+module.exports.testInfo = {"uniqueName":{"container-with-dash":"container-with-dash165899712335902552","////Upper/blob/empty /another 汉字 ру́сский язы́к ру́сский язы́к عربي/عربى にっぽんご/にほんご . special ~!@#$%^&*()_+`1234567890-={}|[]\\:\";'<>?,/'":"////Upper/blob/empty /another 汉字 ру́сский язы́к ру́сский язы́к عربي/عربى にっぽんご/にほんご . special ~!@#$%^&*()_+`1234567890-={}|[]\\:\";'<>?,/'165899712346201288"},"newDate":{"now":"2022-07-28T08:32:03.359Z","tmr":"2022-07-28T08:32:03.359Z"}}
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container-with-dash156816874476402005')
+  .put('/container-with-dash165899712335902552')
   .query(true)
-  .reply(201, "", [ 'Content-Length',
+  .reply(201, "", [
+  'Content-Length',
   '0',
   'Last-Modified',
-  'Wed, 11 Sep 2019 02:25:45 GMT',
+  'Thu, 28 Jul 2022 08:32:03 GMT',
   'ETag',
-  '"0x8D7365F59B6ABD2"',
+  '"0x8DA7073A6154ABC"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'f7ae22ff-101e-0069-7d48-683950000000',
+  '569076d5-201e-0032-785c-a2e4ce000000',
   'x-ms-client-request-id',
-  '5193f055-fb3c-49b4-8be1-4e45b5804fac',
+  'fa6a3be0-ba26-4e2e-9938-ae991b7bc285',
   'x-ms-version',
-  '2019-02-02',
+  '2021-08-06',
   'Date',
-  'Wed, 11 Sep 2019 02:25:44 GMT' ]);
-
+  'Thu, 28 Jul 2022 08:32:03 GMT'
+]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container-with-dash156816874476402005/%2F%2F%2F%2FUpper%2Fblob%2Fempty%20%2Fanother%20%E6%B1%89%E5%AD%97%20%D1%80%D1%83%CC%81%D1%81%D1%81%D0%BA%D0%B8%D0%B9%20%D1%8F%D0%B7%D1%8B%CC%81%D0%BA%20%D1%80%D1%83%CC%81%D1%81%D1%81%D0%BA%D0%B8%D0%B9%20%D1%8F%D0%B7%D1%8B%CC%81%D0%BA%20%D8%B9%D8%B1%D8%A8%D9%8A%2F%D8%B9%D8%B1%D8%A8%D9%89%20%E3%81%AB%E3%81%A3%E3%81%BD%E3%82%93%E3%81%94%2F%E3%81%AB%E3%81%BB%E3%82%93%E3%81%94%20.%20special%20~!%40%23%24%25%5E%26*()_%2B%601234567890-%3D%7B%7D%7C%5B%5D%5C%3A%22%3B%27%3C%3E%3F%2C%2F%27156816874518504593')
-  .reply(201, "", [ 'Content-Length',
+  .put('/container-with-dash165899712335902552/////Upper/blob/empty%20/another%20%E6%B1%89%E5%AD%97%20%D1%80%D1%83%CC%81%D1%81%D1%81%D0%BA%D0%B8%D0%B9%20%D1%8F%D0%B7%D1%8B%CC%81%D0%BA%20%D1%80%D1%83%CC%81%D1%81%D1%81%D0%BA%D0%B8%D0%B9%20%D1%8F%D0%B7%D1%8B%CC%81%D0%BA%20%D8%B9%D8%B1%D8%A8%D9%8A/%D8%B9%D8%B1%D8%A8%D9%89%20%E3%81%AB%E3%81%A3%E3%81%BD%E3%82%93%E3%81%94/%E3%81%AB%E3%81%BB%E3%82%93%E3%81%94%20.%20special%20~!%40%23%24%25%5E%26*()_%2B%601234567890-%3D%7B%7D%7C%5B%5D%5C%3A%22%3B%27%3C%3E%3F%2C/%27165899712346201288')
+  .reply(201, "", [
+  'Content-Length',
   '0',
   'Last-Modified',
-  'Wed, 11 Sep 2019 02:25:45 GMT',
+  'Thu, 28 Jul 2022 08:32:03 GMT',
   'ETag',
-  '"0x8D7365F59F6E699"',
+  '"0x8DA7073A6275028"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '5b92a25e-e01e-001a-6248-684993000000',
+  '569076e9-201e-0032-095c-a2e4ce000000',
   'x-ms-client-request-id',
-  '0fea97ec-0a2a-4537-9830-0c4c5ea2da1f',
+  'bcfe34a8-ce94-40c5-8d11-a9e4c84adf83',
   'x-ms-version',
-  '2019-02-02',
+  '2021-08-06',
   'x-ms-request-server-encrypted',
   'true',
   'Date',
-  'Wed, 11 Sep 2019 02:25:44 GMT' ]);
-
+  'Thu, 28 Jul 2022 08:32:03 GMT'
+]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .head('/container-with-dash156816874476402005/%2F%2F%2F%2FUpper%2Fblob%2Fempty%20%2Fanother%20%E6%B1%89%E5%AD%97%20%D1%80%D1%83%CC%81%D1%81%D1%81%D0%BA%D0%B8%D0%B9%20%D1%8F%D0%B7%D1%8B%CC%81%D0%BA%20%D1%80%D1%83%CC%81%D1%81%D1%81%D0%BA%D0%B8%D0%B9%20%D1%8F%D0%B7%D1%8B%CC%81%D0%BA%20%D8%B9%D8%B1%D8%A8%D9%8A%2F%D8%B9%D8%B1%D8%A8%D9%89%20%E3%81%AB%E3%81%A3%E3%81%BD%E3%82%93%E3%81%94%2F%E3%81%AB%E3%81%BB%E3%82%93%E3%81%94%20.%20special%20~!%40%23%24%25%5E%26*()_%2B%601234567890-%3D%7B%7D%7C%5B%5D%5C%3A%22%3B%27%3C%3E%3F%2C%2F%27156816874518504593')
+  .head('/container-with-dash165899712335902552/////Upper/blob/empty%20/another%20%E6%B1%89%E5%AD%97%20%D1%80%D1%83%CC%81%D1%81%D1%81%D0%BA%D0%B8%D0%B9%20%D1%8F%D0%B7%D1%8B%CC%81%D0%BA%20%D1%80%D1%83%CC%81%D1%81%D1%81%D0%BA%D0%B8%D0%B9%20%D1%8F%D0%B7%D1%8B%CC%81%D0%BA%20%D8%B9%D8%B1%D8%A8%D9%8A/%D8%B9%D8%B1%D8%A8%D9%89%20%E3%81%AB%E3%81%A3%E3%81%BD%E3%82%93%E3%81%94/%E3%81%AB%E3%81%BB%E3%82%93%E3%81%94%20.%20special%20~!%40%23%24%25%5E%26*()_%2B%601234567890-%3D%7B%7D%7C%5B%5D%5C%3A%22%3B%27%3C%3E%3F%2C/%27165899712346201288')
   .query(true)
-  .reply(200, [], [ 'Cache-Control',
+  .reply(200, [], [
+  'Cache-Control',
   'cache-control-override',
   'Content-Length',
   '1024',
@@ -59,23 +64,21 @@ nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParam
   'Content-Language',
   'content-language-override',
   'Last-Modified',
-  'Wed, 11 Sep 2019 02:25:45 GMT',
+  'Thu, 28 Jul 2022 08:32:03 GMT',
   'Accept-Ranges',
   'bytes',
   'ETag',
-  '"0x8D7365F59F6E699"',
+  '"0x8DA7073A6275028"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '1838936f-b01e-004d-2b48-68a01e000000',
+  '5690770b-201e-0032-265c-a2e4ce000000',
   'x-ms-client-request-id',
-  '3140f3ba-9dfe-4e51-8e10-3d222a545816',
+  '2e8d3c94-bbbe-457b-ad3d-faf5c7b58d71',
   'x-ms-version',
-  '2019-02-02',
-  'x-ms-tag-count',
-  '0',
+  '2021-08-06',
   'x-ms-creation-time',
-  'Wed, 11 Sep 2019 02:25:45 GMT',
+  'Thu, 28 Jul 2022 08:32:03 GMT',
   'x-ms-lease-status',
   'unlocked',
   'x-ms-lease-state',
@@ -88,31 +91,28 @@ nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParam
   'content-disposition-override',
   'x-ms-server-encrypted',
   'true',
-  'x-ms-access-tier',
-  'Cool',
-  'x-ms-access-tier-inferred',
-  'true',
   'Access-Control-Expose-Headers',
-  'x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,x-ms-tag-count,Content-Type,Last-Modified,ETag,x-ms-creation-time,x-ms-lease-status,x-ms-lease-state,x-ms-blob-type,x-ms-blob-sequence-number,Cache-Control,Content-Disposition,Content-Encoding,Content-Language,x-ms-server-encrypted,x-ms-access-tier,x-ms-access-tier-inferred,Accept-Ranges,Content-Length,Date,Transfer-Encoding',
+  'x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,Content-Type,Last-Modified,ETag,x-ms-creation-time,x-ms-lease-status,x-ms-lease-state,x-ms-blob-type,x-ms-blob-sequence-number,Cache-Control,Content-Disposition,Content-Encoding,Content-Language,x-ms-server-encrypted,Accept-Ranges,Content-Length,Date,Transfer-Encoding',
   'Access-Control-Allow-Origin',
   '*',
   'Date',
-  'Wed, 11 Sep 2019 02:25:45 GMT' ]);
-
+  'Thu, 28 Jul 2022 08:32:03 GMT'
+]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .delete('/container-with-dash156816874476402005')
+  .delete('/container-with-dash165899712335902552')
   .query(true)
-  .reply(202, "", [ 'Content-Length',
+  .reply(202, "", [
+  'Content-Length',
   '0',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'ed192893-f01e-0005-3a48-689283000000',
+  '56907721-201e-0032-3b5c-a2e4ce000000',
   'x-ms-client-request-id',
-  '1493f33e-ea76-42eb-889e-831af53650a8',
+  '0b45a2f4-7d59-4421-8e22-28300fa3869d',
   'x-ms-version',
-  '2019-02-02',
+  '2021-08-06',
   'Date',
-  'Wed, 11 Sep 2019 02:25:45 GMT' ]);
-
+  'Thu, 28 Jul 2022 08:32:03 GMT'
+]);

--- a/sdk/storage/storage-blob/recordings/node/special_naming_tests/recording_should_work_with_special_blob_name_arabic.js
+++ b/sdk/storage/storage-blob/recordings/node/special_naming_tests/recording_should_work_with_special_blob_name_arabic.js
@@ -1,76 +1,83 @@
 let nock = require('nock');
 
-module.exports.testInfo = {"uniqueName":{"1container-with-dash":"1container-with-dash158018565218806901","عربي/عربى":"عربي/عربى158018565252204590"},"newDate":{}}
+module.exports.hash = "785a27c83e6f1c1d7dba9b80b9d4addd";
+
+module.exports.testInfo = {"uniqueName":{"1container-with-dash":"1container-with-dash165899641924208231","عربي/عربى":"عربي/عربى165899641934304313"},"newDate":{}}
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/1container-with-dash158018565218806901')
+  .put('/1container-with-dash165899641924208231')
   .query(true)
-  .reply(201, "", [ 'Content-Length',
+  .reply(201, "", [
+  'Content-Length',
   '0',
   'Last-Modified',
-  'Tue, 28 Jan 2020 04:27:32 GMT',
+  'Thu, 28 Jul 2022 08:20:19 GMT',
   'ETag',
-  '"0x8D7A3AA64A6F4F4"',
+  '"0x8DA70720265883D"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '6a5463b7-601e-0066-4793-d5d4a6000000',
+  '966ce3ad-301e-0001-345a-a2bb65000000',
   'x-ms-client-request-id',
-  '4cfbd779-6adf-41da-b1f8-9a78f621081e',
+  '18082bbc-bf73-4af7-b7bc-5ba9ac11bd65',
   'x-ms-version',
-  '2019-02-02',
+  '2021-08-06',
   'Date',
-  'Tue, 28 Jan 2020 04:27:32 GMT' ]);
+  'Thu, 28 Jul 2022 08:20:18 GMT'
+]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/1container-with-dash158018565218806901/%D8%B9%D8%B1%D8%A8%D9%8A%2F%D8%B9%D8%B1%D8%A8%D9%89158018565252204590', "A")
-  .reply(201, "", [ 'Content-Length',
+  .put('/1container-with-dash165899641924208231/%D8%B9%D8%B1%D8%A8%D9%8A/%D8%B9%D8%B1%D8%A8%D9%89165899641934304313', "A")
+  .reply(201, "", [
+  'Content-Length',
   '0',
   'Content-MD5',
   'f8VicOenD6gaWTW3Lqy+KQ==',
   'Last-Modified',
-  'Tue, 28 Jan 2020 04:27:32 GMT',
+  'Thu, 28 Jul 2022 08:20:19 GMT',
   'ETag',
-  '"0x8D7A3AA64DBE93C"',
+  '"0x8DA7072027777C7"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '2bd86841-401e-0017-4a93-d5a69f000000',
+  '966ce3cc-301e-0001-515a-a2bb65000000',
   'x-ms-client-request-id',
-  'fc00d5b5-1dcd-41cd-b0b0-30988532e829',
+  '4c3d7811-feed-42d4-a203-459aa84ad21c',
   'x-ms-version',
-  '2019-02-02',
+  '2021-08-06',
   'x-ms-content-crc64',
   'PiO3pTJ67n0=',
   'x-ms-request-server-encrypted',
   'true',
   'Date',
-  'Tue, 28 Jan 2020 04:27:31 GMT' ]);
+  'Thu, 28 Jul 2022 08:20:18 GMT'
+]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .head('/1container-with-dash158018565218806901/%D8%B9%D8%B1%D8%A8%D9%8A%2F%D8%B9%D8%B1%D8%A8%D9%89158018565252204590')
-  .reply(200, "", [ 'Content-Length',
+  .head('/1container-with-dash165899641924208231/%D8%B9%D8%B1%D8%A8%D9%8A/%D8%B9%D8%B1%D8%A8%D9%89165899641934304313')
+  .reply(200, "", [
+  'Content-Length',
   '1',
   'Content-Type',
   'application/octet-stream',
   'Content-MD5',
   'f8VicOenD6gaWTW3Lqy+KQ==',
   'Last-Modified',
-  'Tue, 28 Jan 2020 04:27:32 GMT',
+  'Thu, 28 Jul 2022 08:20:19 GMT',
   'Accept-Ranges',
   'bytes',
   'ETag',
-  '"0x8D7A3AA64DBE93C"',
+  '"0x8DA7072027777C7"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '2bd86867-401e-0017-6b93-d5a69f000000',
+  '966ce3ec-301e-0001-6c5a-a2bb65000000',
   'x-ms-client-request-id',
-  '283e6f24-17b4-4640-8074-e239cccf2974',
+  'bcd359dc-b937-4387-af3b-1bf47d45c2b6',
   'x-ms-version',
-  '2019-02-02',
+  '2021-08-06',
   'x-ms-creation-time',
-  'Tue, 28 Jan 2020 04:27:32 GMT',
+  'Thu, 28 Jul 2022 08:20:19 GMT',
   'x-ms-lease-status',
   'unlocked',
   'x-ms-lease-state',
@@ -80,7 +87,7 @@ nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParam
   'x-ms-server-encrypted',
   'true',
   'x-ms-access-tier',
-  'Cool',
+  'Hot',
   'x-ms-access-tier-inferred',
   'true',
   'Access-Control-Expose-Headers',
@@ -88,42 +95,47 @@ nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParam
   'Access-Control-Allow-Origin',
   '*',
   'Date',
-  'Tue, 28 Jan 2020 04:27:31 GMT' ]);
+  'Thu, 28 Jul 2022 08:20:18 GMT'
+]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .get('/1container-with-dash158018565218806901')
+  .get('/1container-with-dash165899641924208231')
   .query(true)
-  .reply(200, "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults ServiceEndpoint=\"https://fakestorageaccount.blob.core.windows.net/\" ContainerName=\"1container-with-dash158018565218806901\"><Prefix>عربي/عربى158018565252204590</Prefix><Blobs><Blob><Name>عربي/عربى158018565252204590</Name><Properties><Creation-Time>Tue, 28 Jan 2020 04:27:32 GMT</Creation-Time><Last-Modified>Tue, 28 Jan 2020 04:27:32 GMT</Last-Modified><Etag>0x8D7A3AA64DBE93C</Etag><Content-Length>1</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>f8VicOenD6gaWTW3Lqy+KQ==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Cool</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties></Blob></Blobs><NextMarker /></EnumerationResults>", [ 'Transfer-Encoding',
+  .reply(200, "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults ServiceEndpoint=\"https://fakestorageaccount.blob.core.windows.net/\" ContainerName=\"1container-with-dash165899641924208231\"><Prefix>عربي/عربى165899641934304313</Prefix><Blobs><Blob><Name>عربي/عربى165899641934304313</Name><Properties><Creation-Time>Thu, 28 Jul 2022 08:20:19 GMT</Creation-Time><Last-Modified>Thu, 28 Jul 2022 08:20:19 GMT</Last-Modified><Etag>0x8DA7072027777C7</Etag><Content-Length>1</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>f8VicOenD6gaWTW3Lqy+KQ==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties><OrMetadata /></Blob></Blobs><NextMarker /></EnumerationResults>", [
+  'Transfer-Encoding',
   'chunked',
   'Content-Type',
   'application/xml',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '6a5464a8-601e-0066-2a93-d5d4a6000000',
+  '966ce417-301e-0001-125a-a2bb65000000',
   'x-ms-client-request-id',
-  '994d0e78-67c2-42b7-ab1c-765d26f14438',
+  '31b8f579-5a5e-4f5e-9c13-7da0fadacd32',
   'x-ms-version',
-  '2019-02-02',
+  '2021-08-06',
   'Access-Control-Expose-Headers',
   'x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,Content-Type,Content-Length,Date,Transfer-Encoding',
   'Access-Control-Allow-Origin',
   '*',
   'Date',
-  'Tue, 28 Jan 2020 04:27:32 GMT' ]);
+  'Thu, 28 Jul 2022 08:20:18 GMT'
+]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .delete('/1container-with-dash158018565218806901')
+  .delete('/1container-with-dash165899641924208231')
   .query(true)
-  .reply(202, "", [ 'Content-Length',
+  .reply(202, "", [
+  'Content-Length',
   '0',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '6a5464d8-601e-0066-5893-d5d4a6000000',
+  '966ce43d-301e-0001-365a-a2bb65000000',
   'x-ms-client-request-id',
-  'eafc386d-c73b-48b2-b604-d358c744a2be',
+  '446dd4c2-9678-4d91-94af-d0a45472d1b2',
   'x-ms-version',
-  '2019-02-02',
+  '2021-08-06',
   'Date',
-  'Tue, 28 Jan 2020 04:27:32 GMT' ]);
+  'Thu, 28 Jul 2022 08:20:18 GMT'
+]);

--- a/sdk/storage/storage-blob/recordings/node/special_naming_tests/recording_should_work_with_special_blob_name_characters.js
+++ b/sdk/storage/storage-blob/recordings/node/special_naming_tests/recording_should_work_with_special_blob_name_characters.js
@@ -1,76 +1,83 @@
 let nock = require('nock');
 
-module.exports.testInfo = {"uniqueName":{"1container-with-dash":"1container-with-dash158018564632608442","汉字. special ~!@#$%^&*()_+`1234567890-={}|[]\\:\";'<>?,/'":"汉字. special ~!@#$%^&*()_+`1234567890-={}|[]\\:\";'<>?,/'158018564668502064"},"newDate":{}}
+module.exports.hash = "a3e8f44b075dadc9dc9129794d451fba";
+
+module.exports.testInfo = {"uniqueName":{"1container-with-dash":"1container-with-dash165899641814604988","汉字. special ~!@#$%^&*()_+`1234567890-={}|[]\\:\";'<>?,/'":"汉字. special ~!@#$%^&*()_+`1234567890-={}|[]\\:\";'<>?,/'165899641878602248"},"newDate":{}}
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/1container-with-dash158018564632608442')
+  .put('/1container-with-dash165899641814604988')
   .query(true)
-  .reply(201, "", [ 'Content-Length',
+  .reply(201, "", [
+  'Content-Length',
   '0',
   'Last-Modified',
-  'Tue, 28 Jan 2020 04:27:26 GMT',
+  'Thu, 28 Jul 2022 08:20:18 GMT',
   'ETag',
-  '"0x8D7A3AA612BD731"',
+  '"0x8DA7072020D89DB"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'f3c46228-b01e-002b-2193-d51244000000',
+  '966ce298-301e-0001-3c5a-a2bb65000000',
   'x-ms-client-request-id',
-  'f17a2f3d-1c45-4d22-90eb-3e9d5b07640d',
+  'acc221d4-143e-49a2-b8e4-07188b816225',
   'x-ms-version',
-  '2019-02-02',
+  '2021-08-06',
   'Date',
-  'Tue, 28 Jan 2020 04:27:26 GMT' ]);
+  'Thu, 28 Jul 2022 08:20:18 GMT'
+]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/1container-with-dash158018564632608442/%E6%B1%89%E5%AD%97.%20special%20~!%40%23%24%25%5E%26*()_%2B%601234567890-%3D%7B%7D%7C%5B%5D%5C%3A%22%3B%27%3C%3E%3F%2C%2F%27158018564668502064', "A")
-  .reply(201, "", [ 'Content-Length',
+  .put('/1container-with-dash165899641814604988/%E6%B1%89%E5%AD%97.%20special%20~!%40%23%24%25%5E%26*()_%2B%601234567890-%3D%7B%7D%7C%5B%5D%5C%3A%22%3B%27%3C%3E%3F%2C/%27165899641878602248', "A")
+  .reply(201, "", [
+  'Content-Length',
   '0',
   'Content-MD5',
   'f8VicOenD6gaWTW3Lqy+KQ==',
   'Last-Modified',
-  'Tue, 28 Jan 2020 04:27:26 GMT',
+  'Thu, 28 Jul 2022 08:20:19 GMT',
   'ETag',
-  '"0x8D7A3AA6161176D"',
+  '"0x8DA707202240E1B"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'e5a7b250-c01e-0060-3f93-d523de000000',
+  '966ce2ec-301e-0001-055a-a2bb65000000',
   'x-ms-client-request-id',
-  'be189347-d457-4b7d-9215-e8da0574cc1c',
+  '5c8e8457-b4a1-4849-a160-5216ce5db7d9',
   'x-ms-version',
-  '2019-02-02',
+  '2021-08-06',
   'x-ms-content-crc64',
   'PiO3pTJ67n0=',
   'x-ms-request-server-encrypted',
   'true',
   'Date',
-  'Tue, 28 Jan 2020 04:27:26 GMT' ]);
+  'Thu, 28 Jul 2022 08:20:18 GMT'
+]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .head('/1container-with-dash158018564632608442/%E6%B1%89%E5%AD%97.%20special%20~!%40%23%24%25%5E%26*()_%2B%601234567890-%3D%7B%7D%7C%5B%5D%5C%3A%22%3B%27%3C%3E%3F%2C%2F%27158018564668502064')
-  .reply(200, "", [ 'Content-Length',
+  .head('/1container-with-dash165899641814604988/%E6%B1%89%E5%AD%97.%20special%20~!%40%23%24%25%5E%26*()_%2B%601234567890-%3D%7B%7D%7C%5B%5D%5C%3A%22%3B%27%3C%3E%3F%2C/%27165899641878602248')
+  .reply(200, "", [
+  'Content-Length',
   '1',
   'Content-Type',
   'application/octet-stream',
   'Content-MD5',
   'f8VicOenD6gaWTW3Lqy+KQ==',
   'Last-Modified',
-  'Tue, 28 Jan 2020 04:27:26 GMT',
+  'Thu, 28 Jul 2022 08:20:19 GMT',
   'Accept-Ranges',
   'bytes',
   'ETag',
-  '"0x8D7A3AA6161176D"',
+  '"0x8DA707202240E1B"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'e5a7b27f-c01e-0060-6c93-d523de000000',
+  '966ce31c-301e-0001-305a-a2bb65000000',
   'x-ms-client-request-id',
-  'ff304cc0-f173-4164-8352-8491c60e704c',
+  '8fb1b4fd-91d1-4bfb-8cf5-75f20ce58243',
   'x-ms-version',
-  '2019-02-02',
+  '2021-08-06',
   'x-ms-creation-time',
-  'Tue, 28 Jan 2020 04:27:26 GMT',
+  'Thu, 28 Jul 2022 08:20:19 GMT',
   'x-ms-lease-status',
   'unlocked',
   'x-ms-lease-state',
@@ -80,7 +87,7 @@ nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParam
   'x-ms-server-encrypted',
   'true',
   'x-ms-access-tier',
-  'Cool',
+  'Hot',
   'x-ms-access-tier-inferred',
   'true',
   'Access-Control-Expose-Headers',
@@ -88,42 +95,47 @@ nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParam
   'Access-Control-Allow-Origin',
   '*',
   'Date',
-  'Tue, 28 Jan 2020 04:27:26 GMT' ]);
+  'Thu, 28 Jul 2022 08:20:18 GMT'
+]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .get('/1container-with-dash158018564632608442')
+  .get('/1container-with-dash165899641814604988')
   .query(true)
-  .reply(200, "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults ServiceEndpoint=\"https://fakestorageaccount.blob.core.windows.net/\" ContainerName=\"1container-with-dash158018564632608442\"><Prefix>汉字. special ~!@#$%^&amp;*()_+`1234567890-={}|[]/:\";'&lt;&gt;?,/'158018564668502064</Prefix><Blobs><Blob><Name>汉字. special ~!@#$%^&amp;*()_+`1234567890-={}|[]/:\";'&lt;&gt;?,/'158018564668502064</Name><Properties><Creation-Time>Tue, 28 Jan 2020 04:27:26 GMT</Creation-Time><Last-Modified>Tue, 28 Jan 2020 04:27:26 GMT</Last-Modified><Etag>0x8D7A3AA6161176D</Etag><Content-Length>1</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>f8VicOenD6gaWTW3Lqy+KQ==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Cool</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties></Blob></Blobs><NextMarker /></EnumerationResults>", [ 'Transfer-Encoding',
+  .reply(200, "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults ServiceEndpoint=\"https://fakestorageaccount.blob.core.windows.net/\" ContainerName=\"1container-with-dash165899641814604988\"><Prefix>汉字. special ~!@#$%^&amp;*()_+`1234567890-={}|[]/:\";'&lt;&gt;?,/'165899641878602248</Prefix><Blobs><Blob><Name>汉字. special ~!@#$%^&amp;*()_+`1234567890-={}|[]/:\";'&lt;&gt;?,/'165899641878602248</Name><Properties><Creation-Time>Thu, 28 Jul 2022 08:20:19 GMT</Creation-Time><Last-Modified>Thu, 28 Jul 2022 08:20:19 GMT</Last-Modified><Etag>0x8DA707202240E1B</Etag><Content-Length>1</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>f8VicOenD6gaWTW3Lqy+KQ==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties><OrMetadata /></Blob></Blobs><NextMarker /></EnumerationResults>", [
+  'Transfer-Encoding',
   'chunked',
   'Content-Type',
   'application/xml',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'f3c462bf-b01e-002b-2d93-d51244000000',
+  '966ce354-301e-0001-645a-a2bb65000000',
   'x-ms-client-request-id',
-  'a2ac09db-73c9-4dc3-902d-375a7cd347cc',
+  '73e5b99d-37af-4a8d-bf26-0cdf52c5ee45',
   'x-ms-version',
-  '2019-02-02',
+  '2021-08-06',
   'Access-Control-Expose-Headers',
   'x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,Content-Type,Content-Length,Date,Transfer-Encoding',
   'Access-Control-Allow-Origin',
   '*',
   'Date',
-  'Tue, 28 Jan 2020 04:27:26 GMT' ]);
+  'Thu, 28 Jul 2022 08:20:18 GMT'
+]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .delete('/1container-with-dash158018564632608442')
+  .delete('/1container-with-dash165899641814604988')
   .query(true)
-  .reply(202, "", [ 'Content-Length',
+  .reply(202, "", [
+  'Content-Length',
   '0',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'f3c462e2-b01e-002b-5093-d51244000000',
+  '966ce37f-301e-0001-0c5a-a2bb65000000',
   'x-ms-client-request-id',
-  '4875039e-6eca-4a50-8049-a328a8f6c9e9',
+  '0c55e4d6-cdf2-4a26-a740-c81d3a254977',
   'x-ms-version',
-  '2019-02-02',
+  '2021-08-06',
   'Date',
-  'Tue, 28 Jan 2020 04:27:26 GMT' ]);
+  'Thu, 28 Jul 2022 08:20:18 GMT'
+]);

--- a/sdk/storage/storage-blob/recordings/node/special_naming_tests/recording_should_work_with_special_blob_name_japanese.js
+++ b/sdk/storage/storage-blob/recordings/node/special_naming_tests/recording_should_work_with_special_blob_name_japanese.js
@@ -1,76 +1,83 @@
 let nock = require('nock');
 
-module.exports.testInfo = {"uniqueName":{"1container-with-dash":"1container-with-dash158018565505707754","にっぽんご/にほんご":"にっぽんご/にほんご158018565540201753"},"newDate":{}}
+module.exports.hash = "50a564171a05c584c1936e8d7bdac701";
+
+module.exports.testInfo = {"uniqueName":{"1container-with-dash":"1container-with-dash165899641975800053","にっぽんご/にほんご":"にっぽんご/にほんご165899641986002386"},"newDate":{}}
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/1container-with-dash158018565505707754')
+  .put('/1container-with-dash165899641975800053')
   .query(true)
-  .reply(201, "", [ 'Content-Length',
+  .reply(201, "", [
+  'Content-Length',
   '0',
   'Last-Modified',
-  'Tue, 28 Jan 2020 04:27:35 GMT',
+  'Thu, 28 Jul 2022 08:20:20 GMT',
   'ETag',
-  '"0x8D7A3AA665E0398"',
+  '"0x8DA707202B43928"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'b910a3e5-b01e-0046-0793-d5b86a000000',
+  '966ce46a-301e-0001-5d5a-a2bb65000000',
   'x-ms-client-request-id',
-  'd29b0538-3daf-4177-ae33-f7df78071acb',
+  '94be08ba-9fb9-4c11-b684-8794d52d3121',
   'x-ms-version',
-  '2019-02-02',
+  '2021-08-06',
   'Date',
-  'Tue, 28 Jan 2020 04:27:35 GMT' ]);
+  'Thu, 28 Jul 2022 08:20:19 GMT'
+]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/1container-with-dash158018565505707754/%E3%81%AB%E3%81%A3%E3%81%BD%E3%82%93%E3%81%94%2F%E3%81%AB%E3%81%BB%E3%82%93%E3%81%94158018565540201753', "A")
-  .reply(201, "", [ 'Content-Length',
+  .put('/1container-with-dash165899641975800053/%E3%81%AB%E3%81%A3%E3%81%BD%E3%82%93%E3%81%94/%E3%81%AB%E3%81%BB%E3%82%93%E3%81%94165899641986002386', "A")
+  .reply(201, "", [
+  'Content-Length',
   '0',
   'Content-MD5',
   'f8VicOenD6gaWTW3Lqy+KQ==',
   'Last-Modified',
-  'Tue, 28 Jan 2020 04:27:35 GMT',
+  'Thu, 28 Jul 2022 08:20:20 GMT',
   'ETag',
-  '"0x8D7A3AA66927338"',
+  '"0x8DA707202C60055"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '710ed757-e01e-0038-2a93-d527a5000000',
+  '966ce49e-301e-0001-085a-a2bb65000000',
   'x-ms-client-request-id',
-  'b852dd65-fc33-43c5-bcee-0ff1cf9d6da3',
+  'd19d893c-9aa3-4dc9-8f44-68b40628eb75',
   'x-ms-version',
-  '2019-02-02',
+  '2021-08-06',
   'x-ms-content-crc64',
   'PiO3pTJ67n0=',
   'x-ms-request-server-encrypted',
   'true',
   'Date',
-  'Tue, 28 Jan 2020 04:27:34 GMT' ]);
+  'Thu, 28 Jul 2022 08:20:19 GMT'
+]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .head('/1container-with-dash158018565505707754/%E3%81%AB%E3%81%A3%E3%81%BD%E3%82%93%E3%81%94%2F%E3%81%AB%E3%81%BB%E3%82%93%E3%81%94158018565540201753')
-  .reply(200, "", [ 'Content-Length',
+  .head('/1container-with-dash165899641975800053/%E3%81%AB%E3%81%A3%E3%81%BD%E3%82%93%E3%81%94/%E3%81%AB%E3%81%BB%E3%82%93%E3%81%94165899641986002386')
+  .reply(200, "", [
+  'Content-Length',
   '1',
   'Content-Type',
   'application/octet-stream',
   'Content-MD5',
   'f8VicOenD6gaWTW3Lqy+KQ==',
   'Last-Modified',
-  'Tue, 28 Jan 2020 04:27:35 GMT',
+  'Thu, 28 Jul 2022 08:20:20 GMT',
   'Accept-Ranges',
   'bytes',
   'ETag',
-  '"0x8D7A3AA66927338"',
+  '"0x8DA707202C60055"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '710ed76b-e01e-0038-3a93-d527a5000000',
+  '966ce4e5-301e-0001-495a-a2bb65000000',
   'x-ms-client-request-id',
-  '84a4f3a8-cb8d-411f-a601-8716814b7b30',
+  'cab3b49c-b550-49a8-aedb-60bb03db53fa',
   'x-ms-version',
-  '2019-02-02',
+  '2021-08-06',
   'x-ms-creation-time',
-  'Tue, 28 Jan 2020 04:27:35 GMT',
+  'Thu, 28 Jul 2022 08:20:20 GMT',
   'x-ms-lease-status',
   'unlocked',
   'x-ms-lease-state',
@@ -80,7 +87,7 @@ nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParam
   'x-ms-server-encrypted',
   'true',
   'x-ms-access-tier',
-  'Cool',
+  'Hot',
   'x-ms-access-tier-inferred',
   'true',
   'Access-Control-Expose-Headers',
@@ -88,42 +95,47 @@ nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParam
   'Access-Control-Allow-Origin',
   '*',
   'Date',
-  'Tue, 28 Jan 2020 04:27:34 GMT' ]);
+  'Thu, 28 Jul 2022 08:20:19 GMT'
+]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .get('/1container-with-dash158018565505707754')
+  .get('/1container-with-dash165899641975800053')
   .query(true)
-  .reply(200, "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults ServiceEndpoint=\"https://fakestorageaccount.blob.core.windows.net/\" ContainerName=\"1container-with-dash158018565505707754\"><Prefix>にっぽんご/にほんご158018565540201753</Prefix><Blobs><Blob><Name>にっぽんご/にほんご158018565540201753</Name><Properties><Creation-Time>Tue, 28 Jan 2020 04:27:35 GMT</Creation-Time><Last-Modified>Tue, 28 Jan 2020 04:27:35 GMT</Last-Modified><Etag>0x8D7A3AA66927338</Etag><Content-Length>1</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>f8VicOenD6gaWTW3Lqy+KQ==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Cool</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties></Blob></Blobs><NextMarker /></EnumerationResults>", [ 'Transfer-Encoding',
+  .reply(200, "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults ServiceEndpoint=\"https://fakestorageaccount.blob.core.windows.net/\" ContainerName=\"1container-with-dash165899641975800053\"><Prefix>にっぽんご/にほんご165899641986002386</Prefix><Blobs><Blob><Name>にっぽんご/にほんご165899641986002386</Name><Properties><Creation-Time>Thu, 28 Jul 2022 08:20:20 GMT</Creation-Time><Last-Modified>Thu, 28 Jul 2022 08:20:20 GMT</Last-Modified><Etag>0x8DA707202C60055</Etag><Content-Length>1</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>f8VicOenD6gaWTW3Lqy+KQ==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties><OrMetadata /></Blob></Blobs><NextMarker /></EnumerationResults>", [
+  'Transfer-Encoding',
   'chunked',
   'Content-Type',
   'application/xml',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'b910a501-b01e-0046-6c93-d5b86a000000',
+  '966ce508-301e-0001-655a-a2bb65000000',
   'x-ms-client-request-id',
-  'e5b30e48-d5c9-4161-bc07-b998161e3b45',
+  'bf9afe70-004a-467e-a8a1-1aacd9a0015f',
   'x-ms-version',
-  '2019-02-02',
+  '2021-08-06',
   'Access-Control-Expose-Headers',
   'x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,Content-Type,Content-Length,Date,Transfer-Encoding',
   'Access-Control-Allow-Origin',
   '*',
   'Date',
-  'Tue, 28 Jan 2020 04:27:35 GMT' ]);
+  'Thu, 28 Jul 2022 08:20:19 GMT'
+]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .delete('/1container-with-dash158018565505707754')
+  .delete('/1container-with-dash165899641975800053')
   .query(true)
-  .reply(202, "", [ 'Content-Length',
+  .reply(202, "", [
+  'Content-Length',
   '0',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'b910a535-b01e-0046-1393-d5b86a000000',
+  '966ce51e-301e-0001-7a5a-a2bb65000000',
   'x-ms-client-request-id',
-  '7d1763fe-03f6-4171-ba2e-dbb02c300f9a',
+  '61479d7e-878a-4486-b81b-069756bed314',
   'x-ms-version',
-  '2019-02-02',
+  '2021-08-06',
   'Date',
-  'Tue, 28 Jan 2020 04:27:35 GMT' ]);
+  'Thu, 28 Jul 2022 08:20:19 GMT'
+]);

--- a/sdk/storage/storage-blob/recordings/node/special_naming_tests/recording_should_work_with_special_blob_names_chinese_characters.js
+++ b/sdk/storage/storage-blob/recordings/node/special_naming_tests/recording_should_work_with_special_blob_names_chinese_characters.js
@@ -1,76 +1,83 @@
 let nock = require('nock');
 
-module.exports.testInfo = {"uniqueName":{"1container-with-dash":"1container-with-dash158018564436600672","////Upper/blob/empty /another 汉字":"////Upper/blob/empty /another 汉字158018564472508834"},"newDate":{}}
+module.exports.hash = "a5ccd1352b0f424a08a5e84536559ab4";
+
+module.exports.testInfo = {"uniqueName":{"1container-with-dash":"1container-with-dash165899673442401637","////Upper/blob/empty /another 汉字":"////Upper/blob/empty /another 汉字165899673452609363"},"newDate":{}}
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/1container-with-dash158018564436600672')
+  .put('/1container-with-dash165899673442401637')
   .query(true)
-  .reply(201, "", [ 'Content-Length',
+  .reply(201, "", [
+  'Content-Length',
   '0',
   'Last-Modified',
-  'Tue, 28 Jan 2020 04:27:24 GMT',
+  'Thu, 28 Jul 2022 08:25:34 GMT',
   'ETag',
-  '"0x8D7A3AA60007B8B"',
+  '"0x8DA7072BE428C54"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'b5b47178-901e-005a-2193-d5607d000000',
+  '3b57c0c2-701e-0000-525b-a2e4b9000000',
   'x-ms-client-request-id',
-  '4cf1dbfc-a743-4d1b-9419-4de8c3d8ba07',
+  '9a725c32-13aa-4404-b1fe-c8a9f191412b',
   'x-ms-version',
-  '2019-02-02',
+  '2021-08-06',
   'Date',
-  'Tue, 28 Jan 2020 04:27:24 GMT' ]);
+  'Thu, 28 Jul 2022 08:25:34 GMT'
+]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/1container-with-dash158018564436600672/%2F%2F%2F%2FUpper%2Fblob%2Fempty%20%2Fanother%20%E6%B1%89%E5%AD%97158018564472508834', "A")
-  .reply(201, "", [ 'Content-Length',
+  .put('/1container-with-dash165899673442401637/////Upper/blob/empty%20/another%20%E6%B1%89%E5%AD%97165899673452609363', "A")
+  .reply(201, "", [
+  'Content-Length',
   '0',
   'Content-MD5',
   'f8VicOenD6gaWTW3Lqy+KQ==',
   'Last-Modified',
-  'Tue, 28 Jan 2020 04:27:25 GMT',
+  'Thu, 28 Jul 2022 08:25:34 GMT',
   'ETag',
-  '"0x8D7A3AA60350C0D"',
+  '"0x8DA7072BE53E588"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'c235ee87-b01e-0064-3c93-d5d65c000000',
+  '3b57c0ee-701e-0000-735b-a2e4b9000000',
   'x-ms-client-request-id',
-  'f3bbc4aa-350b-4a7f-9be7-ba913440759f',
+  'bb5e37c4-edcb-4548-a4f3-1efe13559932',
   'x-ms-version',
-  '2019-02-02',
+  '2021-08-06',
   'x-ms-content-crc64',
   'PiO3pTJ67n0=',
   'x-ms-request-server-encrypted',
   'true',
   'Date',
-  'Tue, 28 Jan 2020 04:27:24 GMT' ]);
+  'Thu, 28 Jul 2022 08:25:34 GMT'
+]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .head('/1container-with-dash158018564436600672/%2F%2F%2F%2FUpper%2Fblob%2Fempty%20%2Fanother%20%E6%B1%89%E5%AD%97158018564472508834')
-  .reply(200, "", [ 'Content-Length',
+  .head('/1container-with-dash165899673442401637/////Upper/blob/empty%20/another%20%E6%B1%89%E5%AD%97165899673452609363')
+  .reply(200, "", [
+  'Content-Length',
   '1',
   'Content-Type',
   'application/octet-stream',
   'Content-MD5',
   'f8VicOenD6gaWTW3Lqy+KQ==',
   'Last-Modified',
-  'Tue, 28 Jan 2020 04:27:25 GMT',
+  'Thu, 28 Jul 2022 08:25:34 GMT',
   'Accept-Ranges',
   'bytes',
   'ETag',
-  '"0x8D7A3AA60350C0D"',
+  '"0x8DA7072BE53E588"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'c235eec1-b01e-0064-7093-d5d65c000000',
+  '3b57c114-701e-0000-0d5b-a2e4b9000000',
   'x-ms-client-request-id',
-  'f5beb622-d063-49cf-beab-a9fb79b2d12c',
+  'e47b84f6-8018-4ed7-84d0-22dab40895d2',
   'x-ms-version',
-  '2019-02-02',
+  '2021-08-06',
   'x-ms-creation-time',
-  'Tue, 28 Jan 2020 04:27:25 GMT',
+  'Thu, 28 Jul 2022 08:25:34 GMT',
   'x-ms-lease-status',
   'unlocked',
   'x-ms-lease-state',
@@ -80,7 +87,7 @@ nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParam
   'x-ms-server-encrypted',
   'true',
   'x-ms-access-tier',
-  'Cool',
+  'Hot',
   'x-ms-access-tier-inferred',
   'true',
   'Access-Control-Expose-Headers',
@@ -88,42 +95,47 @@ nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParam
   'Access-Control-Allow-Origin',
   '*',
   'Date',
-  'Tue, 28 Jan 2020 04:27:24 GMT' ]);
+  'Thu, 28 Jul 2022 08:25:34 GMT'
+]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .get('/1container-with-dash158018564436600672')
+  .get('/1container-with-dash165899673442401637')
   .query(true)
-  .reply(200, "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults ServiceEndpoint=\"https://fakestorageaccount.blob.core.windows.net/\" ContainerName=\"1container-with-dash158018564436600672\"><Prefix>////Upper/blob/empty /another 汉字158018564472508834</Prefix><Blobs><Blob><Name>////Upper/blob/empty /another 汉字158018564472508834</Name><Properties><Creation-Time>Tue, 28 Jan 2020 04:27:25 GMT</Creation-Time><Last-Modified>Tue, 28 Jan 2020 04:27:25 GMT</Last-Modified><Etag>0x8D7A3AA60350C0D</Etag><Content-Length>1</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>f8VicOenD6gaWTW3Lqy+KQ==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Cool</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties></Blob></Blobs><NextMarker /></EnumerationResults>", [ 'Transfer-Encoding',
+  .reply(200, "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults ServiceEndpoint=\"https://fakestorageaccount.blob.core.windows.net/\" ContainerName=\"1container-with-dash165899673442401637\"><Prefix>////Upper/blob/empty /another 汉字165899673452609363</Prefix><Blobs><Blob><Name>////Upper/blob/empty /another 汉字165899673452609363</Name><Properties><Creation-Time>Thu, 28 Jul 2022 08:25:34 GMT</Creation-Time><Last-Modified>Thu, 28 Jul 2022 08:25:34 GMT</Last-Modified><Etag>0x8DA7072BE53E588</Etag><Content-Length>1</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>f8VicOenD6gaWTW3Lqy+KQ==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties><OrMetadata /></Blob></Blobs><NextMarker /></EnumerationResults>", [
+  'Transfer-Encoding',
   'chunked',
   'Content-Type',
   'application/xml',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'b5b4724c-901e-005a-6793-d5607d000000',
+  '3b57c13d-701e-0000-295b-a2e4b9000000',
   'x-ms-client-request-id',
-  '67a4cd60-14b7-4d65-94a7-1e3974afccee',
+  '57700971-2fbd-4efa-aa0e-d4f159a6c61c',
   'x-ms-version',
-  '2019-02-02',
+  '2021-08-06',
   'Access-Control-Expose-Headers',
   'x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,Content-Type,Content-Length,Date,Transfer-Encoding',
   'Access-Control-Allow-Origin',
   '*',
   'Date',
-  'Tue, 28 Jan 2020 04:27:24 GMT' ]);
+  'Thu, 28 Jul 2022 08:25:34 GMT'
+]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .delete('/1container-with-dash158018564436600672')
+  .delete('/1container-with-dash165899673442401637')
   .query(true)
-  .reply(202, "", [ 'Content-Length',
+  .reply(202, "", [
+  'Content-Length',
   '0',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'b5b47269-901e-005a-0293-d5607d000000',
+  '3b57c183-701e-0000-615b-a2e4b9000000',
   'x-ms-client-request-id',
-  '1094eb94-27cb-44bc-aaf4-fe7c3cbff439',
+  '29d16ded-b076-4afc-b4df-4387868f4ee3',
   'x-ms-version',
-  '2019-02-02',
+  '2021-08-06',
   'Date',
-  'Tue, 28 Jan 2020 04:27:24 GMT' ]);
+  'Thu, 28 Jul 2022 08:25:34 GMT'
+]);

--- a/sdk/storage/storage-blob/recordings/node/special_naming_tests/recording_should_work_with_special_container_and_blob_names_uppercase.js
+++ b/sdk/storage/storage-blob/recordings/node/special_naming_tests/recording_should_work_with_special_container_and_blob_names_uppercase.js
@@ -1,76 +1,83 @@
 let nock = require('nock');
 
-module.exports.testInfo = {"uniqueName":{"1container-with-dash":"1container-with-dash158018564244609958","////Upper/blob/empty /another":"////Upper/blob/empty /another158018564279107954"},"newDate":{}}
+module.exports.hash = "c73f653d8fc446392ad31c3a04e977dc";
+
+module.exports.testInfo = {"uniqueName":{"1container-with-dash":"1container-with-dash165899895177706199","////Upper/blob/empty /another":"////Upper/blob/empty /another165899895187901409"},"newDate":{}}
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/1container-with-dash158018564244609958')
+  .put('/1container-with-dash165899895177706199')
   .query(true)
-  .reply(201, "", [ 'Content-Length',
+  .reply(201, "", [
+  'Content-Length',
   '0',
   'Last-Modified',
-  'Tue, 28 Jan 2020 04:27:22 GMT',
+  'Thu, 28 Jul 2022 09:02:32 GMT',
   'ETag',
-  '"0x8D7A3AA5EDA64AC"',
+  '"0x8DA7077E7E75F57"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '95fa1e6d-b01e-0009-0f93-d57c72000000',
+  '3078eb47-301e-0011-4260-a27e0d000000',
   'x-ms-client-request-id',
-  'df17262d-0deb-465b-aa4a-90908ba200ec',
+  '29735586-2890-49bf-9c9d-808ff788fd2e',
   'x-ms-version',
-  '2019-02-02',
+  '2021-08-06',
   'Date',
-  'Tue, 28 Jan 2020 04:27:22 GMT' ]);
+  'Thu, 28 Jul 2022 09:02:31 GMT'
+]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/1container-with-dash158018564244609958/%2F%2F%2F%2FUpper%2Fblob%2Fempty%20%2Fanother158018564279107954', "A")
-  .reply(201, "", [ 'Content-Length',
+  .put('/1container-with-dash165899895177706199/////Upper/blob/empty%20/another165899895187901409', "A")
+  .reply(201, "", [
+  'Content-Length',
   '0',
   'Content-MD5',
   'f8VicOenD6gaWTW3Lqy+KQ==',
   'Last-Modified',
-  'Tue, 28 Jan 2020 04:27:23 GMT',
+  'Thu, 28 Jul 2022 09:02:32 GMT',
   'ETag',
-  '"0x8D7A3AA5F0F1C1E"',
+  '"0x8DA7077E7F95612"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '4a1d8236-801e-0067-4793-d5d55b000000',
+  '3078eb64-301e-0011-5d60-a27e0d000000',
   'x-ms-client-request-id',
-  '4401c77c-bddc-47a3-a852-6b17e093ee7e',
+  '240b1376-38e8-4ef6-9a80-836e0a807d6f',
   'x-ms-version',
-  '2019-02-02',
+  '2021-08-06',
   'x-ms-content-crc64',
   'PiO3pTJ67n0=',
   'x-ms-request-server-encrypted',
   'true',
   'Date',
-  'Tue, 28 Jan 2020 04:27:22 GMT' ]);
+  'Thu, 28 Jul 2022 09:02:31 GMT'
+]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .head('/1container-with-dash158018564244609958/%2F%2F%2F%2FUpper%2Fblob%2Fempty%20%2Fanother158018564279107954')
-  .reply(200, "", [ 'Content-Length',
+  .head('/1container-with-dash165899895177706199/////Upper/blob/empty%20/another165899895187901409')
+  .reply(200, "", [
+  'Content-Length',
   '1',
   'Content-Type',
   'application/octet-stream',
   'Content-MD5',
   'f8VicOenD6gaWTW3Lqy+KQ==',
   'Last-Modified',
-  'Tue, 28 Jan 2020 04:27:23 GMT',
+  'Thu, 28 Jul 2022 09:02:32 GMT',
   'Accept-Ranges',
   'bytes',
   'ETag',
-  '"0x8D7A3AA5F0F1C1E"',
+  '"0x8DA7077E7F95612"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '4a1d825b-801e-0067-6993-d5d55b000000',
+  '3078eb86-301e-0011-7860-a27e0d000000',
   'x-ms-client-request-id',
-  'bfca2cb4-8a2b-4a38-84f6-f6f92f092e28',
+  'dd4ae8ae-0ac3-4d6b-bd81-069f0ab4c889',
   'x-ms-version',
-  '2019-02-02',
+  '2021-08-06',
   'x-ms-creation-time',
-  'Tue, 28 Jan 2020 04:27:23 GMT',
+  'Thu, 28 Jul 2022 09:02:32 GMT',
   'x-ms-lease-status',
   'unlocked',
   'x-ms-lease-state',
@@ -80,7 +87,7 @@ nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParam
   'x-ms-server-encrypted',
   'true',
   'x-ms-access-tier',
-  'Cool',
+  'Hot',
   'x-ms-access-tier-inferred',
   'true',
   'Access-Control-Expose-Headers',
@@ -88,42 +95,47 @@ nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParam
   'Access-Control-Allow-Origin',
   '*',
   'Date',
-  'Tue, 28 Jan 2020 04:27:23 GMT' ]);
+  'Thu, 28 Jul 2022 09:02:31 GMT'
+]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .get('/1container-with-dash158018564244609958')
+  .get('/1container-with-dash165899895177706199')
   .query(true)
-  .reply(200, "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults ServiceEndpoint=\"https://fakestorageaccount.blob.core.windows.net/\" ContainerName=\"1container-with-dash158018564244609958\"><Prefix>////Upper/blob/empty /another158018564279107954</Prefix><Blobs><Blob><Name>////Upper/blob/empty /another158018564279107954</Name><Properties><Creation-Time>Tue, 28 Jan 2020 04:27:23 GMT</Creation-Time><Last-Modified>Tue, 28 Jan 2020 04:27:23 GMT</Last-Modified><Etag>0x8D7A3AA5F0F1C1E</Etag><Content-Length>1</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>f8VicOenD6gaWTW3Lqy+KQ==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Cool</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties></Blob></Blobs><NextMarker /></EnumerationResults>", [ 'Transfer-Encoding',
+  .reply(200, "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults ServiceEndpoint=\"https://fakestorageaccount.blob.core.windows.net/\" ContainerName=\"1container-with-dash165899895177706199\"><Prefix>////Upper/blob/empty /another165899895187901409</Prefix><Blobs><Blob><Name>////Upper/blob/empty /another165899895187901409</Name><Properties><Creation-Time>Thu, 28 Jul 2022 09:02:32 GMT</Creation-Time><Last-Modified>Thu, 28 Jul 2022 09:02:32 GMT</Last-Modified><Etag>0x8DA7077E7F95612</Etag><Content-Length>1</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>f8VicOenD6gaWTW3Lqy+KQ==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties><OrMetadata /></Blob></Blobs><NextMarker /></EnumerationResults>", [
+  'Transfer-Encoding',
   'chunked',
   'Content-Type',
   'application/xml',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '95fa1f7b-b01e-0009-0f93-d57c72000000',
+  '3078eba4-301e-0011-1160-a27e0d000000',
   'x-ms-client-request-id',
-  '3a763367-6f83-4b0a-8174-dd6a106d6be6',
+  '87cb1b80-2883-4298-9df7-f82ec9425aaa',
   'x-ms-version',
-  '2019-02-02',
+  '2021-08-06',
   'Access-Control-Expose-Headers',
   'x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,Content-Type,Content-Length,Date,Transfer-Encoding',
   'Access-Control-Allow-Origin',
   '*',
   'Date',
-  'Tue, 28 Jan 2020 04:27:22 GMT' ]);
+  'Thu, 28 Jul 2022 09:02:31 GMT'
+]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .delete('/1container-with-dash158018564244609958')
+  .delete('/1container-with-dash165899895177706199')
   .query(true)
-  .reply(202, "", [ 'Content-Length',
+  .reply(202, "", [
+  'Content-Length',
   '0',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '95fa1fae-b01e-0009-4193-d57c72000000',
+  '3078ebbc-301e-0011-2460-a27e0d000000',
   'x-ms-client-request-id',
-  'c9469c8f-dd3a-4df2-96f5-fe7c7ff55d45',
+  'b944ea3d-4240-42ca-8058-6a7f69053839',
   'x-ms-version',
-  '2019-02-02',
+  '2021-08-06',
   'Date',
-  'Tue, 28 Jan 2020 04:27:22 GMT' ]);
+  'Thu, 28 Jul 2022 09:02:31 GMT'
+]);

--- a/sdk/storage/storage-blob/recordings/node/special_naming_tests/recording_should_work_with_special_container_and_blob_names_with_.js
+++ b/sdk/storage/storage-blob/recordings/node/special_naming_tests/recording_should_work_with_special_container_and_blob_names_with_.js
@@ -1,76 +1,83 @@
 let nock = require('nock');
 
-module.exports.testInfo = {"uniqueName":{"1container-with-dash":"1container-with-dash158018564046307953","////blob/empty /another":"////blob/empty /another158018564080603229"},"newDate":{}}
+module.exports.hash = "8ca305fe6831a971523c37d9711ee71f";
+
+module.exports.testInfo = {"uniqueName":{"1container-with-dash":"1container-with-dash165899673336306735","////blob/empty /another":"////blob/empty /another165899673399007500"},"newDate":{}}
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/1container-with-dash158018564046307953')
+  .put('/1container-with-dash165899673336306735')
   .query(true)
-  .reply(201, "", [ 'Content-Length',
+  .reply(201, "", [
+  'Content-Length',
   '0',
   'Last-Modified',
-  'Tue, 28 Jan 2020 04:27:20 GMT',
+  'Thu, 28 Jul 2022 08:25:34 GMT',
   'ETag',
-  '"0x8D7A3AA5DAB4022"',
+  '"0x8DA7072BDEF6F69"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '60e28f67-201e-0048-1993-d55461000000',
+  '3b57bfc6-701e-0000-205b-a2e4b9000000',
   'x-ms-client-request-id',
-  '77d2a3e2-3e36-44d3-8ff9-0daf8744efbb',
+  'b2c6d49c-1d92-4f7f-bbf1-6190c9c2cc1c',
   'x-ms-version',
-  '2019-02-02',
+  '2021-08-06',
   'Date',
-  'Tue, 28 Jan 2020 04:27:20 GMT' ]);
+  'Thu, 28 Jul 2022 08:25:33 GMT'
+]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/1container-with-dash158018564046307953/%2F%2F%2F%2Fblob%2Fempty%20%2Fanother158018564080603229', "A")
-  .reply(201, "", [ 'Content-Length',
+  .put('/1container-with-dash165899673336306735/////blob/empty%20/another165899673399007500', "A")
+  .reply(201, "", [
+  'Content-Length',
   '0',
   'Content-MD5',
   'f8VicOenD6gaWTW3Lqy+KQ==',
   'Last-Modified',
-  'Tue, 28 Jan 2020 04:27:21 GMT',
+  'Thu, 28 Jul 2022 08:25:34 GMT',
   'ETag',
-  '"0x8D7A3AA5DE07832"',
+  '"0x8DA7072BE024FE3"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '96e5b408-e01e-0033-4a93-d53fd1000000',
+  '3b57bffb-701e-0000-435b-a2e4b9000000',
   'x-ms-client-request-id',
-  '6f7963e2-2198-4125-946c-add2abdd3873',
+  'db5444c9-194d-4bce-9956-37b80e136926',
   'x-ms-version',
-  '2019-02-02',
+  '2021-08-06',
   'x-ms-content-crc64',
   'PiO3pTJ67n0=',
   'x-ms-request-server-encrypted',
   'true',
   'Date',
-  'Tue, 28 Jan 2020 04:27:20 GMT' ]);
+  'Thu, 28 Jul 2022 08:25:33 GMT'
+]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .head('/1container-with-dash158018564046307953/%2F%2F%2F%2Fblob%2Fempty%20%2Fanother158018564080603229')
-  .reply(200, "", [ 'Content-Length',
+  .head('/1container-with-dash165899673336306735/////blob/empty%20/another165899673399007500')
+  .reply(200, "", [
+  'Content-Length',
   '1',
   'Content-Type',
   'application/octet-stream',
   'Content-MD5',
   'f8VicOenD6gaWTW3Lqy+KQ==',
   'Last-Modified',
-  'Tue, 28 Jan 2020 04:27:21 GMT',
+  'Thu, 28 Jul 2022 08:25:34 GMT',
   'Accept-Ranges',
   'bytes',
   'ETag',
-  '"0x8D7A3AA5DE07832"',
+  '"0x8DA7072BE024FE3"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '96e5b441-e01e-0033-7893-d53fd1000000',
+  '3b57c02c-701e-0000-685b-a2e4b9000000',
   'x-ms-client-request-id',
-  '647b1df0-ac3b-434e-9e49-a252d09c2136',
+  '92cb6c45-625e-4cd5-8f17-27074a5d7691',
   'x-ms-version',
-  '2019-02-02',
+  '2021-08-06',
   'x-ms-creation-time',
-  'Tue, 28 Jan 2020 04:27:21 GMT',
+  'Thu, 28 Jul 2022 08:25:34 GMT',
   'x-ms-lease-status',
   'unlocked',
   'x-ms-lease-state',
@@ -80,7 +87,7 @@ nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParam
   'x-ms-server-encrypted',
   'true',
   'x-ms-access-tier',
-  'Cool',
+  'Hot',
   'x-ms-access-tier-inferred',
   'true',
   'Access-Control-Expose-Headers',
@@ -88,42 +95,47 @@ nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParam
   'Access-Control-Allow-Origin',
   '*',
   'Date',
-  'Tue, 28 Jan 2020 04:27:20 GMT' ]);
+  'Thu, 28 Jul 2022 08:25:33 GMT'
+]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .get('/1container-with-dash158018564046307953')
+  .get('/1container-with-dash165899673336306735')
   .query(true)
-  .reply(200, "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults ServiceEndpoint=\"https://fakestorageaccount.blob.core.windows.net/\" ContainerName=\"1container-with-dash158018564046307953\"><Prefix>////blob/empty /another158018564080603229</Prefix><Blobs><Blob><Name>////blob/empty /another158018564080603229</Name><Properties><Creation-Time>Tue, 28 Jan 2020 04:27:21 GMT</Creation-Time><Last-Modified>Tue, 28 Jan 2020 04:27:21 GMT</Last-Modified><Etag>0x8D7A3AA5DE07832</Etag><Content-Length>1</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>f8VicOenD6gaWTW3Lqy+KQ==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Cool</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties></Blob></Blobs><NextMarker /></EnumerationResults>", [ 'Transfer-Encoding',
+  .reply(200, "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults ServiceEndpoint=\"https://fakestorageaccount.blob.core.windows.net/\" ContainerName=\"1container-with-dash165899673336306735\"><Prefix>////blob/empty /another165899673399007500</Prefix><Blobs><Blob><Name>////blob/empty /another165899673399007500</Name><Properties><Creation-Time>Thu, 28 Jul 2022 08:25:34 GMT</Creation-Time><Last-Modified>Thu, 28 Jul 2022 08:25:34 GMT</Last-Modified><Etag>0x8DA7072BE024FE3</Etag><Content-Length>1</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>f8VicOenD6gaWTW3Lqy+KQ==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties><OrMetadata /></Blob></Blobs><NextMarker /></EnumerationResults>", [
+  'Transfer-Encoding',
   'chunked',
   'Content-Type',
   'application/xml',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '60e29059-201e-0048-5993-d55461000000',
+  '3b57c05b-701e-0000-0d5b-a2e4b9000000',
   'x-ms-client-request-id',
-  '79c26d18-f384-4ee4-8fac-cf29a60a304a',
+  '82ae3b0c-45cd-4c27-ac5b-06defdbaeef6',
   'x-ms-version',
-  '2019-02-02',
+  '2021-08-06',
   'Access-Control-Expose-Headers',
   'x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,Content-Type,Content-Length,Date,Transfer-Encoding',
   'Access-Control-Allow-Origin',
   '*',
   'Date',
-  'Tue, 28 Jan 2020 04:27:21 GMT' ]);
+  'Thu, 28 Jul 2022 08:25:34 GMT'
+]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .delete('/1container-with-dash158018564046307953')
+  .delete('/1container-with-dash165899673336306735')
   .query(true)
-  .reply(202, "", [ 'Content-Length',
+  .reply(202, "", [
+  'Content-Length',
   '0',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '60e2907c-201e-0048-7893-d55461000000',
+  '3b57c08c-701e-0000-2f5b-a2e4b9000000',
   'x-ms-client-request-id',
-  'beeebacd-2671-4a4e-8d8c-f2e7afd492ce',
+  'd09fe5f7-a393-4696-b996-0278a0680dfc',
   'x-ms-version',
-  '2019-02-02',
+  '2021-08-06',
   'Date',
-  'Tue, 28 Jan 2020 04:27:21 GMT' ]);
+  'Thu, 28 Jul 2022 08:25:34 GMT'
+]);

--- a/sdk/storage/storage-blob/recordings/node/syncuploadfromurl/recording_copysourceblobproperties_eq_false.js
+++ b/sdk/storage/storage-blob/recordings/node/syncuploadfromurl/recording_copysourceblobproperties_eq_false.js
@@ -1,89 +1,85 @@
 let nock = require('nock');
 
-module.exports.hash = "1c0214dcc469fd0e372f2d91fcff6ced";
+module.exports.hash = "3b1c98a18eec371b9e1d1af75a23809a";
 
-module.exports.testInfo = {"uniqueName":{"container":"container160635998026500016","blockblob":"blockblob160635998056505491","srcblob/%2+%2F":"srcblob/%2+%2F160635998056605057"},"newDate":{"expiry":"2020-11-26T03:06:20.874Z"}}
+module.exports.testInfo = {"uniqueName":{"container":"container165899712058409588","blockblob":"blockblob165899712068700106","srcblob/%2+%2F":"srcblob/%2+%2F165899712068704846"},"newDate":{"expiry":"2022-07-28T08:32:00.790Z"}}
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container160635998026500016')
+  .put('/container165899712058409588')
   .query(true)
   .reply(201, "", [
   'Content-Length',
   '0',
   'Last-Modified',
-  'Thu, 26 Nov 2020 03:06:20 GMT',
+  'Thu, 28 Jul 2022 08:32:00 GMT',
   'ETag',
-  '"0x8D891B83FD9F2AA"',
+  '"0x8DA7073A46DA4FD"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'fbc8134b-c01e-0085-16a1-c37820000000',
+  '56907332-201e-0032-525c-a2e4ce000000',
   'x-ms-client-request-id',
-  'd170e2e1-d458-4bce-8af6-7a50fa870e16',
+  '72bb203b-0cb3-4149-9e84-995f2151dfa7',
   'x-ms-version',
-  '2020-04-08',
+  '2021-08-06',
   'Date',
-  'Thu, 26 Nov 2020 03:06:20 GMT'
+  'Thu, 28 Jul 2022 08:32:00 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container160635998026500016/srcblob%2F%252%2B%252F160635998056605057', "Hello World")
+  .put('/container165899712058409588/srcblob/%252%2B%252F165899712068704846', "Hello World")
   .reply(201, "", [
   'Content-Length',
   '0',
   'Content-MD5',
   'sQqNsWTgdUEFt6mb5y4/5Q==',
   'Last-Modified',
-  'Thu, 26 Nov 2020 03:06:20 GMT',
+  'Thu, 28 Jul 2022 08:32:00 GMT',
   'ETag',
-  '"0x8D891B840093B99"',
+  '"0x8DA7073A47F5F59"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'fbc813ea-c01e-0085-27a1-c37820000000',
+  '56907350-201e-0032-6a5c-a2e4ce000000',
   'x-ms-client-request-id',
-  '1d42eb93-6630-4092-b180-46c4d98c9e5d',
+  '0021b61c-6a21-4ba3-bafa-d3dc75e80bae',
   'x-ms-version',
-  '2020-04-08',
+  '2021-08-06',
   'x-ms-content-crc64',
   'YeJLfssylmU=',
   'x-ms-request-server-encrypted',
   'true',
-  'x-ms-version-id',
-  '2020-11-26T03:06:20.7282073Z',
   'Date',
-  'Thu, 26 Nov 2020 03:06:20 GMT'
+  'Thu, 28 Jul 2022 08:32:00 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container160635998026500016/blockblob160635998056505491')
+  .put('/container165899712058409588/blockblob165899712068700106')
   .reply(201, "", [
   'Content-Length',
   '0',
   'Last-Modified',
-  'Thu, 26 Nov 2020 03:06:21 GMT',
+  'Thu, 28 Jul 2022 08:32:01 GMT',
   'ETag',
-  '"0x8D891B8403A3F8C"',
+  '"0x8DA7073A4909AD2"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'fbc81464-c01e-0085-17a1-c37820000000',
+  '56907372-201e-0032-075c-a2e4ce000000',
   'x-ms-client-request-id',
-  '31cb7280-4da6-4fca-99ed-44ba9010e101',
+  'e237d025-72fa-4823-a340-3abe8105648d',
   'x-ms-version',
-  '2020-04-08',
+  '2021-08-06',
   'x-ms-content-crc64',
   'YeJLfssylmU=',
-  'x-ms-version-id',
-  '2020-11-26T03:06:21.0494348Z',
   'x-ms-request-server-encrypted',
   'true',
   'Date',
-  'Thu, 26 Nov 2020 03:06:20 GMT'
+  'Thu, 28 Jul 2022 08:32:00 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .get('/container160635998026500016/blockblob160635998056505491')
+  .get('/container165899712058409588/blockblob165899712068700106')
   .reply(200, "Hello World", [
   'Content-Length',
   '11',
@@ -94,25 +90,21 @@ nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParam
   'Content-MD5',
   'sQqNsWTgdUEFt6mb5y4/5Q==',
   'Last-Modified',
-  'Thu, 26 Nov 2020 03:06:21 GMT',
+  'Thu, 28 Jul 2022 08:32:01 GMT',
   'Accept-Ranges',
   'bytes',
   'ETag',
-  '"0x8D891B8403A3F8C"',
+  '"0x8DA7073A4909AD2"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'fbc814d6-c01e-0085-7ea1-c37820000000',
+  '569073a8-201e-0032-385c-a2e4ce000000',
   'x-ms-client-request-id',
-  '395975a7-de3b-438c-86d7-42e5dd1cf09b',
+  '41aecadf-add5-4780-9c4f-f801e84f3762',
   'x-ms-version',
-  '2020-04-08',
-  'x-ms-version-id',
-  '2020-11-26T03:06:21.0494348Z',
-  'x-ms-is-current-version',
-  'true',
+  '2021-08-06',
   'x-ms-creation-time',
-  'Thu, 26 Nov 2020 03:06:21 GMT',
+  'Thu, 28 Jul 2022 08:32:01 GMT',
   'x-ms-lease-status',
   'unlocked',
   'x-ms-lease-state',
@@ -122,15 +114,15 @@ nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParam
   'x-ms-server-encrypted',
   'true',
   'Access-Control-Expose-Headers',
-  'x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,x-ms-version-id,x-ms-is-current-version,Content-Type,Content-Language,Last-Modified,ETag,x-ms-creation-time,Content-MD5,x-ms-lease-status,x-ms-lease-state,x-ms-blob-type,x-ms-server-encrypted,Accept-Ranges,Content-Length,Date,Transfer-Encoding',
+  'x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,Content-Type,Content-Language,Last-Modified,ETag,x-ms-creation-time,Content-MD5,x-ms-lease-status,x-ms-lease-state,x-ms-blob-type,x-ms-server-encrypted,Accept-Ranges,Content-Length,Date,Transfer-Encoding',
   'Access-Control-Allow-Origin',
   '*',
   'Date',
-  'Thu, 26 Nov 2020 03:06:21 GMT'
+  'Thu, 28 Jul 2022 08:32:01 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .delete('/container160635998026500016')
+  .delete('/container165899712058409588')
   .query(true)
   .reply(202, "", [
   'Content-Length',
@@ -138,11 +130,11 @@ nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParam
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'fbc81534-c01e-0085-55a1-c37820000000',
+  '569073ca-201e-0032-565c-a2e4ce000000',
   'x-ms-client-request-id',
-  'e5f0dceb-6018-43e2-b876-7c35debfdc79',
+  '1f008bb6-7f12-4605-9a96-92bc38ee8f68',
   'x-ms-version',
-  '2020-04-08',
+  '2021-08-06',
   'Date',
-  'Thu, 26 Nov 2020 03:06:21 GMT'
+  'Thu, 28 Jul 2022 08:32:01 GMT'
 ]);

--- a/sdk/storage/storage-blob/recordings/node/syncuploadfromurl/recording_destination_conditon.js
+++ b/sdk/storage/storage-blob/recordings/node/syncuploadfromurl/recording_destination_conditon.js
@@ -1,91 +1,87 @@
 let nock = require('nock');
 
-module.exports.hash = "76c13bf98f27faa124ff283cf322bb74";
+module.exports.hash = "db91269d624628f58db9f724376ca507";
 
-module.exports.testInfo = {"uniqueName":{"container":"container160635998179704218","blockblob":"blockblob160635998209308131","srcblob/%2+%2F":"srcblob/%2+%2F160635998209304700"},"newDate":{"expiry":"2020-11-26T03:06:22.389Z"}}
+module.exports.testInfo = {"uniqueName":{"container":"container165899712111402453","blockblob":"blockblob165899712121705192","srcblob/%2+%2F":"srcblob/%2+%2F165899712121706078"},"newDate":{"expiry":"2022-07-28T08:32:01.320Z"}}
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container160635998179704218')
+  .put('/container165899712111402453')
   .query(true)
   .reply(201, "", [
   'Content-Length',
   '0',
   'Last-Modified',
-  'Thu, 26 Nov 2020 03:06:21 GMT',
+  'Thu, 28 Jul 2022 08:32:01 GMT',
   'ETag',
-  '"0x8D891B840C36B64"',
+  '"0x8DA7073A4BE7850"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'fbc8159e-c01e-0085-38a1-c37820000000',
+  '569073e7-201e-0032-6d5c-a2e4ce000000',
   'x-ms-client-request-id',
-  'f69e1c09-cd10-4cf2-a296-4d7991749b69',
+  '318840b0-56a7-476b-9d4a-7567cbe86cd4',
   'x-ms-version',
-  '2020-04-08',
+  '2021-08-06',
   'Date',
-  'Thu, 26 Nov 2020 03:06:21 GMT'
+  'Thu, 28 Jul 2022 08:32:01 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container160635998179704218/srcblob%2F%252%2B%252F160635998209304700', "Hello World")
+  .put('/container165899712111402453/srcblob/%252%2B%252F165899712121706078', "Hello World")
   .reply(201, "", [
   'Content-Length',
   '0',
   'Content-MD5',
   'sQqNsWTgdUEFt6mb5y4/5Q==',
   'Last-Modified',
-  'Thu, 26 Nov 2020 03:06:22 GMT',
+  'Thu, 28 Jul 2022 08:32:01 GMT',
   'ETag',
-  '"0x8D891B840F0B828"',
+  '"0x8DA7073A4D0321A"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'fbc8160c-c01e-0085-21a1-c37820000000',
+  '56907405-201e-0032-055c-a2e4ce000000',
   'x-ms-client-request-id',
-  '764c0849-d31d-48c8-8af7-edbe4ddaefc6',
+  '0aac2f1e-c130-4762-bcac-b2c099ba5e49',
   'x-ms-version',
-  '2020-04-08',
+  '2021-08-06',
   'x-ms-content-crc64',
   'YeJLfssylmU=',
   'x-ms-request-server-encrypted',
   'true',
-  'x-ms-version-id',
-  '2020-11-26T03:06:22.2452776Z',
   'Date',
-  'Thu, 26 Nov 2020 03:06:22 GMT'
+  'Thu, 28 Jul 2022 08:32:01 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container160635998179704218/blockblob160635998209308131', "hello")
+  .put('/container165899712111402453/blockblob165899712121705192', "hello")
   .reply(201, "", [
   'Content-Length',
   '0',
   'Content-MD5',
   'XUFAKrxLKna5cZ2REBfFkg==',
   'Last-Modified',
-  'Thu, 26 Nov 2020 03:06:22 GMT',
+  'Thu, 28 Jul 2022 08:32:01 GMT',
   'ETag',
-  '"0x8D891B8411F23A5"',
+  '"0x8DA7073A4DFC016"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'fbc816ac-c01e-0085-34a1-c37820000000',
+  '5690741c-201e-0032-1a5c-a2e4ce000000',
   'x-ms-client-request-id',
-  '18bf191f-41e5-43bb-b403-5b82be92dda5',
+  'b911c462-84f5-4dbd-9ad5-b4e75c23ff04',
   'x-ms-version',
-  '2020-04-08',
+  '2021-08-06',
   'x-ms-content-crc64',
   'V0JSBnCFdzM=',
   'x-ms-request-server-encrypted',
   'true',
-  'x-ms-version-id',
-  '2020-11-26T03:06:22.5494949Z',
   'Date',
-  'Thu, 26 Nov 2020 03:06:22 GMT'
+  'Thu, 28 Jul 2022 08:32:01 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .head('/container160635998179704218/blockblob160635998209308131')
+  .head('/container165899712111402453/blockblob165899712121705192')
   .reply(200, "", [
   'Content-Length',
   '5',
@@ -94,25 +90,21 @@ nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParam
   'Content-MD5',
   'XUFAKrxLKna5cZ2REBfFkg==',
   'Last-Modified',
-  'Thu, 26 Nov 2020 03:06:22 GMT',
+  'Thu, 28 Jul 2022 08:32:01 GMT',
   'Accept-Ranges',
   'bytes',
   'ETag',
-  '"0x8D891B8411F23A5"',
+  '"0x8DA7073A4DFC016"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'fbc81710-c01e-0085-0ea1-c37820000000',
+  '56907436-201e-0032-2e5c-a2e4ce000000',
   'x-ms-client-request-id',
-  '5643664b-2064-4b44-a81a-d744ce70283d',
+  'ebfb6c97-f77c-4672-8296-598859afe3d6',
   'x-ms-version',
-  '2020-04-08',
-  'x-ms-version-id',
-  '2020-11-26T03:06:22.5494949Z',
-  'x-ms-is-current-version',
-  'true',
+  '2021-08-06',
   'x-ms-creation-time',
-  'Thu, 26 Nov 2020 03:06:22 GMT',
+  'Thu, 28 Jul 2022 08:32:01 GMT',
   'x-ms-lease-status',
   'unlocked',
   'x-ms-lease-state',
@@ -126,43 +118,41 @@ nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParam
   'x-ms-access-tier-inferred',
   'true',
   'Access-Control-Expose-Headers',
-  'x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,x-ms-version-id,x-ms-is-current-version,Content-Type,Last-Modified,ETag,x-ms-creation-time,Content-MD5,x-ms-lease-status,x-ms-lease-state,x-ms-blob-type,x-ms-server-encrypted,x-ms-access-tier,x-ms-access-tier-inferred,Accept-Ranges,Content-Length,Date,Transfer-Encoding',
+  'x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,Content-Type,Last-Modified,ETag,x-ms-creation-time,Content-MD5,x-ms-lease-status,x-ms-lease-state,x-ms-blob-type,x-ms-server-encrypted,x-ms-access-tier,x-ms-access-tier-inferred,Accept-Ranges,Content-Length,Date,Transfer-Encoding',
   'Access-Control-Allow-Origin',
   '*',
   'Date',
-  'Thu, 26 Nov 2020 03:06:22 GMT'
+  'Thu, 28 Jul 2022 08:32:01 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container160635998179704218/blockblob160635998209308131')
+  .put('/container165899712111402453/blockblob165899712121705192')
   .reply(201, "", [
   'Content-Length',
   '0',
   'Last-Modified',
-  'Thu, 26 Nov 2020 03:06:23 GMT',
+  'Thu, 28 Jul 2022 08:32:01 GMT',
   'ETag',
-  '"0x8D891B8417BD34F"',
+  '"0x8DA7073A4FFED51"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'fbc81794-c01e-0085-0aa1-c37820000000',
+  '56907466-201e-0032-565c-a2e4ce000000',
   'x-ms-client-request-id',
-  'b7e701ca-c3ca-4bdf-8a42-e44a250b6e0d',
+  'faedba73-b94a-4a05-b575-2108184025ac',
   'x-ms-version',
-  '2020-04-08',
+  '2021-08-06',
   'x-ms-content-crc64',
   'YeJLfssylmU=',
-  'x-ms-version-id',
-  '2020-11-26T03:06:23.1579231Z',
   'x-ms-request-server-encrypted',
   'true',
   'Date',
-  'Thu, 26 Nov 2020 03:06:23 GMT'
+  'Thu, 28 Jul 2022 08:32:01 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container160635998179704218/blockblob160635998209308131')
-  .reply(412, "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><Error><Code>TargetConditionNotMet</Code><Message>The target condition specified using HTTP conditional header(s) is not met.\nRequestId:fbc81809-c01e-0085-6fa1-c37820000000\nTime:2020-11-26T03:06:23.4554624Z</Message></Error>", [
+  .put('/container165899712111402453/blockblob165899712121705192')
+  .reply(412, "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><Error><Code>TargetConditionNotMet</Code><Message>The target condition specified using HTTP conditional header(s) is not met.\nRequestId:5690747f-201e-0032-6e5c-a2e4ce000000\nTime:2022-07-28T08:32:01.9019552Z</Message></Error>", [
   'Content-Length',
   '265',
   'Content-Type',
@@ -170,19 +160,19 @@ nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParam
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'fbc81809-c01e-0085-6fa1-c37820000000',
+  '5690747f-201e-0032-6e5c-a2e4ce000000',
   'x-ms-client-request-id',
-  '85107502-cb2e-45f9-b111-ee4c5bd6b991',
+  'a0871f21-054b-481f-bd38-87086bc05d8b',
   'x-ms-version',
-  '2020-04-08',
+  '2021-08-06',
   'x-ms-error-code',
   'TargetConditionNotMet',
   'Date',
-  'Thu, 26 Nov 2020 03:06:23 GMT'
+  'Thu, 28 Jul 2022 08:32:01 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .delete('/container160635998179704218')
+  .delete('/container165899712111402453')
   .query(true)
   .reply(202, "", [
   'Content-Length',
@@ -190,11 +180,11 @@ nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParam
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'fbc8188f-c01e-0085-6ea1-c37820000000',
+  '56907492-201e-0032-7c5c-a2e4ce000000',
   'x-ms-client-request-id',
-  '8da77593-f164-4c35-a709-baac252d8b7f',
+  '6d111c55-7518-4b72-b983-cf442ac6a1c0',
   'x-ms-version',
-  '2020-04-08',
+  '2021-08-06',
   'Date',
-  'Thu, 26 Nov 2020 03:06:23 GMT'
+  'Thu, 28 Jul 2022 08:32:01 GMT'
 ]);

--- a/sdk/storage/storage-blob/recordings/node/syncuploadfromurl/recording_large_content.js
+++ b/sdk/storage/storage-blob/recordings/node/syncuploadfromurl/recording_large_content.js
@@ -1,62 +1,60 @@
 let nock = require('nock');
 
-module.exports.hash = "7fa7e6c7cc64795c138dee9b9094d35d";
+module.exports.hash = "495ead69944cd34f25a84e7e336a213e";
 
-module.exports.testInfo = {"uniqueName":{"container":"container160636021979206718","blockblob":"blockblob160636022118302096","srcblob/%2+%2F":"srcblob/%2+%2F160636022118401150"},"newDate":{"expiry":"2020-11-26T03:10:21.490Z"}}
+module.exports.testInfo = {"uniqueName":{"container":"container165899712300102036","blockblob":"blockblob165899712310609229","srcblob/%2+%2F":"srcblob/%2+%2F165899712310605985"},"newDate":{"expiry":"2022-07-28T08:32:03.211Z"}}
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container160636021979206718')
+  .put('/container165899712300102036')
   .query(true)
   .reply(201, "", [
   'Content-Length',
   '0',
   'Last-Modified',
-  'Thu, 26 Nov 2020 03:10:21 GMT',
+  'Thu, 28 Jul 2022 08:32:03 GMT',
   'ETag',
-  '"0x8D891B8CF44C91D"',
+  '"0x8DA7073A5DE8B41"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '7e2064b9-f01e-0027-38a1-c34239000000',
+  '56907667-201e-0032-155c-a2e4ce000000',
   'x-ms-client-request-id',
-  'e0f2ba4a-bd75-4aaa-9ac1-65b8567d357a',
+  '61191490-fd2b-407a-8b94-409947409a87',
   'x-ms-version',
-  '2020-04-08',
+  '2021-08-06',
   'Date',
-  'Thu, 26 Nov 2020 03:10:20 GMT'
+  'Thu, 28 Jul 2022 08:32:03 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container160636021979206718/srcblob%2F%252%2B%252F160636022118401150', "Hello World")
+  .put('/container165899712300102036/srcblob/%252%2B%252F165899712310605985', "Hello World")
   .reply(201, "", [
   'Content-Length',
   '0',
   'Content-MD5',
   'sQqNsWTgdUEFt6mb5y4/5Q==',
   'Last-Modified',
-  'Thu, 26 Nov 2020 03:10:21 GMT',
+  'Thu, 28 Jul 2022 08:32:03 GMT',
   'ETag',
-  '"0x8D891B8CF7605F8"',
+  '"0x8DA7073A5F0DF32"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '7e206534-f01e-0027-29a1-c34239000000',
+  '56907696-201e-0032-3d5c-a2e4ce000000',
   'x-ms-client-request-id',
-  'b972cd6d-1b23-4a53-9c57-5441375f7b4f',
+  '35cfe443-e847-4bd6-a0df-70d6fa58a86d',
   'x-ms-version',
-  '2020-04-08',
+  '2021-08-06',
   'x-ms-content-crc64',
   'YeJLfssylmU=',
   'x-ms-request-server-encrypted',
   'true',
-  'x-ms-version-id',
-  '2020-11-26T03:10:21.3553656Z',
   'Date',
-  'Thu, 26 Nov 2020 03:10:20 GMT'
+  'Thu, 28 Jul 2022 08:32:03 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .delete('/container160636021979206718')
+  .delete('/container165899712300102036')
   .query(true)
   .reply(202, "", [
   'Content-Length',
@@ -64,11 +62,11 @@ nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParam
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '7e2066c2-f01e-0027-11a1-c34239000000',
+  '569076b7-201e-0032-5a5c-a2e4ce000000',
   'x-ms-client-request-id',
-  'ee5bc8d4-c583-4fcf-9d68-aeac8e6b7eba',
+  '043c38c7-69de-4a57-8598-c6234c0a70e5',
   'x-ms-version',
-  '2020-04-08',
+  '2021-08-06',
   'Date',
-  'Thu, 26 Nov 2020 03:10:22 GMT'
+  'Thu, 28 Jul 2022 08:32:03 GMT'
 ]);

--- a/sdk/storage/storage-blob/recordings/node/syncuploadfromurl/recording_large_content_with_timeout.js
+++ b/sdk/storage/storage-blob/recordings/node/syncuploadfromurl/recording_large_content_with_timeout.js
@@ -1,62 +1,60 @@
 let nock = require('nock');
 
-module.exports.hash = "7fa7e6c7cc64795c138dee9b9094d35d";
+module.exports.hash = "95ba470dab19a37c12a7e1a771024848";
 
-module.exports.testInfo = {"uniqueName":{"container":"container160636021979206718","blockblob":"blockblob160636022118302096","srcblob/%2+%2F":"srcblob/%2+%2F160636022118401150"},"newDate":{"expiry":"2020-11-26T03:10:21.490Z"}}
+module.exports.testInfo = {"uniqueName":{"container":"container165899768304305418","blockblob":"blockblob165899768367404932","srcblob/%2+%2F":"srcblob/%2+%2F165899768367503477"},"newDate":{"expiry":"2022-07-28T08:41:23.782Z"}}
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container160636021979206718')
+  .put('/container165899768304305418')
   .query(true)
   .reply(201, "", [
   'Content-Length',
   '0',
   'Last-Modified',
-  'Thu, 26 Nov 2020 03:10:21 GMT',
+  'Thu, 28 Jul 2022 08:41:23 GMT',
   'ETag',
-  '"0x8D891B8CF44C91D"',
+  '"0x8DA7074F3FE436D"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '7e2064b9-f01e-0027-38a1-c34239000000',
+  'dbdd1e04-701e-0072-485d-a2e3f6000000',
   'x-ms-client-request-id',
-  'e0f2ba4a-bd75-4aaa-9ac1-65b8567d357a',
+  'd9a66d24-bd86-4d79-b304-de26cb53c8b6',
   'x-ms-version',
-  '2020-04-08',
+  '2021-08-06',
   'Date',
-  'Thu, 26 Nov 2020 03:10:20 GMT'
+  'Thu, 28 Jul 2022 08:41:22 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container160636021979206718/srcblob%2F%252%2B%252F160636022118401150', "Hello World")
+  .put('/container165899768304305418/srcblob/%252%2B%252F165899768367503477', "Hello World")
   .reply(201, "", [
   'Content-Length',
   '0',
   'Content-MD5',
   'sQqNsWTgdUEFt6mb5y4/5Q==',
   'Last-Modified',
-  'Thu, 26 Nov 2020 03:10:21 GMT',
+  'Thu, 28 Jul 2022 08:41:23 GMT',
   'ETag',
-  '"0x8D891B8CF7605F8"',
+  '"0x8DA7074F4110401"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '7e206534-f01e-0027-29a1-c34239000000',
+  'dbdd1e3e-701e-0072-625d-a2e3f6000000',
   'x-ms-client-request-id',
-  'b972cd6d-1b23-4a53-9c57-5441375f7b4f',
+  '03037ef9-6be3-4114-bd0e-6873af15a215',
   'x-ms-version',
-  '2020-04-08',
+  '2021-08-06',
   'x-ms-content-crc64',
   'YeJLfssylmU=',
   'x-ms-request-server-encrypted',
   'true',
-  'x-ms-version-id',
-  '2020-11-26T03:10:21.3553656Z',
   'Date',
-  'Thu, 26 Nov 2020 03:10:20 GMT'
+  'Thu, 28 Jul 2022 08:41:22 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .delete('/container160636021979206718')
+  .delete('/container165899768304305418')
   .query(true)
   .reply(202, "", [
   'Content-Length',
@@ -64,11 +62,11 @@ nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParam
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '7e2066c2-f01e-0027-11a1-c34239000000',
+  'dbdd1e4a-701e-0072-695d-a2e3f6000000',
   'x-ms-client-request-id',
-  'ee5bc8d4-c583-4fcf-9d68-aeac8e6b7eba',
+  '9eecf833-df53-45eb-a664-5d98aa4d4cde',
   'x-ms-version',
-  '2020-04-08',
+  '2021-08-06',
   'Date',
-  'Thu, 26 Nov 2020 03:10:22 GMT'
+  'Thu, 28 Jul 2022 08:41:23 GMT'
 ]);

--- a/sdk/storage/storage-blob/recordings/node/syncuploadfromurl/recording_set_some_of_the_properties_on_the_request.js
+++ b/sdk/storage/storage-blob/recordings/node/syncuploadfromurl/recording_set_some_of_the_properties_on_the_request.js
@@ -1,89 +1,85 @@
 let nock = require('nock');
 
-module.exports.hash = "9951c8b08d88b32c9e15d241d4a107ea";
+module.exports.hash = "ad55ff609d5c2f3d94b1b267d1de8150";
 
-module.exports.testInfo = {"uniqueName":{"container":"container160635997841503156","blockblob":"blockblob160635997871504072","srcblob/%2+%2F":"srcblob/%2+%2F160635997871502265"},"newDate":{"expiry":"2020-11-26T03:06:19.019Z"}}
+module.exports.testInfo = {"uniqueName":{"container":"container165899711841301024","blockblob":"blockblob165899711851500618","srcblob/%2+%2F":"srcblob/%2+%2F165899711851508640"},"newDate":{"expiry":"2022-07-28T08:31:58.617Z"}}
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container160635997841503156')
+  .put('/container165899711841301024')
   .query(true)
   .reply(201, "", [
   'Content-Length',
   '0',
   'Last-Modified',
-  'Thu, 26 Nov 2020 03:06:18 GMT',
+  'Thu, 28 Jul 2022 08:31:58 GMT',
   'ETag',
-  '"0x8D891B83EBFC477"',
+  '"0x8DA7073A3224299"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'fbc8109b-c01e-0085-2ca1-c37820000000',
+  '56907059-201e-0032-045c-a2e4ce000000',
   'x-ms-client-request-id',
-  'bee02441-7517-46c4-84ab-abf1b8376b97',
+  '157561a4-7483-402b-b7a3-09dc4ac4fe7f',
   'x-ms-version',
-  '2020-04-08',
+  '2021-08-06',
   'Date',
-  'Thu, 26 Nov 2020 03:06:18 GMT'
+  'Thu, 28 Jul 2022 08:31:58 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container160635997841503156/srcblob%2F%252%2B%252F160635997871502265', "Hello World")
+  .put('/container165899711841301024/srcblob/%252%2B%252F165899711851508640', "Hello World")
   .reply(201, "", [
   'Content-Length',
   '0',
   'Content-MD5',
   'sQqNsWTgdUEFt6mb5y4/5Q==',
   'Last-Modified',
-  'Thu, 26 Nov 2020 03:06:18 GMT',
+  'Thu, 28 Jul 2022 08:31:58 GMT',
   'ETag',
-  '"0x8D891B83EEE2287"',
+  '"0x8DA7073A333FF64"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'fbc81110-c01e-0085-17a1-c37820000000',
+  '56907088-201e-0032-275c-a2e4ce000000',
   'x-ms-client-request-id',
-  '186afb11-6cc8-4dd7-9da8-56a67d5f200d',
+  '2407d82b-134c-43d0-aa54-6137007430c1',
   'x-ms-version',
-  '2020-04-08',
+  '2021-08-06',
   'x-ms-content-crc64',
   'YeJLfssylmU=',
   'x-ms-request-server-encrypted',
   'true',
-  'x-ms-version-id',
-  '2020-11-26T03:06:18.8728967Z',
   'Date',
-  'Thu, 26 Nov 2020 03:06:18 GMT'
+  'Thu, 28 Jul 2022 08:31:58 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container160635997841503156/blockblob160635997871504072')
+  .put('/container165899711841301024/blockblob165899711851500618')
   .reply(201, "", [
   'Content-Length',
   '0',
   'Last-Modified',
-  'Thu, 26 Nov 2020 03:06:19 GMT',
+  'Thu, 28 Jul 2022 08:31:58 GMT',
   'ETag',
-  '"0x8D891B83F1F266E"',
+  '"0x8DA7073A3467316"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'fbc81186-c01e-0085-03a1-c37820000000',
+  '569070bc-201e-0032-4d5c-a2e4ce000000',
   'x-ms-client-request-id',
-  '123ef5a0-ff3f-48ee-bf72-c47dc8ac8cdb',
+  '266072e2-f913-446e-bad2-188766f22827',
   'x-ms-version',
-  '2020-04-08',
+  '2021-08-06',
   'x-ms-content-crc64',
   'YeJLfssylmU=',
-  'x-ms-version-id',
-  '2020-11-26T03:06:19.1941230Z',
   'x-ms-request-server-encrypted',
   'true',
   'Date',
-  'Thu, 26 Nov 2020 03:06:19 GMT'
+  'Thu, 28 Jul 2022 08:31:58 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .get('/container160635997841503156/blockblob160635997871504072')
+  .get('/container165899711841301024/blockblob165899711851500618')
   .reply(200, ["48656c6c6f20576f726c64"], [
   'Cache-Control',
   'blobCacheControl',
@@ -98,27 +94,23 @@ nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParam
   'Content-MD5',
   'sQqNsWTgdUEFt6mb5y4/5Q==',
   'Last-Modified',
-  'Thu, 26 Nov 2020 03:06:19 GMT',
+  'Thu, 28 Jul 2022 08:31:58 GMT',
   'Accept-Ranges',
   'bytes',
   'ETag',
-  '"0x8D891B83F1F266E"',
+  '"0x8DA7073A3467316"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'fbc811e5-c01e-0085-59a1-c37820000000',
+  '569070ef-201e-0032-785c-a2e4ce000000',
   'x-ms-client-request-id',
-  'ff1f8fab-1d98-426b-a33c-64c7660e85f6',
+  '94f9051f-4776-41a9-9bbc-99f6b0d8a075',
   'x-ms-version',
-  '2020-04-08',
+  '2021-08-06',
   'x-ms-tag-count',
   '1',
-  'x-ms-version-id',
-  '2020-11-26T03:06:19.1941230Z',
-  'x-ms-is-current-version',
-  'true',
   'x-ms-creation-time',
-  'Thu, 26 Nov 2020 03:06:19 GMT',
+  'Thu, 28 Jul 2022 08:31:58 GMT',
   'x-ms-lease-status',
   'unlocked',
   'x-ms-lease-state',
@@ -130,37 +122,39 @@ nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParam
   'x-ms-server-encrypted',
   'true',
   'Access-Control-Expose-Headers',
-  'x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,x-ms-tag-count,x-ms-version-id,x-ms-is-current-version,Content-Type,Content-Encoding,Content-Language,Cache-Control,Last-Modified,ETag,x-ms-creation-time,Content-MD5,x-ms-lease-status,x-ms-lease-state,x-ms-blob-type,Content-Disposition,x-ms-server-encrypted,Accept-Ranges,Content-Length,Date,Transfer-Encoding',
+  'x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,x-ms-tag-count,Content-Type,Content-Encoding,Content-Language,Cache-Control,Last-Modified,ETag,x-ms-creation-time,Content-MD5,x-ms-lease-status,x-ms-lease-state,x-ms-blob-type,Content-Disposition,x-ms-server-encrypted,Accept-Ranges,Content-Length,Date,Transfer-Encoding',
   'Access-Control-Allow-Origin',
   '*',
   'Date',
-  'Thu, 26 Nov 2020 03:06:19 GMT'
+  'Thu, 28 Jul 2022 08:31:58 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .get('/container160635997841503156/blockblob160635997871504072')
+  .get('/container165899711841301024/blockblob165899711851500618')
   .query(true)
   .reply(200, "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<Tags><TagSet><Tag><Key>tag1</Key><Value>val1</Value></Tag></TagSet></Tags>", [
   'Content-Length',
   '117',
   'Content-Type',
   'application/xml',
-  'Vary',
-  'Origin',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'fbc81241-c01e-0085-2ea1-c37820000000',
+  '5690712f-201e-0032-2d5c-a2e4ce000000',
   'x-ms-version',
-  '2020-04-08',
+  '2021-08-06',
   'x-ms-client-request-id',
-  'a47eadb4-11a8-43b9-8a8e-444cf80ce5f3',
+  '744588bf-4453-4142-804c-8a578ec44881',
+  'Access-Control-Expose-Headers',
+  'Content-Length,Content-Type,Date,Server,x-ms-client-request-id,x-ms-request-id,x-ms-version',
+  'Access-Control-Allow-Origin',
+  '*',
   'Date',
-  'Thu, 26 Nov 2020 03:06:19 GMT'
+  'Thu, 28 Jul 2022 08:31:59 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .delete('/container160635997841503156')
+  .delete('/container165899711841301024')
   .query(true)
   .reply(202, "", [
   'Content-Length',
@@ -168,11 +162,11 @@ nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParam
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'fbc812c1-c01e-0085-1ea1-c37820000000',
+  '56907150-201e-0032-475c-a2e4ce000000',
   'x-ms-client-request-id',
-  '277c0f33-a35c-4e47-bbb8-356fdde24933',
+  'db30d05d-2108-4664-84e6-b3e375e033a9',
   'x-ms-version',
-  '2020-04-08',
+  '2021-08-06',
   'Date',
-  'Thu, 26 Nov 2020 03:06:19 GMT'
+  'Thu, 28 Jul 2022 08:31:59 GMT'
 ]);

--- a/sdk/storage/storage-blob/recordings/node/syncuploadfromurl/recording_source_conditon.js
+++ b/sdk/storage/storage-blob/recordings/node/syncuploadfromurl/recording_source_conditon.js
@@ -1,90 +1,86 @@
 let nock = require('nock');
 
-module.exports.hash = "a6ae0091cb14abc1683c91f69e9cc18b";
+module.exports.hash = "de3052783fab72358657a6e00c132477";
 
-module.exports.testInfo = {"uniqueName":{"container":"container160635998389803031","blockblob":"blockblob160635998419408351","srcblob/%2+%2F":"srcblob/%2+%2F160635998419402523"},"newDate":{"expiry":"2020-11-26T03:06:24.493Z"}}
+module.exports.testInfo = {"uniqueName":{"container":"container165899712189508492","blockblob":"blockblob165899712199703674","srcblob/%2+%2F":"srcblob/%2+%2F165899712199704488"},"newDate":{"expiry":"2022-07-28T08:32:02.099Z"}}
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container160635998389803031')
+  .put('/container165899712189508492')
   .query(true)
   .reply(201, "", [
   'Content-Length',
   '0',
   'Last-Modified',
-  'Thu, 26 Nov 2020 03:06:24 GMT',
+  'Thu, 28 Jul 2022 08:32:02 GMT',
   'ETag',
-  '"0x8D891B84203ED6A"',
+  '"0x8DA7073A535B9D4"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'fbc818f4-c01e-0085-53a1-c37820000000',
+  '569074e4-201e-0032-3f5c-a2e4ce000000',
   'x-ms-client-request-id',
-  'c4670f62-eb29-4db4-a35a-7cbe921580a9',
+  'b4205f18-4a20-4272-9679-e63b6a921a5f',
   'x-ms-version',
-  '2020-04-08',
+  '2021-08-06',
   'Date',
-  'Thu, 26 Nov 2020 03:06:23 GMT'
+  'Thu, 28 Jul 2022 08:32:02 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container160635998389803031/srcblob%2F%252%2B%252F160635998419402523', "Hello World")
+  .put('/container165899712189508492/srcblob/%252%2B%252F165899712199704488', "Hello World")
   .reply(201, "", [
   'Content-Length',
   '0',
   'Content-MD5',
   'sQqNsWTgdUEFt6mb5y4/5Q==',
   'Last-Modified',
-  'Thu, 26 Nov 2020 03:06:24 GMT',
+  'Thu, 28 Jul 2022 08:32:02 GMT',
   'ETag',
-  '"0x8D891B84231D6B8"',
+  '"0x8DA7073A5474BB0"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'fbc8195b-c01e-0085-31a1-c37820000000',
+  '56907505-201e-0032-595c-a2e4ce000000',
   'x-ms-client-request-id',
-  '937de977-3d64-4a71-84d0-4071e3323dae',
+  'e631a213-49bb-4e8f-8a5d-4e3450a5f46f',
   'x-ms-version',
-  '2020-04-08',
+  '2021-08-06',
   'x-ms-content-crc64',
   'YeJLfssylmU=',
   'x-ms-request-server-encrypted',
   'true',
-  'x-ms-version-id',
-  '2020-11-26T03:06:24.3497656Z',
   'Date',
-  'Thu, 26 Nov 2020 03:06:24 GMT'
+  'Thu, 28 Jul 2022 08:32:02 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container160635998389803031/blockblob160635998419408351')
+  .put('/container165899712189508492/blockblob165899712199703674')
   .reply(201, "", [
   'Content-Length',
   '0',
   'Last-Modified',
-  'Thu, 26 Nov 2020 03:06:24 GMT',
+  'Thu, 28 Jul 2022 08:32:02 GMT',
   'ETag',
-  '"0x8D891B84260DE8D"',
+  '"0x8DA7073A55AD0AB"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'fbc819ab-c01e-0085-79a1-c37820000000',
+  '56907526-201e-0032-745c-a2e4ce000000',
   'x-ms-client-request-id',
-  '9f39e8af-5562-4aba-bd38-dd9149f71efb',
+  'd872ca98-c8b7-471a-a3ee-c31c7af6556b',
   'x-ms-version',
-  '2020-04-08',
+  '2021-08-06',
   'x-ms-content-crc64',
   'YeJLfssylmU=',
-  'x-ms-version-id',
-  '2020-11-26T03:06:24.6579853Z',
   'x-ms-request-server-encrypted',
   'true',
   'Date',
-  'Thu, 26 Nov 2020 03:06:24 GMT'
+  'Thu, 28 Jul 2022 08:32:02 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container160635998389803031/blockblob160635998419408351')
-  .reply(412, "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><Error><Code>SourceConditionNotMet</Code><Message>The source condition specified using HTTP conditional header(s) is not met.\nRequestId:fbc81a35-c01e-0085-78a1-c37820000000\nTime:2020-11-26T03:06:24.9645259Z</Message></Error>", [
+  .put('/container165899712189508492/blockblob165899712199703674')
+  .reply(412, "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><Error><Code>SourceConditionNotMet</Code><Message>The source condition specified using HTTP conditional header(s) is not met.\nRequestId:56907548-201e-0032-145c-a2e4ce000000\nTime:2022-07-28T08:32:02.4966154Z</Message></Error>", [
   'Content-Length',
   '265',
   'Content-Type',
@@ -92,19 +88,19 @@ nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParam
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'fbc81a35-c01e-0085-78a1-c37820000000',
+  '56907548-201e-0032-145c-a2e4ce000000',
   'x-ms-client-request-id',
-  'baf902ed-f9e0-46fc-ac8e-d8ae063a04c6',
+  '12c7677d-f151-40ac-ad3e-5cda35918318',
   'x-ms-version',
-  '2020-04-08',
+  '2021-08-06',
   'x-ms-error-code',
   'SourceConditionNotMet',
   'Date',
-  'Thu, 26 Nov 2020 03:06:24 GMT'
+  'Thu, 28 Jul 2022 08:32:02 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .delete('/container160635998389803031')
+  .delete('/container165899712189508492')
   .query(true)
   .reply(202, "", [
   'Content-Length',
@@ -112,11 +108,11 @@ nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParam
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'fbc81a90-c01e-0085-4ba1-c37820000000',
+  '56907572-201e-0032-385c-a2e4ce000000',
   'x-ms-client-request-id',
-  'e08d4867-9af5-43cc-98dc-f8751059f0a7',
+  '4399e53f-3df5-4d88-b747-16524bba9564',
   'x-ms-version',
-  '2020-04-08',
+  '2021-08-06',
   'Date',
-  'Thu, 26 Nov 2020 03:06:25 GMT'
+  'Thu, 28 Jul 2022 08:32:02 GMT'
 ]);

--- a/sdk/storage/storage-blob/recordings/node/syncuploadfromurl/recording_sourcecontentmd5.js
+++ b/sdk/storage/storage-blob/recordings/node/syncuploadfromurl/recording_sourcecontentmd5.js
@@ -1,90 +1,86 @@
 let nock = require('nock');
 
-module.exports.hash = "76e9c555d4bf488f1c12595f8e98ee8d";
+module.exports.hash = "ba3a945539e4dfd7af88f4969fe5c013";
 
-module.exports.testInfo = {"uniqueName":{"container":"container160635998540905788","blockblob":"blockblob160635998570703453","srcblob/%2+%2F":"srcblob/%2+%2F160635998570806714"},"newDate":{"expiry":"2020-11-26T03:06:26.007Z"}}
+module.exports.testInfo = {"uniqueName":{"container":"container165899712243209190","blockblob":"blockblob165899712253404874","srcblob/%2+%2F":"srcblob/%2+%2F165899712253401632"},"newDate":{"expiry":"2022-07-28T08:32:02.637Z"}}
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container160635998540905788')
+  .put('/container165899712243209190')
   .query(true)
   .reply(201, "", [
   'Content-Length',
   '0',
   'Last-Modified',
-  'Thu, 26 Nov 2020 03:06:25 GMT',
+  'Thu, 28 Jul 2022 08:32:02 GMT',
   'ETag',
-  '"0x8D891B842EAA678"',
+  '"0x8DA7073A5879E52"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'fbc81afc-c01e-0085-2fa1-c37820000000',
+  '5690759b-201e-0032-5d5c-a2e4ce000000',
   'x-ms-client-request-id',
-  'fe0064b5-c569-4d51-a7c7-3e354f93013e',
+  '0db57668-f16c-42d0-abde-79bff056e811',
   'x-ms-version',
-  '2020-04-08',
+  '2021-08-06',
   'Date',
-  'Thu, 26 Nov 2020 03:06:25 GMT'
+  'Thu, 28 Jul 2022 08:32:02 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container160635998540905788/srcblob%2F%252%2B%252F160635998570806714', "Hello World")
+  .put('/container165899712243209190/srcblob/%252%2B%252F165899712253401632', "Hello World")
   .reply(201, "", [
   'Content-Length',
   '0',
   'Content-MD5',
   'sQqNsWTgdUEFt6mb5y4/5Q==',
   'Last-Modified',
-  'Thu, 26 Nov 2020 03:06:25 GMT',
+  'Thu, 28 Jul 2022 08:32:02 GMT',
   'ETag',
-  '"0x8D891B84318DE46"',
+  '"0x8DA7073A5992FB2"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'fbc81b5b-c01e-0085-07a1-c37820000000',
+  '569075bb-201e-0032-795c-a2e4ce000000',
   'x-ms-client-request-id',
-  'face31c4-6ce9-4bdf-b1ee-88538e10431a',
+  '5f1bc27f-8898-4c12-a077-54b747f222f4',
   'x-ms-version',
-  '2020-04-08',
+  '2021-08-06',
   'x-ms-content-crc64',
   'YeJLfssylmU=',
   'x-ms-request-server-encrypted',
   'true',
-  'x-ms-version-id',
-  '2020-11-26T03:06:25.8638406Z',
   'Date',
-  'Thu, 26 Nov 2020 03:06:25 GMT'
+  'Thu, 28 Jul 2022 08:32:02 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container160635998540905788/blockblob160635998570703453')
+  .put('/container165899712243209190/blockblob165899712253404874')
   .reply(201, "", [
   'Content-Length',
   '0',
   'Content-MD5',
   'sQqNsWTgdUEFt6mb5y4/5Q==',
   'Last-Modified',
-  'Thu, 26 Nov 2020 03:06:26 GMT',
+  'Thu, 28 Jul 2022 08:32:02 GMT',
   'ETag',
-  '"0x8D891B84348342D"',
+  '"0x8DA7073A5AA440E"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'fbc81bc2-c01e-0085-65a1-c37820000000',
+  '569075de-201e-0032-175c-a2e4ce000000',
   'x-ms-client-request-id',
-  'e41de19b-27ad-4389-b4ff-0ef7d092a98c',
+  'b4e82d1a-7756-4053-b4b7-eec93aa5d468',
   'x-ms-version',
-  '2020-04-08',
-  'x-ms-version-id',
-  '2020-11-26T03:06:26.1750603Z',
+  '2021-08-06',
   'x-ms-request-server-encrypted',
   'true',
   'Date',
-  'Thu, 26 Nov 2020 03:06:26 GMT'
+  'Thu, 28 Jul 2022 08:32:02 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container160635998540905788/blockblob160635998570703453')
-  .reply(400, "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><Error><Code>Md5Mismatch</Code><Message>The MD5 value specified in the request did not match with the MD5 value calculated by the server.\nRequestId:fbc81c52-c01e-0085-66a1-c37820000000\nTime:2020-11-26T03:06:26.4825964Z</Message><UserSpecifiedMd5>XUFAKrxLKna5cZ2REBfFkg==</UserSpecifiedMd5><ServerCalculatedMd5>sQqNsWTgdUEFt6mb5y4/5Q==</ServerCalculatedMd5></Error>", [
+  .put('/container165899712243209190/blockblob165899712253404874')
+  .reply(400, "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><Error><Code>Md5Mismatch</Code><Message>The MD5 value specified in the request did not match with the MD5 value calculated by the server.\nRequestId:56907606-201e-0032-3c5c-a2e4ce000000\nTime:2022-07-28T08:32:03.0532983Z</Message><UserSpecifiedMd5>XUFAKrxLKna5cZ2REBfFkg==</UserSpecifiedMd5><ServerCalculatedMd5>sQqNsWTgdUEFt6mb5y4/5Q==</ServerCalculatedMd5></Error>", [
   'Content-Length',
   '405',
   'Content-Type',
@@ -92,19 +88,19 @@ nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParam
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'fbc81c52-c01e-0085-66a1-c37820000000',
+  '56907606-201e-0032-3c5c-a2e4ce000000',
   'x-ms-client-request-id',
-  '2fff7f35-cb72-44bb-b879-5677bd5f56d4',
+  '32d6cdf8-0f62-4477-b578-d0e005939990',
   'x-ms-version',
-  '2020-04-08',
+  '2021-08-06',
   'x-ms-error-code',
   'Md5Mismatch',
   'Date',
-  'Thu, 26 Nov 2020 03:06:26 GMT'
+  'Thu, 28 Jul 2022 08:32:02 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .delete('/container160635998540905788')
+  .delete('/container165899712243209190')
   .query(true)
   .reply(202, "", [
   'Content-Length',
@@ -112,11 +108,11 @@ nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParam
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'fbc81cc8-c01e-0085-54a1-c37820000000',
+  '56907645-201e-0032-765c-a2e4ce000000',
   'x-ms-client-request-id',
-  'c5840440-e413-4296-bb59-f83866dbe964',
+  'e1e091e3-5f16-471a-ab5f-bf4787f01eb6',
   'x-ms-version',
-  '2020-04-08',
+  '2021-08-06',
   'Date',
-  'Thu, 26 Nov 2020 03:06:26 GMT'
+  'Thu, 28 Jul 2022 08:32:03 GMT'
 ]);

--- a/sdk/storage/storage-blob/recordings/node/syncuploadfromurl/recording_stageblockfromurl__destination_bearer_token.js
+++ b/sdk/storage/storage-blob/recordings/node/syncuploadfromurl/recording_stageblockfromurl__destination_bearer_token.js
@@ -1,83 +1,87 @@
 let nock = require('nock');
 
-module.exports.hash = "799405a6f868d3f029d421876b240300";
+module.exports.hash = "de5a2ff5c24a1b51b01435f2f89e271f";
 
-module.exports.testInfo = {"uniqueName":{"container":"container164137349511209597","blockblob":"blockblob164137349521505547","srcblob/%2+%2F":"srcblob/%2+%2F164137349521505610","newblockblob":"newblockblob164137349574305703"},"newDate":{"expiry":"2022-01-05T09:04:55.317Z"}}
+module.exports.testInfo = {"uniqueName":{"container":"container165900074958500807","blockblob":"blockblob165900074968508189","srcblob/%2+%2F":"srcblob/%2+%2F165900074968504341","newblockblob":"newblockblob165900075040907799"},"newDate":{"expiry":"2022-07-28T09:32:29.785Z"}}
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container164137349511209597')
+  .put('/container165900074958500807')
   .query(true)
   .reply(201, "", [
   'Content-Length',
   '0',
   'Last-Modified',
-  'Wed, 05 Jan 2022 09:04:55 GMT',
+  'Thu, 28 Jul 2022 09:32:29 GMT',
   'ETag',
-  '"0x8D9D02A71099305"',
+  '"0x8DA707C177D20AF"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'cccf2f26-e01e-0002-3a13-025a01000000',
+  '9eef47b6-401e-000b-1a64-a21fd2000000',
   'x-ms-client-request-id',
-  'ad13a7b3-19ce-41bd-9380-283144483bf7',
+  'fb9210f2-399a-4fed-9319-bb0cc612d493',
   'x-ms-version',
-  '2021-02-12',
+  '2021-08-06',
   'Date',
-  'Wed, 05 Jan 2022 09:04:54 GMT'
+  'Thu, 28 Jul 2022 09:32:29 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container164137349511209597/srcblob%2F%252%2B%252F164137349521505610', "Hello World")
+  .put('/container165900074958500807/srcblob/%252%2B%252F165900074968504341', "Hello World")
   .reply(201, "", [
   'Content-Length',
   '0',
   'Content-MD5',
   'sQqNsWTgdUEFt6mb5y4/5Q==',
   'Last-Modified',
-  'Wed, 05 Jan 2022 09:04:55 GMT',
+  'Thu, 28 Jul 2022 09:32:29 GMT',
   'ETag',
-  '"0x8D9D02A71192E37"',
+  '"0x8DA707C178DC7C6"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'cccf2f3c-e01e-0002-4b13-025a01000000',
+  '9eef47e1-401e-000b-3e64-a21fd2000000',
   'x-ms-client-request-id',
-  'dc8e7c47-7a88-4e08-a180-a8c4494c246d',
+  'b68f9046-a5a4-4c1d-8691-54872c76aab0',
   'x-ms-version',
-  '2021-02-12',
+  '2021-08-06',
   'x-ms-content-crc64',
   'YeJLfssylmU=',
   'x-ms-request-server-encrypted',
   'true',
+  'x-ms-version-id',
+  '2022-07-28T09:32:29.9769798Z',
   'Date',
-  'Wed, 05 Jan 2022 09:04:55 GMT'
+  'Thu, 28 Jul 2022 09:32:29 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container164137349511209597/blockblob164137349521505547', "HelloWorld")
+  .put('/container165900074958500807/blockblob165900074968508189', "HelloWorld")
   .reply(201, "", [
   'Content-Length',
   '0',
   'Content-MD5',
   'aOEJ8PQMpyoV4FzCJ4b45g==',
   'Last-Modified',
-  'Wed, 05 Jan 2022 09:04:55 GMT',
+  'Thu, 28 Jul 2022 09:32:30 GMT',
   'ETag',
-  '"0x8D9D02A7128E35C"',
+  '"0x8DA707C179E18E6"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'cccf2f5e-e01e-0002-6913-025a01000000',
+  '9eef4812-401e-000b-6364-a21fd2000000',
   'x-ms-client-request-id',
-  'c3da37c7-9dbd-4f98-8bc5-e069732394ab',
+  '970a2ecc-5c4e-4fc3-993e-8e8df7108ef8',
   'x-ms-version',
-  '2021-02-12',
+  '2021-08-06',
   'x-ms-content-crc64',
   '8R2aIe9T07E=',
   'x-ms-request-server-encrypted',
   'true',
+  'x-ms-version-id',
+  '2022-07-28T09:32:30.0839142Z',
   'Date',
-  'Wed, 05 Jan 2022 09:04:55 GMT'
+  'Thu, 28 Jul 2022 09:32:29 GMT'
 ]);
 
 nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
@@ -99,19 +103,23 @@ nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
   'P3P',
   'CP="DSP CUR OTPi IND OTRi ONL FIN"',
   'x-ms-request-id',
-  '39a8e413-bd7b-43da-9473-c569e25c8300',
+  '93b7a6c4-36a1-4f96-9878-1639649e3b00',
   'x-ms-ests-server',
-  '2.1.12261.17 - SEASLR1 ProdSlices',
+  '2.1.13355.6 - KRSLR1 ProdSlices',
+  'Content-Security-Policy-Report-Only',
+  "script-src 'self' 'nonce-pN8-ItuTH7w80pT-dnXUgQ' 'unsafe-eval' 'unsafe-inline'; object-src 'none'; base-uri 'none'; report-uri https://csp.microsoft.com/report/ESTS-UX-All",
+  'X-XSS-Protection',
+  '0',
   'Set-Cookie',
-  'fpc=Ah4VpFUoeKZLn15IcDdIA4o; expires=Fri, 04-Feb-2022 09:04:55 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'fpc=AkIJ6h3DQBRDrZK5lfWg2N0; expires=Sat, 27-Aug-2022 09:32:30 GMT; path=/; secure; HttpOnly; SameSite=None',
   'Set-Cookie',
-  'esctx=AQABAAAAAAD--DLA3VO7QrddgJg7WevrB6l_bBo6-X8CNj-bMyZ7rAebEYzpB8_mFOCsUjvQbg7MslOz-Q1aYQlxkItiPzjYloCcnkPIpKaYtpg5LXhfugacHjkg6qLJ_755B3NdnT8yN4fuGLWnwiuLp8v8amoOQUB9X_zh6gd0dCvzKcUMjo_-jZ76NPxXbIt8S6mQaw4gAA; domain=.login.microsoftonline.com; path=/; secure; HttpOnly; SameSite=None',
+  'esctx=AQABAAAAAAD--DLA3VO7QrddgJg7WevrnbI88OVt_S_Q7OLZhx6Rtzjq6xRFabwI7kTGErINpwPqkc7ZBWm49Q_59a8DiNVvSiUD6u2K6q7W4JvrJiYb71qGI0D9Thzu5xwZnNdabBo-gJ1rChVAwoOXfk0mPlmdGDuHAq2x79MadRkggMat3JQgKloTm1BqXP4K4FVybs0gAA; domain=.login.microsoftonline.com; path=/; secure; HttpOnly; SameSite=None',
   'Set-Cookie',
   'x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly',
   'Set-Cookie',
   'stsservicecookie=estsfd; path=/; secure; samesite=none; httponly',
   'Date',
-  'Wed, 05 Jan 2022 09:04:54 GMT',
+  'Thu, 28 Jul 2022 09:32:29 GMT',
   'Content-Length',
   '980'
 ]);
@@ -134,25 +142,27 @@ nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
   'P3P',
   'CP="DSP CUR OTPi IND OTRi ONL FIN"',
   'x-ms-request-id',
-  '7631c509-4b1c-4cf2-86c8-aafef5a57e00',
+  'f13a58d2-0ac9-4bf9-bfc6-b43ddc673b00',
   'x-ms-ests-server',
-  '2.1.12261.17 - KRSLR1 ProdSlices',
+  '2.1.13355.6 - SEASLR1 ProdSlices',
+  'X-XSS-Protection',
+  '0',
   'Set-Cookie',
-  'fpc=Aqi-1g_qT4RGqni-_C4zsLI; expires=Fri, 04-Feb-2022 09:04:55 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'fpc=AkNAUIS_5zJFs9tf1ulURTw; expires=Sat, 27-Aug-2022 09:32:30 GMT; path=/; secure; HttpOnly; SameSite=None',
   'Set-Cookie',
-  'esctx=AQABAAAAAAD--DLA3VO7QrddgJg7WevrrAGyP1izdMhOQ3iTP6HUjVevZKb-8lOYdZOOUZrJ7qBQ3yQOdf8ZcMr-DuTHcO_AnmgELHh6uFrFxN18Rj8F17kziwXmTK4fsJC1XAKe2oHF7kW8OV7I9crFiTBH_m7PI5lFjJsCJgydsYBe_uleUWMZF875dANfdFHUqW_rcUcgAA; domain=.login.microsoftonline.com; path=/; secure; HttpOnly; SameSite=None',
+  'esctx=AQABAAAAAAD--DLA3VO7QrddgJg7Wevr3_cidLJ5Bf2SuygNdlRbdvowO2YsYjopYvA094GJoXFiFUA7o6jc1M0p-7vvbLS-gKZVXLH8_ZZ7WcsOr44K3c1wE3CUWzI2FZAVyooU43JO8mu953zBafCxWWXegooUzJ1V5fGINor3s9jRwqNJdPdo34jSguuX2V6pbrX64zwgAA; domain=.login.microsoftonline.com; path=/; secure; HttpOnly; SameSite=None',
   'Set-Cookie',
   'x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly',
   'Set-Cookie',
   'stsservicecookie=estsfd; path=/; secure; samesite=none; httponly',
   'Date',
-  'Wed, 05 Jan 2022 09:04:54 GMT',
+  'Thu, 28 Jul 2022 09:32:29 GMT',
   'Content-Length',
   '1753'
 ]);
 
 nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
-  .post('/aaaaa/oauth2/v2.0/token', "client_id=aaaaa&scope=https%3A%2F%2Fsanitized%2F&grant_type=client_credentials&x-client-SKU=msal.js.node&x-client-VER=1.4.0&x-client-OS=win32&x-client-CPU=x64&x-ms-lib-capability=retry-after, h429&x-client-current-telemetry=5|771,2,,,|,&x-client-last-telemetry=5|0|||0,0&client-request-id=dd2162ec-d3eb-4a36-9251-23c7e5b84a8d&client_secret=aaaaa&claims=%7B%22access_token%22%3A%7B%22xms_cc%22%3A%7B%22values%22%3A%5B%22cp1%22%5D%7D%7D%7D")
+  .post('/aaaaa/oauth2/v2.0/token', "client_id=aaaaa&scope=https%3A%2F%2Fsanitized%2F&grant_type=client_credentials&x-client-SKU=msal.js.node&x-client-VER=1.11.0&x-client-OS=win32&x-client-CPU=x64&x-ms-lib-capability=retry-after, h429&x-client-current-telemetry=5|771,2,,,|,&x-client-last-telemetry=5|0|||0,0&client-request-id=ad1e0936-b8bf-43c7-81d7-d1b8e03abc4c&client_secret=aaaaa&claims=%7B%22access_token%22%3A%7B%22xms_cc%22%3A%7B%22values%22%3A%5B%22cp1%22%5D%7D%7D%7D")
   .reply(200, {"token_type":"Bearer","expires_in":86399,"ext_expires_in":86399,"access_token":"access_token"}, [
   'Cache-Control',
   'no-store, no-cache',
@@ -169,19 +179,21 @@ nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
   'P3P',
   'CP="DSP CUR OTPi IND OTRi ONL FIN"',
   'x-ms-request-id',
-  '91a6d8dc-a007-449e-8811-fbe65e100600',
+  'a940112a-8d69-4ff8-b453-b1b89d503a00',
   'x-ms-ests-server',
-  '2.1.12261.17 - SEASLR1 ProdSlices',
+  '2.1.13355.6 - KRC ProdSlices',
   'x-ms-clitelem',
   '1,0,0,,',
+  'X-XSS-Protection',
+  '0',
   'Set-Cookie',
-  'fpc=Ak2SE7wFBxhPstROUu6XWqfeeSdeAQAAADdWZ9kOAAAA; expires=Fri, 04-Feb-2022 09:04:55 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'fpc=AomyF55bUdRMv6jQVjczJaLeeSdeAQAAAK5OdNoOAAAA; expires=Sat, 27-Aug-2022 09:32:30 GMT; path=/; secure; HttpOnly; SameSite=None',
   'Set-Cookie',
   'x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly',
   'Set-Cookie',
   'stsservicecookie=estsfd; path=/; secure; samesite=none; httponly',
   'Date',
-  'Wed, 05 Jan 2022 09:04:55 GMT',
+  'Thu, 28 Jul 2022 09:32:29 GMT',
   'Content-Length',
   '1318'
 ]);
@@ -205,19 +217,23 @@ nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
   'P3P',
   'CP="DSP CUR OTPi IND OTRi ONL FIN"',
   'x-ms-request-id',
-  '70f2d6e6-a657-4463-8780-71240e4b8a00',
+  '7cd87c98-932b-44e6-9629-e5854e733a00',
   'x-ms-ests-server',
-  '2.1.12261.17 - SEASLR2 ProdSlices',
+  '2.1.13355.6 - KRSLR1 ProdSlices',
+  'Content-Security-Policy-Report-Only',
+  "script-src 'self' 'nonce-jeKKS4KMk9YmAwiy0CI97Q' 'unsafe-eval' 'unsafe-inline'; object-src 'none'; base-uri 'none'; report-uri https://csp.microsoft.com/report/ESTS-UX-All",
+  'X-XSS-Protection',
+  '0',
   'Set-Cookie',
-  'fpc=AjVJJQ_EzGpDovzSJJnfHnU; expires=Fri, 04-Feb-2022 09:04:55 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'fpc=Aqc7P90gRjNAobCJsVNjw4s; expires=Sat, 27-Aug-2022 09:32:30 GMT; path=/; secure; HttpOnly; SameSite=None',
   'Set-Cookie',
-  'esctx=AQABAAAAAAD--DLA3VO7QrddgJg7WevrxjI-HXdl4HfV3AReXvz66eL0wyfMFJYL1AQ3DYtMdEaXlkqldtqHP96tPd1ajqhC3IUSB_WtPr2JgqcW0_u8a5M_S0H4JptLLUoTyzV9u0BHcJN9ySJLx9fEa5W8Q9P5044mspYO1tHsILAEJLOdIDw6VtAXptqpvlHfis4GjvogAA; domain=.login.microsoftonline.com; path=/; secure; HttpOnly; SameSite=None',
+  'esctx=AQABAAAAAAD--DLA3VO7QrddgJg7Wevrkk42zf_gvPwb9W6HtUspF33LP2VtgLKKflAQzkGk3nJlcWOTY4Xr0tZ2i01UMUoNdk74mhfFWPRe4GHFjCWovJoPVpYIAyq_85OBVG1I7sMJn4LawJ9v5g8KPr8Mt5G1wC2caFdY6Vg-A0b504Y_wOOfQsQI9zHcMxbMEdDt3jkgAA; domain=.login.microsoftonline.com; path=/; secure; HttpOnly; SameSite=None',
   'Set-Cookie',
   'x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly',
   'Set-Cookie',
   'stsservicecookie=estsfd; path=/; secure; samesite=none; httponly',
   'Date',
-  'Wed, 05 Jan 2022 09:04:55 GMT',
+  'Thu, 28 Jul 2022 09:32:29 GMT',
   'Content-Length',
   '980'
 ]);
@@ -240,25 +256,27 @@ nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
   'P3P',
   'CP="DSP CUR OTPi IND OTRi ONL FIN"',
   'x-ms-request-id',
-  '96a016c5-541f-49ed-980f-cd1a30908c00',
+  'a940112a-8d69-4ff8-b453-b1b8a1503a00',
   'x-ms-ests-server',
-  '2.1.12261.17 - KRSLR2 ProdSlices',
+  '2.1.13355.6 - KRC ProdSlices',
+  'X-XSS-Protection',
+  '0',
   'Set-Cookie',
-  'fpc=AgxNcpMGEr1DgesJmXyYabk; expires=Fri, 04-Feb-2022 09:04:56 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'fpc=AmgVh4vkwmxEuSIgDZ-25hg; expires=Sat, 27-Aug-2022 09:32:30 GMT; path=/; secure; HttpOnly; SameSite=None',
   'Set-Cookie',
-  'esctx=AQABAAAAAAD--DLA3VO7QrddgJg7Wevrf5liRhfZb977uyyqfkZqZs6H4-6cJfeYr-uawifAIT7UYMVdszkmdtU7W8HhTyhKtpfMO1rDMo3LPcsA0QzeLJ5jq7RB8jC0kr2xvPdivbBl2ZlwXGw7pT7N12Tjnw42byk69NSBvWUCfUPxrZGZrDfb8h6JO8dVu_OkbKi7RlggAA; domain=.login.microsoftonline.com; path=/; secure; HttpOnly; SameSite=None',
+  'esctx=AQABAAAAAAD--DLA3VO7QrddgJg7WevrIRxvOA8MbMmk9r96vlAeX6hVxyApHCcpozeT24VMr7A4OhRpBl5e8EtqkrZ6q8Krujc12_BKpIc0cRH7WPKvCUvAnu_y8BV7XMCKmFZlETBzu8YHos7G-dPwDm_F_51qD6SUQRY9awTSuKfQvN5Igz94XJYhLS_qEQvWU_8ue3cgAA; domain=.login.microsoftonline.com; path=/; secure; HttpOnly; SameSite=None',
   'Set-Cookie',
   'x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly',
   'Set-Cookie',
   'stsservicecookie=estsfd; path=/; secure; samesite=none; httponly',
   'Date',
-  'Wed, 05 Jan 2022 09:04:55 GMT',
+  'Thu, 28 Jul 2022 09:32:29 GMT',
   'Content-Length',
   '1753'
 ]);
 
 nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
-  .post('/aaaaa/oauth2/v2.0/token', "client_id=aaaaa&scope=https%3A%2F%2Fsanitized%2F&grant_type=client_credentials&x-client-SKU=msal.js.node&x-client-VER=1.4.0&x-client-OS=win32&x-client-CPU=x64&x-ms-lib-capability=retry-after, h429&x-client-current-telemetry=5|771,2,,,|,&x-client-last-telemetry=5|0|||0,0&client-request-id=2de48904-7882-4b36-be9e-b1fdbf9189a4&client_secret=aaaaa&claims=%7B%22access_token%22%3A%7B%22xms_cc%22%3A%7B%22values%22%3A%5B%22cp1%22%5D%7D%7D%7D")
+  .post('/aaaaa/oauth2/v2.0/token', "client_id=aaaaa&scope=https%3A%2F%2Fsanitized%2F&grant_type=client_credentials&x-client-SKU=msal.js.node&x-client-VER=1.11.0&x-client-OS=win32&x-client-CPU=x64&x-ms-lib-capability=retry-after, h429&x-client-current-telemetry=5|771,2,,,|,&x-client-last-telemetry=5|0|||0,0&client-request-id=0bba5d63-23d2-4728-bb11-212bc433e5c5&client_secret=aaaaa&claims=%7B%22access_token%22%3A%7B%22xms_cc%22%3A%7B%22values%22%3A%5B%22cp1%22%5D%7D%7D%7D")
   .reply(200, {"token_type":"Bearer","expires_in":86399,"ext_expires_in":86399,"access_token":"access_token"}, [
   'Cache-Control',
   'no-store, no-cache',
@@ -275,25 +293,27 @@ nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
   'P3P',
   'CP="DSP CUR OTPi IND OTRi ONL FIN"',
   'x-ms-request-id',
-  '96a016c5-541f-49ed-980f-cd1a32908c00',
+  'a940112a-8d69-4ff8-b453-b1b8a3503a00',
   'x-ms-ests-server',
-  '2.1.12261.17 - KRSLR2 ProdSlices',
+  '2.1.13355.6 - KRC ProdSlices',
   'x-ms-clitelem',
   '1,0,0,,',
+  'X-XSS-Protection',
+  '0',
   'Set-Cookie',
-  'fpc=AmbTuvsD6utAoYv9ahLM487eeSdeAQAAADdWZ9kOAAAA; expires=Fri, 04-Feb-2022 09:04:56 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'fpc=AnZy9-AenZNAuxqBkrgohUPeeSdeAQAAAK5OdNoOAAAA; expires=Sat, 27-Aug-2022 09:32:31 GMT; path=/; secure; HttpOnly; SameSite=None',
   'Set-Cookie',
   'x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly',
   'Set-Cookie',
   'stsservicecookie=estsfd; path=/; secure; samesite=none; httponly',
   'Date',
-  'Wed, 05 Jan 2022 09:04:55 GMT',
+  'Thu, 28 Jul 2022 09:32:30 GMT',
   'Content-Length',
   '1318'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container164137349511209597/newblockblob164137349574305703')
+  .put('/container165900074958500807/newblockblob165900075040907799')
   .query(true)
   .reply(201, "", [
   'Content-Length',
@@ -301,21 +321,21 @@ nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParam
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'cccf2fd4-e01e-0002-5113-025a01000000',
+  '9eef4a6f-401e-000b-0264-a21fd2000000',
   'x-ms-client-request-id',
-  'a8a5cb0f-950b-4136-9b61-5b34551ee95d',
+  '283cf09c-4747-44f0-82eb-588bc8c012d5',
   'x-ms-version',
-  '2021-02-12',
+  '2021-08-06',
   'x-ms-content-crc64',
   '8R2aIe9T07E=',
   'x-ms-request-server-encrypted',
   'true',
   'Date',
-  'Wed, 05 Jan 2022 09:04:56 GMT'
+  'Thu, 28 Jul 2022 09:32:30 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container164137349511209597/newblockblob164137349574305703')
+  .put('/container165900074958500807/newblockblob165900075040907799')
   .query(true)
   .reply(201, "", [
   'Content-Length',
@@ -323,47 +343,49 @@ nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParam
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'cccf2fe7-e01e-0002-6113-025a01000000',
+  '9eef4aaa-401e-000b-3564-a21fd2000000',
   'x-ms-client-request-id',
-  '11341588-e2c1-4bc3-8c37-9072ec1f856a',
+  '3d09c928-3d42-4004-a584-ddaa07cd2df9',
   'x-ms-version',
-  '2021-02-12',
+  '2021-08-06',
   'x-ms-content-crc64',
   '8R2aIe9T07E=',
   'x-ms-request-server-encrypted',
   'true',
   'Date',
-  'Wed, 05 Jan 2022 09:04:56 GMT'
+  'Thu, 28 Jul 2022 09:32:30 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container164137349511209597/newblockblob164137349574305703', "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?><BlockList><Latest>MQ==</Latest><Latest>Mg==</Latest></BlockList>")
+  .put('/container165900074958500807/newblockblob165900075040907799', "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?><BlockList><Latest>MQ==</Latest><Latest>Mg==</Latest></BlockList>")
   .query(true)
   .reply(201, "", [
   'Content-Length',
   '0',
   'Last-Modified',
-  'Wed, 05 Jan 2022 09:04:56 GMT',
+  'Thu, 28 Jul 2022 09:32:31 GMT',
   'ETag',
-  '"0x8D9D02A71D70B92"',
+  '"0x8DA707C186122F5"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'cccf2fff-e01e-0002-7513-025a01000000',
+  '9eef4ac3-401e-000b-4d64-a21fd2000000',
   'x-ms-client-request-id',
-  '6ebe077a-632c-40b0-8b9f-cb08fd6af723',
+  '0d16cdf8-15e0-4ead-a246-2bb2f08f85e9',
   'x-ms-version',
-  '2021-02-12',
+  '2021-08-06',
   'x-ms-content-crc64',
   'GFi/o1BSQtU=',
+  'x-ms-version-id',
+  '2022-07-28T09:32:31.3621237Z',
   'x-ms-request-server-encrypted',
   'true',
   'Date',
-  'Wed, 05 Jan 2022 09:04:56 GMT'
+  'Thu, 28 Jul 2022 09:32:30 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .get('/container164137349511209597/newblockblob164137349574305703')
+  .get('/container165900074958500807/newblockblob165900075040907799')
   .query(true)
   .reply(200, "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><BlockList><CommittedBlocks><Block><Name>MQ==</Name><Size>10</Size></Block><Block><Name>Mg==</Name><Size>10</Size></Block></CommittedBlocks></BlockList>", [
   'Transfer-Encoding',
@@ -371,25 +393,29 @@ nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParam
   'Content-Type',
   'application/xml',
   'Last-Modified',
-  'Wed, 05 Jan 2022 09:04:56 GMT',
+  'Thu, 28 Jul 2022 09:32:31 GMT',
   'ETag',
-  '"0x8D9D02A71D70B92"',
+  '"0x8DA707C186122F5"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'cccf3008-e01e-0002-7c13-025a01000000',
+  '9eef4af9-401e-000b-7c64-a21fd2000000',
   'x-ms-client-request-id',
-  '09be7ec4-99fe-48fe-876c-c21b17160674',
+  '701ade08-a455-4a1e-b991-f401af89bcf1',
   'x-ms-version',
-  '2021-02-12',
+  '2021-08-06',
   'x-ms-blob-content-length',
   '20',
+  'Access-Control-Expose-Headers',
+  'x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,Last-Modified,ETag,x-ms-blob-content-length,Content-Type,Content-Length,Date,Transfer-Encoding',
+  'Access-Control-Allow-Origin',
+  '*',
   'Date',
-  'Wed, 05 Jan 2022 09:04:56 GMT'
+  'Thu, 28 Jul 2022 09:32:30 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .delete('/container164137349511209597')
+  .delete('/container165900074958500807')
   .query(true)
   .reply(202, "", [
   'Content-Length',
@@ -397,11 +423,11 @@ nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParam
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'cccf301c-e01e-0002-0e13-025a01000000',
+  '9eef4b17-401e-000b-1864-a21fd2000000',
   'x-ms-client-request-id',
-  'a6fae616-8087-49ad-9910-342b3dd9ce26',
+  '11a5c713-e7d3-4d83-8b2c-db15f8497079',
   'x-ms-version',
-  '2021-02-12',
+  '2021-08-06',
   'Date',
-  'Wed, 05 Jan 2022 09:04:56 GMT'
+  'Thu, 28 Jul 2022 09:32:30 GMT'
 ]);

--- a/sdk/storage/storage-blob/recordings/node/syncuploadfromurl/recording_stageblockfromurl__source_bear_token_and_destination_account_key.js
+++ b/sdk/storage/storage-blob/recordings/node/syncuploadfromurl/recording_stageblockfromurl__source_bear_token_and_destination_account_key.js
@@ -1,83 +1,87 @@
 let nock = require('nock');
 
-module.exports.hash = "bbb8d9627e5933584577a0f941fac109";
+module.exports.hash = "9a7692306c1d84bf253dc3e482407bdb";
 
-module.exports.testInfo = {"uniqueName":{"container":"container164137349378804424","blockblob":"blockblob164137349389204301","srcblob/%2+%2F":"srcblob/%2+%2F164137349389300622","newblockblob":"newblockblob164137349450702610"},"newDate":{"expiry":"2022-01-05T09:04:53.998Z"}}
+module.exports.testInfo = {"uniqueName":{"container":"container165900074811408317","blockblob":"blockblob165900074821501118","srcblob/%2+%2F":"srcblob/%2+%2F165900074821608109","newblockblob":"newblockblob165900074902607855"},"newDate":{"expiry":"2022-07-28T09:32:28.317Z"}}
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container164137349378804424')
+  .put('/container165900074811408317')
   .query(true)
   .reply(201, "", [
   'Content-Length',
   '0',
   'Last-Modified',
-  'Wed, 05 Jan 2022 09:04:54 GMT',
+  'Thu, 28 Jul 2022 09:32:28 GMT',
   'ETag',
-  '"0x8D9D02A703F82EB"',
+  '"0x8DA707C169CCCEC"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'cccf2df8-e01e-0002-4613-025a01000000',
+  '9eef45c4-401e-000b-6c64-a21fd2000000',
   'x-ms-client-request-id',
-  '2a08c5de-1b77-4dea-a472-ace81a710d4b',
+  'c24e2cee-2b4e-4c71-825b-17ef86e03b29',
   'x-ms-version',
-  '2021-02-12',
+  '2021-08-06',
   'Date',
-  'Wed, 05 Jan 2022 09:04:53 GMT'
+  'Thu, 28 Jul 2022 09:32:27 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container164137349378804424/srcblob%2F%252%2B%252F164137349389300622', "Hello World")
+  .put('/container165900074811408317/srcblob/%252%2B%252F165900074821608109', "Hello World")
   .reply(201, "", [
   'Content-Length',
   '0',
   'Content-MD5',
   'sQqNsWTgdUEFt6mb5y4/5Q==',
   'Last-Modified',
-  'Wed, 05 Jan 2022 09:04:54 GMT',
+  'Thu, 28 Jul 2022 09:32:28 GMT',
   'ETag',
-  '"0x8D9D02A704F92B4"',
+  '"0x8DA707C16AD9D5F"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'cccf2e08-e01e-0002-5513-025a01000000',
+  '9eef4601-401e-000b-2064-a21fd2000000',
   'x-ms-client-request-id',
-  '21e437df-4e65-4baa-acc6-148a4ac22fe3',
+  'e9885caa-c816-4045-bbbd-d3c15604097c',
   'x-ms-version',
-  '2021-02-12',
+  '2021-08-06',
   'x-ms-content-crc64',
   'YeJLfssylmU=',
   'x-ms-request-server-encrypted',
   'true',
+  'x-ms-version-id',
+  '2022-07-28T09:32:28.5078879Z',
   'Date',
-  'Wed, 05 Jan 2022 09:04:53 GMT'
+  'Thu, 28 Jul 2022 09:32:27 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container164137349378804424/blockblob164137349389204301', "HelloWorld")
+  .put('/container165900074811408317/blockblob165900074821501118', "HelloWorld")
   .reply(201, "", [
   'Content-Length',
   '0',
   'Content-MD5',
   'aOEJ8PQMpyoV4FzCJ4b45g==',
   'Last-Modified',
-  'Wed, 05 Jan 2022 09:04:54 GMT',
+  'Thu, 28 Jul 2022 09:32:28 GMT',
   'ETag',
-  '"0x8D9D02A70605926"',
+  '"0x8DA707C16BCDD34"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'cccf2e18-e01e-0002-6313-025a01000000',
+  '9eef462c-401e-000b-4764-a21fd2000000',
   'x-ms-client-request-id',
-  '70ca317e-44b5-4b8f-aae3-fd5ea6e81141',
+  '8b7ed1fb-7b19-4914-89fd-109229ff1880',
   'x-ms-version',
-  '2021-02-12',
+  '2021-08-06',
   'x-ms-content-crc64',
   '8R2aIe9T07E=',
   'x-ms-request-server-encrypted',
   'true',
+  'x-ms-version-id',
+  '2022-07-28T09:32:28.6078260Z',
   'Date',
-  'Wed, 05 Jan 2022 09:04:53 GMT'
+  'Thu, 28 Jul 2022 09:32:27 GMT'
 ]);
 
 nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
@@ -99,19 +103,21 @@ nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
   'P3P',
   'CP="DSP CUR OTPi IND OTRi ONL FIN"',
   'x-ms-request-id',
-  '882ce76a-8151-44e0-b77f-469e2c348100',
+  'ac53e1e0-c44c-46f7-8bc1-1a5b7f670500',
   'x-ms-ests-server',
-  '2.1.12261.17 - KRSLR2 ProdSlices',
+  '2.1.13355.6 - SEASLR2 ProdSlices',
+  'X-XSS-Protection',
+  '0',
   'Set-Cookie',
-  'fpc=Ao8itCPCs1VBrKnx_w4VreQ; expires=Fri, 04-Feb-2022 09:04:54 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'fpc=AvCrSb3BsGJKi-qcHq3kaxc; expires=Sat, 27-Aug-2022 09:32:28 GMT; path=/; secure; HttpOnly; SameSite=None',
   'Set-Cookie',
-  'esctx=AQABAAAAAAD--DLA3VO7QrddgJg7WevrWgk9jJbLYuOAMYRIXziGa3XiVvhEEs5Sl0P7Wc5ve8fpOrOAWwIq_NuA3EMjDsnLLqEsHUrKXD3qQs_4IAPMeg21FXoY6_Mu2lUiLzZblTJoEhrsGX6pCSKwCtnONvlQJo1JQ98WCrBLnoWbtytSO2E59pHTMm6GR_omRPD7Di0gAA; domain=.login.microsoftonline.com; path=/; secure; HttpOnly; SameSite=None',
+  'esctx=AQABAAAAAAD--DLA3VO7QrddgJg7WevrlM9g-90aMbbWE8JgEwKSRXKb0pLvO0h737g8yBX3PL_PpDCzrewXWQdNkDJHLkMZkRfyk0TwqoMHOx-xWyuI895n_6XTAz0jjj4yl8fxy1veRR2HY8TXwmLaQEKNcwuNasGqmOgquDVM9Edo9i8pr8LeM-rsfc7ccJ0uWth8V1wgAA; domain=.login.microsoftonline.com; path=/; secure; HttpOnly; SameSite=None',
   'Set-Cookie',
   'x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly',
   'Set-Cookie',
   'stsservicecookie=estsfd; path=/; secure; samesite=none; httponly',
   'Date',
-  'Wed, 05 Jan 2022 09:04:53 GMT',
+  'Thu, 28 Jul 2022 09:32:27 GMT',
   'Content-Length',
   '980'
 ]);
@@ -134,25 +140,27 @@ nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
   'P3P',
   'CP="DSP CUR OTPi IND OTRi ONL FIN"',
   'x-ms-request-id',
-  '91a6d8dc-a007-449e-8811-fbe651100600',
+  '38f8779e-1ba4-46e6-9737-1ca6445a3b00',
   'x-ms-ests-server',
-  '2.1.12261.17 - SEASLR1 ProdSlices',
+  '2.1.13355.6 - KRC ProdSlices',
+  'X-XSS-Protection',
+  '0',
   'Set-Cookie',
-  'fpc=AuhWQ72fR5RPryI8xBFHbbY; expires=Fri, 04-Feb-2022 09:04:54 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'fpc=Au-MP7lfk9dIk-R7RyRHMyI; expires=Sat, 27-Aug-2022 09:32:28 GMT; path=/; secure; HttpOnly; SameSite=None',
   'Set-Cookie',
-  'esctx=AQABAAAAAAD--DLA3VO7QrddgJg7WevrTnw9bCZ8-fXp__Ys3pixvcBhTLgn6h2dYWzp-paSKMzuT_rC1OBKjWYi8g9NuGkEZ0emrNZir52Rd5TUqG82GdBcv8QeLBSXZgpwLWz61rTEcLdUu6bAioBoJ-PstLqe5BsuO8d1d10Z9lmhzKutHYKt4ByqMFaEHZmkVW5X1XEgAA; domain=.login.microsoftonline.com; path=/; secure; HttpOnly; SameSite=None',
+  'esctx=AQABAAAAAAD--DLA3VO7QrddgJg7Wevrj82epKkTuZfxYIzJqd9FPZKKul6-RL5Vy561IMIPKEepSo1acYJR7tjE3BEqK-Sv31udAE-jZ6GgCpNRwyvCPEB1J3q9OLTppBArEmXW87MDaBQmL-7bnT6ZI2xHuwOA2U7yIvURTq1sCZtGvjiuE6Og42jU2YsLd4yKW3Ah0MIgAA; domain=.login.microsoftonline.com; path=/; secure; HttpOnly; SameSite=None',
   'Set-Cookie',
   'x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly',
   'Set-Cookie',
   'stsservicecookie=estsfd; path=/; secure; samesite=none; httponly',
   'Date',
-  'Wed, 05 Jan 2022 09:04:53 GMT',
+  'Thu, 28 Jul 2022 09:32:28 GMT',
   'Content-Length',
   '1753'
 ]);
 
 nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
-  .post('/aaaaa/oauth2/v2.0/token', "client_id=aaaaa&scope=https%3A%2F%2Fsanitized%2F&grant_type=client_credentials&x-client-SKU=msal.js.node&x-client-VER=1.4.0&x-client-OS=win32&x-client-CPU=x64&x-ms-lib-capability=retry-after, h429&x-client-current-telemetry=5|771,2,,,|,&x-client-last-telemetry=5|0|||0,0&client-request-id=776cbeb1-7dff-443d-a336-6ceea80e9d49&client_secret=aaaaa&claims=%7B%22access_token%22%3A%7B%22xms_cc%22%3A%7B%22values%22%3A%5B%22cp1%22%5D%7D%7D%7D")
+  .post('/aaaaa/oauth2/v2.0/token', "client_id=aaaaa&scope=https%3A%2F%2Fsanitized%2F&grant_type=client_credentials&x-client-SKU=msal.js.node&x-client-VER=1.11.0&x-client-OS=win32&x-client-CPU=x64&x-ms-lib-capability=retry-after, h429&x-client-current-telemetry=5|771,2,,,|,&x-client-last-telemetry=5|0|||0,0&client-request-id=04ef109d-2b9d-4b9f-8389-c12ba3778db0&client_secret=aaaaa&claims=%7B%22access_token%22%3A%7B%22xms_cc%22%3A%7B%22values%22%3A%5B%22cp1%22%5D%7D%7D%7D")
   .reply(200, {"token_type":"Bearer","expires_in":86399,"ext_expires_in":86399,"access_token":"access_token"}, [
   'Cache-Control',
   'no-store, no-cache',
@@ -169,25 +177,27 @@ nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
   'P3P',
   'CP="DSP CUR OTPi IND OTRi ONL FIN"',
   'x-ms-request-id',
-  '882ce76a-8151-44e0-b77f-469e2f348100',
+  '087690f7-9838-47aa-9998-e0aad7d33800',
   'x-ms-ests-server',
-  '2.1.12261.17 - KRSLR2 ProdSlices',
+  '2.1.13355.6 - SEASLR1 ProdSlices',
   'x-ms-clitelem',
   '1,0,0,,',
+  'X-XSS-Protection',
+  '0',
   'Set-Cookie',
-  'fpc=AhQGEdkP0IJLoSsPp1FeG7feeSdeAQAAADZWZ9kOAAAA; expires=Fri, 04-Feb-2022 09:04:54 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'fpc=Ag-4H9lNNvNLn_fWbzHL8ZveeSdeAQAAAKxOdNoOAAAA; expires=Sat, 27-Aug-2022 09:32:29 GMT; path=/; secure; HttpOnly; SameSite=None',
   'Set-Cookie',
   'x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly',
   'Set-Cookie',
   'stsservicecookie=estsfd; path=/; secure; samesite=none; httponly',
   'Date',
-  'Wed, 05 Jan 2022 09:04:53 GMT',
+  'Thu, 28 Jul 2022 09:32:28 GMT',
   'Content-Length',
   '1318'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container164137349378804424/newblockblob164137349450702610')
+  .put('/container165900074811408317/newblockblob165900074902607855')
   .query(true)
   .reply(201, "", [
   'Content-Length',
@@ -195,21 +205,21 @@ nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParam
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'cccf2e74-e01e-0002-3013-025a01000000',
+  '9eef473d-401e-000b-2b64-a21fd2000000',
   'x-ms-client-request-id',
-  'ee7d736c-4d30-4946-ad4f-0575f66ea0a8',
+  '7cc5d773-5112-4a17-8220-bc26f7be5ada',
   'x-ms-version',
-  '2021-02-12',
+  '2021-08-06',
   'x-ms-content-crc64',
   '8R2aIe9T07E=',
   'x-ms-request-server-encrypted',
   'true',
   'Date',
-  'Wed, 05 Jan 2022 09:04:54 GMT'
+  'Thu, 28 Jul 2022 09:32:28 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container164137349378804424/newblockblob164137349450702610')
+  .put('/container165900074811408317/newblockblob165900074902607855')
   .query(true)
   .reply(201, "", [
   'Content-Length',
@@ -217,47 +227,49 @@ nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParam
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'cccf2e97-e01e-0002-4e13-025a01000000',
+  '9eef475a-401e-000b-4664-a21fd2000000',
   'x-ms-client-request-id',
-  '59a5b7ce-3ed7-4d72-9e05-e490a6067de0',
+  '64d25632-a639-42b8-97d3-b43e6dcb7340',
   'x-ms-version',
-  '2021-02-12',
+  '2021-08-06',
   'x-ms-content-crc64',
   '8R2aIe9T07E=',
   'x-ms-request-server-encrypted',
   'true',
   'Date',
-  'Wed, 05 Jan 2022 09:04:54 GMT'
+  'Thu, 28 Jul 2022 09:32:28 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container164137349378804424/newblockblob164137349450702610', "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?><BlockList><Latest>MQ==</Latest><Latest>Mg==</Latest></BlockList>")
+  .put('/container165900074811408317/newblockblob165900074902607855', "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?><BlockList><Latest>MQ==</Latest><Latest>Mg==</Latest></BlockList>")
   .query(true)
   .reply(201, "", [
   'Content-Length',
   '0',
   'Last-Modified',
-  'Wed, 05 Jan 2022 09:04:54 GMT',
+  'Thu, 28 Jul 2022 09:32:29 GMT',
   'ETag',
-  '"0x8D9D02A70D6B092"',
+  '"0x8DA707C174CAA66"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'cccf2eb9-e01e-0002-6c13-025a01000000',
+  '9eef476a-401e-000b-5664-a21fd2000000',
   'x-ms-client-request-id',
-  'b644f0b2-8a2b-4d4e-9392-060df2b43d48',
+  'a73cf98a-fe93-4ee8-a4cc-49ecd0f496bd',
   'x-ms-version',
-  '2021-02-12',
+  '2021-08-06',
   'x-ms-content-crc64',
   'GFi/o1BSQtU=',
+  'x-ms-version-id',
+  '2022-07-28T09:32:29.5502438Z',
   'x-ms-request-server-encrypted',
   'true',
   'Date',
-  'Wed, 05 Jan 2022 09:04:54 GMT'
+  'Thu, 28 Jul 2022 09:32:28 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .get('/container164137349378804424/newblockblob164137349450702610')
+  .get('/container165900074811408317/newblockblob165900074902607855')
   .query(true)
   .reply(200, "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><BlockList><CommittedBlocks><Block><Name>MQ==</Name><Size>10</Size></Block><Block><Name>Mg==</Name><Size>10</Size></Block></CommittedBlocks></BlockList>", [
   'Transfer-Encoding',
@@ -265,25 +277,29 @@ nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParam
   'Content-Type',
   'application/xml',
   'Last-Modified',
-  'Wed, 05 Jan 2022 09:04:54 GMT',
+  'Thu, 28 Jul 2022 09:32:29 GMT',
   'ETag',
-  '"0x8D9D02A70D6B092"',
+  '"0x8DA707C174CAA66"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'cccf2edf-e01e-0002-0f13-025a01000000',
+  '9eef4771-401e-000b-5c64-a21fd2000000',
   'x-ms-client-request-id',
-  'f8c22835-3933-4376-beb4-8fc670e4991a',
+  'fa945f02-7a0b-40fa-8912-0ce83129321d',
   'x-ms-version',
-  '2021-02-12',
+  '2021-08-06',
   'x-ms-blob-content-length',
   '20',
+  'Access-Control-Expose-Headers',
+  'x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,Last-Modified,ETag,x-ms-blob-content-length,Content-Type,Content-Length,Date,Transfer-Encoding',
+  'Access-Control-Allow-Origin',
+  '*',
   'Date',
-  'Wed, 05 Jan 2022 09:04:54 GMT'
+  'Thu, 28 Jul 2022 09:32:28 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .delete('/container164137349378804424')
+  .delete('/container165900074811408317')
   .query(true)
   .reply(202, "", [
   'Content-Length',
@@ -291,11 +307,11 @@ nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParam
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'cccf2f06-e01e-0002-1d13-025a01000000',
+  '9eef4799-401e-000b-8064-a21fd2000000',
   'x-ms-client-request-id',
-  '71512ac2-0735-476d-adb2-9c1f4d831f77',
+  'c9f0ea0c-99a4-4bc2-9f80-e20203493743',
   'x-ms-version',
-  '2021-02-12',
+  '2021-08-06',
   'Date',
-  'Wed, 05 Jan 2022 09:04:54 GMT'
+  'Thu, 28 Jul 2022 09:32:29 GMT'
 ]);

--- a/sdk/storage/storage-blob/recordings/node/syncuploadfromurl/recording_stageblockfromurl__source_sas_and_destination_bearer_token.js
+++ b/sdk/storage/storage-blob/recordings/node/syncuploadfromurl/recording_stageblockfromurl__source_sas_and_destination_bearer_token.js
@@ -1,56 +1,58 @@
 let nock = require('nock');
 
-module.exports.hash = "cc2f49408d65f3abe04cb94664ce4189";
+module.exports.hash = "d2657b973ba80bda38491ff6af987359";
 
-module.exports.testInfo = {"uniqueName":{"container":"container164137349170003608","blockblob":"blockblob164137349236809756","srcblob/%2+%2F":"srcblob/%2+%2F164137349237002359"},"newDate":{"expiry":"2022-01-05T09:04:52.487Z"}}
+module.exports.testInfo = {"uniqueName":{"container":"container165900074553801297","blockblob":"blockblob165900074614306823","srcblob/%2+%2F":"srcblob/%2+%2F165900074614400257"},"newDate":{"expiry":"2022-07-28T09:32:26.250Z"}}
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container164137349170003608')
+  .put('/container165900074553801297')
   .query(true)
   .reply(201, "", [
   'Content-Length',
   '0',
   'Last-Modified',
-  'Wed, 05 Jan 2022 09:04:52 GMT',
+  'Thu, 28 Jul 2022 09:32:26 GMT',
   'ETag',
-  '"0x8D9D02A6F5349CD"',
+  '"0x8DA707C155EFDAA"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'cccf2d3f-e01e-0002-2d13-025a01000000',
+  '9eef420b-401e-000b-7964-a21fd2000000',
   'x-ms-client-request-id',
-  '6195f4af-0099-47cf-9072-4f5a84caf78e',
+  'c82d0880-3377-4628-9c00-49c62e7def3c',
   'x-ms-version',
-  '2021-02-12',
+  '2021-08-06',
   'Date',
-  'Wed, 05 Jan 2022 09:04:52 GMT'
+  'Thu, 28 Jul 2022 09:32:25 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container164137349170003608/srcblob%2F%252%2B%252F164137349237002359', "Hello World")
+  .put('/container165900074553801297/srcblob/%252%2B%252F165900074614400257', "Hello World")
   .reply(201, "", [
   'Content-Length',
   '0',
   'Content-MD5',
   'sQqNsWTgdUEFt6mb5y4/5Q==',
   'Last-Modified',
-  'Wed, 05 Jan 2022 09:04:52 GMT',
+  'Thu, 28 Jul 2022 09:32:26 GMT',
   'ETag',
-  '"0x8D9D02A6F68D67D"',
+  '"0x8DA707C1571F3EB"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'cccf2d4d-e01e-0002-3713-025a01000000',
+  '9eef4276-401e-000b-5e64-a21fd2000000',
   'x-ms-client-request-id',
-  '1e709d41-f613-4def-8da0-b38a1f94b804',
+  'a337c5d2-e4f9-421b-a7a7-9171be70db04',
   'x-ms-version',
-  '2021-02-12',
+  '2021-08-06',
   'x-ms-content-crc64',
   'YeJLfssylmU=',
   'x-ms-request-server-encrypted',
   'true',
+  'x-ms-version-id',
+  '2022-07-28T09:32:26.4401656Z',
   'Date',
-  'Wed, 05 Jan 2022 09:04:52 GMT'
+  'Thu, 28 Jul 2022 09:32:25 GMT'
 ]);
 
 nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
@@ -72,19 +74,21 @@ nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
   'P3P',
   'CP="DSP CUR OTPi IND OTRi ONL FIN"',
   'x-ms-request-id',
-  '91a6d8dc-a007-449e-8811-fbe647100600',
+  'db881c6c-ff08-4aae-bed6-bc2547ee3900',
   'x-ms-ests-server',
-  '2.1.12261.17 - SEASLR1 ProdSlices',
+  '2.1.13355.6 - SEASLR1 ProdSlices',
+  'X-XSS-Protection',
+  '0',
   'Set-Cookie',
-  'fpc=AkvCCuryI_lCuuS0up_y4tw; expires=Fri, 04-Feb-2022 09:04:52 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'fpc=Aroee_3j4OBFkJhxI9ZUPeA; expires=Sat, 27-Aug-2022 09:32:26 GMT; path=/; secure; HttpOnly; SameSite=None',
   'Set-Cookie',
-  'esctx=AQABAAAAAAD--DLA3VO7QrddgJg7Wevrof01DXu09GG-7miErxVHYQsjlL97Lh5tNn9pVIDYPOYSauL0ip1A45G1Da1acjfjbWShvcBOkK8wmaTSsMkMb3DsRUoZRvoRfHP99ajM6KdqukuvaD7uimTQ54ko39hJAWy1CqvuWy0hlEoTs0HHk5xt72RI8Fuodluf1lo04ycgAA; domain=.login.microsoftonline.com; path=/; secure; HttpOnly; SameSite=None',
+  'esctx=AQABAAAAAAD--DLA3VO7QrddgJg7WevrSQLvCH6svcQHTK31eQ0blWxB7VGRlhmemZXdkxS8hOtXurP_ecVa8CBdJS99HdW7Lt7cc_U4vy5HVzUPHt0WPf29qyeD5a9kbnWxkwbPiOg-h8ypVpP2kwZW68KHgB7DAk5T6MO9oH3G_LoGErxYCZpTwKQJscnpCl8l6k04LREgAA; domain=.login.microsoftonline.com; path=/; secure; HttpOnly; SameSite=None',
   'Set-Cookie',
   'x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly',
   'Set-Cookie',
   'stsservicecookie=estsfd; path=/; secure; samesite=none; httponly',
   'Date',
-  'Wed, 05 Jan 2022 09:04:52 GMT',
+  'Thu, 28 Jul 2022 09:32:26 GMT',
   'Content-Length',
   '980'
 ]);
@@ -107,25 +111,27 @@ nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
   'P3P',
   'CP="DSP CUR OTPi IND OTRi ONL FIN"',
   'x-ms-request-id',
-  '7631c509-4b1c-4cf2-86c8-aafedaa57e00',
+  '087690f7-9838-47aa-9998-e0aabfd33800',
   'x-ms-ests-server',
-  '2.1.12261.17 - KRSLR1 ProdSlices',
+  '2.1.13355.6 - SEASLR1 ProdSlices',
+  'X-XSS-Protection',
+  '0',
   'Set-Cookie',
-  'fpc=AneQ9EftG31LlQii2i3kYr4; expires=Fri, 04-Feb-2022 09:04:52 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'fpc=AsKCC4qgEc1PnNk8ZXXVJUI; expires=Sat, 27-Aug-2022 09:32:27 GMT; path=/; secure; HttpOnly; SameSite=None',
   'Set-Cookie',
-  'esctx=AQABAAAAAAD--DLA3VO7QrddgJg7WevrBR6pmty46UjToLxcVUs8ME6NPK1wQvx0EQkwTQ18aP_PU21UE0f-9XpHJha3t5GeKZPwYX0lzwOBF3SAT19jfFlIGoRLIbfYkpD5FJV87nZCvuCDrJkdxxPeHI4UpnFj8m6fwtY5lOWGwISxYBeCMsyWbeTzemWwGq9e-VkuHlMgAA; domain=.login.microsoftonline.com; path=/; secure; HttpOnly; SameSite=None',
+  'esctx=AQABAAAAAAD--DLA3VO7QrddgJg7WevrniQ9JFS9ZfcEFX1hoX5OZMuppGEpdSRrJGKbn97puYDrdlYZAxGIfCDd1neDGavZqpJFBp4fVfvhcywV9DgAUh5nD7pXRyJxQ49vq29zFKI5tpU5HTNufW73BU72iRRZSECq_fq1_o1vChqjs9hsr2jQKMT6xRTQOtJj1_JrfgQgAA; domain=.login.microsoftonline.com; path=/; secure; HttpOnly; SameSite=None',
   'Set-Cookie',
   'x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly',
   'Set-Cookie',
   'stsservicecookie=estsfd; path=/; secure; samesite=none; httponly',
   'Date',
-  'Wed, 05 Jan 2022 09:04:52 GMT',
+  'Thu, 28 Jul 2022 09:32:26 GMT',
   'Content-Length',
   '1753'
 ]);
 
 nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
-  .post('/aaaaa/oauth2/v2.0/token', "client_id=aaaaa&scope=https%3A%2F%2Fsanitized%2F&grant_type=client_credentials&x-client-SKU=msal.js.node&x-client-VER=1.4.0&x-client-OS=win32&x-client-CPU=x64&x-ms-lib-capability=retry-after, h429&x-client-current-telemetry=5|771,2,,,|,&x-client-last-telemetry=5|0|||0,0&client-request-id=274eeb27-2296-4901-93a1-fe06a083bf58&client_secret=aaaaa&claims=%7B%22access_token%22%3A%7B%22xms_cc%22%3A%7B%22values%22%3A%5B%22cp1%22%5D%7D%7D%7D")
+  .post('/aaaaa/oauth2/v2.0/token', "client_id=aaaaa&scope=https%3A%2F%2Fsanitized%2F&grant_type=client_credentials&x-client-SKU=msal.js.node&x-client-VER=1.11.0&x-client-OS=win32&x-client-CPU=x64&x-ms-lib-capability=retry-after, h429&x-client-current-telemetry=5|771,2,,,|,&x-client-last-telemetry=5|0|||0,0&client-request-id=3b2a7eb2-515d-4e94-b0cc-7f0c5d7275f8&client_secret=aaaaa&claims=%7B%22access_token%22%3A%7B%22xms_cc%22%3A%7B%22values%22%3A%5B%22cp1%22%5D%7D%7D%7D")
   .reply(200, {"token_type":"Bearer","expires_in":86399,"ext_expires_in":86399,"access_token":"access_token"}, [
   'Cache-Control',
   'no-store, no-cache',
@@ -142,25 +148,27 @@ nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
   'P3P',
   'CP="DSP CUR OTPi IND OTRi ONL FIN"',
   'x-ms-request-id',
-  'c11f8f9a-6879-4d56-8cc3-1fb261d77e00',
+  'ac53e1e0-c44c-46f7-8bc1-1a5b72670500',
   'x-ms-ests-server',
-  '2.1.12261.17 - SEASLR2 ProdSlices',
+  '2.1.13355.6 - SEASLR2 ProdSlices',
   'x-ms-clitelem',
   '1,0,0,,',
+  'X-XSS-Protection',
+  '0',
   'Set-Cookie',
-  'fpc=AuePQTdu66ZGk3cTi0Dsf67eeSdeAQAAADRWZ9kOAAAA; expires=Fri, 04-Feb-2022 09:04:53 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'fpc=AsOSUuTwI0NEpwWfWHEH3fveeSdeAQAAAKtOdNoOAAAA; expires=Sat, 27-Aug-2022 09:32:27 GMT; path=/; secure; HttpOnly; SameSite=None',
   'Set-Cookie',
   'x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly',
   'Set-Cookie',
   'stsservicecookie=estsfd; path=/; secure; samesite=none; httponly',
   'Date',
-  'Wed, 05 Jan 2022 09:04:52 GMT',
+  'Thu, 28 Jul 2022 09:32:26 GMT',
   'Content-Length',
   '1318'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container164137349170003608/blockblob164137349236809756')
+  .put('/container165900074553801297/blockblob165900074614306823')
   .query(true)
   .reply(201, "", [
   'Content-Length',
@@ -168,21 +176,21 @@ nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParam
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'cccf2da8-e01e-0002-0513-025a01000000',
+  '9eef44ba-401e-000b-7e64-a21fd2000000',
   'x-ms-client-request-id',
-  '0272d9eb-26da-4cf7-8757-ac3a6cff1b84',
+  '5e10e69c-7811-4807-b217-65a1067fb8e1',
   'x-ms-version',
-  '2021-02-12',
+  '2021-08-06',
   'x-ms-content-crc64',
   'YeJLfssylmU=',
   'x-ms-request-server-encrypted',
   'true',
   'Date',
-  'Wed, 05 Jan 2022 09:04:53 GMT'
+  'Thu, 28 Jul 2022 09:32:27 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container164137349170003608/blockblob164137349236809756')
+  .put('/container165900074553801297/blockblob165900074614306823')
   .query(true)
   .reply(201, "", [
   'Content-Length',
@@ -190,47 +198,49 @@ nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParam
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'cccf2dc4-e01e-0002-1a13-025a01000000',
+  '9eef44f3-401e-000b-2f64-a21fd2000000',
   'x-ms-client-request-id',
-  '88ebda9a-5438-4e43-a00c-f522004a96bf',
+  'ce9ac69e-cfe7-4462-83ea-1191208172a1',
   'x-ms-version',
-  '2021-02-12',
+  '2021-08-06',
   'x-ms-content-crc64',
   'YeJLfssylmU=',
   'x-ms-request-server-encrypted',
   'true',
   'Date',
-  'Wed, 05 Jan 2022 09:04:53 GMT'
+  'Thu, 28 Jul 2022 09:32:27 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container164137349170003608/blockblob164137349236809756', "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?><BlockList><Latest>MQ==</Latest><Latest>Mg==</Latest></BlockList>")
+  .put('/container165900074553801297/blockblob165900074614306823', "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?><BlockList><Latest>MQ==</Latest><Latest>Mg==</Latest></BlockList>")
   .query(true)
   .reply(201, "", [
   'Content-Length',
   '0',
   'Last-Modified',
-  'Wed, 05 Jan 2022 09:04:53 GMT',
+  'Thu, 28 Jul 2022 09:32:28 GMT',
   'ETag',
-  '"0x8D9D02A700881D5"',
+  '"0x8DA707C166D6A35"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'cccf2dd7-e01e-0002-2a13-025a01000000',
+  '9eef452c-401e-000b-6664-a21fd2000000',
   'x-ms-client-request-id',
-  'b0e1e72b-a2e0-4d4e-8958-17ae90918d9c',
+  '1cf99432-af0a-4de7-9436-21244b7cdd3e',
   'x-ms-version',
-  '2021-02-12',
+  '2021-08-06',
   'x-ms-content-crc64',
   'GFi/o1BSQtU=',
+  'x-ms-version-id',
+  '2022-07-28T09:32:28.0871477Z',
   'x-ms-request-server-encrypted',
   'true',
   'Date',
-  'Wed, 05 Jan 2022 09:04:53 GMT'
+  'Thu, 28 Jul 2022 09:32:27 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .get('/container164137349170003608/blockblob164137349236809756')
+  .get('/container165900074553801297/blockblob165900074614306823')
   .query(true)
   .reply(200, "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><BlockList><CommittedBlocks><Block><Name>MQ==</Name><Size>11</Size></Block><Block><Name>Mg==</Name><Size>11</Size></Block></CommittedBlocks></BlockList>", [
   'Transfer-Encoding',
@@ -238,25 +248,29 @@ nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParam
   'Content-Type',
   'application/xml',
   'Last-Modified',
-  'Wed, 05 Jan 2022 09:04:53 GMT',
+  'Thu, 28 Jul 2022 09:32:28 GMT',
   'ETag',
-  '"0x8D9D02A700881D5"',
+  '"0x8DA707C166D6A35"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'cccf2de8-e01e-0002-3713-025a01000000',
+  '9eef4553-401e-000b-0964-a21fd2000000',
   'x-ms-client-request-id',
-  'e99d964d-51a7-4661-9e54-56ffbabbc8c5',
+  '37f9029c-aeb0-4451-bada-ad600a9f25f0',
   'x-ms-version',
-  '2021-02-12',
+  '2021-08-06',
   'x-ms-blob-content-length',
   '22',
+  'Access-Control-Expose-Headers',
+  'x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,Last-Modified,ETag,x-ms-blob-content-length,Content-Type,Content-Length,Date,Transfer-Encoding',
+  'Access-Control-Allow-Origin',
+  '*',
   'Date',
-  'Wed, 05 Jan 2022 09:04:53 GMT'
+  'Thu, 28 Jul 2022 09:32:27 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .delete('/container164137349170003608')
+  .delete('/container165900074553801297')
   .query(true)
   .reply(202, "", [
   'Content-Length',
@@ -264,11 +278,11 @@ nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParam
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'cccf2df0-e01e-0002-3f13-025a01000000',
+  '9eef4594-401e-000b-3f64-a21fd2000000',
   'x-ms-client-request-id',
-  'b16dced8-1e71-458b-8461-5258984cb97b',
+  '70f2dea0-1694-44fb-9c11-0c4be8fd6cc4',
   'x-ms-version',
-  '2021-02-12',
+  '2021-08-06',
   'Date',
-  'Wed, 05 Jan 2022 09:04:53 GMT'
+  'Thu, 28 Jul 2022 09:32:27 GMT'
 ]);

--- a/sdk/storage/storage-blob/recordings/node/syncuploadfromurl/recording_syncuploadfromurl__destination_bearer_token.js
+++ b/sdk/storage/storage-blob/recordings/node/syncuploadfromurl/recording_syncuploadfromurl__destination_bearer_token.js
@@ -1,83 +1,83 @@
 let nock = require('nock');
 
-module.exports.hash = "dd5dee7f0da29d5228280e9f227a4402";
+module.exports.hash = "e1d66b93e9ff9ef5f84f0c8426f52f27";
 
-module.exports.testInfo = {"uniqueName":{"container":"container164143435625105427","blockblob":"blockblob164143435690104427","srcblob/%2+%2F":"srcblob/%2+%2F164143435690204540","newblockblob":"newblockblob164143435801003448"},"newDate":{"expiry":"2022-01-06T01:59:17.026Z"}}
+module.exports.testInfo = {"uniqueName":{"container":"container165899711651001925","blockblob":"blockblob165899711661301612","srcblob/%2+%2F":"srcblob/%2+%2F165899711661404272","newblockblob":"newblockblob165899711720804249"},"newDate":{"expiry":"2022-07-28T08:31:56.716Z"}}
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container164143435625105427')
+  .put('/container165899711651001925')
   .query(true)
   .reply(201, "", [
   'Content-Length',
   '0',
   'Last-Modified',
-  'Thu, 06 Jan 2022 01:59:17 GMT',
+  'Thu, 28 Jul 2022 08:31:56 GMT',
   'ETag',
-  '"0x8D9D0B82576ED04"',
+  '"0x8DA7073A2000D1C"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '58002227-d01e-0044-2da1-026e86000000',
+  '56906c53-201e-0032-6d5c-a2e4ce000000',
   'x-ms-client-request-id',
-  'da152393-39fe-41a7-824e-33031e6d65d8',
+  'ac4bcde9-3629-4f65-9d04-bd5c027ab55c',
   'x-ms-version',
-  '2021-02-12',
+  '2021-08-06',
   'Date',
-  'Thu, 06 Jan 2022 01:59:16 GMT'
+  'Thu, 28 Jul 2022 08:31:56 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container164143435625105427/srcblob%2F%252%2B%252F164143435690204540', "Hello World")
+  .put('/container165899711651001925/srcblob/%252%2B%252F165899711661404272', "Hello World")
   .reply(201, "", [
   'Content-Length',
   '0',
   'Content-MD5',
   'sQqNsWTgdUEFt6mb5y4/5Q==',
   'Last-Modified',
-  'Thu, 06 Jan 2022 01:59:17 GMT',
+  'Thu, 28 Jul 2022 08:31:56 GMT',
   'ETag',
-  '"0x8D9D0B8258D647B"',
+  '"0x8DA7073A211CBEE"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '5800224f-d01e-0044-4da1-026e86000000',
+  '56906c80-201e-0032-135c-a2e4ce000000',
   'x-ms-client-request-id',
-  'f277109b-1399-4999-a9f2-e1f7124dddb3',
+  '50d365a7-1b9b-40a4-ae3e-066ff72078fe',
   'x-ms-version',
-  '2021-02-12',
+  '2021-08-06',
   'x-ms-content-crc64',
   'YeJLfssylmU=',
   'x-ms-request-server-encrypted',
   'true',
   'Date',
-  'Thu, 06 Jan 2022 01:59:16 GMT'
+  'Thu, 28 Jul 2022 08:31:56 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container164143435625105427/blockblob164143435690104427', "HelloWorld")
+  .put('/container165899711651001925/blockblob165899711661301612', "HelloWorld")
   .reply(201, "", [
   'Content-Length',
   '0',
   'Content-MD5',
   'aOEJ8PQMpyoV4FzCJ4b45g==',
   'Last-Modified',
-  'Thu, 06 Jan 2022 01:59:17 GMT',
+  'Thu, 28 Jul 2022 08:31:56 GMT',
   'ETag',
-  '"0x8D9D0B8259F8A48"',
+  '"0x8DA7073A22159E2"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '5800226a-d01e-0044-62a1-026e86000000',
+  '56906cb8-201e-0032-385c-a2e4ce000000',
   'x-ms-client-request-id',
-  '56f6d15b-a4b9-430e-8855-6671b6f8a9cb',
+  '7127a0d2-63df-481b-a47b-0cc84d0868d3',
   'x-ms-version',
-  '2021-02-12',
+  '2021-08-06',
   'x-ms-content-crc64',
   '8R2aIe9T07E=',
   'x-ms-request-server-encrypted',
   'true',
   'Date',
-  'Thu, 06 Jan 2022 01:59:16 GMT'
+  'Thu, 28 Jul 2022 08:31:56 GMT'
 ]);
 
 nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
@@ -99,19 +99,21 @@ nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
   'P3P',
   'CP="DSP CUR OTPi IND OTRi ONL FIN"',
   'x-ms-request-id',
-  '91a6d8dc-a007-449e-8811-fbe6c8c40b00',
+  'a940112a-8d69-4ff8-b453-b1b8aa913900',
   'x-ms-ests-server',
-  '2.1.12261.17 - SEASLR1 ProdSlices',
+  '2.1.13355.6 - KRC ProdSlices',
+  'X-XSS-Protection',
+  '0',
   'Set-Cookie',
-  'fpc=AmAa09v1AAhCrpGJYB2Wbx0; expires=Sat, 05-Feb-2022 01:59:17 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'fpc=Ar_mx3tKzelFput9GYsaxnU; expires=Sat, 27-Aug-2022 08:31:57 GMT; path=/; secure; HttpOnly; SameSite=None',
   'Set-Cookie',
-  'esctx=AQABAAAAAAD--DLA3VO7QrddgJg7WevrMyMkMnDk6NuD5XsLvr1-FsHa799waP3sr863Z1OYI-gSwP3cSNJIWa8Zj5UF1YV8MYoxXfSHkNgclfkLVp3z_6OABoRYSc9KLcdtm4a7vzDM4YuLoAEi4hdgpKNPAQvNmdA1FEf6lqFrOxp1XtaHLxem_oZGjF5eGBeIl3Cpdk8gAA; domain=.login.microsoftonline.com; path=/; secure; HttpOnly; SameSite=None',
+  'esctx=AQABAAAAAAD--DLA3VO7QrddgJg7WevrPZtNs_gADJWv_TJpBTHUR06sgND6obV6E74Hr6CC0rzxBuySTFWI1KjYS7OkwMJccEM44e6rSxCOCdvjVZCTGE6rpLeZLk07gCa3EVAc2woK0xgN6JDhbSLlgAH-0K89p6upmgMMJep9tVvvbw170F-r_V4R2eIad_lQI7KNT_IgAA; domain=.login.microsoftonline.com; path=/; secure; HttpOnly; SameSite=None',
   'Set-Cookie',
   'x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly',
   'Set-Cookie',
   'stsservicecookie=estsfd; path=/; secure; samesite=none; httponly',
   'Date',
-  'Thu, 06 Jan 2022 01:59:16 GMT',
+  'Thu, 28 Jul 2022 08:31:57 GMT',
   'Content-Length',
   '980'
 ]);
@@ -134,25 +136,29 @@ nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
   'P3P',
   'CP="DSP CUR OTPi IND OTRi ONL FIN"',
   'x-ms-request-id',
-  '4a229268-50b8-4df0-8d9c-388e959e6b00',
+  '2805d2cd-296a-4a03-ae32-276297893900',
   'x-ms-ests-server',
-  '2.1.12261.17 - KRSLR1 ProdSlices',
+  '2.1.13355.6 - KRSLR1 ProdSlices',
+  'Content-Security-Policy-Report-Only',
+  "script-src 'self' 'nonce-gAbSe-hgVHBq4YgMRN7I8w' 'unsafe-eval' 'unsafe-inline'; object-src 'none'; base-uri 'none'; report-uri https://csp.microsoft.com/report/ESTS-UX-All",
+  'X-XSS-Protection',
+  '0',
   'Set-Cookie',
-  'fpc=AhMVggLNLwVEmN7AQrigQOw; expires=Sat, 05-Feb-2022 01:59:17 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'fpc=AkVd1vLzixZArTJkXVUpY70; expires=Sat, 27-Aug-2022 08:31:57 GMT; path=/; secure; HttpOnly; SameSite=None',
   'Set-Cookie',
-  'esctx=AQABAAAAAAD--DLA3VO7QrddgJg7WevrhqFShoo8MK1_Dhc-HuIGQKz1ef7wtiVKz8ebd8B3v9TRjtZBOrFekWPXKLYizDDBVZMjskM6B04ZvPbHu4-V7f8k_5b4xevrQXz8hPUQKqTJ1rveYjCZk6_ccjDb4uUiAeVlZsj-HQL1AEdHJ0SdeEWug8ygoPt_KakGOOjB4ZcgAA; domain=.login.microsoftonline.com; path=/; secure; HttpOnly; SameSite=None',
+  'esctx=AQABAAAAAAD--DLA3VO7QrddgJg7WevrhSIwAnNt80e2k6r4_--TKSf0yivVJHuTyJQcKqT1Cmdro_eyANFCr4eCAtfyEH_khKvnQY3kIte51-ZU38L9TEeg7a_4L-B71Ua2zf29z-zIeppT4dtG2P-QSc-ll2shPGA5RCaOFEnupORXlC0rm7PfCs4v-EIJxmzEZ6cw4logAA; domain=.login.microsoftonline.com; path=/; secure; HttpOnly; SameSite=None',
   'Set-Cookie',
   'x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly',
   'Set-Cookie',
   'stsservicecookie=estsfd; path=/; secure; samesite=none; httponly',
   'Date',
-  'Thu, 06 Jan 2022 01:59:17 GMT',
+  'Thu, 28 Jul 2022 08:31:57 GMT',
   'Content-Length',
   '1753'
 ]);
 
 nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
-  .post('/aaaaa/oauth2/v2.0/token', "client_id=aaaaa&scope=https%3A%2F%2Fsanitized%2F&grant_type=client_credentials&x-client-SKU=msal.js.node&x-client-VER=1.4.0&x-client-OS=win32&x-client-CPU=x64&x-ms-lib-capability=retry-after, h429&x-client-current-telemetry=5|771,2,,,|,&x-client-last-telemetry=5|0|||0,0&client-request-id=1335af69-ad00-455b-92ee-caf2f9890ba4&client_secret=aaaaa&claims=%7B%22access_token%22%3A%7B%22xms_cc%22%3A%7B%22values%22%3A%5B%22cp1%22%5D%7D%7D%7D")
+  .post('/aaaaa/oauth2/v2.0/token', "client_id=aaaaa&scope=https%3A%2F%2Fsanitized%2F&grant_type=client_credentials&x-client-SKU=msal.js.node&x-client-VER=1.11.0&x-client-OS=win32&x-client-CPU=x64&x-ms-lib-capability=retry-after, h429&x-client-current-telemetry=5|771,2,,,|,&x-client-last-telemetry=5|0|||0,0&client-request-id=baf10a76-01cc-4c4b-be91-efe0fc5e0714&client_secret=aaaaa&claims=%7B%22access_token%22%3A%7B%22xms_cc%22%3A%7B%22values%22%3A%5B%22cp1%22%5D%7D%7D%7D")
   .reply(200, {"token_type":"Bearer","expires_in":86399,"ext_expires_in":86399,"access_token":"access_token"}, [
   'Cache-Control',
   'no-store, no-cache',
@@ -169,19 +175,21 @@ nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
   'P3P',
   'CP="DSP CUR OTPi IND OTRi ONL FIN"',
   'x-ms-request-id',
-  '7631c509-4b1c-4cf2-86c8-aafe804b8400',
+  'f36bfaba-1513-4030-bfff-39d2e6c03500',
   'x-ms-ests-server',
-  '2.1.12261.17 - KRSLR1 ProdSlices',
+  '2.1.13355.6 - SEASLR2 ProdSlices',
   'x-ms-clitelem',
   '1,0,0,,',
+  'X-XSS-Protection',
+  '0',
   'Set-Cookie',
-  'fpc=ArifkR0WWBhJtj-9AheP5X_eeSdeAQAAAPVDaNkOAAAA; expires=Sat, 05-Feb-2022 01:59:18 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'fpc=AujuUD4t0Z9MvaRAIB-g0YneeSdeAQAAAH1AdNoOAAAA; expires=Sat, 27-Aug-2022 08:31:57 GMT; path=/; secure; HttpOnly; SameSite=None',
   'Set-Cookie',
   'x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly',
   'Set-Cookie',
   'stsservicecookie=estsfd; path=/; secure; samesite=none; httponly',
   'Date',
-  'Thu, 06 Jan 2022 01:59:17 GMT',
+  'Thu, 28 Jul 2022 08:31:57 GMT',
   'Content-Length',
   '1318'
 ]);
@@ -205,19 +213,21 @@ nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
   'P3P',
   'CP="DSP CUR OTPi IND OTRi ONL FIN"',
   'x-ms-request-id',
-  '4a229268-50b8-4df0-8d9c-388e989e6b00',
+  'f36bfaba-1513-4030-bfff-39d2e8c03500',
   'x-ms-ests-server',
-  '2.1.12261.17 - KRSLR1 ProdSlices',
+  '2.1.13355.6 - SEASLR2 ProdSlices',
+  'X-XSS-Protection',
+  '0',
   'Set-Cookie',
-  'fpc=AqK4WYUQ0VFBkJ1RAKvu8_Q; expires=Sat, 05-Feb-2022 01:59:18 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'fpc=Aq6QENLLdDBEtJ7yHZa7Xns; expires=Sat, 27-Aug-2022 08:31:57 GMT; path=/; secure; HttpOnly; SameSite=None',
   'Set-Cookie',
-  'esctx=AQABAAAAAAD--DLA3VO7QrddgJg7WevrWbtXkkBuYKHdalLZpHZxBm7UAhmaj4U4cKShaVCZ41orXHDLVc0jOrseZkRwB4-hBZYLkhLYWKizC-p_H2lhEzTx3XafXBjYPU84yt8um8msLdAqDuB3ReUR6a_O5_0G34-MPbYcmwOmMiNI0iuvq9yMbVWZm81rCcdj1DjCWiQgAA; domain=.login.microsoftonline.com; path=/; secure; HttpOnly; SameSite=None',
+  'esctx=AQABAAAAAAD--DLA3VO7QrddgJg7Wevr_v1za9UHARfwpiJ3aERrWP7jpNCvUuQmM-xX4poIoxlvDOsJRg83irWTnr8H9WRmVgIAYQGeeIs4CUSqy_yC1sPCcNGi8SbnGnxK-r68FfVcsXXn9hyGDhbrQPkLo3Y03jnnIDM2d8Gdj4yD9zWUgXAb6uvbRDbFFDRtT3jU1L4gAA; domain=.login.microsoftonline.com; path=/; secure; HttpOnly; SameSite=None',
   'Set-Cookie',
   'x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly',
   'Set-Cookie',
   'stsservicecookie=estsfd; path=/; secure; samesite=none; httponly',
   'Date',
-  'Thu, 06 Jan 2022 01:59:17 GMT',
+  'Thu, 28 Jul 2022 08:31:57 GMT',
   'Content-Length',
   '980'
 ]);
@@ -240,25 +250,27 @@ nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
   'P3P',
   'CP="DSP CUR OTPi IND OTRi ONL FIN"',
   'x-ms-request-id',
-  '91a6d8dc-a007-449e-8811-fbe6d0c40b00',
+  'db881c6c-ff08-4aae-bed6-bc255c2a3900',
   'x-ms-ests-server',
-  '2.1.12261.17 - SEASLR1 ProdSlices',
+  '2.1.13355.6 - SEASLR1 ProdSlices',
+  'X-XSS-Protection',
+  '0',
   'Set-Cookie',
-  'fpc=AqdyjIMm0zpEpRiVqDvAmh8; expires=Sat, 05-Feb-2022 01:59:18 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'fpc=AiENhRw2w4VKjkQIYHLYqRk; expires=Sat, 27-Aug-2022 08:31:57 GMT; path=/; secure; HttpOnly; SameSite=None',
   'Set-Cookie',
-  'esctx=AQABAAAAAAD--DLA3VO7QrddgJg7Wevr3x8Z6O7xMmJnt2CnIxc65B_MzTMF2dcnvutabsNYHv3_kSZN94juweX2RrVNQaTlvHPLB0bGl37DaeJ6jhn9HTb-IU7NPTcDzFjvur6n98RYObUXmBpighccjFv0tzl6jXrxI6MaGezyvjnWtJ9h9UTLWoyz9flIFXC7EXfYpBcgAA; domain=.login.microsoftonline.com; path=/; secure; HttpOnly; SameSite=None',
+  'esctx=AQABAAAAAAD--DLA3VO7QrddgJg7WevrRRxhHxVcrmujRlqYfU0bV3mCp2J7FSake3_gZi_UQa7yabg7TVpl5EFg8dn5WElcYFbuvfBpzbHFRkWTIKTuNIBMBTQw74lwnhNA5xfCBRJdF4YwzEGeJn-2IVqWPHKd-IgAzt-oo1tnJqkDTQTiIgXkS8Ljn2HUdS2kfaoPXGEgAA; domain=.login.microsoftonline.com; path=/; secure; HttpOnly; SameSite=None',
   'Set-Cookie',
   'x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly',
   'Set-Cookie',
   'stsservicecookie=estsfd; path=/; secure; samesite=none; httponly',
   'Date',
-  'Thu, 06 Jan 2022 01:59:17 GMT',
+  'Thu, 28 Jul 2022 08:31:57 GMT',
   'Content-Length',
   '1753'
 ]);
 
 nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
-  .post('/aaaaa/oauth2/v2.0/token', "client_id=aaaaa&scope=https%3A%2F%2Fsanitized%2F&grant_type=client_credentials&x-client-SKU=msal.js.node&x-client-VER=1.4.0&x-client-OS=win32&x-client-CPU=x64&x-ms-lib-capability=retry-after, h429&x-client-current-telemetry=5|771,2,,,|,&x-client-last-telemetry=5|0|||0,0&client-request-id=6f59b7ed-e33f-421d-bb0c-54fbcfae77db&client_secret=aaaaa&claims=%7B%22access_token%22%3A%7B%22xms_cc%22%3A%7B%22values%22%3A%5B%22cp1%22%5D%7D%7D%7D")
+  .post('/aaaaa/oauth2/v2.0/token', "client_id=aaaaa&scope=https%3A%2F%2Fsanitized%2F&grant_type=client_credentials&x-client-SKU=msal.js.node&x-client-VER=1.11.0&x-client-OS=win32&x-client-CPU=x64&x-ms-lib-capability=retry-after, h429&x-client-current-telemetry=5|771,2,,,|,&x-client-last-telemetry=5|0|||0,0&client-request-id=2f4e5107-66e9-4c15-95c6-8cb940bedc8e&client_secret=aaaaa&claims=%7B%22access_token%22%3A%7B%22xms_cc%22%3A%7B%22values%22%3A%5B%22cp1%22%5D%7D%7D%7D")
   .reply(200, {"token_type":"Bearer","expires_in":86399,"ext_expires_in":86399,"access_token":"access_token"}, [
   'Cache-Control',
   'no-store, no-cache',
@@ -275,50 +287,54 @@ nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
   'P3P',
   'CP="DSP CUR OTPi IND OTRi ONL FIN"',
   'x-ms-request-id',
-  '7631c509-4b1c-4cf2-86c8-aafe854b8400',
+  '7cd87c98-932b-44e6-9629-e58573ba3900',
   'x-ms-ests-server',
-  '2.1.12261.17 - KRSLR1 ProdSlices',
+  '2.1.13355.6 - KRSLR1 ProdSlices',
   'x-ms-clitelem',
   '1,0,0,,',
+  'Content-Security-Policy-Report-Only',
+  "script-src 'self' 'nonce-ecgSEUUnmXKzlcaI8ShKEQ' 'unsafe-eval' 'unsafe-inline'; object-src 'none'; base-uri 'none'; report-uri https://csp.microsoft.com/report/ESTS-UX-All",
+  'X-XSS-Protection',
+  '0',
   'Set-Cookie',
-  'fpc=AqWzRMJUvVBFqsfMLNaXMWg; expires=Sat, 05-Feb-2022 01:59:18 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'fpc=AnBRYlRC89lJmfnLPUIqm0LeeSdeAQAAAH1AdNoOAAAA; expires=Sat, 27-Aug-2022 08:31:57 GMT; path=/; secure; HttpOnly; SameSite=None',
   'Set-Cookie',
   'x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly',
   'Set-Cookie',
   'stsservicecookie=estsfd; path=/; secure; samesite=none; httponly',
   'Date',
-  'Thu, 06 Jan 2022 01:59:17 GMT',
+  'Thu, 28 Jul 2022 08:31:57 GMT',
   'Content-Length',
   '1318'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container164143435625105427/newblockblob164143435801003448')
+  .put('/container165899711651001925/newblockblob165899711720804249')
   .reply(201, "", [
   'Content-Length',
   '0',
   'Last-Modified',
-  'Thu, 06 Jan 2022 01:59:19 GMT',
+  'Thu, 28 Jul 2022 08:31:57 GMT',
   'ETag',
-  '"0x8D9D0B826FEE761"',
+  '"0x8DA7073A2A2D219"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '58002358-d01e-0044-31a1-026e86000000',
+  '56906e79-201e-0032-285c-a2e4ce000000',
   'x-ms-client-request-id',
-  'b8988e0a-1c34-4af8-a0d0-3743fd363519',
+  'c1be2d58-aee9-4f2b-8a56-d887b33e13c8',
   'x-ms-version',
-  '2021-02-12',
+  '2021-08-06',
   'x-ms-content-crc64',
   '8R2aIe9T07E=',
   'x-ms-request-server-encrypted',
   'true',
   'Date',
-  'Thu, 06 Jan 2022 01:59:19 GMT'
+  'Thu, 28 Jul 2022 08:31:57 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .get('/container164143435625105427/newblockblob164143435801003448')
+  .get('/container165899711651001925/newblockblob165899711720804249')
   .reply(200, "HelloWorld", [
   'Content-Length',
   '10',
@@ -327,21 +343,21 @@ nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParam
   'Content-MD5',
   'aOEJ8PQMpyoV4FzCJ4b45g==',
   'Last-Modified',
-  'Thu, 06 Jan 2022 01:59:19 GMT',
+  'Thu, 28 Jul 2022 08:31:57 GMT',
   'Accept-Ranges',
   'bytes',
   'ETag',
-  '"0x8D9D0B826FEE761"',
+  '"0x8DA7073A2A2D219"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '58002414-d01e-0044-49a1-026e86000000',
+  '56906ebf-201e-0032-5d5c-a2e4ce000000',
   'x-ms-client-request-id',
-  '30d6789d-ce15-44fd-a6c9-77acdae6809c',
+  '075c0564-bd1b-48e9-b71b-d5f3c7874d8c',
   'x-ms-version',
-  '2021-02-12',
+  '2021-08-06',
   'x-ms-creation-time',
-  'Thu, 06 Jan 2022 01:59:19 GMT',
+  'Thu, 28 Jul 2022 08:31:57 GMT',
   'x-ms-lease-status',
   'unlocked',
   'x-ms-lease-state',
@@ -350,12 +366,16 @@ nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParam
   'BlockBlob',
   'x-ms-server-encrypted',
   'true',
+  'Access-Control-Expose-Headers',
+  'x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,Content-Type,Last-Modified,ETag,x-ms-creation-time,Content-MD5,x-ms-lease-status,x-ms-lease-state,x-ms-blob-type,x-ms-server-encrypted,Accept-Ranges,Content-Length,Date,Transfer-Encoding',
+  'Access-Control-Allow-Origin',
+  '*',
   'Date',
-  'Thu, 06 Jan 2022 01:59:19 GMT'
+  'Thu, 28 Jul 2022 08:31:57 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .delete('/container164143435625105427')
+  .delete('/container165899711651001925')
   .query(true)
   .reply(202, "", [
   'Content-Length',
@@ -363,11 +383,11 @@ nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParam
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '58002421-d01e-0044-55a1-026e86000000',
+  '56906ef7-201e-0032-0a5c-a2e4ce000000',
   'x-ms-client-request-id',
-  '545333dd-9e91-49a5-9fa7-cb545048e363',
+  'a0f81fcb-5aec-4abf-8bdd-ff8459c37fa7',
   'x-ms-version',
-  '2021-02-12',
+  '2021-08-06',
   'Date',
-  'Thu, 06 Jan 2022 01:59:19 GMT'
+  'Thu, 28 Jul 2022 08:31:57 GMT'
 ]);

--- a/sdk/storage/storage-blob/recordings/node/syncuploadfromurl/recording_syncuploadfromurl__source_bear_token_and_destination_account_key.js
+++ b/sdk/storage/storage-blob/recordings/node/syncuploadfromurl/recording_syncuploadfromurl__source_bear_token_and_destination_account_key.js
@@ -1,83 +1,83 @@
 let nock = require('nock');
 
-module.exports.hash = "af4364ead538663c32d5c6c0ca517e4b";
+module.exports.hash = "23a3372f1e71dcc72662733cb48a952a";
 
-module.exports.testInfo = {"uniqueName":{"container":"container164137279171401853","blockblob":"blockblob164137279182307519","srcblob/%2+%2F":"srcblob/%2+%2F164137279182308261","newblockblob":"newblockblob164137279265005881"},"newDate":{"expiry":"2022-01-05T08:53:11.931Z"}}
+module.exports.testInfo = {"uniqueName":{"container":"container165899711555806885","blockblob":"blockblob165899711566107289","srcblob/%2+%2F":"srcblob/%2+%2F165899711566100957","newblockblob":"newblockblob165899711618409852"},"newDate":{"expiry":"2022-07-28T08:31:55.763Z"}}
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container164137279171401853')
+  .put('/container165899711555806885')
   .query(true)
   .reply(201, "", [
   'Content-Length',
   '0',
   'Last-Modified',
-  'Wed, 05 Jan 2022 08:53:11 GMT',
+  'Thu, 28 Jul 2022 08:31:55 GMT',
   'ETag',
-  '"0x8D9D028CDC72986"',
+  '"0x8DA7073A16EDECC"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'c921e5d0-a01e-0013-6711-02c0b5000000',
+  '56906b1d-201e-0032-775c-a2e4ce000000',
   'x-ms-client-request-id',
-  '44eef199-76a1-4337-9cb1-8c69d786150a',
+  'f9e6ce2a-2800-4c7e-8ef0-3b2959f4b89e',
   'x-ms-version',
-  '2021-02-12',
+  '2021-08-06',
   'Date',
-  'Wed, 05 Jan 2022 08:53:11 GMT'
+  'Thu, 28 Jul 2022 08:31:55 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container164137279171401853/srcblob%2F%252%2B%252F164137279182308261', "Hello World")
+  .put('/container165899711555806885/srcblob/%252%2B%252F165899711566100957', "Hello World")
   .reply(201, "", [
   'Content-Length',
   '0',
   'Content-MD5',
   'sQqNsWTgdUEFt6mb5y4/5Q==',
   'Last-Modified',
-  'Wed, 05 Jan 2022 08:53:12 GMT',
+  'Thu, 28 Jul 2022 08:31:55 GMT',
   'ETag',
-  '"0x8D9D028CDD7F00A"',
+  '"0x8DA7073A1805095"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'c921e5fc-a01e-0013-0611-02c0b5000000',
+  '56906b31-201e-0032-065c-a2e4ce000000',
   'x-ms-client-request-id',
-  '97336804-1d48-4cbf-8a7d-1efb716d0b89',
+  'e78ba7b8-7b89-4afb-be90-dde33e455a71',
   'x-ms-version',
-  '2021-02-12',
+  '2021-08-06',
   'x-ms-content-crc64',
   'YeJLfssylmU=',
   'x-ms-request-server-encrypted',
   'true',
   'Date',
-  'Wed, 05 Jan 2022 08:53:11 GMT'
+  'Thu, 28 Jul 2022 08:31:55 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container164137279171401853/blockblob164137279182307519', "HelloWorld")
+  .put('/container165899711555806885/blockblob165899711566107289', "HelloWorld")
   .reply(201, "", [
   'Content-Length',
   '0',
   'Content-MD5',
   'aOEJ8PQMpyoV4FzCJ4b45g==',
   'Last-Modified',
-  'Wed, 05 Jan 2022 08:53:12 GMT',
+  'Thu, 28 Jul 2022 08:31:56 GMT',
   'ETag',
-  '"0x8D9D028CDE8B67E"',
+  '"0x8DA7073A18FDE96"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'c921e648-a01e-0013-4611-02c0b5000000',
+  '56906b5b-201e-0032-1c5c-a2e4ce000000',
   'x-ms-client-request-id',
-  'b5bf43a8-4dad-4f93-85e3-86c9c0fc22a0',
+  '79611b56-d90c-43c3-8b35-8de76675fec5',
   'x-ms-version',
-  '2021-02-12',
+  '2021-08-06',
   'x-ms-content-crc64',
   '8R2aIe9T07E=',
   'x-ms-request-server-encrypted',
   'true',
   'Date',
-  'Wed, 05 Jan 2022 08:53:11 GMT'
+  'Thu, 28 Jul 2022 08:31:55 GMT'
 ]);
 
 nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
@@ -99,19 +99,21 @@ nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
   'P3P',
   'CP="DSP CUR OTPi IND OTRi ONL FIN"',
   'x-ms-request-id',
-  '7777f699-653d-4eb0-b230-12e508b57b00',
+  'ac53e1e0-c44c-46f7-8bc1-1a5babae0400',
   'x-ms-ests-server',
-  '2.1.12261.17 - KRSLR1 ProdSlices',
+  '2.1.13355.6 - SEASLR2 ProdSlices',
+  'X-XSS-Protection',
+  '0',
   'Set-Cookie',
-  'fpc=An0IGr6lCM1NjKp9KBDzvYg; expires=Fri, 04-Feb-2022 08:53:12 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'fpc=AoKsdJKgUKhHvgJsT__MzHU; expires=Sat, 27-Aug-2022 08:31:56 GMT; path=/; secure; HttpOnly; SameSite=None',
   'Set-Cookie',
-  'esctx=AQABAAAAAAD--DLA3VO7QrddgJg7WevryT8h3EA08-oZFp_J7mOky3_0uVtEnLuLeNCVWJq4DGC5yuhnHZLA1L6P9n_b6OmO8p6XMr_V7OMiyo7BMtieRZ0rmCqgeX7IP3Q-hL9XEi_7GFT53fE9ZRAfxsHasux2_ERocdLjOxVAn-D7ej1e1rDJPLXMhQZ1CX3TrRhW0bMgAA; domain=.login.microsoftonline.com; path=/; secure; HttpOnly; SameSite=None',
+  'esctx=AQABAAAAAAD--DLA3VO7QrddgJg7Wevr3s-pZL8Rd63cthM47KXVXURfV4BsWj6_zC_Eywzv6ewbVpsC0g6W9IsqXSeaYz1rBIv1U0HXQOCHc_xdZzLNOklXtWcXRB2ZivZyI0LtUSpPMhElZmN2x0RgEGRmo1AHKf9SxUiLxlJqy0J-mCKWwb7OrPQ_E2om9LT3l4iyYwQgAA; domain=.login.microsoftonline.com; path=/; secure; HttpOnly; SameSite=None',
   'Set-Cookie',
   'x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly',
   'Set-Cookie',
   'stsservicecookie=estsfd; path=/; secure; samesite=none; httponly',
   'Date',
-  'Wed, 05 Jan 2022 08:53:12 GMT',
+  'Thu, 28 Jul 2022 08:31:56 GMT',
   'Content-Length',
   '980'
 ]);
@@ -134,25 +136,27 @@ nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
   'P3P',
   'CP="DSP CUR OTPi IND OTRi ONL FIN"',
   'x-ms-request-id',
-  'beda56c1-fe39-453d-915f-522fd3190200',
+  'a940112a-8d69-4ff8-b453-b1b894913900',
   'x-ms-ests-server',
-  '2.1.12261.17 - SEASLR2 ProdSlices',
+  '2.1.13355.6 - KRC ProdSlices',
+  'X-XSS-Protection',
+  '0',
   'Set-Cookie',
-  'fpc=Aokwc-1ZMZ5JuK0y4lAFUQ0; expires=Fri, 04-Feb-2022 08:53:12 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'fpc=AkZZ7chof9VOqHjB3C9r6xE; expires=Sat, 27-Aug-2022 08:31:56 GMT; path=/; secure; HttpOnly; SameSite=None',
   'Set-Cookie',
-  'esctx=AQABAAAAAAD--DLA3VO7QrddgJg7WevrmkpZHTG3KKiYc9bvRSNTTZzzRT6Pb4A5ppZP-lngr77GoEqMZa5l2AwNMZ3yjNu0ooNOIIpE07qgltDEuSN76h3xz1sL_3UjrJmtukzyrMni8OVkW3Yhco-k1LY2cCPJlVcqU1RHvFPxLEM-74ZQtbkZPi1ONwXQEgpmFl-wQ1MgAA; domain=.login.microsoftonline.com; path=/; secure; HttpOnly; SameSite=None',
+  'esctx=AQABAAAAAAD--DLA3VO7QrddgJg7Wevr2etx5F-fU_70dJs5ewLo1cAtEBA3x53cY83JRBgMfnXATQ4DZV5WjLrWPsbzy-XpzQhQEK6TSprzF8yqR-Vi_nzbOY-kGkn0KkSOA5jKWIXSC6sj7__CBZCMC7sScLPI2rhs_dOo9FVp-0RuGDP5reEpcR2StEiJK4eGZbpogbggAA; domain=.login.microsoftonline.com; path=/; secure; HttpOnly; SameSite=None',
   'Set-Cookie',
   'x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly',
   'Set-Cookie',
   'stsservicecookie=estsfd; path=/; secure; samesite=none; httponly',
   'Date',
-  'Wed, 05 Jan 2022 08:53:12 GMT',
+  'Thu, 28 Jul 2022 08:31:56 GMT',
   'Content-Length',
   '1753'
 ]);
 
 nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
-  .post('/aaaaa/oauth2/v2.0/token', "client_id=aaaaa&scope=https%3A%2F%2Fsanitized%2F&grant_type=client_credentials&x-client-SKU=msal.js.node&x-client-VER=1.4.0&x-client-OS=win32&x-client-CPU=x64&x-ms-lib-capability=retry-after, h429&x-client-current-telemetry=5|771,2,,,|,&x-client-last-telemetry=5|0|||0,0&client-request-id=69322513-2b26-4732-9b0e-1af51d4d38ba&client_secret=aaaaa&claims=%7B%22access_token%22%3A%7B%22xms_cc%22%3A%7B%22values%22%3A%5B%22cp1%22%5D%7D%7D%7D")
+  .post('/aaaaa/oauth2/v2.0/token', "client_id=aaaaa&scope=https%3A%2F%2Fsanitized%2F&grant_type=client_credentials&x-client-SKU=msal.js.node&x-client-VER=1.11.0&x-client-OS=win32&x-client-CPU=x64&x-ms-lib-capability=retry-after, h429&x-client-current-telemetry=5|771,2,,,|,&x-client-last-telemetry=5|0|||0,0&client-request-id=6dca15f6-b884-440d-afe3-f2aff65910fc&client_secret=aaaaa&claims=%7B%22access_token%22%3A%7B%22xms_cc%22%3A%7B%22values%22%3A%5B%22cp1%22%5D%7D%7D%7D")
   .reply(200, {"token_type":"Bearer","expires_in":86399,"ext_expires_in":86399,"access_token":"access_token"}, [
   'Cache-Control',
   'no-store, no-cache',
@@ -169,50 +173,52 @@ nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
   'P3P',
   'CP="DSP CUR OTPi IND OTRi ONL FIN"',
   'x-ms-request-id',
-  '65eed48d-5688-4f85-96c3-e74089507d00',
+  'f36bfaba-1513-4030-bfff-39d2d7c03500',
   'x-ms-ests-server',
-  '2.1.12261.17 - KRSLR2 ProdSlices',
+  '2.1.13355.6 - SEASLR2 ProdSlices',
   'x-ms-clitelem',
   '1,0,0,,',
+  'X-XSS-Protection',
+  '0',
   'Set-Cookie',
-  'fpc=AmC4mPD4PjdMsnC2kzvXtCHeeSdeAQAAAHhTZ9kOAAAA; expires=Fri, 04-Feb-2022 08:53:12 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'fpc=AqNefW8GbE1BnQoK5xSBvrzeeSdeAQAAAHxAdNoOAAAA; expires=Sat, 27-Aug-2022 08:31:56 GMT; path=/; secure; HttpOnly; SameSite=None',
   'Set-Cookie',
   'x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly',
   'Set-Cookie',
   'stsservicecookie=estsfd; path=/; secure; samesite=none; httponly',
   'Date',
-  'Wed, 05 Jan 2022 08:53:12 GMT',
+  'Thu, 28 Jul 2022 08:31:56 GMT',
   'Content-Length',
   '1318'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container164137279171401853/newblockblob164137279265005881')
+  .put('/container165899711555806885/newblockblob165899711618409852')
   .reply(201, "", [
   'Content-Length',
   '0',
   'Last-Modified',
-  'Wed, 05 Jan 2022 08:53:12 GMT',
+  'Thu, 28 Jul 2022 08:31:56 GMT',
   'ETag',
-  '"0x8D9D028CE5D1271"',
+  '"0x8DA7073A1D25BA3"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'c921e731-a01e-0013-1011-02c0b5000000',
+  '56906bcd-201e-0032-045c-a2e4ce000000',
   'x-ms-client-request-id',
-  'ccda2a35-a205-4afe-a33f-a61b8364ea7b',
+  '4153fe87-50c3-4f8c-b32a-4143c1075515',
   'x-ms-version',
-  '2021-02-12',
+  '2021-08-06',
   'x-ms-content-crc64',
   '8R2aIe9T07E=',
   'x-ms-request-server-encrypted',
   'true',
   'Date',
-  'Wed, 05 Jan 2022 08:53:12 GMT'
+  'Thu, 28 Jul 2022 08:31:56 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .get('/container164137279171401853/newblockblob164137279265005881')
+  .get('/container165899711555806885/newblockblob165899711618409852')
   .reply(200, "HelloWorld", [
   'Content-Length',
   '10',
@@ -221,21 +227,21 @@ nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParam
   'Content-MD5',
   'aOEJ8PQMpyoV4FzCJ4b45g==',
   'Last-Modified',
-  'Wed, 05 Jan 2022 08:53:12 GMT',
+  'Thu, 28 Jul 2022 08:31:56 GMT',
   'Accept-Ranges',
   'bytes',
   'ETag',
-  '"0x8D9D028CE5D1271"',
+  '"0x8DA7073A1D25BA3"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'c921e760-a01e-0013-3c11-02c0b5000000',
+  '56906bf4-201e-0032-245c-a2e4ce000000',
   'x-ms-client-request-id',
-  'a088cb45-f4d6-457f-bfcb-925bbe239a9d',
+  'bed9d2ef-245e-4297-bcdb-5ee064e647b4',
   'x-ms-version',
-  '2021-02-12',
+  '2021-08-06',
   'x-ms-creation-time',
-  'Wed, 05 Jan 2022 08:53:12 GMT',
+  'Thu, 28 Jul 2022 08:31:56 GMT',
   'x-ms-lease-status',
   'unlocked',
   'x-ms-lease-state',
@@ -244,12 +250,16 @@ nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParam
   'BlockBlob',
   'x-ms-server-encrypted',
   'true',
+  'Access-Control-Expose-Headers',
+  'x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,Content-Type,Last-Modified,ETag,x-ms-creation-time,Content-MD5,x-ms-lease-status,x-ms-lease-state,x-ms-blob-type,x-ms-server-encrypted,Accept-Ranges,Content-Length,Date,Transfer-Encoding',
+  'Access-Control-Allow-Origin',
+  '*',
   'Date',
-  'Wed, 05 Jan 2022 08:53:12 GMT'
+  'Thu, 28 Jul 2022 08:31:56 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .delete('/container164137279171401853')
+  .delete('/container165899711555806885')
   .query(true)
   .reply(202, "", [
   'Content-Length',
@@ -257,11 +267,11 @@ nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParam
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'c921e78d-a01e-0013-6611-02c0b5000000',
+  '56906c1d-201e-0032-435c-a2e4ce000000',
   'x-ms-client-request-id',
-  '468bd4a6-230f-458e-aec6-264f8d14c04b',
+  '613b7cd3-15e2-42b2-a9bb-4e493c615cc6',
   'x-ms-version',
-  '2021-02-12',
+  '2021-08-06',
   'Date',
-  'Wed, 05 Jan 2022 08:53:12 GMT'
+  'Thu, 28 Jul 2022 08:31:56 GMT'
 ]);

--- a/sdk/storage/storage-blob/recordings/node/syncuploadfromurl/recording_syncuploadfromurl__source_sas_and_destination_bearer_token.js
+++ b/sdk/storage/storage-blob/recordings/node/syncuploadfromurl/recording_syncuploadfromurl__source_sas_and_destination_bearer_token.js
@@ -1,56 +1,56 @@
 let nock = require('nock');
 
-module.exports.hash = "af4778186cb3b024de8615b4643f166b";
+module.exports.hash = "945f1e2d2595ce6d5c696b41b72a5a6b";
 
-module.exports.testInfo = {"uniqueName":{"container":"container164137279039306240","blockblob":"blockblob164137279049702601","srcblob/%2+%2F":"srcblob/%2+%2F164137279049704245"},"newDate":{"expiry":"2022-01-05T08:53:10.605Z"}}
+module.exports.testInfo = {"uniqueName":{"container":"container165899711462100456","blockblob":"blockblob165899711472602588","srcblob/%2+%2F":"srcblob/%2+%2F165899711472606363"},"newDate":{"expiry":"2022-07-28T08:31:54.830Z"}}
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container164137279039306240')
+  .put('/container165899711462100456')
   .query(true)
   .reply(201, "", [
   'Content-Length',
   '0',
   'Last-Modified',
-  'Wed, 05 Jan 2022 08:53:10 GMT',
+  'Thu, 28 Jul 2022 08:31:54 GMT',
   'ETag',
-  '"0x8D9D028CCFD196D"',
+  '"0x8DA7073A0DFAC0A"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'c921e482-a01e-0013-3511-02c0b5000000',
+  '56906a3b-201e-0032-335c-a2e4ce000000',
   'x-ms-client-request-id',
-  'd2448a6b-7ee1-4672-b8b3-7f02ae58232d',
+  '6ae530d6-1e19-4355-881f-db58ddfbfe67',
   'x-ms-version',
-  '2021-02-12',
+  '2021-08-06',
   'Date',
-  'Wed, 05 Jan 2022 08:53:10 GMT'
+  'Thu, 28 Jul 2022 08:31:54 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container164137279039306240/srcblob%2F%252%2B%252F164137279049704245', "Hello World")
+  .put('/container165899711462100456/srcblob/%252%2B%252F165899711472606363', "Hello World")
   .reply(201, "", [
   'Content-Length',
   '0',
   'Content-MD5',
   'sQqNsWTgdUEFt6mb5y4/5Q==',
   'Last-Modified',
-  'Wed, 05 Jan 2022 08:53:10 GMT',
+  'Thu, 28 Jul 2022 08:31:55 GMT',
   'ETag',
-  '"0x8D9D028CD0DB865"',
+  '"0x8DA7073A0F1BAF7"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'c921e491-a01e-0013-4111-02c0b5000000',
+  '56906a52-201e-0032-475c-a2e4ce000000',
   'x-ms-client-request-id',
-  '770eedad-f186-4f00-96c2-244d5e2901da',
+  'd895fd85-64a7-4f56-a974-eb78e5e73486',
   'x-ms-version',
-  '2021-02-12',
+  '2021-08-06',
   'x-ms-content-crc64',
   'YeJLfssylmU=',
   'x-ms-request-server-encrypted',
   'true',
   'Date',
-  'Wed, 05 Jan 2022 08:53:10 GMT'
+  'Thu, 28 Jul 2022 08:31:54 GMT'
 ]);
 
 nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
@@ -72,19 +72,21 @@ nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
   'P3P',
   'CP="DSP CUR OTPi IND OTRi ONL FIN"',
   'x-ms-request-id',
-  '1bd63f88-8ecd-4df1-9d86-9bcf25d79200',
+  'f36bfaba-1513-4030-bfff-39d2c0c03500',
   'x-ms-ests-server',
-  '2.1.12261.17 - SEASLR2 ProdSlices',
+  '2.1.13355.6 - SEASLR2 ProdSlices',
+  'X-XSS-Protection',
+  '0',
   'Set-Cookie',
-  'fpc=AjQ6CBZsaqJJkMt5Dzqz0Lo; expires=Fri, 04-Feb-2022 08:53:10 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'fpc=Aq4YNvwjfFtFkeaS79EfOq8; expires=Sat, 27-Aug-2022 08:31:55 GMT; path=/; secure; HttpOnly; SameSite=None',
   'Set-Cookie',
-  'esctx=AQABAAAAAAD--DLA3VO7QrddgJg7WevrZGYYGcFbm6XNA2XY8_Ue8cUihRsizWua6s9UGZIqByFYO65omOD6CwTzan6t2GjreNm8lUbuKAOJc3dhJ5JSVNbjMGh_IWJxLnlVorIISsq7QJFTuDIHR6HkZvDvApqqO_2A0YBcOqtwuVKDOdABPjQRxj2oTACWNZfqubV6FqsgAA; domain=.login.microsoftonline.com; path=/; secure; HttpOnly; SameSite=None',
+  'esctx=AQABAAAAAAD--DLA3VO7QrddgJg7WevrdcYLZT9gc3i39QSiWb6lKxxooHU2YK-GBS0F2vbLJngpPwVMqXN3XlTlJ93WzH1TwIIA169ueUHguo4m8aW-idWr_sSyX8dTSgsnZXvk1bDulCIsRQRjiapWzSVKT_RwRVYElVlCzoa71cSiJBONHtfi8U18ErmKzYh-DfcyrBcgAA; domain=.login.microsoftonline.com; path=/; secure; HttpOnly; SameSite=None',
   'Set-Cookie',
   'x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly',
   'Set-Cookie',
   'stsservicecookie=estsfd; path=/; secure; samesite=none; httponly',
   'Date',
-  'Wed, 05 Jan 2022 08:53:10 GMT',
+  'Thu, 28 Jul 2022 08:31:55 GMT',
   'Content-Length',
   '980'
 ]);
@@ -107,25 +109,27 @@ nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
   'P3P',
   'CP="DSP CUR OTPi IND OTRi ONL FIN"',
   'x-ms-request-id',
-  '7777f699-653d-4eb0-b230-12e5fcb47b00',
+  'a940112a-8d69-4ff8-b453-b1b881913900',
   'x-ms-ests-server',
-  '2.1.12261.17 - KRSLR1 ProdSlices',
+  '2.1.13355.6 - KRC ProdSlices',
+  'X-XSS-Protection',
+  '0',
   'Set-Cookie',
-  'fpc=Ao7rHB7qcIlCkpPhJAKRgAk; expires=Fri, 04-Feb-2022 08:53:11 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'fpc=Akb8YUeNlhtKoeU1BM7M5D4; expires=Sat, 27-Aug-2022 08:31:55 GMT; path=/; secure; HttpOnly; SameSite=None',
   'Set-Cookie',
-  'esctx=AQABAAAAAAD--DLA3VO7QrddgJg7Wevr3mtTxLTFPrlVVKKuKmbX-GaynEygdBhx3vcbzehnqTemMSOP1sNkwtsPNqLARq6w5-1wDdYBa3jb0N-qutHwhgciJZdszYISv_lj05opbk9p39jd-xY03cg32E0csYCXcdV6mPB009k8O1ySkyXWBL2gVxuRDgjDVFJ3OnM5qEwgAA; domain=.login.microsoftonline.com; path=/; secure; HttpOnly; SameSite=None',
+  'esctx=AQABAAAAAAD--DLA3VO7QrddgJg7Wevr1uAl2rxD7GfDwM3A_KAyMWIos6pT7pI7PXjWXorW9ANlcgfw8AJcHM76t2N4huH6rgnBOTuCDYY-WtpnQTsd7J-xfqxn09bN-gAoNNUzNEl0bCMg1WZJvv_PUCndlr6jQeNpcea_XdEjZkxkdeLzXxspY1-md-vOarMDW3a-ZPsgAA; domain=.login.microsoftonline.com; path=/; secure; HttpOnly; SameSite=None',
   'Set-Cookie',
   'x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly',
   'Set-Cookie',
   'stsservicecookie=estsfd; path=/; secure; samesite=none; httponly',
   'Date',
-  'Wed, 05 Jan 2022 08:53:11 GMT',
+  'Thu, 28 Jul 2022 08:31:55 GMT',
   'Content-Length',
   '1753'
 ]);
 
 nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
-  .post('/aaaaa/oauth2/v2.0/token', "client_id=aaaaa&scope=https%3A%2F%2Fsanitized%2F&grant_type=client_credentials&x-client-SKU=msal.js.node&x-client-VER=1.4.0&x-client-OS=win32&x-client-CPU=x64&x-ms-lib-capability=retry-after, h429&x-client-current-telemetry=5|771,2,,,|,&x-client-last-telemetry=5|0|||0,0&client-request-id=d21f6fab-dad6-4427-9135-247b3f30d6c2&client_secret=aaaaa&claims=%7B%22access_token%22%3A%7B%22xms_cc%22%3A%7B%22values%22%3A%5B%22cp1%22%5D%7D%7D%7D")
+  .post('/aaaaa/oauth2/v2.0/token', "client_id=aaaaa&scope=https%3A%2F%2Fsanitized%2F&grant_type=client_credentials&x-client-SKU=msal.js.node&x-client-VER=1.11.0&x-client-OS=win32&x-client-CPU=x64&x-ms-lib-capability=retry-after, h429&x-client-current-telemetry=5|771,2,,,|,&x-client-last-telemetry=5|0|||0,0&client-request-id=7d80091d-5b03-48fa-b94a-01284ddeb814&client_secret=aaaaa&claims=%7B%22access_token%22%3A%7B%22xms_cc%22%3A%7B%22values%22%3A%5B%22cp1%22%5D%7D%7D%7D")
   .reply(200, {"token_type":"Bearer","expires_in":86399,"ext_expires_in":86399,"access_token":"access_token"}, [
   'Cache-Control',
   'no-store, no-cache',
@@ -142,50 +146,52 @@ nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
   'P3P',
   'CP="DSP CUR OTPi IND OTRi ONL FIN"',
   'x-ms-request-id',
-  'f9d8b77c-5495-4058-a16d-afdd888a8200',
+  'f36bfaba-1513-4030-bfff-39d2c2c03500',
   'x-ms-ests-server',
-  '2.1.12261.17 - SEASLR1 ProdSlices',
+  '2.1.13355.6 - SEASLR2 ProdSlices',
   'x-ms-clitelem',
   '1,0,0,,',
+  'X-XSS-Protection',
+  '0',
   'Set-Cookie',
-  'fpc=AmPl1VwOHTlOizYsYvidO1DeeSdeAQAAAHZTZ9kOAAAA; expires=Fri, 04-Feb-2022 08:53:11 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'fpc=AluvDqv27yRNtVa5IQYid93eeSdeAQAAAHtAdNoOAAAA; expires=Sat, 27-Aug-2022 08:31:55 GMT; path=/; secure; HttpOnly; SameSite=None',
   'Set-Cookie',
   'x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly',
   'Set-Cookie',
   'stsservicecookie=estsfd; path=/; secure; samesite=none; httponly',
   'Date',
-  'Wed, 05 Jan 2022 08:53:11 GMT',
+  'Thu, 28 Jul 2022 08:31:55 GMT',
   'Content-Length',
   '1318'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container164137279039306240/blockblob164137279049702601')
+  .put('/container165899711462100456/blockblob165899711472602588')
   .reply(201, "", [
   'Content-Length',
   '0',
   'Last-Modified',
-  'Wed, 05 Jan 2022 08:53:11 GMT',
+  'Thu, 28 Jul 2022 08:31:55 GMT',
   'ETag',
-  '"0x8D9D028CD92B3AB"',
+  '"0x8DA7073A13F0BCD"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'c921e56f-a01e-0013-0e11-02c0b5000000',
+  '56906ad0-201e-0032-395c-a2e4ce000000',
   'x-ms-client-request-id',
-  '4eb8e458-a764-4f7d-a347-3ca6652d4e2e',
+  '4240d89d-3bf5-4766-89e9-8be50c2571db',
   'x-ms-version',
-  '2021-02-12',
+  '2021-08-06',
   'x-ms-content-crc64',
   'YeJLfssylmU=',
   'x-ms-request-server-encrypted',
   'true',
   'Date',
-  'Wed, 05 Jan 2022 08:53:11 GMT'
+  'Thu, 28 Jul 2022 08:31:55 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .get('/container164137279039306240/blockblob164137279049702601')
+  .get('/container165899711462100456/blockblob165899711472602588')
   .reply(200, ["48656c6c6f20576f726c64"], [
   'Cache-Control',
   'blobCacheControl',
@@ -200,21 +206,21 @@ nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParam
   'Content-MD5',
   'sQqNsWTgdUEFt6mb5y4/5Q==',
   'Last-Modified',
-  'Wed, 05 Jan 2022 08:53:11 GMT',
+  'Thu, 28 Jul 2022 08:31:55 GMT',
   'Accept-Ranges',
   'bytes',
   'ETag',
-  '"0x8D9D028CD92B3AB"',
+  '"0x8DA7073A13F0BCD"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'c921e5ac-a01e-0013-4711-02c0b5000000',
+  '56906ae7-201e-0032-4d5c-a2e4ce000000',
   'x-ms-client-request-id',
-  '8f6d554d-61bf-4768-a9f6-c72a11639f1d',
+  '09990efc-5acf-47f8-9090-3a5ce924c740',
   'x-ms-version',
-  '2021-02-12',
+  '2021-08-06',
   'x-ms-creation-time',
-  'Wed, 05 Jan 2022 08:53:11 GMT',
+  'Thu, 28 Jul 2022 08:31:55 GMT',
   'x-ms-lease-status',
   'unlocked',
   'x-ms-lease-state',
@@ -225,12 +231,16 @@ nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParam
   'blobContentDisposition',
   'x-ms-server-encrypted',
   'true',
+  'Access-Control-Expose-Headers',
+  'x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,Content-Type,Content-Encoding,Content-Language,Cache-Control,Last-Modified,ETag,x-ms-creation-time,Content-MD5,x-ms-lease-status,x-ms-lease-state,x-ms-blob-type,Content-Disposition,x-ms-server-encrypted,Accept-Ranges,Content-Length,Date,Transfer-Encoding',
+  'Access-Control-Allow-Origin',
+  '*',
   'Date',
-  'Wed, 05 Jan 2022 08:53:11 GMT'
+  'Thu, 28 Jul 2022 08:31:55 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .delete('/container164137279039306240')
+  .delete('/container165899711462100456')
   .query(true)
   .reply(202, "", [
   'Content-Length',
@@ -238,11 +248,11 @@ nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParam
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'c921e5b9-a01e-0013-5411-02c0b5000000',
+  '56906afc-201e-0032-5d5c-a2e4ce000000',
   'x-ms-client-request-id',
-  '682f2a78-25a8-42cb-a994-b2a2576cc7e2',
+  '075045dc-0860-4a19-958c-28ca13537e9d',
   'x-ms-version',
-  '2021-02-12',
+  '2021-08-06',
   'Date',
-  'Wed, 05 Jan 2022 08:53:11 GMT'
+  'Thu, 28 Jul 2022 08:31:55 GMT'
 ]);

--- a/sdk/storage/storage-blob/recordings/node/syncuploadfromurl/recording_syncuploadfromurl__with_copy_tags.js
+++ b/sdk/storage/storage-blob/recordings/node/syncuploadfromurl/recording_syncuploadfromurl__with_copy_tags.js
@@ -2,92 +2,100 @@ let nock = require('nock');
 
 module.exports.hash = "43807084beb93488dac025d9f32c4bc4";
 
-module.exports.testInfo = {"uniqueName":{"container":"container164917033187009499","blockblob":"blockblob164917033363702142","srcblob/%2+%2F":"srcblob/%2+%2F164917033363906144"},"newDate":{"expiry":"2022-04-05T14:52:13.915Z","tagtestexpiry":"2022-04-05T14:52:14.210Z"}}
+module.exports.testInfo = {"uniqueName":{"container":"container165899711905709036","blockblob":"blockblob165899711916307700","srcblob/%2+%2F":"srcblob/%2+%2F165899711916301733"},"newDate":{"expiry":"2022-07-28T08:31:59.269Z","tagtestexpiry":"2022-07-28T08:31:59.375Z"}}
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container164917033187009499')
+  .put('/container165899711905709036')
   .query(true)
   .reply(201, "", [
-  'Transfer-Encoding',
-  'chunked',
+  'Content-Length',
+  '0',
   'Last-Modified',
-  'Tue, 05 Apr 2022 14:52:13 GMT',
+  'Thu, 28 Jul 2022 08:31:59 GMT',
   'ETag',
-  '"0x8DA1713DEE3CA68"',
+  '"0x8DA7073A38514AA"',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'b8466d0d-a01e-0005-74fc-48f0c9000000',
+  '56907165-201e-0032-595c-a2e4ce000000',
   'x-ms-client-request-id',
-  'b38766b0-63fd-42c5-8c5b-49a78e77c81c',
+  '0193d06b-e525-40a0-95c8-7a21889d8aa6',
   'x-ms-version',
-  '2021-04-10',
+  '2021-08-06',
   'Date',
-  'Tue, 05 Apr 2022 14:52:13 GMT'
+  'Thu, 28 Jul 2022 08:31:59 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container164917033187009499/srcblob%2F%252%2B%252F164917033363906144', "Hello World")
+  .put('/container165899711905709036/srcblob/%252%2B%252F165899711916301733', "Hello World")
   .reply(201, "", [
-  'Transfer-Encoding',
-  'chunked',
+  'Content-Length',
+  '0',
   'Content-MD5',
   'sQqNsWTgdUEFt6mb5y4/5Q==',
   'Last-Modified',
-  'Tue, 05 Apr 2022 14:52:14 GMT',
+  'Thu, 28 Jul 2022 08:31:59 GMT',
   'ETag',
-  '"0x8DA1713DF117BD3"',
+  '"0x8DA7073A396D0AD"',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'b8466d10-a01e-0005-75fc-48f0c9000000',
+  '56907189-201e-0032-775c-a2e4ce000000',
   'x-ms-client-request-id',
-  '22f374c9-457e-44f6-84c4-2b39e3e9776e',
+  'a91a7e2c-45a7-41d0-9b6f-cc64f3ff2a57',
   'x-ms-version',
-  '2021-04-10',
+  '2021-08-06',
   'x-ms-content-crc64',
   'YeJLfssylmU=',
   'x-ms-request-server-encrypted',
   'true',
   'Date',
-  'Tue, 05 Apr 2022 14:52:13 GMT'
+  'Thu, 28 Jul 2022 08:31:59 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container164917033187009499/srcblob%2F%252%2B%252F164917033363906144', "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?><Tags><TagSet><Tag><Key>tag1</Key><Value>val1</Value></Tag></TagSet></Tags>")
+  .put('/container165899711905709036/srcblob/%252%2B%252F165899711916301733', "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?><Tags><TagSet><Tag><Key>tag1</Key><Value>val1</Value></Tag></TagSet></Tags>")
   .query(true)
   .reply(204, "", [
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'b8466d11-a01e-0005-76fc-48f0c9000000',
+  '569071b8-201e-0032-1d5c-a2e4ce000000',
   'x-ms-version',
-  '2021-04-10',
+  '2021-08-06',
   'x-ms-client-request-id',
-  '09eb5b9f-e4e3-48c7-8535-0a3a5095e16e',
+  'da8bfee7-b660-4b67-b16c-eba0e0718b77',
   'Date',
-  'Tue, 05 Apr 2022 14:52:14 GMT'
+  'Thu, 28 Jul 2022 08:31:59 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container164917033187009499/blockblob164917033363702142')
+  .put('/container165899711905709036/blockblob165899711916307700')
   .reply(201, "", [
-  'Transfer-Encoding',
-  'chunked',
+  'Content-Length',
+  '0',
   'Last-Modified',
-  'Tue, 05 Apr 2022 14:52:14 GMT',
+  'Thu, 28 Jul 2022 08:31:59 GMT',
   'ETag',
-  '"0x8DA1713DF76CDDA"',
+  '"0x8DA7073A3C15C9B"',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'b8466d12-a01e-0005-77fc-48f0c9000000',
+  '569071d8-201e-0032-365c-a2e4ce000000',
   'x-ms-client-request-id',
-  'e71c81eb-2621-49a5-b546-ede706a0090c',
+  'e60656b3-c751-40d0-ac84-bcf289c4b060',
   'x-ms-version',
-  '2021-04-10',
+  '2021-08-06',
   'x-ms-content-crc64',
   'YeJLfssylmU=',
   'x-ms-request-server-encrypted',
   'true',
   'Date',
-  'Tue, 05 Apr 2022 14:52:14 GMT'
+  'Thu, 28 Jul 2022 08:31:59 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .get('/container164917033187009499/blockblob164917033363702142')
+  .get('/container165899711905709036/blockblob165899711916307700')
   .reply(200, ["48656c6c6f20576f726c64"], [
   'Cache-Control',
   'blobCacheControl',
@@ -102,21 +110,23 @@ nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParam
   'Content-MD5',
   'sQqNsWTgdUEFt6mb5y4/5Q==',
   'Last-Modified',
-  'Tue, 05 Apr 2022 14:52:14 GMT',
+  'Thu, 28 Jul 2022 08:31:59 GMT',
   'Accept-Ranges',
   'bytes',
   'ETag',
-  '"0x8DA1713DF76CDDA"',
+  '"0x8DA7073A3C15C9B"',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'b8466d15-a01e-0005-7afc-48f0c9000000',
+  '56907216-201e-0032-6b5c-a2e4ce000000',
   'x-ms-client-request-id',
-  'd658ecdb-cf83-4103-b5af-4fb4b2d0aa39',
+  'a9905646-4aa6-48e9-9a57-403fb61bc195',
   'x-ms-version',
-  '2021-04-10',
+  '2021-08-06',
   'x-ms-tag-count',
   '1',
   'x-ms-creation-time',
-  'Tue, 05 Apr 2022 14:52:14 GMT',
+  'Thu, 28 Jul 2022 08:31:59 GMT',
   'x-ms-lease-status',
   'unlocked',
   'x-ms-lease-state',
@@ -128,45 +138,51 @@ nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParam
   'x-ms-server-encrypted',
   'true',
   'Access-Control-Expose-Headers',
-  'x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,x-ms-tag-count,Content-Type,Content-Encoding,Content-Language,Cache-Control,Last-Modified,ETag,x-ms-creation-time,Content-MD5,x-ms-lease-status,x-ms-lease-state,x-ms-blob-type,Content-Disposition,x-ms-server-encrypted,Accept-Ranges',
+  'x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,x-ms-tag-count,Content-Type,Content-Encoding,Content-Language,Cache-Control,Last-Modified,ETag,x-ms-creation-time,Content-MD5,x-ms-lease-status,x-ms-lease-state,x-ms-blob-type,Content-Disposition,x-ms-server-encrypted,Accept-Ranges,Content-Length,Date,Transfer-Encoding',
   'Access-Control-Allow-Origin',
   '*',
   'Date',
-  'Tue, 05 Apr 2022 14:52:14 GMT'
+  'Thu, 28 Jul 2022 08:31:59 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .get('/container164917033187009499/blockblob164917033363702142')
+  .get('/container165899711905709036/blockblob165899711916307700')
   .query(true)
   .reply(200, "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<Tags><TagSet><Tag><Key>tag1</Key><Value>val1</Value></Tag></TagSet></Tags>", [
   'Content-Length',
   '117',
   'Content-Type',
   'application/xml',
-  'Vary',
-  'Origin',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'b8466d16-a01e-0005-7bfc-48f0c9000000',
+  '56907225-201e-0032-785c-a2e4ce000000',
   'x-ms-version',
-  '2021-04-10',
+  '2021-08-06',
   'x-ms-client-request-id',
-  '2285a019-dde9-40ad-86ea-7af34fae88ee',
+  'abcc5dbf-b380-4e25-919c-b8670d116e65',
+  'Access-Control-Expose-Headers',
+  'Content-Length,Content-Type,Date,Server,x-ms-client-request-id,x-ms-request-id,x-ms-version',
+  'Access-Control-Allow-Origin',
+  '*',
   'Date',
-  'Tue, 05 Apr 2022 14:52:14 GMT'
+  'Thu, 28 Jul 2022 08:31:59 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .delete('/container164917033187009499')
+  .delete('/container165899711905709036')
   .query(true)
   .reply(202, "", [
-  'Transfer-Encoding',
-  'chunked',
+  'Content-Length',
+  '0',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'b8466d19-a01e-0005-7cfc-48f0c9000000',
+  '5690723f-201e-0032-0d5c-a2e4ce000000',
   'x-ms-client-request-id',
-  '7a57e49e-ea79-467d-af57-a0370d199f95',
+  '9ae1c6c6-b3ef-422f-bac2-dadc292141b9',
   'x-ms-version',
-  '2021-04-10',
+  '2021-08-06',
   'Date',
-  'Tue, 05 Apr 2022 14:52:15 GMT'
+  'Thu, 28 Jul 2022 08:31:59 GMT'
 ]);

--- a/sdk/storage/storage-blob/recordings/node/syncuploadfromurl/recording_syncuploadfromurl__with_replace_tags.js
+++ b/sdk/storage/storage-blob/recordings/node/syncuploadfromurl/recording_syncuploadfromurl__with_replace_tags.js
@@ -1,93 +1,101 @@
 let nock = require('nock');
 
-module.exports.hash = "80a93132ec0f659bff44a7805dcf306b";
+module.exports.hash = "16204e0756a77bbbe49d64ff34bad4a4";
 
-module.exports.testInfo = {"uniqueName":{"container":"container164917033533308063","blockblob":"blockblob164917033558102381","srcblob/%2+%2F":"srcblob/%2+%2F164917033558204967"},"newDate":{"expiry":"2022-04-05T14:52:15.832Z"}}
+module.exports.testInfo = {"uniqueName":{"container":"container165899711986100136","blockblob":"blockblob165899711996506911","srcblob/%2+%2F":"srcblob/%2+%2F165899711996503719"},"newDate":{"expiry":"2022-07-28T08:32:00.067Z"}}
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container164917033533308063')
+  .put('/container165899711986100136')
   .query(true)
   .reply(201, "", [
-  'Transfer-Encoding',
-  'chunked',
+  'Content-Length',
+  '0',
   'Last-Modified',
-  'Tue, 05 Apr 2022 14:52:15 GMT',
+  'Thu, 28 Jul 2022 08:32:00 GMT',
   'ETag',
-  '"0x8DA1713E012AE61"',
+  '"0x8DA7073A3FF89F5"',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'b8466d1a-a01e-0005-7dfc-48f0c9000000',
+  '5690726b-201e-0032-325c-a2e4ce000000',
   'x-ms-client-request-id',
-  '0d1f4449-f344-4156-814e-0dc5206c1c27',
+  '55908806-5639-41bf-9f01-099ad415cb87',
   'x-ms-version',
-  '2021-04-10',
+  '2021-08-06',
   'Date',
-  'Tue, 05 Apr 2022 14:52:15 GMT'
+  'Thu, 28 Jul 2022 08:32:00 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container164917033533308063/srcblob%2F%252%2B%252F164917033558204967', "Hello World")
+  .put('/container165899711986100136/srcblob/%252%2B%252F165899711996503719', "Hello World")
   .reply(201, "", [
-  'Transfer-Encoding',
-  'chunked',
+  'Content-Length',
+  '0',
   'Content-MD5',
   'sQqNsWTgdUEFt6mb5y4/5Q==',
   'Last-Modified',
-  'Tue, 05 Apr 2022 14:52:16 GMT',
+  'Thu, 28 Jul 2022 08:32:00 GMT',
   'ETag',
-  '"0x8DA1713E0395B7A"',
+  '"0x8DA7073A4111E1F"',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'b8466d1c-a01e-0005-7efc-48f0c9000000',
+  '56907290-201e-0032-4d5c-a2e4ce000000',
   'x-ms-client-request-id',
-  'ee2736fa-7a71-4584-94da-f9336510df31',
+  '94b86268-3b43-490f-8154-117f74e0e041',
   'x-ms-version',
-  '2021-04-10',
+  '2021-08-06',
   'x-ms-content-crc64',
   'YeJLfssylmU=',
   'x-ms-request-server-encrypted',
   'true',
   'Date',
-  'Tue, 05 Apr 2022 14:52:15 GMT'
+  'Thu, 28 Jul 2022 08:32:00 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container164917033533308063/srcblob%2F%252%2B%252F164917033558204967', "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?><Tags><TagSet><Tag><Key>tag1</Key><Value>val1</Value></Tag></TagSet></Tags>")
+  .put('/container165899711986100136/srcblob/%252%2B%252F165899711996503719', "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?><Tags><TagSet><Tag><Key>tag1</Key><Value>val1</Value></Tag></TagSet></Tags>")
   .query(true)
   .reply(204, "", [
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'b8466d1d-a01e-0005-7ffc-48f0c9000000',
+  '569072ab-201e-0032-635c-a2e4ce000000',
   'x-ms-version',
-  '2021-04-10',
+  '2021-08-06',
   'x-ms-client-request-id',
-  '04c8dbb1-30e8-4898-bdb0-dc70381e92c0',
+  '88922684-719c-4b84-93e6-f124c334bacd',
   'Date',
-  'Tue, 05 Apr 2022 14:52:15 GMT'
+  'Thu, 28 Jul 2022 08:32:00 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container164917033533308063/blockblob164917033558102381')
+  .put('/container165899711986100136/blockblob165899711996506911')
   .reply(201, "", [
-  'Transfer-Encoding',
-  'chunked',
+  'Content-Length',
+  '0',
   'Last-Modified',
-  'Tue, 05 Apr 2022 14:52:16 GMT',
+  'Thu, 28 Jul 2022 08:32:00 GMT',
   'ETag',
-  '"0x8DA1713E0886644"',
+  '"0x8DA7073A4317264"',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'b8466d1e-a01e-0005-80fc-48f0c9000000',
+  '569072c0-201e-0032-755c-a2e4ce000000',
   'x-ms-client-request-id',
-  '353b5247-708f-493c-b426-4d2ec7c0206c',
+  'f9dbd2a6-fb34-450a-bcaa-d1f2bfd11317',
   'x-ms-version',
-  '2021-04-10',
+  '2021-08-06',
   'x-ms-content-crc64',
   'YeJLfssylmU=',
   'x-ms-request-server-encrypted',
   'true',
   'Date',
-  'Tue, 05 Apr 2022 14:52:16 GMT'
+  'Thu, 28 Jul 2022 08:32:00 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .get('/container164917033533308063/blockblob164917033558102381')
+  .get('/container165899711986100136/blockblob165899711996506911')
   .reply(200, ["48656c6c6f20576f726c64"], [
   'Cache-Control',
   'blobCacheControl',
@@ -102,21 +110,23 @@ nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParam
   'Content-MD5',
   'sQqNsWTgdUEFt6mb5y4/5Q==',
   'Last-Modified',
-  'Tue, 05 Apr 2022 14:52:16 GMT',
+  'Thu, 28 Jul 2022 08:32:00 GMT',
   'Accept-Ranges',
   'bytes',
   'ETag',
-  '"0x8DA1713E0886644"',
+  '"0x8DA7073A4317264"',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'b8466d21-a01e-0005-03fc-48f0c9000000',
+  '569072d6-201e-0032-075c-a2e4ce000000',
   'x-ms-client-request-id',
-  '65394d6e-fa96-4957-a12d-c9cabdd8cdc5',
+  '378e21af-3c6b-44af-9976-6ef6c53f28ac',
   'x-ms-version',
-  '2021-04-10',
+  '2021-08-06',
   'x-ms-tag-count',
   '1',
   'x-ms-creation-time',
-  'Tue, 05 Apr 2022 14:52:16 GMT',
+  'Thu, 28 Jul 2022 08:32:00 GMT',
   'x-ms-lease-status',
   'unlocked',
   'x-ms-lease-state',
@@ -128,45 +138,51 @@ nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParam
   'x-ms-server-encrypted',
   'true',
   'Access-Control-Expose-Headers',
-  'x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,x-ms-tag-count,Content-Type,Content-Encoding,Content-Language,Cache-Control,Last-Modified,ETag,x-ms-creation-time,Content-MD5,x-ms-lease-status,x-ms-lease-state,x-ms-blob-type,Content-Disposition,x-ms-server-encrypted,Accept-Ranges',
+  'x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,x-ms-tag-count,Content-Type,Content-Encoding,Content-Language,Cache-Control,Last-Modified,ETag,x-ms-creation-time,Content-MD5,x-ms-lease-status,x-ms-lease-state,x-ms-blob-type,Content-Disposition,x-ms-server-encrypted,Accept-Ranges,Content-Length,Date,Transfer-Encoding',
   'Access-Control-Allow-Origin',
   '*',
   'Date',
-  'Tue, 05 Apr 2022 14:52:16 GMT'
+  'Thu, 28 Jul 2022 08:32:00 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .get('/container164917033533308063/blockblob164917033558102381')
+  .get('/container165899711986100136/blockblob165899711996506911')
   .query(true)
   .reply(200, "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<Tags><TagSet><Tag><Key>tag2</Key><Value>val2</Value></Tag></TagSet></Tags>", [
   'Content-Length',
   '117',
   'Content-Type',
   'application/xml',
-  'Vary',
-  'Origin',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'b8466d22-a01e-0005-04fc-48f0c9000000',
+  '569072ed-201e-0032-1b5c-a2e4ce000000',
   'x-ms-version',
-  '2021-04-10',
+  '2021-08-06',
   'x-ms-client-request-id',
-  '1da4c89e-dcd0-4b6a-8c04-2d292364cf92',
+  '717d6e86-3d33-432b-b19a-53d514393a11',
+  'Access-Control-Expose-Headers',
+  'Content-Length,Content-Type,Date,Server,x-ms-client-request-id,x-ms-request-id,x-ms-version',
+  'Access-Control-Allow-Origin',
+  '*',
   'Date',
-  'Tue, 05 Apr 2022 14:52:16 GMT'
+  'Thu, 28 Jul 2022 08:32:00 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .delete('/container164917033533308063')
+  .delete('/container165899711986100136')
   .query(true)
   .reply(202, "", [
-  'Transfer-Encoding',
-  'chunked',
+  'Content-Length',
+  '0',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'b8466d23-a01e-0005-05fc-48f0c9000000',
+  '5690730e-201e-0032-385c-a2e4ce000000',
   'x-ms-client-request-id',
-  'b2592027-5158-4e17-ad3a-13daa4754122',
+  '27d3d216-279a-4b19-b178-68f734c7b4ff',
   'x-ms-version',
-  '2021-04-10',
+  '2021-08-06',
   'Date',
-  'Tue, 05 Apr 2022 14:52:16 GMT'
+  'Thu, 28 Jul 2022 08:32:00 GMT'
 ]);

--- a/sdk/storage/storage-blob/recordings/node/syncuploadfromurl/recording_with_default_options.js
+++ b/sdk/storage/storage-blob/recordings/node/syncuploadfromurl/recording_with_default_options.js
@@ -1,89 +1,85 @@
 let nock = require('nock');
 
-module.exports.hash = "7aa71a635212d34deb91c361e82cba81";
+module.exports.hash = "04abb2fc93630a8b10ddc4eaf79727d6";
 
-module.exports.testInfo = {"uniqueName":{"container":"container160635997567005508","blockblob":"blockblob160635997710607246","srcblob/%2+%2F":"srcblob/%2+%2F160635997710902497"},"newDate":{"expiry":"2020-11-26T03:06:17.431Z"}}
+module.exports.testInfo = {"uniqueName":{"container":"container165899711787606011","blockblob":"blockblob165899711797809699","srcblob/%2+%2F":"srcblob/%2+%2F165899711797800776"},"newDate":{"expiry":"2022-07-28T08:31:58.081Z"}}
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container160635997567005508')
+  .put('/container165899711787606011')
   .query(true)
   .reply(201, "", [
   'Content-Length',
   '0',
   'Last-Modified',
-  'Thu, 26 Nov 2020 03:06:16 GMT',
+  'Thu, 28 Jul 2022 08:31:58 GMT',
   'ETag',
-  '"0x8D891B83DC72DDD"',
+  '"0x8DA7073A2D05E02"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'fbc80cef-c01e-0085-40a1-c37820000000',
+  '56906f5f-201e-0032-575c-a2e4ce000000',
   'x-ms-client-request-id',
-  '8564f6d0-18da-4ea5-ba54-e9781312a606',
+  '85089180-b959-4993-8e27-469b7d839118',
   'x-ms-version',
-  '2020-04-08',
+  '2021-08-06',
   'Date',
-  'Thu, 26 Nov 2020 03:06:16 GMT'
+  'Thu, 28 Jul 2022 08:31:58 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container160635997567005508/srcblob%2F%252%2B%252F160635997710902497', "Hello World")
+  .put('/container165899711787606011/srcblob/%252%2B%252F165899711797800776', "Hello World")
   .reply(201, "", [
   'Content-Length',
   '0',
   'Content-MD5',
   'sQqNsWTgdUEFt6mb5y4/5Q==',
   'Last-Modified',
-  'Thu, 26 Nov 2020 03:06:17 GMT',
+  'Thu, 28 Jul 2022 08:31:58 GMT',
   'ETag',
-  '"0x8D891B83DFB8023"',
+  '"0x8DA7073A2E1F446"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'fbc80de5-c01e-0085-2ba1-c37820000000',
+  '56906f97-201e-0032-7d5c-a2e4ce000000',
   'x-ms-client-request-id',
-  '1848c2bb-90f2-44c3-8baf-8d13b602aeef',
+  'd1f11f2b-9071-4e73-8223-67964dc5ae8a',
   'x-ms-version',
-  '2020-04-08',
+  '2021-08-06',
   'x-ms-content-crc64',
   'YeJLfssylmU=',
   'x-ms-request-server-encrypted',
   'true',
-  'x-ms-version-id',
-  '2020-11-26T03:06:17.2827683Z',
   'Date',
-  'Thu, 26 Nov 2020 03:06:17 GMT'
+  'Thu, 28 Jul 2022 08:31:58 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container160635997567005508/blockblob160635997710607246')
+  .put('/container165899711787606011/blockblob165899711797809699')
   .reply(201, "", [
   'Content-Length',
   '0',
   'Last-Modified',
-  'Thu, 26 Nov 2020 03:06:17 GMT',
+  'Thu, 28 Jul 2022 08:31:58 GMT',
   'ETag',
-  '"0x8D891B83E318E11"',
+  '"0x8DA7073A2F46804"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'fbc80ec6-c01e-0085-01a1-c37820000000',
+  '56906fbf-201e-0032-185c-a2e4ce000000',
   'x-ms-client-request-id',
-  '10d25230-d2bb-461b-b138-79738de242a1',
+  'e1e8f327-a983-4b5a-b753-47cc0fa3deb0',
   'x-ms-version',
-  '2020-04-08',
+  '2021-08-06',
   'x-ms-content-crc64',
   'YeJLfssylmU=',
-  'x-ms-version-id',
-  '2020-11-26T03:06:17.6370193Z',
   'x-ms-request-server-encrypted',
   'true',
   'Date',
-  'Thu, 26 Nov 2020 03:06:17 GMT'
+  'Thu, 28 Jul 2022 08:31:58 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .get('/container160635997567005508/blockblob160635997710607246')
+  .get('/container165899711787606011/blockblob165899711797809699')
   .reply(200, ["48656c6c6f20576f726c64"], [
   'Cache-Control',
   'blobCacheControl',
@@ -98,25 +94,21 @@ nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParam
   'Content-MD5',
   'sQqNsWTgdUEFt6mb5y4/5Q==',
   'Last-Modified',
-  'Thu, 26 Nov 2020 03:06:17 GMT',
+  'Thu, 28 Jul 2022 08:31:58 GMT',
   'Accept-Ranges',
   'bytes',
   'ETag',
-  '"0x8D891B83E318E11"',
+  '"0x8DA7073A2F46804"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'fbc80fa6-c01e-0085-54a1-c37820000000',
+  '56906fe8-201e-0032-355c-a2e4ce000000',
   'x-ms-client-request-id',
-  '4e009627-ee82-4f2e-a419-2006e6e5d44c',
+  '8eb71d4a-a6cf-4e0b-8f93-7c5b608279df',
   'x-ms-version',
-  '2020-04-08',
-  'x-ms-version-id',
-  '2020-11-26T03:06:17.6370193Z',
-  'x-ms-is-current-version',
-  'true',
+  '2021-08-06',
   'x-ms-creation-time',
-  'Thu, 26 Nov 2020 03:06:17 GMT',
+  'Thu, 28 Jul 2022 08:31:58 GMT',
   'x-ms-lease-status',
   'unlocked',
   'x-ms-lease-state',
@@ -128,15 +120,15 @@ nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParam
   'x-ms-server-encrypted',
   'true',
   'Access-Control-Expose-Headers',
-  'x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,x-ms-version-id,x-ms-is-current-version,Content-Type,Content-Encoding,Content-Language,Cache-Control,Last-Modified,ETag,x-ms-creation-time,Content-MD5,x-ms-lease-status,x-ms-lease-state,x-ms-blob-type,Content-Disposition,x-ms-server-encrypted,Accept-Ranges,Content-Length,Date,Transfer-Encoding',
+  'x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,Content-Type,Content-Encoding,Content-Language,Cache-Control,Last-Modified,ETag,x-ms-creation-time,Content-MD5,x-ms-lease-status,x-ms-lease-state,x-ms-blob-type,Content-Disposition,x-ms-server-encrypted,Accept-Ranges,Content-Length,Date,Transfer-Encoding',
   'Access-Control-Allow-Origin',
   '*',
   'Date',
-  'Thu, 26 Nov 2020 03:06:17 GMT'
+  'Thu, 28 Jul 2022 08:31:58 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .delete('/container160635997567005508')
+  .delete('/container165899711787606011')
   .query(true)
   .reply(202, "", [
   'Content-Length',
@@ -144,11 +136,11 @@ nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParam
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'fbc81036-c01e-0085-57a1-c37820000000',
+  '5690702a-201e-0032-655c-a2e4ce000000',
   'x-ms-client-request-id',
-  '1fa5cbaf-4923-4703-8f93-f5918ea60cab',
+  '25086a31-ebcf-45fa-9291-30013305539a',
   'x-ms-version',
-  '2020-04-08',
+  '2021-08-06',
   'Date',
-  'Thu, 26 Nov 2020 03:06:18 GMT'
+  'Thu, 28 Jul 2022 08:31:58 GMT'
 ]);

--- a/sdk/storage/storage-blob/src/ContainerClient.ts
+++ b/sdk/storage/storage-blob/src/ContainerClient.ts
@@ -211,24 +211,24 @@ export interface SignedIdentifier {
 export declare type ContainerGetAccessPolicyResponse = {
   signedIdentifiers: SignedIdentifier[];
 } & ContainerGetAccessPolicyHeaders & {
-  /**
-   * The underlying HTTP response.
-   */
-  _response: HttpResponse & {
     /**
-     * The parsed HTTP response headers.
+     * The underlying HTTP response.
      */
-    parsedHeaders: ContainerGetAccessPolicyHeaders;
-    /**
-     * The response body as text (string format)
-     */
-    bodyAsText: string;
-    /**
-     * The response body as parsed JSON or XML
-     */
-    parsedBody: SignedIdentifierModel[];
+    _response: HttpResponse & {
+      /**
+       * The parsed HTTP response headers.
+       */
+      parsedHeaders: ContainerGetAccessPolicyHeaders;
+      /**
+       * The response body as text (string format)
+       */
+      bodyAsText: string;
+      /**
+       * The response body as parsed JSON or XML
+       */
+      parsedBody: SignedIdentifierModel[];
+    };
   };
-};
 
 /**
  * Options to configure {@link ContainerClient.setAccessPolicy} operation.
@@ -924,10 +924,7 @@ export class ContainerClient extends StorageClient {
    * ```
    */
   public getBlockBlobClient(blobName: string): BlockBlobClient {
-    return new BlockBlobClient(
-      appendToURLPath(this.url, this.escapePath(blobName)),
-      this.pipeline
-    );
+    return new BlockBlobClient(appendToURLPath(this.url, this.escapePath(blobName)), this.pipeline);
   }
 
   /**
@@ -936,38 +933,18 @@ export class ContainerClient extends StorageClient {
    * @param blobName - A page blob name
    */
   public getPageBlobClient(blobName: string): PageBlobClient {
-    return new PageBlobClient(
-      appendToURLPath(this.url, this.escapePath(blobName)),
-      this.pipeline
-    );
+    return new PageBlobClient(appendToURLPath(this.url, this.escapePath(blobName)), this.pipeline);
   }
 
   /**
    * Escape the blobName but keep path separator ('/'). Exactly like in the dotnet SDK client.
    */
   private escapePath(blobName: string): string {
-    blobName = this.trim(blobName, "/");
     const split = blobName.split("/");
     for (let i = 0; i < split.length; i++) {
       split[i] = encodeURIComponent(split[i]);
     }
     return split.join("/");
-  }
-
-  private trim(str: string, ch: string): string {
-    if (str.startsWith("/")) {
-      str = str.substring(1);
-      if (str.startsWith("/")) {
-        return this.trim(str, ch);
-      }
-    }
-    if (str.endsWith("/")) {
-      str = str.substring(0, str.length - 1);
-      if (str.endsWith("/")) {
-        return this.trim(str, ch);
-      }
-    }
-    return str;
   }
 
   /**

--- a/sdk/storage/storage-blob/src/ContainerClient.ts
+++ b/sdk/storage/storage-blob/src/ContainerClient.ts
@@ -211,24 +211,24 @@ export interface SignedIdentifier {
 export declare type ContainerGetAccessPolicyResponse = {
   signedIdentifiers: SignedIdentifier[];
 } & ContainerGetAccessPolicyHeaders & {
+  /**
+   * The underlying HTTP response.
+   */
+  _response: HttpResponse & {
     /**
-     * The underlying HTTP response.
+     * The parsed HTTP response headers.
      */
-    _response: HttpResponse & {
-      /**
-       * The parsed HTTP response headers.
-       */
-      parsedHeaders: ContainerGetAccessPolicyHeaders;
-      /**
-       * The response body as text (string format)
-       */
-      bodyAsText: string;
-      /**
-       * The response body as parsed JSON or XML
-       */
-      parsedBody: SignedIdentifierModel[];
-    };
+    parsedHeaders: ContainerGetAccessPolicyHeaders;
+    /**
+     * The response body as text (string format)
+     */
+    bodyAsText: string;
+    /**
+     * The response body as parsed JSON or XML
+     */
+    parsedBody: SignedIdentifierModel[];
   };
+};
 
 /**
  * Options to configure {@link ContainerClient.setAccessPolicy} operation.
@@ -893,7 +893,7 @@ export class ContainerClient extends StorageClient {
    * @returns A new BlobClient object for the given blob name.
    */
   public getBlobClient(blobName: string): BlobClient {
-    return new BlobClient(appendToURLPath(this.url, encodeURIComponent(blobName)), this.pipeline);
+    return new BlobClient(appendToURLPath(this.url, this.escapePath(blobName)), this.pipeline);
   }
 
   /**
@@ -903,7 +903,7 @@ export class ContainerClient extends StorageClient {
    */
   public getAppendBlobClient(blobName: string): AppendBlobClient {
     return new AppendBlobClient(
-      appendToURLPath(this.url, encodeURIComponent(blobName)),
+      appendToURLPath(this.url, this.escapePath(blobName)),
       this.pipeline
     );
   }
@@ -925,7 +925,7 @@ export class ContainerClient extends StorageClient {
    */
   public getBlockBlobClient(blobName: string): BlockBlobClient {
     return new BlockBlobClient(
-      appendToURLPath(this.url, encodeURIComponent(blobName)),
+      appendToURLPath(this.url, this.escapePath(blobName)),
       this.pipeline
     );
   }
@@ -937,9 +937,37 @@ export class ContainerClient extends StorageClient {
    */
   public getPageBlobClient(blobName: string): PageBlobClient {
     return new PageBlobClient(
-      appendToURLPath(this.url, encodeURIComponent(blobName)),
+      appendToURLPath(this.url, this.escapePath(blobName)),
       this.pipeline
     );
+  }
+
+  /**
+   * Escape the blobName but keep path separator ('/'). Exactly like in the dotnet SDK client.
+   */
+  private escapePath(blobName: string): string {
+    blobName = this.trim(blobName, "/");
+    const split = blobName.split("/");
+    for (let i = 0; i < split.length; i++) {
+      split[i] = encodeURIComponent(split[i]);
+    }
+    return split.join("/");
+  }
+
+  private trim(str: string, ch: string): string {
+    if (str.startsWith("/")) {
+      str = str.substring(1);
+      if (str.startsWith("/")) {
+        return this.trim(str, ch);
+      }
+    }
+    if (str.endsWith("/")) {
+      str = str.substring(0, str.length - 1);
+      if (str.endsWith("/")) {
+        return this.trim(str, ch);
+      }
+    }
+    return str;
   }
 
   /**

--- a/sdk/storage/storage-blob/test/node/blockblobclient.spec.ts
+++ b/sdk/storage/storage-blob/test/node/blockblobclient.spec.ts
@@ -244,7 +244,7 @@ describe("syncUploadFromURL", () => {
     }
   });
 
-  it.only("stageBlockFromURL - source SAS and destination bearer token", async function (this: Context) {
+  it("stageBlockFromURL - source SAS and destination bearer token", async function (this: Context) {
     const stokenBlobServiceClient = getTokenBSUWithDefaultCredential();
     const tokenNewBlockBlobClient = stokenBlobServiceClient
       .getContainerClient(containerClient.containerName)
@@ -272,7 +272,7 @@ describe("syncUploadFromURL", () => {
     assert.equal(listResponse.committedBlocks![1].size, content.length);
   });
 
-  it.only("stageBlockFromURL - source bear token and destination account key", async function (this: Context) {
+  it("stageBlockFromURL - source bear token and destination account key", async function (this: Context) {
     const body = "HelloWorld";
     await blockBlobClient.upload(body, body.length);
 
@@ -317,7 +317,7 @@ describe("syncUploadFromURL", () => {
     assert.equal(listResponse.committedBlocks![1].size, body.length);
   });
 
-  it.only("stageBlockFromURL - destination bearer token", async function (this: Context) {
+  it("stageBlockFromURL - destination bearer token", async function (this: Context) {
     const body = "HelloWorld";
     await blockBlobClient.upload(body, body.length);
 

--- a/sdk/storage/storage-blob/test/node/blockblobclient.spec.ts
+++ b/sdk/storage/storage-blob/test/node/blockblobclient.spec.ts
@@ -244,7 +244,7 @@ describe("syncUploadFromURL", () => {
     }
   });
 
-  it("stageBlockFromURL - source SAS and destination bearer token", async function (this: Context) {
+  it.only("stageBlockFromURL - source SAS and destination bearer token", async function (this: Context) {
     const stokenBlobServiceClient = getTokenBSUWithDefaultCredential();
     const tokenNewBlockBlobClient = stokenBlobServiceClient
       .getContainerClient(containerClient.containerName)
@@ -272,7 +272,7 @@ describe("syncUploadFromURL", () => {
     assert.equal(listResponse.committedBlocks![1].size, content.length);
   });
 
-  it("stageBlockFromURL - source bear token and destination account key", async function (this: Context) {
+  it.only("stageBlockFromURL - source bear token and destination account key", async function (this: Context) {
     const body = "HelloWorld";
     await blockBlobClient.upload(body, body.length);
 
@@ -317,7 +317,7 @@ describe("syncUploadFromURL", () => {
     assert.equal(listResponse.committedBlocks![1].size, body.length);
   });
 
-  it("stageBlockFromURL - destination bearer token", async function (this: Context) {
+  it.only("stageBlockFromURL - destination bearer token", async function (this: Context) {
     const body = "HelloWorld";
     await blockBlobClient.upload(body, body.length);
 


### PR DESCRIPTION
### Packages impacted by this PR
storage-blob

### Issues associated with this PR
#22568

### Describe the problem that is addressed by this PR
Change the encoding of blobNames to exclude the path separator `/`.

Before:

https://mystorageaccount.blob.core.windows.net/my-container/folderA%2Fblob.txt

After:

https://mystorageaccount.blob.core.windows.net/my-container/folderA/blob.txt
