### PR TITLE
[core-amqp][test] fix test issue comparing two timestamps

### DIFF
--- a/sdk/core/core-amqp/package.json
+++ b/sdk/core/core-amqp/package.json
@@ -54,7 +54,7 @@
     "test:node": "npm run clean && tsc -p . && npm run unit-test:node && npm run integration-test:node",
     "test": "npm run clean && tsc -p . && npm run unit-test:node && rollup -c rollup.test.config.js 2>&1 && npm run unit-test:browser && npm run integration-test",
     "unit-test:browser": "karma start --single-run",
-    "unit-test:node": "cross-env TS_NODE_FILES=true TS_NODE_COMPILER_OPTIONS=\"{\\\"module\\\":\\\"commonjs\\\"}\" nyc --reporter=lcov --reporter=text-lcov mocha -r ts-node/register --reporter ../../../common/tools/mocha-multi-reporter.js  --timeout 50000  --full-trace  --exclude \"test/**/browser/*.spec.ts\" \"test/**/*.spec.ts\"",
+    "unit-test:node": "cross-env TS_NODE_FILES=true TS_NODE_COMPILER_OPTIONS=\"{\\\"module\\\":\\\"commonjs\\\"}\" nyc --reporter=lcov --reporter=text-summary --reporter=cobertura mocha -r ts-node/register --reporter ../../../common/tools/mocha-multi-reporter.js  --timeout 50000  --full-trace  --exclude \"test/**/browser/*.spec.ts\" \"test/**/*.spec.ts\"",
     "unit-test": "npm run unit-test:node && npm run unit-test:browser"
   },
   "engines": {

--- a/sdk/core/core-amqp/test/tokenProvider.spec.ts
+++ b/sdk/core/core-amqp/test/tokenProvider.spec.ts
@@ -19,6 +19,7 @@ describe("SasTokenProvider", function (): void {
         /SharedAccessSignature sr=myaudience&sig=(.*)&se=\d{10}&skn=myKeyName/g
       );
       // account for elapsed time between two Date.now() calls
+      // eslint-disable-next-line no-unused-expressions
       (tokenInfo.expiresOnTimestamp - expiry < 2).should.be.true;
     });
 
@@ -34,6 +35,7 @@ describe("SasTokenProvider", function (): void {
         /SharedAccessSignature sr=sb%3A%2F%2Fhostname.servicebus.windows.net%2F&sig=(.*)&se=\d{10}&skn=sakName/g
       );
       // account for elapsed time between two Date.now() calls
+      // eslint-disable-next-line no-unused-expressions
       (tokenInfo.expiresOnTimestamp - expiry < 2).should.be.true;
     });
   });

--- a/sdk/core/core-amqp/test/tokenProvider.spec.ts
+++ b/sdk/core/core-amqp/test/tokenProvider.spec.ts
@@ -13,12 +13,13 @@ describe("SasTokenProvider", function (): void {
       const keyName = "myKeyName";
       const key = "importantValue";
       const tokenProvider = createSasTokenProvider(new AzureNamedKeyCredential(keyName, key));
-      const now = Math.floor(Date.now() / 1000) + 3600;
+      const expiry = Math.floor(Date.now() / 1000) + 3600;
       const tokenInfo = tokenProvider.getToken("myaudience");
       tokenInfo.token.should.match(
         /SharedAccessSignature sr=myaudience&sig=(.*)&se=\d{10}&skn=myKeyName/g
       );
-      tokenInfo.expiresOnTimestamp.should.equal(now);
+      // account for elapsed time between two Date.now() calls
+      (tokenInfo.expiresOnTimestamp - expiry < 2).should.be.true;
     });
 
     it("should work as expected with `shareAccessKeyName` and `sharedAccessKey`", async function (): Promise<void> {
@@ -27,12 +28,13 @@ describe("SasTokenProvider", function (): void {
         sharedAccessKeyName: "sakName",
         sharedAccessKey: "sak",
       });
-      const now = Math.floor(Date.now() / 1000) + 3600;
+      const expiry = Math.floor(Date.now() / 1000) + 3600;
       const tokenInfo = tokenProvider.getToken("sb://hostname.servicebus.windows.net/");
       tokenInfo.token.should.match(
         /SharedAccessSignature sr=sb%3A%2F%2Fhostname.servicebus.windows.net%2F&sig=(.*)&se=\d{10}&skn=sakName/g
       );
-      tokenInfo.expiresOnTimestamp.should.equal(now);
+      // account for elapsed time between two Date.now() calls
+      (tokenInfo.expiresOnTimestamp - expiry < 2).should.be.true;
     });
   });
 


### PR DESCRIPTION
These two tests compare two expiry values from two consecutive Date.now()
calls (the first in the test and the second in the library code) and expect them
to be equal:

    Math.floor(Date.now() / 1000) + 3600

However, it happens that the elapsed time between the two Date.now() call
sometimes can fail the expectation.

> AssertionError: expected 1659139755 to equal 1659139754

This PR change the verification to allow max of 2 milliseconds delta between the
two timestamps.

While at this I also updated the nyc reporters to more useful ones. Previous
ones just print out lines of data that not meant to be human-understandable.
