### PR TITLE
[storage]Fix issue of not be able to parse URL with account name in Path correctly

### DIFF
--- a/sdk/storage/storage-blob/CHANGELOG.md
+++ b/sdk/storage/storage-blob/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Bugs Fixed
 
 - Fixed a hang issue in BlobClient.downloadToBuffer when encountering transient network failure.
+- Fixed an issue of under some conditions, it may not be able to correctly parse URL with account name in URL path.
 
 ## 12.11.0 (2022-07-08)
 

--- a/sdk/storage/storage-blob/CHANGELOG.md
+++ b/sdk/storage/storage-blob/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### Bugs Fixed
 
 - Fixed a hang issue in BlobClient.downloadToBuffer when encountering transient network failure.
-- Fixed an issue of under some conditions, it may not be able to correctly parse URL with account name in URL path.
+- Refined URL parsing method to let it be able to correctly parse URLs with account name in path.
 
 ## 12.11.0 (2022-07-08)
 

--- a/sdk/storage/storage-blob/src/utils/constants.ts
+++ b/sdk/storage/storage-blob/src/utils/constants.ts
@@ -210,3 +210,28 @@ export const StorageBlobLoggingAllowedQueryParameters = [
 export const BlobUsesCustomerSpecifiedEncryptionMsg = "BlobUsesCustomerSpecifiedEncryption";
 export const BlobDoesNotUseCustomerSpecifiedEncryption =
   "BlobDoesNotUseCustomerSpecifiedEncryption";
+
+/// List of ports used for path style addressing.
+/// Path style addressing means that storage account is put in URI's Path segment in instead of in host.
+export const PathStylePorts = [
+  "10000",
+  "10001",
+  "10002",
+  "10003",
+  "10004",
+  "10100",
+  "10101",
+  "10102",
+  "10103",
+  "10104",
+  "11000",
+  "11001",
+  "11002",
+  "11003",
+  "11004",
+  "11100",
+  "11101",
+  "11102",
+  "11103",
+  "11104",
+];

--- a/sdk/storage/storage-blob/src/utils/utils.common.ts
+++ b/sdk/storage/storage-blob/src/utils/utils.common.ts
@@ -32,7 +32,12 @@ import {
   ClearRange,
   BlobPropertiesInternal,
 } from "../generated/src/models";
-import { DevelopmentConnectionString, HeaderConstants, URLConstants } from "./constants";
+import {
+  DevelopmentConnectionString,
+  HeaderConstants,
+  PathStylePorts,
+  URLConstants,
+} from "./constants";
 import {
   Tags,
   ObjectReplicationPolicy,
@@ -603,8 +608,11 @@ export function isIpEndpointStyle(parsedUrl: URLBuilder): boolean {
   // Case 2: localhost(:port), use broad regex to match port part.
   // Case 3: Ipv4, use broad regex which just check if host contains Ipv4.
   // For valid host please refer to https://man7.org/linux/man-pages/man7/hostname.7.html.
-  return /^.*:.*:.*$|^localhost(:[0-9]+)?$|^(\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5])(\.(\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5])){3}(:[0-9]+)?$/.test(
-    host
+  return (
+    /^.*:.*:.*$|^localhost(:[0-9]+)?$|^(\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5])(\.(\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5])){3}(:[0-9]+)?$/.test(
+      host
+    ) ||
+    (parsedUrl.getPort() !== undefined && PathStylePorts.includes(parsedUrl.getPort()!))
   );
 }
 

--- a/sdk/storage/storage-file-datalake/CHANGELOG.md
+++ b/sdk/storage/storage-file-datalake/CHANGELOG.md
@@ -12,7 +12,7 @@
 ### Bugs Fixed
 
 - Correted permission string parsing in DataLakePathClient.setPermissions() and DataLakePathClient.getAccessControl().
-- Fixed an issue of under some conditions, it may not be able to correctly parse URL with account name in URL path.
+- Refined URL parsing method to let it be able to correctly parse URLs with account name in path.
 
 ## 12.10.0 (2022-07-08)
 

--- a/sdk/storage/storage-file-datalake/CHANGELOG.md
+++ b/sdk/storage/storage-file-datalake/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### Bugs Fixed
 
 - Correted permission string parsing in DataLakePathClient.setPermissions() and DataLakePathClient.getAccessControl().
+- Fixed an issue of under some conditions, it may not be able to correctly parse URL with account name in URL path.
 
 ## 12.10.0 (2022-07-08)
 

--- a/sdk/storage/storage-file-datalake/src/utils/constants.ts
+++ b/sdk/storage/storage-file-datalake/src/utils/constants.ts
@@ -229,3 +229,28 @@ export const PathResultTypeConstants = {
   FileResourceType: "file",
   DirectoryResourceType: "directory",
 };
+
+/// List of ports used for path style addressing.
+/// Path style addressing means that storage account is put in URI's Path segment in instead of in host.
+export const PathStylePorts = [
+  "10000",
+  "10001",
+  "10002",
+  "10003",
+  "10004",
+  "10100",
+  "10101",
+  "10102",
+  "10103",
+  "10104",
+  "11000",
+  "11001",
+  "11002",
+  "11003",
+  "11004",
+  "11100",
+  "11101",
+  "11102",
+  "11103",
+  "11104",
+];

--- a/sdk/storage/storage-file-datalake/src/utils/utils.common.ts
+++ b/sdk/storage/storage-file-datalake/src/utils/utils.common.ts
@@ -9,6 +9,7 @@ import {
   DevelopmentConnectionString,
   EncryptionAlgorithmAES25,
   HeaderConstants,
+  PathStylePorts,
   UrlConstants,
 } from "./constants";
 
@@ -571,8 +572,11 @@ export function isIpEndpointStyle(parsedUrl: URLBuilder): boolean {
   // Case 2: localhost(:port), use broad regex to match port part.
   // Case 3: Ipv4, use broad regex which just check if host contains Ipv4.
   // For valid host please refer to https://man7.org/linux/man-pages/man7/hostname.7.html.
-  return /^.*:.*:.*$|^localhost(:[0-9]+)?$|^(\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5])(\.(\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5])){3}(:[0-9]+)?$/.test(
-    host
+  return (
+    /^.*:.*:.*$|^localhost(:[0-9]+)?$|^(\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5])(\.(\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5])){3}(:[0-9]+)?$/.test(
+      host
+    ) ||
+    (parsedUrl.getPort() !== undefined && PathStylePorts.includes(parsedUrl.getPort()!))
   );
 }
 

--- a/sdk/storage/storage-file-share/CHANGELOG.md
+++ b/sdk/storage/storage-file-share/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### Bugs Fixed
 
 - Fixed a hang issue in ShareFileClient.downloadToBuffer when encountering transient network failure.
-- Fixed an issue of under some conditions, it may not be able to correctly parse URL with account name in URL path.
+- Refined URL parsing method to let it be able to correctly parse URLs with account name in path.
 
 ### Other Changes
 

--- a/sdk/storage/storage-file-share/CHANGELOG.md
+++ b/sdk/storage/storage-file-share/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Bugs Fixed
 
 - Fixed a hang issue in ShareFileClient.downloadToBuffer when encountering transient network failure.
+- Fixed an issue of under some conditions, it may not be able to correctly parse URL with account name in URL path.
 
 ### Other Changes
 

--- a/sdk/storage/storage-file-share/src/utils/constants.ts
+++ b/sdk/storage/storage-file-share/src/utils/constants.ts
@@ -136,3 +136,28 @@ export const StorageFileLoggingAllowedQueryParameters = [
   "copyid",
   "restype",
 ];
+
+/// List of ports used for path style addressing.
+/// Path style addressing means that storage account is put in URI's Path segment in instead of in host.
+export const PathStylePorts = [
+  "10000",
+  "10001",
+  "10002",
+  "10003",
+  "10004",
+  "10100",
+  "10101",
+  "10102",
+  "10103",
+  "10104",
+  "11000",
+  "11001",
+  "11002",
+  "11003",
+  "11004",
+  "11100",
+  "11101",
+  "11102",
+  "11103",
+  "11104",
+];

--- a/sdk/storage/storage-file-share/src/utils/utils.common.ts
+++ b/sdk/storage/storage-file-share/src/utils/utils.common.ts
@@ -4,7 +4,7 @@
 import { AbortSignalLike } from "@azure/abort-controller";
 import { HttpHeaders, isNode, URLBuilder } from "@azure/core-http";
 import { HttpAuthorization } from "../models";
-import { HeaderConstants, URLConstants } from "./constants";
+import { HeaderConstants, PathStylePorts, URLConstants } from "./constants";
 
 /**
  * Reserved URL characters must be properly escaped for Storage services like Blob or File.
@@ -442,8 +442,11 @@ export function isIpEndpointStyle(parsedUrl: URLBuilder): boolean {
   // Case 2: localhost(:port), use broad regex to match port part.
   // Case 3: Ipv4, use broad regex which just check if host contains Ipv4.
   // For valid host please refer to https://man7.org/linux/man-pages/man7/hostname.7.html.
-  return /^.*:.*:.*$|^localhost(:[0-9]+)?$|^(\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5])(\.(\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5])){3}(:[0-9]+)?$/.test(
-    host
+  return (
+    /^.*:.*:.*$|^localhost(:[0-9]+)?$|^(\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5])(\.(\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5])){3}(:[0-9]+)?$/.test(
+      host
+    ) ||
+    (parsedUrl.getPort() !== undefined && PathStylePorts.includes(parsedUrl.getPort()!))
   );
 }
 

--- a/sdk/storage/storage-queue/CHANGELOG.md
+++ b/sdk/storage/storage-queue/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Fixed an issue of under some conditions, it may not be able to correctly parse URL with account name in URL path.
+
 ### Other Changes
 
 ## 12.10.0 (2022-07-08)

--- a/sdk/storage/storage-queue/CHANGELOG.md
+++ b/sdk/storage/storage-queue/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Bugs Fixed
 
-- Fixed an issue of under some conditions, it may not be able to correctly parse URL with account name in URL path.
+- Refined URL parsing method to let it be able to correctly parse URLs with account name in path.
 
 ### Other Changes
 

--- a/sdk/storage/storage-queue/src/utils/constants.ts
+++ b/sdk/storage/storage-queue/src/utils/constants.ts
@@ -101,3 +101,28 @@ export const StorageQueueLoggingAllowedQueryParameters = [
   "popreceipt",
   "visibilitytimeout",
 ];
+
+/// List of ports used for path style addressing.
+/// Path style addressing means that storage account is put in URI's Path segment in instead of in host.
+export const PathStylePorts = [
+  "10000",
+  "10001",
+  "10002",
+  "10003",
+  "10004",
+  "10100",
+  "10101",
+  "10102",
+  "10103",
+  "10104",
+  "11000",
+  "11001",
+  "11002",
+  "11003",
+  "11004",
+  "11100",
+  "11101",
+  "11102",
+  "11103",
+  "11104",
+];

--- a/sdk/storage/storage-queue/src/utils/utils.common.ts
+++ b/sdk/storage/storage-queue/src/utils/utils.common.ts
@@ -2,7 +2,12 @@
 // Licensed under the MIT license.
 import { AbortSignalLike } from "@azure/abort-controller";
 import { HttpHeaders, URLBuilder } from "@azure/core-http";
-import { HeaderConstants, URLConstants, DevelopmentConnectionString } from "./constants";
+import {
+  HeaderConstants,
+  URLConstants,
+  DevelopmentConnectionString,
+  PathStylePorts,
+} from "./constants";
 import { StorageClientContext } from "../generated/src/storageClientContext";
 import { Pipeline } from "../Pipeline";
 
@@ -370,8 +375,11 @@ export function isIpEndpointStyle(parsedUrl: URLBuilder): boolean {
   // Case 2: localhost(:port), use broad regex to match port part.
   // Case 3: Ipv4, use broad regex which just check if host contains Ipv4.
   // For valid host please refer to https://man7.org/linux/man-pages/man7/hostname.7.html.
-  return /^.*:.*:.*$|^localhost(:[0-9]+)?$|^(\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5])(\.(\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5])){3}(:[0-9]+)?$/.test(
-    host
+  return (
+    /^.*:.*:.*$|^localhost(:[0-9]+)?$|^(\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5])(\.(\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5])){3}(:[0-9]+)?$/.test(
+      host
+    ) ||
+    (parsedUrl.getPort() !== undefined && PathStylePorts.includes(parsedUrl.getPort()!))
   );
 }
 


### PR DESCRIPTION
### Packages impacted by this PR

@azure/storage-blob
@azure/storage-file-share
@azure/storage-file-datalake
@azure/storage-queue

### Issues associated with this PR


### Describe the problem that is addressed by this PR


### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [x] Added impacted package name to the issue description
- [x] Does this PR needs any fixes in the SDK Generator? No
- [x] Added a changelog (if necessary)
