### PR TITLE
[Language Text] Rename cancelOperation to sendCancellationRequest

### DIFF
--- a/sdk/cognitivelanguage/ai-language-text/CHANGELOG.md
+++ b/sdk/cognitivelanguage/ai-language-text/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Breaking Changes
 
 - `AnalyzeBatchPoller` has been updated by removing `isStarted`, `isCanceled`, and `isCompleted`.
+- `cancelOperation` in `AnalyzeBatchPoller` has been renamed to `sendCancellationRequest`.
 - Extractive Summarization action has been removed because it is still in beta. Use @azure/ai-language-text@1.0.0-beta.1 to access this feature.
 - FHIR has been removed from healthcare actions because it is still in beta. Use @azure/ai-language-text@1.0.0-beta.1 to access this feature.
 - `apiVersion` option in the client class constructor options bag has been renamed to `serviceVersion`.

--- a/sdk/cognitivelanguage/ai-language-text/review/ai-language-text.api.md
+++ b/sdk/cognitivelanguage/ai-language-text/review/ai-language-text.api.md
@@ -754,7 +754,7 @@ export interface PiiEntityRecognitionSuccessResult extends TextAnalysisSuccessRe
 
 // @public
 export interface PollerLike<TState extends OperationState<TResult>, TResult> extends SimplePollerLike<TState, TResult> {
-    cancelOperation: () => Promise<void>;
+    sendCancellationRequest: () => Promise<void>;
 }
 
 // @public

--- a/sdk/cognitivelanguage/ai-language-text/src/lro.ts
+++ b/sdk/cognitivelanguage/ai-language-text/src/lro.ts
@@ -298,7 +298,7 @@ export function createPollerWithCancellation(settings: {
   const { client, options, poller, id, tracing } = settings;
   return {
     ...poller,
-    cancelOperation: async () => {
+    sendCancellationRequest: async () => {
       await tracing.withSpan(`${clientName}.beginAnalyzeBatch`, options, async (finalOptions) =>
         throwError(
           getRawResponse(

--- a/sdk/cognitivelanguage/ai-language-text/src/models.ts
+++ b/sdk/cognitivelanguage/ai-language-text/src/models.ts
@@ -947,5 +947,5 @@ export interface PollerLike<TState extends OperationState<TResult>, TResult>
   /**
    * sends a cancellation request.
    */
-  cancelOperation: () => Promise<void>;
+  sendCancellationRequest: () => Promise<void>;
 }

--- a/sdk/cognitivelanguage/ai-language-text/test/public/analyzeBatch.spec.ts
+++ b/sdk/cognitivelanguage/ai-language-text/test/public/analyzeBatch.spec.ts
@@ -858,7 +858,7 @@ matrix([["APIKey", "AAD"]] as const, async (authMethod: AuthMethod) => {
           const pollPromise = poller.pollUntilDone();
           poller.onProgress(async (state) => {
             if (state.actionInProgressCount < actions.length) {
-              await poller.cancelOperation();
+              await poller.sendCancellationRequest();
             }
           });
           await assert.isRejected(pollPromise, /Operation was canceled/);


### PR DESCRIPTION
Rename `cancelOperation` to `sendCancellationRequest` after offline discussion with the JS architect.

EDIT: I created https://github.com/Azure/azure-sdk-for-js/issues/23138 to track whether to add a `cancelOperation` in the future.