### PR TITLE
[ServiceBus] Fix bug in converting ServiceBusMessage to RheaMessage

### DIFF
--- a/sdk/servicebus/service-bus/CHANGELOG.md
+++ b/sdk/servicebus/service-bus/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Bugs Fixed
 
+- Fix an invalid date issue when converting a `ServiceBusMessage` with `timeToLive` property set to a `RheaMessage`.
+
 ### Other Changes
 
 - Updated our `@azure/core-tracing` dependency to the latest version (v1.0.0)

--- a/sdk/servicebus/service-bus/samples-dev/sendMessages.ts
+++ b/sdk/servicebus/service-bus/samples-dev/sendMessages.ts
@@ -70,6 +70,16 @@ export async function main() {
     console.log(`Sending the last 5 scientists (as a ServiceBusMessageBatch)`);
     await sender.sendMessages(batch);
 
+    // Send a single message
+    console.log(`Sending one scientists`);
+    const message: ServiceBusMessage = {
+      contentType: "application/json",
+      subject: "Scientist",
+      body: { firstName: "Albert", lastName: "Einstein" },
+      timeToLive: 2 * 60 * 1000, // message expires in 2 minutes
+    };
+    await sender.sendMessages(message);
+
     // Close the sender
     console.log(`Done sending, closing...`);
     await sender.close();

--- a/sdk/servicebus/service-bus/samples/v7/javascript/sendMessages.js
+++ b/sdk/servicebus/service-bus/samples/v7/javascript/sendMessages.js
@@ -16,8 +16,7 @@
 const { ServiceBusClient } = require("@azure/service-bus");
 
 // Load the .env file if it exists
-const dotenv = require("dotenv");
-dotenv.config();
+require("dotenv").config();
 
 // Define connection string and related Service Bus entity names here
 const connectionString = process.env.SERVICEBUS_CONNECTION_STRING || "<connection string>";
@@ -69,6 +68,16 @@ async function main() {
     console.log(`Sending the last 5 scientists (as a ServiceBusMessageBatch)`);
     await sender.sendMessages(batch);
 
+    // Send a single message
+    console.log(`Sending one scientists`);
+    const message = {
+      contentType: "application/json",
+      subject: "Scientist",
+      body: { firstName: "Albert", lastName: "Einstein" },
+      timeToLive: 2 * 60 * 1000, // message expires in 2 minutes
+    };
+    await sender.sendMessages(message);
+
     // Close the sender
     console.log(`Done sending, closing...`);
     await sender.close();
@@ -81,3 +90,5 @@ main().catch((err) => {
   console.log("sendMessages Sample: Error occurred: ", err);
   process.exit(1);
 });
+
+module.exports = { main };

--- a/sdk/servicebus/service-bus/samples/v7/typescript/src/sendMessages.ts
+++ b/sdk/servicebus/service-bus/samples/v7/typescript/src/sendMessages.ts
@@ -69,6 +69,16 @@ export async function main() {
     console.log(`Sending the last 5 scientists (as a ServiceBusMessageBatch)`);
     await sender.sendMessages(batch);
 
+    // Send a single message
+    console.log(`Sending one scientists`);
+    const message: ServiceBusMessage = {
+      contentType: "application/json",
+      subject: "Scientist",
+      body: { firstName: "Albert", lastName: "Einstein" },
+      timeToLive: 2 * 60 * 1000, // message expires in 2 minutes
+    };
+    await sender.sendMessages(message);
+
     // Close the sender
     console.log(`Done sending, closing...`);
     await sender.close();

--- a/sdk/servicebus/service-bus/src/serviceBusMessage.ts
+++ b/sdk/servicebus/service-bus/src/serviceBusMessage.ts
@@ -327,7 +327,7 @@ export function toRheaMessage(
   if (amqpMsg.ttl != null && amqpMsg.ttl !== Constants.maxDurationValue) {
     amqpMsg.creation_time = new Date();
     amqpMsg.absolute_expiry_time = new Date(
-      Math.min(Constants.maxAbsoluteExpiryTime, (amqpMsg.creation_time as any) + amqpMsg.ttl)
+      Math.min(Constants.maxAbsoluteExpiryTime, amqpMsg.creation_time.getTime() + amqpMsg.ttl)
     );
   }
 

--- a/sdk/servicebus/service-bus/test/internal/unit/amqpUnitTests.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/unit/amqpUnitTests.spec.ts
@@ -174,5 +174,20 @@ describe("AMQP message encoding", () => {
 
       assert.equal(rheaMessage.body.typecode, valueSectionTypeCode);
     });
+
+    it("sets absolute_expiry_time when timeToLive is passed", () => {
+      const ttl = 2 * 60 * 1000;
+      const sbMessage: ServiceBusMessage = {
+        body: "hello",
+        timeToLive: ttl,
+      };
+
+      const rheaMessage = toRheaMessage(sbMessage, defaultDataTransformer);
+      assert.equal(rheaMessage.ttl, ttl);
+      assert.ok(
+        rheaMessage.absolute_expiry_time instanceof Date &&
+          !isNaN(rheaMessage.absolute_expiry_time.getTime())
+      );
+    });
   });
 });


### PR DESCRIPTION
when the `ServiceBusMessage` has `timeToLive` property set.

The problem is that we are adding a number to a `Date` object, resulting in an
invalid date value for `absolute_expiry_time`. This PR corrects it by calling
`getTime()` on the `Date` object first before adding the ttl number.

A unit test is added and the sendMessages sample is updated to show how to set
`timeToLive`.


### Packages impacted by this PR
`@azure/service-bus`
