### PR TITLE
[Perf] Display results with 4 significant figures

### DIFF
--- a/eng/common/pipelines/templates/jobs/perf.yml
+++ b/eng/common/pipelines/templates/jobs/perf.yml
@@ -42,7 +42,7 @@ resources:
     type: github
     endpoint: Azure
     name: Azure/azure-sdk-tools
-    ref: main
+    ref: refs/pull/3770/merge
 
 variables:
 - ${{ parameters.Variables }}

--- a/eng/common/pipelines/templates/jobs/perf.yml
+++ b/eng/common/pipelines/templates/jobs/perf.yml
@@ -42,7 +42,7 @@ resources:
     type: github
     endpoint: Azure
     name: Azure/azure-sdk-tools
-    ref: refs/pull/3770/merge
+    ref: main
 
 variables:
 - ${{ parameters.Variables }}

--- a/sdk/test-utils/perf/src/managerProgram.ts
+++ b/sdk/test-utils/perf/src/managerProgram.ts
@@ -11,7 +11,7 @@ import { DefaultPerfOptions, ParsedPerfOptions } from "./options";
 import { Snapshot } from "./snapshot";
 import { PerfTestBase, PerfTestConstructor } from "./perfTestBase";
 import { PerfProgram } from "./program";
-import { formatDuration } from "./utils";
+import { formatDuration, formatNumber } from "./utils";
 
 /**
  * The manager program which is responsible for spawning workers which run the actual perf test.
@@ -96,17 +96,9 @@ export class ManagerPerfProgram implements PerfProgram {
         maximumFractionDigits: 0,
       })} ` +
         `operations in a weighted-average of ` +
-        `${weightedAverage.toLocaleString(undefined, {
-          maximumFractionDigits: 2,
-          minimumFractionDigits: 2,
-        })}s ` +
-        `(${operationsPerSecond.toLocaleString(undefined, {
-          maximumFractionDigits: 2,
-        })} ops/s, ` +
-        `${secondsPerOperation.toLocaleString(undefined, {
-          maximumFractionDigits: 3,
-          minimumFractionDigits: 3,
-        })} s/op)`
+        `${formatNumber(weightedAverage, 4)}s ` +
+        `(${formatNumber(operationsPerSecond, 4)} ops/s, ` +
+        `${formatNumber(secondsPerOperation, 4)} s/op)`
     );
   }
 

--- a/sdk/test-utils/perf/src/utils.ts
+++ b/sdk/test-utils/perf/src/utils.ts
@@ -101,13 +101,15 @@ export function formatDuration(durationMilliseconds: number): string {
   return `${minutes < 10 ? "0" : ""}${minutes}:${seconds < 10 ? "0" : ""}${seconds}`;
 }
 
-// Formats a number with a minimum number of significant digits.
-// Digits to the left of the decimal point are always significant.
-// Examples:
-// - formatNumber(0, 4) -> "0.000"
-// - formatNumber(12345, 4) -> "12,345"
-// - formatNumber(1.2345, 4) -> "1.235"
-// - formatNumber(0.00012345, 4) -> "0.0001235"
+/**
+  * Formats a number with a minimum number of significant digits.
+  * Digits to the left of the decimal point are always significant.
+  * Examples:
+  *  - formatNumber(0, 4) -> "0.000"
+  *  - formatNumber(12345, 4) -> "12,345"
+  *  - formatNumber(1.2345, 4) -> "1.235"
+  *  - formatNumber(0.00012345, 4) -> "0.0001235"
+  */
 export function formatNumber(value: number, minSignificantDigits: number) {
   // Special case since log(0) is undefined
   if (value == 0) {

--- a/sdk/test-utils/perf/src/utils.ts
+++ b/sdk/test-utils/perf/src/utils.ts
@@ -109,12 +109,11 @@ export function formatDuration(durationMilliseconds: number): string {
 // - formatNumber(1.2345, 4) -> "1.235"
 // - formatNumber(0.00012345, 4) -> "0.0001235"
 export function formatNumber(value: number, minSignificantDigits: number) {
-
   // Special case since log(0) is undefined
   if (value == 0) {
     return value.toLocaleString(undefined, {
       minimumSignificantDigits: minSignificantDigits,
-      maximumSignificantDigits: minSignificantDigits
+      maximumSignificantDigits: minSignificantDigits,
     });
   }
 
@@ -123,6 +122,6 @@ export function formatNumber(value: number, minSignificantDigits: number) {
 
   return value.toLocaleString(undefined, {
     minimumSignificantDigits: significantDigits,
-    maximumSignificantDigits: significantDigits
+    maximumSignificantDigits: significantDigits,
   });
 }

--- a/sdk/test-utils/perf/src/utils.ts
+++ b/sdk/test-utils/perf/src/utils.ts
@@ -100,3 +100,19 @@ export function formatDuration(durationMilliseconds: number): string {
 
   return `${minutes < 10 ? "0" : ""}${minutes}:${seconds < 10 ? "0" : ""}${seconds}`;
 }
+
+// Formats a number with the specified minimum number of significant digits.
+// Digits to the left of the decimal point are never dropped.
+// Examples:
+// - formatNumber(12345, 4) -> "12,345"
+// - formatNumber(1.2345, 4) -> "1.235"
+// - formatNumber(0.00012345, 4) -> "0.0001234"
+export function formatNumber(value: number, minSignificantDigits: number) {
+  const log = Math.log10(Math.abs(value));
+  const significantDigits = Math.max(Math.ceil(log), minSignificantDigits);
+
+  return value.toLocaleString(undefined, {
+    minimumSignificantDigits: significantDigits,
+    maximumSignificantDigits: significantDigits
+  });
+}

--- a/sdk/test-utils/perf/src/utils.ts
+++ b/sdk/test-utils/perf/src/utils.ts
@@ -102,14 +102,14 @@ export function formatDuration(durationMilliseconds: number): string {
 }
 
 /**
-  * Formats a number with a minimum number of significant digits.
-  * Digits to the left of the decimal point are always significant.
-  * Examples:
-  *  - formatNumber(0, 4) -> "0.000"
-  *  - formatNumber(12345, 4) -> "12,345"
-  *  - formatNumber(1.2345, 4) -> "1.235"
-  *  - formatNumber(0.00012345, 4) -> "0.0001235"
-  */
+ * Formats a number with a minimum number of significant digits.
+ * Digits to the left of the decimal point are always significant.
+ * Examples:
+ *  - formatNumber(0, 4) -> "0.000"
+ *  - formatNumber(12345, 4) -> "12,345"
+ *  - formatNumber(1.2345, 4) -> "1.235"
+ *  - formatNumber(0.00012345, 4) -> "0.0001235"
+ */
 export function formatNumber(value: number, minSignificantDigits: number) {
   // Special case since log(0) is undefined
   if (value == 0) {

--- a/sdk/test-utils/perf/src/utils.ts
+++ b/sdk/test-utils/perf/src/utils.ts
@@ -101,13 +101,23 @@ export function formatDuration(durationMilliseconds: number): string {
   return `${minutes < 10 ? "0" : ""}${minutes}:${seconds < 10 ? "0" : ""}${seconds}`;
 }
 
-// Formats a number with the specified minimum number of significant digits.
-// Digits to the left of the decimal point are never dropped.
+// Formats a number with a minimum number of significant digits.
+// Digits to the left of the decimal point are always significant.
 // Examples:
+// - formatNumber(0, 4) -> "0.000"
 // - formatNumber(12345, 4) -> "12,345"
 // - formatNumber(1.2345, 4) -> "1.235"
-// - formatNumber(0.00012345, 4) -> "0.0001234"
+// - formatNumber(0.00012345, 4) -> "0.0001235"
 export function formatNumber(value: number, minSignificantDigits: number) {
+
+  // Special case since log(0) is undefined
+  if (value == 0) {
+    return value.toLocaleString(undefined, {
+      minimumSignificantDigits: minSignificantDigits,
+      maximumSignificantDigits: minSignificantDigits
+    });
+  }
+
   const log = Math.log10(Math.abs(value));
   const significantDigits = Math.max(Math.ceil(log), minSignificantDigits);
 


### PR DESCRIPTION
## Before
```
Completed 7,421 operations in a weighted-average of 5.00s (1,482.92 ops/s, 0.001 s/op)
```

| Test       | Arguments                                                | 12.11.0 | source  | %Change |
|------------|----------------------------------------------------------|---------|---------|---------|
| download   | --size 10240 --parallel 64                               | 1991.58 | 1911.60 | -4.02%  |
| download   | --size 10485760 --parallel 32                            | 144.92  | 145.36  | 0.30%   |
| download   | --size 10485760 --parallel 32 --sync                     | -1.00   | -1.00   | 0.00%   |
| download   | --size 1073741824 --parallel 1 --warmup 60 --duration 60 | 0.17    | 0.18    | 5.88%   |
| download   | --size 1073741824 --parallel 8 --warmup 60 --duration 60 | 1.24    | 1.25    | 0.81%   |


## After
```
Completed 7,392 operations in a weighted-average of 4.999s (1,479 ops/s, 0.0006763 s/op)
```

| Test       | Arguments                                                | 12.11.0 | source | %Change |
|------------|----------------------------------------------------------|---------|--------|---------|
| download   | --size 10240 --parallel 64                               | 1,974   | 1,881  | -4.71%  |
| download   | --size 10485760 --parallel 32                            | 147.6   | 141.7  | -4.00%  |
| download   | --size 1073741824 --parallel 1 --warmup 60 --duration 60 | 0.1398  | 0.1461 | 4.51%   |
| download   | --size 1073741824 --parallel 8 --warmup 60 --duration 60 | 1.069   | 1.092  | 2.15%   |


## Validation Build
https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1743984&view=results