### PR TITLE
[KeyVault] Fix minmax tests for keyvault-certificates

### DIFF
--- a/sdk/keyvault/keyvault-certificates/package.json
+++ b/sdk/keyvault/keyvault-certificates/package.json
@@ -121,7 +121,7 @@
     "@azure/dev-tool": "^1.0.0",
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
     "@azure/identity": "^2.1.0-beta.2",
-    "@azure/keyvault-secrets": "^4.2.0",
+    "@azure/keyvault-secrets": "^4.5.0",
     "@azure/test-utils": "^1.0.0",
     "@azure-tools/test-credential": "^1.0.0",
     "@azure-tools/test-recorder": "^2.0.0",


### PR DESCRIPTION
### Packages impacted by this PR

- `@azure/keyvault-certificates`

### Describe the problem that is addressed by this PR

This PR bumps dev dependency on `@azure/keyvault-secrets` to `^4.5.0` (the minimum version with Core v2 support) to fix the minmax tests.