### PR TITLE
[recorder] Throw error if RECORDINGS_RELATIVE_PATH not set in browser

### DIFF
--- a/sdk/test-utils/recorder/CHANGELOG.md
+++ b/sdk/test-utils/recorder/CHANGELOG.md
@@ -21,6 +21,7 @@
 ### Other Changes
 
 - Improved formatting of error messages returned by the test proxy. [#21575](https://github.com/Azure/azure-sdk-for-js/pull/21575)
+- An error is now thrown if the RECORDINGS_RELATIVE_PATH is not set in browser mode. [#23057](https://github.com/Azure/azure-sdk-for-js/pull/23057)
 
 ## 2.0.0 (2022-04-11)
 

--- a/sdk/test-utils/recorder/src/utils/sessionFilePath.ts
+++ b/sdk/test-utils/recorder/src/utils/sessionFilePath.ts
@@ -8,7 +8,17 @@ import { relativeRecordingsPath } from "./relativePathCalculator";
 import { RecorderError } from "./utils";
 
 export function sessionFilePath(testContext: Mocha.Test): string {
-  const recordingsFolder = !isNode ? env.RECORDINGS_RELATIVE_PATH : relativeRecordingsPath(); // sdk/service/project/recordings
+  let recordingsFolder: string;
+  if (isNode) {
+    recordingsFolder = relativeRecordingsPath(); // sdk/service/project/recordings
+  } else if (env.RECORDINGS_RELATIVE_PATH) {
+    recordingsFolder = env.RECORDINGS_RELATIVE_PATH;
+  } else {
+    throw new RecorderError(
+      "RECORDINGS_RELATIVE_PATH was not set while in browser mode. Ensure that process.env.RELATIVE_RECORDINGS_PATH has been set properly in your Karma configuration."
+    );
+  }
+
   return `${recordingsFolder}/${recordingFilePath(testContext)}`;
   // sdk/service/project/recordings/{node|browsers}/<describe-block-title>/recording_<test-title>.json
 }


### PR DESCRIPTION
### Packages impacted by this PR

- `@azure-tools/test-recorder`

### Issues associated with this PR

- Fixes #22800 

### Describe the problem that is addressed by this PR

For recorded browser tests to work, the `RECORDINGS_RELATIVE_PATH` environment variable needs to be set programmatically in the Karma configuration (as detailed in the [recorder migration guide]). The recorder does not throw if the environment variable is not set, and instead uses `undefined`. This causes browser recordings to be saved in a directory named 'undefined' at the SDK root, which is both confusing and incorrect. This PR makes the recorder throw an error if `RECORDINGS_RELATIVE_PATH` is left undefined, making it easier for users to diagnose and resolve the issue.

[recorder migration guide]: https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/test-utils/recorder/MIGRATION.md#browser-tests-and-modifications-to-karma-configuration