### PR TITLE
[dev-tool] ensure test file `**` glob pattern option is quoted

### DIFF
--- a/common/tools/dev-tool/src/commands/run/testNodeJSInput.ts
+++ b/common/tools/dev-tool/src/commands/run/testNodeJSInput.ts
@@ -12,14 +12,10 @@ export const commandInfo = makeCommandInfo(
 export default leafCommand(commandInfo, async (options) => {
   const defaultMochaArgs =
     "-r esm --require source-map-support/register --reporter ../../../common/tools/mocha-multi-reporter.js --full-trace";
-  for (let i = 0; i < (options["--"]?.length ?? 0); i++) {
-    const opt = options["--"]![i];
-    if (opt.includes("**") && !opt.startsWith("'") && !opt.startsWith('"')) {
-      options["--"]![i] = `"${opt}"`
-    }
-  }
-  const mochaArgs = options["--"]?.length
-    ? options["--"]?.join(" ")
+  const updatedArgs = options["--"]?.map(opt =>
+    opt.includes("**") && !opt.startsWith("'") && !opt.startsWith('"') ? `"${opt}"` : opt)
+  const mochaArgs = updatedArgs?.length
+    ? updatedArgs?.join(" ")
     : '--timeout 5000000 "dist-esm/test/{,!(browser)/**/}/*.spec.js"';
   return runTestsWithProxyTool({
     command: `nyc mocha ${defaultMochaArgs} ${mochaArgs}`,

--- a/common/tools/dev-tool/src/commands/run/testNodeJSInput.ts
+++ b/common/tools/dev-tool/src/commands/run/testNodeJSInput.ts
@@ -12,6 +12,12 @@ export const commandInfo = makeCommandInfo(
 export default leafCommand(commandInfo, async (options) => {
   const defaultMochaArgs =
     "-r esm --require source-map-support/register --reporter ../../../common/tools/mocha-multi-reporter.js --full-trace";
+  for (let i = 0; i < (options["--"]?.length ?? 0); i++) {
+    const opt = options["--"]![i];
+    if (opt.includes("**") && !opt.startsWith("'") && !opt.startsWith('"')) {
+      options["--"]![i] = `"${opt}"`
+    }
+  }
   const mochaArgs = options["--"]?.length
     ? options["--"]?.join(" ")
     : '--timeout 5000000 "dist-esm/test/{,!(browser)/**/}/*.spec.js"';

--- a/common/tools/dev-tool/src/commands/run/testNodeTSInput.ts
+++ b/common/tools/dev-tool/src/commands/run/testNodeTSInput.ts
@@ -12,8 +12,10 @@ export const commandInfo = makeCommandInfo(
 export default leafCommand(commandInfo, async (options) => {
   const defaultMochaArgs =
     "-r esm -r ts-node/register --reporter ../../../common/tools/mocha-multi-reporter.js --full-trace";
-  const mochaArgs = options["--"]?.length
-    ? options["--"]?.join(" ")
+  const updatedArgs = options["--"]?.map(opt =>
+    opt.includes("**") && !opt.startsWith("'") && !opt.startsWith('"') ? `"${opt}"` : opt)
+  const mochaArgs = updatedArgs?.length
+    ? updatedArgs?.join(" ")
     : '--timeout 1200000 --exclude "test/**/browser/*.spec.ts" "test/**/*.spec.ts"';
   return runTestsWithProxyTool({
     command: `mocha ${defaultMochaArgs} ${mochaArgs}`,


### PR DESCRIPTION
It appears that dev-tool doesn't receive the wrapping quotes around glob pattern on Linux/MacOS from the `process.argv` variable, which prevents Mocha from handle the pattern correctly.

This PR adds the quotes when the argument is a glob pattern that contains "**" so that expansion can be done by Mocha.