### PR TITLE
[core-http-compat] Policy factory compat

### DIFF
--- a/dataplane.code-workspace
+++ b/dataplane.code-workspace
@@ -274,6 +274,9 @@
     },
     {
       "path": "sdk/instrumentation/opentelemetry-instrumentation-azure-sdk"
+    },
+    {
+      "path": "sdk/core/core-http-compat"
     }
   ],
   "settings": {

--- a/sdk/core/core-http-compat/review/core-http-compat.api.md
+++ b/sdk/core/core-http-compat/review/core-http-compat.api.md
@@ -10,6 +10,7 @@ import { FullOperationResponse } from '@azure/core-client';
 import { HttpMethods } from '@azure/core-rest-pipeline';
 import { OperationArguments } from '@azure/core-client';
 import { OperationSpec } from '@azure/core-client';
+import { PipelinePolicy } from '@azure/core-rest-pipeline';
 import { ProxySettings } from '@azure/core-rest-pipeline';
 import { ServiceClient } from '@azure/core-client';
 import { ServiceClientOptions } from '@azure/core-client';
@@ -19,6 +20,9 @@ export interface CompatResponse extends Omit<FullOperationResponse, "request" | 
     headers: HttpHeadersLike;
     request: WebResourceLike;
 }
+
+// @public
+export function createRequestPolicyFactoryPolicy(factories: RequestPolicyFactory[]): PipelinePolicy;
 
 // @public (undocumented)
 export const disbaleKeepAlivePolicyName = "DisableKeepAlivePolicy";
@@ -64,6 +68,18 @@ export interface HttpHeadersLike {
 }
 
 // @public
+export enum HttpPipelineLogLevel {
+    // (undocumented)
+    ERROR = 1,
+    // (undocumented)
+    INFO = 3,
+    // (undocumented)
+    OFF = 0,
+    // (undocumented)
+    WARNING = 2
+}
+
+// @public
 export interface KeepAliveOptions {
     enable?: boolean;
 }
@@ -77,6 +93,29 @@ export type RawHttpHeaders = {
 export interface RedirectOptions {
     handleRedirects?: boolean;
     maxRetries?: number;
+}
+
+// @public
+export interface RequestPolicy {
+    // (undocumented)
+    sendRequest(httpRequest: WebResourceLike): Promise<CompatResponse>;
+}
+
+// @public
+export interface RequestPolicyFactory {
+    // (undocumented)
+    create(nextPolicy: RequestPolicy, options: RequestPolicyOptionsLike): RequestPolicy;
+}
+
+// @public
+export const requestPolicyFactoryPolicyName = "RequestPolicyFactoryPolicy";
+
+// @public
+export interface RequestPolicyOptionsLike {
+    // (undocumented)
+    log(logLevel: HttpPipelineLogLevel, message: string): void;
+    // (undocumented)
+    shouldLog(logLevel: HttpPipelineLogLevel): boolean;
 }
 
 // @public

--- a/sdk/core/core-http-compat/src/extendedClient.ts
+++ b/sdk/core/core-http-compat/src/extendedClient.ts
@@ -14,7 +14,7 @@ import {
   FullOperationResponse,
   RawResponseCallback,
 } from "@azure/core-client";
-import { toWebResourceLike, toHttpHeaderLike, WebResourceLike, HttpHeadersLike } from "./util";
+import { toCompatResponse } from "./response";
 
 /**
  * Options specific to Shim Clients.
@@ -94,28 +94,10 @@ export class ExtendedServiceClient extends ServiceClient {
 
     if (lastResponse) {
       Object.defineProperty(result, "_response", {
-        value: {
-          ...lastResponse,
-          request: toWebResourceLike(lastResponse.request),
-          headers: toHttpHeaderLike(lastResponse.headers),
-        },
+        value: toCompatResponse(lastResponse),
       });
     }
 
     return result;
   }
-}
-
-/**
- * Http Response that is compatible with the core-v1(core-http).
- */
-export interface CompatResponse extends Omit<FullOperationResponse, "request" | "headers"> {
-  /**
-   * A description of a HTTP request to be made to a remote server.
-   */
-  request: WebResourceLike;
-  /**
-   * A collection of HTTP header key/value pairs.
-   */
-  headers: HttpHeadersLike;
 }

--- a/sdk/core/core-http-compat/src/extendedClient.ts
+++ b/sdk/core/core-http-compat/src/extendedClient.ts
@@ -6,13 +6,13 @@ import { createDisableKeepAlivePolicy } from "./policies/disableKeepAlivePolicy"
 import { RedirectOptions } from "./policies/redirectOptions";
 import { redirectPolicyName } from "@azure/core-rest-pipeline";
 import {
-  ServiceClient,
-  ServiceClientOptions,
   CommonClientOptions,
+  FullOperationResponse,
   OperationArguments,
   OperationSpec,
-  FullOperationResponse,
   RawResponseCallback,
+  ServiceClient,
+  ServiceClientOptions,
 } from "@azure/core-client";
 import { toCompatResponse } from "./response";
 

--- a/sdk/core/core-http-compat/src/index.ts
+++ b/sdk/core/core-http-compat/src/index.ts
@@ -11,8 +11,16 @@ export {
   ExtendedServiceClientOptions,
   ExtendedCommonClientOptions,
   ExtendedClientOptions,
-  CompatResponse,
 } from "./extendedClient";
+export { CompatResponse } from "./response";
+export {
+  requestPolicyFactoryPolicyName,
+  createRequestPolicyFactoryPolicy,
+  RequestPolicyFactory,
+  RequestPolicy,
+  RequestPolicyOptionsLike,
+  HttpPipelineLogLevel,
+} from "./policies/requestPolicyFactoryPolicy";
 export { KeepAliveOptions } from "./policies/keepAliveOptions";
 export { RedirectOptions } from "./policies/redirectOptions";
 export { disbaleKeepAlivePolicyName } from "./policies/disableKeepAlivePolicy";

--- a/sdk/core/core-http-compat/src/policies/disableKeepAlivePolicy.ts
+++ b/sdk/core/core-http-compat/src/policies/disableKeepAlivePolicy.ts
@@ -4,8 +4,8 @@
 import {
   PipelinePolicy,
   PipelineRequest,
-  SendRequest,
   PipelineResponse,
+  SendRequest,
 } from "@azure/core-rest-pipeline";
 
 export const disbaleKeepAlivePolicyName = "DisableKeepAlivePolicy";

--- a/sdk/core/core-http-compat/src/policies/requestPolicyFactoryPolicy.ts
+++ b/sdk/core/core-http-compat/src/policies/requestPolicyFactoryPolicy.ts
@@ -1,0 +1,86 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import {
+  PipelinePolicy,
+  PipelineRequest,
+  SendRequest,
+  PipelineResponse,
+} from "@azure/core-rest-pipeline";
+import { WebResourceLike, toWebResourceLike, toPipelineRequest } from "../util";
+import { CompatResponse, toCompatResponse, toPipelineResponse } from "../response";
+
+/**
+ * A compatible interface for core-http request policies
+ */
+export interface RequestPolicy {
+  sendRequest(httpRequest: WebResourceLike): Promise<CompatResponse>;
+}
+
+/**
+ * An enum for compatibility with RequestPolicy
+ */
+export enum HttpPipelineLogLevel {
+  ERROR = 1,
+  INFO = 3,
+  OFF = 0,
+  WARNING = 2,
+}
+
+/**
+ * An interface for compatibility with RequestPolicy
+ */
+export interface RequestPolicyOptionsLike {
+  log(logLevel: HttpPipelineLogLevel, message: string): void;
+  shouldLog(logLevel: HttpPipelineLogLevel): boolean;
+}
+
+const mockRequestPolicyOptions: RequestPolicyOptionsLike = {
+  log(_logLevel: HttpPipelineLogLevel, _message: string): void {
+    /* do nothing */
+  },
+  shouldLog(_logLevel: HttpPipelineLogLevel): boolean {
+    return false;
+  },
+};
+
+/**
+ * An interface for compatibility with core-http's RequestPolicyFactory
+ */
+export interface RequestPolicyFactory {
+  create(nextPolicy: RequestPolicy, options: RequestPolicyOptionsLike): RequestPolicy;
+}
+
+/**
+ * The name of the RequestPolicyFactoryPolicy
+ */
+export const requestPolicyFactoryPolicyName = "RequestPolicyFactoryPolicy";
+
+/**
+ * A policy that wraps policies written for core-http.
+ * @param factories An array of `RequestPolicyFactory` objects from a core-http pipeline
+ */
+export function createRequestPolicyFactoryPolicy(
+  factories: RequestPolicyFactory[]
+): PipelinePolicy {
+  const orderedFactories = factories.slice().reverse();
+
+  return {
+    name: requestPolicyFactoryPolicyName,
+    async sendRequest(request: PipelineRequest, next: SendRequest): Promise<PipelineResponse> {
+      let httpPipeline: RequestPolicy = {
+        async sendRequest(httpRequest) {
+          const response = await next(toPipelineRequest(httpRequest));
+          return toCompatResponse(response, { createProxy: true });
+        },
+      };
+      for (const factory of orderedFactories) {
+        httpPipeline = factory.create(httpPipeline, mockRequestPolicyOptions);
+      }
+
+      const webResourceLike = toWebResourceLike(request, { createProxy: true });
+      const response = await httpPipeline.sendRequest(webResourceLike);
+      return toPipelineResponse(response);
+    },
+  };
+}

--- a/sdk/core/core-http-compat/src/policies/requestPolicyFactoryPolicy.ts
+++ b/sdk/core/core-http-compat/src/policies/requestPolicyFactoryPolicy.ts
@@ -4,10 +4,10 @@
 import {
   PipelinePolicy,
   PipelineRequest,
-  SendRequest,
   PipelineResponse,
+  SendRequest,
 } from "@azure/core-rest-pipeline";
-import { WebResourceLike, toWebResourceLike, toPipelineRequest } from "../util";
+import { WebResourceLike, toPipelineRequest, toWebResourceLike } from "../util";
 import { CompatResponse, toCompatResponse, toPipelineResponse } from "../response";
 
 /**
@@ -58,7 +58,7 @@ export const requestPolicyFactoryPolicyName = "RequestPolicyFactoryPolicy";
 
 /**
  * A policy that wraps policies written for core-http.
- * @param factories An array of `RequestPolicyFactory` objects from a core-http pipeline
+ * @param factories - An array of `RequestPolicyFactory` objects from a core-http pipeline
  */
 export function createRequestPolicyFactoryPolicy(
   factories: RequestPolicyFactory[]

--- a/sdk/core/core-http-compat/src/response.ts
+++ b/sdk/core/core-http-compat/src/response.ts
@@ -2,13 +2,13 @@
 // Licensed under the MIT license.
 
 import { FullOperationResponse } from "@azure/core-client";
-import { createHttpHeaders, PipelineResponse } from "@azure/core-rest-pipeline";
+import { PipelineResponse, createHttpHeaders } from "@azure/core-rest-pipeline";
 import {
-  toWebResourceLike,
-  toHttpHeaderLike,
-  WebResourceLike,
   HttpHeadersLike,
+  WebResourceLike,
+  toHttpHeaderLike,
   toPipelineRequest,
+  toWebResourceLike,
 } from "./util";
 /**
  * Http Response that is compatible with the core-v1(core-http).
@@ -29,7 +29,7 @@ type ExtendedCompatResponse = CompatResponse & { [originalResponse]?: FullOperat
 
 /**
  * A helper to convert response objects from the new pipeline back to the old one.
- * @param response A response object from core-client.
+ * @param response - A response object from core-client.
  * @returns A response compatible with `HttpOperationResponse` from core-http.
  */
 export function toCompatResponse(
@@ -68,7 +68,7 @@ export function toCompatResponse(
 
 /**
  * A helper to convert back to a PipelineResponse
- * @param compatResponse A response compatible with `HttpOperationResponse` from core-http.
+ * @param compatResponse - A response compatible with `HttpOperationResponse` from core-http.
  */
 export function toPipelineResponse(compatResponse: CompatResponse): PipelineResponse {
   const extendedCompatResponse = compatResponse as ExtendedCompatResponse;

--- a/sdk/core/core-http-compat/src/response.ts
+++ b/sdk/core/core-http-compat/src/response.ts
@@ -1,0 +1,87 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { FullOperationResponse } from "@azure/core-client";
+import { createHttpHeaders, PipelineResponse } from "@azure/core-rest-pipeline";
+import {
+  toWebResourceLike,
+  toHttpHeaderLike,
+  WebResourceLike,
+  HttpHeadersLike,
+  toPipelineRequest,
+} from "./util";
+/**
+ * Http Response that is compatible with the core-v1(core-http).
+ */
+export interface CompatResponse extends Omit<FullOperationResponse, "request" | "headers"> {
+  /**
+   * A description of a HTTP request to be made to a remote server.
+   */
+  request: WebResourceLike;
+  /**
+   * A collection of HTTP header key/value pairs.
+   */
+  headers: HttpHeadersLike;
+}
+
+const originalResponse = Symbol("Original FullOperationResponse");
+type ExtendedCompatResponse = CompatResponse & { [originalResponse]?: FullOperationResponse };
+
+/**
+ * A helper to convert response objects from the new pipeline back to the old one.
+ * @param response A response object from core-client.
+ * @returns A response compatible with `HttpOperationResponse` from core-http.
+ */
+export function toCompatResponse(
+  response: FullOperationResponse,
+  options?: { createProxy?: boolean }
+): CompatResponse {
+  let request = toWebResourceLike(response.request);
+  let headers = toHttpHeaderLike(response.headers);
+  if (options?.createProxy) {
+    return new Proxy(response, {
+      get(target, prop, receiver) {
+        if (prop === "headers") {
+          return headers;
+        } else if (prop === "request") {
+          return request;
+        }
+        return Reflect.get(target, prop, receiver);
+      },
+      set(target, prop, value, receiver) {
+        if (prop === "headers") {
+          headers = value;
+        } else if (prop === "request") {
+          request = value;
+        }
+        return Reflect.set(target, prop, value, receiver);
+      },
+    }) as unknown as CompatResponse;
+  } else {
+    return {
+      ...response,
+      request,
+      headers,
+    };
+  }
+}
+
+/**
+ * A helper to convert back to a PipelineResponse
+ * @param compatResponse A response compatible with `HttpOperationResponse` from core-http.
+ */
+export function toPipelineResponse(compatResponse: CompatResponse): PipelineResponse {
+  const extendedCompatResponse = compatResponse as ExtendedCompatResponse;
+  const response = extendedCompatResponse[originalResponse];
+  const headers = createHttpHeaders(compatResponse.headers.toJson({ preserveCase: true }));
+  if (response) {
+    response.headers = headers;
+    return response;
+  } else {
+    return {
+      ...compatResponse,
+      headers,
+      request: toPipelineRequest(compatResponse.request),
+    };
+  }
+}

--- a/sdk/core/core-http-compat/src/util.ts
+++ b/sdk/core/core-http-compat/src/util.ts
@@ -2,10 +2,10 @@
 // Licensed under the MIT license.
 
 import {
-  createHttpHeaders,
-  createPipelineRequest,
   HttpMethods,
   ProxySettings,
+  createHttpHeaders,
+  createPipelineRequest,
 } from "@azure/core-rest-pipeline";
 import { AbortSignalLike } from "@azure/abort-controller";
 import { HttpHeaders as HttpHeadersV2, PipelineRequest } from "@azure/core-rest-pipeline";

--- a/sdk/core/core-http-compat/src/util.ts
+++ b/sdk/core/core-http-compat/src/util.ts
@@ -1,19 +1,76 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { HttpMethods, ProxySettings } from "@azure/core-rest-pipeline";
+import {
+  createHttpHeaders,
+  createPipelineRequest,
+  HttpMethods,
+  ProxySettings,
+} from "@azure/core-rest-pipeline";
 import { AbortSignalLike } from "@azure/abort-controller";
 import { HttpHeaders as HttpHeadersV2, PipelineRequest } from "@azure/core-rest-pipeline";
 
-export function toWebResourceLike(request: PipelineRequest): WebResourceLike {
-  return {
+const originalRequest = Symbol("Original PipelineRequest");
+type CompatWebResourceLike = WebResourceLike & { [originalRequest]?: PipelineRequest };
+
+export function toPipelineRequest(webResource: WebResourceLike): PipelineRequest {
+  const compatWebResource = webResource as CompatWebResourceLike;
+  const request = compatWebResource[originalRequest];
+  const headers = createHttpHeaders(webResource.headers.toJson({ preserveCase: true }));
+  if (request) {
+    request.headers = headers;
+    return request;
+  } else {
+    return createPipelineRequest({
+      url: webResource.url,
+      method: webResource.method,
+      headers,
+      withCredentials: webResource.withCredentials,
+      timeout: webResource.timeout,
+      requestId: webResource.requestId,
+    });
+  }
+}
+
+export function toWebResourceLike(
+  request: PipelineRequest,
+  options?: { createProxy?: boolean }
+): WebResourceLike {
+  const webResource: WebResourceLike = {
     url: request.url,
     method: request.method,
     headers: toHttpHeaderLike(request.headers),
     withCredentials: request.withCredentials,
     timeout: request.timeout,
-    requestId: request.headers.get("x-ms-client-request-id") || "",
+    requestId: request.headers.get("x-ms-client-request-id") || request.requestId,
   };
+
+  if (options?.createProxy) {
+    return new Proxy(webResource, {
+      get(target, prop, receiver) {
+        if (prop === originalRequest) {
+          return request;
+        }
+        return Reflect.get(target, prop, receiver);
+      },
+      set(target: any, prop, value, receiver) {
+        if (prop === "url") {
+          request.url = value;
+        } else if (prop === "method") {
+          request.method = value;
+        } else if (prop === "withCredentials") {
+          request.withCredentials = value;
+        } else if (prop === "timeout") {
+          request.timeout = value;
+        } else if (prop === "requestId") {
+          request.requestId = value;
+        }
+        return Reflect.set(target, prop, value, receiver);
+      },
+    });
+  } else {
+    return webResource;
+  }
 }
 
 export function toHttpHeaderLike(headers: HttpHeadersV2): HttpHeadersLike {

--- a/sdk/core/core-http-compat/test/extendedClient.spec.ts
+++ b/sdk/core/core-http-compat/test/extendedClient.spec.ts
@@ -2,14 +2,14 @@
 // Licensed under the MIT license.
 
 import { assert } from "@azure/test-utils";
-import { PipelinePolicy, createHttpHeaders, createEmptyPipeline } from "@azure/core-rest-pipeline";
+import { PipelinePolicy, createEmptyPipeline, createHttpHeaders } from "@azure/core-rest-pipeline";
 import {
-  serializationPolicy,
-  OperationRequest,
-  createSerializer,
   DictionaryMapper,
   OperationArguments,
+  OperationRequest,
   OperationSpec,
+  createSerializer,
+  serializationPolicy,
 } from "@azure/core-client";
 import { ExtendedServiceClient, disbaleKeepAlivePolicyName } from "../src/index";
 

--- a/sdk/core/core-http-compat/test/requestPolicyFactoryPolicy.spec.ts
+++ b/sdk/core/core-http-compat/test/requestPolicyFactoryPolicy.spec.ts
@@ -1,0 +1,73 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { assert } from "@azure/test-utils";
+import {
+  createEmptyPipeline,
+  createHttpHeaders,
+  createPipelineRequest,
+  HttpClient,
+} from "@azure/core-rest-pipeline";
+import { createRequestPolicyFactoryPolicy } from "../src/policies/requestPolicyFactoryPolicy";
+import { mutateRequestPolicy, mutateResponsePolicy } from "./testPolicies";
+
+describe("requestPolicyFactoryPolicy", function () {
+  const testHttpClient: HttpClient = {
+    sendRequest: async (request) => {
+      return {
+        request,
+        headers: createHttpHeaders({ "server-header": "some-value" }),
+        status: 200,
+      };
+    },
+  };
+  it("should preserve changes to headers in the request", async function () {
+    const policy = createRequestPolicyFactoryPolicy([
+      mutateRequestPolicy({ headersToSet: { "x-ms-test": "testValue" } }),
+    ]);
+    const pipeline = createEmptyPipeline();
+    pipeline.addPolicy(policy);
+    const result = await pipeline.sendRequest(
+      testHttpClient,
+      createPipelineRequest({ url: "test" })
+    );
+    assert.strictEqual(result.headers.get("server-header"), "some-value");
+    assert.strictEqual(result.request.headers.get("x-ms-test"), "testValue");
+  });
+
+  it("should preserve changes to headers in the response", async function () {
+    const policy = createRequestPolicyFactoryPolicy([
+      mutateResponsePolicy({ headersToSet: { "x-ms-test": "testValue" } }),
+    ]);
+    const pipeline = createEmptyPipeline();
+    pipeline.addPolicy(policy);
+    const result = await pipeline.sendRequest(
+      testHttpClient,
+      createPipelineRequest({ url: "test" })
+    );
+    assert.strictEqual(result.headers.get("server-header"), "some-value");
+    assert.strictEqual(result.headers.get("x-ms-test"), "testValue");
+  });
+
+  it("should preserve changes made to both request and response", async function () {
+    const policy = createRequestPolicyFactoryPolicy([
+      mutateRequestPolicy({
+        headersToSet: { "x-ms-test": "request" },
+        url: "test2",
+        timeout: 9000,
+      }),
+      mutateResponsePolicy({ headersToSet: { "x-ms-test": "response" } }),
+    ]);
+    const pipeline = createEmptyPipeline();
+    pipeline.addPolicy(policy);
+    const result = await pipeline.sendRequest(
+      testHttpClient,
+      createPipelineRequest({ url: "test" })
+    );
+    assert.strictEqual(result.request.url, "test2");
+    assert.strictEqual(result.request.timeout, 9000);
+    assert.strictEqual(result.request.headers.get("x-ms-test"), "request");
+    assert.strictEqual(result.headers.get("server-header"), "some-value");
+    assert.strictEqual(result.headers.get("x-ms-test"), "response");
+  });
+});

--- a/sdk/core/core-http-compat/test/requestPolicyFactoryPolicy.spec.ts
+++ b/sdk/core/core-http-compat/test/requestPolicyFactoryPolicy.spec.ts
@@ -3,10 +3,10 @@
 
 import { assert } from "@azure/test-utils";
 import {
+  HttpClient,
   createEmptyPipeline,
   createHttpHeaders,
   createPipelineRequest,
-  HttpClient,
 } from "@azure/core-rest-pipeline";
 import { createRequestPolicyFactoryPolicy } from "../src/policies/requestPolicyFactoryPolicy";
 import { mutateRequestPolicy, mutateResponsePolicy } from "./testPolicies";

--- a/sdk/core/core-http-compat/test/testPolicies.ts
+++ b/sdk/core/core-http-compat/test/testPolicies.ts
@@ -2,11 +2,11 @@
 // Licensed under the MIT license.
 
 import {
-  WebResourceLike,
+  CompatResponse,
   RequestPolicy,
   RequestPolicyFactory,
   RequestPolicyOptionsLike,
-  CompatResponse,
+  WebResourceLike,
 } from "../src/index";
 
 export interface MutateOptions {

--- a/sdk/core/core-http-compat/test/testPolicies.ts
+++ b/sdk/core/core-http-compat/test/testPolicies.ts
@@ -1,0 +1,78 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import {
+  WebResourceLike,
+  RequestPolicy,
+  RequestPolicyFactory,
+  RequestPolicyOptionsLike,
+  CompatResponse,
+} from "../src/index";
+
+export interface MutateOptions {
+  headersToSet?: { [name: string]: string };
+}
+
+export interface RequestMutateOptions extends MutateOptions {
+  url?: string;
+  timeout?: number;
+}
+
+export function mutateRequestPolicy(mutateOptions: RequestMutateOptions): RequestPolicyFactory {
+  return {
+    create: (nextPolicy: RequestPolicy, options: RequestPolicyOptionsLike) => {
+      return new MutateRequestPolicy(nextPolicy, options, mutateOptions);
+    },
+  };
+}
+
+export class MutateRequestPolicy {
+  constructor(
+    private _nextPolicy: RequestPolicy,
+    _options: RequestPolicyOptionsLike,
+    private readonly _mutateOptions: RequestMutateOptions
+  ) {
+    /** Nothing much to do here */
+  }
+
+  public async sendRequest(request: WebResourceLike): Promise<CompatResponse> {
+    const headersToSet = this._mutateOptions.headersToSet;
+    for (const [name, value] of Object.entries(headersToSet ?? {})) {
+      request.headers.set(name, value);
+    }
+    if (this._mutateOptions.url) {
+      request.url = this._mutateOptions.url;
+    }
+    if (typeof this._mutateOptions.timeout === "number") {
+      request.timeout = this._mutateOptions.timeout;
+    }
+    return this._nextPolicy.sendRequest(request);
+  }
+}
+
+export function mutateResponsePolicy(mutateOptions: MutateOptions): RequestPolicyFactory {
+  return {
+    create: (nextPolicy: RequestPolicy, options: RequestPolicyOptionsLike) => {
+      return new MutateResponsePolicy(nextPolicy, options, mutateOptions);
+    },
+  };
+}
+
+export class MutateResponsePolicy {
+  constructor(
+    private _nextPolicy: RequestPolicy,
+    _options: RequestPolicyOptionsLike,
+    private readonly _mutateOptions: MutateOptions
+  ) {
+    /** Nothing much to do here */
+  }
+
+  public async sendRequest(request: WebResourceLike): Promise<CompatResponse> {
+    const response = await this._nextPolicy.sendRequest(request);
+    const headersToSet = this._mutateOptions.headersToSet;
+    for (const [name, value] of Object.entries(headersToSet ?? {})) {
+      response.headers.set(name, value);
+    }
+    return response;
+  }
+}


### PR DESCRIPTION
New compat behavior requested by storage team:

- A corev2 policy that can wrap core-http style policies and insert them into the pipeline.

This will allow Storage to keep using their `PipelineLike` interface without breaking changes by allowing old-style http policies to participate in corev2 pipelines.