### PR TITLE
[core-rest-pipeline] Fix issue with afterPhase policies getting run later than expected

### DIFF
--- a/sdk/core/core-rest-pipeline/src/pipeline.ts
+++ b/sdk/core/core-rest-pipeline/src/pipeline.ts
@@ -108,6 +108,7 @@ interface Phase {
   name: PipelinePhase | "None";
   policies: Set<PolicyGraphNode>;
   hasRun: boolean;
+  hasAfterPolicies: boolean;
 }
 
 /**
@@ -236,6 +237,7 @@ class HttpPipeline implements Pipeline {
         name,
         policies: new Set<PolicyGraphNode>(),
         hasRun: false,
+        hasAfterPolicies: false,
       };
     }
 
@@ -279,6 +281,7 @@ class HttpPipeline implements Pipeline {
       };
       if (options.afterPhase) {
         node.afterPhase = getPhase(options.afterPhase);
+        node.afterPhase.hasAfterPolicies = true;
       }
       policyMap.set(policyName, node);
       const phase = getPhase(options.phase);
@@ -357,6 +360,11 @@ class HttpPipeline implements Pipeline {
           }
           // Don't proceed to the next phase until this phase finishes.
           return;
+        }
+
+        if (phase.hasAfterPolicies) {
+          // Run any policies unblocked by this phase
+          walkPhase(noPhase);
         }
       }
     }

--- a/sdk/core/core-rest-pipeline/test/pipeline.spec.ts
+++ b/sdk/core/core-rest-pipeline/test/pipeline.spec.ts
@@ -423,4 +423,20 @@ describe("HttpsPipeline", function () {
     const policies = pipeline.getOrderedPolicies();
     assert.deepStrictEqual(policies, [testPolicy]);
   });
+
+  it("afterPhase respects phase ordering", function () {
+    const pipeline = createEmptyPipeline();
+    const testPolicy: PipelinePolicy = {
+      sendRequest: (request, next) => next(request),
+      name: "test",
+    };
+    const testPolicy2: PipelinePolicy = {
+      sendRequest: (request, next) => next(request),
+      name: "test2",
+    };
+    pipeline.addPolicy(testPolicy, { afterPhase: "Retry" });
+    pipeline.addPolicy(testPolicy2, { phase: "Sign" });
+    const policies = pipeline.getOrderedPolicies();
+    assert.deepStrictEqual(policies, [testPolicy, testPolicy2]);
+  });
 });


### PR DESCRIPTION
### Packages impacted by this PR

`@azure/core-rest-pipeline`

### Describe the problem that is addressed by this PR

Policies using 'afterPhase' would get executed later than expected due to `noPhase` not getting run again until the full phase walk finished.

### Are there test cases added in this PR?

Yes
