### PR TITLE
[identity] Partially revert #19356

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -1205,27 +1205,18 @@ packages:
       - supports-color
     dev: false
 
-  /@azure/msal-common/5.2.0:
-    resolution: {integrity: sha512-oVc4soy5MEZOp9NvCDqBk57mtiUTJXQQ8Z8S/4UiRQP8RG8snuCFQUs9xxdIfvl2FWIvgiBz+SMByyjTaRX42Q==}
-    engines: {node: '>=0.8.0'}
-    dependencies:
-      debug: 4.3.4
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
   /@azure/msal-common/7.2.0:
     resolution: {integrity: sha512-+Oz8LKTOACDHqDmv+MZy/z+DZRH8RZbMjhadmvp0scQ0R75OrzZro+HkxifWhtDG8l1ViYkvV9NHb4pEZyajAQ==}
     engines: {node: '>=0.8.0'}
     dev: false
 
-  /@azure/msal-node-extensions/1.0.0-alpha.13:
-    resolution: {integrity: sha512-vOxGmRl/GAiSywTz5K67Rj/pZNll9LAIYlet76zBJG/I2m0BCvAHixx1cBMqGTLYKoTrPtJK21HKP0DIS2TetA==}
+  /@azure/msal-node-extensions/1.0.0-alpha.9:
+    resolution: {integrity: sha512-p6ulfziYQDbPmFH0LZ7ekvC6WJu4coHTHPtH4iA6wEeMMy6aD8afv4KgXZDm7bX0rXlTIb+1O8hQYOATz4j5vA==}
     engines: {node: '>=10'}
     requiresBuild: true
     dependencies:
-      '@azure/msal-common': 5.2.0
-      bindings: github.com/samuelkubai/node-bindings/3a5a099ed0178b65079ce18e11fccc7130e0af1e
+      '@azure/msal-common': 4.5.1
+      bindings: 1.5.0
       keytar: 7.9.0
       nan: 2.16.0
     transitivePeerDependencies:
@@ -3201,6 +3192,12 @@ packages:
     engines: {node: '>=8'}
     dev: false
 
+  /bindings/1.5.0:
+    resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
+    dependencies:
+      file-uri-to-path: 1.0.0
+    dev: false
+
   /bl/4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
     dependencies:
@@ -3974,7 +3971,7 @@ packages:
     dependencies:
       semver: 7.3.7
       shelljs: 0.8.5
-      typescript: 4.8.0-dev.20220803
+      typescript: 4.8.0-dev.20220804
     dev: false
 
   /downlevel-dts/0.4.0:
@@ -5672,7 +5669,7 @@ packages:
     dev: false
 
   /isarray/0.0.1:
-    resolution: {integrity: sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=}
+    resolution: {integrity: sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==}
     dev: false
 
   /isarray/1.0.0:
@@ -8863,8 +8860,8 @@ packages:
     hasBin: true
     dev: false
 
-  /typescript/4.8.0-dev.20220803:
-    resolution: {integrity: sha512-kSQ2BkI4A0i81bjz+X+ibWVlC/DiImiNzJkz8tOj3U3hSgtgBTWw0a2YnVVHvyVdw7R59qDjE/sjX/3p8zY7xg==}
+  /typescript/4.8.0-dev.20220804:
+    resolution: {integrity: sha512-N5tKzl5WE31E6YHL3nlYls2zCxkCfax3gb3zKKcrRJXEzfPRFodE0xzkIgGJIshTLQnF/uwiN2Nc8TG50aE9Hg==}
     engines: {node: '>=4.2.0'}
     hasBin: true
     dev: false
@@ -8921,7 +8918,7 @@ packages:
     dev: false
 
   /unpipe/1.0.0:
-    resolution: {integrity: sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=}
+    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
     engines: {node: '>= 0.8'}
     dev: false
 
@@ -16601,13 +16598,13 @@ packages:
     dev: false
 
   file:projects/identity-cache-persistence.tgz:
-    resolution: {integrity: sha512-wEozmQpm8/Sgtw3a8E5vOaVxQ27n99u30WHzBCenrzaH79g9GWWnU5Zo+y99+jKZNjpv/QwGpRusmqE8Go3Vbw==, tarball: file:projects/identity-cache-persistence.tgz}
+    resolution: {integrity: sha512-qgvvEWqF56bvJm7BBAuz+yFU30ICHkH5DjoTRlTCBW4sTEvcvEFHW8Y8K5IQ83ERjV74G3QOwg/IwqMtT4Gqrw==, tarball: file:projects/identity-cache-persistence.tgz}
     name: '@rush-temp/identity-cache-persistence'
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
       '@azure/msal-node': 1.12.0
-      '@azure/msal-node-extensions': 1.0.0-alpha.13
+      '@azure/msal-node-extensions': 1.0.0-alpha.9
       '@microsoft/api-extractor': 7.18.11
       '@types/jws': 3.2.4
       '@types/mocha': 7.0.2
@@ -19235,12 +19232,4 @@ packages:
       - encoding
       - supports-color
       - utf-8-validate
-    dev: false
-
-  github.com/samuelkubai/node-bindings/3a5a099ed0178b65079ce18e11fccc7130e0af1e:
-    resolution: {tarball: https://codeload.github.com/samuelkubai/node-bindings/tar.gz/3a5a099ed0178b65079ce18e11fccc7130e0af1e}
-    name: bindings
-    version: 1.5.0
-    dependencies:
-      file-uri-to-path: 1.0.0
     dev: false

--- a/sdk/identity/identity-cache-persistence/CHANGELOG.md
+++ b/sdk/identity/identity-cache-persistence/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### Other Changes
 
-- Updated `@azure/msal-node` to version `^1.4.0` and `@azure/msal-node-extensions` to version `1.0.0-alpha.13`.
+- Updated `@azure/msal-node` to version `^1.4.0`.
 
 ## 1.0.0 (2021-10-15)
 

--- a/sdk/identity/identity-cache-persistence/package.json
+++ b/sdk/identity/identity-cache-persistence/package.json
@@ -62,7 +62,7 @@
     "@azure/core-auth": "^1.3.0",
     "@azure/identity": "^2.1.0",
     "@azure/msal-node": "^1.4.0",
-    "@azure/msal-node-extensions": "1.0.0-alpha.13",
+    "@azure/msal-node-extensions": "1.0.0-alpha.9",
     "keytar": "^7.6.0",
     "tslib": "^2.2.0"
   },


### PR DESCRIPTION
This removes a transitive dependency on github.com/samuelkubai/node-bindings from the repo.

An NPM bug (https://github.com/npm/cli/issues/4896) causes github package references to hang on Linux hosts because it attempts to use the unsupported git protocol.

This causes a two minute delay when running rush update from linux hosts, including our pipeline agents. Furthermore, github-based dependencies are altogether risky, since they can naturally subvert versioning constraints, so we will be blocked from upgrading msal-node-extensions until we can upgrade to a version that does not have this behavior.

Fortunately, we never shipped a dependency on msal-node-extensions 13, so this downgrade shouldn't require a release.

CC @mikeharder @xirzec 