### PR TITLE
[ServiceBus] fix existence checking of `PeekMessagesOptions.fromSequenceNumber`

### DIFF
--- a/sdk/servicebus/service-bus/src/receivers/receiver.ts
+++ b/sdk/servicebus/service-bus/src/receivers/receiver.ts
@@ -453,7 +453,7 @@ export class ServiceBusReceiverImpl implements ServiceBusReceiver {
       timeoutInMs: this._retryOptions?.timeoutInMs,
     };
     const peekOperationPromise = async (): Promise<ServiceBusReceivedMessage[]> => {
-      if (options.fromSequenceNumber) {
+      if (options.fromSequenceNumber !== undefined) {
         return this._context
           .getManagementClient(this.entityPath)
           .peekBySequenceNumber(

--- a/sdk/servicebus/service-bus/src/receivers/sessionReceiver.ts
+++ b/sdk/servicebus/service-bus/src/receivers/sessionReceiver.ts
@@ -301,7 +301,7 @@ export class ServiceBusSessionReceiverImpl implements ServiceBusSessionReceiver 
       timeoutInMs: this._retryOptions?.timeoutInMs,
     };
     const peekOperationPromise = async (): Promise<ServiceBusReceivedMessage[]> => {
-      if (options.fromSequenceNumber) {
+      if (options.fromSequenceNumber !== undefined) {
         return this._context
           .getManagementClient(this.entityPath)
           .peekBySequenceNumber(

--- a/sdk/servicebus/service-bus/test/public/invalidParameters.spec.ts
+++ b/sdk/servicebus/service-bus/test/public/invalidParameters.spec.ts
@@ -133,6 +133,22 @@ describe("invalid parameters", () => {
       );
     });
 
+    [false, 0, -0, "", NaN].forEach((falsyValue) => {
+      it("PeekBySequenceNumber: Wrong type sequenceNumber in SessionReceiver when passing falsy value that is not undefined or null", async function (): Promise<void> {
+        let caughtError: Error | undefined;
+        try {
+          await receiver.peekMessages(1, { fromSequenceNumber: falsyValue as any });
+        } catch (error: any) {
+          caughtError = error;
+        }
+        should.equal(caughtError && caughtError.name, "TypeError");
+        should.equal(
+          caughtError && caughtError.message,
+          `The parameter "fromSequenceNumber" should be of type "Long"`
+        );
+      });
+    });
+
     it("RegisterMessageHandler: Missing onMessage in SessionReceiver", async function (): Promise<void> {
       let caughtError: Error | undefined;
       try {
@@ -290,6 +306,22 @@ describe("invalid parameters", () => {
         caughtError && caughtError.message,
         `The parameter "fromSequenceNumber" should be of type "Long"`
       );
+    });
+
+    [false, 0, -0, "", NaN].forEach((falsyValue) => {
+      it("PeekBySequenceNumber: Wrong type fromSequenceNumber for Queue when passing falsy value that is not undefined or null", async function (): Promise<void> {
+        let caughtError: Error | undefined;
+        try {
+          await receiver.peekMessages(1, { fromSequenceNumber: falsyValue as any });
+        } catch (error: any) {
+          caughtError = error;
+        }
+        should.equal(caughtError && caughtError.name, "TypeError");
+        should.equal(
+          caughtError && caughtError.message,
+          `The parameter "fromSequenceNumber" should be of type "Long"`
+        );
+      });
     });
 
     it("RegisterMessageHandler: Missing onMessage in Receiver", async function (): Promise<void> {


### PR DESCRIPTION
We intended to call `peekBySequenceNumber()` when `PeekMessagesOptions.fromSequenceNumber` property is specified.  However, currently other falsey values would also fail the condition. This resulting in `peek()` is called instead, leading to unexpected behavior.

This PR changes the condition to check for `undefined`.
