### PR TITLE
[test-utils] run `format` npm script

### DIFF
--- a/sdk/test-utils/test-utils/src/xhrHttpClient.ts
+++ b/sdk/test-utils/test-utils/src/xhrHttpClient.ts
@@ -22,8 +22,8 @@ function isNodeReadableStream(body: any): body is NodeJS.ReadableStream {
 function isReadableStream(body: unknown): body is ReadableStream {
   return Boolean(
     body &&
-    typeof (body as ReadableStream).getReader === "function" &&
-    typeof (body as ReadableStream).tee === "function"
+      typeof (body as ReadableStream).getReader === "function" &&
+      typeof (body as ReadableStream).tee === "function"
   );
 }
 


### PR DESCRIPTION
Not sure why the change was fine in PR but now check-format failed.

This PR is the result of `npm run format`
