### PR TITLE
Added test fix for nightly build run

### DIFF
--- a/sdk/digitaltwins/digital-twins-core/test/public/testModels.spec.ts
+++ b/sdk/digitaltwins/digital-twins-core/test/public/testModels.spec.ts
@@ -102,9 +102,10 @@ describe("DigitalTwins Models - create, read, list, delete operations", () => {
       await client.createModels([]);
     } catch (error: any) {
       errorWasThrown = true;
-      assert.include(
-        error.message,
-        "Operation failed as models provided was empty or of a type that is not supported."
+      assert.isTrue(
+        error.message.includes(
+          "Operation failed as models provided was empty or of a type that is not supported."
+        ) || error.message.includes(`should satisfy the constraint "MinItems`)
       );
     }
     should.equal(errorWasThrown, true, "Error was not thrown");


### PR DESCRIPTION
### Packages impacted by this PR
NA

### Issues associated with this PR
The nightly build runs fail due to a previous change with the @azure/core-http dependency. In order to make it work, a test assertion needs to be modified.

### Describe the problem that is addressed by this PR
The test assertion originally was modified to work against 2.2.6 version within the builds. However, 2.2.6 is an unreleased version that should not be specified with the package.json. Since the tests need to be compatible with <= 2.2.6, this change is to allow it work against all environments for the nightly build.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?
NA

### Are there test cases added in this PR? _(If not, why?)_
NA

### Provide a list of related PRs _(if any)_
https://github.com/Azure/azure-sdk-for-js/pull/22644

### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [ ] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
