### PR TITLE
[engsys] remove typedoc dependency and usage

### DIFF
--- a/sdk/communication/communication-job-router/package.json
+++ b/sdk/communication/communication-job-router/package.json
@@ -30,8 +30,7 @@
     "test:node": "npm run build:test && npm run unit-test:node && npm run integration-test:node",
     "unit-test:browser": "dev-tool run test:browser",
     "unit-test:node": "dev-tool run test:node-ts-input -- --timeout 1200000 --exclude 'test/**/browser/*.spec.ts' 'test/**/*.spec.ts'",
-    "unit-test": "npm run unit-test:node && npm run unit-test:browser",
-    "docs": "typedoc --excludePrivate --excludeNotExported --excludeExternals --stripInternal --mode file --out ./dist/docs ./src"
+    "unit-test": "npm run unit-test:node && npm run unit-test:browser"
   },
   "files": [
     "dist/",
@@ -125,7 +124,6 @@
     "rollup": "^1.16.3",
     "sinon": "^9.0.2",
     "typescript": "~4.2.0",
-    "util": "^0.12.1",
-    "typedoc": "0.15.2"
+    "util": "^0.12.1"
   }
 }


### PR DESCRIPTION
We have tool to generate docs in ci pipelines. Individual package shouldn't need
to generate docs any more.


### Packages impacted by this PR
commmunication-job-router

### Issues associated with this PR
#23038 
