### PR TITLE
[Language Text] Implement cancellation outside pollers

### DIFF
--- a/sdk/cognitivelanguage/ai-language-text/package.json
+++ b/sdk/cognitivelanguage/ai-language-text/package.json
@@ -86,7 +86,7 @@
     "@azure/core-auth": "^1.3.0",
     "@azure/core-client": "^1.0.0",
     "@azure/core-rest-pipeline": "^1.8.1",
-    "@azure/core-lro": "2.3.0-beta.1",
+    "@azure/core-lro": "^2.3.0",
     "@azure/core-paging": "^1.3.0",
     "@azure/core-tracing": "1.0.0",
     "@azure/logger": "^1.0.0",

--- a/sdk/cognitivelanguage/ai-language-text/review/ai-language-text.api.md
+++ b/sdk/cognitivelanguage/ai-language-text/review/ai-language-text.api.md
@@ -8,9 +8,9 @@ import { AzureKeyCredential } from '@azure/core-auth';
 import { CommonClientOptions } from '@azure/core-client';
 import { KeyCredential } from '@azure/core-auth';
 import { OperationOptions } from '@azure/core-client';
+import { OperationState } from '@azure/core-lro';
 import { PagedAsyncIterableIterator } from '@azure/core-paging';
-import { PollerLike } from '@azure/core-lro';
-import { PollOperationState } from '@azure/core-lro';
+import { SimplePollerLike } from '@azure/core-lro';
 import { TokenCredential } from '@azure/core-auth';
 
 // @public
@@ -85,6 +85,12 @@ export const AnalyzeBatchActionNames: {
 };
 
 // @public
+export interface AnalyzeBatchOperation {
+    poller: AnalyzeBatchPoller;
+    sendCancellationRequest(): Promise<void>;
+}
+
+// @public
 export interface AnalyzeBatchOperationMetadata {
     readonly actionFailedCount: number;
     readonly actionInProgressCount: number;
@@ -94,15 +100,14 @@ export interface AnalyzeBatchOperationMetadata {
     readonly expiresOn?: Date;
     readonly id: string;
     readonly modifiedOn: Date;
-    readonly status: OperationStatus;
 }
 
 // @public
-export interface AnalyzeBatchOperationState extends PollOperationState<PagedAnalyzeBatchResult>, AnalyzeBatchOperationMetadata {
+export interface AnalyzeBatchOperationState extends OperationState<PagedAnalyzeBatchResult>, AnalyzeBatchOperationMetadata {
 }
 
 // @public
-export type AnalyzeBatchPoller = PollerLike<AnalyzeBatchOperationState, PagedAnalyzeBatchResult>;
+export type AnalyzeBatchPoller = SimplePollerLike<AnalyzeBatchOperationState, PagedAnalyzeBatchResult>;
 
 // @public
 export type AnalyzeBatchResult = EntityLinkingBatchResult | EntityRecognitionBatchResult | KeyPhraseExtractionBatchResult | PiiEntityRecognitionBatchResult | SentimentAnalysisBatchResult | HealthcareBatchResult | ExtractiveSummarizationBatchResult | CustomEntityRecognitionBatchResult | CustomSingleLabelClassificationBatchResult | CustomMultiLabelClassificationBatchResult;
@@ -890,9 +895,9 @@ export class TextAnalysisClient {
     analyze<ActionName extends "LanguageDetection">(actionName: ActionName, documents: string[], countryHint?: string, options?: AnalyzeActionParameters<ActionName> & TextAnalysisOperationOptions): Promise<AnalyzeResult<ActionName>>;
     analyze<ActionName extends AnalyzeActionName = AnalyzeActionName>(actionName: ActionName, documents: TextDocumentInput[], options?: AnalyzeActionParameters<ActionName> & TextAnalysisOperationOptions): Promise<AnalyzeResult<ActionName>>;
     analyze<ActionName extends AnalyzeActionName = AnalyzeActionName>(actionName: ActionName, documents: string[], languageCode?: string, options?: AnalyzeActionParameters<ActionName> & TextAnalysisOperationOptions): Promise<AnalyzeResult<ActionName>>;
-    beginAnalyzeBatch(actions: AnalyzeBatchAction[], documents: string[], languageCode?: string, options?: BeginAnalyzeBatchOptions): Promise<AnalyzeBatchPoller>;
-    beginAnalyzeBatch(actions: AnalyzeBatchAction[], documents: TextDocumentInput[], options?: BeginAnalyzeBatchOptions): Promise<AnalyzeBatchPoller>;
-    restoreAnalyzeBatchPoller(serializedState: string, options?: RestoreAnalyzeBatchPollerOptions): Promise<AnalyzeBatchPoller>;
+    beginAnalyzeBatch(actions: AnalyzeBatchAction[], documents: string[], languageCode?: string, options?: BeginAnalyzeBatchOptions): Promise<AnalyzeBatchOperation>;
+    beginAnalyzeBatch(actions: AnalyzeBatchAction[], documents: TextDocumentInput[], options?: BeginAnalyzeBatchOptions): Promise<AnalyzeBatchOperation>;
+    restoreAnalyzeBatchPoller(serializedState: string, options?: RestoreAnalyzeBatchPollerOptions): Promise<AnalyzeBatchOperation>;
 }
 
 // @public

--- a/sdk/cognitivelanguage/ai-language-text/samples-dev/batching.ts
+++ b/sdk/cognitivelanguage/ai-language-text/samples-dev/batching.ts
@@ -51,7 +51,7 @@ export async function main() {
       modelVersion: "latest",
     },
   ];
-  const poller = await client.beginAnalyzeBatch(actions, documents, "en");
+  const { poller } = await client.beginAnalyzeBatch(actions, documents, "en");
 
   poller.onProgress(() => {
     console.log(

--- a/sdk/cognitivelanguage/ai-language-text/samples-dev/customEntityRecognition.ts
+++ b/sdk/cognitivelanguage/ai-language-text/samples-dev/customEntityRecognition.ts
@@ -43,7 +43,7 @@ export async function main() {
       projectName,
     },
   ];
-  const poller = await client.beginAnalyzeBatch(actions, documents, "en");
+  const { poller } = await client.beginAnalyzeBatch(actions, documents, "en");
   const results = await poller.pollUntilDone();
 
   for await (const actionResult of results) {

--- a/sdk/cognitivelanguage/ai-language-text/samples-dev/customMultiLabelClassification.ts
+++ b/sdk/cognitivelanguage/ai-language-text/samples-dev/customMultiLabelClassification.ts
@@ -42,7 +42,7 @@ export async function main() {
       projectName,
     },
   ];
-  const poller = await client.beginAnalyzeBatch(actions, documents, "en");
+  const { poller } = await client.beginAnalyzeBatch(actions, documents, "en");
   const results = await poller.pollUntilDone();
 
   for await (const actionResult of results) {

--- a/sdk/cognitivelanguage/ai-language-text/samples-dev/customSingleLabelClassification.ts
+++ b/sdk/cognitivelanguage/ai-language-text/samples-dev/customSingleLabelClassification.ts
@@ -42,7 +42,7 @@ export async function main() {
       projectName,
     },
   ];
-  const poller = await client.beginAnalyzeBatch(actions, documents, "en");
+  const { poller } = await client.beginAnalyzeBatch(actions, documents, "en");
   const results = await poller.pollUntilDone();
 
   for await (const actionResult of results) {

--- a/sdk/cognitivelanguage/ai-language-text/samples-dev/extractiveSummarization.ts
+++ b/sdk/cognitivelanguage/ai-language-text/samples-dev/extractiveSummarization.ts
@@ -46,7 +46,7 @@ export async function main() {
       maxSentenceCount: 2,
     },
   ];
-  const poller = await client.beginAnalyzeBatch(actions, documents, "en");
+  const { poller } = await client.beginAnalyzeBatch(actions, documents, "en");
 
   poller.onProgress(() => {
     console.log(

--- a/sdk/cognitivelanguage/ai-language-text/samples-dev/healthcare.ts
+++ b/sdk/cognitivelanguage/ai-language-text/samples-dev/healthcare.ts
@@ -41,7 +41,7 @@ export async function main() {
       fhirVersion: KnownFhirVersion["4.0.1"],
     },
   ];
-  const poller = await client.beginAnalyzeBatch(actions, documents, "en");
+  const { poller } = await client.beginAnalyzeBatch(actions, documents, "en");
 
   poller.onProgress(() => {
     console.log(

--- a/sdk/cognitivelanguage/ai-language-text/samples-dev/modelVersion.ts
+++ b/sdk/cognitivelanguage/ai-language-text/samples-dev/modelVersion.ts
@@ -46,7 +46,7 @@ export async function main() {
     },
   });
 
-  const poller = await client.beginAnalyzeBatch(
+  const { poller } = await client.beginAnalyzeBatch(
     [
       {
         kind: "Healthcare",

--- a/sdk/cognitivelanguage/ai-language-text/samples-dev/paging.ts
+++ b/sdk/cognitivelanguage/ai-language-text/samples-dev/paging.ts
@@ -37,7 +37,7 @@ export async function main() {
   let continuationToken: string | undefined = undefined;
   let stopOverwrite = false;
 
-  const poller = await client.beginAnalyzeBatch(
+  const { poller } = await client.beginAnalyzeBatch(
     [
       {
         kind: "EntityRecognition",

--- a/sdk/cognitivelanguage/ai-language-text/samples-dev/rehydratePolling.ts
+++ b/sdk/cognitivelanguage/ai-language-text/samples-dev/rehydratePolling.ts
@@ -30,7 +30,7 @@ export async function main() {
 
   const client = new TextAnalysisClient(endpoint, new AzureKeyCredential(apiKey));
 
-  const poller = await client.beginAnalyzeBatch(
+  const { poller } = await client.beginAnalyzeBatch(
     [
       {
         kind: "EntityRecognition",
@@ -63,7 +63,7 @@ export async function main() {
   const serializedState = poller.toString();
 
   /** Create a new poller from the serialized state */
-  const rehydratedPoller = await client.restoreAnalyzeBatchPoller(serializedState);
+  const { poller: rehydratedPoller } = await client.restoreAnalyzeBatchPoller(serializedState);
 
   /** Use the new poller to get the operation results */
   const actionResults = await rehydratedPoller.pollUntilDone();

--- a/sdk/cognitivelanguage/ai-language-text/samples-dev/stats.ts
+++ b/sdk/cognitivelanguage/ai-language-text/samples-dev/stats.ts
@@ -67,7 +67,7 @@ export async function main() {
     console.log(`\t\t-Transaction count: ${stats.transactionCount}`);
   }
 
-  const poller = await client.beginAnalyzeBatch(
+  const { poller } = await client.beginAnalyzeBatch(
     [
       {
         kind: "Healthcare",

--- a/sdk/cognitivelanguage/ai-language-text/src/models.ts
+++ b/sdk/cognitivelanguage/ai-language-text/src/models.ts
@@ -23,7 +23,6 @@ import {
   KnownInnerErrorCode,
   LanguageDetectionAction,
   LinkedEntity,
-  OperationStatus,
   PiiEntityRecognitionAction,
   RelationType,
   SentenceSentimentLabel,
@@ -36,7 +35,7 @@ import {
   TokenSentimentLabel,
 } from "./generated";
 import { CommonClientOptions, OperationOptions } from "@azure/core-client";
-import { PollOperationState, PollerLike } from "@azure/core-lro";
+import { OperationState, SimplePollerLike } from "@azure/core-lro";
 import { PagedAsyncIterableIterator } from "@azure/core-paging";
 
 /**
@@ -954,7 +953,25 @@ export type PagedAnalyzeBatchResult = PagedAsyncIterableIterator<AnalyzeBatchRes
 /**
  * A poller that polls long-running operations started by {@link TextAnalysisClient.beginAnalyzeBatch}.
  */
-export type AnalyzeBatchPoller = PollerLike<AnalyzeBatchOperationState, PagedAnalyzeBatchResult>;
+export type AnalyzeBatchPoller = SimplePollerLike<
+  AnalyzeBatchOperationState,
+  PagedAnalyzeBatchResult
+>;
+
+/**
+ * A representation of an analyze batch actions operation. It contains methods
+ * to get the operation poller and to send a cancellation request.
+ */
+export interface AnalyzeBatchOperation {
+  /**
+   * Sends a cancellation request for this particular actions batch operation.
+   */
+  sendCancellationRequest(): Promise<void>;
+  /**
+   * A poller for this particular actions batch operation.
+   */
+  poller: AnalyzeBatchPoller;
+}
 
 /**
  * The metadata for long-running operations started by {@link TextAnalysisClient.beginAnalyzeBatch}.
@@ -977,10 +994,6 @@ export interface AnalyzeBatchOperationMetadata {
    */
   readonly modifiedOn: Date;
   /**
-   * The current status of the operation.
-   */
-  readonly status: OperationStatus;
-  /**
    * Number of successfully completed actions.
    */
   readonly actionSucceededCount: number;
@@ -1002,5 +1015,5 @@ export interface AnalyzeBatchOperationMetadata {
  * The state of the begin analyze polling operation.
  */
 export interface AnalyzeBatchOperationState
-  extends PollOperationState<PagedAnalyzeBatchResult>,
+  extends OperationState<PagedAnalyzeBatchResult>,
     AnalyzeBatchOperationMetadata {}

--- a/sdk/cognitivelanguage/ai-language-text/src/util.ts
+++ b/sdk/cognitivelanguage/ai-language-text/src/util.ts
@@ -5,20 +5,16 @@ import { LanguageDetectionInput, TextDocumentInput } from "./generated";
 import { TextAnalysisOperationOptions } from "./models";
 import { logger } from "./logger";
 
-interface IdObject {
-  id: string;
-}
-
 /**
  * Given a sorted array of input objects (with a unique ID) and an unsorted array of results,
  * return a sorted array of results.
  *
  * @internal
- * @param sortedArray - An array of entries sorted by `id`
+ * @param sortedIds - An array of entries sorted by `id`
  * @param unsortedArray - An array of entries that contain `id` but are not sorted
  */
-export function sortResponseIdObjects<U extends IdObject>(
-  sortedArray: IdObject[],
+export function sortResponseIdObjects<U extends { id: string }>(
+  sortedIds: string[],
   unsortedArray: U[]
 ): U[] {
   const unsortedMap = new Map<string, U>();
@@ -26,8 +22,8 @@ export function sortResponseIdObjects<U extends IdObject>(
     unsortedMap.set(item.id, item);
   }
 
-  if (unsortedArray.length !== sortedArray.length) {
-    const ordinal = unsortedArray.length > sortedArray.length ? "more" : "fewer";
+  if (unsortedArray.length !== sortedIds.length) {
+    const ordinal = unsortedArray.length > sortedIds.length ? "more" : "fewer";
     logger.warning(
       `The service returned ${ordinal} responses than inputs. Some errors may be treated as fatal.`
     );
@@ -39,8 +35,8 @@ export function sortResponseIdObjects<U extends IdObject>(
    * items than unsortedArray so it is ok to ignore the case when a sorted item
    * ID is not found in `unsortedMap`.
    */
-  for (const sortedItem of sortedArray) {
-    const item = unsortedMap.get(sortedItem.id);
+  for (const id of sortedIds) {
+    const item = unsortedMap.get(id);
     if (item) {
       result.push(item);
     }

--- a/sdk/cognitivelanguage/ai-language-text/test/public/analyzeBatch.spec.ts
+++ b/sdk/cognitivelanguage/ai-language-text/test/public/analyzeBatch.spec.ts
@@ -48,7 +48,7 @@ import {
   expectation9,
 } from "./expectations";
 import { windows365ArticlePart1, windows365ArticlePart2 } from "./inputs";
-import { getDocsFromState } from "../../src/lro";
+import { getDocIDsFromState } from "../../src/lro";
 
 matrix([["APIKey", "AAD"]] as const, async (authMethod: AuthMethod) => {
   describe(`[${authMethod}] TextAnalysisClient`, function (this: Suite) {
@@ -84,7 +84,7 @@ matrix([["APIKey", "AAD"]] as const, async (authMethod: AuthMethod) => {
                 text: "Microsoft fue fundado por Bill Gates y Paul Allen",
               },
             ];
-            const poller = await client.beginAnalyzeBatch(
+            const { poller } = await client.beginAnalyzeBatch(
               [
                 {
                   kind: AnalyzeBatchActionNames.EntityRecognition,
@@ -113,7 +113,7 @@ matrix([["APIKey", "AAD"]] as const, async (authMethod: AuthMethod) => {
                 text: "Microsoft fue fundado por Bill Gates y Paul Allen",
               },
             ];
-            const poller = await client.beginAnalyzeBatch(
+            const { poller } = await client.beginAnalyzeBatch(
               [
                 {
                   kind: AnalyzeBatchActionNames.KeyPhraseExtraction,
@@ -133,7 +133,7 @@ matrix([["APIKey", "AAD"]] as const, async (authMethod: AuthMethod) => {
               "Microsoft moved its headquarters to Bellevue, Washington in January 1979.",
               "Steve Ballmer stepped down as CEO of Microsoft and was succeeded by Satya Nadella.",
             ];
-            const poller = await client.beginAnalyzeBatch(
+            const { poller } = await client.beginAnalyzeBatch(
               [
                 {
                   kind: AnalyzeBatchActionNames.EntityLinking,
@@ -155,7 +155,7 @@ matrix([["APIKey", "AAD"]] as const, async (authMethod: AuthMethod) => {
               "Your ABA number - 111000025 - is the first 9 digits in the lower left hand corner of your personal check.",
               "Is 998.214.865-68 your Brazilian CPF number?",
             ];
-            const poller = await client.beginAnalyzeBatch(
+            const { poller } = await client.beginAnalyzeBatch(
               [
                 {
                   kind: AnalyzeBatchActionNames.PiiEntityRecognition,
@@ -176,7 +176,7 @@ matrix([["APIKey", "AAD"]] as const, async (authMethod: AuthMethod) => {
               "My SSN is 859-98-0987 and your ABA number - 111000025 - is the first 9 digits in the lower left hand corner of your personal check.",
               "Your ABA number - 111000025 - is the first 9 digits in the lower left hand corner of your personal check.",
             ];
-            const poller = await client.beginAnalyzeBatch(
+            const { poller } = await client.beginAnalyzeBatch(
               [
                 {
                   kind: AnalyzeBatchActionNames.PiiEntityRecognition,
@@ -198,7 +198,7 @@ matrix([["APIKey", "AAD"]] as const, async (authMethod: AuthMethod) => {
               "My SSN is 859-98-0987 and your ABA number - 111000025 - is the first 9 digits in the lower left hand corner of your personal check.",
               "Your ABA number - 111000025 - is the first 9 digits in the lower left hand corner of your personal check.",
             ];
-            const poller = await client.beginAnalyzeBatch(
+            const { poller } = await client.beginAnalyzeBatch(
               [
                 {
                   kind: AnalyzeBatchActionNames.PiiEntityRecognition,
@@ -225,7 +225,7 @@ matrix([["APIKey", "AAD"]] as const, async (authMethod: AuthMethod) => {
               "Nice rooms but bathrooms were old and the toilet was dirty when we arrived.",
               "The toilet smelled.",
             ];
-            const poller = await client.beginAnalyzeBatch(
+            const { poller } = await client.beginAnalyzeBatch(
               [
                 {
                   kind: AnalyzeBatchActionNames.SentimentAnalysis,
@@ -248,7 +248,7 @@ matrix([["APIKey", "AAD"]] as const, async (authMethod: AuthMethod) => {
               "Prescribed 100mg ibuprofen, taken twice daily.",
               "Baby not likely to have Meningitis. in case of fever in the mother, consider Penicillin for the baby too.",
             ];
-            const poller = await client.beginAnalyzeBatch(
+            const { poller } = await client.beginAnalyzeBatch(
               [
                 {
                   kind: AnalyzeBatchActionNames.Healthcare,
@@ -269,7 +269,7 @@ matrix([["APIKey", "AAD"]] as const, async (authMethod: AuthMethod) => {
               "Prescribed 100mg ibuprofen, taken twice daily.",
               "Baby not likely to have Meningitis. in case of fever in the mother, consider Penicillin for the baby too.",
             ];
-            const poller = await client.beginAnalyzeBatch(
+            const { poller } = await client.beginAnalyzeBatch(
               [
                 {
                   kind: AnalyzeBatchActionNames.Healthcare,
@@ -289,7 +289,7 @@ matrix([["APIKey", "AAD"]] as const, async (authMethod: AuthMethod) => {
 
           it("extractive summarization", async function () {
             const docs = [windows365ArticlePart1, windows365ArticlePart2];
-            const poller = await client.beginAnalyzeBatch(
+            const { poller } = await client.beginAnalyzeBatch(
               [
                 {
                   kind: AnalyzeBatchActionNames.ExtractiveSummarization,
@@ -306,7 +306,7 @@ matrix([["APIKey", "AAD"]] as const, async (authMethod: AuthMethod) => {
 
           it("extractive summarization with maxSentenceCount", async function () {
             const docs = [windows365ArticlePart1, windows365ArticlePart2];
-            const poller = await client.beginAnalyzeBatch(
+            const { poller } = await client.beginAnalyzeBatch(
               [
                 {
                   kind: AnalyzeBatchActionNames.ExtractiveSummarization,
@@ -324,7 +324,7 @@ matrix([["APIKey", "AAD"]] as const, async (authMethod: AuthMethod) => {
 
           it("extractive summarization with orderBy", async function () {
             const docs = [windows365ArticlePart1, windows365ArticlePart2];
-            const poller = await client.beginAnalyzeBatch(
+            const { poller } = await client.beginAnalyzeBatch(
               [
                 {
                   kind: AnalyzeBatchActionNames.ExtractiveSummarization,
@@ -346,7 +346,7 @@ matrix([["APIKey", "AAD"]] as const, async (authMethod: AuthMethod) => {
             const docs = [
               "A recent report by the Government Accountability Office (GAO) found that the dramatic increase in oil and natural gas development on federal lands over the past six years has stretched the staff of the BLM to a point that it has been unable to meet its environmental protection responsibilities.",
             ];
-            const poller = await client.beginAnalyzeBatch(
+            const { poller } = await client.beginAnalyzeBatch(
               [
                 {
                   kind: AnalyzeBatchActionNames.CustomEntityRecognition,
@@ -371,7 +371,7 @@ matrix([["APIKey", "AAD"]] as const, async (authMethod: AuthMethod) => {
             const docs = [
               "A recent report by the Government Accountability Office (GAO) found that the dramatic increase in oil and natural gas development on federal lands over the past six years has stretched the staff of the BLM to a point that it has been unable to meet its environmental protection responsibilities.",
             ];
-            const poller = await client.beginAnalyzeBatch(
+            const { poller } = await client.beginAnalyzeBatch(
               [
                 {
                   kind: AnalyzeBatchActionNames.CustomSingleLabelClassification,
@@ -396,7 +396,7 @@ matrix([["APIKey", "AAD"]] as const, async (authMethod: AuthMethod) => {
             const docs = [
               "A recent report by the Government Accountability Office (GAO) found that the dramatic increase in oil and natural gas development on federal lands over the past six years has stretched the staff of the BLM to a point that it has been unable to meet its environmental protection responsibilities.",
             ];
-            const poller = await client.beginAnalyzeBatch(
+            const { poller } = await client.beginAnalyzeBatch(
               [
                 {
                   kind: AnalyzeBatchActionNames.CustomMultiLabelClassification,
@@ -554,7 +554,7 @@ matrix([["APIKey", "AAD"]] as const, async (authMethod: AuthMethod) => {
               text = text + "x";
             }
             const docs = [text];
-            const poller = await client.beginAnalyzeBatch(
+            const { poller } = await client.beginAnalyzeBatch(
               [
                 {
                   kind: AnalyzeBatchActionNames.Healthcare,
@@ -572,7 +572,7 @@ matrix([["APIKey", "AAD"]] as const, async (authMethod: AuthMethod) => {
 
         it("unique multiple actions per type are allowed", async function () {
           const docs = ["I will go to the park."];
-          const poller = await client.beginAnalyzeBatch(
+          const { poller } = await client.beginAnalyzeBatch(
             [
               {
                 kind: AnalyzeBatchActionNames.PiiEntityRecognition,
@@ -606,7 +606,7 @@ matrix([["APIKey", "AAD"]] as const, async (authMethod: AuthMethod) => {
               text: "The restaurant had really good food. I recommend you try it.",
             },
           ];
-          const poller = await client.beginAnalyzeBatch(
+          const { poller } = await client.beginAnalyzeBatch(
             [
               {
                 kind: AnalyzeBatchActionNames.EntityRecognition,
@@ -640,7 +640,7 @@ matrix([["APIKey", "AAD"]] as const, async (authMethod: AuthMethod) => {
               text: "",
             },
           ];
-          const poller = await client.beginAnalyzeBatch(
+          const { poller } = await client.beginAnalyzeBatch(
             [
               {
                 kind: AnalyzeBatchActionNames.EntityRecognition,
@@ -668,7 +668,7 @@ matrix([["APIKey", "AAD"]] as const, async (authMethod: AuthMethod) => {
             { id: "4", text: "four" },
             { id: "5", text: "five" },
           ];
-          const poller = await client.beginAnalyzeBatch(
+          const { poller } = await client.beginAnalyzeBatch(
             [
               {
                 kind: AnalyzeBatchActionNames.EntityRecognition,
@@ -696,7 +696,7 @@ matrix([["APIKey", "AAD"]] as const, async (authMethod: AuthMethod) => {
             { id: "19", text: ":P" },
             { id: "1", text: ":D" },
           ];
-          const poller = await client.beginAnalyzeBatch(
+          const { poller } = await client.beginAnalyzeBatch(
             [
               {
                 kind: AnalyzeBatchActionNames.EntityRecognition,
@@ -718,7 +718,7 @@ matrix([["APIKey", "AAD"]] as const, async (authMethod: AuthMethod) => {
 
         it("statistics", async function () {
           const docs = [":)", ":(", "", ":P", ":D"];
-          const poller = await client.beginAnalyzeBatch(
+          const { poller } = await client.beginAnalyzeBatch(
             [
               {
                 kind: AnalyzeBatchActionNames.EntityRecognition,
@@ -765,7 +765,7 @@ matrix([["APIKey", "AAD"]] as const, async (authMethod: AuthMethod) => {
             "I did not like the hotel we stayed at. It was too expensive.",
             "The restaurant was not as good as I hoped.",
           ];
-          const poller = await client.beginAnalyzeBatch(
+          const { poller } = await client.beginAnalyzeBatch(
             [
               {
                 kind: AnalyzeBatchActionNames.EntityRecognition,
@@ -792,7 +792,7 @@ matrix([["APIKey", "AAD"]] as const, async (authMethod: AuthMethod) => {
             "I did not like the hotel we stayed at. It was too expensive.",
             "The restaurant was not as good as I hoped.",
           ];
-          const poller = await client.beginAnalyzeBatch(
+          const { poller } = await client.beginAnalyzeBatch(
             [
               {
                 kind: AnalyzeBatchActionNames.EntityRecognition,
@@ -819,7 +819,7 @@ matrix([["APIKey", "AAD"]] as const, async (authMethod: AuthMethod) => {
             { id: "2", text: "Este es un document escrito en Español." },
             { id: "3", text: "猫は幸せ" },
           ];
-          const poller = await client.beginAnalyzeBatch(
+          const { poller } = await client.beginAnalyzeBatch(
             [
               {
                 kind: AnalyzeBatchActionNames.EntityRecognition,
@@ -841,7 +841,7 @@ matrix([["APIKey", "AAD"]] as const, async (authMethod: AuthMethod) => {
 
         it("invalid language hint", async function () {
           const docs = ["This should fail because we're passing in an invalid language hint"];
-          const poller = await client.beginAnalyzeBatch(
+          const { poller } = await client.beginAnalyzeBatch(
             [
               {
                 kind: AnalyzeBatchActionNames.EntityRecognition,
@@ -866,7 +866,7 @@ matrix([["APIKey", "AAD"]] as const, async (authMethod: AuthMethod) => {
           const totalDocs = 25;
           const docs = Array(totalDocs - 1).fill("random text");
           docs.push("Microsoft was founded by Bill Gates and Paul Allen");
-          const poller = await client.beginAnalyzeBatch(
+          const { poller } = await client.beginAnalyzeBatch(
             [
               {
                 kind: AnalyzeBatchActionNames.EntityRecognition,
@@ -888,7 +888,7 @@ matrix([["APIKey", "AAD"]] as const, async (authMethod: AuthMethod) => {
 
         it("operation metadata", async function () {
           const docs = ["I will go to the park."];
-          const poller = await client.beginAnalyzeBatch(
+          const { poller } = await client.beginAnalyzeBatch(
             [
               {
                 kind: AnalyzeBatchActionNames.EntityRecognition,
@@ -925,34 +925,35 @@ matrix([["APIKey", "AAD"]] as const, async (authMethod: AuthMethod) => {
             "Patient does not suffer from high blood pressure.",
             "Prescribed 100mg ibuprofen, taken twice daily.",
           ];
-          const originalPoller = await client.beginAnalyzeBatch(
-            [
+          const { poller: originalPoller, sendCancellationRequest } =
+            await client.beginAnalyzeBatch(
+              [
+                {
+                  kind: AnalyzeBatchActionNames.Healthcare,
+                },
+                {
+                  kind: AnalyzeBatchActionNames.EntityRecognition,
+                },
+                {
+                  kind: AnalyzeBatchActionNames.PiiEntityRecognition,
+                },
+                {
+                  kind: AnalyzeBatchActionNames.SentimentAnalysis,
+                  includeOpinionMining: true,
+                },
+              ],
+              docs,
+              "en",
               {
-                kind: AnalyzeBatchActionNames.Healthcare,
-              },
-              {
-                kind: AnalyzeBatchActionNames.EntityRecognition,
-              },
-              {
-                kind: AnalyzeBatchActionNames.PiiEntityRecognition,
-              },
-              {
-                kind: AnalyzeBatchActionNames.SentimentAnalysis,
-                includeOpinionMining: true,
-              },
-            ],
-            docs,
-            "en",
-            {
-              updateIntervalInMs: pollingInterval,
-            }
-          );
+                updateIntervalInMs: pollingInterval,
+              }
+            );
           if (originalPoller.isDone()) {
             assert.fail(`Operation has finished processing before requested to be cancelled`);
           }
-          await originalPoller.cancelOperation();
-          await assert.isRejected(originalPoller.pollUntilDone(), /Poller cancelled/);
-          assert.isTrue(originalPoller.getOperationState().isCancelled);
+          await sendCancellationRequest();
+          await assert.isRejected(originalPoller.pollUntilDone(), /Operation was cancelled/);
+          assert.equal(originalPoller.getOperationState().status, "canceled");
         });
 
         /**
@@ -980,14 +981,15 @@ matrix([["APIKey", "AAD"]] as const, async (authMethod: AuthMethod) => {
               includeOpinionMining: true,
             },
           ];
-          const originalPoller = await client.beginAnalyzeBatch(actions, docs, "en", {
+          const { poller: originalPoller } = await client.beginAnalyzeBatch(actions, docs, "en", {
             updateIntervalInMs: 100,
           });
 
           originalPoller.onProgress(async (state) => {
             if (state.status === "running" && state.actionInProgressCount < actions.length) {
-              const newPoller = await client.restoreAnalyzeBatchPoller(originalPoller.toString());
-              await originalPoller.cancelOperation();
+              const { poller: newPoller, sendCancellationRequest } =
+                await client.restoreAnalyzeBatchPoller(originalPoller.toString());
+              await sendCancellationRequest();
               let nonEmptyActionResults = false;
               for await (const actionResult of await newPoller.pollUntilDone()) {
                 nonEmptyActionResults = true;
@@ -1010,7 +1012,7 @@ matrix([["APIKey", "AAD"]] as const, async (authMethod: AuthMethod) => {
             { id: "0", language: "en", text: "Patient does not suffer from high blood pressure." },
             { id: "1", language: "en", text: "Prescribed 100mg ibuprofen, taken twice daily." },
           ];
-          const originalPoller = await client.beginAnalyzeBatch(
+          const { poller: originalPoller } = await client.beginAnalyzeBatch(
             [
               {
                 kind: AnalyzeBatchActionNames.Healthcare,
@@ -1034,9 +1036,18 @@ matrix([["APIKey", "AAD"]] as const, async (authMethod: AuthMethod) => {
           if (originalPoller.isDone()) {
             assert.fail("Operation finished processing before creating a new poller");
           }
+          await originalPoller.poll();
           const serializedState = originalPoller.toString();
-          assert.deepEqual(getDocsFromState(serializedState), docs);
-          const rehydratedPoller = await client.restoreAnalyzeBatchPoller(serializedState);
+          assert.deepEqual(
+            getDocIDsFromState(serializedState),
+            docs.map(({ id }) => id)
+          );
+          const { poller: rehydratedPoller } = await client.restoreAnalyzeBatchPoller(
+            serializedState,
+            {
+              updateIntervalInMs: pollingInterval,
+            }
+          );
           await assertActionResults(await rehydratedPoller.pollUntilDone(), expectation26);
           await assertActionResults(await originalPoller.pollUntilDone(), expectation26);
         });
@@ -1044,7 +1055,7 @@ matrix([["APIKey", "AAD"]] as const, async (authMethod: AuthMethod) => {
         describe("stringIndexType", function () {
           it("family emoji wit skin tone modifier", async function () {
             const docs = ["👩🏻‍👩🏽‍👧🏾‍👦🏿 SSN: 859-98-0987"];
-            const poller = await client.beginAnalyzeBatch(
+            const { poller } = await client.beginAnalyzeBatch(
               [
                 {
                   kind: AnalyzeBatchActionNames.PiiEntityRecognition,
@@ -1062,7 +1073,7 @@ matrix([["APIKey", "AAD"]] as const, async (authMethod: AuthMethod) => {
 
           it("family emoji wit skin tone modifier with Utf16CodeUnit", async function () {
             const docs = ["👩🏻‍👩🏽‍👧🏾‍👦🏿 ibuprofen"];
-            const poller = await client.beginAnalyzeBatch(
+            const { poller } = await client.beginAnalyzeBatch(
               [
                 {
                   kind: AnalyzeBatchActionNames.Healthcare,
@@ -1080,7 +1091,7 @@ matrix([["APIKey", "AAD"]] as const, async (authMethod: AuthMethod) => {
 
           it("family emoji wit skin tone modifier with UnicodeCodePoint", async function () {
             const docs = ["👩🏻‍👩🏽‍👧🏾‍👦🏿 ibuprofen"];
-            const poller = await client.beginAnalyzeBatch(
+            const { poller } = await client.beginAnalyzeBatch(
               [
                 {
                   kind: AnalyzeBatchActionNames.Healthcare,


### PR DESCRIPTION
Canceling a long-running operation is currently done by calling `cancelOperation`: https://github.com/Azure/azure-sdk-for-js/blob/eb0aa1da675c97b07739cf02ba0482c9b1ae8901/sdk/core/core-lro/src/poller.ts#L79-L82 However the cancellation behavior could vary between APIs in a way that makes `cancelOperation` a confusing abstraction. In particular, when sending a cancellation request, the service may respond with either a 200 or a 202 response, depending on the API and/or the operation, where the former indicates the operation has been canceled immediately and the latter indicates it could be some time before the operation is deemed as canceled. Handling 202 responses needs care to set the customer's expectation about wait times and this is typically done by providing a poller object that customer could use to optionally block until the operation finishes. This discrepancy in behavior makes `cancelOperation` not a suitable abstraction for the case when cancellation returns a 202 response.

## LRO Cancellation

This LRO cancellation returns a 202 response so cancellation itself is an LRO. I am proposing to implement cancellation by returning a function named `sendCancellationRequest` alongside the operation poller, so the return type is:

```ts
interface AnalyzeBatchOperation {
    poller: AnalyzeBatchPoller;
    sendCancellationRequest(): Promise<void>;
}
```

And client code can simply destruct the output object as follows to get access to the poller and the cancellation function:

```ts
const { poller, sendCancellationRequest } = await client.beginAnalyzeBatch(actions, documents, "en");
...
// Let's cancel the operation
await sendCancellationRequest(); // poller.cancelOperation() no longer exists
```

Design considerations:
- cancellation as a concept is not related to polling so a poller is not the right place to send cancellation requests
- canceling an operation requires knowing the operation ID/location, but we shouldn't ask customers for that information because it is an implementation detail
- cancellation is an LRO but it doesn't have its own operation location, i.e. the operation location is the same for the operation being cancelled and the cancellation operation itself. This means there is no need to create a dedicated poller for the cancellation operation and customers could still use the existing poller to await their operation or its cancellation
- cancellation is a POST request with no interesting response, so it should be modeled programmatically as `(): Promise<void>` function