### PR TITLE
Remove api management ci from running on eng/common changes

### DIFF
--- a/sdk/apimanagement/ci.yml
+++ b/sdk/apimanagement/ci.yml
@@ -8,9 +8,7 @@ trigger:
       - hotfix/*
   paths:
     include:
-      - sdk/apimanagement/      
-      # eng/common code changes trigger apimanagement pipeline for basic checking.
-      - eng/common/
+      - sdk/apimanagement/
 
 pr:
   branches:
@@ -22,11 +20,9 @@ pr:
   paths:
     include:
       - sdk/apimanagement/
-      # eng/common code changes trigger apimanagement pipeline for basic checking.
-      - eng/common/
 
 extends:
-  template: ../../eng/pipelines/templates/stages/archetype-sdk-client.yml
+  template: /eng/pipelines/templates/stages/archetype-sdk-client.yml
   parameters:
     ServiceDirectory: apimanagement
     Artifacts:


### PR DESCRIPTION
It is not necessary and adds time/failures to eng/common sync changes