### PR TITLE
[core-http] Add support for headers having original casing during deserialization.

### DIFF
--- a/sdk/core/core-http/CHANGELOG.md
+++ b/sdk/core/core-http/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Addressed an issue where when header casing is preserved via a custom `HttpClient`, we would not deserialize headers correctly. [PR #22888](https://github.com/Azure/azure-sdk-for-js/pull/22888)
+
 ### Other Changes
 
 ## 2.2.6 (2022-08-04)

--- a/sdk/core/core-http/src/policies/deserializationPolicy.ts
+++ b/sdk/core/core-http/src/policies/deserializationPolicy.ts
@@ -223,7 +223,7 @@ export function deserializeResponseBody(
         if (responseSpec.headersMapper) {
           parsedResponse.parsedHeaders = operationSpec.serializer.deserialize(
             responseSpec.headersMapper,
-            parsedResponse.headers.rawHeaders(),
+            parsedResponse.headers.toJson(),
             "operationRes.parsedHeaders",
             options
           );
@@ -322,7 +322,7 @@ function handleErrorResponse(
     if (parsedResponse.headers && defaultHeadersMapper) {
       error.response!.parsedHeaders = operationSpec.serializer.deserialize(
         defaultHeadersMapper,
-        parsedResponse.headers.rawHeaders(),
+        parsedResponse.headers.toJson(),
         "operationRes.parsedHeaders"
       );
     }

--- a/sdk/core/core-http/test/policies/deserializationPolicyTests.ts
+++ b/sdk/core/core-http/test/policies/deserializationPolicyTests.ts
@@ -1048,6 +1048,129 @@ describe("deserializationPolicy", function () {
         assert.equal(e.message, "The specified container already exists.");
       }
     });
+
+    it(`with response headers in different casing`, async function () {
+      const BodyMapper: CompositeMapper = {
+        serializedName: "getproperties-body",
+        type: {
+          name: "Composite",
+          className: "PropertiesBody",
+          modelProperties: {
+            message: {
+              type: {
+                name: "String",
+              },
+            },
+          },
+        },
+      };
+
+      const HeadersMapper: CompositeMapper = {
+        serializedName: "getproperties-headers",
+        type: {
+          name: "Composite",
+          className: "PropertiesHeaders",
+          modelProperties: {
+            errorCode: {
+              serializedName: "x-ms-error-code",
+              type: {
+                name: "String",
+              },
+            },
+          },
+        },
+      };
+
+      const serializer = new Serializer(HeadersMapper, true);
+
+      const operationSpec: OperationSpec = {
+        httpMethod: "GET",
+        responses: {
+          200: {
+            headersMapper: HeadersMapper,
+            bodyMapper: BodyMapper,
+          },
+        },
+        serializer,
+      };
+
+      const response: HttpOperationResponse = {
+        request: createRequest(operationSpec),
+        status: 200,
+        headers: new HttpHeaders({
+          "X-MS-Error-Code": "InvalidResourceNameHeader",
+        }),
+        bodyAsText: '{"message": "InvalidResourceNameBody"}',
+      };
+
+      const result = await deserializeResponse(response);
+      assert.strictEqual(result.parsedHeaders?.errorCode, "InvalidResourceNameHeader");
+      assert.strictEqual(result.parsedBody.message, "InvalidResourceNameBody");
+    });
+
+    it(`with response headers in different casing inside errors`, async function () {
+      const BodyMapper: CompositeMapper = {
+        serializedName: "getproperties-body",
+        type: {
+          name: "Composite",
+          className: "PropertiesBody",
+          modelProperties: {
+            message: {
+              type: {
+                name: "String",
+              },
+            },
+          },
+        },
+      };
+
+      const HeadersMapper: CompositeMapper = {
+        serializedName: "getproperties-headers",
+        type: {
+          name: "Composite",
+          className: "PropertiesHeaders",
+          modelProperties: {
+            errorCode: {
+              serializedName: "x-ms-error-code",
+              type: {
+                name: "String",
+              },
+            },
+          },
+        },
+      };
+
+      const serializer = new Serializer(HeadersMapper, true);
+
+      const operationSpec: OperationSpec = {
+        httpMethod: "GET",
+        responses: {
+          default: {
+            headersMapper: HeadersMapper,
+            bodyMapper: BodyMapper,
+          },
+        },
+        serializer,
+      };
+
+      const response: HttpOperationResponse = {
+        request: createRequest(operationSpec),
+        status: 500,
+        headers: new HttpHeaders({
+          "X-MS-Error-Code": "InvalidResourceNameHeader",
+        }),
+        bodyAsText: '{"message": "InvalidResourceNameBody"}',
+      };
+
+      try {
+        await deserializeResponse(response);
+        assert.fail();
+      } catch (e: any) {
+        assert(e);
+        assert.strictEqual(e.response.parsedHeaders.errorCode, "InvalidResourceNameHeader");
+        assert.strictEqual(e.response.parsedBody.message, "InvalidResourceNameBody");
+      }
+    });
   });
 });
 


### PR DESCRIPTION
### Packages impacted by this PR

@azure/core-http and its dependents

### Issues associated with this PR

Fixes #22881

### Describe the problem that is addressed by this PR

node-fetch forces a lowercase normalization of header names coming over the wire, but storage has scenarios where this is undesirable (see #8117).

Until we get storage moved over to the new pipeline, we would like advanced consumers to be able to preserve header casing via a custom `HttpClient`.

This PR addresses the issue by ensuring we pass the normalized (rather than the original) header casing to the deserialization policy which always hardcodes the lowercase version of the name.

### Are there test cases added in this PR? _(If not, why?)_

Yes! Two new cases, one for normal responses and one for error responses.

