### PR TITLE
[ServiceBus] add `identifer` property to more types and options

### DIFF
--- a/sdk/servicebus/service-bus/review/service-bus.api.md
+++ b/sdk/servicebus/service-bus/review/service-bus.api.md
@@ -216,6 +216,7 @@ export interface ProcessErrorArgs {
     error: Error | ServiceBusError;
     errorSource: "abandon" | "complete" | "processMessageCallback" | "receive" | "renewLock";
     fullyQualifiedNamespace: string;
+    identifier: string;
 }
 
 // @public
@@ -333,7 +334,7 @@ export class ServiceBusClient {
     createReceiver(queueName: string, options?: ServiceBusReceiverOptions): ServiceBusReceiver;
     createReceiver(topicName: string, subscriptionName: string, options?: ServiceBusReceiverOptions): ServiceBusReceiver;
     createRuleManager(topicName: string, subscriptionName: string): ServiceBusRuleManager;
-    createSender(queueOrTopicName: string): ServiceBusSender;
+    createSender(queueOrTopicName: string, options?: ServiceBusSenderOptions): ServiceBusSender;
     fullyQualifiedNamespace: string;
     identifier: string;
 }
@@ -485,6 +486,7 @@ export interface ServiceBusReceiver {
     }): Promise<void>;
     entityPath: string;
     getMessageIterator(options?: GetMessageIteratorOptions): AsyncIterableIterator<ServiceBusReceivedMessage>;
+    identifier: string;
     isClosed: boolean;
     peekMessages(maxMessageCount: number, options?: PeekMessagesOptions): Promise<ServiceBusReceivedMessage[]>;
     receiveDeferredMessages(sequenceNumbers: Long_2 | Long_2[], options?: OperationOptionsBase): Promise<ServiceBusReceivedMessage[]>;
@@ -498,6 +500,7 @@ export interface ServiceBusReceiver {
 
 // @public
 export interface ServiceBusReceiverOptions {
+    identifier?: string;
     maxAutoLockRenewalDurationInMs?: number;
     receiveMode?: "peekLock" | "receiveAndDelete";
     skipParsingBodyAsJson?: boolean;
@@ -518,9 +521,15 @@ export interface ServiceBusSender {
     close(): Promise<void>;
     createMessageBatch(options?: CreateMessageBatchOptions): Promise<ServiceBusMessageBatch>;
     entityPath: string;
+    identifier: string;
     isClosed: boolean;
     scheduleMessages(messages: ServiceBusMessage | ServiceBusMessage[] | AmqpAnnotatedMessage | AmqpAnnotatedMessage[], scheduledEnqueueTimeUtc: Date, options?: OperationOptionsBase): Promise<Long_2[]>;
     sendMessages(messages: ServiceBusMessage | ServiceBusMessage[] | ServiceBusMessageBatch | AmqpAnnotatedMessage | AmqpAnnotatedMessage[], options?: OperationOptionsBase): Promise<void>;
+}
+
+// @public
+export interface ServiceBusSenderOptions {
+    identifier?: string;
 }
 
 // @public
@@ -537,6 +546,7 @@ export interface ServiceBusSessionReceiver extends ServiceBusReceiver {
 
 // @public
 export interface ServiceBusSessionReceiverOptions extends OperationOptionsBase {
+    identifier?: string;
     maxAutoLockRenewalDurationInMs?: number;
     receiveMode?: "peekLock" | "receiveAndDelete";
     skipParsingBodyAsJson?: boolean;

--- a/sdk/servicebus/service-bus/src/core/batchingReceiver.ts
+++ b/sdk/servicebus/service-bus/src/core/batchingReceiver.ts
@@ -32,16 +32,17 @@ export class BatchingReceiver extends MessageReceiver {
   /**
    * Instantiate a new BatchingReceiver.
    *
+   * @param identifier - name to identify this receiver.
    * @param connectionContext - The client entity context.
    * @param options - Options for how you'd like to connect.
    */
   constructor(
-    clientId: string,
+    identifier: string,
     connectionContext: ConnectionContext,
     entityPath: string,
     options: ReceiveOptions
   ) {
-    super(clientId, connectionContext, entityPath, "batching", options);
+    super(identifier, connectionContext, entityPath, "batching", options);
 
     this._batchingReceiverLite = new BatchingReceiverLite(
       connectionContext,

--- a/sdk/servicebus/service-bus/src/core/messageReceiver.ts
+++ b/sdk/servicebus/service-bus/src/core/messageReceiver.ts
@@ -133,7 +133,7 @@ export abstract class MessageReceiver extends LinkEntity<Receiver> {
   protected _lockRenewer: LockRenewer | undefined;
 
   constructor(
-    private clientId: string,
+    public identifier: string,
     context: ConnectionContext,
     entityPath: string,
     receiverType: ReceiverType,
@@ -166,7 +166,7 @@ export abstract class MessageReceiver extends LinkEntity<Receiver> {
       {
         address: this.address,
       },
-      this.clientId,
+      this.identifier,
       {
         onSettled: (context: EventContext) => {
           return onMessageSettled(this.logPrefix, context.delivery, this._deliveryDispositionMap);

--- a/sdk/servicebus/service-bus/src/core/messageSender.ts
+++ b/sdk/servicebus/service-bus/src/core/messageSender.ts
@@ -64,7 +64,7 @@ export class MessageSender extends LinkEntity<AwaitableSender> {
   private _retryOptions: RetryOptions;
 
   constructor(
-    private clientId: string,
+    private identifier: string,
     connectionContext: ConnectionContext,
     entityPath: string,
     retryOptions: RetryOptions
@@ -140,7 +140,7 @@ export class MessageSender extends LinkEntity<AwaitableSender> {
       target: {
         address: this.address,
       },
-      source: this.clientId,
+      source: this.identifier,
       onError: this._onAmqpError,
       onClose: this._onAmqpClose,
       onSessionError: this._onSessionError,
@@ -457,14 +457,14 @@ export class MessageSender extends LinkEntity<AwaitableSender> {
   }
 
   static create(
-    clientId: string,
+    identifier: string,
     context: ConnectionContext,
     entityPath: string,
     retryOptions: RetryOptions
   ): MessageSender {
     throwErrorIfConnectionClosed(context);
 
-    const sbSender = new MessageSender(clientId, context, entityPath, retryOptions);
+    const sbSender = new MessageSender(identifier, context, entityPath, retryOptions);
     context.senders[sbSender.name] = sbSender;
     return sbSender;
   }

--- a/sdk/servicebus/service-bus/src/core/streamingReceiver.ts
+++ b/sdk/servicebus/service-bus/src/core/streamingReceiver.ts
@@ -129,17 +129,17 @@ export class StreamingReceiver extends MessageReceiver {
   /**
    * Instantiate a new Streaming receiver for receiving messages with handlers.
    *
-   * @param clientId - the client id
+   * @param identifier - the name used to identifier the receiver
    * @param connectionContext - The client entity context.
    * @param options - Options for how you'd like to connect.
    */
   constructor(
-    clientId: string,
+    identifier: string,
     connectionContext: ConnectionContext,
     entityPath: string,
     options: ReceiveOptions
   ) {
-    super(clientId, connectionContext, entityPath, "streaming", options);
+    super(identifier, connectionContext, entityPath, "streaming", options);
 
     if (typeof options?.maxConcurrentCalls === "number" && options?.maxConcurrentCalls > 0) {
       this.maxConcurrentCalls = options.maxConcurrentCalls;
@@ -215,6 +215,7 @@ export class StreamingReceiver extends MessageReceiver {
           errorSource: "receive",
           entityPath: this.entityPath,
           fullyQualifiedNamespace: this._context.config.host,
+          identifier,
         });
       }
     };
@@ -232,6 +233,7 @@ export class StreamingReceiver extends MessageReceiver {
           errorSource: "receive",
           entityPath: this.entityPath,
           fullyQualifiedNamespace: this._context.config.host,
+          identifier,
         });
       }
     };
@@ -262,6 +264,7 @@ export class StreamingReceiver extends MessageReceiver {
           errorSource: "renewLock",
           entityPath: this.entityPath,
           fullyQualifiedNamespace: this._context.config.host,
+          identifier,
         });
       });
 
@@ -320,6 +323,7 @@ export class StreamingReceiver extends MessageReceiver {
               errorSource: "abandon",
               entityPath: this.entityPath,
               fullyQualifiedNamespace: this._context.config.host,
+              identifier,
             });
           }
         }
@@ -369,6 +373,7 @@ export class StreamingReceiver extends MessageReceiver {
             errorSource: "complete",
             entityPath: this.entityPath,
             fullyQualifiedNamespace: this._context.config.host,
+            identifier,
           });
         }
       }
@@ -384,6 +389,7 @@ export class StreamingReceiver extends MessageReceiver {
         entityPath: this.entityPath,
         errorSource: "internal",
         fullyQualifiedNamespace: this._context.config.host,
+        identifier: this.identifier,
       };
 
       return messageHandlers.processError(errorArgs as ProcessErrorArgs);
@@ -459,6 +465,7 @@ export class StreamingReceiver extends MessageReceiver {
         fullyQualifiedNamespace: this._context.config.host,
         errorSource: "receive",
         error: err,
+        identifier: this.identifier,
       });
 
       throw err;
@@ -503,6 +510,7 @@ export class StreamingReceiver extends MessageReceiver {
             errorSource: "processMessageCallback",
             entityPath: this.entityPath,
             fullyQualifiedNamespace: this._context.config.host,
+            identifier: this.identifier,
           });
           throw err;
         }
@@ -518,6 +526,7 @@ export class StreamingReceiver extends MessageReceiver {
             errorSource: "processMessageCallback",
             entityPath: this.entityPath,
             fullyQualifiedNamespace: this._context.config.host,
+            identifier: this.identifier,
           })
         );
       },
@@ -532,6 +541,7 @@ export class StreamingReceiver extends MessageReceiver {
             errorSource: "processMessageCallback",
             entityPath: this.entityPath,
             fullyQualifiedNamespace: this._context.config.host,
+            identifier: this.identifier,
           })
         );
       },
@@ -564,6 +574,7 @@ export class StreamingReceiver extends MessageReceiver {
             errorSource: "receive",
             entityPath: this.entityPath,
             fullyQualifiedNamespace: this._context.config.host,
+            identifier: this.identifier,
           }),
         logPrefix: this.logPrefix,
         logger,
@@ -621,6 +632,7 @@ export class StreamingReceiver extends MessageReceiver {
           errorSource: "receive",
           entityPath: this.entityPath,
           fullyQualifiedNamespace: this._context.config.host,
+          identifier: this.identifier,
         });
       }
       throw err;

--- a/sdk/servicebus/service-bus/src/index.ts
+++ b/sdk/servicebus/service-bus/src/index.ts
@@ -26,6 +26,7 @@ export {
   ReceiveMessagesOptions,
   ServiceBusReceiverOptions,
   ServiceBusSessionReceiverOptions,
+  ServiceBusSenderOptions,
   SubscribeOptions,
 } from "./models";
 export { OperationOptionsBase, TryAddOptions } from "./modelsToBeSharedWithEventHubs";

--- a/sdk/servicebus/service-bus/src/models.ts
+++ b/sdk/servicebus/service-bus/src/models.ts
@@ -32,6 +32,10 @@ export interface ProcessErrorArgs {
    * The fully qualified namespace for the Service Bus.
    */
   fullyQualifiedNamespace: string;
+  /**
+   * The identifier of the client that raised this event.
+   */
+  identifier: string;
 }
 
 /**
@@ -161,6 +165,22 @@ export interface ServiceBusReceiverOptions {
    * prefer to work directly with the bytes present in the message body than have the client attempt to parse it.
    */
   skipParsingBodyAsJson?: boolean;
+  /**
+   * Sets the {@link ServiceBusReceiver} ID to identify the receiver. This can be used to correlate logs and exceptions.
+   * If not specified or empty, a random unique one will be used.
+   */
+  identifier?: string;
+}
+
+/**
+ * Options to use when creating a sender.
+ */
+export interface ServiceBusSenderOptions {
+  /**
+   * Sets the {@link ServiceBusSender} ID to identify the sender. This can be used to correlate logs and exceptions.
+   * If not specified or empty, a random unique one will be used.
+   */
+  identifier?: string;
 }
 
 /**
@@ -271,6 +291,11 @@ export interface ServiceBusSessionReceiverOptions extends OperationOptionsBase {
    * prefer to work directly with the bytes present in the message body than have the client attempt to parse it.
    */
   skipParsingBodyAsJson?: boolean;
+  /**
+   * Sets the {@link ServiceBusReceiver} ID to identify the receiver. This can be used to correlate logs and exceptions.
+   * If not specified or empty, a random unique one will be used.
+   */
+  identifier?: string;
 }
 
 /**

--- a/sdk/servicebus/service-bus/src/models.ts
+++ b/sdk/servicebus/service-bus/src/models.ts
@@ -166,7 +166,7 @@ export interface ServiceBusReceiverOptions {
    */
   skipParsingBodyAsJson?: boolean;
   /**
-   * Sets the {@link ServiceBusReceiver} ID to identify the receiver. This can be used to correlate logs and exceptions.
+   * Sets the name to identify the receiver. This can be used to correlate logs and exceptions.
    * If not specified or empty, a random unique one will be used.
    */
   identifier?: string;
@@ -177,7 +177,7 @@ export interface ServiceBusReceiverOptions {
  */
 export interface ServiceBusSenderOptions {
   /**
-   * Sets the {@link ServiceBusSender} ID to identify the sender. This can be used to correlate logs and exceptions.
+   * Sets the name to identify the sender. This can be used to correlate logs and exceptions.
    * If not specified or empty, a random unique one will be used.
    */
   identifier?: string;
@@ -292,7 +292,7 @@ export interface ServiceBusSessionReceiverOptions extends OperationOptionsBase {
    */
   skipParsingBodyAsJson?: boolean;
   /**
-   * Sets the {@link ServiceBusReceiver} ID to identify the receiver. This can be used to correlate logs and exceptions.
+   * Sets the name to identify the session receiver. This can be used to correlate logs and exceptions.
    * If not specified or empty, a random unique one will be used.
    */
   identifier?: string;

--- a/sdk/servicebus/service-bus/src/receivers/receiver.ts
+++ b/sdk/servicebus/service-bus/src/receivers/receiver.ts
@@ -38,6 +38,7 @@ import { Constants, RetryConfig, RetryOperationType, RetryOptions, retry } from 
 import { LockRenewer } from "../core/autoLockRenewer";
 import { receiverLogger as logger } from "../log";
 import { translateServiceBusError } from "../serviceBusError";
+import { generate_uuid } from "rhea-promise";
 
 /**
  * The default time to wait for messages _after_ the first message
@@ -53,6 +54,12 @@ export const defaultMaxTimeAfterFirstMessageForBatchingMs = 1000;
  * A receiver that does not handle sessions.
  */
 export interface ServiceBusReceiver {
+  /**
+   * A name used to identify the receiver. This can be used to correlate logs and exceptions.
+   * If not specified or empty, a random unique one will be generated.
+   */
+  identifier: string;
+
   /**
    * Streams messages to message handlers.
    * @param handlers - A handler that gets called for messages and errors.
@@ -266,6 +273,7 @@ export interface ServiceBusReceiver {
  * @internal
  */
 export class ServiceBusReceiverImpl implements ServiceBusReceiver {
+  public identifier: string;
   private _retryOptions: RetryOptions;
   /**
    * Denotes if close() was called on this receiver
@@ -291,13 +299,13 @@ export class ServiceBusReceiverImpl implements ServiceBusReceiver {
    * @throws Error if the underlying connection is closed.
    */
   constructor(
-    private clientId: string,
     private _context: ConnectionContext,
     public entityPath: string,
     public receiveMode: "peekLock" | "receiveAndDelete",
     maxAutoRenewLockDurationInMs: number,
     private skipParsingBodyAsJson: boolean,
-    retryOptions: RetryOptions = {}
+    retryOptions: RetryOptions = {},
+    identifier?: string
   ) {
     throwErrorIfConnectionClosed(_context);
     this._retryOptions = retryOptions;
@@ -306,6 +314,7 @@ export class ServiceBusReceiverImpl implements ServiceBusReceiver {
       maxAutoRenewLockDurationInMs,
       receiveMode
     );
+    this.identifier = identifier ? identifier : `${this.entityPath}-${generate_uuid()}`;
   }
 
   private _throwIfAlreadyReceiving(): void {
@@ -508,7 +517,7 @@ export class ServiceBusReceiverImpl implements ServiceBusReceiver {
 
     this._streamingReceiver =
       this._streamingReceiver ??
-      new StreamingReceiver(this.clientId, this._context, this.entityPath, {
+      new StreamingReceiver(this.identifier, this._context, this.entityPath, {
         ...options,
         receiveMode: this.receiveMode,
         retryOptions: this._retryOptions,
@@ -651,7 +660,7 @@ export class ServiceBusReceiverImpl implements ServiceBusReceiver {
     entityPath: string,
     options: ReceiveOptions
   ): BatchingReceiver {
-    return BatchingReceiver.create(this.clientId, context, entityPath, options);
+    return BatchingReceiver.create(this.identifier, context, entityPath, options);
   }
 
   /**

--- a/sdk/servicebus/service-bus/src/receivers/receiver.ts
+++ b/sdk/servicebus/service-bus/src/receivers/receiver.ts
@@ -38,7 +38,7 @@ import { Constants, RetryConfig, RetryOperationType, RetryOptions, retry } from 
 import { LockRenewer } from "../core/autoLockRenewer";
 import { receiverLogger as logger } from "../log";
 import { translateServiceBusError } from "../serviceBusError";
-import { generate_uuid } from "rhea-promise";
+import { ensureValidIdentifier } from "../util/utils";
 
 /**
  * The default time to wait for messages _after_ the first message
@@ -314,7 +314,7 @@ export class ServiceBusReceiverImpl implements ServiceBusReceiver {
       maxAutoRenewLockDurationInMs,
       receiveMode
     );
-    this.identifier = identifier ? identifier : `${this.entityPath}-${generate_uuid()}`;
+    this.identifier = ensureValidIdentifier(this.entityPath, identifier);
   }
 
   private _throwIfAlreadyReceiving(): void {

--- a/sdk/servicebus/service-bus/src/receivers/sessionReceiver.ts
+++ b/sdk/servicebus/service-bus/src/receivers/sessionReceiver.ts
@@ -112,6 +112,7 @@ export interface ServiceBusSessionReceiver extends ServiceBusReceiver {
  */
 export class ServiceBusSessionReceiverImpl implements ServiceBusSessionReceiver {
   public sessionId: string;
+  public identifier: string;
 
   /**
    * Denotes if close() was called on this receiver
@@ -136,6 +137,7 @@ export class ServiceBusSessionReceiverImpl implements ServiceBusSessionReceiver 
   ) {
     throwErrorIfConnectionClosed(_context);
     this.sessionId = _messageSession.sessionId;
+    this.identifier = _messageSession.identifier;
   }
 
   private _throwIfReceiverOrConnectionClosed(): void {
@@ -498,6 +500,7 @@ export class ServiceBusSessionReceiverImpl implements ServiceBusSessionReceiver 
         errorSource: "receive",
         entityPath: this.entityPath,
         fullyQualifiedNamespace: this._context.config.host,
+        identifier: this.identifier,
       });
     }
   }

--- a/sdk/servicebus/service-bus/src/sender.ts
+++ b/sdk/servicebus/service-bus/src/sender.ts
@@ -27,6 +27,7 @@ import { TracingSpanLink } from "@azure/core-tracing";
 import { senderLogger as logger } from "./log";
 import { ServiceBusError } from "./serviceBusError";
 import { toSpanOptions, tracingClient } from "./diagnostics/tracing";
+import { generate_uuid } from "rhea-promise";
 
 /**
  * A Sender can be used to send messages, schedule messages to be sent at a later time
@@ -35,6 +36,11 @@ import { toSpanOptions, tracingClient } from "./diagnostics/tracing";
  * The Sender class is an abstraction over the underlying AMQP sender link.
  */
 export interface ServiceBusSender {
+  /**
+   * A name used to identify the sender. This can be used to correlate logs and exceptions.
+   * If not specified or empty, a random unique one will be generated.
+   */
+  identifier: string;
   /**
    * Sends the given messages after creating an AMQP Sender link if it doesn't already exist.
    *
@@ -140,6 +146,7 @@ export interface ServiceBusSender {
  * @internal
  */
 export class ServiceBusSenderImpl implements ServiceBusSender {
+  public identifier: string;
   private _retryOptions: RetryOptions;
   /**
    * Denotes if close() was called on this sender
@@ -157,14 +164,15 @@ export class ServiceBusSenderImpl implements ServiceBusSender {
    * @throws Error if the underlying connection is closed.
    */
   constructor(
-    clientId: string,
     private _context: ConnectionContext,
     private _entityPath: string,
-    retryOptions: RetryOptions = {}
+    retryOptions: RetryOptions = {},
+    identifier?: string
   ) {
     throwErrorIfConnectionClosed(_context);
     this.entityPath = _entityPath;
-    this._sender = MessageSender.create(clientId, this._context, _entityPath, retryOptions);
+    this.identifier = identifier ? identifier : `${this.entityPath}-${generate_uuid()}`;
+    this._sender = MessageSender.create(this.identifier, this._context, _entityPath, retryOptions);
     this._retryOptions = retryOptions;
   }
 

--- a/sdk/servicebus/service-bus/src/sender.ts
+++ b/sdk/servicebus/service-bus/src/sender.ts
@@ -27,7 +27,7 @@ import { TracingSpanLink } from "@azure/core-tracing";
 import { senderLogger as logger } from "./log";
 import { ServiceBusError } from "./serviceBusError";
 import { toSpanOptions, tracingClient } from "./diagnostics/tracing";
-import { generate_uuid } from "rhea-promise";
+import { ensureValidIdentifier } from "./util/utils";
 
 /**
  * A Sender can be used to send messages, schedule messages to be sent at a later time
@@ -171,7 +171,7 @@ export class ServiceBusSenderImpl implements ServiceBusSender {
   ) {
     throwErrorIfConnectionClosed(_context);
     this.entityPath = _entityPath;
-    this.identifier = identifier ? identifier : `${this.entityPath}-${generate_uuid()}`;
+    this.identifier = ensureValidIdentifier(this.entityPath, identifier);
     this._sender = MessageSender.create(this.identifier, this._context, _entityPath, retryOptions);
     this._retryOptions = retryOptions;
   }

--- a/sdk/servicebus/service-bus/src/serviceBusClient.ts
+++ b/sdk/servicebus/service-bus/src/serviceBusClient.ts
@@ -25,7 +25,7 @@ import { ServiceBusSender, ServiceBusSenderImpl } from "./sender";
 import { entityPathMisMatchError } from "./util/errors";
 import { MessageSession } from "./session/messageSession";
 import { isCredential, isDefined } from "./util/typeGuards";
-import { generate_uuid } from "rhea-promise";
+import { ensureValidIdentifier } from "./util/utils";
 
 /**
  * A client that can create Sender instances for sending messages to queues and
@@ -107,9 +107,10 @@ export class ServiceBusClient {
       );
     }
     this.fullyQualifiedNamespace = this._connectionContext.config.host;
-    this.identifier = this._clientOptions.identifier
-      ? this._clientOptions.identifier
-      : `${this.fullyQualifiedNamespace}-${generate_uuid()}`;
+    this.identifier = ensureValidIdentifier(
+      this.fullyQualifiedNamespace,
+      this._clientOptions.identifier
+    );
     this._clientOptions.retryOptions = this._clientOptions.retryOptions || {};
 
     const timeoutInMs = this._clientOptions.retryOptions.timeoutInMs;
@@ -349,11 +350,8 @@ export class ServiceBusClient {
       throw new Error("Unhandled set of parameters");
     }
 
-    const identifier = options?.identifier
-      ? options?.identifier
-      : `${entityPath}-${generate_uuid()}`;
     const messageSession = await MessageSession.create(
-      identifier,
+      ensureValidIdentifier(entityPath, options?.identifier),
       this._connectionContext,
       entityPath,
       sessionId,
@@ -439,11 +437,8 @@ export class ServiceBusClient {
       options3
     );
 
-    const identifier = options?.identifier
-      ? options?.identifier
-      : `${entityPath}-${generate_uuid()}`;
     const messageSession = await MessageSession.create(
-      identifier,
+      ensureValidIdentifier(entityPath, options?.identifier),
       this._connectionContext,
       entityPath,
       undefined,

--- a/sdk/servicebus/service-bus/src/serviceBusClient.ts
+++ b/sdk/servicebus/service-bus/src/serviceBusClient.ts
@@ -9,7 +9,12 @@ import {
   createConnectionContextForCredential,
 } from "./constructorHelpers";
 import { ConnectionContext } from "./connectionContext";
-import { ServiceBusReceiverOptions, ServiceBusSessionReceiverOptions, ReceiveMode } from "./models";
+import {
+  ServiceBusReceiverOptions,
+  ServiceBusSessionReceiverOptions,
+  ReceiveMode,
+  ServiceBusSenderOptions,
+} from "./models";
 import { ServiceBusReceiver, ServiceBusReceiverImpl } from "./receivers/receiver";
 import {
   ServiceBusSessionReceiver,
@@ -35,8 +40,8 @@ export class ServiceBusClient {
    */
   public fullyQualifiedNamespace: string;
   /**
-   * ID to identify this client which can be specified when creating an instance of this client.
-   * If not specified, a unique one will be generated.
+   * The name used to identify this ServiceBusClient.
+   * If not specified or empty, a random unique one will be generated.
    */
   public identifier: string;
   /**
@@ -102,7 +107,9 @@ export class ServiceBusClient {
       );
     }
     this.fullyQualifiedNamespace = this._connectionContext.config.host;
-    this.identifier = this._clientOptions.identifier ?? generate_uuid();
+    this.identifier = this._clientOptions.identifier
+      ? this._clientOptions.identifier
+      : `${this.fullyQualifiedNamespace}-${generate_uuid()}`;
     this._clientOptions.retryOptions = this._clientOptions.retryOptions || {};
 
     const timeoutInMs = this._clientOptions.retryOptions.timeoutInMs;
@@ -215,13 +222,13 @@ export class ServiceBusClient {
         : 5 * 60 * 1000;
 
     return new ServiceBusReceiverImpl(
-      this.identifier,
       this._connectionContext,
       entityPathWithSubQueue,
       receiveMode,
       maxLockAutoRenewDurationInMs,
       options?.skipParsingBodyAsJson ?? false,
-      this._clientOptions.retryOptions
+      this._clientOptions.retryOptions,
+      options?.identifier
     );
   }
 
@@ -342,8 +349,11 @@ export class ServiceBusClient {
       throw new Error("Unhandled set of parameters");
     }
 
+    const identifier = options?.identifier
+      ? options?.identifier
+      : `${entityPath}-${generate_uuid()}`;
     const messageSession = await MessageSession.create(
-      this.identifier,
+      identifier,
       this._connectionContext,
       entityPath,
       sessionId,
@@ -429,8 +439,11 @@ export class ServiceBusClient {
       options3
     );
 
+    const identifier = options?.identifier
+      ? options?.identifier
+      : `${entityPath}-${generate_uuid()}`;
     const messageSession = await MessageSession.create(
-      this.identifier,
+      identifier,
       this._connectionContext,
       entityPath,
       undefined,
@@ -460,14 +473,14 @@ export class ServiceBusClient {
    * to the service until one of the methods on the sender is called.
    * @param queueOrTopicName - The name of a queue or topic to send messages to.
    */
-  createSender(queueOrTopicName: string): ServiceBusSender {
+  createSender(queueOrTopicName: string, options: ServiceBusSenderOptions = {}): ServiceBusSender {
     validateEntityPath(this._connectionContext.config, queueOrTopicName);
 
     return new ServiceBusSenderImpl(
-      this.identifier,
       this._connectionContext,
       queueOrTopicName,
-      this._clientOptions.retryOptions
+      this._clientOptions.retryOptions,
+      options.identifier
     );
   }
 

--- a/sdk/servicebus/service-bus/src/session/messageSession.ts
+++ b/sdk/servicebus/service-bus/src/session/messageSession.ts
@@ -258,9 +258,9 @@ export class MessageSession extends LinkEntity<Receiver> {
   /**
    * Creates a new AMQP receiver under a new AMQP session.
    */
-  private async _init(clientId: string, abortSignal?: AbortSignalLike): Promise<void> {
+  private async _init(abortSignal?: AbortSignalLike): Promise<void> {
     try {
-      const options = this._createMessageSessionOptions(clientId);
+      const options = this._createMessageSessionOptions(this.identifier);
       await this.initLink(options, abortSignal);
 
       if (this.link == null) {
@@ -365,6 +365,7 @@ export class MessageSession extends LinkEntity<Receiver> {
    * to indicate we want the next unlocked non-empty session.
    */
   constructor(
+    public identifier: string,
     connectionContext: ConnectionContext,
     entityPath: string,
     private _providedSessionId: string | undefined,
@@ -431,6 +432,7 @@ export class MessageSession extends LinkEntity<Receiver> {
           errorSource: "receive",
           entityPath: this.entityPath,
           fullyQualifiedNamespace: this._context.config.host,
+          identifier: this.identifier,
         });
       }
     };
@@ -452,6 +454,7 @@ export class MessageSession extends LinkEntity<Receiver> {
           errorSource: "receive",
           entityPath: this.entityPath,
           fullyQualifiedNamespace: this._context.config.host,
+          identifier: this.identifier,
         });
       }
     };
@@ -656,6 +659,7 @@ export class MessageSession extends LinkEntity<Receiver> {
             errorSource: "processMessageCallback",
             entityPath: this.entityPath,
             fullyQualifiedNamespace: this._context.config.host,
+            identifier: this.identifier,
           });
 
           const error = translateServiceBusError(err);
@@ -694,6 +698,7 @@ export class MessageSession extends LinkEntity<Receiver> {
                 errorSource: "abandon",
                 entityPath: this.entityPath,
                 fullyQualifiedNamespace: this._context.config.host,
+                identifier: this.identifier,
               });
             }
           }
@@ -735,6 +740,7 @@ export class MessageSession extends LinkEntity<Receiver> {
               errorSource: "complete",
               entityPath: this.entityPath,
               fullyQualifiedNamespace: this._context.config.host,
+              identifier: this.identifier,
             });
           }
         }
@@ -768,6 +774,7 @@ export class MessageSession extends LinkEntity<Receiver> {
         errorSource: "receive",
         entityPath: this.entityPath,
         fullyQualifiedNamespace: this._context.config.host,
+        identifier: this.identifier,
       });
     }
   }
@@ -791,6 +798,7 @@ export class MessageSession extends LinkEntity<Receiver> {
       errorSource: "processMessageCallback",
       entityPath: this.entityPath,
       fullyQualifiedNamespace: this._context.config.host,
+      identifier: this.identifier,
     });
   }
 
@@ -838,6 +846,7 @@ export class MessageSession extends LinkEntity<Receiver> {
         fullyQualifiedNamespace: this._context.config.host,
         error: translateServiceBusError(connectionError),
         errorSource: "receive",
+        identifier: this.identifier,
       });
     } catch (error: any) {
       logger.error(
@@ -921,19 +930,20 @@ export class MessageSession extends LinkEntity<Receiver> {
 
   /**
    * Creates a new instance of the MessageSession based on the provided parameters.
+   * @param identifier - name to identify the message session
    * @param context - The client entity context
    * @param options - Options that can be provided while creating the MessageSession.
    */
   static async create(
-    clientId: string,
+    identifier: string,
     context: ConnectionContext,
     entityPath: string,
     sessionId: string | undefined,
     options: MessageSessionOptions
   ): Promise<MessageSession> {
     throwErrorIfConnectionClosed(context);
-    const messageSession = new MessageSession(context, entityPath, sessionId, options);
-    await messageSession._init(clientId, options?.abortSignal);
+    const messageSession = new MessageSession(identifier, context, entityPath, sessionId, options);
+    await messageSession._init(options?.abortSignal);
     return messageSession;
   }
 

--- a/sdk/servicebus/service-bus/src/util/utils.ts
+++ b/sdk/servicebus/service-bus/src/util/utils.ts
@@ -40,6 +40,18 @@ export function getUniqueName(name: string): string {
 
 /**
  * @internal
+ * Returns the passed identifier if it is not undefined or empty;
+ * otherwise generate and returns a unique one in the following format;
+ *   `{prefix}-{uuid}`.
+ * @param prefix - The prefix used to generate identifier
+ * @param identifier - an identifier name
+ */
+export function ensureValidIdentifier(prefix: string, identifier?: string): string {
+  return identifier ? identifier : getUniqueName(prefix);
+}
+
+/**
+ * @internal
  * If you try to turn a Guid into a Buffer in .NET, the bytes of the first three groups get
  * flipped within the group, but the last two groups don't get flipped, so we end up with a
  * different byte order. This is the order of bytes needed to make Service Bus recognize the token.

--- a/sdk/servicebus/service-bus/test/internal/serviceBusClient.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/serviceBusClient.spec.ts
@@ -222,7 +222,7 @@ describe("ServiceBusClient live tests", () => {
     });
 
     it("throws error when receiving streaming data from a non existing namespace", async function (): Promise<void> {
-      const receiver = sbClient.createReceiver("some-queue");
+      const receiver = sbClient.createReceiver("some-queue", { identifier: "receiverId" });
       reduceRetries(receiver);
 
       try {
@@ -235,12 +235,14 @@ describe("ServiceBusClient live tests", () => {
               errorSource: args.errorSource,
               entityPath: args.entityPath,
               fullyQualifiedNamespace: args.fullyQualifiedNamespace,
+              identifier: args.identifier,
             };
 
             actual.should.deep.equal({
               errorSource: "receive",
               entityPath: receiver.entityPath,
               fullyQualifiedNamespace: sbClient.fullyQualifiedNamespace,
+              identifier: "receiverId",
             } as Omit<ProcessErrorArgs, "error">);
 
             testError(args.error);
@@ -326,7 +328,7 @@ describe("ServiceBusClient live tests", () => {
     });
 
     it("throws error when receiving streaming data from a non existing queue", async function (): Promise<void> {
-      const receiver = sbClient.createReceiver("some-name");
+      const receiver = sbClient.createReceiver("some-name", { identifier: "receiverId" });
       reduceRetries(receiver);
 
       receiver.subscribe({
@@ -338,12 +340,14 @@ describe("ServiceBusClient live tests", () => {
             errorSource: args.errorSource,
             entityPath: args.entityPath,
             fullyQualifiedNamespace: args.fullyQualifiedNamespace,
+            identifier: args.identifier,
           };
 
           actual.should.deep.equal({
             errorSource: "receive",
             entityPath: receiver.entityPath,
             fullyQualifiedNamespace: sbClient.fullyQualifiedNamespace,
+            identifier: "receiverId",
           } as Omit<ProcessErrorArgs, "error">);
 
           testError(args.error, "some-name");
@@ -359,10 +363,9 @@ describe("ServiceBusClient live tests", () => {
     });
 
     it("throws error when receiving streaming data from a non existing topic", async function (): Promise<void> {
-      const receiver = sbClient.createReceiver(
-        "some-topic-name",
-        "some-subscription-name"
-      ) as ServiceBusReceiverImpl;
+      const receiver = sbClient.createReceiver("some-topic-name", "some-subscription-name", {
+        identifier: "receiverId",
+      }) as ServiceBusReceiverImpl;
       reduceRetries(receiver);
 
       receiver.subscribe({
@@ -374,12 +377,14 @@ describe("ServiceBusClient live tests", () => {
             errorSource: args.errorSource,
             entityPath: args.entityPath,
             fullyQualifiedNamespace: args.fullyQualifiedNamespace,
+            identifier: args.identifier,
           };
 
           expected.should.deep.equal({
             errorSource: "receive",
             entityPath: receiver.entityPath,
             fullyQualifiedNamespace: sbClient.fullyQualifiedNamespace,
+            identifier: "receiverId",
           } as Omit<ProcessErrorArgs, "error">);
 
           testError(args.error, "some-topic-name/Subscriptions/some-subscription-name");
@@ -404,10 +409,9 @@ describe("ServiceBusClient live tests", () => {
       if (!entityNames.topic) {
         throw new Error("Expecting valid topic name");
       }
-      const receiver = sbClient.createReceiver(
-        entityNames.topic,
-        "some-subscription-name"
-      ) as ServiceBusReceiverImpl;
+      const receiver = sbClient.createReceiver(entityNames.topic, "some-subscription-name", {
+        identifier: "receiverId",
+      }) as ServiceBusReceiverImpl;
       reduceRetries(receiver);
 
       receiver.subscribe({
@@ -419,12 +423,14 @@ describe("ServiceBusClient live tests", () => {
             errorSource: args.errorSource,
             entityPath: args.entityPath,
             fullyQualifiedNamespace: args.fullyQualifiedNamespace,
+            identifier: args.identifier,
           };
 
           expected.should.deep.equal({
             errorSource: "receive",
             entityPath: receiver.entityPath,
             fullyQualifiedNamespace: sbClient.fullyQualifiedNamespace,
+            identifier: "receiverId",
           } as Omit<ProcessErrorArgs, "error">);
 
           testError(args.error);

--- a/sdk/servicebus/service-bus/test/internal/unit/abortSignal.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/unit/abortSignal.spec.ts
@@ -428,7 +428,6 @@ describe("AbortSignal", () => {
 
     it("Receiver.subscribe", async () => {
       const receiver = new ServiceBusReceiverImpl(
-        "serviceBusClientId",
         createConnectionContextForTests(),
         "entityPath",
         "peekLock",

--- a/sdk/servicebus/service-bus/test/internal/unit/batchingReceiver.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/unit/batchingReceiver.spec.ts
@@ -50,7 +50,6 @@ describe("BatchingReceiver unit tests", () => {
     it("is plumbed into BatchingReceiver from ServiceBusReceiverImpl", async () => {
       const origAbortSignal = createAbortSignalForTest();
       const receiver = new ServiceBusReceiverImpl(
-        "serviceBusClientId",
         createConnectionContextForTests(),
         "fakeEntityPath",
         "peekLock",

--- a/sdk/servicebus/service-bus/test/internal/unit/linkentity.unittest.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/unit/linkentity.unittest.spec.ts
@@ -420,11 +420,17 @@ describe("LinkEntity unit tests", () => {
     });
 
     it("session", () => {
-      const messageSession = new MessageSession(connectionContext, "entityPath", "session-id", {
-        abortSignal: undefined,
-        retryOptions: {},
-        skipParsingBodyAsJson: false,
-      });
+      const messageSession = new MessageSession(
+        "identifier",
+        connectionContext,
+        "entityPath",
+        "session-id",
+        {
+          abortSignal: undefined,
+          retryOptions: {},
+          skipParsingBodyAsJson: false,
+        }
+      );
 
       initCachedLinks(messageSession.name);
 

--- a/sdk/servicebus/service-bus/test/internal/unit/messageSession.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/unit/messageSession.spec.ts
@@ -49,6 +49,7 @@ describe("Message session unit tests", () => {
 
         it("1. We received 'max messages'", async () => {
           const receiver = new MessageSession(
+            "identifier",
             createConnectionContextForTests(),
             "dummyEntityPath",
             undefined,
@@ -80,6 +81,7 @@ describe("Message session unit tests", () => {
         // because otherwise it'd be one of the others.
         it("2. We've waited 'max wait time'", async () => {
           const receiver = new MessageSession(
+            "identifier",
             createConnectionContextForTests(),
             "dummyEntityPath",
             undefined,
@@ -111,6 +113,7 @@ describe("Message session unit tests", () => {
           `3a. (with idle timeout) We've received 1 message and _now_ have exceeded 'max wait time past first message'`,
           async () => {
             const receiver = new MessageSession(
+              "identifier",
               createConnectionContextForTests(),
               "dummyEntityPath",
               undefined,
@@ -158,6 +161,7 @@ describe("Message session unit tests", () => {
         // When we eliminate that bug we can remove this test in favor of the idle timeout test above.
         (lockMode === "receiveAndDelete" ? it : it.skip)(`3b. (without idle timeout)`, async () => {
           const receiver = new MessageSession(
+            "identifier",
             createConnectionContextForTests(),
             "dummyEntityPath",
             undefined,
@@ -211,6 +215,7 @@ describe("Message session unit tests", () => {
           "4. sanity check that we're using getRemainingWaitTimeInMs",
           async () => {
             const receiver = new MessageSession(
+              "identifier",
               createConnectionContextForTests(),
               "dummyEntityPath",
               undefined,

--- a/sdk/servicebus/service-bus/test/internal/unit/receiver.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/unit/receiver.spec.ts
@@ -119,7 +119,6 @@ describe("Receiver unit tests", () => {
 
     it("can't subscribe while another subscribe is active", async () => {
       receiverImpl = new ServiceBusReceiverImpl(
-        "serviceBusClientId",
         createConnectionContextForTests(),
         "fakeEntityPath",
         "peekLock",
@@ -153,7 +152,6 @@ describe("Receiver unit tests", () => {
       let closeWasCalled = false;
 
       receiverImpl = new ServiceBusReceiverImpl(
-        "serviceBusClientId",
         createConnectionContextForTests({
           onCreateReceiverCalled: (receiver) => {
             (receiver as any).close = () => {
@@ -192,7 +190,6 @@ describe("Receiver unit tests", () => {
 
     it("can re-subscribe after previous subscription is aborted", async () => {
       receiverImpl = new ServiceBusReceiverImpl(
-        "serviceBusClientId",
         createConnectionContextForTests(),
         "fakeEntityPath",
         "peekLock",
@@ -237,7 +234,6 @@ describe("Receiver unit tests", () => {
   describe("getMessageIterator", () => {
     it("abortSignal is passed through (receiver)", async () => {
       const impl = new ServiceBusReceiverImpl(
-        "serviceBusClientId",
         createConnectionContextForTests(),
         "entity path",
         "peekLock",
@@ -309,14 +305,7 @@ describe("Receiver unit tests", () => {
 
     it("create() with an existing _streamingReceiver", async () => {
       const context = createConnectionContextForTests();
-      impl = new ServiceBusReceiverImpl(
-        "serviceBusClientId",
-        context,
-        "entity path",
-        "peekLock",
-        1,
-        false
-      );
+      impl = new ServiceBusReceiverImpl(context, "entity path", "peekLock", 1, false);
 
       const existingStreamingReceiver = createStreamingReceiver("entityPath");
       const subscribeStub = sinon.spy(existingStreamingReceiver, "subscribe");
@@ -343,14 +332,7 @@ describe("Receiver unit tests", () => {
     it("create() with an existing receiver and that receiver is NOT open()", async () => {
       const context = createConnectionContextForTests();
 
-      impl = new ServiceBusReceiverImpl(
-        "serviceBusClientId",
-        context,
-        "entity path",
-        "peekLock",
-        1,
-        false
-      );
+      impl = new ServiceBusReceiverImpl(context, "entity path", "peekLock", 1, false);
 
       await subscribeAndWaitForInitialize(impl);
 

--- a/sdk/servicebus/service-bus/test/internal/unit/receiverCommon.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/unit/receiverCommon.spec.ts
@@ -378,6 +378,7 @@ it("error handler wrapper", () => {
             entityPath: args.entityPath,
             errorSource: args.errorSource,
             code: sbe.code,
+            identifier: args.identifier,
           },
           {
             name: "ServiceBusError",
@@ -386,6 +387,7 @@ it("error handler wrapper", () => {
             entityPath: "entity path",
             errorSource: "renewLock",
             code: "ServiceCommunicationProblem",
+            identifier: "identifier",
           }
         );
 
@@ -411,6 +413,7 @@ it("error handler wrapper", () => {
     entityPath: "entity path",
     errorSource: "renewLock",
     fullyQualifiedNamespace: "fully qualified namespace",
+    identifier: "identifier",
   });
 
   assert.isTrue(logErrorCalled, "log error should have been called");

--- a/sdk/servicebus/service-bus/test/internal/unit/sender.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/unit/sender.spec.ts
@@ -29,7 +29,7 @@ describe("Sender helper unit tests", () => {
 
 describe("sender unit tests", () => {
   const fakeContext = createConnectionContextForTests();
-  const sender = new ServiceBusSenderImpl("serviceBusClientId", fakeContext, "fakeEntityPath");
+  const sender = new ServiceBusSenderImpl(fakeContext, "fakeEntityPath", {}, "serviceBusClientId");
   sender["_sender"].createBatch = async () => {
     return new ServiceBusMessageBatchImpl(fakeContext, 100);
   };

--- a/sdk/servicebus/service-bus/test/internal/unit/serviceBusClient.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/unit/serviceBusClient.spec.ts
@@ -298,18 +298,18 @@ describe("serviceBusClient unit tests", () => {
   describe("client identifier option", () => {
     const connectionString =
       "Endpoint=sb://testnamespace/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=testKey;EntityPath=testEntityPath";
-    it("message sender created with client identifier", () => {
+    it("message sender created with specified identifier", () => {
       const client = new ServiceBusClient(connectionString, { identifier: "sbClientIdentifier" });
-      const sender = client.createSender("testEntityPath");
+      const sender = client.createSender("testEntityPath", { identifier: "sbSenderId" });
 
-      assert.equal((sender as ServiceBusSenderImpl)["_sender"]["clientId"], "sbClientIdentifier");
+      assert.equal((sender as ServiceBusSenderImpl)["_sender"]["identifier"], "sbSenderId");
     });
 
-    it("message receiver created with client identifier", () => {
+    it("message receiver created with specified identifier", () => {
       const client = new ServiceBusClient(connectionString, { identifier: "sbClientIdentifier" });
-      const sender = client.createReceiver("testEntityPath");
+      const receiver = client.createReceiver("testEntityPath", { identifier: "sbReceiverId" });
 
-      assert.equal((sender as unknown as MessageReceiver)["clientId"], "sbClientIdentifier");
+      assert.equal((receiver as unknown as MessageReceiver)["identifier"], "sbReceiverId");
     });
 
     it("unique client identifier is created if not specified via options", () => {
@@ -319,9 +319,127 @@ describe("serviceBusClient unit tests", () => {
       assert.ok(client2.identifier, "expect valid identifier for client2");
       assert.notEqual(client1.identifier, client2.identifier, "client identifier should be unique");
       const uuidRegex =
-        /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
-      assert.ok(uuidRegex.test(client1.identifier), "expect uuid identifer for client1");
-      assert.ok(uuidRegex.test(client2.identifier), "expect uuid identifer for client2");
+        /^testnamespace-[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
+      assert.ok(uuidRegex.test(client1.identifier), "expect random identifier for client1");
+      assert.ok(uuidRegex.test(client2.identifier), "expect random identifier for client2");
+    });
+
+    it("unique sender identifier is created if not specified via options", () => {
+      const client = new ServiceBusClient(connectionString, { identifier: "sbClientIdentifier" });
+      const sender = client.createSender("testEntityPath");
+
+      const uuidRegex =
+        /^testEntityPath-[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
+
+      assert.ok(
+        uuidRegex.test((sender as ServiceBusSenderImpl)["_sender"]["identifier"]),
+        "expect random receiver identifier"
+      );
+    });
+
+    it("unique receiver identifier is created if not specified via options", () => {
+      const client = new ServiceBusClient(connectionString);
+      const receiver = client.createReceiver("testEntityPath");
+      const uuidRegex =
+        /^testEntityPath-[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
+
+      assert.ok(
+        uuidRegex.test((receiver as unknown as MessageReceiver)["identifier"]),
+        "expect random receiver identifier"
+      );
+    });
+
+    testEntities.forEach(async (testEntity) => {
+      const connectionString =
+        "Endpoint=sb://testnamespace/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=testKey";
+
+      it("acceptSession receiver created with specified identifier", async () => {
+        const client = new ServiceBusClient(connectionString);
+        const origConnectionContext = client["_connectionContext"];
+        client["_connectionContext"] = createConnectionContextForTestsWithSessionId("sessionId", {
+          ...origConnectionContext.config,
+          entityPath: testEntity.topic ? testEntity.topic : testEntity.queue,
+        });
+        try {
+          let receiver: ServiceBusSessionReceiver;
+          if (testEntity.queue) {
+            receiver = await client.acceptSession(testEntity.queue, "sessionId", {
+              identifier: "sbSessionReceiverId",
+            });
+          } else {
+            receiver = await client.acceptSession(
+              testEntity.topic!,
+              testEntity.subscription!,
+              "sessionId",
+              { identifier: "sbSessionReceiverId" }
+            );
+          }
+
+          assert.equal(
+            (receiver as unknown as MessageReceiver)["identifier"],
+            "sbSessionReceiverId"
+          );
+        } finally {
+          await client.close();
+        }
+      });
+
+      it("acceptNextSession receiver created with specified identifier", async () => {
+        const client = new ServiceBusClient(connectionString);
+        const origConnectionContext = client["_connectionContext"];
+        client["_connectionContext"] = createConnectionContextForTestsWithSessionId("sessionId", {
+          ...origConnectionContext.config,
+          entityPath: testEntity.topic ? testEntity.topic : testEntity.queue,
+        });
+        try {
+          let receiver: ServiceBusSessionReceiver;
+          if (testEntity.queue) {
+            receiver = await client.acceptNextSession(testEntity.queue, {
+              identifier: "sbSessionReceiverId",
+            });
+          } else {
+            receiver = await client.acceptNextSession(testEntity.topic!, testEntity.subscription!, {
+              identifier: "sbSessionReceiverId",
+            });
+          }
+
+          assert.equal(
+            (receiver as unknown as MessageReceiver)["identifier"],
+            "sbSessionReceiverId"
+          );
+        } finally {
+          await client.close();
+        }
+      });
+
+      it("unique session receiver identifier is created if not specified via options", async () => {
+        const client = new ServiceBusClient(connectionString);
+        const origConnectionContext = client["_connectionContext"];
+        client["_connectionContext"] = createConnectionContextForTestsWithSessionId("sessionId", {
+          ...origConnectionContext.config,
+          entityPath: testEntity.topic ? testEntity.topic : testEntity.queue,
+        });
+        try {
+          let receiver: ServiceBusSessionReceiver;
+          let uuidRegex: RegExp;
+          if (testEntity.queue) {
+            receiver = await client.acceptNextSession(testEntity.queue);
+            uuidRegex =
+              /^thequeue-[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
+          } else {
+            receiver = await client.acceptNextSession(testEntity.topic!, testEntity.subscription!);
+            uuidRegex =
+              /^thetopic\/Subscriptions\/thesubscription-[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
+          }
+
+          assert.ok(
+            uuidRegex.test((receiver as unknown as ServiceBusSessionReceiver)["identifier"]),
+            "expect random session receiver identifier"
+          );
+        } finally {
+          await client.close();
+        }
+      });
     });
   });
 

--- a/sdk/servicebus/service-bus/test/internal/unit/serviceBusClient.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/unit/serviceBusClient.spec.ts
@@ -350,11 +350,11 @@ describe("serviceBusClient unit tests", () => {
     });
 
     testEntities.forEach(async (testEntity) => {
-      const connectionString =
+      const connectionStr =
         "Endpoint=sb://testnamespace/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=testKey";
 
       it("acceptSession receiver created with specified identifier", async () => {
-        const client = new ServiceBusClient(connectionString);
+        const client = new ServiceBusClient(connectionStr);
         const origConnectionContext = client["_connectionContext"];
         client["_connectionContext"] = createConnectionContextForTestsWithSessionId("sessionId", {
           ...origConnectionContext.config,
@@ -385,7 +385,7 @@ describe("serviceBusClient unit tests", () => {
       });
 
       it("acceptNextSession receiver created with specified identifier", async () => {
-        const client = new ServiceBusClient(connectionString);
+        const client = new ServiceBusClient(connectionStr);
         const origConnectionContext = client["_connectionContext"];
         client["_connectionContext"] = createConnectionContextForTestsWithSessionId("sessionId", {
           ...origConnectionContext.config,
@@ -413,7 +413,7 @@ describe("serviceBusClient unit tests", () => {
       });
 
       it("unique session receiver identifier is created if not specified via options", async () => {
-        const client = new ServiceBusClient(connectionString);
+        const client = new ServiceBusClient(connectionStr);
         const origConnectionContext = client["_connectionContext"];
         client["_connectionContext"] = createConnectionContextForTestsWithSessionId("sessionId", {
           ...origConnectionContext.config,

--- a/sdk/servicebus/service-bus/test/internal/unit/serviceBusReceiverUnitTests.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/unit/serviceBusReceiverUnitTests.spec.ts
@@ -14,8 +14,6 @@ describe("ServiceBusReceiver unit tests", () => {
 
   beforeEach(() => {
     receiver = new ServiceBusReceiverImpl(
-      "serviceBusClientId",
-
       createConnectionContextForTests(),
       "entityPath",
       "peekLock",

--- a/sdk/servicebus/service-bus/test/internal/unit/streamingReceiver.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/unit/streamingReceiver.spec.ts
@@ -296,6 +296,7 @@ describe("StreamingReceiver unit tests", () => {
       error: new Error("hello"),
       errorSource: "receive",
       fullyQualifiedNamespace: "fqns",
+      identifier: "receiverId",
     });
 
     assert.deepEqual(processErrorMessages, ["hello"]);


### PR DESCRIPTION
- add public `identifier` property to senders, receivers, and their corresponding options

- `ProcessErrorArgs` now has `identifier` indicating by which client the error is raised.


### Packages impacted by this PR
`@azure/service-bus`

### Issues associated with this PR
#21902 
