### PR TITLE
[core-client] Increment core-rest-pipeline version to `^1.9.1`

### DIFF
--- a/sdk/core/core-client/package.json
+++ b/sdk/core/core-client/package.json
@@ -70,7 +70,7 @@
   "dependencies": {
     "@azure/abort-controller": "^1.0.0",
     "@azure/core-auth": "^1.4.0",
-    "@azure/core-rest-pipeline": "^1.5.0",
+    "@azure/core-rest-pipeline": "^1.9.1",
     "@azure/core-tracing": "^1.0.0",
     "@azure/core-util": "^1.0.0",
     "@azure/logger": "^1.0.0",


### PR DESCRIPTION
This is to ensure that core-client and core-rest-pipeline are using core-auth
1.4.0 or later for the new `GetTokenOptions.claims` property.
