### PR TITLE
[notification hubs] Fixing AMQP version used by Notification Hubs

### DIFF
--- a/sdk/notificationhubs/ci.yml
+++ b/sdk/notificationhubs/ci.yml
@@ -19,8 +19,6 @@ pr:
       - feature/*
       - release/*
       - hotfix/*
-    exclude:
-      - feature/v4
   paths:
     include:
       - sdk/notificationhubs/

--- a/sdk/notificationhubs/notification-hubs/CHANGELOG.md
+++ b/sdk/notificationhubs/notification-hubs/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Release History
 
-## 1.0.0-beta.1 (2022-08-03)
+## 1.0.0-beta.1 (2022-08-04)
 
 - Initial release

--- a/sdk/notificationhubs/notification-hubs/package.json
+++ b/sdk/notificationhubs/notification-hubs/package.json
@@ -131,13 +131,13 @@
   "dependencies": {
     "@azure/abort-controller": "^1.1.0",
     "@azure/core-amqp": "^3.1.0",
-    "@azure/core-auth": "^1.3.2",
-    "@azure/core-client": "^1.6.0",
+    "@azure/core-auth": "^1.4.0",
+    "@azure/core-client": "^1.6.1",
     "@azure/core-paging": "^1.3.1",
     "@azure/core-rest-pipeline": "^1.8.1",
     "@azure/core-tracing": "^1.0.1",
     "@azure/core-util": "^1.0.0",
-    "@azure/core-xml": "^1.2.1",
+    "@azure/core-xml": "^1.3.0",
     "@azure/logger": "^1.0.3",
     "tslib": "^2.4.0"
   }

--- a/sdk/notificationhubs/notification-hubs/package.json
+++ b/sdk/notificationhubs/notification-hubs/package.json
@@ -130,7 +130,7 @@
   },
   "dependencies": {
     "@azure/abort-controller": "^1.1.0",
-    "@azure/core-amqp": "^3.1.1",
+    "@azure/core-amqp": "^3.1.0",
     "@azure/core-auth": "^1.3.2",
     "@azure/core-client": "^1.6.0",
     "@azure/core-paging": "^1.3.1",


### PR DESCRIPTION
### Packages impacted by this PR

- [notification hubs]

### Issues associated with this PR


### Describe the problem that is addressed by this PR

- `@azure/core-amqp` was being used for version `3.1.1` which was not yet published. Downgraded to `3.1.0`

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [x] Added a changelog (if necessary)
