### PR TITLE
[notification hubs] Fix empty registration feed bug

### DIFF
--- a/sdk/notificationhubs/notification-hubs/src/serializers/registrationSerializer.ts
+++ b/sdk/notificationhubs/notification-hubs/src/serializers/registrationSerializer.ts
@@ -187,7 +187,11 @@ export const registrationDescriptionParser: RegistrationDescriptionParser = {
    */
   async parseRegistrationFeed(bodyText: string): Promise<RegistrationDescription[]> {
     const xml = await parseXML(bodyText, { includeRoot: true });
-    const results = [];
+    const results: RegistrationDescription[] = [];
+    if (!isDefined(xml.feed.entry)) {
+      return results;
+    }
+
     for (const entry of xml.feed.entry) {
       delete entry.content["$"];
 

--- a/sdk/notificationhubs/notification-hubs/test/internal/unit/registrationSerializer.spec.ts
+++ b/sdk/notificationhubs/notification-hubs/test/internal/unit/registrationSerializer.spec.ts
@@ -491,6 +491,14 @@ const REGISTRATION_FEED = `<?xml version="1.0" encoding="utf-8" ?>
   </entry>
 </feed>`;
 
+const EMPTY_REGISTRATION_FEED = `<?xml version="1.0" encoding="utf-8" ?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title type="text">Registrations</title>
+  <id>https://testns.servicebus.windows.net/testhub/registrations/?api-version=2020-06</id>
+  <updated>2022-09-06T20:06:33Z</updated>
+  <link rel="self" href="https://testns.servicebus.windows.net/testhub/registrations/?api-version=2020-06" />
+</feed>`;
+
 describe("parseRegistrationFeed", () => {
   it("should parse a registration feed", async () => {
     const registrations = await registrationDescriptionParser.parseRegistrationFeed(
@@ -508,6 +516,14 @@ describe("parseRegistrationFeed", () => {
     assert.equal(appleRegistration.registrationId, "{Registration Id}");
     assert.equal(appleRegistration.deviceToken, "{DeviceToken}");
     assert.deepEqual(appleRegistration.tags, ["myTag", "myOtherTag"]);
+  });
+
+  it("should parse an empty feed", async () => {
+    const registrations = await registrationDescriptionParser.parseRegistrationFeed(
+      EMPTY_REGISTRATION_FEED
+    );
+
+    assert.equal(registrations.length, 0);
   });
 });
 


### PR DESCRIPTION
### Packages impacted by this PR

- [notification hubs]

### Issues associated with this PR

- #23089

### Describe the problem that is addressed by this PR

Fixes an issue if there are no registration entries that an empty collection is returned.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?

This checks if the `feed.entry` list is undefined and returns an empty list if undefined.

### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
