### PR TITLE
[notification hubs] Remove core-util from SAS generation

### DIFF
--- a/sdk/notificationhubs/notification-hubs/package.json
+++ b/sdk/notificationhubs/notification-hubs/package.json
@@ -136,7 +136,6 @@
   },
   "dependencies": {
     "@azure/abort-controller": "^1.1.0",
-    "@azure/core-auth": "^1.4.0",
     "@azure/core-client": "^1.6.1",
     "@azure/core-paging": "^1.3.0",
     "@azure/core-rest-pipeline": "^1.8.1",

--- a/sdk/notificationhubs/notification-hubs/src/auth/hmacSha256.browser.ts
+++ b/sdk/notificationhubs/notification-hubs/src/auth/hmacSha256.browser.ts
@@ -1,68 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-// stubs for browser self.crypto
-interface JsonWebKey {}
-
-interface CryptoKey {}
-
-type KeyUsage =
-  | "decrypt"
-  | "deriveBits"
-  | "deriveKey"
-  | "encrypt"
-  | "sign"
-  | "unwrapKey"
-  | "verify"
-  | "wrapKey";
-
-interface Algorithm {
-  name: string;
-}
-
-interface SubtleCrypto {
-  importKey(
-    format: string,
-    keyData: JsonWebKey,
-    algorithm: HmacImportParams,
-    extractable: boolean,
-    usage: KeyUsage[]
-  ): Promise<CryptoKey>;
-  sign(
-    algorithm: HmacImportParams,
-    key: CryptoKey,
-    data: ArrayBufferView | ArrayBuffer
-  ): Promise<ArrayBuffer>;
-  digest(algorithm: Algorithm, data: ArrayBufferView | ArrayBuffer): Promise<ArrayBuffer>;
-}
-
-interface Crypto {
-  readonly subtle: SubtleCrypto;
-  getRandomValues<T extends ArrayBufferView | null>(array: T): T;
-}
-
-declare const self: {
-  crypto: Crypto;
-};
-
-interface HmacImportParams {
-  name: string;
-  hash: Algorithm;
-  length?: number;
-}
-
-// stubs for browser TextEncoder
-interface TextEncoder {
-  encode(input?: string): Uint8Array;
-}
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-declare const TextEncoder: {
-  prototype: TextEncoder;
-  new (): TextEncoder;
-};
-
-declare function btoa(str: string | Buffer): string;
+/// <reference lib="dom" />
 
 export async function signString(key: string, toSign: string): Promise<string> {
   const enc = new TextEncoder();


### PR DESCRIPTION
### Packages impacted by this PR

- [notification hubs]

### Issues associated with this PR

- #23065

### Describe the problem that is addressed by this PR

The methods used in the SAS token generation were not needed as the SAS Connection String does not vary per Notification Hubs.  This removes the issue that happened with core-util having an unpublished function.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
