### PR TITLE
[@azure/search-documents] Code Changes for Search Release 11.3.0

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -258,6 +258,27 @@ packages:
       node: '>=8.0.0'
     resolution:
       integrity: sha512-cNumz3ckyFZY5zWOgcTHSO7AKRVwxbodG8WfcEGcdH+ZJL3KvJEI/vN58H6xk5v3ijulU2x/WPGJqrMVvcI79A==
+  /@azure/core-http/2.2.6:
+    dependencies:
+      '@azure/abort-controller': 1.0.4
+      '@azure/core-auth': 1.3.0
+      '@azure/core-tracing': 1.0.0-preview.13
+      '@azure/logger': 1.0.2
+      '@types/node-fetch': 2.5.10
+      '@types/tunnel': 0.0.3
+      form-data: 4.0.0
+      node-fetch: 2.6.7
+      process: 0.11.10
+      tough-cookie: 4.0.0
+      tslib: 2.2.0
+      tunnel: 0.0.6
+      uuid: 8.3.2
+      xml2js: 0.4.23
+    dev: false
+    engines:
+      node: '>=12.0.0'
+    resolution:
+      integrity: sha512-Lx7A3k2JIXpIbixfUaOOG79WNSo/Y7dhZ0LaLhaayyZ6PwQdVsEQXAR+oIPqPSfgPzv7RtwPSVviJ2APrsQKvQ==
   /@azure/core-lro/1.0.4:
     dependencies:
       '@azure/abort-controller': 1.0.4
@@ -330,6 +351,24 @@ packages:
       node: '>=8.0.0'
     resolution:
       integrity: sha512-frF0pJc9HTmKncVokhBxCqipjbql02DThQ1ZJ9wLi7SDMLdPAFyDI5xZNzX5guLz+/DtPkY+SGK2li9FIXqshQ==
+  /@azure/core-tracing/1.0.0-preview.12:
+    dependencies:
+      '@opentelemetry/api': 1.1.0
+      tslib: 2.2.0
+    dev: false
+    engines:
+      node: '>=12.0.0'
+    resolution:
+      integrity: sha512-nvo2Wc4EKZGN6eFu9n3U7OXmASmL8VxoPIH7xaD6OlQqi44bouF0YIi9ID5rEsKLiAU59IYx6M297nqWVMWPDg==
+  /@azure/core-tracing/1.0.0-preview.13:
+    dependencies:
+      '@opentelemetry/api': 1.1.0
+      tslib: 2.2.0
+    dev: false
+    engines:
+      node: '>=12.0.0'
+    resolution:
+      integrity: sha512-KxDlhXyMlh2Jhj2ykX6vNEU0Vou4nHr025KoSEiz7cS3BNiHNaZcdECk/DmLkEB0as5T7b/TpRcehJ5yV6NeXQ==
   /@azure/core-tracing/1.0.0-preview.9:
     dependencies:
       '@opencensus/web-types': 0.0.7
@@ -613,6 +652,20 @@ packages:
       node: 10 || 12 || 14
     resolution:
       integrity: sha512-ZOHmoImpePXWTUS+78jzMgbhyTzeW0ydI3dJ9DupZZBxImV+Bqz5wfth0yKdNGV65rKWYuUIQtBVjnGwSqmpTQ==
+  /@azure/search-documents/11.3.0-beta.1:
+    dependencies:
+      '@azure/core-auth': 1.3.0
+      '@azure/core-http': 2.2.6
+      '@azure/core-paging': 1.1.3
+      '@azure/core-tracing': 1.0.0-preview.12
+      '@azure/logger': 1.0.2
+      events: 3.3.0
+      tslib: 2.2.0
+    dev: false
+    engines:
+      node: '>=12.0.0'
+    resolution:
+      integrity: sha512-ts1ahBGqfWebUu1ENqhno7XWfRh6+FYwUYPeahykPeGn0vNpP8YIwbmJhVtfHvD/nvUZfcZM3urTpdamb+fkcw==
   /@azure/service-bus/7.0.5:
     dependencies:
       '@azure/abort-controller': 1.0.4
@@ -991,6 +1044,12 @@ packages:
       node: '>=8.0.0'
     resolution:
       integrity: sha512-iXKByCMfrlO5S6Oh97BuM56tM2cIBB0XsL/vWF/AtJrJEKx4MC/Xdu0xDsGXMGcNWpqF7ujMsjjnp0+UHBwnDQ==
+  /@opentelemetry/api/1.1.0:
+    dev: false
+    engines:
+      node: '>=8.0.0'
+    resolution:
+      integrity: sha512-hf+3bwuBwtXsugA2ULBc95qxrOqP2pOekLz34BJhcAKawt94vfeNyUKpYc0lZQ/3sCP6LqRa7UAdHA7i5UODzQ==
   /@opentelemetry/context-async-hooks/0.19.0_@opentelemetry+api@1.0.0-rc.0:
     dependencies:
       '@opentelemetry/api': 1.0.0-rc.0
@@ -1036,6 +1095,7 @@ packages:
       '@opentelemetry/propagator-jaeger': 0.19.0_@opentelemetry+api@1.0.0-rc.0
       '@opentelemetry/tracing': 0.19.0_@opentelemetry+api@1.0.0-rc.0
       semver: 7.3.5
+    deprecated: Package renamed to @opentelemetry/sdk-trace-node
     dev: false
     engines:
       node: '>=8.0.0'
@@ -1103,6 +1163,7 @@ packages:
       '@opentelemetry/resources': 0.18.2
       '@opentelemetry/semantic-conventions': 0.18.2
       lodash.merge: 4.6.2
+    deprecated: Package renamed to @opentelemetry/sdk-trace-base
     dev: false
     engines:
       node: '>=8.0.0'
@@ -1115,6 +1176,7 @@ packages:
       '@opentelemetry/resources': 0.19.0_@opentelemetry+api@1.0.0-rc.0
       '@opentelemetry/semantic-conventions': 0.19.0
       lodash.merge: 4.6.2
+    deprecated: Package renamed to @opentelemetry/sdk-trace-base
     dev: false
     engines:
       node: '>=8.0.0'
@@ -1412,7 +1474,7 @@ packages:
   /@types/json5/0.0.29:
     dev: false
     resolution:
-      integrity: sha1-7ihweulOEdK4J7y+UnC86n8+ce4=
+      integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==
   /@types/jsonwebtoken/8.5.1:
     dependencies:
       '@types/node': 14.14.37
@@ -1509,7 +1571,7 @@ packages:
   /@types/priorityqueuejs/1.0.1:
     dev: false
     resolution:
-      integrity: sha1-bqrDJHpMXO/JRILl2Hw3MLNfUFM=
+      integrity: sha512-rt2GvuoXcYb+R4X8SF4jlTSXDWoUmkZf7OB8iTRRfE5dmqHn47rY8CRIEPDD5lY28cU86+xXYQ5RsXq/9nydvQ==
   /@types/qs/6.9.6:
     dev: false
     resolution:
@@ -1565,6 +1627,12 @@ packages:
     dev: false
     resolution:
       integrity: sha512-AOqu6bQu5MSWwYvehMXLukFHnupHrpZ8nvgae5Ggie9UwzDR1CCwoXgSSWNZJuyOlCdfdsWMA5F2LlmvyoTv8A==
+  /@types/tunnel/0.0.3:
+    dependencies:
+      '@types/node': 14.14.37
+    dev: false
+    resolution:
+      integrity: sha512-sOUTGn6h1SfQ+gbgqC364jLFBw2lnFqkgF3q0WovEHRLMrVD1sd5aufqi/aJObLekJO+Aq5z646U4Oxy6shXMA==
   /@types/underscore/1.11.1:
     dev: false
     resolution:
@@ -1744,7 +1812,7 @@ packages:
     engines:
       node: '>= 0.6.15'
     resolution:
-      integrity: sha1-RoxLs+u9lrEnBmn0ucuk4AZepIU=
+      integrity: sha512-98nQ5MQSyJR0ZY/R0Mue/cv4OkebRyKz4hS40GdkZU42Bq49ldHeup7UeAo/0vROMB57CX2et6IF0U/Pe1rY3A==
   /agent-base/5.1.1:
     dev: false
     engines:
@@ -1794,13 +1862,13 @@ packages:
     engines:
       node: '>=0.10.0'
     resolution:
-      integrity: sha1-w7M6te42DYbg5ijwRorn7yfWVN8=
+      integrity: sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==
   /ansi-regex/3.0.0:
     dev: false
     engines:
       node: '>=4'
     resolution:
-      integrity: sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=
+      integrity: sha512-wFUFA5bg5dviipbQQ32yOQhl6gcJaJXiHE7dvR8VYPG97+J/GNC5FKGepKdEDUFeXRzDxPF1X/Btc8L+v7oqIQ==
   /ansi-regex/4.1.0:
     dev: false
     engines:
@@ -1818,7 +1886,7 @@ packages:
     engines:
       node: '>=0.10.0'
     resolution:
-      integrity: sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=
+      integrity: sha512-kmCevFghRiWM7HB5zTPULl4r9bVFSWjz62MhqizDGUrq2NWuNMQyuv4tHHoKJHs69M/MF64lEcHdYIocrdWQYA==
   /ansi-styles/3.2.1:
     dependencies:
       color-convert: 1.9.3
@@ -1860,7 +1928,7 @@ packages:
   /archy/1.0.0:
     dev: false
     resolution:
-      integrity: sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=
+      integrity: sha512-Xg+9RwCg/0p32teKdGMPTPnVXKD0w3DfHnFTficozsAgsvq2XenPJq/MYpzzQ/v8zrOyJn6Ds39VA4JIDwFfqw==
   /are-we-there-yet/1.1.5:
     dependencies:
       delegates: 1.0.0
@@ -1884,15 +1952,15 @@ packages:
     engines:
       node: '>=0.10.0'
     resolution:
-      integrity: sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=
+      integrity: sha512-sKpyeERZ02v1FeCZT8lrfJq5u6goHCtpTAzPwJYe7c8SPFOboNjNg1vz2L4VTn9T4PQxEx13TbXLmYUcS6Ug7Q==
   /array-filter/1.0.0:
     dev: false
     resolution:
-      integrity: sha1-uveeYubvTCpMC4MSMtr/7CUfnYM=
+      integrity: sha512-Ene1hbrinPZ1qPoZp7NSx4jQnh4nr7MtY78pHNb+yr8yHbxmTS7ChGW0a55JKA7TkRDeoQxK4GcJaCvBYplSKA==
   /array-flatten/1.1.1:
     dev: false
     resolution:
-      integrity: sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=
+      integrity: sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==
   /array-includes/3.1.3:
     dependencies:
       call-bind: 1.0.2
@@ -1924,7 +1992,7 @@ packages:
   /asap/2.0.6:
     dev: false
     resolution:
-      integrity: sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=
+      integrity: sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==
   /asn1/0.2.4:
     dependencies:
       safer-buffer: 2.1.2
@@ -1936,7 +2004,7 @@ packages:
     engines:
       node: '>=0.8'
     resolution:
-      integrity: sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=
+      integrity: sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==
   /assert/1.5.0:
     dependencies:
       object-assign: 4.1.1
@@ -1967,7 +2035,7 @@ packages:
     engines:
       node: '>=0.10.0'
     resolution:
-      integrity: sha1-yL4BCitc0A3qlsgRFgNGk9/dgtE=
+      integrity: sha512-/ywTADOcaEnwiAnOEi0UB/rAcIq5bTFfCV9euv3jLYFUMmy6KvKccTQUnLlp8Ensmfj43wHSmbGiPqjsZ6RhNA==
   /async-limiter/1.0.1:
     dev: false
     resolution:
@@ -1989,7 +2057,7 @@ packages:
   /asynckit/0.4.0:
     dev: false
     resolution:
-      integrity: sha1-x57Zf380y48robyXkLzDZkdLS3k=
+      integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
   /atob/2.1.2:
     dev: false
     engines:
@@ -2014,7 +2082,7 @@ packages:
   /aws-sign2/0.7.0:
     dev: false
     resolution:
-      integrity: sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=
+      integrity: sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA==
   /aws4/1.11.0:
     dev: false
     resolution:
@@ -2105,6 +2173,7 @@ packages:
       validator: 9.4.1
       xml2js: 0.2.8
       xmlbuilder: 9.0.7
+    deprecated: 'Please note: newer packages @azure/storage-blob, @azure/storage-queue and @azure/storage-file are available as of November 2019 and @azure/data-tables is available as of June 2021. While the legacy azure-storage package will continue to receive critical bug fixes, we strongly encourage you to upgrade. Migration guide can be found: https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/storage/MigrationGuide.md'
     dev: false
     engines:
       node: '>= 0.8.26'
@@ -2116,7 +2185,7 @@ packages:
       regenerator-runtime: 0.11.1
     dev: false
     resolution:
-      integrity: sha1-llxwWGaOgrVde/4E/yM3vItWR/4=
+      integrity: sha512-ITKNuq2wKlW1fJg9sSW52eepoYgZBggvOAHC0u/CYu/qxQ9EVzThCgR69BnSXLHjy2f7SY5zaQ4yt7H9ZVxY2g==
   /backbone/1.4.0:
     dependencies:
       underscore: 1.12.1
@@ -2132,7 +2201,7 @@ packages:
     engines:
       node: '>= 0.6.0'
     resolution:
-      integrity: sha1-mBjHngWbE1X5fgQooBfIOOkLqBI=
+      integrity: sha512-a1eIFi4R9ySrbiMuyTGx5e92uRH5tQY6kArNcFaKBUleIoLjdjBg7Zxm3Mqm3Kmkf27HLR/1fnxX9q8GQ7Iavg==
   /base64-js/1.5.1:
     dev: false
     resolution:
@@ -2148,7 +2217,7 @@ packages:
       tweetnacl: 0.14.5
     dev: false
     resolution:
-      integrity: sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=
+      integrity: sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==
   /binary-extensions/2.2.0:
     dev: false
     engines:
@@ -2202,7 +2271,7 @@ packages:
   /browserify-mime/1.2.9:
     dev: false
     resolution:
-      integrity: sha1-rrGvKN5sDXpqLOQK22j/GEIq8x8=
+      integrity: sha512-uz+ItyJXBLb6wgon1ELEiVowJBEsy03PUWGRQU7cxxx9S+DW2hujPp+DaMYEOClRPzsn7NB99NtJ6pGnt8y+CQ==
   /browserslist/4.16.3:
     dependencies:
       caniuse-lite: 1.0.30001207
@@ -2219,11 +2288,11 @@ packages:
   /buffer-crc32/0.2.13:
     dev: false
     resolution:
-      integrity: sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=
+      integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==
   /buffer-equal-constant-time/1.0.1:
     dev: false
     resolution:
-      integrity: sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk=
+      integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==
   /buffer-from/1.1.1:
     dev: false
     resolution:
@@ -2296,7 +2365,7 @@ packages:
   /caseless/0.12.0:
     dev: false
     resolution:
-      integrity: sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=
+      integrity: sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==
   /chai-as-promised/7.1.1_chai@4.3.4:
     dependencies:
       chai: 4.3.4
@@ -2347,7 +2416,7 @@ packages:
     engines:
       node: '>=0.10.0'
     resolution:
-      integrity: sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=
+      integrity: sha512-U3lRVLMSlsCfjqYPbLyVv11M9CPW4I728d6TCKMAOJueEeB9/8o+eSsMnxPJD+Q+K909sdESg7C+tIkoH6on1A==
   /chalk/2.4.2:
     dependencies:
       ansi-styles: 3.2.1
@@ -2379,17 +2448,17 @@ packages:
   /charenc/0.0.2:
     dev: false
     resolution:
-      integrity: sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc=
+      integrity: sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==
   /check-error/1.0.2:
     dev: false
     resolution:
-      integrity: sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=
+      integrity: sha512-BrgHpW9NURQgzoNyjfq0Wu6VFO6D7IZEmJNdtgNqpzGG8RuNFHt2jQxWlAs4HMe119chBnv+34syEZtc6IhLtA==
   /check-more-types/2.24.0:
     dev: false
     engines:
       node: '>= 0.8.0'
     resolution:
-      integrity: sha1-FCD/sQ/URNz8ebQ4kbv//TKoRgA=
+      integrity: sha512-Pj779qHxV2tuapviy1bSZNEL1maXr13bPYpsvSDB68HlYcYuhlDrmGd63i0JHMCLKzc7rUSNIrpdJlhVlNwrxA==
   /chokidar/3.3.0:
     dependencies:
       anymatch: 3.1.2
@@ -2459,7 +2528,7 @@ packages:
       node: '>=0.10.0'
     optional: true
     resolution:
-      integrity: sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=
+      integrity: sha512-RpAVKQA5T63xEj6/giIbUEtZwJ4UFIc3ZtvEkiaUERylqe8xb5IvqcgOurZLahv93CLKfxcw5YI+DZcUBRyLXA==
   /color-convert/1.9.3:
     dependencies:
       color-name: 1.1.3
@@ -2477,7 +2546,7 @@ packages:
   /color-name/1.1.3:
     dev: false
     resolution:
-      integrity: sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=
+      integrity: sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==
   /color-name/1.1.4:
     dev: false
     resolution:
@@ -2519,7 +2588,7 @@ packages:
   /commondir/1.0.1:
     dev: false
     resolution:
-      integrity: sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=
+      integrity: sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==
   /component-emitter/1.3.0:
     dev: false
     resolution:
@@ -2527,7 +2596,7 @@ packages:
   /concat-map/0.0.1:
     dev: false
     resolution:
-      integrity: sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=
+      integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==
   /connect/3.7.0:
     dependencies:
       debug: 2.6.9
@@ -2543,13 +2612,13 @@ packages:
     dev: false
     optional: true
     resolution:
-      integrity: sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=
+      integrity: sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==
   /contains-path/0.1.0:
     dev: false
     engines:
       node: '>=0.10.0'
     resolution:
-      integrity: sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=
+      integrity: sha512-OKZnPGeMQy2RPaUIBPFFd71iNf4791H12MCRuVQDnzGRwCYNYmTDy5pdafo2SLAcEMKzTOQnLWG4QdcjeJUMEg==
   /content-disposition/0.5.3:
     dependencies:
       safe-buffer: 5.1.2
@@ -2573,7 +2642,7 @@ packages:
   /cookie-signature/1.0.6:
     dev: false
     resolution:
-      integrity: sha1-4wOogrNCzD7oylE6eZmXNNqzriw=
+      integrity: sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==
   /cookie/0.4.0:
     dev: false
     engines:
@@ -2587,12 +2656,13 @@ packages:
     resolution:
       integrity: sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==
   /core-js/2.6.12:
-    deprecated: core-js@<3.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Please, upgrade your dependencies to the actual version of core-js.
+    deprecated: core-js@<3.23.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Some versions have web compatibility issues. Please, upgrade your dependencies to the actual version of core-js.
     dev: false
     requiresBuild: true
     resolution:
       integrity: sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==
   /core-js/3.10.1:
+    deprecated: core-js@<3.23.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Some versions have web compatibility issues. Please, upgrade your dependencies to the actual version of core-js.
     dev: false
     requiresBuild: true
     resolution:
@@ -2600,7 +2670,7 @@ packages:
   /core-util-is/1.0.2:
     dev: false
     resolution:
-      integrity: sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=
+      integrity: sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==
   /cors/2.8.5:
     dependencies:
       object-assign: 4.1.1
@@ -2643,7 +2713,7 @@ packages:
       which: 1.3.1
     dev: false
     resolution:
-      integrity: sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=
+      integrity: sha512-yAXz/pA1tD8Gtg2S98Ekf/sewp3Lcp3YoFKJ4Hkp5h5yLWnKVTDU0kwjKJ8NDCYcfTLfyGkzTikst+jWypT1iA==
   /cross-spawn/6.0.5:
     dependencies:
       nice-try: 1.0.5
@@ -2669,7 +2739,7 @@ packages:
   /crypt/0.0.2:
     dev: false
     resolution:
-      integrity: sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs=
+      integrity: sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==
   /csv-parse/4.15.3:
     dev: false
     resolution:
@@ -2677,7 +2747,7 @@ packages:
   /custom-event/1.0.1:
     dev: false
     resolution:
-      integrity: sha1-XQKkaFCt8bSjF5RqOSj8y1v9BCU=
+      integrity: sha512-GAj5FOq0Hd+RsCGVJxZuKaIDXDf3h6GQoNEjFgbLLI/trgtavwUbSnZ5pVfg27DVCaWjIohryS0JFwIJyT2cMg==
   /dashdash/1.14.1:
     dependencies:
       assert-plus: 1.0.0
@@ -2685,7 +2755,7 @@ packages:
     engines:
       node: '>=0.10'
     resolution:
-      integrity: sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=
+      integrity: sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==
   /data-uri-to-buffer/3.0.1:
     dev: false
     engines:
@@ -2693,12 +2763,14 @@ packages:
     resolution:
       integrity: sha512-WboRycPNsVw3B3TL559F7kuBUM4d8CgMEvk6xEJlOp7OBPjt6G7z8WMWlD2rOFZLk6OYfFIUGsCOWzcQH9K2og==
   /date-format/2.1.0:
+    deprecated: 2.x is no longer supported. Please upgrade to 4.x or higher.
     dev: false
     engines:
       node: '>=4.0'
     resolution:
       integrity: sha512-bYQuGLeFxhkxNOF3rcMtiZxvCBAquGzZm6oWA1oZ0g2THUzivaRhv8uOhdr19LmoobSOLoIAxeUK2RdbM8IFTA==
   /date-format/3.0.0:
+    deprecated: 3.x is no longer supported. Please upgrade to 4.x or higher.
     dev: false
     engines:
       node: '>=4.0'
@@ -2709,7 +2781,7 @@ packages:
     engines:
       node: '>0.4.0'
     resolution:
-      integrity: sha1-YfsWzcEnSzyayq/+n8ad+HIKK2Q=
+      integrity: sha512-wJMBjqlwXR0Iv0wUo/lFbhSQ7MmG1hl36iuxuE91kW+5b5sWbase73manEqNH9sOLFAMG83B4ffNKq9/Iq0FVA==
   /debounce/1.2.1:
     dev: false
     resolution:
@@ -2758,13 +2830,13 @@ packages:
     engines:
       node: '>=0.10.0'
     resolution:
-      integrity: sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=
+      integrity: sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==
   /decode-uri-component/0.2.0:
     dev: false
     engines:
       node: '>=0.10'
     resolution:
-      integrity: sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=
+      integrity: sha512-hjf+xovcEn31w/EUYdTXQh/8smFL/dzYjohQGEIgjyNavaJfBY2p5F527Bo1VPATxv0VYTUC2bOcXvqFwk78Og==
   /decompress-response/4.2.1:
     dependencies:
       mimic-response: 2.1.0
@@ -2792,11 +2864,11 @@ packages:
   /deep-freeze/0.0.1:
     dev: false
     resolution:
-      integrity: sha1-OgsABd4YZygZ39OM0x+RF5yJPoQ=
+      integrity: sha512-Z+z8HiAvsGwmjqlphnHW5oz6yWlOwu6EQfFTjmeTWlDeda3FS2yv3jhq35TX/ewmsnqB+RX2IdsIOyjJCQN5tg==
   /deep-is/0.1.3:
     dev: false
     resolution:
-      integrity: sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=
+      integrity: sha512-GtxAN4HvBachZzm4OnWqc45ESpUCMwkYcsjnsPs23FwJbsO+k4t0k9bQCgOmzIlpHO28+WPK/KRbRk0DDHuuDw==
   /deepmerge/4.2.2:
     dev: false
     engines:
@@ -2810,7 +2882,7 @@ packages:
     engines:
       node: '>=4'
     resolution:
-      integrity: sha1-9fj7sYp9bVCyH2QfZJ67Uiz+JPc=
+      integrity: sha512-B0n2zDIXpzLzKeoEozorDSa1cHc1t0NjmxP0zuAxbizNU2MBqYJJKYXrrFdKuQliojXynrxgd7l4ahfg/+aA5g==
   /define-properties/1.1.3:
     dependencies:
       object-keys: 1.1.1
@@ -2840,22 +2912,22 @@ packages:
     engines:
       node: '>=0.4.0'
     resolution:
-      integrity: sha1-3zrhmayt+31ECqrgsp4icrJOxhk=
+      integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==
   /delegates/1.0.0:
     dev: false
     optional: true
     resolution:
-      integrity: sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=
+      integrity: sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==
   /depd/1.1.2:
     dev: false
     engines:
       node: '>= 0.6'
     resolution:
-      integrity: sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=
+      integrity: sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==
   /destroy/1.0.4:
     dev: false
     resolution:
-      integrity: sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=
+      integrity: sha512-3NdhDuEXnfun/z7x9GOElY49LoqVHoGScmOKwmxhsS8N5Y+Z8KyPPDnaSzqWgYt/ji4mqwfTS34Htrk0zPIXVg==
   /detect-libc/1.0.3:
     dev: false
     engines:
@@ -2863,11 +2935,11 @@ packages:
     hasBin: true
     optional: true
     resolution:
-      integrity: sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=
+      integrity: sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==
   /di/0.0.1:
     dev: false
     resolution:
-      integrity: sha1-gGZJMmzqp8qjMG112YXqJ0i6kTw=
+      integrity: sha512-uJaamHkagcZtHPqCIHZxnFrXlunQXgBOsZSUOWwFw31QJCAbyTBoHMW75YOTur5ZNx8pIeAKgf6GWIgaqqiLhA==
   /diff/3.5.0:
     dev: false
     engines:
@@ -2906,7 +2978,7 @@ packages:
     engines:
       node: '>=0.10.0'
     resolution:
-      integrity: sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=
+      integrity: sha512-lsGyRuYr4/PIB0txi+Fy2xOMI2dGaTguCaotzFGkVZuKR5usKfcRWIFKNM3QNrU7hh/+w2bwTW+ZeXPK5l8uVg==
   /doctrine/3.0.0:
     dependencies:
       esutils: 2.0.3
@@ -2923,7 +2995,7 @@ packages:
       void-elements: 2.0.1
     dev: false
     resolution:
-      integrity: sha1-ViromZ9Evl6jB29UGdzVnrQ6yVs=
+      integrity: sha512-Yra4DbvoW7/Z6LBN560ZwXMjoNOSAN2wRsKFGc4iBeso+mpIA6qj1vfdf9HpMaKAqG6wXTy+1SYEzmNpKXOSsQ==
   /dom-walk/0.1.2:
     dev: false
     resolution:
@@ -2948,7 +3020,7 @@ packages:
       safer-buffer: 2.1.2
     dev: false
     resolution:
-      integrity: sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=
+      integrity: sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==
   /ecdsa-sig-formatter/1.0.11:
     dependencies:
       safe-buffer: 5.2.1
@@ -2958,11 +3030,11 @@ packages:
   /edge-launcher/1.2.2:
     dev: false
     resolution:
-      integrity: sha1-60Cq+9Bnpup27/+rBke81VCbN7I=
+      integrity: sha512-JcD5WBi3BHZXXVSSeEhl6sYO8g5cuynk/hifBzds2Bp4JdzCGLNMHgMCKu5DvrO1yatMgF0goFsxXRGus0yh1g==
   /ee-first/1.1.1:
     dev: false
     resolution:
-      integrity: sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=
+      integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==
   /electron-to-chromium/1.3.710:
     dev: false
     resolution:
@@ -2980,7 +3052,7 @@ packages:
     engines:
       node: '>= 0.8'
     resolution:
-      integrity: sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=
+      integrity: sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==
   /end-of-stream/1.4.4:
     dependencies:
       once: 1.4.0
@@ -3020,7 +3092,7 @@ packages:
   /ent/2.2.0:
     dev: false
     resolution:
-      integrity: sha1-6WQhkyWiHQX0RGai9obtbOX13R0=
+      integrity: sha512-GHrMyVZQWvTIdDtpiEXdHZnFQKzeO09apj8Cbl4pKWy4i0Oprcq17usfDt5aO63swf0JOeMWjWQE/LzgSRuWpA==
   /error-ex/1.3.2:
     dependencies:
       is-arrayish: 0.2.1
@@ -3077,19 +3149,19 @@ packages:
   /escape-html/1.0.3:
     dev: false
     resolution:
-      integrity: sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=
+      integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==
   /escape-quotes/1.0.2:
     dependencies:
       escape-string-regexp: 1.0.5
     dev: false
     resolution:
-      integrity: sha1-tIltSmz4LdWzP0m3E0CMY4D2zZc=
+      integrity: sha512-JpLFzklNReeakCpyj59s78P5F72q0ZUpDnp2BuIk9TtTjj2HMsgiWBChw17BlZT8dRhMtmSb1jE2+pTP1iFYyw==
   /escape-string-regexp/1.0.5:
     dev: false
     engines:
       node: '>=0.8.0'
     resolution:
-      integrity: sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
+      integrity: sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==
   /escodegen/1.14.3:
     dependencies:
       esprima: 4.0.1
@@ -3343,7 +3415,7 @@ packages:
     engines:
       node: '>= 0.6'
     resolution:
-      integrity: sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=
+      integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==
   /event-target-shim/5.0.1:
     dev: false
     engines:
@@ -3391,7 +3463,7 @@ packages:
     engines:
       node: '>=0.10.0'
     resolution:
-      integrity: sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=
+      integrity: sha512-A5EmesHW6rfnZ9ysHQjPdJRni0SRar0tjtG5MNtm9n5TUvsYU8oozprtRD4AqHxcZWWlVuAmQo2nWKfN9oyjTw==
   /express/4.17.1:
     dependencies:
       accepts: 1.3.7
@@ -3451,7 +3523,7 @@ packages:
     engines:
       '0': node >=0.6.0
     resolution:
-      integrity: sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=
+      integrity: sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g==
   /fast-deep-equal/3.1.3:
     dev: false
     resolution:
@@ -3476,7 +3548,7 @@ packages:
   /fast-levenshtein/2.0.6:
     dev: false
     resolution:
-      integrity: sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
+      integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==
   /fastq/1.11.0:
     dependencies:
       reusify: 1.0.4
@@ -3486,13 +3558,13 @@ packages:
   /fclone/1.0.11:
     dev: false
     resolution:
-      integrity: sha1-EOhdo4v+p/xZk0HClu4ddyZu5kA=
+      integrity: sha512-GDqVQezKzRABdeqflsgMr7ktzgF9CyS+p2oe0jJqUY6izSSbhPIQJDpoU4PtGcD7VPM9xh/dVrTu6z1nwgmEGw==
   /fd-slicer/1.1.0:
     dependencies:
       pend: 1.2.0
     dev: false
     resolution:
-      integrity: sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=
+      integrity: sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==
   /fetch-mock/9.11.0_node-fetch@2.6.1:
     dependencies:
       '@babel/core': 7.13.14
@@ -3569,7 +3641,7 @@ packages:
     engines:
       node: '>=4'
     resolution:
-      integrity: sha1-RdG35QbHF93UgndaK3eSCjwMV6c=
+      integrity: sha512-NWzkk0jSJtTt08+FBFMvXoeZnOJD+jTtsRmBYbAIzJdX6l7dLgR7CTubCM5/eDdPUBvLCeVasP1brfVR/9/EZQ==
   /find-up/3.0.0:
     dependencies:
       locate-path: 3.0.0
@@ -3646,18 +3718,18 @@ packages:
   /foreach/2.0.5:
     dev: false
     resolution:
-      integrity: sha1-C+4AUBiusmDQo6865ljdATbsG5k=
+      integrity: sha512-ZBbtRiapkZYLsqoPyZOR+uPfto0GRMNQN1GwzZtZt7iZvPPbDDQV0JF5Hx4o/QFQ5c0vyuoZ98T8RSBbopzWtA==
   /foreground-child/1.5.6:
     dependencies:
       cross-spawn: 4.0.2
       signal-exit: 3.0.3
     dev: false
     resolution:
-      integrity: sha1-T9ca0t/elnibmApcCilZN8svXOk=
+      integrity: sha512-3TOY+4TKV0Ml83PXJQY+JFQaHNV38lzQDIzzXYg1kWdBLenGgoZhAs0CKgzI31vi2pWEpQMq/Yi4bpKwCPkw7g==
   /forever-agent/0.6.1:
     dev: false
     resolution:
-      integrity: sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=
+      integrity: sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==
   /form-data/2.3.3:
     dependencies:
       asynckit: 0.4.0
@@ -3688,18 +3760,28 @@ packages:
       node: '>= 6'
     resolution:
       integrity: sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==
+  /form-data/4.0.0:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      mime-types: 2.1.30
+    dev: false
+    engines:
+      node: '>= 6'
+    resolution:
+      integrity: sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==
   /forwarded/0.1.2:
     dev: false
     engines:
       node: '>= 0.6'
     resolution:
-      integrity: sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ=
+      integrity: sha512-Ua9xNhH0b8pwE3yRbFfXJvfdWF0UHNCdeyb2sbi9Ul/M+r3PTdrz7Cv4SCfZRMjmzEM9PhraqfZFbGTIg3OMyA==
   /fresh/0.5.2:
     dev: false
     engines:
       node: '>= 0.6'
     resolution:
-      integrity: sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=
+      integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==
   /fs-constants/1.0.0:
     dev: false
     resolution:
@@ -3727,7 +3809,7 @@ packages:
   /fs.realpath/1.0.0:
     dev: false
     resolution:
-      integrity: sha1-FQStJSMVjKpA20onh8sBQRmU6k8=
+      integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
   /fsevents/2.1.3:
     deprecated: '"Please update to latest v2.3 or v2.2"'
     dev: false
@@ -3755,7 +3837,7 @@ packages:
     engines:
       node: '>=0.8.0'
     resolution:
-      integrity: sha1-kZfYYa2BQvPmPVqDv+TFn3MwiF0=
+      integrity: sha512-faFVML1aBx2UoDStmLwv2Wptt4vw5x03xxX172nhA5Y5HBshW5JweqQ2W4xL4dezQTG8inJsuYcpPHHU3X5OTQ==
   /function-bind/1.1.1:
     dev: false
     resolution:
@@ -3763,7 +3845,7 @@ packages:
   /functional-red-black-tree/1.0.1:
     dev: false
     resolution:
-      integrity: sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=
+      integrity: sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==
   /gauge/2.7.4:
     dependencies:
       aproba: 1.2.0
@@ -3777,7 +3859,7 @@ packages:
     dev: false
     optional: true
     resolution:
-      integrity: sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=
+      integrity: sha512-14x4kjc6lkD3ltw589k0NrPD6cCNTD6CWoVUNpB85+DrtONoZn+Rug6xZU5RvSC4+TZPxA5AnBibQYAvZn41Hg==
   /gensync/1.0.0-beta.2:
     dev: false
     engines:
@@ -3797,7 +3879,7 @@ packages:
   /get-func-name/2.0.0:
     dev: false
     resolution:
-      integrity: sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=
+      integrity: sha512-Hm0ixYtaSZ/V7C8FJrtZIuBBI+iSgL+1Aq82zSu8VQNB4S3Gk8e7Qs3VwBDJAhmRZcFqkl3tQu36g/Foh5I5ig==
   /get-intrinsic/1.1.1:
     dependencies:
       function-bind: 1.1.1
@@ -3838,12 +3920,12 @@ packages:
       assert-plus: 1.0.0
     dev: false
     resolution:
-      integrity: sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=
+      integrity: sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==
   /github-from-package/0.0.0:
     dev: false
     optional: true
     resolution:
-      integrity: sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4=
+      integrity: sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==
   /glob-parent/5.1.2:
     dependencies:
       is-glob: 4.0.1
@@ -3899,7 +3981,7 @@ packages:
     engines:
       node: '>=0.10.0'
     resolution:
-      integrity: sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=
+      integrity: sha512-5lsx1NUDHtSjfg0eHlmYvZKv8/nVqX4ckFbM+FrGcQ+04KWcWFo9P5MxPZYSzUvyzmdTbI7Eix8Q4IbELDqzKg==
   /global/4.4.0:
     dependencies:
       min-document: 2.19.0
@@ -3975,7 +4057,7 @@ packages:
     engines:
       node: '>=4'
     resolution:
-      integrity: sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=
+      integrity: sha512-Oqluz6zhGX8cyRaTQlFMPw80bSJVG2x/cFb8ZPhUILGgHka9SsokCCOQgpveePerqidZOrT14ipqfJb7ILcW5Q==
   /har-validator/5.1.5:
     dependencies:
       ajv: 6.12.6
@@ -3993,7 +4075,7 @@ packages:
     engines:
       node: '>=0.10.0'
     resolution:
-      integrity: sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=
+      integrity: sha512-C8vBJ8DwUCx19vhm7urhTuUsr4/IyP6l4VzNQDv+ryHQObW3TTTp9yB68WpYgRe2bbaGuZ/se74IqFeVnMnLZg==
   /has-bigints/1.0.1:
     dev: false
     resolution:
@@ -4003,7 +4085,7 @@ packages:
     engines:
       node: '>=4'
     resolution:
-      integrity: sha1-tdRU3CGZriJWmfNGfloH87lVuv0=
+      integrity: sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==
   /has-flag/4.0.0:
     dev: false
     engines:
@@ -4017,7 +4099,7 @@ packages:
     engines:
       node: '>=0.10.0'
     resolution:
-      integrity: sha1-mqqe7b/7G6OZCnsAEPtnjuAIEgc=
+      integrity: sha512-D+8A457fBShSEI3tFCj65PAbT++5sKiFtdCdOam0gnfBgw9D277OERk+HM9qYJXmdVLZ/znez10SqHN0BBQ50g==
   /has-only/1.1.1:
     dev: false
     engines:
@@ -4034,7 +4116,7 @@ packages:
     dev: false
     optional: true
     resolution:
-      integrity: sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=
+      integrity: sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==
   /has/1.0.3:
     dependencies:
       function-bind: 1.1.1
@@ -4060,7 +4142,7 @@ packages:
     engines:
       node: '>=4'
     resolution:
-      integrity: sha1-UqMvq4Vp1BymmmH/GiFPjrfIvTk=
+      integrity: sha512-w0Kz8lJFBoyaurBiNrIvxPqr/gJ6fOfSkpAPOepN3oECqGJag37xPbOv57izi/KP8auHgNYxn5fXtAb+1LsJ6w==
   /he/1.2.0:
     dev: false
     hasBin: true
@@ -4154,7 +4236,7 @@ packages:
       node: '>=0.8'
       npm: '>=1.3.7'
     resolution:
-      integrity: sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=
+      integrity: sha512-CAbnr6Rz4CYQkLYUtSNXxQPUH2gK8f3iWexVlsnMeD+GjlsQ0Xsy1cOX+mN3dtxYomRy21CiOzU8Uhw6OwncEQ==
   /https-proxy-agent/4.0.0:
     dependencies:
       agent-base: 5.1.1
@@ -4223,22 +4305,22 @@ packages:
     engines:
       node: '>=0.8.19'
     resolution:
-      integrity: sha1-khi5srkoojixPcT7a21XbyMUU+o=
+      integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==
   /inflight/1.0.6:
     dependencies:
       once: 1.4.0
       wrappy: 1.0.2
     dev: false
     resolution:
-      integrity: sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=
+      integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==
   /inherits/2.0.1:
     dev: false
     resolution:
-      integrity: sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=
+      integrity: sha512-8nWq2nLTAwd02jTqJExUYFSD/fKq6VH9Y/oG2accc/kdI0V98Bag8d5a4gi3XHz73rDWa2PvTtvcWYquKqSENA==
   /inherits/2.0.3:
     dev: false
     resolution:
-      integrity: sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=
+      integrity: sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw==
   /inherits/2.0.4:
     dev: false
     resolution:
@@ -4258,11 +4340,11 @@ packages:
     engines:
       node: '>=4'
     resolution:
-      integrity: sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk=
+      integrity: sha512-58yWmlHpp7VYfcdTwMTvwMmqx/Elfxjd9RXTDyMsbL7lLWmhMylLEqiYVLKuLzOZqVgiWXD9MfR62Vv89VRxkw==
   /ip/1.1.5:
     dev: false
     resolution:
-      integrity: sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=
+      integrity: sha512-rBtCAQAJm8A110nbwn6YdveUnuZH3WrC36IwkRXxDnq53JvXA2NVQvB7IHyKomxK1MJ4VDNw3UtFDdXQ+AvLYA==
   /ipaddr.js/1.9.1:
     dev: false
     engines:
@@ -4280,7 +4362,7 @@ packages:
   /is-arrayish/0.2.1:
     dev: false
     resolution:
-      integrity: sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=
+      integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==
   /is-bigint/1.0.1:
     dev: false
     resolution:
@@ -4348,7 +4430,7 @@ packages:
     engines:
       node: '>=0.10.0'
     resolution:
-      integrity: sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=
+      integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==
   /is-fullwidth-code-point/1.0.0:
     dependencies:
       number-is-nan: 1.0.1
@@ -4357,13 +4439,13 @@ packages:
       node: '>=0.10.0'
     optional: true
     resolution:
-      integrity: sha1-754xOG8DGn8NZDr4L95QxFfvAMs=
+      integrity: sha512-1pqUqRjkhPJ9miNq9SwMfdvi6lBJcd6eFxvfaivQhaH3SgisfiuudvFntdKOmxuee/77l+FPjKrQjWvmPjWrRw==
   /is-fullwidth-code-point/2.0.0:
     dev: false
     engines:
       node: '>=4'
     resolution:
-      integrity: sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=
+      integrity: sha512-VHskAKYM8RfSFXwee5t5cbN5PZeq1Wrh6qd5bkyiXIf6UQcN6w/A0eXM9r6t8d+GYOh+o6ZhiEnb88LN/Y8m2w==
   /is-fullwidth-code-point/3.0.0:
     dev: false
     engines:
@@ -4383,7 +4465,7 @@ packages:
     engines:
       node: '>=0.10.0'
     resolution:
-      integrity: sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=
+      integrity: sha512-UFpDDrPgM6qpnFNI+rh/p3bUaq9hKLZN8bMUWzxmcnZVS3omf4IPK+BrewlnWjO1WmUsMYuSjKh4UJuV4+Lqmw==
   /is-glob/4.0.1:
     dependencies:
       is-extglob: 2.1.1
@@ -4395,7 +4477,7 @@ packages:
   /is-module/1.0.0:
     dev: false
     resolution:
-      integrity: sha1-Mlj7afeMFNW4FdZkM2tM/7ZEFZE=
+      integrity: sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g==
   /is-negative-zero/2.0.1:
     dev: false
     engines:
@@ -4434,7 +4516,7 @@ packages:
     engines:
       node: '>=0.10.0'
     resolution:
-      integrity: sha1-EtSj3U5o4Lec6428hBc66A2RykQ=
+      integrity: sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==
   /is-stream/2.0.0:
     dev: false
     engines:
@@ -4450,7 +4532,7 @@ packages:
   /is-subset/0.1.1:
     dev: false
     resolution:
-      integrity: sha1-ilkRfZMt4d4A8kX83TnOQ/HpOaY=
+      integrity: sha512-6Ybun0IkarhmEqxXCNw/C0bna6Zb/TkfUX9UbwJtK6ObwAVCxmAP308WWTHviM/zAqXk05cdhYsUsZeGQh99iw==
   /is-symbol/1.0.3:
     dependencies:
       has-symbols: 1.0.2
@@ -4474,13 +4556,13 @@ packages:
   /is-typedarray/1.0.0:
     dev: false
     resolution:
-      integrity: sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=
+      integrity: sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==
   /is-valid-glob/1.0.0:
     dev: false
     engines:
       node: '>=0.10.0'
     resolution:
-      integrity: sha1-Kb8+/3Ab4tTTFdusw5vDn+j2Aao=
+      integrity: sha512-AhiROmoEFDSsjx8hW+5sGwgKVIORcXnrlAx/R0ZSeaPw70Vw0CqkGBBhHGL58Uox2eXnU1AnvXJl1XlyedO5bA==
   /is-windows/1.0.2:
     dev: false
     engines:
@@ -4498,11 +4580,11 @@ packages:
   /isarray/0.0.1:
     dev: false
     resolution:
-      integrity: sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=
+      integrity: sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==
   /isarray/1.0.0:
     dev: false
     resolution:
-      integrity: sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=
+      integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==
   /isbinaryfile/4.0.6:
     dev: false
     engines:
@@ -4512,11 +4594,11 @@ packages:
   /isexe/2.0.0:
     dev: false
     resolution:
-      integrity: sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=
+      integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==
   /isstream/0.1.2:
     dev: false
     resolution:
-      integrity: sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=
+      integrity: sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==
   /istanbul-lib-coverage/2.0.5:
     dev: false
     engines:
@@ -4626,7 +4708,7 @@ packages:
     engines:
       node: '>=6'
     resolution:
-      integrity: sha1-IGXxiD7LVoxl9xEt2/EjQB+uSvA=
+      integrity: sha512-GYUWFxViqxDvGzsNEItTEuOqqAQVx29Xl9Lh5YUqyJd6gPHTCMiIbjqcjjyUzsBUqEcgwIdRoydwgfFw1oYbhg==
   /jest-worker/24.9.0:
     dependencies:
       merge-stream: 2.0.0
@@ -4639,7 +4721,7 @@ packages:
   /jju/1.4.0:
     dev: false
     resolution:
-      integrity: sha1-o6vicYryQaKykE+EpiWXDzia4yo=
+      integrity: sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==
   /jquery/3.6.0:
     dev: false
     resolution:
@@ -4671,7 +4753,7 @@ packages:
   /jsbn/0.1.1:
     dev: false
     resolution:
-      integrity: sha1-peZUwuWi3rXyAdls77yoDA7y9RM=
+      integrity: sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==
   /jsesc/2.5.2:
     dev: false
     engines:
@@ -4684,7 +4766,7 @@ packages:
       jsonparse: 1.2.0
     dev: false
     resolution:
-      integrity: sha1-HmCw/vG8CvZ7wNFG393lSGzWFbQ=
+      integrity: sha512-J1U9mk6lf8dPULcaMwALXB6yel3cJyyhk9Z8FQ4sMwiazNwjaUhegIcpZyZFNMvLRtnXwh+TkCjX9uYUObBBYA==
   /json-parse-better-errors/1.0.2:
     dev: false
     resolution:
@@ -4700,7 +4782,7 @@ packages:
   /json-schema/0.2.3:
     dev: false
     resolution:
-      integrity: sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=
+      integrity: sha512-a3xHnILGMtk+hDOqNwHzF6e2fNbiMrXZvxKQiEv2MlgQP+pjIOzqAmKYD2mDpXYE/44M7g+n9p2bKkYWDUcXCQ==
   /json-schema/0.3.0:
     dev: false
     resolution:
@@ -4708,11 +4790,11 @@ packages:
   /json-stable-stringify-without-jsonify/1.0.1:
     dev: false
     resolution:
-      integrity: sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=
+      integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==
   /json-stringify-safe/5.0.1:
     dev: false
     resolution:
-      integrity: sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=
+      integrity: sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==
   /json5/1.0.1:
     dependencies:
       minimist: 1.2.5
@@ -4734,13 +4816,13 @@ packages:
     optionalDependencies:
       graceful-fs: 4.2.6
     resolution:
-      integrity: sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=
+      integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==
   /jsonparse/1.2.0:
     dev: false
     engines:
       '0': node >= 0.2.0
     resolution:
-      integrity: sha1-XAxWhRBxYOcv50ib3eoLRMK8Z70=
+      integrity: sha512-LkDEYtKnPFI9hQ/IURETe6F1dUH80cbRkaF6RaViSwoSNPwaxQpi6TgJGvJKyLQ2/9pQW+XCxK3hBoR44RAjkg==
   /jsonwebtoken/8.5.1:
     dependencies:
       jws: 3.2.2
@@ -4769,7 +4851,7 @@ packages:
     engines:
       '0': node >=0.6.0
     resolution:
-      integrity: sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=
+      integrity: sha512-4Dj8Rf+fQ+/Pn7C5qeEX02op1WfOss3PKTE9Nsop3Dx+6UPxlm1dr/og7o2cRa5hNN07CACr4NFzRLtj/rjWog==
   /jsrsasign/10.3.0:
     dev: false
     resolution:
@@ -4820,7 +4902,7 @@ packages:
   /jwt-decode/2.2.0:
     dev: false
     resolution:
-      integrity: sha1-fYa9VmefWM5qhHBKZX3TkruoGnk=
+      integrity: sha512-86GgN2vzfUu7m9Wcj63iUkuDzFNYFVmjeDm2GzWpUk+opB0pEpMsw6ePCMrhYkumz2C1ihqtZzOMAg7FiXcNoQ==
   /karma-chai/0.1.0_chai@4.3.4+karma@6.3.2:
     dependencies:
       chai: 4.3.4
@@ -4830,7 +4912,7 @@ packages:
       chai: '*'
       karma: '>=0.10.9'
     resolution:
-      integrity: sha1-vuWtQEAFF4Ea40u5RfdikJEIt5o=
+      integrity: sha512-mqKCkHwzPMhgTYca10S90aCEX9+HjVjjrBFAsw36Zj7BlQNbokXXCAe6Ji04VUMsxcY5RLP7YphpfO06XOubdg==
   /karma-chrome-launcher/3.1.0:
     dependencies:
       which: 1.3.1
@@ -4864,7 +4946,7 @@ packages:
   /karma-env-preprocessor/0.1.1:
     dev: false
     resolution:
-      integrity: sha1-u+jIfVnADtt2BwvTwxtLOdXcfhU=
+      integrity: sha512-3FAuA0B1lS4DXNyOpD1Y+BjteVmnfX0WXUpsZ19aYykTk/GPz0kqnjzdApDiEe4sapreVeVSme2qTALnbHJb/A==
   /karma-firefox-launcher/1.3.0:
     dependencies:
       is-wsl: 2.2.0
@@ -4879,7 +4961,7 @@ packages:
     peerDependencies:
       karma: '>=0.9'
     resolution:
-      integrity: sha1-SXmGhCxJAZA0bNifVJTKmDDG1Zw=
+      integrity: sha512-ts71ke8pHvw6qdRtq0+7VY3ANLoZuUNNkA8abRaWV13QRPNm7TtSOqyszjHUtuwOWKcsSz4tbUtrNICrQC+SXQ==
   /karma-json-preprocessor/0.3.3_karma@6.3.2:
     dependencies:
       karma: 6.3.2
@@ -4887,7 +4969,7 @@ packages:
     peerDependencies:
       karma: '>=0.9'
     resolution:
-      integrity: sha1-X36ZW+uuS06PCiy1IVBVSq8LHi4=
+      integrity: sha512-z2AuF8wxw/3zbbkF1xoodeA3bLJZzjmqKVIpzUS7pqTX9DO4u5lrSpELTjKXdbLj2Xgn+fX/ECr8s6ST6C9Jog==
   /karma-json-to-file-reporter/1.0.1:
     dependencies:
       json5: 2.2.0
@@ -4916,7 +4998,7 @@ packages:
     peerDependencies:
       karma: '>=0.13'
     resolution:
-      integrity: sha1-FRIAlejtgZGG5HoLAS8810GJVWA=
+      integrity: sha512-Hr6nhkIp0GIJJrvzY8JFeHpQZNseuIakGac4bpw8K1+5F0tLb6l7uvXRa8mt2Z+NVwYgCct4QAfp2R2QP6o00w==
   /karma-mocha/2.0.1:
     dependencies:
       minimist: 1.2.5
@@ -5025,7 +5107,7 @@ packages:
     engines:
       node: '> 0.8'
     resolution:
-      integrity: sha1-eZllXoZGwX8In90YfRUNMyTVRRM=
+      integrity: sha512-cc8oEVoctTvsFZ/Oje/kGnHbpWHYBe8IAJe4C0QNc3t8uM/0Y8+erSz/7Y1ALuXTEZTMvxXwO6YbX1ey3ujiZw==
   /levn/0.3.0:
     dependencies:
       prelude-ls: 1.1.2
@@ -5034,7 +5116,7 @@ packages:
     engines:
       node: '>= 0.8.0'
     resolution:
-      integrity: sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=
+      integrity: sha512-0OO4y2iOHix2W6ujICbKIaEQXvFQHue65vUG3pb5EUomzPI90z9hsA1VsO/dbIIpC53J8gxM9Q4Oho0jrCM/yA==
   /levn/0.4.1:
     dependencies:
       prelude-ls: 1.2.1
@@ -5054,7 +5136,7 @@ packages:
     engines:
       node: '>=4'
     resolution:
-      integrity: sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=
+      integrity: sha512-3p6ZOGNbiX4CdvEd1VcE6yi78UrGNpjHO33noGwHCnT/o2fyllJDepsm8+mFFv/DvtwFHht5HIHSyOy5a+ChVQ==
   /load-json-file/4.0.0:
     dependencies:
       graceful-fs: 4.2.6
@@ -5065,7 +5147,7 @@ packages:
     engines:
       node: '>=4'
     resolution:
-      integrity: sha1-L19Fq5HjMhYjT9U62rZo607AmTs=
+      integrity: sha512-Kx8hMakjX03tiGTLAIdJ+lL0htKnXjEZN6hk/tozf/WOuYGdZBJrZ+rCJRbVCugsjB3jMLn9746NsQIf5VjBMw==
   /locate-path/2.0.0:
     dependencies:
       p-locate: 2.0.0
@@ -5074,7 +5156,7 @@ packages:
     engines:
       node: '>=4'
     resolution:
-      integrity: sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=
+      integrity: sha512-NCI2kiDkyR7VeEKm27Kda/iQHyKJe1Bu0FlTbYp3CqJu+9IFe9bLyAjMxf5ZDDbEg+iMPzB5zYyUTSm8wVTKmA==
   /locate-path/3.0.0:
     dependencies:
       p-locate: 3.0.0
@@ -5087,47 +5169,47 @@ packages:
   /lodash.clonedeep/4.5.0:
     dev: false
     resolution:
-      integrity: sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=
+      integrity: sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==
   /lodash.flatten/4.4.0:
     dev: false
     resolution:
-      integrity: sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8=
+      integrity: sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g==
   /lodash.flattendeep/4.4.0:
     dev: false
     resolution:
-      integrity: sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=
+      integrity: sha512-uHaJFihxmJcEX3kT4I23ABqKKalJ/zDrDg0lsFtc1h+3uw49SIJ5beyhx5ExVRti3AvKoOJngIj7xz3oylPdWQ==
   /lodash.get/4.4.2:
     dev: false
     resolution:
-      integrity: sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=
+      integrity: sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==
   /lodash.includes/4.3.0:
     dev: false
     resolution:
-      integrity: sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8=
+      integrity: sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==
   /lodash.isboolean/3.0.3:
     dev: false
     resolution:
-      integrity: sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY=
+      integrity: sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==
   /lodash.isequal/4.5.0:
     dev: false
     resolution:
-      integrity: sha1-QVxEePK8wwEgwizhDtMib30+GOA=
+      integrity: sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==
   /lodash.isinteger/4.0.4:
     dev: false
     resolution:
-      integrity: sha1-YZwK89A/iwTDH1iChAt3sRzWg0M=
+      integrity: sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==
   /lodash.isnumber/3.0.3:
     dev: false
     resolution:
-      integrity: sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w=
+      integrity: sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==
   /lodash.isplainobject/4.0.6:
     dev: false
     resolution:
-      integrity: sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=
+      integrity: sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==
   /lodash.isstring/4.0.1:
     dev: false
     resolution:
-      integrity: sha1-1SfftUVuynzJu5XV2ur4i6VKVFE=
+      integrity: sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==
   /lodash.merge/4.6.2:
     dev: false
     resolution:
@@ -5135,15 +5217,15 @@ packages:
   /lodash.once/4.1.1:
     dev: false
     resolution:
-      integrity: sha1-DdOXEhPHxW34gJd9UEyI+0cal6w=
+      integrity: sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==
   /lodash.sortby/4.7.0:
     dev: false
     resolution:
-      integrity: sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=
+      integrity: sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==
   /lodash.truncate/4.4.2:
     dev: false
     resolution:
-      integrity: sha1-WjUNoLERO4N+z//VgSy+WNbq4ZM=
+      integrity: sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==
   /lodash/4.17.21:
     dev: false
     resolution:
@@ -5266,7 +5348,7 @@ packages:
       inherits: 2.0.4
     dev: false
     resolution:
-      integrity: sha1-6b296UogpawYsENA/Fdk1bCdkB0=
+      integrity: sha512-cBB1zpoIg3GaI1IJyoc715xmWofOcXbMhVHAR/TLYk+RO+Y6xQfAp+UshPZTojAcju91Jyk5fw4CiLBuBVaQjw==
   /md5/2.3.0:
     dependencies:
       charenc: 0.0.2
@@ -5280,17 +5362,17 @@ packages:
     engines:
       node: '>= 0.6'
     resolution:
-      integrity: sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=
+      integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==
   /memorystream/0.3.1:
     dev: false
     engines:
       node: '>= 0.10.0'
     resolution:
-      integrity: sha1-htcJCzDORV1j+64S3aUaR93K+bI=
+      integrity: sha512-S3UwM3yj5mtUSEfP41UZmt/0SCoVYUcU1rkXv+BQ5Ig8ndL4sPoJNBUJERafdPb5jjHJGuMgytgKvKIf58XNBw==
   /merge-descriptors/1.0.1:
     dev: false
     resolution:
-      integrity: sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=
+      integrity: sha512-cCi6g3/Zr1iqQi6ySbseM1Xvooa98N0w31jzUYrXPX2xqObmFGHJ0tQ5u74H3mVh7wLouTseZyYIq39g8cNp1w==
   /merge-source-map/1.1.0:
     dependencies:
       source-map: 0.6.1
@@ -5312,7 +5394,7 @@ packages:
     engines:
       node: '>= 0.6'
     resolution:
-      integrity: sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=
+      integrity: sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==
   /micromatch/4.0.2:
     dependencies:
       braces: 3.0.2
@@ -5368,7 +5450,7 @@ packages:
       dom-walk: 0.1.2
     dev: false
     resolution:
-      integrity: sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=
+      integrity: sha512-9Wy1B3m3f66bPPmU5hdA4DR4PB2OfDU/+GS3yAB7IQozE3tqXaVv2zOjgla7MEGSRv95+ILmOuvhLkOK6wJtCQ==
   /minimatch/3.0.4:
     dependencies:
       brace-expansion: 1.1.11
@@ -5462,7 +5544,7 @@ packages:
   /ms/2.0.0:
     dev: false
     resolution:
-      integrity: sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=
+      integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==
   /ms/2.1.1:
     dev: false
     resolution:
@@ -5498,7 +5580,7 @@ packages:
   /natural-compare/1.4.0:
     dev: false
     resolution:
-      integrity: sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
+      integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
   /negotiator/0.6.2:
     dev: false
     engines:
@@ -5573,6 +5655,19 @@ packages:
       node: 4.x || >=6.0.0
     resolution:
       integrity: sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
+  /node-fetch/2.6.7:
+    dependencies:
+      whatwg-url: 5.0.0
+    dev: false
+    engines:
+      node: 4.x || >=6.0.0
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
+    resolution:
+      integrity: sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==
   /node-releases/1.1.71:
     dev: false
     resolution:
@@ -5581,7 +5676,7 @@ packages:
     dev: false
     optional: true
     resolution:
-      integrity: sha1-lKKxYzxPExdVMAfYlm/Q6EG2pMI=
+      integrity: sha512-6kM8CLXvuW5crTxsAtva2YLrRrDaiTIkIePWs9moLHqbFWT94WpNFjwS/5dfLfECg5i/lkmw3aoqVidxt23TEQ==
   /normalize-package-data/2.5.0:
     dependencies:
       hosted-git-info: 2.8.9
@@ -5598,7 +5693,7 @@ packages:
     engines:
       node: '>=0.10.0'
     resolution:
-      integrity: sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=
+      integrity: sha512-3pKJwH184Xo/lnH6oyP1q2pMd7HcypqqmRs91/6/i2CGtWwIKGCkOOMTm/zXbgTEWHw1uNpNi/igc3ePOYHb6w==
   /normalize-path/3.0.0:
     dev: false
     engines:
@@ -5646,7 +5741,7 @@ packages:
       node: '>=0.10.0'
     optional: true
     resolution:
-      integrity: sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=
+      integrity: sha512-4jbtZXNAsfZbAHiiqjLPBiCl16dES1zI4Hpzzxw61Tk+loF+sBDBKx1ICKKKwIqQ7M0mFn1TmkN7euSncWgHiQ==
   /nyc/14.1.1:
     dependencies:
       archy: 1.0.0
@@ -5689,7 +5784,7 @@ packages:
     engines:
       node: '>=0.10.0'
     resolution:
-      integrity: sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
+      integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==
   /object-inspect/1.9.0:
     dev: false
     resolution:
@@ -5750,13 +5845,13 @@ packages:
     engines:
       node: '>= 0.8'
     resolution:
-      integrity: sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=
+      integrity: sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==
   /once/1.4.0:
     dependencies:
       wrappy: 1.0.2
     dev: false
     resolution:
-      integrity: sha1-WDsap3WWHUsROsF9nFC6753Xa9E=
+      integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==
   /onetime/5.1.2:
     dependencies:
       mimic-fn: 2.1.0
@@ -5805,7 +5900,7 @@ packages:
     engines:
       node: '>=0.10.0'
     resolution:
-      integrity: sha1-/7xJiDNuDoM94MFox+8VISGqf7M=
+      integrity: sha512-B5JU3cabzk8c67mRRd3ECmROafjYMXbuzlwtqdM8IbS8ktlTix8aFGb2bAGKrSRIlnfKwovGUUr72JUPyOb6kQ==
   /p-finally/2.0.1:
     dev: false
     engines:
@@ -5835,7 +5930,7 @@ packages:
     engines:
       node: '>=4'
     resolution:
-      integrity: sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=
+      integrity: sha512-nQja7m7gSKuewoVRen45CtVfODR3crN3goVQ0DDZ9N3yHxgpkuBhZqsaiotSQRrADUrne346peY7kT3TSACykg==
   /p-locate/3.0.0:
     dependencies:
       p-limit: 2.3.0
@@ -5849,7 +5944,7 @@ packages:
     engines:
       node: '>=4'
     resolution:
-      integrity: sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=
+      integrity: sha512-U1etNYuMJoIz3ZXSrrySFjsXQTWOx2/jdi86L+2pRvph/qMKL6sbcCYdH23fqsbm8TH2Gn0OybpT4eSFlCVHww==
   /p-try/2.2.0:
     dev: false
     engines:
@@ -5908,7 +6003,7 @@ packages:
     engines:
       node: '>=0.10.0'
     resolution:
-      integrity: sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=
+      integrity: sha512-QR/GGaKCkhwk1ePQNYDRKYZ3mwU9ypsKhB0XyFnLQdomyEqk3e8wpW3V5Jp88zbxK4n5ST1nqo+g9juTpownhQ==
   /parse-json/4.0.0:
     dependencies:
       error-ex: 1.3.2
@@ -5917,13 +6012,13 @@ packages:
     engines:
       node: '>=4'
     resolution:
-      integrity: sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=
+      integrity: sha512-aOIos8bujGN93/8Ox/jPLh7RwVnPEysynVFE+fQZyg6jKELEHwzgKdLRFHUgXJL6kylijVSBC4BvN9OmsB48Rw==
   /parse-passwd/1.0.0:
     dev: false
     engines:
       node: '>=0.10.0'
     resolution:
-      integrity: sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=
+      integrity: sha512-1Y1A//QUXEZK7YKz+rD9WydcE1+EuPr6ZBgKecAB8tmoW6UFv0NREVJe1p+jRxtThkcbbKkfwIbWJe/IeE6m2Q==
   /parseurl/1.3.3:
     dev: false
     engines:
@@ -5939,19 +6034,19 @@ packages:
     engines:
       node: '>=4'
     resolution:
-      integrity: sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=
+      integrity: sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==
   /path-is-absolute/1.0.1:
     dev: false
     engines:
       node: '>=0.10.0'
     resolution:
-      integrity: sha1-F0uSaHNVNP+8es5r9TpanhtcX18=
+      integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==
   /path-key/2.0.1:
     dev: false
     engines:
       node: '>=4'
     resolution:
-      integrity: sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=
+      integrity: sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw==
   /path-key/3.1.1:
     dev: false
     engines:
@@ -5965,7 +6060,7 @@ packages:
   /path-to-regexp/0.1.7:
     dev: false
     resolution:
-      integrity: sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=
+      integrity: sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ==
   /path-to-regexp/1.8.0:
     dependencies:
       isarray: 0.0.1
@@ -5983,7 +6078,7 @@ packages:
     engines:
       node: '>=4'
     resolution:
-      integrity: sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=
+      integrity: sha512-dUnb5dXUf+kzhC/W/F4e5/SkluXIFf5VUHolW1Eg1irn1hGWjPGdsRcvYJ1nD6lhk8Ir7VM0bHJKsYTx8Jx9OQ==
   /path-type/3.0.0:
     dependencies:
       pify: 3.0.0
@@ -6005,11 +6100,11 @@ packages:
   /pend/1.2.0:
     dev: false
     resolution:
-      integrity: sha1-elfrVQpng/kRUzH89GY9XI4AelA=
+      integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==
   /performance-now/2.1.0:
     dev: false
     resolution:
-      integrity: sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=
+      integrity: sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==
   /picomatch/2.2.2:
     dev: false
     engines:
@@ -6028,13 +6123,13 @@ packages:
     engines:
       node: '>=0.10.0'
     resolution:
-      integrity: sha1-7RQaasBDqEnqWISY59yosVMw6Qw=
+      integrity: sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==
   /pify/3.0.0:
     dev: false
     engines:
       node: '>=4'
     resolution:
-      integrity: sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=
+      integrity: sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==
   /pify/4.0.1:
     dev: false
     engines:
@@ -6048,7 +6143,7 @@ packages:
     engines:
       node: '>=4'
     resolution:
-      integrity: sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=
+      integrity: sha512-ojakdnUgL5pzJYWw2AIDEupaQCX5OPbM688ZevubICjdIX01PRSYKqm33fJoCOJBRseYCTUlQRnBNX+Pchaejw==
   /pkg-dir/3.0.0:
     dependencies:
       find-up: 3.0.0
@@ -6091,7 +6186,7 @@ packages:
     engines:
       node: '>= 0.8.0'
     resolution:
-      integrity: sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=
+      integrity: sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w==
   /prelude-ls/1.2.1:
     dev: false
     engines:
@@ -6115,11 +6210,11 @@ packages:
   /priorityqueuejs/1.0.0:
     dev: false
     resolution:
-      integrity: sha1-LuTyPCVgkT4IwHzlzN1t498sWvg=
+      integrity: sha512-lg++21mreCEOuGWTbO5DnJKAdxfjrdN0S9ysoW9SzdSJvbkWpkaDdpG/cdsPCsEnoLUwmd9m3WcZhngW7yKA2g==
   /process-nextick-args/1.0.7:
     dev: false
     resolution:
-      integrity: sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=
+      integrity: sha512-yN0WQmuCX63LP/TMvAg31nvT6m4vDqJEiiv2CAZqWOGNWutc9DfDk1NPYYmKUFmaVM2UwDowH4u5AHWYP/jxKw==
   /process-nextick-args/2.0.1:
     dev: false
     resolution:
@@ -6129,7 +6224,7 @@ packages:
     engines:
       node: '>= 0.6.0'
     resolution:
-      integrity: sha1-czIwDoQBYb2j5podHZGn1LwW8YI=
+      integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==
   /progress/2.0.3:
     dev: false
     engines:
@@ -6179,7 +6274,7 @@ packages:
   /pseudomap/1.0.2:
     dev: false
     resolution:
-      integrity: sha1-8FKijacOYYkX7wqKw0wa5aaChrM=
+      integrity: sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ==
   /psl/1.8.0:
     dev: false
     resolution:
@@ -6194,7 +6289,7 @@ packages:
   /punycode/1.3.2:
     dev: false
     resolution:
-      integrity: sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=
+      integrity: sha512-RofWgt/7fL5wP1Y7fxE7/EmTLzQVnB0ycyibJ0OOHIlJqTNzglYFxVwETOcIoJqJmpDXJ9xImDv+Fq34F/d4Dw==
   /punycode/2.1.1:
     dev: false
     engines:
@@ -6213,6 +6308,7 @@ packages:
       tar-fs: 2.1.1
       unbzip2-stream: 1.4.3
       ws: 7.4.4
+    deprecated: Version no longer supported. Upgrade to @latest
     dev: false
     engines:
       node: '>=10.18.1'
@@ -6256,12 +6352,14 @@ packages:
     resolution:
       integrity: sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==
   /querystring/0.2.0:
+    deprecated: The querystring API is considered Legacy. new code should use the URLSearchParams API instead.
     dev: false
     engines:
       node: '>=0.4.x'
     resolution:
-      integrity: sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=
+      integrity: sha512-X/xY82scca2tau62i9mDyU9K+I+djTMUsvwf7xnUX5GLvVzgJybOJf4Y6o9Zx3oJK/LSXg5tTZBjwzqVPaPO2g==
   /querystring/0.2.1:
+    deprecated: The querystring API is considered Legacy. new code should use the URLSearchParams API instead.
     dev: false
     engines:
       node: '>=0.4.x'
@@ -6274,7 +6372,7 @@ packages:
   /quote/0.4.0:
     dev: false
     resolution:
-      integrity: sha1-EIOSF/bBNiuJGUBE0psjP9fzLwE=
+      integrity: sha512-KHp3y3xDjuBhRx+tYKOgzPnVHMRlgpn2rU450GcU4PL24r1H6ls/hfPrxDwX2pvYMlwODHI2l8WwgoV69x5rUQ==
   /ramda/0.27.1:
     dev: false
     resolution:
@@ -6332,7 +6430,7 @@ packages:
     engines:
       node: '>=4'
     resolution:
-      integrity: sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=
+      integrity: sha512-1orxQfbWGUiTn9XsPlChs6rLie/AV9jwZTGmu2NZw/CUDJQchXJFYE0Fq5j7+n558T1JhDWLdhyd1Zj+wLY//w==
   /read-pkg-up/4.0.0:
     dependencies:
       find-up: 3.0.0
@@ -6351,7 +6449,7 @@ packages:
     engines:
       node: '>=4'
     resolution:
-      integrity: sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=
+      integrity: sha512-eFIBOPW7FGjzBuk3hdXEuNSiTZS/xEMlH49HxMyzb0hyPfu4EhVjT2DH32K1hSSmVq4sebAWnZuuY5auISUTGA==
   /read-pkg/3.0.0:
     dependencies:
       load-json-file: 4.0.0
@@ -6361,7 +6459,7 @@ packages:
     engines:
       node: '>=4'
     resolution:
-      integrity: sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=
+      integrity: sha512-BLq/cCO9two+lBgiTYNqD6GdtK8s4NpaWrl6/rCO9w0TUS8oJl7cmToOZfRYllKTISY6nt1U7jQ53brmKqY6BA==
   /readable-stream/1.1.14:
     dependencies:
       core-util-is: 1.0.2
@@ -6370,7 +6468,7 @@ packages:
       string_decoder: 0.10.31
     dev: false
     resolution:
-      integrity: sha1-fPTFTvZI44EwhMY23SB54WbAgdk=
+      integrity: sha512-+MeVjFf4L44XUkhM1eYbD8fyEsxcV81pqMSR5gblfcLCHfZvbrqy4/qYHE+/R5HoBUT11WV5O08Cr1n3YXkWVQ==
   /readable-stream/2.0.6:
     dependencies:
       core-util-is: 1.0.2
@@ -6381,7 +6479,7 @@ packages:
       util-deprecate: 1.0.2
     dev: false
     resolution:
-      integrity: sha1-j5A0HmilPMySh4jaz80Rs265t44=
+      integrity: sha512-TXcFfb63BQe1+ySzsHZI/5v1aJPCShfqvWJ64ayNImXMsN1Cd0YGk/wm8KB7/OeessgPc9QvS9Zou8QTkFzsLw==
   /readable-stream/2.3.7:
     dependencies:
       core-util-is: 1.0.2
@@ -6427,7 +6525,7 @@ packages:
     engines:
       node: '>= 0.10'
     resolution:
-      integrity: sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=
+      integrity: sha512-HFM8rkZ+i3zrV+4LQjwQ0W+ez98pApMGM3HUrN04j3CqzPOzl9nmP15Y8YXNm8QHGv/eacOVEjqhmWpkRV0NAw==
   /regenerator-runtime/0.11.1:
     dev: false
     resolution:
@@ -6449,11 +6547,11 @@ packages:
     engines:
       node: '>=4'
     resolution:
-      integrity: sha1-CXALflB0Mpc5Mw5TXFqQ+2eFFzA=
+      integrity: sha512-gUAyHVHPPC5wdqX/LG4LWtRYtgjxyX78oanFNTMMyFEfOqdC54s3eE82imuWKbOeqYht2CrNf64Qb8vgmmtZGA==
   /remove-trailing-separator/1.1.0:
     dev: false
     resolution:
-      integrity: sha1-wkvOKig62tW8P1jg1IJJuSN52O8=
+      integrity: sha512-/hS+Y0u3aOfIETiaiirUFwDBDzmXPvO+jAfKTitUngIPzdKc6Z0LoFjM/CK5PL4C+eKwHohlHAb6H0VFfmmUsw==
   /request/2.88.2:
     dependencies:
       aws-sign2: 0.7.0
@@ -6487,7 +6585,7 @@ packages:
     engines:
       node: '>=0.10.0'
     resolution:
-      integrity: sha1-jGStX9MNqxyXbiNE/+f3kqam30I=
+      integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==
   /require-from-string/2.0.2:
     dev: false
     engines:
@@ -6508,7 +6606,7 @@ packages:
   /requires-port/1.0.0:
     dev: false
     resolution:
-      integrity: sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=
+      integrity: sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==
   /resolve-dir/1.0.1:
     dependencies:
       expand-tilde: 2.0.2
@@ -6517,7 +6615,7 @@ packages:
     engines:
       node: '>=0.10.0'
     resolution:
-      integrity: sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=
+      integrity: sha512-R7uiTjECzvOsWSfdM0QKFNBVFcK27aHOUwdvK53BcW8zqnGdYp0Fbj82cy54+2A4P2tFM22J5kRfe1R+lM/1yg==
   /resolve-from/4.0.0:
     dev: false
     engines:
@@ -6528,7 +6626,7 @@ packages:
     deprecated: https://github.com/lydell/resolve-url#deprecated
     dev: false
     resolution:
-      integrity: sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=
+      integrity: sha512-ZuF55hVUQaaczgOIwqWzkEcEidmlD/xl44x1UZnhOXcYuFN2S6+rcxpG+C1N3So0wvNI3DmJICUFfu2SxhBmvg==
   /resolve/1.17.0:
     dependencies:
       path-parse: 1.0.6
@@ -6619,7 +6717,7 @@ packages:
   /rollup-plugin-local-resolve/1.0.7:
     dev: false
     resolution:
-      integrity: sha1-xIZwFxbBWt0hJ1ZcLqoQESMyCIc=
+      integrity: sha512-qYd2aYtcidHiQQ3RLLsgG9PO/pw+U9OJcHtszetaOnfFmAR7FC9vwByMwHRUllqgs83jRjaMdwlsPSXx4856Wg==
   /rollup-plugin-node-resolve/3.4.0:
     dependencies:
       builtin-modules: 2.0.0
@@ -6645,7 +6743,7 @@ packages:
     peerDependencies:
       rollup: '>=0.31.2'
     resolution:
-      integrity: sha1-YhJaqUCHqt97g+9N+vYptHMTXoc=
+      integrity: sha512-pHUvzofmQx/C3zCkX14h9J9MbRfMjaARED8j8qOY+au4prtk2d567GD29WAHQTeGsDAVeStms3cPnRboC41YzA==
   /rollup-plugin-terser/5.3.1_rollup@1.32.1:
     dependencies:
       '@babel/code-frame': 7.12.13
@@ -6710,7 +6808,7 @@ packages:
   /sax/0.5.8:
     dev: false
     resolution:
-      integrity: sha1-1HLbIo6zMcJQaw6MFVJK25OdEsE=
+      integrity: sha512-c0YL9VcSfcdH3F1Qij9qpYJFpKFKMXNOkLWFssBL3RuF7ZS8oZhllR2rWlCRjDTJsfq3R6wbSsaRU6o0rkEdNw==
   /sax/1.2.4:
     dev: false
     resolution:
@@ -6725,7 +6823,7 @@ packages:
     dev: false
     hasBin: true
     resolution:
-      integrity: sha1-myzl094C0XxgEq0yaqa00M9U+U8=
+      integrity: sha512-mfmm3/H9+67MCVix1h+IXTpDwL6710LyHuk7+cWC9T1mE0qz4iHhh6r4hU2wrIT9iTsAAC2XQRvfblL028cpLw==
   /semver/5.7.1:
     dev: false
     hasBin: true
@@ -6785,7 +6883,7 @@ packages:
   /set-blocking/2.0.0:
     dev: false
     resolution:
-      integrity: sha1-BF+XgtARrppoA93TgrJDkrPYkPc=
+      integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==
   /setprototypeof/1.1.1:
     dev: false
     resolution:
@@ -6797,7 +6895,7 @@ packages:
     engines:
       node: '>=0.10.0'
     resolution:
-      integrity: sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=
+      integrity: sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==
   /shebang-command/2.0.0:
     dependencies:
       shebang-regex: 3.0.0
@@ -6811,7 +6909,7 @@ packages:
     engines:
       node: '>=0.10.0'
     resolution:
-      integrity: sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=
+      integrity: sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ==
   /shebang-regex/3.0.0:
     dev: false
     engines:
@@ -7013,6 +7111,7 @@ packages:
       resolve-url: 0.2.1
       source-map-url: 0.4.1
       urix: 0.1.0
+    deprecated: See https://github.com/lydell/source-map-resolve#deprecated
     dev: false
     resolution:
       integrity: sha512-Htz+RnsXWk5+P2slx5Jh3Q66vhQj1Cllm0zvnaY98+NFx+Dv2CF/f5O/t8x+KaNdrdIAsruNzoh/KpialbqAnw==
@@ -7024,6 +7123,7 @@ packages:
     resolution:
       integrity: sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==
   /source-map-url/0.4.1:
+    deprecated: See https://github.com/lydell/source-map-url#deprecated
     dev: false
     resolution:
       integrity: sha512-cPiFOTLUKvJFIg4SKVScy4ilPPW6rFgMgfuZJPNoDuMs3nC1HbMUycBoJw77xFIp6z1UJQJOfx6C9GMH80DiTw==
@@ -7032,7 +7132,7 @@ packages:
     engines:
       node: '>=0.10.0'
     resolution:
-      integrity: sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=
+      integrity: sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==
   /source-map/0.6.1:
     dev: false
     engines:
@@ -7085,7 +7185,7 @@ packages:
   /sprintf-js/1.0.3:
     dev: false
     resolution:
-      integrity: sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
+      integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==
   /sshpk/1.16.1:
     dependencies:
       asn1: 0.2.4
@@ -7108,7 +7208,7 @@ packages:
     engines:
       node: '>= 0.6'
     resolution:
-      integrity: sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=
+      integrity: sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==
   /stoppable/1.1.0:
     dev: false
     engines:
@@ -7128,6 +7228,7 @@ packages:
       date-format: 2.1.0
       debug: 4.3.1
       fs-extra: 8.1.0
+    deprecated: 2.x is no longer supported. Please upgrade to 3.x or higher.
     dev: false
     engines:
       node: '>=8.0'
@@ -7138,7 +7239,7 @@ packages:
     engines:
       node: '>=0.10.0'
     resolution:
-      integrity: sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=
+      integrity: sha512-R3f198pcvnB+5IpnBlRkphuE9n46WyVl8I39W/ZUTZLz4nqSP/oLYUrcnJrw462Ds8he4YKMov2efsTIw1BDGQ==
   /string-argv/0.3.1:
     dev: false
     engines:
@@ -7155,7 +7256,7 @@ packages:
       node: '>=0.10.0'
     optional: true
     resolution:
-      integrity: sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=
+      integrity: sha512-0XsVpQLnVCXHJfyEs8tC0zpTVIr5PKKsQtkT29IwupnPTjtPmQ3xT/4yCREF9hYkV/3M3kzcUTSAZT6a6h81tw==
   /string-width/2.1.1:
     dependencies:
       is-fullwidth-code-point: 2.0.0
@@ -7212,7 +7313,7 @@ packages:
   /string_decoder/0.10.31:
     dev: false
     resolution:
-      integrity: sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=
+      integrity: sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ==
   /string_decoder/1.1.1:
     dependencies:
       safe-buffer: 5.1.2
@@ -7232,7 +7333,7 @@ packages:
     engines:
       node: '>=0.10.0'
     resolution:
-      integrity: sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=
+      integrity: sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==
   /strip-ansi/4.0.0:
     dependencies:
       ansi-regex: 3.0.0
@@ -7240,7 +7341,7 @@ packages:
     engines:
       node: '>=4'
     resolution:
-      integrity: sha1-qEeQIusaw2iocTibY1JixQXuNo8=
+      integrity: sha512-4XaJ2zQdCzROZDivEVIDPkcQn8LMFSa8kj8Gxb/Lnwzv9A8VctNZ+lfivC/sV3ivW8ElJTERXZoPBRrZKkNKow==
   /strip-ansi/5.2.0:
     dependencies:
       ansi-regex: 4.1.0
@@ -7262,7 +7363,7 @@ packages:
     engines:
       node: '>=4'
     resolution:
-      integrity: sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=
+      integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==
   /strip-final-newline/2.0.0:
     dev: false
     engines:
@@ -7274,7 +7375,7 @@ packages:
     engines:
       node: '>=0.10.0'
     resolution:
-      integrity: sha1-PFMZQukIwml8DsNEhYwobHygpgo=
+      integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==
   /strip-json-comments/3.1.1:
     dev: false
     engines:
@@ -7286,7 +7387,7 @@ packages:
     engines:
       node: '>=0.8.0'
     resolution:
-      integrity: sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=
+      integrity: sha512-KKNVtd6pCYgPIKU4cp2733HWYCpplQhddZLBUryaAHou723x+FRzQ5Df824Fj+IyyuiQTRoub4SnIFfIcrp70g==
   /supports-color/5.5.0:
     dependencies:
       has-flag: 3.0.0
@@ -7381,15 +7482,15 @@ packages:
   /text-table/0.2.0:
     dev: false
     resolution:
-      integrity: sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=
+      integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==
   /through/2.3.8:
     dev: false
     resolution:
-      integrity: sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=
+      integrity: sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==
   /timsort/0.3.0:
     dev: false
     resolution:
-      integrity: sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q=
+      integrity: sha512-qsdtZH+vMoCARQtyod4imc2nIJwg9Cc7lPRrw9CzF8ZKR0khdr8+2nX80PBhET3tcyTtJDxAffGh2rXH4tyU8A==
   /tmp/0.2.1:
     dependencies:
       rimraf: 3.0.2
@@ -7403,7 +7504,7 @@ packages:
     engines:
       node: '>=4'
     resolution:
-      integrity: sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=
+      integrity: sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==
   /to-regex-range/5.0.1:
     dependencies:
       is-number: 7.0.0
@@ -7447,12 +7548,16 @@ packages:
       node: '>=6'
     resolution:
       integrity: sha512-tHdtEpQCMrc1YLrMaqXXcj6AxhYi/xgit6mZu1+EDWUn+qhUf8wMQoFIy9NXuq23zAwtcB0t/MjACGR18pcRbg==
+  /tr46/0.0.3:
+    dev: false
+    resolution:
+      integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==
   /tr46/1.0.1:
     dependencies:
       punycode: 2.1.1
     dev: false
     resolution:
-      integrity: sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=
+      integrity: sha512-dTpowEjclQ7Kgx5SdBkqRzVhERQXov8/l9Ft9dVM9fmg0W0KQSVaXX9T4i6twCPNtYiZM53lpSSUAwJbFPOHxA==
   /ts-node/9.1.1_typescript@4.2.4:
     dependencies:
       arg: 4.1.3
@@ -7503,7 +7608,7 @@ packages:
       safe-buffer: 5.2.1
     dev: false
     resolution:
-      integrity: sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=
+      integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==
   /tunnel/0.0.6:
     dev: false
     engines:
@@ -7513,7 +7618,7 @@ packages:
   /tweetnacl/0.14.5:
     dev: false
     resolution:
-      integrity: sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=
+      integrity: sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==
   /type-check/0.3.2:
     dependencies:
       prelude-ls: 1.1.2
@@ -7521,7 +7626,7 @@ packages:
     engines:
       node: '>= 0.8.0'
     resolution:
-      integrity: sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=
+      integrity: sha512-ZCmOJdvOWDBYJlzAoFkC+Q0+bUyEOS1ltgp1MGU03fqHG+dbi9tBFU2Rd9QKiDZFAYrhPh2JUf7rZRIuHRKtOg==
   /type-check/0.4.0:
     dependencies:
       prelude-ls: 1.2.1
@@ -7653,7 +7758,7 @@ packages:
   /underscore/1.8.3:
     dev: false
     resolution:
-      integrity: sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI=
+      integrity: sha512-5WsVTFcH1ut/kkhAaHf4PVgI8c7++GiVcpCGxPouI6ZVjsqPnSDf8h/8HtVqc0t4fzRXwnMK70EcZeAs3PIddg==
   /universal-user-agent/6.0.0:
     dev: false
     resolution:
@@ -7669,7 +7774,7 @@ packages:
     engines:
       node: '>= 0.8'
     resolution:
-      integrity: sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=
+      integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==
   /uri-js/4.4.1:
     dependencies:
       punycode: 2.1.1
@@ -7680,24 +7785,24 @@ packages:
     deprecated: Please see https://github.com/lydell/urix#deprecated
     dev: false
     resolution:
-      integrity: sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=
+      integrity: sha512-Am1ousAhSLBeB9cG/7k7r2R0zj50uDRlZHPGbazid5s9rlF1F/QKYObEKSIunSjIOkJZqwRRLpvewjEkM7pSqg==
   /url/0.11.0:
     dependencies:
       punycode: 1.3.2
       querystring: 0.2.0
     dev: false
     resolution:
-      integrity: sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=
+      integrity: sha512-kbailJa29QrtXnxgq+DdCEGlbTeYM2eJUxsz6vjZavrCYPMIFHMKQmSKYAIuUK2i7hgPm28a8piX5NTUtM/LKQ==
   /util-deprecate/1.0.2:
     dev: false
     resolution:
-      integrity: sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=
+      integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==
   /util/0.10.3:
     dependencies:
       inherits: 2.0.1
     dev: false
     resolution:
-      integrity: sha1-evsa/lCAUkZInj23/g7TeTNqwPk=
+      integrity: sha512-5KiHfsmkqacuKjkRkdV7SsfDJ2EGiPsK92s2MhNSY0craxjTdKTtqKsJaCWp4LW33ZZ0OPUv1WO/TFvNQRiQxQ==
   /util/0.11.1:
     dependencies:
       inherits: 2.0.3
@@ -7720,7 +7825,7 @@ packages:
     engines:
       node: '>= 0.4.0'
     resolution:
-      integrity: sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=
+      integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==
   /uuid/3.4.0:
     deprecated: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.
     dev: false
@@ -7761,13 +7866,13 @@ packages:
       object-assign: 4.1.1
     dev: false
     resolution:
-      integrity: sha1-0r1cZtt2wTh52W5qMG7cmJ35eNo=
+      integrity: sha512-0Jk/MsCNtL/fCuVIbsLxwXpABGZCzN57btcPbSsjOOAwkdHJ3Y58fo8BoUfG7jghnvglbwo+5Hk1KOJ2W2Ormw==
   /vary/1.1.2:
     dev: false
     engines:
       node: '>= 0.8'
     resolution:
-      integrity: sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=
+      integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==
   /verror/1.10.0:
     dependencies:
       assert-plus: 1.0.0
@@ -7777,17 +7882,28 @@ packages:
     engines:
       '0': node >=0.6.0
     resolution:
-      integrity: sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=
+      integrity: sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==
   /void-elements/2.0.1:
     dev: false
     engines:
       node: '>=0.10.0'
     resolution:
-      integrity: sha1-wGavtYK7HLQSjWDqkjkulNXp2+w=
+      integrity: sha512-qZKX4RnBzH2ugr8Lxa7x+0V6XD9Sb/ouARtiasEQCHB1EVU4NXtmHsDDrx1dO4ne5fc3J6EW05BP1Dl0z0iung==
+  /webidl-conversions/3.0.1:
+    dev: false
+    resolution:
+      integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==
   /webidl-conversions/4.0.2:
     dev: false
     resolution:
       integrity: sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==
+  /whatwg-url/5.0.0:
+    dependencies:
+      tr46: 0.0.3
+      webidl-conversions: 3.0.1
+    dev: false
+    resolution:
+      integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==
   /whatwg-url/6.5.0:
     dependencies:
       lodash.sortby: 4.7.0
@@ -7809,7 +7925,7 @@ packages:
   /which-module/2.0.0:
     dev: false
     resolution:
-      integrity: sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=
+      integrity: sha512-B+enWhmw6cjfVC7kS8Pj9pCrKSc5txArRyaYGe088shv/FGWH+0Rjx/xPgtsWfsUtS27FkP697E4DDhgrgoc0Q==
   /which-typed-array/1.1.4:
     dependencies:
       available-typed-arrays: 1.0.2
@@ -7855,7 +7971,7 @@ packages:
   /wordwrap/1.0.0:
     dev: false
     resolution:
-      integrity: sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=
+      integrity: sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==
   /wrap-ansi/5.1.0:
     dependencies:
       ansi-styles: 3.2.1
@@ -7879,7 +7995,7 @@ packages:
   /wrappy/1.0.2:
     dev: false
     resolution:
-      integrity: sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=
+      integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==
   /write-file-atomic/2.4.3:
     dependencies:
       graceful-fs: 4.2.6
@@ -7918,13 +8034,13 @@ packages:
   /xml/1.0.1:
     dev: false
     resolution:
-      integrity: sha1-eLpyAgApxbyHuKgaPPzXS0ovweU=
+      integrity: sha512-huCv9IH9Tcf95zuYCsQraZtWnJvBtLVE0QHMOs8bWyZAFZNDcYjsPq1nEx8jKA9y+Beo9v+7OBPRisQTjinQMw==
   /xml2js/0.2.8:
     dependencies:
       sax: 0.5.8
     dev: false
     resolution:
-      integrity: sha1-m4FpCTFjH/CdGVdUn69U9PmAs8I=
+      integrity: sha512-ZHZBIAO55GHCn2jBYByVPHvHS+o3j8/a/qmpEe6kxO3cTnTCWC3Htq9RYJ5G4XMwMMClD2QkXA9SNdPadLyn3Q==
   /xml2js/0.4.23:
     dependencies:
       sax: 1.2.4
@@ -7951,7 +8067,7 @@ packages:
     engines:
       node: '>=4.0'
     resolution:
-      integrity: sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=
+      integrity: sha512-7YXTQc3P2l9+0rjaUbLwMKRhtmwg1M1eDf6nag7urC7pIPYLD9W/jmzQ4ptRSUbodw5S0jfoGTflLemQibSpeQ==
   /xmldom/0.5.0:
     dev: false
     engines:
@@ -7967,7 +8083,7 @@ packages:
   /xregexp/2.0.0:
     dev: false
     resolution:
-      integrity: sha1-UqY+VsoLhKfzpfPWGHLxJq16WUM=
+      integrity: sha512-xl/50/Cf32VsGq/1R8jJE5ajH1yMCQkpmoS10QbFZWl2Oor4H0Me64Pu2yxvsRWK3m6soJbmGfzSR7BYmDcWAA==
   /y18n/4.0.3:
     dev: false
     resolution:
@@ -7981,7 +8097,7 @@ packages:
   /yallist/2.1.2:
     dev: false
     resolution:
-      integrity: sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=
+      integrity: sha512-ncTzHV7NvsQZkYe1DW7cbDLm0YpzHmZF5r/iyP3ZnQtMiJ+pjzisCiMNI+Sj+xQF5pXhSHxSB3uDbsBTzY/c2A==
   /yallist/3.1.1:
     dev: false
     resolution:
@@ -8054,7 +8170,7 @@ packages:
       fd-slicer: 1.1.0
     dev: false
     resolution:
-      integrity: sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=
+      integrity: sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==
   /yn/3.1.1:
     dev: false
     engines:
@@ -8971,7 +9087,7 @@ packages:
     dev: false
     name: '@rush-temp/core-amqp'
     resolution:
-      integrity: sha512-/YV3V78se14tbDHiMQ98vnFK3pjdUa1zhzArgECevZVnGzrXcj3gwZil7Hg8fCBYP4ngoVanpE6WTfy7vv9fWw==
+      integrity: sha512-z4y18ou4apTqiXLk+5UuT2pO1azsv/gqRqDjZMlR7uszr3zliN1ox1Rq5DLed/6wYMVmNW/M3nmQcWYa7SPVGQ==
       tarball: file:projects/core-amqp.tgz
     version: 0.0.0
   file:projects/core-asynciterator-polyfill.tgz:
@@ -10686,6 +10802,7 @@ packages:
   file:projects/perf-search-documents.tgz:
     dependencies:
       '@azure/identity': 1.3.0
+      '@azure/search-documents': 11.3.0-beta.1
       '@types/node': 8.10.66
       dotenv: 8.2.0
       eslint: 7.23.0
@@ -10697,7 +10814,7 @@ packages:
     dev: false
     name: '@rush-temp/perf-search-documents'
     resolution:
-      integrity: sha512-8Vow24y5DwbPb4BS7uf+qZQgMEMYdToxQxfMsvKcw1pueM1d39F+ezpNsHbaBY6VoKhdrFVGb/03IY5MDb3+4A==
+      integrity: sha512-qE5r//wbqshU4dhvPAYi4lOKYAiXoMfRShjS6d7+WmqW6BHQbLIV+YhlEI1xpgy+Pq/LNO7N/9BGyD1WwU1Wmw==
       tarball: file:projects/perf-search-documents.tgz
     version: 0.0.0
   file:projects/perf-storage-blob.tgz:

--- a/sdk/search/perf-tests/search-documents/package.json
+++ b/sdk/search/perf-tests/search-documents/package.json
@@ -7,7 +7,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@azure/search-documents": "11.3.0-beta.1",
+    "@azure/search-documents": "11.3.0",
     "@azure/identity": "^1.1.0",
     "@azure/test-utils-perfstress": "^1.0.0",
     "dotenv": "^8.2.0"

--- a/sdk/search/search-documents/CHANGELOG.md
+++ b/sdk/search/search-documents/CHANGELOG.md
@@ -1,6 +1,17 @@
 # Release History
 
-## 11.3.0-beta.1 (Unreleased)
+## 11.3.0 (Unreleased)
+
+### Features Added
+
+- Enabled national cloud support for Azure Search SDK. Please refer [#22887](https://github.com/Azure/azure-sdk-for-js/pull/22887) for further details.
+- Support for TokenCredential has been added. With this addition, the Search SDK supports authentication via AAD.
+
+### Bugs Fixed
+
+- Converted the complex fields correctly within the Search Fields. Please refer [#16489](https://github.com/Azure/azure-sdk-for-js/issues/16489) for more details.
+- Fixed the typos `anayzerName` to `analyzerName` and `normalizerNames` to `normalizerName` in `convertFieldsToPublic` method of `serviceUtils.ts`.
+- Fixed the issue with the presence of recursive structure while uploading documents. Please refer [#15656](https://github.com/Azure/azure-sdk-for-js/issues/15656) for further details.
 
 ## 11.2.0 (2021-06-08)
 

--- a/sdk/search/search-documents/package.json
+++ b/sdk/search/search-documents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/search-documents",
-  "version": "11.3.0-beta.1",
+  "version": "11.3.0",
   "description": "Azure client library to use Cognitive Search for node.js and browser.",
   "sdk-type": "client",
   "main": "dist/index.js",
@@ -41,7 +41,8 @@
     "LICENSE"
   ],
   "browser": {
-    "./dist-esm/src/base64.js": "./dist-esm/src/base64.browser.js"
+    "./dist-esm/src/base64.js": "./dist-esm/src/base64.browser.js",
+    "./dist-esm/src/synonymMapHelper.js": "./dist-esm/src/synonymMapHelper.browser.js"
   },
   "//metadata": {
     "constantPaths": [

--- a/sdk/search/search-documents/review/search-documents.api.md
+++ b/sdk/search/search-documents/review/search-documents.api.md
@@ -10,6 +10,7 @@ import { OperationOptions } from '@azure/core-http';
 import { PagedAsyncIterableIterator } from '@azure/core-paging';
 import { PipelineOptions } from '@azure/core-http';
 import { RestError } from '@azure/core-http';
+import { TokenCredential } from '@azure/core-auth';
 
 // @public
 export interface AnalyzedTokenInfo {
@@ -287,6 +288,9 @@ export interface CreateOrUpdateSynonymMapOptions extends OperationOptions {
 
 // @public
 export type CreateSkillsetOptions = OperationOptions;
+
+// @public
+export function createSynonymMapFromFile(name: string, filePath: string): Promise<SynonymMap>;
 
 // @public
 export type CreateSynonymMapOptions = OperationOptions;
@@ -1574,7 +1578,7 @@ export type ScoringStatistics = "local" | "global";
 
 // @public
 export class SearchClient<T> implements IndexDocumentsClient<T> {
-    constructor(endpoint: string, indexName: string, credential: KeyCredential, options?: SearchClientOptions);
+    constructor(endpoint: string, indexName: string, credential: KeyCredential | TokenCredential, options?: SearchClientOptions);
     readonly apiVersion: string;
     autocomplete<Fields extends keyof T>(searchText: string, suggesterName: string, options?: AutocompleteOptions<Fields>): Promise<AutocompleteResult>;
     deleteDocuments(documents: T[], options?: DeleteDocumentsOptions): Promise<IndexDocumentsResult>;
@@ -1594,6 +1598,7 @@ export class SearchClient<T> implements IndexDocumentsClient<T> {
 // @public
 export interface SearchClientOptions extends PipelineOptions {
     apiVersion?: string;
+    audience?: string;
 }
 
 // @public
@@ -1643,7 +1648,7 @@ export interface SearchIndex {
 
 // @public
 export class SearchIndexClient {
-    constructor(endpoint: string, credential: KeyCredential, options?: SearchIndexClientOptions);
+    constructor(endpoint: string, credential: KeyCredential | TokenCredential, options?: SearchIndexClientOptions);
     analyzeText(indexName: string, options: AnalyzeTextOptions): Promise<AnalyzeResult>;
     readonly apiVersion: string;
     createIndex(index: SearchIndex, options?: CreateIndexOptions): Promise<SearchIndex>;
@@ -1667,6 +1672,7 @@ export class SearchIndexClient {
 // @public
 export interface SearchIndexClientOptions extends PipelineOptions {
     apiVersion?: string;
+    audience?: string;
 }
 
 // @public
@@ -1687,7 +1693,7 @@ export interface SearchIndexer {
 
 // @public
 export class SearchIndexerClient {
-    constructor(endpoint: string, credential: KeyCredential, options?: SearchIndexerClientOptions);
+    constructor(endpoint: string, credential: KeyCredential | TokenCredential, options?: SearchIndexerClientOptions);
     readonly apiVersion: string;
     createDataSourceConnection(dataSourceConnection: SearchIndexerDataSourceConnection, options?: CreateDataSourceConnectionOptions): Promise<SearchIndexerDataSourceConnection>;
     createIndexer(indexer: SearchIndexer, options?: CreateIndexerOptions): Promise<SearchIndexer>;
@@ -1716,6 +1722,7 @@ export class SearchIndexerClient {
 // @public
 export interface SearchIndexerClientOptions extends PipelineOptions {
     apiVersion?: string;
+    audience?: string;
 }
 
 // @public

--- a/sdk/search/search-documents/src/constants.ts
+++ b/sdk/search/search-documents/src/constants.ts
@@ -1,4 +1,4 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-export const SDK_VERSION: string = "11.3.0-beta.1";
+export const SDK_VERSION: string = "11.3.0";

--- a/sdk/search/search-documents/src/generated/data/searchClientContext.ts
+++ b/sdk/search/search-documents/src/generated/data/searchClientContext.ts
@@ -13,7 +13,7 @@ import {
 } from "./models";
 
 const packageName = "@azure/search-documents";
-const packageVersion = "11.3.0-beta.1";
+const packageVersion = "11.3.0";
 
 /** @internal */
 export class SearchClientContext extends coreHttp.ServiceClient {

--- a/sdk/search/search-documents/src/generated/service/searchServiceClientContext.ts
+++ b/sdk/search/search-documents/src/generated/service/searchServiceClientContext.ts
@@ -13,7 +13,7 @@ import {
 } from "./models";
 
 const packageName = "@azure/search-documents";
-const packageVersion = "11.3.0-beta.1";
+const packageVersion = "11.3.0";
 
 /** @internal */
 export class SearchServiceClientContext extends coreHttp.ServiceClient {

--- a/sdk/search/search-documents/src/index.ts
+++ b/sdk/search/search-documents/src/index.ts
@@ -5,7 +5,7 @@ export { SearchClient, SearchClientOptions } from "./searchClient";
 export {
   DEFAULT_BATCH_SIZE,
   DEFAULT_FLUSH_WINDOW,
-  DEFAULT_RETRY_COUNT
+  DEFAULT_RETRY_COUNT,
 } from "./searchIndexingBufferedSender";
 export {
   AutocompleteRequest,
@@ -36,7 +36,7 @@ export {
   SearchIndexingBufferedSenderFlushDocumentsOptions,
   SearchIndexingBufferedSenderMergeDocumentsOptions,
   SearchIndexingBufferedSenderMergeOrUploadDocumentsOptions,
-  SearchIndexingBufferedSenderUploadDocumentsOptions
+  SearchIndexingBufferedSenderUploadDocumentsOptions,
 } from "./indexModels";
 export { SearchIndexingBufferedSender, IndexDocumentsClient } from "./searchIndexingBufferedSender";
 export { SearchIndexClient, SearchIndexClientOptions } from "./searchIndexClient";
@@ -111,7 +111,7 @@ export {
   SearchIndexStatistics,
   SearchServiceStatistics,
   SearchIndexer,
-  LexicalNormalizer
+  LexicalNormalizer,
 } from "./serviceModels";
 export { default as GeographyPoint } from "./geographyPoint";
 export { odata } from "./odata";
@@ -134,7 +134,7 @@ export {
   Speller,
   KnownSpeller,
   CaptionResult,
-  AnswerResult
+  AnswerResult,
 } from "./generated/data/models";
 export {
   RegexFlags,
@@ -298,6 +298,7 @@ export {
   SearchIndexerKnowledgeStoreBlobProjectionSelector,
   SearchIndexerKnowledgeStoreProjectionSelector,
   SearchIndexerKnowledgeStoreObjectProjectionSelector,
-  SearchIndexerKnowledgeStoreTableProjectionSelector
+  SearchIndexerKnowledgeStoreTableProjectionSelector,
 } from "./generated/service/models";
 export { AzureKeyCredential } from "@azure/core-auth";
+export { createSynonymMapFromFile } from "./synonymMapHelper";

--- a/sdk/search/search-documents/src/searchAudience.ts
+++ b/sdk/search/search-documents/src/searchAudience.ts
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+/**
+ * Known values for Search Audience
+ */
+export enum KnownSearchAudience {
+  /**
+   * Audience for Azure China
+   */
+  AzureChina = "https://search.azure.cn",
+  /**
+   * Audience for Azure Government
+   */
+  AzureGovernment = "https://search.azure.us",
+  /**
+   * Audience for Azure Public
+   */
+  AzurePublicCloud = "https://search.azure.com",
+}

--- a/sdk/search/search-documents/src/searchClient.ts
+++ b/sdk/search/search-documents/src/searchClient.ts
@@ -8,10 +8,12 @@ import {
   InternalPipelineOptions,
   createPipelineFromOptions,
   OperationOptions,
-  operationOptionsToRequestOptionsBase
+  operationOptionsToRequestOptionsBase,
+  RequestPolicyFactory,
+  bearerTokenAuthenticationPolicy,
 } from "@azure/core-http";
 import { SearchClient as GeneratedClient } from "./generated/data/searchClient";
-import { KeyCredential } from "@azure/core-auth";
+import { KeyCredential, TokenCredential, isTokenCredential } from "@azure/core-auth";
 import { createSearchApiKeyCredentialPolicy } from "./searchApiKeyCredentialPolicy";
 import { SDK_VERSION } from "./constants";
 import { logger } from "./logger";
@@ -19,7 +21,7 @@ import {
   AutocompleteResult,
   AutocompleteRequest,
   SuggestRequest,
-  IndexDocumentsResult
+  IndexDocumentsResult,
 } from "./generated/data/models";
 import { createSpan } from "./tracing";
 import { SpanStatusCode } from "@azure/core-tracing";
@@ -41,13 +43,15 @@ import {
   DeleteDocumentsOptions,
   SearchDocumentsPageResult,
   MergeOrUploadDocumentsOptions,
-  SearchRequest
+  SearchRequest,
 } from "./indexModels";
 import { odataMetadataPolicy } from "./odataMetadataPolicy";
 import { IndexDocumentsBatch } from "./indexDocumentsBatch";
 import { encode, decode } from "./base64";
 import * as utils from "./serviceUtils";
 import { IndexDocumentsClient } from "./searchIndexingBufferedSender";
+import { KnownSearchAudience } from "./searchAudience";
+
 /**
  * Client options used to configure Cognitive Search API requests.
  */
@@ -56,6 +60,13 @@ export interface SearchClientOptions extends PipelineOptions {
    * The API version to use when communicating with the service.
    */
   apiVersion?: string;
+
+  /**
+   * The Audience to use for authentication with Azure Active Directory (AAD). The
+   * audience is not considered when using a shared key.
+   * {@link KnownSearchAudience} can be used interchangeably with audience
+   */
+  audience?: string;
 }
 
 /**
@@ -110,7 +121,7 @@ export class SearchClient<T> implements IndexDocumentsClient<T> {
   constructor(
     endpoint: string,
     indexName: string,
-    credential: KeyCredential,
+    credential: KeyCredential | TokenCredential,
     options: SearchClientOptions = {}
   ) {
     this.endpoint = endpoint;
@@ -137,16 +148,22 @@ export class SearchClient<T> implements IndexDocumentsClient<T> {
             "OData-MaxVersion",
             "OData-Version",
             "Prefer",
-            "throttle-reason"
-          ]
-        }
-      }
+            "throttle-reason",
+          ],
+        },
+      },
     };
 
-    const pipeline = createPipelineFromOptions(
-      internalPipelineOptions,
-      createSearchApiKeyCredentialPolicy(credential)
-    );
+    const scope: string = options.audience
+      ? `${options.audience}/.default`
+      : `${KnownSearchAudience.AzurePublicCloud}/.default`;
+
+    const requestPolicyFactory: RequestPolicyFactory = isTokenCredential(credential)
+      ? bearerTokenAuthenticationPolicy(credential, scope)
+      : createSearchApiKeyCredentialPolicy(credential);
+
+    const pipeline = createPipelineFromOptions(internalPipelineOptions, requestPolicyFactory);
+
     if (Array.isArray(pipeline.requestPolicyFactories)) {
       pipeline.requestPolicyFactories.unshift(odataMetadataPolicy("none"));
     }
@@ -154,7 +171,7 @@ export class SearchClient<T> implements IndexDocumentsClient<T> {
     let apiVersion = this.apiVersion;
 
     if (options.apiVersion) {
-      if (!["2020-06-30-Preview", "2020-06-30"].includes(options.apiVersion)) {
+      if (!["2020-06-30", "2021-04-30-Preview"].includes(options.apiVersion)) {
         throw new Error(`Invalid Api Version: ${options.apiVersion}`);
       }
       apiVersion = options.apiVersion;
@@ -177,7 +194,7 @@ export class SearchClient<T> implements IndexDocumentsClient<T> {
     } catch (e) {
       span.setStatus({
         code: SpanStatusCode.ERROR,
-        message: e.message
+        message: e.message,
       });
       throw e;
     } finally {
@@ -203,7 +220,7 @@ export class SearchClient<T> implements IndexDocumentsClient<T> {
       searchText: searchText,
       suggesterName: suggesterName,
       searchFields: this.convertSearchFields<Fields>(searchFields),
-      ...nonFieldOptions
+      ...nonFieldOptions,
     };
 
     if (!fullOptions.searchText) {
@@ -225,7 +242,7 @@ export class SearchClient<T> implements IndexDocumentsClient<T> {
     } catch (e) {
       span.setStatus({
         code: SpanStatusCode.ERROR,
-        message: e.message
+        message: e.message,
       });
       throw e;
     } finally {
@@ -245,7 +262,7 @@ export class SearchClient<T> implements IndexDocumentsClient<T> {
       select: this.convertSelect<Fields>(select),
       orderBy: this.convertOrderBy(orderBy),
       ...nonFieldOptions,
-      ...nextPageParameters
+      ...nextPageParameters,
     };
 
     const { span, updatedOptions } = createSpan("SearchClient-searchDocuments", operationOptions);
@@ -255,7 +272,7 @@ export class SearchClient<T> implements IndexDocumentsClient<T> {
         {
           ...fullOptions,
           includeTotalResultCount: fullOptions.includeTotalCount,
-          searchText: searchText
+          searchText: searchText,
         },
         operationOptionsToRequestOptionsBase(updatedOptions)
       );
@@ -270,14 +287,14 @@ export class SearchClient<T> implements IndexDocumentsClient<T> {
         coverage,
         facets,
         answers,
-        continuationToken: this.encodeContinuationToken(nextLink, result.nextPageParameters)
+        continuationToken: this.encodeContinuationToken(nextLink, result.nextPageParameters),
       };
 
       return deserialize<SearchDocumentsPageResult<Pick<T, Fields>>>(converted);
     } catch (e) {
       span.setStatus({
         code: SpanStatusCode.ERROR,
-        message: e.message
+        message: e.message,
       });
       throw e;
     } finally {
@@ -320,7 +337,7 @@ export class SearchClient<T> implements IndexDocumentsClient<T> {
     yield* firstPage.results;
     if (firstPage.continuationToken) {
       for await (const page of this.listSearchResultsPage(searchText, options, {
-        continuationToken: firstPage.continuationToken
+        continuationToken: firstPage.continuationToken,
       })) {
         yield* page.results;
       }
@@ -343,7 +360,7 @@ export class SearchClient<T> implements IndexDocumentsClient<T> {
       },
       byPage: (settings: ListSearchResultsPageSettings = {}) => {
         return this.listSearchResultsPage(searchText, options, settings);
-      }
+      },
     };
   }
 
@@ -369,12 +386,12 @@ export class SearchClient<T> implements IndexDocumentsClient<T> {
         coverage,
         facets,
         answers,
-        results: this.listSearchResults(pageResult, searchText, updatedOptions)
+        results: this.listSearchResults(pageResult, searchText, updatedOptions),
       };
     } catch (e) {
       span.setStatus({
         code: SpanStatusCode.ERROR,
-        message: e.message
+        message: e.message,
       });
       throw e;
     } finally {
@@ -402,7 +419,7 @@ export class SearchClient<T> implements IndexDocumentsClient<T> {
       searchFields: this.convertSearchFields<Fields>(searchFields),
       select: this.convertSelect<Fields>(select),
       orderBy: this.convertOrderBy(orderBy),
-      ...nonFieldOptions
+      ...nonFieldOptions,
     };
 
     if (!fullOptions.searchText) {
@@ -421,15 +438,14 @@ export class SearchClient<T> implements IndexDocumentsClient<T> {
         operationOptionsToRequestOptionsBase(updatedOptions)
       );
 
-      const modifiedResult = utils.generatedSuggestDocumentsResultToPublicSuggestDocumentsResult<T>(
-        result
-      );
+      const modifiedResult =
+        utils.generatedSuggestDocumentsResultToPublicSuggestDocumentsResult<T>(result);
 
       return deserialize<SuggestDocumentsResult<Pick<T, Fields>>>(modifiedResult);
     } catch (e) {
       span.setStatus({
         code: SpanStatusCode.ERROR,
-        message: e.message
+        message: e.message,
       });
       throw e;
     } finally {
@@ -456,7 +472,7 @@ export class SearchClient<T> implements IndexDocumentsClient<T> {
     } catch (e) {
       span.setStatus({
         code: SpanStatusCode.ERROR,
-        message: e.message
+        message: e.message,
       });
       throw e;
     } finally {
@@ -492,7 +508,7 @@ export class SearchClient<T> implements IndexDocumentsClient<T> {
     } catch (e) {
       span.setStatus({
         code: SpanStatusCode.ERROR,
-        message: e.message
+        message: e.message,
       });
       throw e;
     } finally {
@@ -519,7 +535,7 @@ export class SearchClient<T> implements IndexDocumentsClient<T> {
     } catch (e) {
       span.setStatus({
         code: SpanStatusCode.ERROR,
-        message: e.message
+        message: e.message,
       });
       throw e;
     } finally {
@@ -547,7 +563,7 @@ export class SearchClient<T> implements IndexDocumentsClient<T> {
     } catch (e) {
       span.setStatus({
         code: SpanStatusCode.ERROR,
-        message: e.message
+        message: e.message,
       });
       throw e;
     } finally {
@@ -575,7 +591,7 @@ export class SearchClient<T> implements IndexDocumentsClient<T> {
     } catch (e) {
       span.setStatus({
         code: SpanStatusCode.ERROR,
-        message: e.message
+        message: e.message,
       });
       throw e;
     } finally {
@@ -624,7 +640,7 @@ export class SearchClient<T> implements IndexDocumentsClient<T> {
     } catch (e) {
       span.setStatus({
         code: SpanStatusCode.ERROR,
-        message: e.message
+        message: e.message,
       });
       throw e;
     } finally {
@@ -642,7 +658,7 @@ export class SearchClient<T> implements IndexDocumentsClient<T> {
     const payload = JSON.stringify({
       apiVersion: this.apiVersion,
       nextLink,
-      nextPageParameters
+      nextPageParameters,
     });
     return encode(payload);
   }
@@ -669,7 +685,7 @@ export class SearchClient<T> implements IndexDocumentsClient<T> {
 
       return {
         nextLink: result.nextLink,
-        nextPageParameters: result.nextPageParameters
+        nextPageParameters: result.nextPageParameters,
       };
     } catch (e) {
       throw new Error(`Corrupted or invalid continuation token: ${decodedToken}`);
@@ -689,9 +705,9 @@ export class SearchClient<T> implements IndexDocumentsClient<T> {
       operationOptions: {
         abortSignal,
         requestOptions,
-        tracingOptions
+        tracingOptions,
       },
-      restOptions
+      restOptions,
     };
   }
 

--- a/sdk/search/search-documents/src/searchIndexerClient.ts
+++ b/sdk/search/search-documents/src/searchIndexerClient.ts
@@ -1,12 +1,14 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { KeyCredential } from "@azure/core-auth";
+import { KeyCredential, TokenCredential, isTokenCredential } from "@azure/core-auth";
 import {
   createPipelineFromOptions,
   InternalPipelineOptions,
   operationOptionsToRequestOptionsBase,
-  PipelineOptions
+  PipelineOptions,
+  RequestPolicyFactory,
+  bearerTokenAuthenticationPolicy,
 } from "@azure/core-http";
 import { SpanStatusCode } from "@azure/core-tracing";
 import { SDK_VERSION } from "./constants";
@@ -35,11 +37,12 @@ import {
   CreateDataSourceConnectionOptions,
   DeleteDataSourceConnectionOptions,
   GetDataSourceConnectionOptions,
-  CreateorUpdateDataSourceConnectionOptions
+  CreateorUpdateDataSourceConnectionOptions,
 } from "./serviceModels";
 import * as utils from "./serviceUtils";
 import { createSpan } from "./tracing";
 import { odataMetadataPolicy } from "./odataMetadataPolicy";
+import { KnownSearchAudience } from "./searchAudience";
 
 /**
  * Client options used to configure Cognitive Search API requests.
@@ -49,6 +52,13 @@ export interface SearchIndexerClientOptions extends PipelineOptions {
    * The API version to use when communicating with the service.
    */
   apiVersion?: string;
+
+  /**
+   * The Audience to use for authentication with Azure Active Directory (AAD). The
+   * audience is not considered when using a shared key.
+   * {@link KnownSearchAudience} can be used interchangeably with audience
+   */
+  audience?: string;
 }
 
 /**
@@ -92,7 +102,7 @@ export class SearchIndexerClient {
    */
   constructor(
     endpoint: string,
-    credential: KeyCredential,
+    credential: KeyCredential | TokenCredential,
     options: SearchIndexerClientOptions = {}
   ) {
     this.endpoint = endpoint;
@@ -118,16 +128,21 @@ export class SearchIndexerClient {
             "OData-MaxVersion",
             "OData-Version",
             "Prefer",
-            "throttle-reason"
-          ]
-        }
-      }
+            "throttle-reason",
+          ],
+        },
+      },
     };
 
-    const pipeline = createPipelineFromOptions(
-      internalPipelineOptions,
-      createSearchApiKeyCredentialPolicy(credential)
-    );
+    const scope: string = options.audience
+      ? `${options.audience}/.default`
+      : `${KnownSearchAudience.AzurePublicCloud}/.default`;
+
+    const requestPolicyFactory: RequestPolicyFactory = isTokenCredential(credential)
+      ? bearerTokenAuthenticationPolicy(credential, scope)
+      : createSearchApiKeyCredentialPolicy(credential);
+
+    const pipeline = createPipelineFromOptions(internalPipelineOptions, requestPolicyFactory);
 
     if (Array.isArray(pipeline.requestPolicyFactories)) {
       pipeline.requestPolicyFactories.unshift(odataMetadataPolicy("minimal"));
@@ -136,7 +151,7 @@ export class SearchIndexerClient {
     let apiVersion = this.apiVersion;
 
     if (options.apiVersion) {
-      if (!["2020-06-30-Preview", "2020-06-30"].includes(options.apiVersion)) {
+      if (!["2020-06-30", "2021-04-30-Preview"].includes(options.apiVersion)) {
         throw new Error(`Invalid Api Version: ${options.apiVersion}`);
       }
       apiVersion = options.apiVersion;
@@ -159,7 +174,7 @@ export class SearchIndexerClient {
     } catch (e) {
       span.setStatus({
         code: SpanStatusCode.ERROR,
-        message: e.message
+        message: e.message,
       });
       throw e;
     } finally {
@@ -176,13 +191,13 @@ export class SearchIndexerClient {
     try {
       const result = await this.client.indexers.list({
         ...operationOptionsToRequestOptionsBase(updatedOptions),
-        select: "name"
+        select: "name",
       });
       return result.indexers.map((idx) => idx.name);
     } catch (e) {
       span.setStatus({
         code: SpanStatusCode.ERROR,
-        message: e.message
+        message: e.message,
       });
       throw e;
     } finally {
@@ -209,7 +224,7 @@ export class SearchIndexerClient {
     } catch (e) {
       span.setStatus({
         code: SpanStatusCode.ERROR,
-        message: e.message
+        message: e.message,
       });
       throw e;
     } finally {
@@ -231,13 +246,13 @@ export class SearchIndexerClient {
     try {
       const result = await this.client.dataSources.list({
         ...operationOptionsToRequestOptionsBase(updatedOptions),
-        select: "name"
+        select: "name",
       });
       return result.dataSources.map((ds) => ds.name);
     } catch (e) {
       span.setStatus({
         code: SpanStatusCode.ERROR,
-        message: e.message
+        message: e.message,
       });
       throw e;
     } finally {
@@ -261,7 +276,7 @@ export class SearchIndexerClient {
     } catch (e) {
       span.setStatus({
         code: SpanStatusCode.ERROR,
-        message: e.message
+        message: e.message,
       });
       throw e;
     } finally {
@@ -278,13 +293,13 @@ export class SearchIndexerClient {
     try {
       const result = await this.client.skillsets.list({
         ...operationOptionsToRequestOptionsBase(updatedOptions),
-        select: "name"
+        select: "name",
       });
       return result.skillsets.map((sks) => sks.name);
     } catch (e) {
       span.setStatus({
         code: SpanStatusCode.ERROR,
-        message: e.message
+        message: e.message,
       });
       throw e;
     } finally {
@@ -311,7 +326,7 @@ export class SearchIndexerClient {
     } catch (e) {
       span.setStatus({
         code: SpanStatusCode.ERROR,
-        message: e.message
+        message: e.message,
       });
       throw e;
     } finally {
@@ -341,7 +356,7 @@ export class SearchIndexerClient {
     } catch (e) {
       span.setStatus({
         code: SpanStatusCode.ERROR,
-        message: e.message
+        message: e.message,
       });
       throw e;
     } finally {
@@ -368,7 +383,7 @@ export class SearchIndexerClient {
     } catch (e) {
       span.setStatus({
         code: SpanStatusCode.ERROR,
-        message: e.message
+        message: e.message,
       });
       throw e;
     } finally {
@@ -395,7 +410,7 @@ export class SearchIndexerClient {
     } catch (e) {
       span.setStatus({
         code: SpanStatusCode.ERROR,
-        message: e.message
+        message: e.message,
       });
       throw e;
     } finally {
@@ -425,7 +440,7 @@ export class SearchIndexerClient {
     } catch (e) {
       span.setStatus({
         code: SpanStatusCode.ERROR,
-        message: e.message
+        message: e.message,
       });
       throw e;
     } finally {
@@ -452,7 +467,7 @@ export class SearchIndexerClient {
     } catch (e) {
       span.setStatus({
         code: SpanStatusCode.ERROR,
-        message: e.message
+        message: e.message,
       });
       throw e;
     } finally {
@@ -481,14 +496,14 @@ export class SearchIndexerClient {
         utils.publicSearchIndexerToGeneratedSearchIndexer(indexer),
         {
           ...operationOptionsToRequestOptionsBase(updatedOptions),
-          ifMatch: etag
+          ifMatch: etag,
         }
       );
       return utils.generatedSearchIndexerToPublicSearchIndexer(result);
     } catch (e) {
       span.setStatus({
         code: SpanStatusCode.ERROR,
-        message: e.message
+        message: e.message,
       });
       throw e;
     } finally {
@@ -517,14 +532,14 @@ export class SearchIndexerClient {
         utils.publicDataSourceToGeneratedDataSource(dataSourceConnection),
         {
           ...operationOptionsToRequestOptionsBase(updatedOptions),
-          ifMatch: etag
+          ifMatch: etag,
         }
       );
       return utils.generatedDataSourceToPublicDataSource(result);
     } catch (e) {
       span.setStatus({
         code: SpanStatusCode.ERROR,
-        message: e.message
+        message: e.message,
       });
       throw e;
     } finally {
@@ -553,7 +568,7 @@ export class SearchIndexerClient {
         utils.publicSkillsetToGeneratedSkillset(skillset),
         {
           ...operationOptionsToRequestOptionsBase(updatedOptions),
-          ifMatch: etag
+          ifMatch: etag,
         }
       );
 
@@ -561,7 +576,7 @@ export class SearchIndexerClient {
     } catch (e) {
       span.setStatus({
         code: SpanStatusCode.ERROR,
-        message: e.message
+        message: e.message,
       });
       throw e;
     } finally {
@@ -590,12 +605,12 @@ export class SearchIndexerClient {
 
       await this.client.indexers.delete(indexerName, {
         ...operationOptionsToRequestOptionsBase(updatedOptions),
-        ifMatch: etag
+        ifMatch: etag,
       });
     } catch (e) {
       span.setStatus({
         code: SpanStatusCode.ERROR,
-        message: e.message
+        message: e.message,
       });
       throw e;
     } finally {
@@ -628,12 +643,12 @@ export class SearchIndexerClient {
 
       await this.client.dataSources.delete(dataSourceConnectionName, {
         ...operationOptionsToRequestOptionsBase(updatedOptions),
-        ifMatch: etag
+        ifMatch: etag,
       });
     } catch (e) {
       span.setStatus({
         code: SpanStatusCode.ERROR,
-        message: e.message
+        message: e.message,
       });
       throw e;
     } finally {
@@ -662,12 +677,12 @@ export class SearchIndexerClient {
 
       await this.client.skillsets.delete(skillsetName, {
         ...operationOptionsToRequestOptionsBase(updatedOptions),
-        ifMatch: etag
+        ifMatch: etag,
       });
     } catch (e) {
       span.setStatus({
         code: SpanStatusCode.ERROR,
-        message: e.message
+        message: e.message,
       });
       throw e;
     } finally {
@@ -694,7 +709,7 @@ export class SearchIndexerClient {
     } catch (e) {
       span.setStatus({
         code: SpanStatusCode.ERROR,
-        message: e.message
+        message: e.message,
       });
       throw e;
     } finally {
@@ -717,7 +732,7 @@ export class SearchIndexerClient {
     } catch (e) {
       span.setStatus({
         code: SpanStatusCode.ERROR,
-        message: e.message
+        message: e.message,
       });
       throw e;
     } finally {
@@ -740,7 +755,7 @@ export class SearchIndexerClient {
     } catch (e) {
       span.setStatus({
         code: SpanStatusCode.ERROR,
-        message: e.message
+        message: e.message,
       });
       throw e;
     } finally {

--- a/sdk/search/search-documents/src/serialization.ts
+++ b/sdk/search/search-documents/src/serialization.ts
@@ -28,7 +28,7 @@ function walk(start: unknown, mapper: (val: any) => any): any {
   const seenMarker = new WeakMap<object, boolean>();
   const result = { value: undefined };
   const queue: { value: any; parent: any; key: string }[] = [
-    { value: start, parent: result, key: "value" }
+    { value: start, parent: result, key: "value" },
   ];
 
   while (queue.length) {
@@ -36,7 +36,7 @@ function walk(start: unknown, mapper: (val: any) => any): any {
 
     if (typeof current.value === "object" && current.value !== null) {
       if (seenMarker.has(current.value)) {
-        throw new Error("Cannot map a recusive structure.");
+        continue;
       } else {
         seenMarker.set(current.value, true);
       }
@@ -51,7 +51,7 @@ function walk(start: unknown, mapper: (val: any) => any): any {
         queue.push({
           value: mapped[key],
           parent: mapped,
-          key
+          key,
         });
       }
     }
@@ -132,7 +132,7 @@ function isGeoJSONPoint(obj: any): obj is GeoJSONPoint {
         default:
           return false;
       }
-    }
+    },
   });
 }
 
@@ -163,7 +163,7 @@ function isCrs(maybeCrs: any): boolean {
         default:
           return false;
       }
-    }
+    },
   });
 }
 
@@ -176,7 +176,7 @@ function isCrsProperties(maybeProperties: any): boolean {
       } else {
         return false;
       }
-    }
+    },
   });
 }
 

--- a/sdk/search/search-documents/src/synonymMapHelper.browser.ts
+++ b/sdk/search/search-documents/src/synonymMapHelper.browser.ts
@@ -1,0 +1,19 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { SynonymMap } from "./serviceModels";
+
+/**
+ * Helper method to create a SynonymMap object. This is a NodeJS only method.
+ * Will throw an error for browser.
+ *
+ * @param _name - Name of the SynonymMap.
+ * @param _filePath - Path of the file that contains the Synonyms (seperated by new lines)
+ * @returns SynonymMap object
+ */
+export async function createSynonymMapFromFile(
+  _name: string,
+  _filePath: string
+): Promise<SynonymMap> {
+  throw new Error("Not implemented for browser.");
+}

--- a/sdk/search/search-documents/src/synonymMapHelper.ts
+++ b/sdk/search/search-documents/src/synonymMapHelper.ts
@@ -1,0 +1,27 @@
+import { SynonymMap } from "./serviceModels";
+import { promisify } from "util";
+import * as fs from "fs";
+const readFileAsync = promisify(fs.readFile);
+
+/**
+ * Helper method to create a SynonymMap object. This is a NodeJS only method.
+ *
+ * @param name - Name of the SynonymMap.
+ * @param filePath - Path of the file that contains the Synonyms (seperated by new lines)
+ * @returns SynonymMap object
+ */
+export async function createSynonymMapFromFile(
+  name: string,
+  filePath: string
+): Promise<SynonymMap> {
+  const synonyms: string[] = (await readFileAsync(filePath, "utf-8"))
+    .replace(/\r/g, "")
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean);
+
+  return {
+    name,
+    synonyms,
+  };
+}

--- a/sdk/search/search-documents/test/internal/browser/synonymMap.browser.spec.ts
+++ b/sdk/search/search-documents/test/internal/browser/synonymMap.browser.spec.ts
@@ -1,0 +1,17 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { assert } from "chai";
+import { createSynonymMapFromFile } from "../../../src/synonymMapHelper.browser";
+
+describe("synonymmap", () => {
+  it("create synonymmap from file(browser)", async function () {
+    let errorThrown = false;
+    try {
+      await createSynonymMapFromFile("my-synonym-map-1", "./test/internal/synonymMap.txt");
+    } catch (ex) {
+      errorThrown = true;
+    }
+    assert.isTrue(errorThrown, "Expected createSynonymMapFromFile to fail with an exception");
+  });
+});

--- a/sdk/search/search-documents/test/internal/node/synonymMap.node.spec.ts
+++ b/sdk/search/search-documents/test/internal/node/synonymMap.node.spec.ts
@@ -1,0 +1,19 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { assert } from "chai";
+import { createSynonymMapFromFile } from "../../../src";
+import { SynonymMap } from "../../../src/serviceModels";
+
+describe("synonymmap", () => {
+  it("create synonymmap from file(node)", async function () {
+    const synonymMap: SynonymMap = await createSynonymMapFromFile(
+      "my-synonym-map-1",
+      "./test/internal/synonymMap.txt"
+    );
+    assert.equal(synonymMap.name, "my-synonym-map-1");
+    assert.equal(synonymMap.synonyms.length, 2);
+    assert.equal(synonymMap.synonyms[0], "United States, United States of America => USA");
+    assert.equal(synonymMap.synonyms[1], "Washington, Wash. => WA");
+  });
+});

--- a/sdk/search/search-documents/test/internal/serialization.spec.ts
+++ b/sdk/search/search-documents/test/internal/serialization.spec.ts
@@ -14,9 +14,31 @@ describe("serialization.serialize", () => {
   });
 
   it("circular", () => {
-    const circluarInput: any = { a: null };
-    circluarInput.a = circluarInput;
-    assert.throws(() => serialize(circluarInput));
+    const circularInput: any = { a: null };
+    circularInput.a = circularInput;
+    const result = serialize(circularInput);
+    assert.deepEqual(circularInput, result);
+  });
+
+  it("recursive 1", () => {
+    const child = { hello: "world" };
+    const documents = [
+      { id: "1", children: [child] },
+      { id: "2", children: [child] },
+    ];
+    const result = serialize(documents);
+    assert.deepEqual(documents, result);
+  });
+
+  it("recursive 2", () => {
+    const child = { hello: Infinity, world: -Infinity, universe: NaN };
+    const documents = [
+      { id: "1", children: [child] },
+      { id: "2", children: [child] },
+      { id: "3", children: [child] },
+    ];
+    const result = serialize(documents);
+    assert.deepEqual(documents, result);
   });
 
   it("NaN", () => {
@@ -47,9 +69,31 @@ describe("serialization.deserialize", () => {
   });
 
   it("circular", () => {
-    const circluarInput: any = { a: null };
-    circluarInput.a = circluarInput;
-    assert.throws(() => deserialize(circluarInput));
+    const circularInput: any = { a: null };
+    circularInput.a = circularInput;
+    const result = deserialize(circularInput);
+    assert.deepEqual(circularInput, result);
+  });
+
+  it("recursive 1", () => {
+    const child = { hello: "world" };
+    const documents = [
+      { id: "1", children: [child] },
+      { id: "2", children: [child] },
+    ];
+    const result = deserialize(documents);
+    assert.deepEqual(documents, result);
+  });
+
+  it("recursive 2", () => {
+    const child = { hello: "INF", world: "-INF", universe: "NaN" };
+    const documents = [
+      { id: "1", children: [child] },
+      { id: "2", children: [child] },
+      { id: "3", children: [child] },
+    ];
+    const result = deserialize(documents);
+    assert.deepEqual(documents, result);
   });
 
   it("NaN", () => {
@@ -95,8 +139,8 @@ describe("serialization.deserialize", () => {
       location: {
         type: "Point",
         coordinates: [-84.527771, 37.989769],
-        crs: { type: "name", properties: { name: "EPSG:4326" } }
-      }
+        crs: { type: "name", properties: { name: "EPSG:4326" } },
+      },
     });
     assert.instanceOf(result.location, GeographyPoint);
     assert.equal(result.location.latitude, 37.989769);

--- a/sdk/search/search-documents/test/internal/synonymMap.txt
+++ b/sdk/search/search-documents/test/internal/synonymMap.txt
@@ -1,0 +1,2 @@
+United States, United States of America => USA
+Washington, Wash. => WA


### PR DESCRIPTION
### Packages impacted by this PR
@azure/search-documents

### Issues associated with this PR
N/A

### Describe the problem that is addressed by this PR
We have released the `@azure/search-documents` SDK V 11.2.1 on August 2021. Now, the request has come to release 11.3.0. But, only 3 features must be included for this release:

1. TokenCredential AAD Support
2. National Cloud Support
3. Any Bug Fixes that went in after August 2021 

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?

So, I have branched off from the 11.2.1 code base and added the appropriate changes. This does not include any regenration or swagger changes.

### Are there test cases added in this PR? _(If not, why?)_
Wherever appropriate, I have modified the test cases to include changes. 

### Provide a list of related PRs _(if any)_
None

### Checklists
- [X ] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [X] Added a changelog (if necessary)

@xirzec @ShivangiReja Please review and approve the PR.
