### PR TITLE
Fixing issues for containers and databases with ids with white spaces or special characters

### DIFF
--- a/sdk/cosmosdb/cosmos/src/client/Item/Item.ts
+++ b/sdk/cosmosdb/cosmos/src/client/Item/Item.ts
@@ -5,7 +5,7 @@ import {
   createDocumentUri,
   getIdFromLink,
   getPathFromLink,
-  isResourceValid,
+  isItemResourceValid,
   ResourceType,
   StatusCodes,
 } from "../../common";
@@ -150,7 +150,7 @@ export class Item {
     }
 
     const err = {};
-    if (!isResourceValid(body, err)) {
+    if (!isItemResourceValid(body, err)) {
       throw err;
     }
 

--- a/sdk/cosmosdb/cosmos/src/client/Item/Items.ts
+++ b/sdk/cosmosdb/cosmos/src/client/Item/Items.ts
@@ -5,7 +5,7 @@ const uuid = v4;
 import { ChangeFeedIterator } from "../../ChangeFeedIterator";
 import { ChangeFeedOptions } from "../../ChangeFeedOptions";
 import { ClientContext } from "../../ClientContext";
-import { getIdFromLink, getPathFromLink, isResourceValid, ResourceType } from "../../common";
+import { getIdFromLink, getPathFromLink, isItemResourceValid, ResourceType } from "../../common";
 import { extractPartitionKey } from "../../extractPartitionKey";
 import { FetchFunctionCallback, SqlQuerySpec } from "../../queryExecutionContext";
 import { QueryIterator } from "../../queryIterator";
@@ -269,7 +269,7 @@ export class Items {
     const partitionKey = extractPartitionKey(body, partitionKeyDefinition);
 
     const err = {};
-    if (!isResourceValid(body, err)) {
+    if (!isItemResourceValid(body, err)) {
       throw err;
     }
 
@@ -341,7 +341,7 @@ export class Items {
     }
 
     const err = {};
-    if (!isResourceValid(body, err)) {
+    if (!isItemResourceValid(body, err)) {
       throw err;
     }
 

--- a/sdk/cosmosdb/cosmos/src/common/helper.ts
+++ b/sdk/cosmosdb/cosmos/src/common/helper.ts
@@ -5,7 +5,7 @@ import { OperationType, ResourceType } from "./constants";
 
 const trimLeftSlashes = new RegExp("^[/]+");
 const trimRightSlashes = new RegExp("[/]+$");
-const illegalResourceIdCharacters = new RegExp("[/\\\\?#]");
+const illegalResourceIdCharacters = new RegExp("[/\\\\?#]"); 
 
 /** @hidden */
 export function jsonStringifyAndEscapeNonASCII(arg: unknown): string {
@@ -187,6 +187,35 @@ export function parsePath(path: string): string[] {
  * @hidden
  */
 export function isResourceValid(resource: { id?: string }, err: { message?: string }): boolean {
+  // TODO: fix strictness issues so that caller contexts respects the types of the functions
+  if (resource.id) {
+    if (typeof resource.id !== "string") {
+      err.message = "Id must be a string.";
+      return false;
+    }
+
+    if (
+      resource.id.indexOf("/") !== -1 ||
+      resource.id.indexOf("\\") !== -1 ||
+      resource.id.indexOf("?") !== -1 ||
+      resource.id.indexOf("#") !== -1
+    ) {
+      err.message = "Id contains illegal chars.";
+      return false;
+    }
+
+    if (resource.id[resource.id.length - 1] === " ") {
+      err.message = "Id ends with a space.";
+      return false;
+    }
+  }
+  return true;
+}
+
+/**
+ * @hidden
+ */
+ export function isItemResourceValid(resource: { id?: string }, err: { message?: string }): boolean {
   // TODO: fix strictness issues so that caller contexts respects the types of the functions
   if (resource.id) {
     if (typeof resource.id !== "string") {

--- a/sdk/cosmosdb/cosmos/src/common/helper.ts
+++ b/sdk/cosmosdb/cosmos/src/common/helper.ts
@@ -5,7 +5,7 @@ import { OperationType, ResourceType } from "./constants";
 
 const trimLeftSlashes = new RegExp("^[/]+");
 const trimRightSlashes = new RegExp("[/]+$");
-const illegalResourceIdCharacters = new RegExp("[/\\\\?#]"); 
+const illegalResourceIdCharacters = new RegExp("[/\\\\?#]");
 
 /** @hidden */
 export function jsonStringifyAndEscapeNonASCII(arg: unknown): string {
@@ -215,7 +215,7 @@ export function isResourceValid(resource: { id?: string }, err: { message?: stri
 /**
  * @hidden
  */
- export function isItemResourceValid(resource: { id?: string }, err: { message?: string }): boolean {
+export function isItemResourceValid(resource: { id?: string }, err: { message?: string }): boolean {
   // TODO: fix strictness issues so that caller contexts respects the types of the functions
   if (resource.id) {
     if (typeof resource.id !== "string") {


### PR DESCRIPTION
### Packages impacted by this PR
@azure/cosmos

### Issues associated with this PR
n/a

### Describe the problem that is addressed by this PR
With recent changes creating databases and containers with special characters in id wasn't blocked by the SDK anymore - this caused issues because databases created couldn't be deleted afterwards via SDK anymore.
This PR just adds back the id character validation for any resource but items. Fixing why the SDK can't delete these resources will be added in subsequent PR.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?
n/a

### Are there test cases added in this PR? _(If not, why?)_
No - existing test failed.

### Provide a list of related PRs _(if any)_
n/a

### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_
n/a
### Checklists
- [x] Added impacted package name to the issue description
- [x] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [x] Added a changelog (if necessary)
