### PR TITLE
[@azure/search-documents] Enable national cloud support for Azure Search SDK

### DIFF
--- a/sdk/search/search-documents/CHANGELOG.md
+++ b/sdk/search/search-documents/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## 11.3.0-beta.8 (unreleased)
 
-Added `core-http-compat` dependency
+- Added `core-http-compat` dependency
+- Enabled national cloud support for Azure Search SDK. Please refer [#22887](https://github.com/Azure/azure-sdk-for-js/pull/22887) for further details.
 
 ## 11.3.0-beta.7 (2022-03-08)
 

--- a/sdk/search/search-documents/README.md
+++ b/sdk/search/search-documents/README.md
@@ -20,6 +20,7 @@ Use the @azure/search-documents client library to:
 - Optimize results through scoring profiles to factor in business logic or freshness.
 
 Key links:
+
 - [Source code](https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/search/search-documents/)
 - [Package (NPM)](https://www.npmjs.com/package/@azure/search-documents)
 - [API reference documentation](https://docs.microsoft.com/javascript/api/@azure/search-documents)
@@ -67,9 +68,9 @@ az search admin-key show --resource-group <your-resource-group-name> --service-n
 
 Alternatively, you can get the endpoint and Admin Key from the resource information in the [Azure Portal][azure_portal].
 
-There are two types of keys used to access your search service: **admin** *(read-write)* and **query** *(read-only)* keys.  Restricting access and operations in client apps is essential to safeguarding the search assets on your service.  Always use a query key rather than an admin key for any query originating from a client app.
+There are two types of keys used to access your search service: **admin** _(read-write)_ and **query** _(read-only)_ keys. Restricting access and operations in client apps is essential to safeguarding the search assets on your service. Always use a query key rather than an admin key for any query originating from a client app.
 
-*Note: The example Azure CLI snippet above retrieves an admin key so it's easier to get started exploring APIs, but it should be managed carefully.*
+_Note: The example Azure CLI snippet above retrieves an admin key so it's easier to get started exploring APIs, but it should be managed carefully._
 
 Once you have an api-key, you can use it as follows:
 
@@ -95,25 +96,62 @@ const indexClient = new SearchIndexClient("<endpoint>", new AzureKeyCredential("
 const indexerClient = new SearchIndexerClient("<endpoint>", new AzureKeyCredential("<apiKey>"));
 ```
 
+### Authenticate in a National Cloud
+
+To authenticate in a [National Cloud](https://docs.microsoft.com/azure/active-directory/develop/authentication-national-cloud), you will need to make the following additions to your client configuration:
+
+- Set the `Audience` in `SearchClientOptions`
+
+```js
+const {
+  SearchClient,
+  SearchIndexClient,
+  SearchIndexerClient,
+  AzureKeyCredential,
+} = require("@azure/search-documents");
+
+// To query and manipulate documents
+const searchClient = new SearchClient(
+  "<endpoint>",
+  "<indexName>",
+  new AzureKeyCredential("<apiKey>"),
+  {
+    audience: SearchAudience.AzureChina,
+  }
+);
+
+// To manage indexes and synonymmaps
+const indexClient = new SearchIndexClient("<endpoint>", new AzureKeyCredential("<apiKey>"), {
+  audience: SearchAudience.AzureChina,
+});
+
+// To manage indexers, datasources and skillsets
+const indexerClient = new SearchIndexerClient("<endpoint>", new AzureKeyCredential("<apiKey>"), {
+  audience: SearchAudience.AzureChina,
+});
+```
+
 ## Key concepts
-An Azure Cognitive Search service contains one or more indexes that provide persistent storage of searchable data in the form of JSON documents.  _(If you're brand new to search, you can make a very rough analogy between indexes and database tables.)_  The @azure/search-documents client library
+
+An Azure Cognitive Search service contains one or more indexes that provide persistent storage of searchable data in the form of JSON documents. _(If you're brand new to search, you can make a very rough analogy between indexes and database tables.)_ The @azure/search-documents client library
 exposes operations on these resources through three main client types.
 
-* `SearchClient` helps with:
-  * [Searching](https://docs.microsoft.com/azure/search/search-lucene-query-architecture) your indexed documents using [rich queries](https://docs.microsoft.com/azure/search/search-query-overview) and [powerful data shaping](https://docs.microsoft.com/azure/search/search-filters)
-  * [Autocompleting](https://docs.microsoft.com/rest/api/searchservice/autocomplete) partially typed search terms based on documents in the index
-  * [Suggesting](https://docs.microsoft.com/rest/api/searchservice/suggestions) the most likely matching text in documents as a user types
-  * [Adding, Updating or Deleting Documents](https://docs.microsoft.com/rest/api/searchservice/addupdate-or-delete-documents) documents from an index
-* `SearchIndexClient` allows you to:
-  * [Create, delete, update, or configure a search index](https://docs.microsoft.com/rest/api/searchservice/index-operations)
-  * [Declare custom synonym maps to expand or rewrite queries](https://docs.microsoft.com/rest/api/searchservice/synonym-map-operations)
-* `SearchIndexerClient` allows you to:
-  * [Start indexers to automatically crawl data sources](https://docs.microsoft.com/rest/api/searchservice/indexer-operations)
-  * [Define AI powered Skillsets to transform and enrich your data](https://docs.microsoft.com/rest/api/searchservice/skillset-operations)
+- `SearchClient` helps with:
+  - [Searching](https://docs.microsoft.com/azure/search/search-lucene-query-architecture) your indexed documents using [rich queries](https://docs.microsoft.com/azure/search/search-query-overview) and [powerful data shaping](https://docs.microsoft.com/azure/search/search-filters)
+  - [Autocompleting](https://docs.microsoft.com/rest/api/searchservice/autocomplete) partially typed search terms based on documents in the index
+  - [Suggesting](https://docs.microsoft.com/rest/api/searchservice/suggestions) the most likely matching text in documents as a user types
+  - [Adding, Updating or Deleting Documents](https://docs.microsoft.com/rest/api/searchservice/addupdate-or-delete-documents) documents from an index
+- `SearchIndexClient` allows you to:
+  - [Create, delete, update, or configure a search index](https://docs.microsoft.com/rest/api/searchservice/index-operations)
+  - [Declare custom synonym maps to expand or rewrite queries](https://docs.microsoft.com/rest/api/searchservice/synonym-map-operations)
+- `SearchIndexerClient` allows you to:
+  - [Start indexers to automatically crawl data sources](https://docs.microsoft.com/rest/api/searchservice/indexer-operations)
+  - [Define AI powered Skillsets to transform and enrich your data](https://docs.microsoft.com/rest/api/searchservice/skillset-operations)
 
 **Note**: These clients cannot function in the browser because the APIs it calls do not have support for Cross-Origin Resource Sharing (CORS).
 
 ## TypeScript/JavaScript specific concepts
+
 ### Documents
 
 An item stored inside a search index. The shape of this document is described in the index using `Field`s. Each Field has a name, a datatype, and additional metadata such as if it is searchable or filterable.
@@ -136,13 +174,13 @@ Typically you will only wish to [show a subset of search results](https://docs.m
 
 The following examples demonstrate the basics - please [check out our samples](https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/search/search-documents/samples) for much more.
 
-* [Creating an index](#create-an-index)
-* [Retrieving a specific document from your index](#retrieve-a-specific-document-from-an-index)
-* [Adding documents to your index](#adding-documents-into-an-index)
-* [Perform a search on documents](#perform-a-search-on-documents)
-  * [Querying with TypeScript](#querying-with-typescript)
-  * [Querying with OData filters](#querying-with-odata-filters)
-  * [Querying with facets](#querying-with-facets)
+- [Creating an index](#create-an-index)
+- [Retrieving a specific document from your index](#retrieve-a-specific-document-from-an-index)
+- [Adding documents to your index](#adding-documents-into-an-index)
+- [Perform a search on documents](#perform-a-search-on-documents)
+  - [Querying with TypeScript](#querying-with-typescript)
+  - [Querying with OData filters](#querying-with-odata-filters)
+  - [Querying with facets](#querying-with-facets)
 
 ### Create an Index
 
@@ -204,11 +242,7 @@ A specific document can be retrieved by its primary key value:
 ```js
 const { SearchClient, AzureKeyCredential } = require("@azure/search-documents");
 
-const client = new SearchClient(
-  "<endpoint>",
-  "<indexName>",
-  new AzureKeyCredential("<apiKey>")
-);
+const client = new SearchClient("<endpoint>", "<indexName>", new AzureKeyCredential("<apiKey>"));
 
 async function main() {
   const result = await client.getDocument("1234");
@@ -225,11 +259,7 @@ You can upload multiple documents into index inside a batch:
 ```js
 const { SearchClient, AzureKeyCredential } = require("@azure/search-documents");
 
-const client = new SearchClient(
-  "<endpoint>",
-  "<indexName>",
-  new AzureKeyCredential("<apiKey>")
-);
+const client = new SearchClient("<endpoint>", "<indexName>", new AzureKeyCredential("<apiKey>"));
 
 async function main() {
   const uploadResult = await client.uploadDocuments([
@@ -253,11 +283,7 @@ To list all results of a particular query, you can use `search` with a search st
 ```js
 const { SearchClient, AzureKeyCredential } = require("@azure/search-documents");
 
-const client = new SearchClient(
-  "<endpoint>",
-  "<indexName>",
-  new AzureKeyCredential("<apiKey>")
-);
+const client = new SearchClient("<endpoint>", "<indexName>", new AzureKeyCredential("<apiKey>"));
 
 async function main() {
   const searchResults = await client.search("wifi -luxury");
@@ -274,11 +300,7 @@ For a more advanced search that uses [Lucene syntax](https://docs.microsoft.com/
 ```js
 const { SearchClient, AzureKeyCredential } = require("@azure/search-documents");
 
-const client = new SearchClient(
-  "<endpoint>",
-  "<indexName>",
-  new AzureKeyCredential("<apiKey>")
-);
+const client = new SearchClient("<endpoint>", "<indexName>", new AzureKeyCredential("<apiKey>"));
 
 async function main() {
   const searchResults = await client.search('Category:budget AND "recently renovated"^3', {
@@ -340,11 +362,7 @@ Using the `filter` query parameter allows you to query an index using the syntax
 ```js
 const { SearchClient, AzureKeyCredential, odata } = require("@azure/search-documents");
 
-const client = new SearchClient(
-  "<endpoint>",
-  "<indexName>",
-  new AzureKeyCredential("<apiKey>")
-);
+const client = new SearchClient("<endpoint>", "<indexName>", new AzureKeyCredential("<apiKey>"));
 
 async function main() {
   const baseRateMax = 200;
@@ -371,11 +389,7 @@ main();
 ```js
 const { SearchClient, AzureKeyCredential } = require("@azure/search-documents");
 
-const client = new SearchClient(
-  "<endpoint>",
-  "<indexName>",
-  new AzureKeyCredential("<apiKey>")
-);
+const client = new SearchClient("<endpoint>", "<indexName>", new AzureKeyCredential("<apiKey>"));
 
 async function main() {
   const searchResults = await client.search("WiFi", {
@@ -417,15 +431,16 @@ setLogLevel("info");
 For more detailed instructions on how to enable logs, you can look at the [@azure/logger package docs](https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/core/logger).
 
 ## Next steps
-* [Go further with search-documents and our samples](https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/search/search-documents/samples)
-* [Watch a demo or deep dive video](https://azure.microsoft.com/resources/videos/index/?services=search)
-* [Read more about the Azure Cognitive Search service](https://docs.microsoft.com/azure/search/search-what-is-azure-search)
+
+- [Go further with search-documents and our samples](https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/search/search-documents/samples)
+- [Watch a demo or deep dive video](https://azure.microsoft.com/resources/videos/index/?services=search)
+- [Read more about the Azure Cognitive Search service](https://docs.microsoft.com/azure/search/search-what-is-azure-search)
 
 ## Contributing
 
 If you'd like to contribute to this library, please read the [contributing guide](https://github.com/Azure/azure-sdk-for-js/blob/main/CONTRIBUTING.md) to learn more about how to build and test the code.
 
-This project welcomes contributions and suggestions.  Most contributions require you to agree to a Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us the rights to use your contribution. For details, visit [cla.microsoft.com][cla].
+This project welcomes contributions and suggestions. Most contributions require you to agree to a Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us the rights to use your contribution. For details, visit [cla.microsoft.com][cla].
 
 This project has adopted the [Microsoft Open Source Code of Conduct][coc].For more information see the [Code of Conduct FAQ][coc_faq] or contact [opencode@microsoft.com][coc_contact] with any additional questions or comments.
 

--- a/sdk/search/search-documents/README.md
+++ b/sdk/search/search-documents/README.md
@@ -108,6 +108,7 @@ const {
   SearchIndexClient,
   SearchIndexerClient,
   AzureKeyCredential,
+  SearchAudience,
 } = require("@azure/search-documents");
 
 // To query and manipulate documents

--- a/sdk/search/search-documents/README.md
+++ b/sdk/search/search-documents/README.md
@@ -108,7 +108,7 @@ const {
   SearchIndexClient,
   SearchIndexerClient,
   AzureKeyCredential,
-  SearchAudience,
+  KnownSearchAudience,
 } = require("@azure/search-documents");
 
 // To query and manipulate documents
@@ -117,18 +117,18 @@ const searchClient = new SearchClient(
   "<indexName>",
   new AzureKeyCredential("<apiKey>"),
   {
-    audience: SearchAudience.AzureChina,
+    audience: KnownSearchAudience.AzureChina,
   }
 );
 
 // To manage indexes and synonymmaps
 const indexClient = new SearchIndexClient("<endpoint>", new AzureKeyCredential("<apiKey>"), {
-  audience: SearchAudience.AzureChina,
+  audience: KnownSearchAudience.AzureChina,
 });
 
 // To manage indexers, datasources and skillsets
 const indexerClient = new SearchIndexerClient("<endpoint>", new AzureKeyCredential("<apiKey>"), {
-  audience: SearchAudience.AzureChina,
+  audience: KnownSearchAudience.AzureChina,
 });
 ```
 

--- a/sdk/search/search-documents/review/search-documents.api.md
+++ b/sdk/search/search-documents/review/search-documents.api.md
@@ -1839,6 +1839,13 @@ export interface SearchAlias {
 }
 
 // @public
+export enum SearchAudience {
+    AzureChina = "https://search.azure.cn",
+    AzureGovernment = "https://search.azure.us",
+    AzurePublicCloud = "https://search.azure.com"
+}
+
+// @public
 export class SearchClient<T> implements IndexDocumentsClient<T> {
     constructor(endpoint: string, indexName: string, credential: KeyCredential | TokenCredential, options?: SearchClientOptions);
     // @deprecated
@@ -1863,6 +1870,7 @@ export class SearchClient<T> implements IndexDocumentsClient<T> {
 export interface SearchClientOptions extends ExtendedCommonClientOptions {
     // @deprecated
     apiVersion?: string;
+    audience?: SearchAudience;
     serviceVersion?: string;
 }
 
@@ -1949,6 +1957,7 @@ export class SearchIndexClient {
 export interface SearchIndexClientOptions extends ExtendedCommonClientOptions {
     // @deprecated
     apiVersion?: string;
+    audience?: SearchAudience;
     serviceVersion?: string;
 }
 
@@ -2011,6 +2020,7 @@ export class SearchIndexerClient {
 export interface SearchIndexerClientOptions extends ExtendedCommonClientOptions {
     // @deprecated
     apiVersion?: string;
+    audience?: SearchAudience;
     serviceVersion?: string;
 }
 

--- a/sdk/search/search-documents/review/search-documents.api.md
+++ b/sdk/search/search-documents/review/search-documents.api.md
@@ -1288,6 +1288,13 @@ export enum KnownRegexFlags {
 }
 
 // @public
+export enum KnownSearchAudience {
+    AzureChina = "https://search.azure.cn",
+    AzureGovernment = "https://search.azure.us",
+    AzurePublicCloud = "https://search.azure.com"
+}
+
+// @public
 export enum KnownSearchIndexerDataSourceType {
     AdlsGen2 = "adlsgen2",
     AzureBlob = "azureblob",
@@ -1839,13 +1846,6 @@ export interface SearchAlias {
 }
 
 // @public
-export enum SearchAudience {
-    AzureChina = "https://search.azure.cn",
-    AzureGovernment = "https://search.azure.us",
-    AzurePublicCloud = "https://search.azure.com"
-}
-
-// @public
 export class SearchClient<T> implements IndexDocumentsClient<T> {
     constructor(endpoint: string, indexName: string, credential: KeyCredential | TokenCredential, options?: SearchClientOptions);
     // @deprecated
@@ -1870,7 +1870,7 @@ export class SearchClient<T> implements IndexDocumentsClient<T> {
 export interface SearchClientOptions extends ExtendedCommonClientOptions {
     // @deprecated
     apiVersion?: string;
-    audience?: SearchAudience;
+    audience?: string;
     serviceVersion?: string;
 }
 
@@ -1957,7 +1957,7 @@ export class SearchIndexClient {
 export interface SearchIndexClientOptions extends ExtendedCommonClientOptions {
     // @deprecated
     apiVersion?: string;
-    audience?: SearchAudience;
+    audience?: string;
     serviceVersion?: string;
 }
 
@@ -2020,7 +2020,7 @@ export class SearchIndexerClient {
 export interface SearchIndexerClientOptions extends ExtendedCommonClientOptions {
     // @deprecated
     apiVersion?: string;
-    audience?: SearchAudience;
+    audience?: string;
     serviceVersion?: string;
 }
 

--- a/sdk/search/search-documents/src/index.ts
+++ b/sdk/search/search-documents/src/index.ts
@@ -342,4 +342,4 @@ export {
 } from "./generated/service/models";
 export { AzureKeyCredential } from "@azure/core-auth";
 export { createSynonymMapFromFile } from "./synonymMapHelper";
-export { SearchAudience } from "./searchAudience";
+export { KnownSearchAudience } from "./searchAudience";

--- a/sdk/search/search-documents/src/index.ts
+++ b/sdk/search/search-documents/src/index.ts
@@ -342,3 +342,4 @@ export {
 } from "./generated/service/models";
 export { AzureKeyCredential } from "@azure/core-auth";
 export { createSynonymMapFromFile } from "./synonymMapHelper";
+export { SearchAudience } from "./searchAudience";

--- a/sdk/search/search-documents/src/searchAudience.ts
+++ b/sdk/search/search-documents/src/searchAudience.ts
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+/**
+ * Possible values for Search Audience
+ */
+export enum SearchAudience {
+  /**
+   * Audience for Azure China
+   */
+  AzureChina = "https://search.azure.cn",
+  /**
+   * Audience for Azure Government
+   */
+  AzureGovernment = "https://search.azure.us",
+  /**
+   * Audience for Azure Public
+   */
+  AzurePublicCloud = "https://search.azure.com",
+}

--- a/sdk/search/search-documents/src/searchAudience.ts
+++ b/sdk/search/search-documents/src/searchAudience.ts
@@ -2,9 +2,9 @@
 // Licensed under the MIT license.
 
 /**
- * Possible values for Search Audience
+ * Known values for Search Audience
  */
-export enum SearchAudience {
+export enum KnownSearchAudience {
   /**
    * Audience for Azure China
    */

--- a/sdk/search/search-documents/src/searchClient.ts
+++ b/sdk/search/search-documents/src/searchClient.ts
@@ -43,6 +43,7 @@ import { encode, decode } from "./base64";
 import * as utils from "./serviceUtils";
 import { IndexDocumentsClient } from "./searchIndexingBufferedSender";
 import { ExtendedCommonClientOptions } from "@azure/core-http-compat";
+import { SearchAudience } from "./searchAudience";
 
 /**
  * Client options used to configure Cognitive Search API requests.
@@ -58,6 +59,12 @@ export interface SearchClientOptions extends ExtendedCommonClientOptions {
    * The service version to use when communicating with the service.
    */
   serviceVersion?: string;
+
+  /**
+   * The Audience to use for authentication with Azure Active Directory (AAD). The
+   * audience is not considered when using a shared key.
+   */
+  audience?: SearchAudience;
 }
 
 /**
@@ -175,8 +182,12 @@ export class SearchClient<T> implements IndexDocumentsClient<T> {
     );
 
     if (isTokenCredential(credential)) {
+      let scope: string = options.audience
+        ? `${options.audience}/.default`
+        : `${SearchAudience.AzurePublicCloud}/.default`;
+
       this.client.pipeline.addPolicy(
-        bearerTokenAuthenticationPolicy({ credential, scopes: utils.DEFAULT_SEARCH_SCOPE })
+        bearerTokenAuthenticationPolicy({ credential, scopes: scope })
       );
     } else {
       this.client.pipeline.addPolicy(createSearchApiKeyCredentialPolicy(credential));

--- a/sdk/search/search-documents/src/searchClient.ts
+++ b/sdk/search/search-documents/src/searchClient.ts
@@ -43,7 +43,7 @@ import { encode, decode } from "./base64";
 import * as utils from "./serviceUtils";
 import { IndexDocumentsClient } from "./searchIndexingBufferedSender";
 import { ExtendedCommonClientOptions } from "@azure/core-http-compat";
-import { SearchAudience } from "./searchAudience";
+import { KnownSearchAudience } from "./searchAudience";
 
 /**
  * Client options used to configure Cognitive Search API requests.
@@ -63,8 +63,9 @@ export interface SearchClientOptions extends ExtendedCommonClientOptions {
   /**
    * The Audience to use for authentication with Azure Active Directory (AAD). The
    * audience is not considered when using a shared key.
+   * {@link KnownSearchAudience} can be used interchangeably with audience
    */
-  audience?: SearchAudience;
+  audience?: string;
 }
 
 /**
@@ -184,7 +185,7 @@ export class SearchClient<T> implements IndexDocumentsClient<T> {
     if (isTokenCredential(credential)) {
       const scope: string = options.audience
         ? `${options.audience}/.default`
-        : `${SearchAudience.AzurePublicCloud}/.default`;
+        : `${KnownSearchAudience.AzurePublicCloud}/.default`;
 
       this.client.pipeline.addPolicy(
         bearerTokenAuthenticationPolicy({ credential, scopes: scope })

--- a/sdk/search/search-documents/src/searchClient.ts
+++ b/sdk/search/search-documents/src/searchClient.ts
@@ -182,7 +182,7 @@ export class SearchClient<T> implements IndexDocumentsClient<T> {
     );
 
     if (isTokenCredential(credential)) {
-      let scope: string = options.audience
+      const scope: string = options.audience
         ? `${options.audience}/.default`
         : `${SearchAudience.AzurePublicCloud}/.default`;
 

--- a/sdk/search/search-documents/src/searchIndexClient.ts
+++ b/sdk/search/search-documents/src/searchIndexClient.ts
@@ -44,7 +44,7 @@ import { createSpan } from "./tracing";
 import { createOdataMetadataPolicy } from "./odataMetadataPolicy";
 import { SearchClient, SearchClientOptions as GetSearchClientOptions } from "./searchClient";
 import { ExtendedCommonClientOptions } from "@azure/core-http-compat";
-import { SearchAudience } from "./searchAudience";
+import { KnownSearchAudience } from "./searchAudience";
 
 /**
  * Client options used to configure Cognitive Search API requests.
@@ -64,8 +64,9 @@ export interface SearchIndexClientOptions extends ExtendedCommonClientOptions {
   /**
    * The Audience to use for authentication with Azure Active Directory (AAD). The
    * audience is not considered when using a shared key.
+   * {@link KnownSearchAudience} can be used interchangeably with audience
    */
-  audience?: SearchAudience;
+  audience?: string;
 }
 
 /**
@@ -184,7 +185,7 @@ export class SearchIndexClient {
     if (isTokenCredential(credential)) {
       const scope: string = options.audience
         ? `${options.audience}/.default`
-        : `${SearchAudience.AzurePublicCloud}/.default`;
+        : `${KnownSearchAudience.AzurePublicCloud}/.default`;
 
       this.client.pipeline.addPolicy(
         bearerTokenAuthenticationPolicy({ credential, scopes: scope })

--- a/sdk/search/search-documents/src/searchIndexClient.ts
+++ b/sdk/search/search-documents/src/searchIndexClient.ts
@@ -182,7 +182,7 @@ export class SearchIndexClient {
     );
 
     if (isTokenCredential(credential)) {
-      let scope: string = options.audience
+      const scope: string = options.audience
         ? `${options.audience}/.default`
         : `${SearchAudience.AzurePublicCloud}/.default`;
 

--- a/sdk/search/search-documents/src/searchIndexClient.ts
+++ b/sdk/search/search-documents/src/searchIndexClient.ts
@@ -44,6 +44,7 @@ import { createSpan } from "./tracing";
 import { createOdataMetadataPolicy } from "./odataMetadataPolicy";
 import { SearchClient, SearchClientOptions as GetSearchClientOptions } from "./searchClient";
 import { ExtendedCommonClientOptions } from "@azure/core-http-compat";
+import { SearchAudience } from "./searchAudience";
 
 /**
  * Client options used to configure Cognitive Search API requests.
@@ -59,6 +60,12 @@ export interface SearchIndexClientOptions extends ExtendedCommonClientOptions {
    * The service version to use when communicating with the service.
    */
   serviceVersion?: string;
+
+  /**
+   * The Audience to use for authentication with Azure Active Directory (AAD). The
+   * audience is not considered when using a shared key.
+   */
+  audience?: SearchAudience;
 }
 
 /**
@@ -175,8 +182,12 @@ export class SearchIndexClient {
     );
 
     if (isTokenCredential(credential)) {
+      let scope: string = options.audience
+        ? `${options.audience}/.default`
+        : `${SearchAudience.AzurePublicCloud}/.default`;
+
       this.client.pipeline.addPolicy(
-        bearerTokenAuthenticationPolicy({ credential, scopes: utils.DEFAULT_SEARCH_SCOPE })
+        bearerTokenAuthenticationPolicy({ credential, scopes: scope })
       );
     } else {
       this.client.pipeline.addPolicy(createSearchApiKeyCredentialPolicy(credential));

--- a/sdk/search/search-documents/src/searchIndexerClient.ts
+++ b/sdk/search/search-documents/src/searchIndexerClient.ts
@@ -164,7 +164,7 @@ export class SearchIndexerClient {
     );
 
     if (isTokenCredential(credential)) {
-      let scope: string = options.audience
+      const scope: string = options.audience
         ? `${options.audience}/.default`
         : `${SearchAudience.AzurePublicCloud}/.default`;
 

--- a/sdk/search/search-documents/src/searchIndexerClient.ts
+++ b/sdk/search/search-documents/src/searchIndexerClient.ts
@@ -38,6 +38,7 @@ import * as utils from "./serviceUtils";
 import { createSpan } from "./tracing";
 import { createOdataMetadataPolicy } from "./odataMetadataPolicy";
 import { ExtendedCommonClientOptions } from "@azure/core-http-compat";
+import { SearchAudience } from "./searchAudience";
 
 /**
  * Client options used to configure Cognitive Search API requests.
@@ -53,6 +54,12 @@ export interface SearchIndexerClientOptions extends ExtendedCommonClientOptions 
    * The service version to use when communicating with the service.
    */
   serviceVersion?: string;
+
+  /**
+   * The Audience to use for authentication with Azure Active Directory (AAD). The
+   * audience is not considered when using a shared key.
+   */
+  audience?: SearchAudience;
 }
 
 /**
@@ -157,8 +164,12 @@ export class SearchIndexerClient {
     );
 
     if (isTokenCredential(credential)) {
+      let scope: string = options.audience
+        ? `${options.audience}/.default`
+        : `${SearchAudience.AzurePublicCloud}/.default`;
+
       this.client.pipeline.addPolicy(
-        bearerTokenAuthenticationPolicy({ credential, scopes: utils.DEFAULT_SEARCH_SCOPE })
+        bearerTokenAuthenticationPolicy({ credential, scopes: scope })
       );
     } else {
       this.client.pipeline.addPolicy(createSearchApiKeyCredentialPolicy(credential));

--- a/sdk/search/search-documents/src/searchIndexerClient.ts
+++ b/sdk/search/search-documents/src/searchIndexerClient.ts
@@ -38,7 +38,7 @@ import * as utils from "./serviceUtils";
 import { createSpan } from "./tracing";
 import { createOdataMetadataPolicy } from "./odataMetadataPolicy";
 import { ExtendedCommonClientOptions } from "@azure/core-http-compat";
-import { SearchAudience } from "./searchAudience";
+import { KnownSearchAudience } from "./searchAudience";
 
 /**
  * Client options used to configure Cognitive Search API requests.
@@ -58,8 +58,9 @@ export interface SearchIndexerClientOptions extends ExtendedCommonClientOptions 
   /**
    * The Audience to use for authentication with Azure Active Directory (AAD). The
    * audience is not considered when using a shared key.
+   * {@link KnownSearchAudience} can be used interchangeably with audience
    */
-  audience?: SearchAudience;
+  audience?: string;
 }
 
 /**
@@ -166,7 +167,7 @@ export class SearchIndexerClient {
     if (isTokenCredential(credential)) {
       const scope: string = options.audience
         ? `${options.audience}/.default`
-        : `${SearchAudience.AzurePublicCloud}/.default`;
+        : `${KnownSearchAudience.AzurePublicCloud}/.default`;
 
       this.client.pipeline.addPolicy(
         bearerTokenAuthenticationPolicy({ credential, scopes: scope })

--- a/sdk/search/search-documents/src/serviceUtils.ts
+++ b/sdk/search/search-documents/src/serviceUtils.ts
@@ -85,8 +85,6 @@ import {
   SearchResult as GeneratedSearchResult,
 } from "./generated/data/models";
 
-export const DEFAULT_SEARCH_SCOPE = "https://search.azure.com/.default";
-
 export function convertSkillsToPublic(skills: SearchIndexerSkillUnion[]): SearchIndexerSkill[] {
   if (!skills) {
     return skills;


### PR DESCRIPTION
### Packages impacted by this PR
`@azure/search-documents`

### Issues associated with this PR
https://github.com/Azure/azure-sdk-for-js/issues/22813

### Describe the problem that is addressed by this PR
This PR is to enable national cloud support for Azure Search Documents. This PR uses the .NET PR - https://github.com/Azure/azure-sdk-for-net/pull/30316 as reference.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?
This is a standard straight forward implementation. No specific design concerns.

### Provide a list of related PRs _(if any)_
https://github.com/Azure/azure-sdk-for-net/pull/30316

### Checklists
- [X] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
