### PR TITLE
Fix failures in passing or converting permissions

### DIFF
--- a/sdk/storage/storage-file-datalake/CHANGELOG.md
+++ b/sdk/storage/storage-file-datalake/CHANGELOG.md
@@ -9,6 +9,10 @@
 - Added support for encryption scopes.
 - Added support for encryption scope SAS.
 
+### Bugs Fixed
+
+- Correted permission string parsing in DataLakePathClient.setPermissions() and DataLakePathClient.getAccessControl().
+
 ## 12.10.0 (2022-07-08)
 
 ### Features Added

--- a/sdk/storage/storage-file-datalake/recordings/node/datalakepathclient_nodejs_only/recording_setpermissions.js
+++ b/sdk/storage/storage-file-datalake/recordings/node/datalakepathclient_nodejs_only/recording_setpermissions.js
@@ -1,118 +1,131 @@
 let nock = require('nock');
 
-module.exports.testInfo = {"uniqueName":{"filesystem":"filesystem157534404368207790","file":"file157534404482207959"},"newDate":{}}
+module.exports.hash = "33c9ca91414f7662a44d52aaeb9a68ca";
+
+module.exports.testInfo = {"uniqueName":{"filesystem":"filesystem165881686135906220","file":"file165881686204805318"},"newDate":{}}
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/filesystem157534404368207790')
+  .put('/filesystem165881686135906220')
   .query(true)
-  .reply(201, "", [ 'Content-Length',
+  .reply(201, "", [
+  'Content-Length',
   '0',
   'Last-Modified',
-  'Tue, 03 Dec 2019 03:28:06 GMT',
+  'Tue, 26 Jul 2022 06:27:42 GMT',
   'ETag',
-  '"0x8D777A0CFF17BDC"',
+  '"0x8DA6ECFF1FCA9FC"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '352ec019-f01e-005e-7689-a9b69d000000',
+  'eb8791c1-e01e-0058-43b8-a0215e000000',
   'x-ms-client-request-id',
-  'b290dfef-17db-4156-ad72-a6f4384026d9',
+  '042a75e2-0f7b-47d7-8186-e9b43c0e0c25',
   'x-ms-version',
-  '2019-02-02',
+  '2021-08-06',
   'Date',
-  'Tue, 03 Dec 2019 03:28:05 GMT' ]);
+  'Tue, 26 Jul 2022 06:27:42 GMT'
+]);
 
 nock('https://fakestorageaccount.dfs.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/filesystem157534404368207790/file157534404482207959')
+  .put('/filesystem165881686135906220/file165881686204805318')
   .query(true)
-  .reply(201, "", [ 'Last-Modified',
-  'Tue, 03 Dec 2019 03:28:07 GMT',
+  .reply(201, "", [
+  'Last-Modified',
+  'Tue, 26 Jul 2022 06:27:42 GMT',
   'ETag',
-  '"0x8D777A0D0C85801"',
-  'Server',
-  'Windows-Azure-HDFS/1.0 Microsoft-HTTPAPI/2.0',
-  'x-ms-request-id',
-  '50374722-a01f-0081-2b89-a9e7c9000000',
-  'x-ms-version',
-  '2019-02-02',
-  'x-ms-client-request-id',
-  '0932c788-b975-43a4-afd0-0b9dd3d43d98',
-  'Date',
-  'Tue, 03 Dec 2019 03:28:06 GMT',
-  'Content-Length',
-  '0' ]);
-
-nock('https://fakestorageaccount.dfs.core.windows.net:443', {"encodedQueryParams":true})
-  .patch('/filesystem157534404368207790/file157534404482207959', "Hello World")
-  .query(true)
-  .reply(202, "", [ 'Server',
-  'Windows-Azure-HDFS/1.0 Microsoft-HTTPAPI/2.0',
-  'x-ms-request-server-encrypted',
-  'true',
-  'x-ms-request-id',
-  '50374724-a01f-0081-2c89-a9e7c9000000',
-  'x-ms-version',
-  '2019-02-02',
-  'x-ms-client-request-id',
-  '1fa4f317-bc6e-41ad-b37c-3a95d4c05fa9',
-  'Date',
-  'Tue, 03 Dec 2019 03:28:07 GMT',
-  'Content-Length',
-  '0' ]);
-
-nock('https://fakestorageaccount.dfs.core.windows.net:443', {"encodedQueryParams":true})
-  .patch('/filesystem157534404368207790/file157534404482207959')
-  .query(true)
-  .reply(200, "", [ 'Last-Modified',
-  'Tue, 03 Dec 2019 03:28:08 GMT',
-  'ETag',
-  '"0x8D777A0D12030B0"',
+  '"0x8DA6ECFF25F4C80"',
   'Server',
   'Windows-Azure-HDFS/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-server-encrypted',
   'true',
   'x-ms-request-id',
-  '50374725-a01f-0081-2d89-a9e7c9000000',
+  'bfc4cc08-401f-0041-29b8-a0a1e5000000',
   'x-ms-version',
-  '2019-02-02',
+  '2021-08-06',
   'x-ms-client-request-id',
-  'b52fe083-10c6-4c2c-b215-a106af035e2a',
+  'b64b316d-03c6-43ac-a9d3-131bcc6abcaa',
   'Date',
-  'Tue, 03 Dec 2019 03:28:07 GMT',
+  'Tue, 26 Jul 2022 06:27:42 GMT',
   'Content-Length',
-  '0' ]);
+  '0'
+]);
 
 nock('https://fakestorageaccount.dfs.core.windows.net:443', {"encodedQueryParams":true})
-  .patch('/filesystem157534404368207790/file157534404482207959')
+  .patch('/filesystem165881686135906220/file165881686204805318', "Hello World")
   .query(true)
-  .reply(200, "", [ 'Last-Modified',
-  'Tue, 03 Dec 2019 03:28:08 GMT',
+  .reply(202, "", [
+  'Server',
+  'Windows-Azure-HDFS/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-server-encrypted',
+  'true',
+  'x-ms-request-id',
+  'bfc4cc09-401f-0041-2ab8-a0a1e5000000',
+  'x-ms-version',
+  '2021-08-06',
+  'x-ms-client-request-id',
+  '33d98d36-a201-4c12-9f4b-72bee71c1d77',
+  'Date',
+  'Tue, 26 Jul 2022 06:27:42 GMT',
+  'Content-Length',
+  '0'
+]);
+
+nock('https://fakestorageaccount.dfs.core.windows.net:443', {"encodedQueryParams":true})
+  .patch('/filesystem165881686135906220/file165881686204805318')
+  .query(true)
+  .reply(200, "", [
+  'Last-Modified',
+  'Tue, 26 Jul 2022 06:27:43 GMT',
   'ETag',
-  '"0x8D777A0D12030B0"',
+  '"0x8DA6ECFF281D269"',
+  'Server',
+  'Windows-Azure-HDFS/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-server-encrypted',
+  'false',
+  'x-ms-request-id',
+  'bfc4cc0a-401f-0041-2bb8-a0a1e5000000',
+  'x-ms-version',
+  '2021-08-06',
+  'x-ms-client-request-id',
+  '5469220a-3beb-4f40-8411-0d6cc32ac307',
+  'Date',
+  'Tue, 26 Jul 2022 06:27:42 GMT',
+  'Content-Length',
+  '0'
+]);
+
+nock('https://fakestorageaccount.dfs.core.windows.net:443', {"encodedQueryParams":true})
+  .patch('/filesystem165881686135906220/file165881686204805318')
+  .query(true)
+  .reply(200, "", [
+  'Last-Modified',
+  'Tue, 26 Jul 2022 06:27:43 GMT',
+  'ETag',
+  '"0x8DA6ECFF281D269"',
   'Server',
   'Windows-Azure-HDFS/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-namespace-enabled',
   'true',
   'x-ms-request-id',
-  '50374726-a01f-0081-2e89-a9e7c9000000',
+  'bfc4cc0b-401f-0041-2cb8-a0a1e5000000',
   'x-ms-version',
-  '2019-02-02',
+  '2021-08-06',
   'x-ms-client-request-id',
-  'f7cfe19d-36ca-4ad5-accb-e27fdd74636d',
+  '590ccd10-7ed7-4a10-9903-4f404c51156b',
   'Date',
-  'Tue, 03 Dec 2019 03:28:07 GMT',
+  'Tue, 26 Jul 2022 06:27:42 GMT',
   'Content-Length',
-  '0' ]);
+  '0'
+]);
 
 nock('https://fakestorageaccount.dfs.core.windows.net:443', {"encodedQueryParams":true})
-  .head('/filesystem157534404368207790/file157534404482207959')
+  .head('/filesystem165881686135906220/file165881686204805318')
   .query(true)
-  .reply(200, "", [ 'Last-Modified',
-  'Tue, 03 Dec 2019 03:28:08 GMT',
+  .reply(200, "", [
+  'Last-Modified',
+  'Tue, 26 Jul 2022 06:27:43 GMT',
   'ETag',
-  '"0x8D777A0D12030B0"',
-  'Vary',
-  'Origin',
+  '"0x8DA6ECFF281D269"',
   'Server',
   'Windows-Azure-HDFS/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-owner',
@@ -120,30 +133,37 @@ nock('https://fakestorageaccount.dfs.core.windows.net:443', {"encodedQueryParams
   'x-ms-group',
   '$superuser',
   'x-ms-permissions',
-  'rw-r-x-wt',
+  'rw-r-x-wT',
   'x-ms-acl',
-  'user::rw-,group::r-x,other::-wx',
+  'user::rw-,group::r-x,other::-w-',
   'x-ms-request-id',
-  '50374727-a01f-0081-2f89-a9e7c9000000',
+  'bfc4cc0c-401f-0041-2db8-a0a1e5000000',
   'x-ms-version',
-  '2019-02-02',
+  '2021-08-06',
   'x-ms-client-request-id',
-  'e5687623-c232-432e-911b-04178d3b97d1',
+  '9a3c063d-6449-4a3d-9e85-30f4d6b5dee9',
+  'Access-Control-Expose-Headers',
+  'Content-Length,Date,ETag,Last-Modified,Server,x-ms-acl,x-ms-client-request-id,x-ms-group,x-ms-owner,x-ms-permissions,x-ms-request-id,x-ms-version',
+  'Access-Control-Allow-Origin',
+  '*',
   'Date',
-  'Tue, 03 Dec 2019 03:28:08 GMT' ]);
+  'Tue, 26 Jul 2022 06:27:42 GMT'
+]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .delete('/filesystem157534404368207790')
+  .delete('/filesystem165881686135906220')
   .query(true)
-  .reply(202, "", [ 'Content-Length',
+  .reply(202, "", [
+  'Content-Length',
   '0',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '352ec3be-f01e-005e-3889-a9b69d000000',
+  'eb879228-e01e-0058-14b8-a0215e000000',
   'x-ms-client-request-id',
-  '5b1b08bc-48da-4d79-b178-9237fb217976',
+  'de7c4835-5b5c-4c4e-a872-8b20f0af93fc',
   'x-ms-version',
-  '2019-02-02',
+  '2021-08-06',
   'Date',
-  'Tue, 03 Dec 2019 03:28:08 GMT' ]);
+  'Tue, 26 Jul 2022 06:27:43 GMT'
+]);

--- a/sdk/storage/storage-file-datalake/src/transforms.ts
+++ b/sdk/storage/storage-file-datalake/src/transforms.ts
@@ -213,10 +213,7 @@ export function toPathGetAccessControlResponse(
   };
 }
 
-export function toRolePermissions(
-  permissionsString: string,
-  allowStickyBit: boolean = false
-): RolePermissions {
+export function toRolePermissions(permissionsString: string): RolePermissions {
   const error = new RangeError(
     `toRolePermissions() Invalid role permissions string ${permissionsString}`
   );
@@ -243,12 +240,6 @@ export function toRolePermissions(
   let execute = false;
   if (permissionsString[2] === "x") {
     execute = true;
-  } else if (allowStickyBit) {
-    if (permissionsString[2] === "t") {
-      execute = true;
-    } else if (permissionsString[2] !== "-") {
-      throw error;
-    }
   } else if (permissionsString[2] !== "-") {
     throw error;
   }
@@ -265,13 +256,21 @@ export function toPermissions(permissionsString?: string): PathPermissions | und
     throw RangeError(`toPermissions() Invalid permissions string ${permissionsString}`);
   }
 
-  // Case insensitive
-  permissionsString = permissionsString.toLowerCase();
-
   let stickyBit = false;
   if (permissionsString[8] === "t") {
     stickyBit = true;
+    const firstPart = permissionsString.substr(0, 8);
+    const lastPart = permissionsString.substr(9);
+    permissionsString = firstPart + "x" + lastPart;
+  } else if (permissionsString[8] === "T") {
+    stickyBit = true;
+    const firstPart = permissionsString.substr(0, 8);
+    const lastPart = permissionsString.substr(9);
+    permissionsString = firstPart + "-" + lastPart;
   }
+
+  // Case insensitive
+  permissionsString = permissionsString.toLowerCase();
 
   let extendedAcls = false;
   if (permissionsString.length === 10) {
@@ -284,9 +283,9 @@ export function toPermissions(permissionsString?: string): PathPermissions | und
     }
   }
 
-  const owner = toRolePermissions(permissionsString.substr(0, 3), false);
-  const group = toRolePermissions(permissionsString.substr(3, 3), false);
-  const other = toRolePermissions(permissionsString.substr(6, 3), true);
+  const owner = toRolePermissions(permissionsString.substr(0, 3));
+  const group = toRolePermissions(permissionsString.substr(3, 3));
+  const other = toRolePermissions(permissionsString.substr(6, 3));
 
   return {
     owner,
@@ -432,7 +431,9 @@ export function toAclString(acl: PathAccessControlItem[]): string {
 }
 
 export function toRolePermissionsString(p: RolePermissions, stickyBit: boolean = false): string {
-  return `${p.read ? "r" : "-"}${p.write ? "w" : "-"}${stickyBit ? "t" : p.execute ? "x" : "-"}`;
+  return `${p.read ? "r" : "-"}${p.write ? "w" : "-"}${
+    stickyBit ? (p.execute ? "t" : "T") : p.execute ? "x" : "-"
+  }`;
 }
 
 export function toPermissionsString(permissions: PathPermissions): string {

--- a/sdk/storage/storage-file-datalake/test/node/pathclient.spec.ts
+++ b/sdk/storage/storage-file-datalake/test/node/pathclient.spec.ts
@@ -540,7 +540,7 @@ describe("DataLakePathClient Node.js only", () => {
         permissions: {
           read: false,
           write: true,
-          execute: true,
+          execute: false,
         },
       },
     ];
@@ -571,10 +571,7 @@ describe("DataLakePathClient Node.js only", () => {
 
     assert.deepStrictEqual(response.owner, "$superuser");
     assert.deepStrictEqual(response.group, "$superuser");
-    assert.deepStrictEqual(response.permissions, {
-      ...permissions,
-      other: { ...permissions.other, execute: true },
-    });
+    assert.deepStrictEqual(response.permissions, permissions);
     assert.deepStrictEqual(response.acl, acl);
   });
 
@@ -628,7 +625,7 @@ describe("DataLakePathClient Node.js only", () => {
       other: {
         read: false,
         write: true,
-        execute: false,
+        execute: true,
       },
     };
 

--- a/sdk/storage/storage-file-datalake/test/transforms.spec.ts
+++ b/sdk/storage/storage-file-datalake/test/transforms.spec.ts
@@ -102,46 +102,25 @@ describe("transforms", () => {
     assert.deepStrictEqual(toRolePermissions("R-X"), { read: true, write: false, execute: true });
     assert.deepStrictEqual(toRolePermissions("-W-"), { read: false, write: true, execute: false });
 
-    assert.deepStrictEqual(toRolePermissions("rwx", true), {
+    assert.deepStrictEqual(toRolePermissions("rwx"), {
       read: true,
       write: true,
       execute: true,
     });
-    assert.deepStrictEqual(toRolePermissions("---", true), {
+    assert.deepStrictEqual(toRolePermissions("---"), {
       read: false,
       write: false,
       execute: false,
     });
-    assert.deepStrictEqual(toRolePermissions("r-x", true), {
+    assert.deepStrictEqual(toRolePermissions("r-x"), {
       read: true,
       write: false,
       execute: true,
     });
-    assert.deepStrictEqual(toRolePermissions("-w-", true), {
+    assert.deepStrictEqual(toRolePermissions("-w-"), {
       read: false,
       write: true,
       execute: false,
-    });
-
-    assert.deepStrictEqual(toRolePermissions("rwt", true), {
-      read: true,
-      write: true,
-      execute: true,
-    });
-    assert.deepStrictEqual(toRolePermissions("--t", true), {
-      read: false,
-      write: false,
-      execute: true,
-    });
-    assert.deepStrictEqual(toRolePermissions("r-t", true), {
-      read: true,
-      write: false,
-      execute: true,
-    });
-    assert.deepStrictEqual(toRolePermissions("-wt", true), {
-      read: false,
-      write: true,
-      execute: true,
     });
   });
 
@@ -191,7 +170,7 @@ describe("transforms", () => {
     assert.deepStrictEqual(toPermissions("---R-x--T"), {
       owner: { read: false, write: false, execute: false },
       group: { read: true, write: false, execute: true },
-      other: { read: false, write: false, execute: true },
+      other: { read: false, write: false, execute: false },
       stickyBit: true,
       extendedAcls: false,
     });
@@ -364,7 +343,7 @@ describe("transforms", () => {
     );
     assert.deepStrictEqual(
       toRolePermissionsString({ read: false, write: true, execute: false }, true),
-      "-wt"
+      "-wT"
     );
   });
 


### PR DESCRIPTION
### Packages impacted by this PR
@azure/storage-file-datalake

### Issues associated with this PR


### Describe the problem that is addressed by this PR


For pathClient.setPermission interface, following is doc for permission string format:
```
    Optional and only valid if Hierarchical Namespace is enabled for the account. Sets POSIX access permissions for the file owner, the file owning group, and others. Each class may be granted read(4), write(2), or execute(1) permission. Both symbolic (rwxrw-rw-) and 4-digit octal notation (e.g. 0766) are supported. 
    The sticky bit is also supported and in symbolic notation, its represented either by the letter t or T in the final character-place depending on whether the execution bit for the others category is set or unset respectively (e.g. rwxrw-rw- with sticky bit is represented as rwxrw-rwT. A rwxrw-rwx with sticky bit is represented as rwxrw-rwt), absence of t or T indicates sticky bit not set. In 4-digit octal notation, its represented by 1st digit (e.g. 1766 represents rwxrw-rw- with sticky bit and 0766 represents rwxrw-rw- without sticky bit). 
  Invalid in conjunction with x-ms-acl.
```

The SDK currently only support 't', but doesn't support 'T'. This PR is to add support for 'T'. 


### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [x] Added impacted package name to the issue description
- [x] Does this PR needs any fixes in the SDK Generator? No
- [x] Added a changelog (if necessary)
