### PR TITLE
[engsys][identity] enable code coverage result generation

### DIFF
--- a/sdk/identity/identity/.nycrc
+++ b/sdk/identity/identity/.nycrc
@@ -1,0 +1,19 @@
+{
+    "include": [
+      "dist-esm/src/**/*.js"
+    ],
+    "exclude": [
+      "**/*.d.ts",
+      "dist-esm/src/generated/*"
+    ],
+    "reporter": [
+      "text-summary",
+      "html",
+      "cobertura"
+    ],
+    "exclude-after-remap": false,
+    "sourceMap": true,
+    "produce-source-map": true,
+    "instrument": true,
+    "all": true
+  }


### PR DESCRIPTION
The dev-tool runs nyc for integration tests. However, without proper reporter
configurations, desired code coverage reports are not generated.

This PR adds the .nycrc file that is copied from the template project thus
enables code coverage report generation.
