### PR TITLE
[engsys] upgrade dev dep `rollup-plugin-visualizer` version to `^5.5.2`

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -7674,20 +7674,6 @@ packages:
       terser: 4.8.1
     dev: false
 
-  /rollup-plugin-visualizer/4.2.2_rollup@2.77.0:
-    resolution: {integrity: sha512-10/TsugsaQL5rdynl0lrklBngTtkRBESZdxUJy+3fN+xKqNdg5cr7JQU1OoPx4p5mhQ+nspa6EvX3qc8SsBvnA==}
-    engines: {node: '>=10'}
-    hasBin: true
-    peerDependencies:
-      rollup: '>=1.20.0'
-    dependencies:
-      nanoid: 3.3.4
-      open: 7.4.2
-      rollup: 2.77.0
-      source-map: 0.7.4
-      yargs: 16.2.0
-    dev: false
-
   /rollup-plugin-visualizer/5.7.1_rollup@2.77.0:
     resolution: {integrity: sha512-E/IgOMnmXKlc6ICyf53ok1b6DxPeNVUs3R0kYYPuDpGfofT4bkiG+KtSMlGjMACFmfwbbqTVDZBIF7sMZVKJbA==}
     engines: {node: '>=14'}
@@ -14688,7 +14674,7 @@ packages:
     dev: false
 
   file:projects/communication-network-traversal.tgz:
-    resolution: {integrity: sha512-Bf+HzU78QK1PW+rslrxtuSU7lE0Y/DYXlB5TaRUVSvVmD95qcPssXbE1oOe1pWVOgN2KoRQnn5995Xt6YRthFg==, tarball: file:projects/communication-network-traversal.tgz}
+    resolution: {integrity: sha512-GnIa/6iFWJLhKsqhGm0K++3/8Pe541yrJJBwfhRTqjypzqdGjzubntJuEEwwW1J7FFk7IzzK0sHM6hqkcpmzwA==, tarball: file:projects/communication-network-traversal.tgz}
     name: '@rush-temp/communication-network-traversal'
     version: 0.0.0
     dependencies:
@@ -14731,7 +14717,7 @@ packages:
       rollup-plugin-shim: 1.0.0
       rollup-plugin-sourcemaps: 0.6.3_f9bf48cb46bf0bc60daa3b180b80918f
       rollup-plugin-terser: 5.3.1_rollup@2.77.0
-      rollup-plugin-visualizer: 4.2.2_rollup@2.77.0
+      rollup-plugin-visualizer: 5.7.1_rollup@2.77.0
       sinon: 9.2.4
       tslib: 2.4.0
       typescript: 4.6.4
@@ -15052,7 +15038,7 @@ packages:
     dev: false
 
   file:projects/core-client-1.tgz:
-    resolution: {integrity: sha512-xlAOKcTcn7drAiTVx828Q2fq6wqQrzf++KaUpW47exuucVwzlZwkf/M0Tkj3gxLRiRXX4qkrma0YK21aRlU03g==, tarball: file:projects/core-client-1.tgz}
+    resolution: {integrity: sha512-6PZ587NIybJLDzewczuBOSlwGt+EdWwp/NzVly2Aj95laOU2F5+dMQ6zNGW9ppWssvq2ddvcMHRtI68LP3N2vw==, tarball: file:projects/core-client-1.tgz}
     name: '@rush-temp/core-client-1'
     version: 0.0.0
     dependencies:

--- a/sdk/communication/communication-network-traversal/package.json
+++ b/sdk/communication/communication-network-traversal/package.json
@@ -142,7 +142,7 @@
     "rollup-plugin-shim": "^1.0.0",
     "rollup-plugin-sourcemaps": "^0.6.3",
     "rollup-plugin-terser": "^5.1.1",
-    "rollup-plugin-visualizer": "^4.0.4",
+    "rollup-plugin-visualizer": "^5.5.2",
     "sinon": "^9.0.2",
     "typescript": "~4.6.0"
   }


### PR DESCRIPTION
to be consistent the version used in the repo

### Issues associated with this PR
resolves #19239

