### PR TITLE
[Cosmos] Fixed strictness issues in inMemoryCollectionRoutingMap.ts

### DIFF
--- a/sdk/cosmosdb/cosmos/src/routing/inMemoryCollectionRoutingMap.ts
+++ b/sdk/cosmosdb/cosmos/src/routing/inMemoryCollectionRoutingMap.ts
@@ -69,7 +69,7 @@ export class InMemoryCollectionRoutingMap {
       }
 
       // Start at the end and work backwards
-      let maxIndex: number;
+      let maxIndex: number | undefined;
       for (let i = this.orderedRanges.length - 1; i >= 0; i--) {
         const range = this.orderedRanges[i];
         if (queryRange.max > range.min && queryRange.max < range.max) {
@@ -86,10 +86,8 @@ export class InMemoryCollectionRoutingMap {
         }
       }
 
-      if (maxIndex > this.orderedRanges.length) {
-        throw new Error(
-          "error in collection routing map, queried value is greater than the end range."
-        );
+      if (typeof maxIndex === "undefined") {
+        throw new Error("Error in collection routing map, not able to query any value.");
       }
 
       for (let j = minIndex; j < maxIndex + 1; j++) {


### PR DESCRIPTION
### Packages impacted by this PR
cosmosdb

### Issues associated with this PR
https://github.com/Azure/azure-sdk-for-js/issues/12745

### Describe the problem that is addressed by this PR
Deleted an unnecessary if-check
```typescript
if (maxIndex > this.orderedRanges.length) {
        throw new Error(
          "error in collection routing map, queried value is greater than the end range."
        );
```
maxIndex cannot be bigger than this.orderedRanges.length, since if it exists, it's received by iterating through the indexes of this.orderedRanges.length and replacing its value with an index. And all the indexes are obviously smaller than this.orderedRanges.length (the biggest index is this.orderedRanges.length).

Then I switched the type of maxIndex to `number | undefined` and added an additional check to see if maxIndex exists after iterating through this.orderedRanges indexes. If it doesn't exist, an error is thrown. If there is no check for the maxIndex, there wil be an error thrown from the following iteration, since an undefined value doesn't work with numbers. My code fixes the TypeScript strict-error.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_
The outcomes can be easily concluded without tests.

### Provide a list of related PRs _(if any)_
None

### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_
None

### Checklists
- [x] Added impacted package name to the issue description
- [x] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [x] Added a changelog (if necessary)
