### PR TITLE
Jay-most/cosmos diagnostics feature

### DIFF
--- a/sdk/cosmosdb/cosmos/review/cosmos.api.md
+++ b/sdk/cosmosdb/cosmos/review/cosmos.api.md
@@ -765,7 +765,7 @@ export class FeedResponse<TResource> {
     // (undocumented)
     diagnostics: any;
     // (undocumented)
-    get diagnosticsToString(): string;
+    get getDiagnostics(): string;
     // (undocumented)
     readonly hasMoreResults: boolean;
     // (undocumented)
@@ -1502,9 +1502,9 @@ export class ResourceResponse<TResource> {
     // (undocumented)
     get activityId(): string;
     // (undocumented)
-    get diagnosticsToString(): string;
-    // (undocumented)
     get etag(): string;
+    // (undocumented)
+    get getDiagnostics(): string;
     // (undocumented)
     readonly headers: CosmosHeaders_2;
     // (undocumented)

--- a/sdk/cosmosdb/cosmos/review/cosmos.api.md
+++ b/sdk/cosmosdb/cosmos/review/cosmos.api.md
@@ -703,10 +703,8 @@ export interface ErrorBody {
     message: string;
 }
 
-// Warning: (ae-forgotten-export) The symbol "CosmosException" needs to be exported by the entry point index.d.ts
-//
 // @public (undocumented)
-export interface ErrorResponse extends CosmosException {
+export interface ErrorResponse {
     // (undocumented)
     [key: string]: any;
     // (undocumented)
@@ -755,8 +753,10 @@ export interface FeedOptions extends SharedOptions {
     useIncrementalFeed?: boolean;
 }
 
+// Warning: (ae-forgotten-export) The symbol "CosmosDiagnostic" needs to be exported by the entry point index.d.ts
+//
 // @public (undocumented)
-export class FeedResponse<TResource> {
+export class FeedResponse<TResource> extends CosmosDiagnostic {
     constructor(resources: TResource[], headers: CosmosHeaders, hasMoreResults: boolean);
     // (undocumented)
     get activityId(): string;
@@ -765,9 +765,7 @@ export class FeedResponse<TResource> {
     // (undocumented)
     get continuationToken(): string;
     // (undocumented)
-    get getDiagnostics(): string;
-    // (undocumented)
-    get getDuration(): number;
+    cosmosdiagnostics: CosmosDiagnostic;
     // (undocumented)
     readonly hasMoreResults: boolean;
     // (undocumented)
@@ -911,6 +909,10 @@ export class Items {
     // (undocumented)
     readonly container: Container;
     create<T extends ItemDefinition = any>(body: T, options?: RequestOptions): Promise<ItemResponse<T>>;
+    // Warning: (ae-forgotten-export) The symbol "CosmosException" needs to be exported by the entry point index.d.ts
+    //
+    // (undocumented)
+    error: CosmosException;
     query(query: string | SqlQuerySpec, options?: FeedOptions): QueryIterator<any>;
     query<T>(query: string | SqlQuerySpec, options?: FeedOptions): QueryIterator<T>;
     readAll(options?: FeedOptions): QueryIterator<ItemDefinition>;
@@ -1499,16 +1501,12 @@ export interface Resource {
 }
 
 // @public (undocumented)
-export class ResourceResponse<TResource> {
+export class ResourceResponse<TResource> extends CosmosDiagnostic {
     constructor(resource: TResource | undefined, headers: CosmosHeaders_2, statusCode: StatusCode, substatus?: SubStatusCode);
     // (undocumented)
     get activityId(): string;
     // (undocumented)
     get etag(): string;
-    // (undocumented)
-    get getDiagnostics(): string;
-    // (undocumented)
-    get getDuration(): number;
     // (undocumented)
     readonly headers: CosmosHeaders_2;
     // (undocumented)

--- a/sdk/cosmosdb/cosmos/review/cosmos.api.md
+++ b/sdk/cosmosdb/cosmos/review/cosmos.api.md
@@ -1501,10 +1501,18 @@ export interface Resource {
 }
 
 // @public (undocumented)
-export class ResourceResponse<TResource> extends CosmosDiagnostic {
+export class ResourceResponse<TResource> {
     constructor(resource: TResource | undefined, headers: CosmosHeaders_2, statusCode: StatusCode, substatus?: SubStatusCode);
     // (undocumented)
     get activityId(): string;
+    // (undocumented)
+    get cosmosDiagnostics(): string;
+    // Warning: (ae-forgotten-export) The symbol "DiagnosticHeaders" needs to be exported by the entry point index.d.ts
+    //
+    // (undocumented)
+    get cosmosDiagnosticsRegionsContacted(): DiagnosticHeaders;
+    // (undocumented)
+    get cosmosDiagnostisDurationInMs(): number;
     // (undocumented)
     get etag(): string;
     // (undocumented)

--- a/sdk/cosmosdb/cosmos/review/cosmos.api.md
+++ b/sdk/cosmosdb/cosmos/review/cosmos.api.md
@@ -913,10 +913,6 @@ export class Items {
     // (undocumented)
     readonly container: Container;
     create<T extends ItemDefinition = any>(body: T, options?: RequestOptions): Promise<ItemResponse<T>>;
-    // Warning: (ae-forgotten-export) The symbol "CosmosException" needs to be exported by the entry point index.d.ts
-    //
-    // (undocumented)
-    error: CosmosException;
     query(query: string | SqlQuerySpec, options?: FeedOptions): QueryIterator<any>;
     query<T>(query: string | SqlQuerySpec, options?: FeedOptions): QueryIterator<T>;
     readAll(options?: FeedOptions): QueryIterator<ItemDefinition>;

--- a/sdk/cosmosdb/cosmos/review/cosmos.api.md
+++ b/sdk/cosmosdb/cosmos/review/cosmos.api.md
@@ -765,9 +765,9 @@ export class FeedResponse<TResource> {
     // (undocumented)
     get continuationToken(): string;
     // (undocumented)
-    diagnostics: any;
-    // (undocumented)
     get getDiagnostics(): string;
+    // (undocumented)
+    get getDuration(): number;
     // (undocumented)
     readonly hasMoreResults: boolean;
     // (undocumented)
@@ -1507,6 +1507,8 @@ export class ResourceResponse<TResource> {
     get etag(): string;
     // (undocumented)
     get getDiagnostics(): string;
+    // (undocumented)
+    get getDuration(): number;
     // (undocumented)
     readonly headers: CosmosHeaders_2;
     // (undocumented)

--- a/sdk/cosmosdb/cosmos/review/cosmos.api.md
+++ b/sdk/cosmosdb/cosmos/review/cosmos.api.md
@@ -765,6 +765,12 @@ export class FeedResponse<TResource> extends CosmosDiagnostics {
     // (undocumented)
     get continuationToken(): string;
     // (undocumented)
+    getcosmosDiagnostics(): string;
+    // (undocumented)
+    getcosmosDiagnosticsRegionsContacted(): string;
+    // (undocumented)
+    getcosmosDiagnostisDurationInMs(): number;
+    // (undocumented)
     readonly hasMoreResults: boolean;
     // (undocumented)
     get queryMetrics(): string;
@@ -1499,18 +1505,18 @@ export interface Resource {
 }
 
 // @public (undocumented)
-export class ResourceResponse<TResource> {
+export class ResourceResponse<TResource> extends CosmosDiagnostics {
     constructor(resource: TResource | undefined, headers: CosmosHeaders_2, statusCode: StatusCode, substatus?: SubStatusCode);
     // (undocumented)
     get activityId(): string;
     // (undocumented)
-    get cosmosDiagnostics(): string;
-    // (undocumented)
-    get cosmosDiagnosticsRegionsContacted(): string;
-    // (undocumented)
-    get cosmosDiagnostisDurationInMs(): number;
-    // (undocumented)
     get etag(): string;
+    // (undocumented)
+    getcosmosDiagnostics(): string;
+    // (undocumented)
+    getcosmosDiagnosticsRegionsContacted(): string;
+    // (undocumented)
+    getcosmosDiagnostisDurationInMs(): number;
     // (undocumented)
     readonly headers: CosmosHeaders_2;
     // (undocumented)

--- a/sdk/cosmosdb/cosmos/review/cosmos.api.md
+++ b/sdk/cosmosdb/cosmos/review/cosmos.api.md
@@ -753,10 +753,10 @@ export interface FeedOptions extends SharedOptions {
     useIncrementalFeed?: boolean;
 }
 
-// Warning: (ae-forgotten-export) The symbol "CosmosDiagnostic" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "CosmosDiagnostics" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
-export class FeedResponse<TResource> extends CosmosDiagnostic {
+export class FeedResponse<TResource> extends CosmosDiagnostics {
     constructor(resources: TResource[], headers: CosmosHeaders, hasMoreResults: boolean);
     // (undocumented)
     get activityId(): string;
@@ -764,8 +764,6 @@ export class FeedResponse<TResource> extends CosmosDiagnostic {
     get continuation(): string;
     // (undocumented)
     get continuationToken(): string;
-    // (undocumented)
-    cosmosdiagnostics: CosmosDiagnostic;
     // (undocumented)
     readonly hasMoreResults: boolean;
     // (undocumented)
@@ -1507,10 +1505,8 @@ export class ResourceResponse<TResource> {
     get activityId(): string;
     // (undocumented)
     get cosmosDiagnostics(): string;
-    // Warning: (ae-forgotten-export) The symbol "DiagnosticHeaders" needs to be exported by the entry point index.d.ts
-    //
     // (undocumented)
-    get cosmosDiagnosticsRegionsContacted(): DiagnosticHeaders;
+    get cosmosDiagnosticsRegionsContacted(): string;
     // (undocumented)
     get cosmosDiagnostisDurationInMs(): number;
     // (undocumented)

--- a/sdk/cosmosdb/cosmos/review/cosmos.api.md
+++ b/sdk/cosmosdb/cosmos/review/cosmos.api.md
@@ -763,6 +763,10 @@ export class FeedResponse<TResource> {
     // (undocumented)
     get continuationToken(): string;
     // (undocumented)
+    diagnostics: any;
+    // (undocumented)
+    get diagnosticsToString(): string;
+    // (undocumented)
     readonly hasMoreResults: boolean;
     // (undocumented)
     get queryMetrics(): string;
@@ -1497,6 +1501,8 @@ export class ResourceResponse<TResource> {
     constructor(resource: TResource | undefined, headers: CosmosHeaders_2, statusCode: StatusCode, substatus?: SubStatusCode);
     // (undocumented)
     get activityId(): string;
+    // (undocumented)
+    get diagnosticsToString(): string;
     // (undocumented)
     get etag(): string;
     // (undocumented)

--- a/sdk/cosmosdb/cosmos/review/cosmos.api.md
+++ b/sdk/cosmosdb/cosmos/review/cosmos.api.md
@@ -703,8 +703,10 @@ export interface ErrorBody {
     message: string;
 }
 
+// Warning: (ae-forgotten-export) The symbol "CosmosException" needs to be exported by the entry point index.d.ts
+//
 // @public (undocumented)
-export interface ErrorResponse extends Error {
+export interface ErrorResponse extends CosmosException {
     // (undocumented)
     [key: string]: any;
     // (undocumented)

--- a/sdk/cosmosdb/cosmos/samples-dev/CosmosDiagnostics.ts
+++ b/sdk/cosmosdb/cosmos/samples-dev/CosmosDiagnostics.ts
@@ -1,0 +1,39 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { CosmosClient } from "@azure/cosmos";
+const masterKey = process.env.COSMOS_KEY || "<cosmos key>";
+const endpoint = process.env.COSMOS_ENDPOINT || "<cosmos endpoint>";
+
+/**
+ * @summary Demonstrates getting Cosmos Diagnostics from database, container, and item.
+ */
+
+const client = new CosmosClient({
+  key: masterKey,
+  endpoint: endpoint,
+  connectionPolicy: { enableBackgroundEndpointRefreshing: false },
+});
+
+const databases = await client.databases.create({
+  id: "1",
+});
+
+console.log(databases.getCosmosDiagnostics());
+
+const containers = await databases.database.containers.create({
+  id: "testContainer",
+});
+
+console.log(containers.getCosmosDiagnostics());
+
+await containers.container.items.create({
+  id: "1",
+  category: "fun",
+  name: "Cosmos diagnostics",
+  description: "Cosmos diagnostics is fun ⚡.",
+  isComplete: false,
+});
+const item = await containers.container.items.readAll().fetchAll();
+
+console.log(item.getCosmosDiagnostics());

--- a/sdk/cosmosdb/cosmos/src/ChangeFeedIterator.ts
+++ b/sdk/cosmosdb/cosmos/src/ChangeFeedIterator.ts
@@ -6,6 +6,7 @@ import { ChangeFeedResponse } from "./ChangeFeedResponse";
 import { Resource } from "./client";
 import { ClientContext } from "./ClientContext";
 import { Constants, ResourceType, StatusCodes } from "./common";
+import { CosmosException } from "./diagnostics/CosmosException";
 import { FeedOptions } from "./request";
 import { Response } from "./request";
 
@@ -89,7 +90,7 @@ export class ChangeFeedIterator<T> {
 
   private async getFeedResponse(): Promise<ChangeFeedResponse<Array<T & Resource>>> {
     if (!this.isPartitionSpecified) {
-      throw new Error(
+      throw new CosmosException(
         "Container is partitioned, but no partition key or partition key range id was specified."
       );
     }

--- a/sdk/cosmosdb/cosmos/src/ClientContext.ts
+++ b/sdk/cosmosdb/cosmos/src/ClientContext.ts
@@ -756,8 +756,7 @@ export class ClientContext {
             err.response.substatus !== SubStatusCodes.ReadSessionNotAvailable)))
     ) {
       this.sessionContainer.set(request, resHeaders);
-    } else {
-      throw new CosmosException(err);
+      new CosmosException(err);
     }
   }
 

--- a/sdk/cosmosdb/cosmos/src/ClientContext.ts
+++ b/sdk/cosmosdb/cosmos/src/ClientContext.ts
@@ -30,7 +30,7 @@ import { SessionContext } from "./session/SessionContext";
 import { BulkOptions } from "./utils/batch";
 import { sanitizeEndpoint } from "./utils/checkURL";
 import { AzureLogger, createClientLogger } from "@azure/logger";
-import { recordDiagnostics } from "./diagnostics/CosmosDiagnostics";
+import { CosmosException } from "./diagnostics/CosmosException";
 
 const logger: AzureLogger = createClientLogger("ClientContext");
 
@@ -298,7 +298,7 @@ export class ClientContext {
       return response;
     } catch (err: any) {
       this.captureSessionToken(err, path, OperationType.Upsert, (err as ErrorResponse).headers);
-      recordDiagnostics({"cosmos-diagnostics-client-upsert-error": (err as ErrorResponse).message});
+      CosmosException.record({"cosmos-diagnostics-client-upsert-error": (err as ErrorResponse).message});
       throw err;
     }
   }
@@ -759,7 +759,7 @@ export class ClientContext {
       this.sessionContainer.set(request, resHeaders);
     }
     else{
-      recordDiagnostics({"cosmos-diagnostics-capture-session-token-error": (err as ErrorResponse)});
+      CosmosException.record({"cosmos-diagnostics-capture-session-token-error": (err as ErrorResponse)});
     }
   }
 

--- a/sdk/cosmosdb/cosmos/src/CosmosClient.ts
+++ b/sdk/cosmosdb/cosmos/src/CosmosClient.ts
@@ -7,7 +7,7 @@ import { parseConnectionString } from "./common";
 import { Constants } from "./common/constants";
 import { getUserAgent } from "./common/platform";
 import { CosmosClientOptions } from "./CosmosClientOptions";
-import { recordDiagnostics } from "./diagnostics/CosmosDiagnostics";
+import { CosmosException } from "./diagnostics/CosmosException";
 import { DatabaseAccount, defaultConnectionPolicy } from "./documents";
 import { GlobalEndpointManager } from "./globalEndpointManager";
 import { RequestOptions, ResourceResponse } from "./request";
@@ -69,7 +69,7 @@ export class CosmosClient {
     const endpoint = checkURL(optionsOrConnectionString.endpoint);
     if (!endpoint) {
       const err =  new Error("Invalid endpoint specified");
-      recordDiagnostics({"cosmos-diagnostics-client-endpoint-error": err});
+      CosmosException.record({"cosmos-diagnostics-client-endpoint-error": err});
       throw err;
     }
 

--- a/sdk/cosmosdb/cosmos/src/CosmosClient.ts
+++ b/sdk/cosmosdb/cosmos/src/CosmosClient.ts
@@ -7,6 +7,7 @@ import { parseConnectionString } from "./common";
 import { Constants } from "./common/constants";
 import { getUserAgent } from "./common/platform";
 import { CosmosClientOptions } from "./CosmosClientOptions";
+import { CosmosException } from "./diagnostics/CosmosException";
 import { DatabaseAccount, defaultConnectionPolicy } from "./documents";
 import { GlobalEndpointManager } from "./globalEndpointManager";
 import { RequestOptions, ResourceResponse } from "./request";
@@ -67,8 +68,7 @@ export class CosmosClient {
 
     const endpoint = checkURL(optionsOrConnectionString.endpoint);
     if (!endpoint) {
-      const err = new Error("Invalid endpoint specified");
-      throw err;
+      throw new CosmosException("Invalid endpoint specified");
     }
 
     optionsOrConnectionString.connectionPolicy = Object.assign(

--- a/sdk/cosmosdb/cosmos/src/CosmosClient.ts
+++ b/sdk/cosmosdb/cosmos/src/CosmosClient.ts
@@ -7,6 +7,7 @@ import { parseConnectionString } from "./common";
 import { Constants } from "./common/constants";
 import { getUserAgent } from "./common/platform";
 import { CosmosClientOptions } from "./CosmosClientOptions";
+import { recordDiagnostics } from "./diagnostics/CosmosDiagnostics";
 import { DatabaseAccount, defaultConnectionPolicy } from "./documents";
 import { GlobalEndpointManager } from "./globalEndpointManager";
 import { RequestOptions, ResourceResponse } from "./request";
@@ -67,7 +68,9 @@ export class CosmosClient {
 
     const endpoint = checkURL(optionsOrConnectionString.endpoint);
     if (!endpoint) {
-      throw new Error("Invalid endpoint specified");
+      const err =  new Error("Invalid endpoint specified");
+      recordDiagnostics({"cosmos-diagnostics-client-endpoint-error": err});
+      throw err;
     }
 
     optionsOrConnectionString.connectionPolicy = Object.assign(

--- a/sdk/cosmosdb/cosmos/src/CosmosClient.ts
+++ b/sdk/cosmosdb/cosmos/src/CosmosClient.ts
@@ -7,7 +7,6 @@ import { parseConnectionString } from "./common";
 import { Constants } from "./common/constants";
 import { getUserAgent } from "./common/platform";
 import { CosmosClientOptions } from "./CosmosClientOptions";
-import { CosmosException } from "./diagnostics/CosmosException";
 import { DatabaseAccount, defaultConnectionPolicy } from "./documents";
 import { GlobalEndpointManager } from "./globalEndpointManager";
 import { RequestOptions, ResourceResponse } from "./request";
@@ -68,8 +67,7 @@ export class CosmosClient {
 
     const endpoint = checkURL(optionsOrConnectionString.endpoint);
     if (!endpoint) {
-      const err =  new Error("Invalid endpoint specified");
-      CosmosException.record({"cosmos-diagnostics-client-endpoint-error": err});
+      const err = new Error("Invalid endpoint specified");
       throw err;
     }
 

--- a/sdk/cosmosdb/cosmos/src/auth.ts
+++ b/sdk/cosmosdb/cosmos/src/auth.ts
@@ -10,6 +10,7 @@ import {
 } from "./common";
 import { CosmosClientOptions } from "./CosmosClientOptions";
 import { CosmosHeaders } from "./queryExecutionContext";
+import { recordDiagnostics } from "./diagnostics/CosmosDiagnostics";
 
 /** @hidden */
 export interface RequestInfo {
@@ -38,8 +39,10 @@ export async function setAuthorizationHeader(
     for (const permission of clientOptions.permissionFeed) {
       const id = getResourceIdFromPath(permission.resource);
       if (!id) {
-        throw new Error(`authorization error: ${id} \
+        const err = new Error(`authorization error: ${id} \
                           is an invalid resourceId in permissionFeed`);
+                          recordDiagnostics({ "cosmos-diagnostics-setAuthorizationHeader-error": JSON.stringify(Error(err.message))});
+                          throw err;
       }
 
       clientOptions.resourceTokens[id] = (permission as any)._token; // TODO: any

--- a/sdk/cosmosdb/cosmos/src/auth.ts
+++ b/sdk/cosmosdb/cosmos/src/auth.ts
@@ -39,10 +39,9 @@ export async function setAuthorizationHeader(
     for (const permission of clientOptions.permissionFeed) {
       const id = getResourceIdFromPath(permission.resource);
       if (!id) {
-        const err = new Error(`authorization error: ${id} \
+        const err = new CosmosException(`authorization error: ${id} \
                           is an invalid resourceId in permissionFeed`);
-                          CosmosException.record({ "cosmos-diagnostics-setAuthorizationHeader-error": JSON.stringify(Error(err.message))});
-                          throw err;
+        throw err;
       }
 
       clientOptions.resourceTokens[id] = (permission as any)._token; // TODO: any
@@ -114,6 +113,7 @@ export function getAuthorizationTokenUsingResourceTokens(
     // minimum valid path /dbs
     if (!path || path.length < 4) {
       // TODO: This should throw an error
+      // throw new CosmosException("error: minimum valid path /dbs");
       return null;
     }
 
@@ -143,5 +143,6 @@ export function getAuthorizationTokenUsingResourceTokens(
   }
 
   // TODO: This should throw an error
+  // throw new CosmosException("function call: getAuthorizationTokenUsingResourceTokens");
   return null;
 }

--- a/sdk/cosmosdb/cosmos/src/auth.ts
+++ b/sdk/cosmosdb/cosmos/src/auth.ts
@@ -39,9 +39,8 @@ export async function setAuthorizationHeader(
     for (const permission of clientOptions.permissionFeed) {
       const id = getResourceIdFromPath(permission.resource);
       if (!id) {
-        const err = new CosmosException(`authorization error: ${id} \
+        throw new CosmosException(`authorization error: ${id} \
                           is an invalid resourceId in permissionFeed`);
-        throw err;
       }
 
       clientOptions.resourceTokens[id] = (permission as any)._token; // TODO: any

--- a/sdk/cosmosdb/cosmos/src/auth.ts
+++ b/sdk/cosmosdb/cosmos/src/auth.ts
@@ -112,7 +112,6 @@ export function getAuthorizationTokenUsingResourceTokens(
     // minimum valid path /dbs
     if (!path || path.length < 4) {
       // TODO: This should throw an error
-      // throw new CosmosException("error: minimum valid path /dbs");
       return null;
     }
 
@@ -142,6 +141,5 @@ export function getAuthorizationTokenUsingResourceTokens(
   }
 
   // TODO: This should throw an error
-  // throw new CosmosException("function call: getAuthorizationTokenUsingResourceTokens");
   return null;
 }

--- a/sdk/cosmosdb/cosmos/src/auth.ts
+++ b/sdk/cosmosdb/cosmos/src/auth.ts
@@ -10,7 +10,7 @@ import {
 } from "./common";
 import { CosmosClientOptions } from "./CosmosClientOptions";
 import { CosmosHeaders } from "./queryExecutionContext";
-import { recordDiagnostics } from "./diagnostics/CosmosDiagnostics";
+import { CosmosException } from "./diagnostics/CosmosException";
 
 /** @hidden */
 export interface RequestInfo {
@@ -41,7 +41,7 @@ export async function setAuthorizationHeader(
       if (!id) {
         const err = new Error(`authorization error: ${id} \
                           is an invalid resourceId in permissionFeed`);
-                          recordDiagnostics({ "cosmos-diagnostics-setAuthorizationHeader-error": JSON.stringify(Error(err.message))});
+                          CosmosException.record({ "cosmos-diagnostics-setAuthorizationHeader-error": JSON.stringify(Error(err.message))});
                           throw err;
       }
 

--- a/sdk/cosmosdb/cosmos/src/client/Container/Container.ts
+++ b/sdk/cosmosdb/cosmos/src/client/Container/Container.ts
@@ -23,7 +23,7 @@ import { PartitionKeyRange } from "./PartitionKeyRange";
 import { Offer, OfferDefinition } from "../Offer";
 import { OfferResponse } from "../Offer/OfferResponse";
 import { Resource } from "../Resource";
-import { CosmosException } from "../../diagnostics/CosmosException";
+import { setDiagnostics } from "../../diagnostics/Diagnostics";
 
 /**
  * Operations for reading, replacing, or deleting a specific, existing container by id.
@@ -143,7 +143,8 @@ export class Container {
   ): Promise<ContainerResponse> {
     const err = {};
     if (!isResourceValid(body, err)) {
-      throw new CosmosException(err);
+      setDiagnostics(`${err}`);
+      throw err;
     }
 
     const path = getPathFromLink(this.url);

--- a/sdk/cosmosdb/cosmos/src/client/Container/Container.ts
+++ b/sdk/cosmosdb/cosmos/src/client/Container/Container.ts
@@ -23,6 +23,7 @@ import { PartitionKeyRange } from "./PartitionKeyRange";
 import { Offer, OfferDefinition } from "../Offer";
 import { OfferResponse } from "../Offer/OfferResponse";
 import { Resource } from "../Resource";
+import { recordDiagnostics } from "../../diagnostics/CosmosDiagnostics";
 
 /**
  * Operations for reading, replacing, or deleting a specific, existing container by id.
@@ -142,6 +143,7 @@ export class Container {
   ): Promise<ContainerResponse> {
     const err = {};
     if (!isResourceValid(body, err)) {
+      recordDiagnostics({"cosmos-diagnostics-replace-container-error": err});
       throw err;
     }
 

--- a/sdk/cosmosdb/cosmos/src/client/Container/Container.ts
+++ b/sdk/cosmosdb/cosmos/src/client/Container/Container.ts
@@ -23,7 +23,7 @@ import { PartitionKeyRange } from "./PartitionKeyRange";
 import { Offer, OfferDefinition } from "../Offer";
 import { OfferResponse } from "../Offer/OfferResponse";
 import { Resource } from "../Resource";
-import { recordDiagnostics } from "../../diagnostics/CosmosDiagnostics";
+import { CosmosException } from "../../diagnostics/CosmosException";
 
 /**
  * Operations for reading, replacing, or deleting a specific, existing container by id.
@@ -143,7 +143,7 @@ export class Container {
   ): Promise<ContainerResponse> {
     const err = {};
     if (!isResourceValid(body, err)) {
-      recordDiagnostics({"cosmos-diagnostics-replace-container-error": err});
+      CosmosException.record({"cosmos-diagnostics-replace-container-error": err});
       throw err;
     }
 

--- a/sdk/cosmosdb/cosmos/src/client/Container/Container.ts
+++ b/sdk/cosmosdb/cosmos/src/client/Container/Container.ts
@@ -143,8 +143,7 @@ export class Container {
   ): Promise<ContainerResponse> {
     const err = {};
     if (!isResourceValid(body, err)) {
-      new CosmosException(err);
-      throw err;
+      throw new CosmosException(err);
     }
 
     const path = getPathFromLink(this.url);

--- a/sdk/cosmosdb/cosmos/src/client/Container/Container.ts
+++ b/sdk/cosmosdb/cosmos/src/client/Container/Container.ts
@@ -143,7 +143,7 @@ export class Container {
   ): Promise<ContainerResponse> {
     const err = {};
     if (!isResourceValid(body, err)) {
-      CosmosException.record({"cosmos-diagnostics-replace-container-error": err});
+      new CosmosException(err);
       throw err;
     }
 

--- a/sdk/cosmosdb/cosmos/src/client/Container/Containers.ts
+++ b/sdk/cosmosdb/cosmos/src/client/Container/Containers.ts
@@ -21,6 +21,7 @@ import { ContainerRequest } from "./ContainerRequest";
 import { ContainerResponse } from "./ContainerResponse";
 import { validateOffer } from "../../utils/offers";
 import { CosmosException } from "../../diagnostics/CosmosException";
+import { setDiagnostics } from "../../diagnostics/Diagnostics";
 
 /**
  * Operations for creating new containers, and reading/querying all containers
@@ -108,7 +109,8 @@ export class Containers {
   ): Promise<ContainerResponse> {
     const err = {};
     if (!isResourceValid(body, err)) {
-      throw new CosmosException(err);
+      setDiagnostics(`${err}`);
+      throw err;
     }
     const path = getPathFromLink(this.database.url, ResourceType.container);
     const id = getIdFromLink(this.database.url);
@@ -195,7 +197,7 @@ export class Containers {
     options?: RequestOptions
   ): Promise<ContainerResponse> {
     if (!body || body.id === null || body.id === undefined) {
-      throw new Error("body parameter must be an object with an id property");
+      throw new CosmosException("body parameter must be an object with an id property");
     }
     /*
       1. Attempt to read the Container (based on an assumption that most containers will already exist, so its faster)
@@ -212,7 +214,8 @@ export class Containers {
         new CosmosException(err);
         return createResponse;
       } else {
-        throw new CosmosException(err);
+        setDiagnostics(`${err}`);
+        throw err;
       }
     }
   }

--- a/sdk/cosmosdb/cosmos/src/client/Container/Containers.ts
+++ b/sdk/cosmosdb/cosmos/src/client/Container/Containers.ts
@@ -108,8 +108,7 @@ export class Containers {
   ): Promise<ContainerResponse> {
     const err = {};
     if (!isResourceValid(body, err)) {
-      CosmosException.record({"cosmos-diagnostics-create-container-error": err});
-      throw err;
+      throw new CosmosException(err);
     }
     const path = getPathFromLink(this.database.url, ResourceType.container);
     const id = getIdFromLink(this.database.url);
@@ -147,8 +146,7 @@ export class Containers {
 
     if (typeof body.partitionKey === "string") {
       if (!body.partitionKey.startsWith("/")) {
-        const err = new Error("Partition key must start with '/'");
-        CosmosException.record({"cosmos-diagnostics-partition-key-error": err});
+        const err = new CosmosException("Partition key must start with '/'");
         throw err;
       }
       body.partitionKey = {
@@ -212,11 +210,10 @@ export class Containers {
         const createResponse = await this.create(body, options);
         // Must merge the headers to capture RU costskaty
         mergeHeaders(createResponse.headers, err.headers);
-        CosmosException.record({"cosmos-diagnostics-container-readResponse-substatus-notfound-error": err});
+        new CosmosException(err);
         return createResponse;
       } else {
-        CosmosException.record({"cosmos-diagnostics-container-readResponse-error": err});
-        throw err;
+        throw new CosmosException(err);
       }
     }
   }

--- a/sdk/cosmosdb/cosmos/src/client/Container/Containers.ts
+++ b/sdk/cosmosdb/cosmos/src/client/Container/Containers.ts
@@ -20,7 +20,7 @@ import { ContainerDefinition } from "./ContainerDefinition";
 import { ContainerRequest } from "./ContainerRequest";
 import { ContainerResponse } from "./ContainerResponse";
 import { validateOffer } from "../../utils/offers";
-import { recordDiagnostics } from "../../diagnostics/CosmosDiagnostics";
+import { CosmosException } from "../../diagnostics/CosmosException";
 
 /**
  * Operations for creating new containers, and reading/querying all containers
@@ -108,7 +108,7 @@ export class Containers {
   ): Promise<ContainerResponse> {
     const err = {};
     if (!isResourceValid(body, err)) {
-      recordDiagnostics({"cosmos-diagnostics-create-container-error": err});
+      CosmosException.record({"cosmos-diagnostics-create-container-error": err});
       throw err;
     }
     const path = getPathFromLink(this.database.url, ResourceType.container);
@@ -148,7 +148,7 @@ export class Containers {
     if (typeof body.partitionKey === "string") {
       if (!body.partitionKey.startsWith("/")) {
         const err = new Error("Partition key must start with '/'");
-        recordDiagnostics({"cosmos-diagnostics-partition-key-error": err});
+        CosmosException.record({"cosmos-diagnostics-partition-key-error": err});
         throw err;
       }
       body.partitionKey = {
@@ -212,10 +212,10 @@ export class Containers {
         const createResponse = await this.create(body, options);
         // Must merge the headers to capture RU costskaty
         mergeHeaders(createResponse.headers, err.headers);
-        recordDiagnostics({"cosmos-diagnostics-container-readResponse-substatus-notfound-error": err});
+        CosmosException.record({"cosmos-diagnostics-container-readResponse-substatus-notfound-error": err});
         return createResponse;
       } else {
-        recordDiagnostics({"cosmos-diagnostics-container-readResponse-error": err});
+        CosmosException.record({"cosmos-diagnostics-container-readResponse-error": err});
         throw err;
       }
     }

--- a/sdk/cosmosdb/cosmos/src/client/Container/Containers.ts
+++ b/sdk/cosmosdb/cosmos/src/client/Container/Containers.ts
@@ -146,8 +146,7 @@ export class Containers {
 
     if (typeof body.partitionKey === "string") {
       if (!body.partitionKey.startsWith("/")) {
-        const err = new CosmosException("Partition key must start with '/'");
-        throw err;
+        throw new CosmosException("Partition key must start with '/'");
       }
       body.partitionKey = {
         paths: [body.partitionKey],

--- a/sdk/cosmosdb/cosmos/src/client/Container/Containers.ts
+++ b/sdk/cosmosdb/cosmos/src/client/Container/Containers.ts
@@ -211,7 +211,7 @@ export class Containers {
         const createResponse = await this.create(body, options);
         // Must merge the headers to capture RU costskaty
         mergeHeaders(createResponse.headers, err.headers);
-        new CosmosException(err);
+        setDiagnostics(`${err}`);
         return createResponse;
       } else {
         setDiagnostics(`${err}`);

--- a/sdk/cosmosdb/cosmos/src/client/Database/Databases.ts
+++ b/sdk/cosmosdb/cosmos/src/client/Database/Databases.ts
@@ -102,8 +102,7 @@ export class Databases {
   ): Promise<DatabaseResponse> {
     const err = {};
     if (!isResourceValid(body, err)) {
-      CosmosException.record({"cosmos-diagnostics-isResourceValid-error": err})
-      throw err;
+      throw new CosmosException(err);
     }
 
     validateOffer(body);
@@ -169,8 +168,7 @@ export class Databases {
     options?: RequestOptions
   ): Promise<DatabaseResponse> {
     if (!body || body.id === null || body.id === undefined) {
-      const err = new Error("body parameter must be an object with an id property");
-      CosmosException.record({"cosmos-diagnostics-isResourceValid-error": err})
+      const err = new CosmosException("body parameter must be an object with an id property");
       throw err;
     }
     /*
@@ -185,11 +183,10 @@ export class Databases {
         const createResponse = await this.create(body, options);
         // Must merge the headers to capture RU costskaty
         mergeHeaders(createResponse.headers, err.headers);
-        CosmosException.record({"cosmos-diagnostics-database-readResponse-substatus-notfound-error": err});
+        new CosmosException(err);
         return createResponse;
       } else {
-        CosmosException.record({"cosmos-diagnostics-database-readResponse-substatus-notfound-error": err});
-        throw err;
+        throw new CosmosException(err);
       }
     }
   }

--- a/sdk/cosmosdb/cosmos/src/client/Database/Databases.ts
+++ b/sdk/cosmosdb/cosmos/src/client/Database/Databases.ts
@@ -12,7 +12,6 @@ import { DatabaseDefinition } from "./DatabaseDefinition";
 import { DatabaseRequest } from "./DatabaseRequest";
 import { DatabaseResponse } from "./DatabaseResponse";
 import { validateOffer } from "../../utils/offers";
-import { CosmosException } from "../../diagnostics/CosmosException";
 import { setDiagnostics } from "../../diagnostics/Diagnostics";
 
 /**
@@ -170,7 +169,8 @@ export class Databases {
     options?: RequestOptions
   ): Promise<DatabaseResponse> {
     if (!body || body.id === null || body.id === undefined) {
-      throw new CosmosException("body parameter must be an object with an id property");
+      setDiagnostics("body parameter must be an object with an id property");
+      throw new Error("body parameter must be an object with an id property");
     }
     /*
       1. Attempt to read the Database (based on an assumption that most databases will already exist, so its faster)
@@ -185,10 +185,10 @@ export class Databases {
         // Must merge the headers to capture RU costskaty
         mergeHeaders(createResponse.headers, err.headers);
         // add error to diagnostics.
-        new CosmosException(err);
+        setDiagnostics(`${err}`);
         return createResponse;
       } else {
-        new CosmosException(err);
+        setDiagnostics(err);
       }
     }
   }

--- a/sdk/cosmosdb/cosmos/src/client/Database/Databases.ts
+++ b/sdk/cosmosdb/cosmos/src/client/Database/Databases.ts
@@ -186,7 +186,7 @@ export class Databases {
         new CosmosException(err);
         return createResponse;
       } else {
-        throw new CosmosException(err);
+        new CosmosException(err);
       }
     }
   }

--- a/sdk/cosmosdb/cosmos/src/client/Database/Databases.ts
+++ b/sdk/cosmosdb/cosmos/src/client/Database/Databases.ts
@@ -13,6 +13,7 @@ import { DatabaseRequest } from "./DatabaseRequest";
 import { DatabaseResponse } from "./DatabaseResponse";
 import { validateOffer } from "../../utils/offers";
 import { CosmosException } from "../../diagnostics/CosmosException";
+import { setDiagnostics } from "../../diagnostics/Diagnostics";
 
 /**
  * Operations for creating new databases, and reading/querying all databases
@@ -102,7 +103,8 @@ export class Databases {
   ): Promise<DatabaseResponse> {
     const err = {};
     if (!isResourceValid(body, err)) {
-      throw new CosmosException(err);
+      setDiagnostics(`${err}`);
+      throw err;
     }
 
     validateOffer(body);

--- a/sdk/cosmosdb/cosmos/src/client/Database/Databases.ts
+++ b/sdk/cosmosdb/cosmos/src/client/Database/Databases.ts
@@ -12,7 +12,7 @@ import { DatabaseDefinition } from "./DatabaseDefinition";
 import { DatabaseRequest } from "./DatabaseRequest";
 import { DatabaseResponse } from "./DatabaseResponse";
 import { validateOffer } from "../../utils/offers";
-import { recordDiagnostics } from "../../diagnostics/CosmosDiagnostics";
+import { CosmosException } from "../../diagnostics/CosmosException";
 
 /**
  * Operations for creating new databases, and reading/querying all databases
@@ -102,7 +102,7 @@ export class Databases {
   ): Promise<DatabaseResponse> {
     const err = {};
     if (!isResourceValid(body, err)) {
-      recordDiagnostics({"cosmos-diagnostics-isResourceValid-error": err})
+      CosmosException.record({"cosmos-diagnostics-isResourceValid-error": err})
       throw err;
     }
 
@@ -170,7 +170,7 @@ export class Databases {
   ): Promise<DatabaseResponse> {
     if (!body || body.id === null || body.id === undefined) {
       const err = new Error("body parameter must be an object with an id property");
-      recordDiagnostics({"cosmos-diagnostics-isResourceValid-error": err})
+      CosmosException.record({"cosmos-diagnostics-isResourceValid-error": err})
       throw err;
     }
     /*
@@ -185,10 +185,10 @@ export class Databases {
         const createResponse = await this.create(body, options);
         // Must merge the headers to capture RU costskaty
         mergeHeaders(createResponse.headers, err.headers);
-        recordDiagnostics({"cosmos-diagnostics-database-readResponse-substatus-notfound-error": err});
+        CosmosException.record({"cosmos-diagnostics-database-readResponse-substatus-notfound-error": err});
         return createResponse;
       } else {
-        recordDiagnostics({"cosmos-diagnostics-database-readResponse-substatus-notfound-error": err});
+        CosmosException.record({"cosmos-diagnostics-database-readResponse-substatus-notfound-error": err});
         throw err;
       }
     }

--- a/sdk/cosmosdb/cosmos/src/client/Database/Databases.ts
+++ b/sdk/cosmosdb/cosmos/src/client/Database/Databases.ts
@@ -168,8 +168,7 @@ export class Databases {
     options?: RequestOptions
   ): Promise<DatabaseResponse> {
     if (!body || body.id === null || body.id === undefined) {
-      const err = new CosmosException("body parameter must be an object with an id property");
-      throw err;
+      throw new CosmosException("body parameter must be an object with an id property");
     }
     /*
       1. Attempt to read the Database (based on an assumption that most databases will already exist, so its faster)
@@ -183,6 +182,7 @@ export class Databases {
         const createResponse = await this.create(body, options);
         // Must merge the headers to capture RU costskaty
         mergeHeaders(createResponse.headers, err.headers);
+        // add error to diagnostics.
         new CosmosException(err);
         return createResponse;
       } else {

--- a/sdk/cosmosdb/cosmos/src/client/Item/Item.ts
+++ b/sdk/cosmosdb/cosmos/src/client/Item/Item.ts
@@ -93,8 +93,7 @@ export class Item {
       });
     } catch (error: any) {
       if (error.code !== StatusCodes.NotFound) {
-        CosmosException.record({"cosmos-diagnostics-read-item-response-error": error});
-        throw error;
+        throw new CosmosException(error);
       }
       response = error;
     }
@@ -144,11 +143,9 @@ export class Item {
         await this.container.readPartitionKeyDefinition();
       this.partitionKey = extractPartitionKey(body, partitionKeyDefinition);
     }
-
     const err = {};
     if (!isResourceValid(body, err)) {
-      CosmosException.record({"cosmos-diagnostics-replace-item-response-error": err});
-      throw err;
+      throw new CosmosException(`"ItemDefinition.replace": ${err}`);
     }
 
     const path = getPathFromLink(this.url);

--- a/sdk/cosmosdb/cosmos/src/client/Item/Item.ts
+++ b/sdk/cosmosdb/cosmos/src/client/Item/Item.ts
@@ -9,7 +9,7 @@ import {
   ResourceType,
   StatusCodes,
 } from "../../common";
-import { CosmosException } from "../../diagnostics/CosmosException";
+import { setDiagnostics } from "../../diagnostics/Diagnostics";
 import { PartitionKey } from "../../documents";
 import { extractPartitionKey, undefinedPartitionKey } from "../../extractPartitionKey";
 import { RequestOptions, Response } from "../../request";
@@ -93,7 +93,8 @@ export class Item {
       });
     } catch (error: any) {
       if (error.code !== StatusCodes.NotFound) {
-        throw new CosmosException(error);
+        setDiagnostics(`${error}`);
+        throw error;
       }
       response = error;
     }
@@ -145,7 +146,8 @@ export class Item {
     }
     const err = {};
     if (!isResourceValid(body, err)) {
-      throw new CosmosException(`"ItemDefinition.replace": ${err}`);
+      setDiagnostics(`"ItemDefinition.replace": ${err}`);
+      throw err;
     }
 
     const path = getPathFromLink(this.url);

--- a/sdk/cosmosdb/cosmos/src/client/Item/Items.ts
+++ b/sdk/cosmosdb/cosmos/src/client/Item/Items.ts
@@ -27,6 +27,7 @@ import {
 } from "../../utils/batch";
 import { hashV1PartitionKey } from "../../utils/hashing/v1";
 import { hashV2PartitionKey } from "../../utils/hashing/v2";
+import { setDiagnostics } from "../../diagnostics/Diagnostics";
 
 /**
  * @hidden
@@ -270,6 +271,7 @@ export class Items {
 
     const err = {};
     if (!isItemResourceValid(body, err)) {
+      setDiagnostics(`${err}`);
       throw err;
     }
 
@@ -342,6 +344,7 @@ export class Items {
 
     const err = {};
     if (!isItemResourceValid(body, err)) {
+      setDiagnostics(`${err}`);
       throw err;
     }
 

--- a/sdk/cosmosdb/cosmos/src/client/Offer/Offer.ts
+++ b/sdk/cosmosdb/cosmos/src/client/Offer/Offer.ts
@@ -3,6 +3,7 @@
 import { ClientContext } from "../../ClientContext";
 import { Constants, isResourceValid, ResourceType } from "../../common";
 import { CosmosClient } from "../../CosmosClient";
+import { setDiagnostics } from "../../diagnostics/Diagnostics";
 import { RequestOptions } from "../../request";
 import { OfferDefinition } from "./OfferDefinition";
 import { OfferResponse } from "./OfferResponse";
@@ -50,6 +51,7 @@ export class Offer {
   public async replace(body: OfferDefinition, options?: RequestOptions): Promise<OfferResponse> {
     const err = {};
     if (!isResourceValid(body, err)) {
+      setDiagnostics(`${err}`);
       throw err;
     }
     const response = await this.clientContext.replace<OfferDefinition>({

--- a/sdk/cosmosdb/cosmos/src/client/Permission/Permission.ts
+++ b/sdk/cosmosdb/cosmos/src/client/Permission/Permission.ts
@@ -8,6 +8,7 @@ import {
   isResourceValid,
   ResourceType,
 } from "../../common";
+import { setDiagnostics } from "../../diagnostics/Diagnostics";
 import { RequestOptions } from "../../request/RequestOptions";
 import { User } from "../User";
 import { PermissionBody } from "./PermissionBody";
@@ -63,6 +64,7 @@ export class Permission {
   ): Promise<PermissionResponse> {
     const err = {};
     if (!isResourceValid(body, err)) {
+      setDiagnostics(`${err}`);
       throw err;
     }
 

--- a/sdk/cosmosdb/cosmos/src/client/Permission/Permissions.ts
+++ b/sdk/cosmosdb/cosmos/src/client/Permission/Permissions.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 import { ClientContext } from "../../ClientContext";
 import { getIdFromLink, getPathFromLink, isResourceValid, ResourceType } from "../../common";
+import { setDiagnostics } from "../../diagnostics/Diagnostics";
 import { SqlQuerySpec } from "../../queryExecutionContext";
 import { QueryIterator } from "../../queryIterator";
 import { FeedOptions, RequestOptions } from "../../request";
@@ -74,6 +75,7 @@ export class Permissions {
   ): Promise<PermissionResponse> {
     const err = {};
     if (!isResourceValid(body, err)) {
+      setDiagnostics(`${err}`);
       throw err;
     }
 
@@ -103,6 +105,7 @@ export class Permissions {
   ): Promise<PermissionResponse> {
     const err = {};
     if (!isResourceValid(body, err)) {
+      setDiagnostics(`${err}`);
       throw err;
     }
 

--- a/sdk/cosmosdb/cosmos/src/client/StoredProcedure/StoredProcedure.ts
+++ b/sdk/cosmosdb/cosmos/src/client/StoredProcedure/StoredProcedure.ts
@@ -8,6 +8,7 @@ import {
   isResourceValid,
   ResourceType,
 } from "../../common";
+import { setDiagnostics } from "../../diagnostics/Diagnostics";
 import { PartitionKey } from "../../documents/PartitionKey";
 import { undefinedPartitionKey } from "../../extractPartitionKey";
 import { RequestOptions, ResourceResponse } from "../../request";
@@ -68,6 +69,7 @@ export class StoredProcedure {
 
     const err = {};
     if (!isResourceValid(body, err)) {
+      setDiagnostics(`${err}`);
       throw err;
     }
 

--- a/sdk/cosmosdb/cosmos/src/client/StoredProcedure/StoredProcedures.ts
+++ b/sdk/cosmosdb/cosmos/src/client/StoredProcedure/StoredProcedures.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 import { ClientContext } from "../../ClientContext";
 import { getIdFromLink, getPathFromLink, isResourceValid, ResourceType } from "../../common";
+import { setDiagnostics } from "../../diagnostics/Diagnostics";
 import { SqlQuerySpec } from "../../queryExecutionContext";
 import { QueryIterator } from "../../queryIterator";
 import { FeedOptions, RequestOptions } from "../../request";
@@ -102,6 +103,7 @@ export class StoredProcedures {
 
     const err = {};
     if (!isResourceValid(body, err)) {
+      setDiagnostics(`${err}`);
       throw err;
     }
 

--- a/sdk/cosmosdb/cosmos/src/client/Trigger/Trigger.ts
+++ b/sdk/cosmosdb/cosmos/src/client/Trigger/Trigger.ts
@@ -8,6 +8,7 @@ import {
   isResourceValid,
   ResourceType,
 } from "../../common";
+import { setDiagnostics } from "../../diagnostics/Diagnostics";
 import { RequestOptions } from "../../request";
 import { Container } from "../Container";
 import { TriggerDefinition } from "./TriggerDefinition";
@@ -67,6 +68,7 @@ export class Trigger {
 
     const err = {};
     if (!isResourceValid(body, err)) {
+      setDiagnostics(`${err}`);
       throw err;
     }
 

--- a/sdk/cosmosdb/cosmos/src/client/Trigger/Triggers.ts
+++ b/sdk/cosmosdb/cosmos/src/client/Trigger/Triggers.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 import { ClientContext } from "../../ClientContext";
 import { getIdFromLink, getPathFromLink, isResourceValid, ResourceType } from "../../common";
+import { setDiagnostics } from "../../diagnostics/Diagnostics";
 import { SqlQuerySpec } from "../../queryExecutionContext";
 import { QueryIterator } from "../../queryIterator";
 import { FeedOptions, RequestOptions } from "../../request";
@@ -77,6 +78,7 @@ export class Triggers {
 
     const err = {};
     if (!isResourceValid(body, err)) {
+      setDiagnostics(`${err}`);
       throw err;
     }
 

--- a/sdk/cosmosdb/cosmos/src/client/User/User.ts
+++ b/sdk/cosmosdb/cosmos/src/client/User/User.ts
@@ -8,6 +8,7 @@ import {
   isResourceValid,
   ResourceType,
 } from "../../common";
+import { setDiagnostics } from "../../diagnostics/Diagnostics";
 import { RequestOptions } from "../../request";
 import { Database } from "../Database";
 import { Permission, Permissions } from "../Permission";
@@ -77,6 +78,7 @@ export class User {
   public async replace(body: UserDefinition, options?: RequestOptions): Promise<UserResponse> {
     const err = {};
     if (!isResourceValid(body, err)) {
+      setDiagnostics(`${err}`);
       throw err;
     }
 

--- a/sdk/cosmosdb/cosmos/src/client/User/Users.ts
+++ b/sdk/cosmosdb/cosmos/src/client/User/Users.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 import { ClientContext } from "../../ClientContext";
 import { getIdFromLink, getPathFromLink, isResourceValid, ResourceType } from "../../common";
+import { setDiagnostics } from "../../diagnostics/Diagnostics";
 import { SqlQuerySpec } from "../../queryExecutionContext";
 import { QueryIterator } from "../../queryIterator";
 import { FeedOptions, RequestOptions } from "../../request";
@@ -67,6 +68,7 @@ export class Users {
   public async create(body: UserDefinition, options?: RequestOptions): Promise<UserResponse> {
     const err = {};
     if (!isResourceValid(body, err)) {
+      setDiagnostics(`${err}`);
       throw err;
     }
 
@@ -90,6 +92,7 @@ export class Users {
   public async upsert(body: UserDefinition, options?: RequestOptions): Promise<UserResponse> {
     const err = {};
     if (!isResourceValid(body, err)) {
+      setDiagnostics(`${err}`);
       throw err;
     }
 

--- a/sdk/cosmosdb/cosmos/src/client/UserDefinedFunction/UserDefinedFunctions.ts
+++ b/sdk/cosmosdb/cosmos/src/client/UserDefinedFunction/UserDefinedFunctions.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 import { ClientContext } from "../../ClientContext";
 import { getIdFromLink, getPathFromLink, isResourceValid, ResourceType } from "../../common";
+import { setDiagnostics } from "../../diagnostics/Diagnostics";
 import { SqlQuerySpec } from "../../queryExecutionContext";
 import { QueryIterator } from "../../queryIterator";
 import { FeedOptions, RequestOptions } from "../../request";
@@ -81,6 +82,7 @@ export class UserDefinedFunctions {
 
     const err = {};
     if (!isResourceValid(body, err)) {
+      setDiagnostics(`${err}`);
       throw err;
     }
 

--- a/sdk/cosmosdb/cosmos/src/common/constants.ts
+++ b/sdk/cosmosdb/cosmos/src/common/constants.ts
@@ -182,14 +182,17 @@ export const Constants = {
   // Platform
   CurrentVersion: "2020-07-15",
   /**
- * @hidden
- */
+   * @hidden
+   */
   AzureNamespace: "Azure.Cosmos",
   /**
- * @hidden
- */
+   * @hidden
+   */
   AzurePackageName: "@azure/cosmos",
   SDKName: "azure-cosmos-js",
+  /**
+   * @hidden
+   */
   SDKVersion: "3.17.1",
 
   Quota: {

--- a/sdk/cosmosdb/cosmos/src/common/constants.ts
+++ b/sdk/cosmosdb/cosmos/src/common/constants.ts
@@ -181,7 +181,13 @@ export const Constants = {
 
   // Platform
   CurrentVersion: "2020-07-15",
+  /**
+ * @hidden
+ */
   AzureNamespace: "Azure.Cosmos",
+  /**
+ * @hidden
+ */
   AzurePackageName: "@azure/cosmos",
   SDKName: "azure-cosmos-js",
   SDKVersion: "3.17.1",

--- a/sdk/cosmosdb/cosmos/src/diagnostics/CosmosDiagnostics.ts
+++ b/sdk/cosmosdb/cosmos/src/diagnostics/CosmosDiagnostics.ts
@@ -5,30 +5,31 @@
 //  *
 //  * @internal
 
-import { CosmosException } from "./CosmosException";
+import { jsonStringifyAndEscapeNonASCII } from "../common";
+import { DiagnosticSpan } from "./CosmosException";
 
-export function diagnosticToString(): string {
-  return JSON.stringify(cosmosException);
+export function getCosmosDiagnostics(): string {
+  return jsonStringifyAndEscapeNonASCII(_diagnosticsSpan);
 };
 
 const _startTime = new Date().getTime();
 
-const startDiagnostics: CosmosException = {
+const _root: DiagnosticSpan  = {
 "cosmosdiagnostics": "Started Cosmos Diagnostics",
 "diagnosticStartTime": new Date().toLocaleString(),
 "durationInMs": (new Date().getTime() - _startTime)
 }
 
-const cosmosException: CosmosException[] = [startDiagnostics];
+const _diagnosticsSpan: DiagnosticSpan[] = [_root];
 
-export function recordDiagnostics(message: CosmosException | string) {
-  if(cosmosException.length === 0){
-recordDiagnostics(startDiagnostics);
+export function recordDiagnostics(message: DiagnosticSpan | string) {
+  if(_diagnosticsSpan.length === 0){
+recordDiagnostics(_diagnosticsSpan);
   }
-  cosmosException.push({"diagnosticsthread": cosmosException.length.toString(),
+  _diagnosticsSpan.push({"diagnosticsthread": _diagnosticsSpan.length.toString(),
   "excpetion": message,
   "durationInMs": (new Date().getTime() - _startTime)},
   )}; 
 export function getdiagnosticsdurationMilliseconds() {
-return (cosmosException[ cosmosException.length - 1 ]);
+return (_diagnosticsSpan[ _diagnosticsSpan.length - 1 ]);
 }

--- a/sdk/cosmosdb/cosmos/src/diagnostics/CosmosDiagnostics.ts
+++ b/sdk/cosmosdb/cosmos/src/diagnostics/CosmosDiagnostics.ts
@@ -1,0 +1,34 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+// /**
+//  * Cosmos Diagnostics for this package.
+//  *
+//  * @internal
+
+import { CosmosException } from "./CosmosException";
+
+export function diagnosticToString(): string {
+  return JSON.stringify(cosmosException);
+};
+
+const _startTime = new Date().getTime();
+
+const startDiagnostics: CosmosException = {
+"cosmosdiagnostics": "Started Cosmos Diagnostics",
+"diagnosticStartTime": new Date().toLocaleString(),
+"durationInMs": (new Date().getTime() - _startTime)
+}
+
+const cosmosException: CosmosException[] = [startDiagnostics];
+
+export function recordDiagnostics(message: CosmosException | string) {
+  if(cosmosException.length === 0){
+recordDiagnostics(startDiagnostics);
+  }
+  cosmosException.push({"diagnosticsthread": cosmosException.length.toString(),
+  "excpetion": message,
+  "durationInMs": (new Date().getTime() - _startTime)},
+  )}; 
+export function getdiagnosticsdurationMilliseconds() {
+return (cosmosException[ cosmosException.length - 1 ]);
+}

--- a/sdk/cosmosdb/cosmos/src/diagnostics/CosmosDiagnostics.ts
+++ b/sdk/cosmosdb/cosmos/src/diagnostics/CosmosDiagnostics.ts
@@ -1,12 +1,19 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { getCosmosDiagnosticsToString, getdiagnosticsdurationMilliseconds } from "./Diagnostics"; //static?
+import {
+  getCosmosDiagnosticsToString,
+  getdiagnosticsdurationMilliseconds,
+  getRegionsContacted,
+} from "./Diagnostics";
+
 export class CosmosDiagnostics {
   /**
    * Regions contacted for this request.
    */
-  getRegionsContacted() {}
+  getRegionsContacted() {
+    return getRegionsContacted();
+  }
   /**
    * 	Retrieves duration related to the completion of the request. This represents end to end duration of an operation including all the retries. This is meant for point operation only, for query please use toString() to get full query diagnostics.
    */
@@ -17,6 +24,7 @@ export class CosmosDiagnostics {
    * Retrieves Response Diagnostic String.
    */
   getCosmosDiagnostics(): string {
+    console.log(getCosmosDiagnosticsToString());
     return getCosmosDiagnosticsToString();
   }
 }

--- a/sdk/cosmosdb/cosmos/src/diagnostics/CosmosDiagnostics.ts
+++ b/sdk/cosmosdb/cosmos/src/diagnostics/CosmosDiagnostics.ts
@@ -24,7 +24,6 @@ export class CosmosDiagnostics {
    * Retrieves Response Diagnostic String.
    */
   getCosmosDiagnostics(): string {
-    console.log(getCosmosDiagnosticsToString());
     return getCosmosDiagnosticsToString();
   }
 }

--- a/sdk/cosmosdb/cosmos/src/diagnostics/CosmosDiagnostics.ts
+++ b/sdk/cosmosdb/cosmos/src/diagnostics/CosmosDiagnostics.ts
@@ -1,32 +1,33 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-const _startTime = new Date().getTime();
-const _root: DiagnosticSpan = {
-  cosmosdiagnostics: "Started Cosmos Diagnostics",
-  diagnosticStartTime: new Date().toLocaleString(),
-  durationInMs: new Date().getTime() - _startTime,
-};
-const _diagnosticsSpan: DiagnosticSpan[] = [_root];
-
-export function recordDiagnostics(message: DiagnosticSpan | string) {
-  if (_diagnosticsSpan.length === 0) {
-    recordDiagnostics(_diagnosticsSpan);
+import { ErrorResponse } from "../request/ErrorResponse";
+import {
+  getCosmosDiagnostics,
+  getdiagnosticsdurationMilliseconds,
+  getDiagnosticsRaw,
+} from "./Diagnostics"; //static?
+export class CosmosDiagnostic implements ErrorResponse {
+  /**
+   * Regions contacted for this request.
+   */
+  getRegionsContacted() {}
+  /**
+   * 	Retrieves duration related to the completion of the request. This represents end to end duration of an operation including all the retries. This is meant for point operation only, for query please use toString() to get full query diagnostics.
+   */
+  getDuration() {
+    return getdiagnosticsdurationMilliseconds();
   }
-  _diagnosticsSpan.push({
-    diagnosticsthread: _diagnosticsSpan.length.toString(),
-    excpetion: message,
-    durationInMs: new Date().getTime() - _startTime,
-  });
-}
-export function getdiagnosticsdurationMilliseconds(): number {
-  if (_diagnosticsSpan.length > 0) {
-    return Number(_diagnosticsSpan[_diagnosticsSpan.length - 1].durationInMs);
+  /**
+   * Retrieves Response Diagnostic String.
+   */
+  getCosmosDiagnostics(): string {
+    return getCosmosDiagnostics();
   }
-}
-export function getCosmosDiagnostics(): string {
-  return JSON.stringify(_diagnosticsSpan);
-}
-export interface DiagnosticSpan {
-  [key: string]: string | boolean | number | any;
+  /**
+   * Retrieves Response Diagnostic String.
+   */
+  raw(): string {
+    return getDiagnosticsRaw();
+  }
 }

--- a/sdk/cosmosdb/cosmos/src/diagnostics/CosmosDiagnostics.ts
+++ b/sdk/cosmosdb/cosmos/src/diagnostics/CosmosDiagnostics.ts
@@ -1,35 +1,32 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
-// /**
-//  * Cosmos Diagnostics for this package.
-//  *
-//  * @internal
-
-import { jsonStringifyAndEscapeNonASCII } from "../common";
-import { DiagnosticSpan } from "./CosmosException";
-
-export function getCosmosDiagnostics(): string {
-  return jsonStringifyAndEscapeNonASCII(_diagnosticsSpan);
-};
 
 const _startTime = new Date().getTime();
-
-const _root: DiagnosticSpan  = {
-"cosmosdiagnostics": "Started Cosmos Diagnostics",
-"diagnosticStartTime": new Date().toLocaleString(),
-"durationInMs": (new Date().getTime() - _startTime)
-}
-
+const _root: DiagnosticSpan = {
+  cosmosdiagnostics: "Started Cosmos Diagnostics",
+  diagnosticStartTime: new Date().toLocaleString(),
+  durationInMs: new Date().getTime() - _startTime,
+};
 const _diagnosticsSpan: DiagnosticSpan[] = [_root];
 
 export function recordDiagnostics(message: DiagnosticSpan | string) {
-  if(_diagnosticsSpan.length === 0){
-recordDiagnostics(_diagnosticsSpan);
+  if (_diagnosticsSpan.length === 0) {
+    recordDiagnostics(_diagnosticsSpan);
   }
-  _diagnosticsSpan.push({"diagnosticsthread": _diagnosticsSpan.length.toString(),
-  "excpetion": message,
-  "durationInMs": (new Date().getTime() - _startTime)},
-  )}; 
-export function getdiagnosticsdurationMilliseconds() {
-return (_diagnosticsSpan[ _diagnosticsSpan.length - 1 ]);
+  _diagnosticsSpan.push({
+    diagnosticsthread: _diagnosticsSpan.length.toString(),
+    excpetion: message,
+    durationInMs: new Date().getTime() - _startTime,
+  });
+}
+export function getdiagnosticsdurationMilliseconds(): number {
+  if (_diagnosticsSpan.length > 0) {
+    return Number(_diagnosticsSpan[_diagnosticsSpan.length - 1].durationInMs);
+  }
+}
+export function getCosmosDiagnostics(): string {
+  return JSON.stringify(_diagnosticsSpan);
+}
+export interface DiagnosticSpan {
+  [key: string]: string | boolean | number | any;
 }

--- a/sdk/cosmosdb/cosmos/src/diagnostics/CosmosDiagnostics.ts
+++ b/sdk/cosmosdb/cosmos/src/diagnostics/CosmosDiagnostics.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 
 import { getCosmosDiagnosticsToString, getdiagnosticsdurationMilliseconds } from "./Diagnostics"; //static?
-export class CosmosDiagnostic {
+export class CosmosDiagnostics {
   /**
    * Regions contacted for this request.
    */

--- a/sdk/cosmosdb/cosmos/src/diagnostics/CosmosDiagnostics.ts
+++ b/sdk/cosmosdb/cosmos/src/diagnostics/CosmosDiagnostics.ts
@@ -1,13 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { ErrorResponse } from "../request/ErrorResponse";
-import {
-  getCosmosDiagnostics,
-  getdiagnosticsdurationMilliseconds,
-  getDiagnosticsRaw,
-} from "./Diagnostics"; //static?
-export class CosmosDiagnostic implements ErrorResponse {
+import { getCosmosDiagnosticsToString, getdiagnosticsdurationMilliseconds } from "./Diagnostics"; //static?
+export class CosmosDiagnostic {
   /**
    * Regions contacted for this request.
    */
@@ -22,12 +17,6 @@ export class CosmosDiagnostic implements ErrorResponse {
    * Retrieves Response Diagnostic String.
    */
   getCosmosDiagnostics(): string {
-    return getCosmosDiagnostics();
-  }
-  /**
-   * Retrieves Response Diagnostic String.
-   */
-  raw(): string {
-    return getDiagnosticsRaw();
+    return getCosmosDiagnosticsToString();
   }
 }

--- a/sdk/cosmosdb/cosmos/src/diagnostics/CosmosException.ts
+++ b/sdk/cosmosdb/cosmos/src/diagnostics/CosmosException.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 
 import { ErrorResponse } from "..";
-import { getCosmosDiagnostics, setDiagnostics } from "./Diagnostics";
+import { getCosmosDiagnosticsToString, setDiagnostics } from "./Diagnostics";
 
 export class CosmosException extends Error {
   response?: ErrorResponse;
@@ -16,6 +16,7 @@ export class CosmosException extends Error {
     }
   }
   getDiagnostics() {
-    return getCosmosDiagnostics();
+    const diagnostic = getCosmosDiagnosticsToString();
+    return diagnostic;
   }
 }

--- a/sdk/cosmosdb/cosmos/src/diagnostics/CosmosException.ts
+++ b/sdk/cosmosdb/cosmos/src/diagnostics/CosmosException.ts
@@ -12,8 +12,8 @@ export class CosmosException extends Error{
         return getCosmosDiagnostics();
     }
 
-     static record(m: string){
-      recordDiagnostics(m);
+     static record(m: string | DiagnosticSpan ){
+      recordDiagnostics(jsonStringifyAndEscapeNonASCII(m));
       return new CosmosException(m);
      }
 }

--- a/sdk/cosmosdb/cosmos/src/diagnostics/CosmosException.ts
+++ b/sdk/cosmosdb/cosmos/src/diagnostics/CosmosException.ts
@@ -1,4 +1,23 @@
 
-export interface CosmosException {
+import { jsonStringifyAndEscapeNonASCII } from "../common";
+import { getCosmosDiagnostics, recordDiagnostics } from "./CosmosDiagnostics";
+
+export class CosmosException extends Error{
+  constructor(m: string | any) {
+        super(jsonStringifyAndEscapeNonASCII(m));
+        Object.setPrototypeOf(this, CosmosException.prototype);
+    }
+
+    static getDiagnostics() {
+        return getCosmosDiagnostics();
+    }
+
+     static record(m: string){
+      recordDiagnostics(m);
+      return new CosmosException(m);
+     }
+}
+
+export interface DiagnosticSpan {
   [key: string]: string | boolean | number | any;
 }

--- a/sdk/cosmosdb/cosmos/src/diagnostics/CosmosException.ts
+++ b/sdk/cosmosdb/cosmos/src/diagnostics/CosmosException.ts
@@ -1,29 +1,18 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import {
-  DiagnosticSpan,
-  getCosmosDiagnostics,
-  getdiagnosticsdurationMilliseconds,
-  recordDiagnostics,
-} from "./CosmosDiagnostics";
+import { ErrorResponse } from "..";
+import { setDiagnostics } from "./Diagnostics";
 
 export class CosmosException extends Error {
-  constructor(m: string | any) {
-    super(JSON.stringify(m));
+  response?: ErrorResponse;
+
+  constructor(m?: any, errorResponse?: ErrorResponse) {
+    super(m);
     Object.setPrototypeOf(this, CosmosException.prototype);
-  }
-
-  static getdiagnostics(): string {
-    return getCosmosDiagnostics();
-  }
-
-  static getduration() {
-    return getdiagnosticsdurationMilliseconds();
-  }
-
-  static record(m: string | DiagnosticSpan) {
-    recordDiagnostics(JSON.stringify(m));
-    return new CosmosException(m);
+    this.response = errorResponse;
+    if (typeof m !== "undefined") {
+      setDiagnostics(m);
+    }
   }
 }

--- a/sdk/cosmosdb/cosmos/src/diagnostics/CosmosException.ts
+++ b/sdk/cosmosdb/cosmos/src/diagnostics/CosmosException.ts
@@ -1,22 +1,44 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { ErrorResponse } from "..";
-import { getCosmosDiagnosticsToString, setDiagnostics } from "./Diagnostics";
+import { CosmosHeaders } from "../queryExecutionContext/CosmosHeaders";
+import { ErrorBody, ErrorResponse } from "../request";
+import {
+  getCosmosDiagnosticsToString,
+  getdiagnosticsdurationMilliseconds,
+  getRegionsContacted,
+  setDiagnostics,
+} from "./Diagnostics";
 
-export class CosmosException extends Error {
-  response?: ErrorResponse;
-
-  constructor(m?: any, errorResponse?: ErrorResponse) {
+export class CosmosException extends Error implements ErrorResponse {
+  constructor(m?: any) {
     super(m);
     Object.setPrototypeOf(this, CosmosException.prototype);
-    this.response = errorResponse;
     if (typeof m !== "undefined") {
       setDiagnostics(m);
     }
   }
+  [key: string]: any;
+  code?: number;
+  substatus?: number;
+  body?: ErrorBody;
+  headers?: CosmosHeaders;
+  activityId?: string;
+  retryAfterInMs?: number;
+  retryAfterInMilliseconds?: number;
+  name: string;
+  message: string;
+  stack?: string;
   getDiagnostics() {
     const diagnostic = getCosmosDiagnosticsToString();
     return diagnostic;
+  }
+  getDuration() {
+    const duration = getdiagnosticsdurationMilliseconds();
+    return duration;
+  }
+  getRegions() {
+    const regions = getRegionsContacted();
+    return regions;
   }
 }

--- a/sdk/cosmosdb/cosmos/src/diagnostics/CosmosException.ts
+++ b/sdk/cosmosdb/cosmos/src/diagnostics/CosmosException.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 
 import { ErrorResponse } from "..";
-import { setDiagnostics } from "./Diagnostics";
+import { getCosmosDiagnostics, setDiagnostics } from "./Diagnostics";
 
 export class CosmosException extends Error {
   response?: ErrorResponse;
@@ -14,5 +14,8 @@ export class CosmosException extends Error {
     if (typeof m !== "undefined") {
       setDiagnostics(m);
     }
+  }
+  getDiagnostics() {
+    return getCosmosDiagnostics();
   }
 }

--- a/sdk/cosmosdb/cosmos/src/diagnostics/CosmosException.ts
+++ b/sdk/cosmosdb/cosmos/src/diagnostics/CosmosException.ts
@@ -1,0 +1,4 @@
+
+export interface CosmosException {
+  [key: string]: string | boolean | number | any;
+}

--- a/sdk/cosmosdb/cosmos/src/diagnostics/CosmosException.ts
+++ b/sdk/cosmosdb/cosmos/src/diagnostics/CosmosException.ts
@@ -12,10 +12,10 @@ import {
 
 export class CosmosException extends Error implements ErrorResponse {
   constructor(m?: any) {
-    super(m);
+    super(`${m}`);
     Object.setPrototypeOf(this, CosmosException.prototype);
     if (typeof m !== "undefined") {
-      setDiagnostics(m);
+      setDiagnostics(`${m}`);
     }
   }
   [key: string]: any;

--- a/sdk/cosmosdb/cosmos/src/diagnostics/CosmosException.ts
+++ b/sdk/cosmosdb/cosmos/src/diagnostics/CosmosException.ts
@@ -1,23 +1,29 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
 
-import { jsonStringifyAndEscapeNonASCII } from "../common";
-import { getCosmosDiagnostics, recordDiagnostics } from "./CosmosDiagnostics";
+import {
+  DiagnosticSpan,
+  getCosmosDiagnostics,
+  getdiagnosticsdurationMilliseconds,
+  recordDiagnostics,
+} from "./CosmosDiagnostics";
 
-export class CosmosException extends Error{
+export class CosmosException extends Error {
   constructor(m: string | any) {
-        super(jsonStringifyAndEscapeNonASCII(m));
-        Object.setPrototypeOf(this, CosmosException.prototype);
-    }
+    super(JSON.stringify(m));
+    Object.setPrototypeOf(this, CosmosException.prototype);
+  }
 
-    static getDiagnostics() {
-        return getCosmosDiagnostics();
-    }
+  static getdiagnostics(): string {
+    return getCosmosDiagnostics();
+  }
 
-     static record(m: string | DiagnosticSpan ){
-      recordDiagnostics(jsonStringifyAndEscapeNonASCII(m));
-      return new CosmosException(m);
-     }
-}
+  static getduration() {
+    return getdiagnosticsdurationMilliseconds();
+  }
 
-export interface DiagnosticSpan {
-  [key: string]: string | boolean | number | any;
+  static record(m: string | DiagnosticSpan) {
+    recordDiagnostics(JSON.stringify(m));
+    return new CosmosException(m);
+  }
 }

--- a/sdk/cosmosdb/cosmos/src/diagnostics/Diagnostics.ts
+++ b/sdk/cosmosdb/cosmos/src/diagnostics/Diagnostics.ts
@@ -5,7 +5,7 @@ import { defaultLogger } from "../common/logger";
 
 const _startTime = new Date().getTime();
 const _defaultHeader: DiagnosticHeader = {
-  cosmosdiagnostics: "Cosmos Diagnostics Summary",
+  diagnostics: "Cosmos Diagnostics Summary",
   diagnosticStartTime: new Date().toLocaleString(),
   durationInMs: new Date().getTime() - _startTime,
   activityId: "",
@@ -93,11 +93,11 @@ function parseTransportRequestTimeline(data: string = ""): string {
 function parseDiagnosticHeader(data: string): string {
   try {
     const header: DiagnosticHeader = {
-      cosmosdiagnostics: "Started Cosmos Diagnostics",
+      diagnostics: `Cosmos Diagnostics at ${_startTime}`,
       diagnosticStartTime: new Date().toLocaleString(),
       durationInMs: new Date().getTime() - _startTime,
       activityId: parseActivityId(data),
-      data: ["Summary"],
+      data: [""],
       requestCharge: parseRequestCharge(data),
       transportRequestTimeline: parseTransportRequestTimeline(data),
       contactedRegions: parseContactedRegions(data),
@@ -139,7 +139,7 @@ export function getRegionsContacted(): string {
 }
 
 export interface DiagnosticHeader {
-  cosmosdiagnostics: string;
+  diagnostics: string;
   diagnosticStartTime: string;
   durationInMs: number;
   activityId: string;

--- a/sdk/cosmosdb/cosmos/src/diagnostics/Diagnostics.ts
+++ b/sdk/cosmosdb/cosmos/src/diagnostics/Diagnostics.ts
@@ -1,0 +1,53 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+const _startTime = new Date().getTime();
+export const defaultHeaders: DiagnosticHeaders = {
+  cosmosdiagnostics: "Started Cosmos Diagnostics",
+  diagnosticStartTime: new Date().toLocaleString(),
+  durationInMs: new Date().getTime() - _startTime,
+};
+const _diagnosticHeaders: DiagnosticHeaders[] = [defaultHeaders];
+/**
+ * @internal
+ */
+export function setDiagnostics(message: DiagnosticHeaders | string) {
+  if (_diagnosticHeaders.length === 0) {
+    setDiagnostics(_diagnosticHeaders);
+  }
+  _diagnosticHeaders.push({
+    diagnosticsthread: _diagnosticHeaders.length.toString(),
+    durationInMs: new Date().getTime() - _startTime,
+    data: message,
+  });
+}
+/**
+ * @internal
+ */
+export function getdiagnosticsdurationMilliseconds(): number | undefined {
+  if (_diagnosticHeaders.length > 0) {
+    return Number(_diagnosticHeaders[_diagnosticHeaders.length - 1].durationInMs);
+  }
+  return undefined;
+}
+
+/**
+ * @internal
+ */
+export function getCosmosDiagnostics(): string {
+  return JSON.stringify(_diagnosticHeaders);
+}
+
+export function getDiagnosticsRaw(): string {
+  if (_diagnosticHeaders.length > 0) {
+    return JSON.stringify(
+      _diagnosticHeaders.map((diagnostic) => {
+        return JSON.stringify(diagnostic.excpetion);
+      })
+    );
+  }
+  return JSON.stringify(_diagnosticHeaders);
+}
+
+export interface DiagnosticHeaders {
+  [key: string]: string | boolean | number | any;
+}

--- a/sdk/cosmosdb/cosmos/src/diagnostics/Diagnostics.ts
+++ b/sdk/cosmosdb/cosmos/src/diagnostics/Diagnostics.ts
@@ -16,7 +16,7 @@ const _diagnosticHeader: DiagnosticHeader[] = [];
  */
 export function setDiagnostics(message?: string | DiagnosticHeader) {
   if (_diagnosticHeader.length === 0) {
-    setDiagnostics(_defaultHeader);
+    _diagnosticHeader.push(_defaultHeader);
   }
   if (typeof message === "string") {
     _diagnosticHeader.push(parseDiagnosticHeader(message));
@@ -24,19 +24,21 @@ export function setDiagnostics(message?: string | DiagnosticHeader) {
 }
 
 function parseDiagnosticHeader(data: string): DiagnosticHeader {
-  console.log(data);
+  if (JSON.parse(data)) {
+    return JSON.parse(data);
+  }
   const header = {
     cosmosdiagnostics: "Started Cosmos Diagnostics",
     diagnosticStartTime: new Date().toLocaleString(),
     durationInMs: new Date().getTime() - _startTime,
     activityId: "",
-    requestCharge: 0,
+    requestCharge: parseRequestCharge(),
     transportRequestTimeline: {},
     data: data,
   };
   return header;
 }
-/**
+/*
  * @internal
  */
 export function getdiagnosticsdurationMilliseconds(): number | undefined {
@@ -45,11 +47,48 @@ export function getdiagnosticsdurationMilliseconds(): number | undefined {
   }
   return undefined;
 }
-
+/**
+ * @internal
+ */
+export function parseTransportRequestTimeline(): number | undefined {
+  if (_diagnosticHeader.length > 0) {
+    return Number(_diagnosticHeader[_diagnosticHeader.length - 1].durationInMs);
+  }
+  return undefined;
+}
+/**
+ * @internal
+ */
+export function parseRequestCharge(): number | undefined {
+  if (_diagnosticHeader.length > 0) {
+    return Number(_diagnosticHeader[_diagnosticHeader.length - 1].durationInMs);
+  }
+  return undefined;
+}
+/**
+ * @internal
+ */
+export function parseContactedRegions(): number | undefined {
+  if (_diagnosticHeader.length > 0) {
+    return Number(_diagnosticHeader[_diagnosticHeader.length - 1].durationInMs);
+  }
+  return undefined;
+}
 /**
  * @internal
  */
 export function getCosmosDiagnosticsToString(): string {
+  if (_diagnosticHeader !== undefined) {
+    return JSON.stringify(_diagnosticHeader);
+  }
+  setDiagnostics(_defaultHeader);
+  return JSON.stringify(_diagnosticHeader);
+}
+
+/**
+ * @internal
+ */
+export function getRegionsContacted(): string {
   if (_diagnosticHeader !== undefined) {
     return JSON.stringify(_diagnosticHeader);
   }

--- a/sdk/cosmosdb/cosmos/src/diagnostics/Diagnostics.ts
+++ b/sdk/cosmosdb/cosmos/src/diagnostics/Diagnostics.ts
@@ -1,31 +1,47 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 const _startTime = new Date().getTime();
-export const defaultHeaders: DiagnosticHeaders = {
+const _defaultHeader: DiagnosticHeader = {
   cosmosdiagnostics: "Started Cosmos Diagnostics",
   diagnosticStartTime: new Date().toLocaleString(),
   durationInMs: new Date().getTime() - _startTime,
+  activityId: "",
+  requestCharge: 0,
+  transportRequestTimeline: {},
+  data: {},
 };
-const _diagnosticHeaders: DiagnosticHeaders[] = [defaultHeaders];
+const _diagnosticHeader: DiagnosticHeader[] = [];
 /**
  * @internal
  */
-export function setDiagnostics(message: DiagnosticHeaders | string) {
-  if (_diagnosticHeaders.length === 0) {
-    setDiagnostics(_diagnosticHeaders);
+export function setDiagnostics(message?: string | DiagnosticHeader) {
+  if (_diagnosticHeader.length === 0) {
+    setDiagnostics(_defaultHeader);
   }
-  _diagnosticHeaders.push({
-    diagnosticsthread: _diagnosticHeaders.length.toString(),
+  if (typeof message === "string") {
+    _diagnosticHeader.push(parseDiagnosticHeader(message));
+  }
+}
+
+function parseDiagnosticHeader(data: string): DiagnosticHeader {
+  console.log(data);
+  const header = {
+    cosmosdiagnostics: "Started Cosmos Diagnostics",
+    diagnosticStartTime: new Date().toLocaleString(),
     durationInMs: new Date().getTime() - _startTime,
-    data: message,
-  });
+    activityId: "",
+    requestCharge: 0,
+    transportRequestTimeline: {},
+    data: data,
+  };
+  return header;
 }
 /**
  * @internal
  */
 export function getdiagnosticsdurationMilliseconds(): number | undefined {
-  if (_diagnosticHeaders.length > 0) {
-    return Number(_diagnosticHeaders[_diagnosticHeaders.length - 1].durationInMs);
+  if (_diagnosticHeader.length > 0) {
+    return Number(_diagnosticHeader[_diagnosticHeader.length - 1].durationInMs);
   }
   return undefined;
 }
@@ -34,25 +50,31 @@ export function getdiagnosticsdurationMilliseconds(): number | undefined {
  * @internal
  */
 export function getCosmosDiagnosticsToString(): string {
-  if (_diagnosticHeaders !== undefined) {
-    return JSON.stringify(_diagnosticHeaders);
+  if (_diagnosticHeader !== undefined) {
+    return JSON.stringify(_diagnosticHeader);
   }
-  setDiagnostics(defaultHeaders);
-  return JSON.stringify(_diagnosticHeaders);
+  setDiagnostics(_defaultHeader);
+  return JSON.stringify(_diagnosticHeader);
 }
 
 export function getDiagnosticsRaw(): string {
-  if (_diagnosticHeaders.length > 0) {
+  if (_diagnosticHeader.length > 0) {
     return JSON.stringify(
-      _diagnosticHeaders.map((diagnostic) => {
-        return JSON.stringify(diagnostic.excpetion);
+      _diagnosticHeader.map((diagnostic) => {
+        return JSON.stringify(diagnostic.data);
       })
     );
   }
-  setDiagnostics(defaultHeaders);
-  return JSON.stringify(_diagnosticHeaders);
+  setDiagnostics(_defaultHeader);
+  return JSON.stringify(_diagnosticHeader);
 }
 
-export interface DiagnosticHeaders {
-  [key: string]: string | boolean | number | any;
+export interface DiagnosticHeader {
+  cosmosdiagnostics: string;
+  diagnosticStartTime: string;
+  durationInMs: number;
+  activityId: string;
+  requestCharge?: number;
+  transportRequestTimeline?: any;
+  data?: any;
 }

--- a/sdk/cosmosdb/cosmos/src/diagnostics/Diagnostics.ts
+++ b/sdk/cosmosdb/cosmos/src/diagnostics/Diagnostics.ts
@@ -33,7 +33,11 @@ export function getdiagnosticsdurationMilliseconds(): number | undefined {
 /**
  * @internal
  */
-export function getCosmosDiagnostics(): string {
+export function getCosmosDiagnosticsToString(): string {
+  if (_diagnosticHeaders !== undefined) {
+    return JSON.stringify(_diagnosticHeaders);
+  }
+  setDiagnostics(defaultHeaders);
   return JSON.stringify(_diagnosticHeaders);
 }
 
@@ -45,6 +49,7 @@ export function getDiagnosticsRaw(): string {
       })
     );
   }
+  setDiagnostics(defaultHeaders);
   return JSON.stringify(_diagnosticHeaders);
 }
 

--- a/sdk/cosmosdb/cosmos/src/diagnostics/Diagnostics.ts
+++ b/sdk/cosmosdb/cosmos/src/diagnostics/Diagnostics.ts
@@ -7,6 +7,7 @@ const _defaultHeader: DiagnosticHeader = {
   diagnosticStartTime: new Date().toLocaleString(),
   durationInMs: new Date().getTime() - _startTime,
   activityId: "",
+  data: [""],
   requestCharge: "0",
   transportRequestTimeline: {},
   contactedRegions: "",
@@ -16,10 +17,10 @@ const _diagnosticHeader: DiagnosticHeader = _defaultHeader;
 /**
  * @internal
  */
-export function setDiagnostics(message?: string | DiagnosticHeader) {
-  if (!_diagnosticHeader.data) {
-    _diagnosticHeader.data = [_defaultHeader];
-  }
+export function setDiagnostics(message?: string) {
+  // if (!_diagnosticHeader.data) {
+  //   _diagnosticHeader.data = [parseDiagnosticHeader(_defaultHeader)];
+  // }
   if (typeof message === "string") {
     _diagnosticHeader.data.push(parseDiagnosticHeader(message));
   }
@@ -83,20 +84,19 @@ function parseTransportRequestTimeline(data: string): string {
 /**
  * @internal
  */
-function parseDiagnosticHeader(data: string): DiagnosticHeader {
+function parseDiagnosticHeader(data: string): string {
   const header: DiagnosticHeader = {
     cosmosdiagnostics: "Started Cosmos Diagnostics",
     diagnosticStartTime: new Date().toLocaleString(),
     durationInMs: new Date().getTime() - _startTime,
     activityId: parseActivityId(data), //parseDiagnosticMessage(data),
+    data: [""],
     requestCharge: parseRequestCharge(data),
     transportRequestTimeline: parseTransportRequestTimeline(data),
     contactedRegions: parseContactedRegions(data),
   };
-  if (header.data) {
-    header.data.push(parseDiagnosticHeader(data));
-  }
-  return header;
+  header.data.push(data);
+  return JSON.stringify(header);
 }
 
 /*
@@ -113,11 +113,11 @@ export function getdiagnosticsdurationMilliseconds(): number {
  * @internal
  */
 export function getCosmosDiagnosticsToString(): string {
-  if (_diagnosticHeader) {
-    return String(_diagnosticHeader);
-  }
-  setDiagnostics(_defaultHeader);
-  return String(_diagnosticHeader);
+  // if (_diagnosticHeader) {
+  //   return JSON.stringify(_diagnosticHeader);
+  // }
+  //setDiagnostics(_defaultHeader);
+  return JSON.stringify(_diagnosticHeader);
 }
 
 /**
@@ -135,8 +135,8 @@ export interface DiagnosticHeader {
   diagnosticStartTime: string;
   durationInMs: number;
   activityId: string;
+  data: [string];
   requestCharge?: string;
   transportRequestTimeline?: any;
   contactedRegions?: string;
-  data?: [DiagnosticHeader];
 }

--- a/sdk/cosmosdb/cosmos/src/queryExecutionContext/defaultQueryExecutionContext.ts
+++ b/sdk/cosmosdb/cosmos/src/queryExecutionContext/defaultQueryExecutionContext.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 import { AzureLogger, createClientLogger } from "@azure/logger";
 import { Constants } from "../common";
+import { CosmosException } from "../diagnostics/CosmosException";
 import { ClientSideMetrics, QueryMetrics } from "../queryMetrics";
 import { FeedOptions, Response } from "../request";
 import { getInitialHeader } from "./headerUtils";
@@ -157,7 +158,7 @@ export class DefaultQueryExecutionContext implements ExecutionContext {
       this.state = DefaultQueryExecutionContext.STATES.ended;
       // return callback(err, undefined, responseHeaders);
       // TODO: Error and data being returned is an antipattern, this might broken
-      throw err;
+      throw new CosmosException("Error and data being returned is an antipattern");
     }
 
     this.state = DefaultQueryExecutionContext.STATES.inProgress;

--- a/sdk/cosmosdb/cosmos/src/queryExecutionContext/documentProducer.ts
+++ b/sdk/cosmosdb/cosmos/src/queryExecutionContext/documentProducer.ts
@@ -10,7 +10,7 @@ import {
   StatusCodes,
   SubStatusCodes,
 } from "../common";
-import { recordDiagnostics} from "../diagnostics/CosmosDiagnostics";
+import { CosmosException } from "../diagnostics/CosmosException";
 import { FeedOptions } from "../request";
 import { Response } from "../request";
 import { DefaultQueryExecutionContext } from "./defaultQueryExecutionContext";
@@ -143,7 +143,7 @@ export class DocumentProducer {
   }
 
   private static _needPartitionKeyRangeCacheRefresh(error: any): boolean {
-     recordDiagnostics({"cosmos-diagnostics-needPartitionKeyRangeCacheRefresh-error": error});
+     CosmosException.record({"cosmos-diagnostics-needPartitionKeyRangeCacheRefresh-error": error});
     return (
       error.code === StatusCodes.Gone &&
       "substatus" in error &&

--- a/sdk/cosmosdb/cosmos/src/queryExecutionContext/documentProducer.ts
+++ b/sdk/cosmosdb/cosmos/src/queryExecutionContext/documentProducer.ts
@@ -10,7 +10,7 @@ import {
   StatusCodes,
   SubStatusCodes,
 } from "../common";
-import { CosmosException } from "../diagnostics/CosmosException";
+import { setDiagnostics } from "../diagnostics/Diagnostics";
 import { FeedOptions } from "../request";
 import { Response } from "../request";
 import { DefaultQueryExecutionContext } from "./defaultQueryExecutionContext";
@@ -147,7 +147,7 @@ export class DocumentProducer {
       error.code === StatusCodes.Gone &&
       "substatus" in error &&
       error["substatus"] === SubStatusCodes.PartitionKeyRangeGone;
-    new CosmosException(error);
+    setDiagnostics(`${error}`);
     return error;
   }
 

--- a/sdk/cosmosdb/cosmos/src/queryExecutionContext/documentProducer.ts
+++ b/sdk/cosmosdb/cosmos/src/queryExecutionContext/documentProducer.ts
@@ -10,7 +10,6 @@ import {
   StatusCodes,
   SubStatusCodes,
 } from "../common";
-import { CosmosException } from "../diagnostics/CosmosException";
 import { FeedOptions } from "../request";
 import { Response } from "../request";
 import { DefaultQueryExecutionContext } from "./defaultQueryExecutionContext";
@@ -143,7 +142,6 @@ export class DocumentProducer {
   }
 
   private static _needPartitionKeyRangeCacheRefresh(error: any): boolean {
-     CosmosException.record({"cosmos-diagnostics-needPartitionKeyRangeCacheRefresh-error": error});
     return (
       error.code === StatusCodes.Gone &&
       "substatus" in error &&

--- a/sdk/cosmosdb/cosmos/src/queryExecutionContext/documentProducer.ts
+++ b/sdk/cosmosdb/cosmos/src/queryExecutionContext/documentProducer.ts
@@ -10,6 +10,7 @@ import {
   StatusCodes,
   SubStatusCodes,
 } from "../common";
+import { CosmosException } from "../diagnostics/CosmosException";
 import { FeedOptions } from "../request";
 import { Response } from "../request";
 import { DefaultQueryExecutionContext } from "./defaultQueryExecutionContext";
@@ -142,11 +143,12 @@ export class DocumentProducer {
   }
 
   private static _needPartitionKeyRangeCacheRefresh(error: any): boolean {
-    return (
+    error =
       error.code === StatusCodes.Gone &&
       "substatus" in error &&
-      error["substatus"] === SubStatusCodes.PartitionKeyRangeGone
-    );
+      error["substatus"] === SubStatusCodes.PartitionKeyRangeGone;
+    new CosmosException(error);
+    return error;
   }
 
   /**

--- a/sdk/cosmosdb/cosmos/src/queryExecutionContext/documentProducer.ts
+++ b/sdk/cosmosdb/cosmos/src/queryExecutionContext/documentProducer.ts
@@ -10,6 +10,7 @@ import {
   StatusCodes,
   SubStatusCodes,
 } from "../common";
+import { recordDiagnostics} from "../diagnostics/CosmosDiagnostics";
 import { FeedOptions } from "../request";
 import { Response } from "../request";
 import { DefaultQueryExecutionContext } from "./defaultQueryExecutionContext";
@@ -142,7 +143,7 @@ export class DocumentProducer {
   }
 
   private static _needPartitionKeyRangeCacheRefresh(error: any): boolean {
-    // TODO: error
+     recordDiagnostics({"cosmos-diagnostics-needPartitionKeyRangeCacheRefresh-error": error});
     return (
       error.code === StatusCodes.Gone &&
       "substatus" in error &&

--- a/sdk/cosmosdb/cosmos/src/queryExecutionContext/parallelQueryExecutionContextBase.ts
+++ b/sdk/cosmosdb/cosmos/src/queryExecutionContext/parallelQueryExecutionContextBase.ts
@@ -15,6 +15,7 @@ import { ExecutionContext } from "./ExecutionContext";
 import { getInitialHeader, mergeHeaders } from "./headerUtils";
 import { SqlQuerySpec } from "./SqlQuerySpec";
 import { CosmosException } from "../diagnostics/CosmosException";
+import { setDiagnostics } from "../diagnostics/Diagnostics";
 
 /** @hidden */
 const logger: AzureLogger = createClientLogger("parallelQueryExecutionContextBase");
@@ -278,7 +279,7 @@ export abstract class ParallelQueryExecutionContextBase implements ExecutionCont
       "substatus" in error &&
       error["substatus"] === SubStatusCodes.PartitionKeyRangeGone;
 
-    new CosmosException(
+    setDiagnostics(
       `queryExecutionContext.parallelQueryExecutionContextBase._needPartitionKeyRangeCacheRefresh : ${error}`
     );
     return error;

--- a/sdk/cosmosdb/cosmos/src/queryExecutionContext/parallelQueryExecutionContextBase.ts
+++ b/sdk/cosmosdb/cosmos/src/queryExecutionContext/parallelQueryExecutionContextBase.ts
@@ -14,7 +14,7 @@ import { DocumentProducer } from "./documentProducer";
 import { ExecutionContext } from "./ExecutionContext";
 import { getInitialHeader, mergeHeaders } from "./headerUtils";
 import { SqlQuerySpec } from "./SqlQuerySpec";
-import { recordDiagnostics } from "../diagnostics/CosmosDiagnostics";
+import { CosmosException } from "../diagnostics/CosmosException";
 
 /** @hidden */
 const logger: AzureLogger = createClientLogger("parallelQueryExecutionContextBase");
@@ -271,7 +271,7 @@ export abstract class ParallelQueryExecutionContextBase implements ExecutionCont
   }
 
   private static _needPartitionKeyRangeCacheRefresh(error: any): boolean {
-    recordDiagnostics({"cosmos-diagnostics-needPartitionKeyRangeCacheRefresh-error": error});
+    CosmosException.record({"cosmos-diagnostics-needPartitionKeyRangeCacheRefresh-error": error});
     return (
       error.code === StatusCodes.Gone &&
       "substatus" in error &&

--- a/sdk/cosmosdb/cosmos/src/queryExecutionContext/parallelQueryExecutionContextBase.ts
+++ b/sdk/cosmosdb/cosmos/src/queryExecutionContext/parallelQueryExecutionContextBase.ts
@@ -14,6 +14,7 @@ import { DocumentProducer } from "./documentProducer";
 import { ExecutionContext } from "./ExecutionContext";
 import { getInitialHeader, mergeHeaders } from "./headerUtils";
 import { SqlQuerySpec } from "./SqlQuerySpec";
+import { recordDiagnostics } from "../diagnostics/CosmosDiagnostics";
 
 /** @hidden */
 const logger: AzureLogger = createClientLogger("parallelQueryExecutionContextBase");
@@ -270,7 +271,7 @@ export abstract class ParallelQueryExecutionContextBase implements ExecutionCont
   }
 
   private static _needPartitionKeyRangeCacheRefresh(error: any): boolean {
-    // TODO: any error
+    recordDiagnostics({"cosmos-diagnostics-needPartitionKeyRangeCacheRefresh-error": error});
     return (
       error.code === StatusCodes.Gone &&
       "substatus" in error &&

--- a/sdk/cosmosdb/cosmos/src/queryIterator.ts
+++ b/sdk/cosmosdb/cosmos/src/queryIterator.ts
@@ -219,8 +219,7 @@ export class QueryIterator<T> {
     const queryPlan = queryPlanResponse.result;
     const queryInfo = queryPlan.queryInfo;
     if (queryInfo.aggregates.length > 0 && queryInfo.hasSelectValue === false) {
-      const err = new CosmosException("Aggregate queries must use the VALUE keyword");
-      throw err;
+      throw new CosmosException("Aggregate queries must use the VALUE keyword");
     }
     this.queryExecutionContext = new PipelinedQueryExecutionContext(
       this.clientContext,
@@ -284,7 +283,7 @@ export class QueryIterator<T> {
       );
       error.response.code = 503;
       error.response.originalError = err;
-      throw new CosmosException(error);
+      new CosmosException(error);
     } else {
       throw new CosmosException(err);
     }

--- a/sdk/cosmosdb/cosmos/src/queryIterator.ts
+++ b/sdk/cosmosdb/cosmos/src/queryIterator.ts
@@ -283,7 +283,7 @@ export class QueryIterator<T> {
       );
       error.response.code = 503;
       error.response.originalError = err;
-      new CosmosException(error);
+      throw new CosmosException(error);
     } else {
       throw new CosmosException(err);
     }

--- a/sdk/cosmosdb/cosmos/src/request/ErrorResponse.ts
+++ b/sdk/cosmosdb/cosmos/src/request/ErrorResponse.ts
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
+import { CosmosException } from "../diagnostics/CosmosException";
 import { CosmosHeaders } from "../index";
 
 export interface ErrorBody {
@@ -55,7 +56,7 @@ export interface GroupByAliasToAggregateType {
   [key: string]: AggregateType;
 }
 
-export interface ErrorResponse extends Error {
+export interface ErrorResponse extends CosmosException {
   code?: number;
   substatus?: number;
   body?: ErrorBody;

--- a/sdk/cosmosdb/cosmos/src/request/ErrorResponse.ts
+++ b/sdk/cosmosdb/cosmos/src/request/ErrorResponse.ts
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
-import { CosmosException } from "../diagnostics/CosmosException";
 import { CosmosHeaders } from "../index";
 
 export interface ErrorBody {
@@ -56,7 +55,7 @@ export interface GroupByAliasToAggregateType {
   [key: string]: AggregateType;
 }
 
-export interface ErrorResponse extends CosmosException {
+export interface ErrorResponse {
   code?: number;
   substatus?: number;
   body?: ErrorBody;

--- a/sdk/cosmosdb/cosmos/src/request/FeedResponse.ts
+++ b/sdk/cosmosdb/cosmos/src/request/FeedResponse.ts
@@ -12,6 +12,16 @@ export class FeedResponse<TResource> extends CosmosDiagnostics {
   ) {
     super();
   }
+
+  public getcosmosDiagnosticsRegionsContacted() {
+    return this.getRegionsContacted();
+  }
+  public getcosmosDiagnostisDurationInMs() {
+    return this.getDuration();
+  }
+  public getcosmosDiagnostics(): string {
+    return this.getCosmosDiagnostics();
+  }
   public get continuation(): string {
     return this.continuationToken;
   }

--- a/sdk/cosmosdb/cosmos/src/request/FeedResponse.ts
+++ b/sdk/cosmosdb/cosmos/src/request/FeedResponse.ts
@@ -1,11 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 import { Constants } from "../common";
-import { CosmosDiagnostic } from "../diagnostics/CosmosDiagnostics";
+import { CosmosDiagnostics } from "../diagnostics/CosmosDiagnostics";
 import { CosmosHeaders } from "../queryExecutionContext";
 
-export class FeedResponse<TResource> extends CosmosDiagnostic {
-  cosmosdiagnostics = new CosmosDiagnostic();
+export class FeedResponse<TResource> extends CosmosDiagnostics {
   constructor(
     public readonly resources: TResource[],
     private readonly headers: CosmosHeaders,

--- a/sdk/cosmosdb/cosmos/src/request/FeedResponse.ts
+++ b/sdk/cosmosdb/cosmos/src/request/FeedResponse.ts
@@ -5,7 +5,6 @@ import { CosmosException } from "../diagnostics/CosmosException";
 import { CosmosHeaders } from "../queryExecutionContext";
 
 export class FeedResponse<TResource> {
-  diagnostics: any;
   constructor(
     public readonly resources: TResource[],
     private readonly headers: CosmosHeaders,
@@ -26,7 +25,10 @@ export class FeedResponse<TResource> {
   public get activityId(): string {
     return this.headers[Constants.HttpHeaders.ActivityId];
   }
-  get getDiagnostics(): string {
-    return CosmosException.getDiagnostics();
+  public get getDiagnostics(): string {
+    return CosmosException.getdiagnostics();
+  }
+  public get getDuration() {
+    return CosmosException.getduration();
   }
 }

--- a/sdk/cosmosdb/cosmos/src/request/FeedResponse.ts
+++ b/sdk/cosmosdb/cosmos/src/request/FeedResponse.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 import { Constants } from "../common";
-import { diagnosticToString } from "../diagnostics/CosmosDiagnostics";
+import { CosmosException } from "../diagnostics/CosmosException";
 import { CosmosHeaders } from "../queryExecutionContext";
 
 export class FeedResponse<TResource> {
@@ -26,7 +26,7 @@ export class FeedResponse<TResource> {
   public get activityId(): string {
     return this.headers[Constants.HttpHeaders.ActivityId];
   }
-  get diagnosticsToString(): string {
-    return diagnosticToString();
+  get getDiagnostics(): string {
+    return CosmosException.getDiagnostics();
   }
 }

--- a/sdk/cosmosdb/cosmos/src/request/FeedResponse.ts
+++ b/sdk/cosmosdb/cosmos/src/request/FeedResponse.ts
@@ -1,15 +1,18 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 import { Constants } from "../common";
-import { CosmosException } from "../diagnostics/CosmosException";
+import { CosmosDiagnostic } from "../diagnostics/CosmosDiagnostics";
 import { CosmosHeaders } from "../queryExecutionContext";
 
-export class FeedResponse<TResource> {
+export class FeedResponse<TResource> extends CosmosDiagnostic {
+  cosmosdiagnostics = new CosmosDiagnostic();
   constructor(
     public readonly resources: TResource[],
     private readonly headers: CosmosHeaders,
     public readonly hasMoreResults: boolean
-  ) {}
+  ) {
+    super();
+  }
   public get continuation(): string {
     return this.continuationToken;
   }
@@ -24,11 +27,5 @@ export class FeedResponse<TResource> {
   }
   public get activityId(): string {
     return this.headers[Constants.HttpHeaders.ActivityId];
-  }
-  public get getDiagnostics(): string {
-    return CosmosException.getdiagnostics();
-  }
-  public get getDuration() {
-    return CosmosException.getduration();
   }
 }

--- a/sdk/cosmosdb/cosmos/src/request/FeedResponse.ts
+++ b/sdk/cosmosdb/cosmos/src/request/FeedResponse.ts
@@ -1,9 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 import { Constants } from "../common";
+import { diagnosticToString } from "../diagnostics/CosmosDiagnostics";
 import { CosmosHeaders } from "../queryExecutionContext";
 
 export class FeedResponse<TResource> {
+  diagnostics: any;
   constructor(
     public readonly resources: TResource[],
     private readonly headers: CosmosHeaders,
@@ -23,5 +25,8 @@ export class FeedResponse<TResource> {
   }
   public get activityId(): string {
     return this.headers[Constants.HttpHeaders.ActivityId];
+  }
+  get diagnosticsToString(): string {
+    return diagnosticToString();
   }
 }

--- a/sdk/cosmosdb/cosmos/src/request/RequestHandler.ts
+++ b/sdk/cosmosdb/cosmos/src/request/RequestHandler.ts
@@ -18,7 +18,7 @@ import { Response as CosmosResponse } from "./Response";
 import { TimeoutError } from "./TimeoutError";
 import { getCachedDefaultHttpClient } from "../utils/cachedClient";
 import { AzureLogger, createClientLogger } from "@azure/logger";
-import { recordDiagnostics } from "../diagnostics/CosmosDiagnostics";
+import { CosmosException } from "../diagnostics/CosmosException";
 
 const logger: AzureLogger = createClientLogger("RequestHandler");
 
@@ -108,7 +108,7 @@ async function httpRequest(requestContext: RequestContext): Promise<{
 
   if (response.status >= 400) {
     const errorResponse: ErrorResponse = new Error(result.message);
-      recordDiagnostics({ "cosmos-diagnostics-request-error": JSON.stringify(Error(result.message))});
+      CosmosException.record({ "cosmos-diagnostics-request-error": JSON.stringify(Error(result.message))});
 
     logger.warning(
       response.status +

--- a/sdk/cosmosdb/cosmos/src/request/RequestHandler.ts
+++ b/sdk/cosmosdb/cosmos/src/request/RequestHandler.ts
@@ -18,7 +18,6 @@ import { TimeoutError } from "./TimeoutError";
 import { getCachedDefaultHttpClient } from "../utils/cachedClient";
 import { AzureLogger, createClientLogger } from "@azure/logger";
 import { CosmosException } from "../diagnostics/CosmosException";
-import { CosmosDiagnostic } from "../diagnostics/CosmosDiagnostics";
 
 const logger: AzureLogger = createClientLogger("RequestHandler");
 
@@ -108,7 +107,7 @@ async function httpRequest(requestContext: RequestContext): Promise<{
 
   if (response.status >= 400) {
     const error = new CosmosException(result.message);
-    logger.warning(CosmosDiagnostic.toString());
+    logger.warning(error.getDiagnostics());
     error.response = response;
 
     error.response.code = response.status;

--- a/sdk/cosmosdb/cosmos/src/request/RequestHandler.ts
+++ b/sdk/cosmosdb/cosmos/src/request/RequestHandler.ts
@@ -18,6 +18,7 @@ import { Response as CosmosResponse } from "./Response";
 import { TimeoutError } from "./TimeoutError";
 import { getCachedDefaultHttpClient } from "../utils/cachedClient";
 import { AzureLogger, createClientLogger } from "@azure/logger";
+import { recordDiagnostics } from "../diagnostics/CosmosDiagnostics";
 
 const logger: AzureLogger = createClientLogger("RequestHandler");
 
@@ -107,6 +108,7 @@ async function httpRequest(requestContext: RequestContext): Promise<{
 
   if (response.status >= 400) {
     const errorResponse: ErrorResponse = new Error(result.message);
+      recordDiagnostics({ "cosmos-diagnostics-request-error": JSON.stringify(Error(result.message))});
 
     logger.warning(
       response.status +

--- a/sdk/cosmosdb/cosmos/src/request/RequestHandler.ts
+++ b/sdk/cosmosdb/cosmos/src/request/RequestHandler.ts
@@ -18,6 +18,7 @@ import { TimeoutError } from "./TimeoutError";
 import { getCachedDefaultHttpClient } from "../utils/cachedClient";
 import { AzureLogger, createClientLogger } from "@azure/logger";
 import { CosmosException } from "../diagnostics/CosmosException";
+import { setDiagnostics } from "../diagnostics/Diagnostics";
 
 const logger: AzureLogger = createClientLogger("RequestHandler");
 
@@ -87,12 +88,14 @@ async function httpRequest(requestContext: RequestContext): Promise<{
       // If the user passed signal caused the abort, cancel the timeout and rethrow the error
       if (userSignal && userSignal.aborted === true) {
         clearTimeout(timeout);
-        throw new CosmosException(error);
+        setDiagnostics(`${error}`);
+        throw error;
       }
       // If the user didn't cancel, it must be an abort we called due to timeout
       throw new CosmosException(new TimeoutError());
     }
-    throw new CosmosException(error);
+    setDiagnostics(`${error}`);
+    throw error;
   }
 
   clearTimeout(timeout);

--- a/sdk/cosmosdb/cosmos/src/request/ResourceResponse.ts
+++ b/sdk/cosmosdb/cosmos/src/request/ResourceResponse.ts
@@ -5,6 +5,7 @@ import { Constants } from "../common";
 import {
   getCosmosDiagnosticsToString,
   getdiagnosticsdurationMilliseconds,
+  getRegionsContacted,
 } from "../diagnostics/Diagnostics";
 import { CosmosHeaders } from "../queryExecutionContext/CosmosHeaders";
 import { StatusCode, SubStatusCode } from "./StatusCodes";
@@ -17,7 +18,7 @@ export class ResourceResponse<TResource> {
     public readonly substatus?: SubStatusCode
   ) {}
   public get cosmosDiagnosticsRegionsContacted(): string {
-    return getCosmosDiagnosticsToString();
+    return getRegionsContacted();
   }
   public get cosmosDiagnostisDurationInMs(): number {
     return getdiagnosticsdurationMilliseconds();

--- a/sdk/cosmosdb/cosmos/src/request/ResourceResponse.ts
+++ b/sdk/cosmosdb/cosmos/src/request/ResourceResponse.ts
@@ -2,17 +2,19 @@
 // Licensed under the MIT license.
 
 import { Constants } from "../common";
-import { CosmosException } from "../diagnostics/CosmosException";
+import { CosmosDiagnostic } from "../diagnostics/CosmosDiagnostics";
 import { CosmosHeaders } from "../queryExecutionContext/CosmosHeaders";
 import { StatusCode, SubStatusCode } from "./StatusCodes";
 
-export class ResourceResponse<TResource> {
+export class ResourceResponse<TResource> extends CosmosDiagnostic {
   constructor(
     public readonly resource: TResource | undefined,
     public readonly headers: CosmosHeaders,
     public readonly statusCode: StatusCode,
-    public readonly substatus?: SubStatusCode,
-  ) {}
+    public readonly substatus?: SubStatusCode
+  ) {
+    super();
+  }
   public get requestCharge(): number {
     return Number(this.headers[Constants.HttpHeaders.RequestCharge]) || 0;
   }
@@ -21,11 +23,5 @@ export class ResourceResponse<TResource> {
   }
   public get etag(): string {
     return this.headers[Constants.HttpHeaders.ETag] as string;
-  }
-  get getDiagnostics(): string {
-    return CosmosException.getdiagnostics();
-  }
-   public get getDuration() {
-    return CosmosException.getduration();
   }
 }

--- a/sdk/cosmosdb/cosmos/src/request/ResourceResponse.ts
+++ b/sdk/cosmosdb/cosmos/src/request/ResourceResponse.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 
 import { Constants } from "../common";
-import { diagnosticToString } from "../diagnostics/CosmosDiagnostics";
+import { CosmosException } from "../diagnostics/CosmosException";
 import { CosmosHeaders } from "../queryExecutionContext/CosmosHeaders";
 import { StatusCode, SubStatusCode } from "./StatusCodes";
 
@@ -22,7 +22,7 @@ export class ResourceResponse<TResource> {
   public get etag(): string {
     return this.headers[Constants.HttpHeaders.ETag] as string;
   }
- public get diagnosticsToString(): string {
-    return diagnosticToString();
+  get getDiagnostics(): string {
+    return CosmosException.getDiagnostics();
   }
 }

--- a/sdk/cosmosdb/cosmos/src/request/ResourceResponse.ts
+++ b/sdk/cosmosdb/cosmos/src/request/ResourceResponse.ts
@@ -23,6 +23,9 @@ export class ResourceResponse<TResource> {
     return this.headers[Constants.HttpHeaders.ETag] as string;
   }
   get getDiagnostics(): string {
-    return CosmosException.getDiagnostics();
+    return CosmosException.getdiagnostics();
+  }
+   public get getDuration() {
+    return CosmosException.getduration();
   }
 }

--- a/sdk/cosmosdb/cosmos/src/request/ResourceResponse.ts
+++ b/sdk/cosmosdb/cosmos/src/request/ResourceResponse.ts
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
+
 import { Constants } from "../common";
+import { diagnosticToString } from "../diagnostics/CosmosDiagnostics";
 import { CosmosHeaders } from "../queryExecutionContext/CosmosHeaders";
 import { StatusCode, SubStatusCode } from "./StatusCodes";
 
@@ -9,7 +11,7 @@ export class ResourceResponse<TResource> {
     public readonly resource: TResource | undefined,
     public readonly headers: CosmosHeaders,
     public readonly statusCode: StatusCode,
-    public readonly substatus?: SubStatusCode
+    public readonly substatus?: SubStatusCode,
   ) {}
   public get requestCharge(): number {
     return Number(this.headers[Constants.HttpHeaders.RequestCharge]) || 0;
@@ -19,5 +21,8 @@ export class ResourceResponse<TResource> {
   }
   public get etag(): string {
     return this.headers[Constants.HttpHeaders.ETag] as string;
+  }
+ public get diagnosticsToString(): string {
+    return diagnosticToString();
   }
 }

--- a/sdk/cosmosdb/cosmos/src/request/ResourceResponse.ts
+++ b/sdk/cosmosdb/cosmos/src/request/ResourceResponse.ts
@@ -2,18 +2,29 @@
 // Licensed under the MIT license.
 
 import { Constants } from "../common";
-import { CosmosDiagnostic } from "../diagnostics/CosmosDiagnostics";
+import {
+  DiagnosticHeaders,
+  getCosmosDiagnosticsToString,
+  getdiagnosticsdurationMilliseconds,
+} from "../diagnostics/Diagnostics";
 import { CosmosHeaders } from "../queryExecutionContext/CosmosHeaders";
 import { StatusCode, SubStatusCode } from "./StatusCodes";
 
-export class ResourceResponse<TResource> extends CosmosDiagnostic {
+export class ResourceResponse<TResource> {
   constructor(
     public readonly resource: TResource | undefined,
     public readonly headers: CosmosHeaders,
     public readonly statusCode: StatusCode,
     public readonly substatus?: SubStatusCode
-  ) {
-    super();
+  ) {}
+  public get cosmosDiagnosticsRegionsContacted(): DiagnosticHeaders {
+    return {};
+  }
+  public get cosmosDiagnostisDurationInMs(): number {
+    return getdiagnosticsdurationMilliseconds();
+  }
+  public get cosmosDiagnostics(): string {
+    return getCosmosDiagnosticsToString();
   }
   public get requestCharge(): number {
     return Number(this.headers[Constants.HttpHeaders.RequestCharge]) || 0;

--- a/sdk/cosmosdb/cosmos/src/request/ResourceResponse.ts
+++ b/sdk/cosmosdb/cosmos/src/request/ResourceResponse.ts
@@ -3,7 +3,6 @@
 
 import { Constants } from "../common";
 import {
-  DiagnosticHeaders,
   getCosmosDiagnosticsToString,
   getdiagnosticsdurationMilliseconds,
 } from "../diagnostics/Diagnostics";
@@ -17,8 +16,8 @@ export class ResourceResponse<TResource> {
     public readonly statusCode: StatusCode,
     public readonly substatus?: SubStatusCode
   ) {}
-  public get cosmosDiagnosticsRegionsContacted(): DiagnosticHeaders {
-    return {};
+  public get cosmosDiagnosticsRegionsContacted(): string {
+    return getCosmosDiagnosticsToString();
   }
   public get cosmosDiagnostisDurationInMs(): number {
     return getdiagnosticsdurationMilliseconds();

--- a/sdk/cosmosdb/cosmos/src/request/ResourceResponse.ts
+++ b/sdk/cosmosdb/cosmos/src/request/ResourceResponse.ts
@@ -2,29 +2,28 @@
 // Licensed under the MIT license.
 
 import { Constants } from "../common";
-import {
-  getCosmosDiagnosticsToString,
-  getdiagnosticsdurationMilliseconds,
-  getRegionsContacted,
-} from "../diagnostics/Diagnostics";
+import { CosmosDiagnostics } from "../diagnostics/CosmosDiagnostics";
 import { CosmosHeaders } from "../queryExecutionContext/CosmosHeaders";
 import { StatusCode, SubStatusCode } from "./StatusCodes";
 
-export class ResourceResponse<TResource> {
+export class ResourceResponse<TResource> extends CosmosDiagnostics {
   constructor(
     public readonly resource: TResource | undefined,
     public readonly headers: CosmosHeaders,
     public readonly statusCode: StatusCode,
     public readonly substatus?: SubStatusCode
-  ) {}
-  public get cosmosDiagnosticsRegionsContacted(): string {
-    return getRegionsContacted();
+  ) {
+    super();
   }
-  public get cosmosDiagnostisDurationInMs(): number {
-    return getdiagnosticsdurationMilliseconds();
+  public getcosmosDiagnosticsRegionsContacted() {
+    return this.getRegionsContacted();
   }
-  public get cosmosDiagnostics(): string {
-    return getCosmosDiagnosticsToString();
+  public getcosmosDiagnostisDurationInMs() {
+    return this.getDuration();
+  }
+  public getcosmosDiagnostics(): string {
+    console.log(this.getCosmosDiagnostics());
+    return this.getCosmosDiagnostics();
   }
   public get requestCharge(): number {
     return Number(this.headers[Constants.HttpHeaders.RequestCharge]) || 0;

--- a/sdk/cosmosdb/cosmos/src/retry/retryUtility.ts
+++ b/sdk/cosmosdb/cosmos/src/retry/retryUtility.ts
@@ -100,7 +100,7 @@ export async function execute({
     } else {
       retryPolicy = retryPolicies.defaultRetryPolicy;
     }
-    CosmosException.record({"cosmos-diagnostics-shouldRetry-error": err.message});
+    new CosmosException(err.message);
     const results = await retryPolicy.shouldRetry(err, retryContext, requestContext.endpoint);
     if (!results) {
       headers[Constants.ThrottleRetryCount] =
@@ -108,7 +108,8 @@ export async function execute({
       headers[Constants.ThrottleRetryWaitTimeInMs] =
         retryPolicies.resourceThrottleRetryPolicy.cummulativeWaitTimeinMs;
       err.headers = { ...err.headers, ...headers };
-      CosmosException.record({"cosmos-diagnostics-retry-error": err});
+      new CosmosException(err.message);
+      new CosmosException(err);
       throw err;
     } else {
       requestContext.retryCount++;

--- a/sdk/cosmosdb/cosmos/src/retry/retryUtility.ts
+++ b/sdk/cosmosdb/cosmos/src/retry/retryUtility.ts
@@ -3,7 +3,7 @@
 import { Constants } from "../common/constants";
 import { sleep } from "../common/helper";
 import { StatusCodes, SubStatusCodes } from "../common/statusCodes";
-import { recordDiagnostics } from "../diagnostics/CosmosDiagnostics";
+import { CosmosException } from "../diagnostics/CosmosException";
 import { Response } from "../request";
 import { RequestContext } from "../request/RequestContext";
 import { DefaultRetryPolicy } from "./defaultRetryPolicy";
@@ -100,7 +100,7 @@ export async function execute({
     } else {
       retryPolicy = retryPolicies.defaultRetryPolicy;
     }
-    recordDiagnostics({"cosmos-diagnostics-shouldRetry-error": err.message});
+    CosmosException.record({"cosmos-diagnostics-shouldRetry-error": err.message});
     const results = await retryPolicy.shouldRetry(err, retryContext, requestContext.endpoint);
     if (!results) {
       headers[Constants.ThrottleRetryCount] =
@@ -108,7 +108,7 @@ export async function execute({
       headers[Constants.ThrottleRetryWaitTimeInMs] =
         retryPolicies.resourceThrottleRetryPolicy.cummulativeWaitTimeinMs;
       err.headers = { ...err.headers, ...headers };
-      recordDiagnostics({"cosmos-diagnostics-retry-error": err});
+      CosmosException.record({"cosmos-diagnostics-retry-error": err});
       throw err;
     } else {
       requestContext.retryCount++;

--- a/sdk/cosmosdb/cosmos/src/retry/retryUtility.ts
+++ b/sdk/cosmosdb/cosmos/src/retry/retryUtility.ts
@@ -100,7 +100,6 @@ export async function execute({
     } else {
       retryPolicy = retryPolicies.defaultRetryPolicy;
     }
-    new CosmosException(err.message);
     const results = await retryPolicy.shouldRetry(err, retryContext, requestContext.endpoint);
     if (!results) {
       headers[Constants.ThrottleRetryCount] =
@@ -108,9 +107,7 @@ export async function execute({
       headers[Constants.ThrottleRetryWaitTimeInMs] =
         retryPolicies.resourceThrottleRetryPolicy.cummulativeWaitTimeinMs;
       err.headers = { ...err.headers, ...headers };
-      new CosmosException(err.message);
-      new CosmosException(err);
-      throw err;
+      throw new CosmosException(err);
     } else {
       requestContext.retryCount++;
       const newUrl = (results as any)[1]; // TODO: any hack

--- a/sdk/cosmosdb/cosmos/src/retry/retryUtility.ts
+++ b/sdk/cosmosdb/cosmos/src/retry/retryUtility.ts
@@ -3,7 +3,7 @@
 import { Constants } from "../common/constants";
 import { sleep } from "../common/helper";
 import { StatusCodes, SubStatusCodes } from "../common/statusCodes";
-import { CosmosException } from "../diagnostics/CosmosException";
+import { setDiagnostics } from "../diagnostics/Diagnostics";
 import { Response } from "../request";
 import { RequestContext } from "../request/RequestContext";
 import { DefaultRetryPolicy } from "./defaultRetryPolicy";
@@ -107,7 +107,8 @@ export async function execute({
       headers[Constants.ThrottleRetryWaitTimeInMs] =
         retryPolicies.resourceThrottleRetryPolicy.cummulativeWaitTimeinMs;
       err.headers = { ...err.headers, ...headers };
-      throw new CosmosException(err);
+      setDiagnostics(err);
+      throw err;
     } else {
       requestContext.retryCount++;
       const newUrl = (results as any)[1]; // TODO: any hack

--- a/sdk/cosmosdb/cosmos/test/public/functional/container.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/public/functional/container.spec.ts
@@ -62,8 +62,11 @@ describe("Containers", function (this: Suite) {
           },
         ],
       };
-      const { resources: results } = await database.containers.query(querySpec).fetchAll();
+      const { resources: results, getCosmosDiagnostics } = await database.containers
+        .query(querySpec)
+        .fetchAll();
       assert(results.length > 0, "number of results for the query should be > 0");
+      console.log(getCosmosDiagnostics());
 
       const { resources: ranges } = await container.readPartitionKeyRanges().fetchAll();
       assert(ranges.length > 0, "container should have at least 1 partition");
@@ -393,7 +396,8 @@ describe("createIfNotExists", function () {
 
   it("should handle container does not exist", async function () {
     const def: ContainerDefinition = { id: "does not exist" };
-    const { container } = await database.containers.createIfNotExists(def);
+    const { container, getCosmosDiagnostics } = await database.containers.createIfNotExists(def);
+    console.log(getCosmosDiagnostics);
     const { resource: readDef } = await container.read();
     assert.equal(def.id, readDef.id);
   });

--- a/sdk/cosmosdb/cosmos/test/public/functional/item.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/public/functional/item.spec.ts
@@ -222,8 +222,8 @@ describe("Item CRUD", function (this: Suite) {
   });
 });
 
-describe("bulk/batch item operations", function () {
-  describe("with v1 container", function () {
+describe.only("bulk/batch item operations", function () {
+  describe.only("with v1 container", function () {
     let container: Container;
     let readItemId: string;
     let replaceItemId: string;
@@ -236,12 +236,17 @@ describe("bulk/batch item operations", function () {
         },
         throughput: 25100,
       });
+      afterEach(async function () {
+        //console.log(diagnosticToString);
+      });
+      
       readItemId = addEntropy("item1");
-      await container.items.create({
+      const itemResponse = await container.items.create({
         id: readItemId,
         key: "A",
         class: "2010",
       });
+      console.log(itemResponse.diagnosticsToString);
       deleteItemId = addEntropy("item2");
       await container.items.create({
         id: deleteItemId,

--- a/sdk/cosmosdb/cosmos/test/public/functional/item.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/public/functional/item.spec.ts
@@ -246,7 +246,7 @@ describe("bulk/batch item operations", function () {
         key: "A",
         class: "2010",
       });
-      console.log(itemResponse.getCosmosDiagnostics());
+      console.log(itemResponse.cosmosDiagnostics);
       deleteItemId = addEntropy("item2");
       await container.items.create({
         id: deleteItemId,

--- a/sdk/cosmosdb/cosmos/test/public/functional/item.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/public/functional/item.spec.ts
@@ -236,9 +236,7 @@ describe("bulk/batch item operations", function () {
         },
         throughput: 25100,
       });
-      afterEach(async function () {
-        //console.log(diagnosticToString);
-      });
+      afterEach(async function () {});
 
       readItemId = addEntropy("item1");
       const itemResponse = await container.items.create({

--- a/sdk/cosmosdb/cosmos/test/public/functional/item.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/public/functional/item.spec.ts
@@ -236,15 +236,12 @@ describe("bulk/batch item operations", function () {
         },
         throughput: 25100,
       });
-      afterEach(async function () {});
-
       readItemId = addEntropy("item1");
-      const itemResponse = await container.items.create({
+      await container.items.create({
         id: readItemId,
         key: "A",
         class: "2010",
       });
-      console.log(itemResponse.getcosmosDiagnostics);
       deleteItemId = addEntropy("item2");
       await container.items.create({
         id: deleteItemId,

--- a/sdk/cosmosdb/cosmos/test/public/functional/item.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/public/functional/item.spec.ts
@@ -246,7 +246,7 @@ describe.only("bulk/batch item operations", function () {
         key: "A",
         class: "2010",
       });
-      console.log(itemResponse.diagnosticsToString);
+      console.log(itemResponse.getDiagnostics);
       deleteItemId = addEntropy("item2");
       await container.items.create({
         id: deleteItemId,

--- a/sdk/cosmosdb/cosmos/test/public/functional/item.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/public/functional/item.spec.ts
@@ -222,8 +222,8 @@ describe("Item CRUD", function (this: Suite) {
   });
 });
 
-describe.only("bulk/batch item operations", function () {
-  describe.only("with v1 container", function () {
+describe("bulk/batch item operations", function () {
+  describe("with v1 container", function () {
     let container: Container;
     let readItemId: string;
     let replaceItemId: string;
@@ -239,14 +239,14 @@ describe.only("bulk/batch item operations", function () {
       afterEach(async function () {
         //console.log(diagnosticToString);
       });
-      
+
       readItemId = addEntropy("item1");
       const itemResponse = await container.items.create({
         id: readItemId,
         key: "A",
         class: "2010",
       });
-      console.log(itemResponse.getDiagnostics);
+      console.log(itemResponse.getCosmosDiagnostics());
       deleteItemId = addEntropy("item2");
       await container.items.create({
         id: deleteItemId,

--- a/sdk/cosmosdb/cosmos/test/public/functional/item.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/public/functional/item.spec.ts
@@ -244,7 +244,7 @@ describe("bulk/batch item operations", function () {
         key: "A",
         class: "2010",
       });
-      console.log(itemResponse.cosmosDiagnostics);
+      console.log(itemResponse.getcosmosDiagnostics);
       deleteItemId = addEntropy("item2");
       await container.items.create({
         id: deleteItemId,

--- a/sdk/cosmosdb/cosmos/test/public/functional/plugin.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/public/functional/plugin.spec.ts
@@ -5,6 +5,7 @@ import { RequestContext } from "../../../src";
 import { Plugin, Next, PluginConfig } from "../../../src";
 
 import * as assert from "assert";
+import { CosmosException } from "../../../src/diagnostics/CosmosException";
 
 describe("Plugin", function () {
   it("should handle all requests", async function () {
@@ -62,7 +63,7 @@ describe("Plugin", function () {
       return successResponse;
     };
     const alwaysThrow: Plugin<any> = async () => {
-      throw new Error("I always throw!");
+      throw new CosmosException("I always throw!");
     };
 
     const options: CosmosClientOptions = {

--- a/sdk/cosmosdb/cosmos/test/public/integration/diagnostics.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/public/integration/diagnostics.spec.ts
@@ -12,17 +12,17 @@ import { removeAllDatabases } from "../common/TestHelpers";
 //import { CosmosException } from "../../../src/diagnostics/CosmosException";
 //import { createOrUpsertPermission, getTestDatabase } from "../common/TestHelpers";
 
-describe.only("Cosmos Diagnostic Tests", async function (this: Suite) {
+describe("Cosmos Diagnostic Tests", async function (this: Suite) {
   this.timeout(process.env.MOCHA_TIMEOUT || 10000);
   beforeEach(async function () {
     await removeAllDatabases();
   });
 
   describe("Cosmos diagnostic test", function () {
-    it.only("should return cosmos diagnostics", async function () {
+    it("should return cosmos diagnostics", async function () {
       const client = new CosmosClient({ key: masterKey, endpoint });
       const db = await client.databases.createIfNotExists({ id: "diagnostics" });
-      console.log(db.cosmosDiagnostics);
+      console.log(db.getcosmosDiagnostics());
     });
 
     it("should handle duration condition", async function () {
@@ -33,10 +33,10 @@ describe.only("Cosmos Diagnostic Tests", async function (this: Suite) {
       console.log(diagnostics);
       assert(diagnostics);
       assert(JSON.parse(diagnostics));
-      assert(typeof readItem.cosmosDiagnostisDurationInMs === "number");
+      assert(typeof readItem.getcosmosDiagnostisDurationInMs() === "number");
       assert(
-        readItem.cosmosDiagnostisDurationInMs > 0 ||
-          readItem.cosmosDiagnostisDurationInMs === undefined
+        readItem.getcosmosDiagnostisDurationInMs() > 0 ||
+          readItem.getcosmosDiagnostisDurationInMs() === undefined
       );
       assert(!diagnostics.includes('""systemHistory":null'));
       // assert(diagnostics.includes('"RequestStats ":"Create"'));
@@ -60,8 +60,8 @@ describe.only("Cosmos Diagnostic Tests", async function (this: Suite) {
         const container: Container = database.container(containerdef.id);
         // read items
         const items = await container.items.readAll().fetchAll();
-        if (items.getDuration() > 60) {
-          assert(items.getDuration);
+        if (items.getcosmosDiagnostisDurationInMs() > 60) {
+          assert(items.getcosmosDiagnostisDurationInMs());
           throw new CosmosException(`custom message`);
         }
       } catch (err: any) {

--- a/sdk/cosmosdb/cosmos/test/public/integration/diagnostics.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/public/integration/diagnostics.spec.ts
@@ -19,26 +19,29 @@ describe.only("Cosmos Diagnostic Tests", async function (this: Suite) {
     key: masterKey,
   });
 
-  describe.only("Cosmos diagnostic test", function () {
-    it("should return cosmos diagnostics", async function () {
-      try {
-        const database = await client.databases.createIfNotExists({ id: "CosmosDiagnosticsTest" });
-        const databaseDiagnostics = database.getDiagnostics;
-        assert.notStrictEqual(undefined, databaseDiagnostics);
-        assert.strictEqual(CosmosException.getdiagnostics(), databaseDiagnostics);
-      } catch (err: any) {
-        console.log(CosmosException.getduration());
-        throw new CosmosException(err);
-      }
+  describe("Cosmos diagnostic test", function () {
+    it.only("should return cosmos diagnostics", async function () {
+      const database = await client.databases.createIfNotExists({ id: "CosmosDiagnosticsTest" });
+      const databaseDiagnostics = database.getCosmosDiagnostics;
+      console.log(databaseDiagnostics);
     });
 
     it("should handle duration condition", async function () {
       const response = await client.databases.createIfNotExists({ id: "CosmosDiagnosticsTest" });
       const readItem = await response.database.read();
+      const diagnostics = readItem.getCosmosDiagnostics();
+      console.log(diagnostics);
+      assert(diagnostics);
+      assert(JSON.parse(diagnostics));
       assert(typeof readItem.getDuration === "number");
-      assert(readItem.getDuration);
-      assert(readItem.getDuration > 0);
-      assert.notStrictEqual(undefined, readItem.getDuration, "duration not present");
+      assert(readItem.getDuration() > 0 || readItem.getDuration === undefined);
+      assert(!diagnostics.includes('""systemHistory":null'));
+      // assert(diagnostics.includes('"RequestStats ":"Create"'));
+      // //assert(diagnostics.includes('"metaDataName":"CONTAINER_LOOK_UP"'));
+      //assert(diagnostics.includes('"serializationType":"PARTITION_KEY_FETCH_SERIALIZATION"'));
+      // assert.notStrictEqual(undefined, readItem.getDuration, "duration not present");
+      //ssert(diagnostics.match('(?s).*?"activityId":"[^\\s"]+".*'));
+      //validateRegionContacted(createResponse.getDiagnostics(), testGatewayClient.asyncClient());
     });
 
     it("should throw cosmos exception", async function () {
@@ -53,14 +56,8 @@ describe.only("Cosmos Diagnostic Tests", async function (this: Suite) {
         const container: Container = database.container(containerdef.id);
         // read items
         const items = await container.items.readAll().fetchAll();
-        if (items.getDuration > 60) {
-          assert.strictEqual(items.getDuration, CosmosException.getduration);
-          assert.strictEqual(
-            items.getDiagnostics.length,
-            CosmosException.getdiagnostics.length,
-            "duration not present"
-          );
-
+        if (items.getDuration() > 60) {
+          assert(items.getDuration);
           throw new CosmosException(`custom message`);
         }
       } catch (err: any) {

--- a/sdk/cosmosdb/cosmos/test/public/integration/diagnostics.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/public/integration/diagnostics.spec.ts
@@ -13,8 +13,8 @@ describe("Cosmos Diagnostic Tests", async function (this: Suite) {
     await removeAllDatabases();
   });
 
-  describe.only("Cosmos diagnostic test", function () {
-    it.only("should return cosmos diagnostics", async function () {
+  describe("Cosmos diagnostic test", function () {
+    it("should return cosmos diagnostics", async function () {
       const client = new CosmosClient({
         key: masterKey,
         endpoint: endpoint,

--- a/sdk/cosmosdb/cosmos/test/public/integration/diagnostics.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/public/integration/diagnostics.spec.ts
@@ -1,0 +1,71 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+import assert from "assert";
+import { Suite } from "mocha";
+import { Container, CosmosClient } from "../../../src";
+import { endpoint } from "../common/_testConfig";
+import { masterKey } from "../common/_fakeTestSecrets";
+import { CosmosException } from "../../../src/diagnostics/CosmosException";
+//import { removeAllDatabases } from "../common/TestHelpers";
+//import { recordDiagnostics } from "../../../src/diagnostics/CosmosDiagnostics";
+//import { CosmosException } from "../../../src/diagnostics/CosmosException";
+//import { createOrUpsertPermission, getTestDatabase } from "../common/TestHelpers";
+
+describe.only("Cosmos Diagnostic Tests", async function (this: Suite) {
+  this.timeout(process.env.MOCHA_TIMEOUT || 10000);
+
+  const client = new CosmosClient({
+    endpoint,
+    key: masterKey,
+  });
+
+  describe.only("Cosmos diagnostic test", function () {
+    it("should return cosmos diagnostics", async function () {
+      try {
+        const database = await client.databases.createIfNotExists({ id: "CosmosDiagnosticsTest" });
+        const databaseDiagnostics = database.getDiagnostics;
+        assert.notStrictEqual(undefined, databaseDiagnostics);
+        assert.strictEqual(CosmosException.getdiagnostics(), databaseDiagnostics);
+      } catch (err: any) {
+        console.log(CosmosException.getduration());
+        throw new CosmosException(err);
+      }
+    });
+
+    it("should handle duration condition", async function () {
+      const response = await client.databases.createIfNotExists({ id: "CosmosDiagnosticsTest" });
+      const readItem = await response.database.read();
+      assert(typeof readItem.getDuration === "number");
+      assert(readItem.getDuration);
+      assert(readItem.getDuration > 0);
+      assert.notStrictEqual(undefined, readItem.getDuration, "duration not present");
+    });
+
+    it("should throw cosmos exception", async function () {
+      try {
+        const { database: database } = await client.databases.createIfNotExists({
+          id: "CosmosDiagnosticsTest",
+        });
+        // create container
+        const { resource: containerdef } = await database.containers.create({
+          id: "sample container",
+        });
+        const container: Container = database.container(containerdef.id);
+        // read items
+        const items = await container.items.readAll().fetchAll();
+        if (items.getDuration > 60) {
+          assert.strictEqual(items.getDuration, CosmosException.getduration);
+          assert.strictEqual(
+            items.getDiagnostics.length,
+            CosmosException.getdiagnostics.length,
+            "duration not present"
+          );
+
+          throw new CosmosException(`custom message`);
+        }
+      } catch (err: any) {
+        assert(err);
+      }
+    });
+  });
+});

--- a/sdk/cosmosdb/cosmos/tsconfig.strict.json
+++ b/sdk/cosmosdb/cosmos/tsconfig.strict.json
@@ -173,6 +173,7 @@
     "test/public/functional/ttl.spec.ts",
     "test/public/functional/udf.spec.ts",
     "test/public/functional/user.spec.ts",
+    "test/public/integration/diagnostics.spec.ts",
     "test/public/integration/aggregateQuery.spec.ts",
     "test/public/integration/authorization.spec.ts",
     "test/public/integration/changeFeed.spec.ts",

--- a/sdk/cosmosdb/cosmos/tsconfig.strict.json
+++ b/sdk/cosmosdb/cosmos/tsconfig.strict.json
@@ -6,7 +6,11 @@
     // THIS HAS TO ALWAYS BE ENABLED
     "strict": true
   },
-  "include": ["src/**/*.ts", "test/**/*.ts", "samples-dev/**/*.(ts|json)"],
+  "include": [
+    "src/**/*.ts",
+    "test/**/*.ts",
+    "samples-dev/**/*.(ts|json)"
+  ],
   // ADDITION TO THIS LIST IS NOT ALLOWED
   "exclude": [
     "src/documents/DatabaseAccount.ts",
@@ -127,6 +131,8 @@
     "src/utils/tracing.ts",
     "src/client/SasToken/SasTokenProperties.ts",
     "src/client/SasToken/PermissionScopeValues.ts",
+    "src/diagnostics/CosmosException.ts",
+    "src/diagnostics/CosmosDiagnostics.ts",
     "test/public/common/TestHelpers.ts",
     "test/internal/session.spec.ts",
     "test/internal/unit/auth.spec.ts",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2017",
-    "module": "es6",
+    "module": "esnext",
     "lib": [],
     "declaration": true,
     "declarationMap": true,


### PR DESCRIPTION
### Cosmos Diagnostics
Diagnostic settings in Azure are used to collect resource logs. Azure resource Logs are emitted by a resource and provide rich, frequent data about the operation of that resource. These logs are captured per request and they are also referred to as "data plane logs". Some examples of the data plane operations include delete, insert, and readFeed. The content of these logs varies by resource type.

```typescript
const client = new CosmosClient({
  key: masterKey,
  endpoint: endpoint,
  connectionPolicy: { enableBackgroundEndpointRefreshing: false },
});

const databases = await client.databases.create({
  id: "1",
});

console.log(databases.getCosmosDiagnostics());

const containers = await databases.database.containers.create({
  id: "testContainer",
});

console.log(containers.getCosmosDiagnostics());

await containers.container.items.create({
  id: "1",
  category: "fun",
  name: "Cosmos diagnostics",
  description: "Cosmos diagnostics is fun ⚡.",
  isComplete: false,
});
const item = await containers.container.items.readAll().fetchAll();

console.log(item.getCosmosDiagnostics());

```


```