### PR TITLE
max integrated cache staleness in Ms zero check fix

### DIFF
--- a/sdk/cosmosdb/cosmos/review/cosmos.api.md
+++ b/sdk/cosmosdb/cosmos/review/cosmos.api.md
@@ -1720,8 +1720,7 @@ export function setAuthorizationTokenHeaderUsingMasterKey(verb: HTTPMethod, reso
 export interface SharedOptions {
     abortSignal?: AbortSignal_2;
     initialHeaders?: CosmosHeaders;
-    // @beta
-    maxIntegratedCacheStalenessInMs?: number;
+    maxIntegratedCacheStalenessInMs?: string;
     sessionToken?: string;
 }
 

--- a/sdk/cosmosdb/cosmos/review/cosmos.api.md
+++ b/sdk/cosmosdb/cosmos/review/cosmos.api.md
@@ -1720,7 +1720,7 @@ export function setAuthorizationTokenHeaderUsingMasterKey(verb: HTTPMethod, reso
 export interface SharedOptions {
     abortSignal?: AbortSignal_2;
     initialHeaders?: CosmosHeaders;
-    maxIntegratedCacheStalenessInMs?: string;
+    maxIntegratedCacheStalenessInMs?: number;
     sessionToken?: string;
 }
 

--- a/sdk/cosmosdb/cosmos/src/request/SharedOptions.ts
+++ b/sdk/cosmosdb/cosmos/src/request/SharedOptions.ts
@@ -32,5 +32,5 @@ export interface SharedOptions {
    *
    * <p>Cache Staleness is supported in milliseconds granularity. Anything smaller than milliseconds will be ignored.</p>
    */
-  maxIntegratedCacheStalenessInMs?: string;
+  maxIntegratedCacheStalenessInMs?: number;
 }

--- a/sdk/cosmosdb/cosmos/src/request/SharedOptions.ts
+++ b/sdk/cosmosdb/cosmos/src/request/SharedOptions.ts
@@ -24,7 +24,7 @@ export interface SharedOptions {
   abortSignal?: AbortSignal;
   /**
    * Sets the staleness value associated with the request in the Azure CosmosDB service. For requests where the {@link
-   * com.azure.cosmos.ConsistencyLevel} is {@link com.azure.cosmos.ConsistencyLevel#EVENTUAL}, responses from the
+   * com.azure.cosmos.ConsistencyLevel} is {@link com.azure.cosmos.ConsistencyLevel#EVENTUAL}  or {@link com.azure.cosmos.ConsistencyLevel#SESSION}, responses from the
    * integrated cache are guaranteed to be no staler than value indicated by this maxIntegratedCacheStaleness. When the
    * consistency level is not set, this property is ignored.
    *

--- a/sdk/cosmosdb/cosmos/src/request/SharedOptions.ts
+++ b/sdk/cosmosdb/cosmos/src/request/SharedOptions.ts
@@ -23,7 +23,6 @@ export interface SharedOptions {
    */
   abortSignal?: AbortSignal;
   /**
-   * **(Beta - There may be breaking changes in this property in future releases)**
    * Sets the staleness value associated with the request in the Azure CosmosDB service. For requests where the {@link
    * com.azure.cosmos.ConsistencyLevel} is {@link com.azure.cosmos.ConsistencyLevel#EVENTUAL}, responses from the
    * integrated cache are guaranteed to be no staler than value indicated by this maxIntegratedCacheStaleness. When the
@@ -32,7 +31,6 @@ export interface SharedOptions {
    * <p>Default value is null</p>
    *
    * <p>Cache Staleness is supported in milliseconds granularity. Anything smaller than milliseconds will be ignored.</p>
-   * @beta
    */
-  maxIntegratedCacheStalenessInMs?: number;
+  maxIntegratedCacheStalenessInMs?: string;
 }

--- a/sdk/cosmosdb/cosmos/src/request/request.ts
+++ b/sdk/cosmosdb/cosmos/src/request/request.ts
@@ -128,8 +128,13 @@ export async function getHeaders({
   }
 
   if (options.maxIntegratedCacheStalenessInMs && resourceType === ResourceType.item) {
-    headers[Constants.HttpHeaders.DedicatedGatewayPerRequestCacheStaleness] =
-      options.maxIntegratedCacheStalenessInMs;
+    if (typeof options.maxIntegratedCacheStalenessInMs === "number") {
+      headers[
+        Constants.HttpHeaders.DedicatedGatewayPerRequestCacheStaleness
+      ] = `${options.maxIntegratedCacheStalenessInMs}`;
+    } else {
+      headers[Constants.HttpHeaders.DedicatedGatewayPerRequestCacheStaleness] = "null";
+    }
   }
 
   if (options.resourceTokenExpirySeconds) {

--- a/sdk/cosmosdb/cosmos/src/request/request.ts
+++ b/sdk/cosmosdb/cosmos/src/request/request.ts
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
+import { logger } from "@azure/identity";
 import { setAuthorizationHeader } from "../auth";
 import { Constants, HTTPMethod, jsonStringifyAndEscapeNonASCII, ResourceType } from "../common";
 import { CosmosClientOptions } from "../CosmosClientOptions";
@@ -129,10 +130,12 @@ export async function getHeaders({
 
   if (options.maxIntegratedCacheStalenessInMs && resourceType === ResourceType.item) {
     if (typeof options.maxIntegratedCacheStalenessInMs === "number") {
-      headers[Constants.HttpHeaders.DedicatedGatewayPerRequestCacheStaleness] = String(
-        options.maxIntegratedCacheStalenessInMs
-      );
+      headers[Constants.HttpHeaders.DedicatedGatewayPerRequestCacheStaleness] =
+        options.maxIntegratedCacheStalenessInMs.toString();
     } else {
+      logger.error(
+        `RangeError: maxIntegratedCacheStalenessInMs "${options.maxIntegratedCacheStalenessInMs}" is not a valid parameter.`
+      );
       headers[Constants.HttpHeaders.DedicatedGatewayPerRequestCacheStaleness] = "null";
     }
   }

--- a/sdk/cosmosdb/cosmos/src/request/request.ts
+++ b/sdk/cosmosdb/cosmos/src/request/request.ts
@@ -129,9 +129,9 @@ export async function getHeaders({
 
   if (options.maxIntegratedCacheStalenessInMs && resourceType === ResourceType.item) {
     if (typeof options.maxIntegratedCacheStalenessInMs === "number") {
-      headers[
-        Constants.HttpHeaders.DedicatedGatewayPerRequestCacheStaleness
-      ] = `${options.maxIntegratedCacheStalenessInMs}`;
+      headers[Constants.HttpHeaders.DedicatedGatewayPerRequestCacheStaleness] = String(
+        options.maxIntegratedCacheStalenessInMs
+      );
     } else {
       headers[Constants.HttpHeaders.DedicatedGatewayPerRequestCacheStaleness] = "null";
     }

--- a/sdk/cosmosdb/cosmos/test/internal/session.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/internal/session.spec.ts
@@ -76,7 +76,7 @@ describe("Integrated Cache Staleness", async function (this: Suite) {
   });
   const dbId = addEntropy("maxIntegratedCacheTestDB");
   const containerId = addEntropy("maxIntegratedCacheTestContainer");
-  const dedicatedGatewayMaxAge = 600000;
+  const dedicatedGatewayMaxAge = "0";
   const client = new CosmosClient({
     endpoint,
     key: masterKey,
@@ -85,42 +85,53 @@ describe("Integrated Cache Staleness", async function (this: Suite) {
       {
         on: "request",
         plugin: async (context, next) => {
-          it("Should check if the max integrated cache staleness header is set and the value is correct.", async function () {
-            if (context.headers["x-ms-consistency-level"]) {
-              if (context.resourceType === ResourceType.item) {
-                if (context.headers["x-ms-dedicatedgateway-max-age"]) {
-                  assert.strictEqual(
-                    context.headers["x-ms-dedicatedgateway-max-age"].valueOf(),
-                    dedicatedGatewayMaxAge
-                  );
-                } else {
-                  assert(
-                    context.headers["x-ms-dedicatedgateway-max-age"],
-                    "x-ms-dedicatedgateway-max-age is not set."
-                  );
-                  assert.ifError(context.headers["x-ms-dedicatedgateway-max-age"]);
-                }
-              } else {
-                assert(
-                  context.headers["x-ms-dedicatedgateway-max-age"],
-                  "Attempt to use x-ms-dedicatedgateway-max-age on a non-item request."
-                );
-                assert.ifError(context.headers["x-ms-dedicatedgateway-max-age"]);
-              }
-            } else {
-              assert(
-                context.headers["x-ms-consistency-level"],
-                "x-ms-consistency-level is not set."
+          if (
+            context.resourceType === ResourceType.item &&
+            context.operationType !== OperationType.Create
+          ) {
+            assert.ok(typeof context.headers["x-ms-consistency-level"] === "undefined");
+            assert.ok(typeof context.headers["x-ms-dedicatedgateway-max-age"] !== "undefined");
+            assert.ok(typeof context.headers["x-ms-consistency-level"] === "string");
+            assert.ok(
+              context.headers["x-ms-consistency-level"] === "Eventual" ||
+                context.headers["x-ms-consistency-level"] === "Session",
+              `${context.headers["x-ms-dedicatedgateway-max-age"]} = EVENTUAL or SESSION`
+            );
+            assert.ok(
+              typeof context.headers["x-ms-dedicatedgateway-max-age"] !== "undefined",
+              `${context.headers["x-ms-dedicatedgateway-max-age"]} = undefined`
+            );
+            assert.ok(
+              typeof context.headers["x-ms-dedicatedgateway-max-age"] === "string",
+              `${context.headers["x-ms-dedicatedgateway-max-age"]} = string`
+            );
+            if (
+              context.headers["x-ms-dedicatedgateway-max-age"] === "null" ||
+              context.headers["x-ms-dedicatedgateway-max-age"] === undefined ||
+              typeof context.headers["x-ms-dedicatedgateway-max-age"] === "undefined"
+            ) {
+              assert.ok(
+                context.headers["x-ms-dedicatedgateway-max-age"] === "null",
+                "x-ms-dedicatedgateway-max-age will be ignored."
               );
-              assert.ifError(context.headers["x-ms-consistency-level"]);
             }
-          });
+            assert.ok(
+              context.headers["x-ms-dedicatedgateway-max-age"] === "0",
+              "x-ms-dedicatedgateway-max-age will be ignored."
+            );
+
+            assert.ok(
+              context.headers["x-ms-dedicatedgateway-max-age"] === dedicatedGatewayMaxAge,
+              `${context.headers["x-ms-dedicatedgateway-max-age"]} = ${dedicatedGatewayMaxAge}`
+            );
+          }
           const response = await next(context);
           return response;
         },
       },
     ],
   });
+
   const itemRequestFeedOptions = {
     maxIntegratedCacheStalenessInMs: dedicatedGatewayMaxAge,
   };
@@ -131,33 +142,29 @@ describe("Integrated Cache Staleness", async function (this: Suite) {
     id: containerId,
   });
 
-  // Should pass with maxIntegratedCacheStalenessInMs and consistency level set.
-  await container.items.create({ id: "1" });
-  await container.item("1").read(itemRequestFeedOptions);
+  it("Should pass with maxIntegratedCacheStalenessInMs and consistency level set.", async function () {
+    assert.ok(container.items.create({ id: "1" }));
+    container.item("1").read(itemRequestFeedOptions);
+    container.items
+      .readAll({
+        maxIntegratedCacheStalenessInMs: "0",
+      })
+      .fetchAll();
+    const querySpec = {
+      query: "SELECT * FROM root r WHERE r.id=@id",
+      parameters: [
+        {
+          name: "@id",
+          value: "1",
+        },
+      ],
+    };
+    container.items.query(querySpec, itemRequestFeedOptions).fetchAll();
 
-  // Should pass with maxIntegratedCacheStalenessInMs and consistency level set.
-  // read document.
-  await container.items.readAll(itemRequestFeedOptions).fetchAll();
-
-  // Should pass with maxIntegratedCacheStalenessInMs and consistency level set.
-  // query documents
-  const querySpec = {
-    query: "SELECT * FROM root r WHERE r.id=@id",
-    parameters: [
-      {
-        name: "@id",
-        value: "1",
-      },
-    ],
-  };
-  await container.items.query(querySpec, itemRequestFeedOptions).fetchAll();
-
-  // Should fail: maxIntegratedCacheStalenessInMs should only be set at the item request level and query feed options
-  assert.doesNotThrow(async () => {
-    await container.read({
-      maxIntegratedCacheStalenessInMs: dedicatedGatewayMaxAge,
-    });
-  }, "maxIntegratedCacheStalenessInMs should only be set at the item request level and query feed options");
+    // Should fail: maxIntegratedCacheStalenessInMs cannot be 0
+    this.dedicatedGatewayMaxAge = 0;
+    await container.read(this.dedicatedGatewayMaxAge);
+  });
 });
 
 // For some reason this test does not pass against the emulator. Skipping it for now

--- a/sdk/cosmosdb/cosmos/test/internal/session.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/internal/session.spec.ts
@@ -76,7 +76,7 @@ describe("Integrated Cache Staleness", async function (this: Suite) {
   });
   const dbId = addEntropy("maxIntegratedCacheTestDB");
   const containerId = addEntropy("maxIntegratedCacheTestContainer");
-  const dedicatedGatewayMaxAge = "0";
+  const dedicatedGatewayMaxAge = 20;
   const client = new CosmosClient({
     endpoint,
     key: masterKey,
@@ -97,14 +97,6 @@ describe("Integrated Cache Staleness", async function (this: Suite) {
                 context.headers["x-ms-consistency-level"] === "Session",
               `${context.headers["x-ms-dedicatedgateway-max-age"]} = EVENTUAL or SESSION`
             );
-            assert.ok(
-              typeof context.headers["x-ms-dedicatedgateway-max-age"] !== "undefined",
-              `${context.headers["x-ms-dedicatedgateway-max-age"]} = undefined`
-            );
-            assert.ok(
-              typeof context.headers["x-ms-dedicatedgateway-max-age"] === "string",
-              `${context.headers["x-ms-dedicatedgateway-max-age"]} = string`
-            );
             if (
               context.headers["x-ms-dedicatedgateway-max-age"] === "null" ||
               context.headers["x-ms-dedicatedgateway-max-age"] === undefined ||
@@ -116,13 +108,17 @@ describe("Integrated Cache Staleness", async function (this: Suite) {
               );
             }
             assert.ok(
+              typeof context.headers["x-ms-dedicatedgateway-max-age"] === "string",
+              `${context.headers["x-ms-dedicatedgateway-max-age"]} = string`
+            );
+            assert.ok(
               context.headers["x-ms-dedicatedgateway-max-age"] === "0",
               "x-ms-dedicatedgateway-max-age will be ignored."
             );
 
             assert.ok(
-              context.headers["x-ms-dedicatedgateway-max-age"] === dedicatedGatewayMaxAge,
-              `${context.headers["x-ms-dedicatedgateway-max-age"]} = ${dedicatedGatewayMaxAge}`
+              context.headers["x-ms-dedicatedgateway-max-age"] === `"${dedicatedGatewayMaxAge}"`,
+              `${context.headers["x-ms-dedicatedgateway-max-age"]} = "${dedicatedGatewayMaxAge}"`
             );
           }
           const response = await next(context);
@@ -147,7 +143,7 @@ describe("Integrated Cache Staleness", async function (this: Suite) {
     container.item("1").read(itemRequestFeedOptions);
     container.items
       .readAll({
-        maxIntegratedCacheStalenessInMs: "0",
+        maxIntegratedCacheStalenessInMs: 0,
       })
       .fetchAll();
     const querySpec = {


### PR DESCRIPTION
## Original PR + notes [link](https://github.com/Azure/azure-sdk-for-js/pull/22803)
### Packages impacted by this PR
Describe the bug https://github.com/Azure/azure-sdk-for-js/issues/22765
Setting maxIntegratedCacheStalenessInMs doesn't set the staleness to 0 and instead it appears to fall back to the default cache staleness of 5 minutes.

Issue
To Reproduce
Steps to reproduce the behavior:

The first request should cost X RUs and the second request should also cost X RUs, indicating that request 1 wasn't cached due to staleness being set to 0. The same behavior should apply to the options for container.items.query()

const requestOptions = {
maxIntegratedCacheStalenessInMs: 0, };

const { resource: readDoc, requestCharge: charge } = await container.item("1", "1").read(requestOptions);
console.log(Reading item: + readDoc.id + RUs: + charge);

const { resource: readDoc2, requestCharge: charge2 } = await container.item("1", "1").read(requestOptions);
console.log(Reading item: + readDoc2.id + RUs: + charge2);

Expected behavior
Setting maxIntegratedCacheStalenessInMs to 0 should bypass the integrated cache and each subsequent request should be refreshed from the backend. https://docs.microsoft.com/en-us/azure/cosmos-db/how-to-configure-integrated-cache#adjust-maxintegratedcachestaleness