### PR TITLE
[Event Hubs, Service Bus] Remove unnecessary dependency on `@types/long`

### DIFF
--- a/sdk/eventhub/event-hubs/package.json
+++ b/sdk/eventhub/event-hubs/package.json
@@ -139,7 +139,6 @@
     "@types/chai-as-promised": "^7.1.0",
     "@types/chai-string": "^1.4.1",
     "@types/debug": "^4.1.4",
-    "@types/long": "^4.0.1",
     "@types/mocha": "^7.0.2",
     "@types/node": "^12.0.0",
     "@types/sinon": "^9.0.4",

--- a/sdk/servicebus/service-bus/package.json
+++ b/sdk/servicebus/service-bus/package.json
@@ -116,7 +116,6 @@
     "@azure/core-xml": "^1.0.0",
     "@azure/logger": "^1.0.0",
     "@types/is-buffer": "^2.0.0",
-    "@types/long": "^4.0.1",
     "buffer": "^6.0.0",
     "is-buffer": "^2.0.3",
     "jssha": "^3.1.0",

--- a/sdk/servicebus/service-bus/review/service-bus.api.md
+++ b/sdk/servicebus/service-bus/review/service-bus.api.md
@@ -12,7 +12,7 @@ import { CommonClientOptions } from '@azure/core-client';
 import { delay } from '@azure/core-amqp';
 import { Delivery } from 'rhea-promise';
 import { HttpMethods } from '@azure/core-rest-pipeline';
-import { default as Long_2 } from 'long';
+import Long from 'long';
 import { MessagingError } from '@azure/core-amqp';
 import { NamedKeyCredential } from '@azure/core-auth';
 import { OperationOptions } from '@azure/core-client';
@@ -205,7 +205,7 @@ export function parseServiceBusConnectionString(connectionString: string): Servi
 
 // @public
 export interface PeekMessagesOptions extends OperationOptionsBase {
-    fromSequenceNumber?: Long_2;
+    fromSequenceNumber?: Long;
     // @beta
     omitMessageBody?: boolean;
 }
@@ -467,7 +467,7 @@ export interface ServiceBusReceivedMessage extends ServiceBusMessage {
     lockedUntilUtc?: Date;
     readonly lockToken?: string;
     readonly _rawAmqpMessage: AmqpAnnotatedMessage;
-    readonly sequenceNumber?: Long_2;
+    readonly sequenceNumber?: Long;
     readonly state: "active" | "deferred" | "scheduled";
 }
 
@@ -489,7 +489,7 @@ export interface ServiceBusReceiver {
     identifier: string;
     isClosed: boolean;
     peekMessages(maxMessageCount: number, options?: PeekMessagesOptions): Promise<ServiceBusReceivedMessage[]>;
-    receiveDeferredMessages(sequenceNumbers: Long_2 | Long_2[], options?: OperationOptionsBase): Promise<ServiceBusReceivedMessage[]>;
+    receiveDeferredMessages(sequenceNumbers: Long | Long[], options?: OperationOptionsBase): Promise<ServiceBusReceivedMessage[]>;
     receiveMessages(maxMessageCount: number, options?: ReceiveMessagesOptions): Promise<ServiceBusReceivedMessage[]>;
     receiveMode: "peekLock" | "receiveAndDelete";
     renewMessageLock(message: ServiceBusReceivedMessage): Promise<Date>;
@@ -517,13 +517,13 @@ export interface ServiceBusRuleManager {
 
 // @public
 export interface ServiceBusSender {
-    cancelScheduledMessages(sequenceNumbers: Long_2 | Long_2[], options?: OperationOptionsBase): Promise<void>;
+    cancelScheduledMessages(sequenceNumbers: Long | Long[], options?: OperationOptionsBase): Promise<void>;
     close(): Promise<void>;
     createMessageBatch(options?: CreateMessageBatchOptions): Promise<ServiceBusMessageBatch>;
     entityPath: string;
     identifier: string;
     isClosed: boolean;
-    scheduleMessages(messages: ServiceBusMessage | ServiceBusMessage[] | AmqpAnnotatedMessage | AmqpAnnotatedMessage[], scheduledEnqueueTimeUtc: Date, options?: OperationOptionsBase): Promise<Long_2[]>;
+    scheduleMessages(messages: ServiceBusMessage | ServiceBusMessage[] | AmqpAnnotatedMessage | AmqpAnnotatedMessage[], scheduledEnqueueTimeUtc: Date, options?: OperationOptionsBase): Promise<Long[]>;
     sendMessages(messages: ServiceBusMessage | ServiceBusMessage[] | ServiceBusMessageBatch | AmqpAnnotatedMessage | AmqpAnnotatedMessage[], options?: OperationOptionsBase): Promise<void>;
 }
 

--- a/sdk/servicebus/service-bus/test/public/sendAndSchedule.spec.ts
+++ b/sdk/servicebus/service-bus/test/public/sendAndSchedule.spec.ts
@@ -352,7 +352,7 @@ describe("Sender Tests", () => {
     compareSequenceNumbers(sequenceNumbers[0], sequenceNumbers[2]);
     compareSequenceNumbers(sequenceNumbers[1], sequenceNumbers[2]);
 
-    function compareSequenceNumbers(sequenceNumber1: Long.Long, sequenceNumber2: Long.Long): void {
+    function compareSequenceNumbers(sequenceNumber1: Long, sequenceNumber2: Long): void {
       should.equal(
         sequenceNumber1.compare(sequenceNumber2) !== 0,
         true,


### PR DESCRIPTION
### Packages impacted by this PR

- `@azure/event-hubs`
- `@azure/service-bus`

### Issues associated with this PR

- Fixes #22897

### Describe the problem that is addressed by this PR

`@types/long` is a stub type package. The `long` package provides its own type definitions, so the dependency on the type definitions package is unnecessary. This PR removes the unnecessary dependency.