### PR TITLE
[engsys] Remove unused `@types/inquirer` dependency from api-management-custom-widgets-tools

### DIFF
--- a/sdk/apimanagement/api-management-custom-widgets-tools/package.json
+++ b/sdk/apimanagement/api-management-custom-widgets-tools/package.json
@@ -65,7 +65,6 @@
     "@types/mime": "~2.0.3",
     "@types/node": "^12.0.0",
     "@types/glob": "^7.1.1",
-    "@types/inquirer": "^8.2.1",
     "@types/yargs": "^17.0.10",
     "@types/yargs-parser": "^21.0.0",
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",


### PR DESCRIPTION
### Packages impacted by this PR

- `@azure/api-management-custom-widgets-tools`

### Issues associated with this PR

- Fixes #22842 

### Describe the problem that is addressed by this PR

Removes type definition dependency that is unused (there's no corresponding dependency on the actual `inquirer` package and no references to the types in the code.