### PR TITLE
[ServiceBus] Pass timeout to server when accepting next session

### DIFF
--- a/sdk/servicebus/service-bus/src/core/shared.ts
+++ b/sdk/servicebus/service-bus/src/core/shared.ts
@@ -77,6 +77,8 @@ export function onMessageSettled(
   }
 }
 
+// Placed in Service Bus for now and can be promoted to core-amqp if also useful for Event Hubs in the future.
+const timeoutName = `${Constants.vendorString}:timeout`;
 /**
  * Creates the options that need to be specified while creating an AMQP receiver link.
  *
@@ -87,8 +89,13 @@ export function createReceiverOptions(
   receiveMode: ReceiveMode,
   source: Source,
   clientId: string,
-  handlers: ReceiverHandlers
+  handlers: ReceiverHandlers,
+  timeoutInMs?: number
 ): ReceiverOptions {
+  const properties =
+    timeoutInMs !== undefined
+      ? { [Constants.receiverIdentifierName]: clientId, [timeoutName]: timeoutInMs }
+      : { [Constants.receiverIdentifierName]: clientId };
   const rcvrOptions: ReceiverOptions = {
     name,
     // "autoaccept" being true in the "receiveAndDelete" mode sets the "settled" flag to true on the deliveries
@@ -101,7 +108,7 @@ export function createReceiverOptions(
     source,
     target: clientId,
     credit_window: 0,
-    properties: { [Constants.receiverIdentifierName]: clientId },
+    properties,
     ...handlers,
   };
 

--- a/sdk/servicebus/service-bus/src/serviceBusClient.ts
+++ b/sdk/servicebus/service-bus/src/serviceBusClient.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { ConnectionConfig, Constants } from "@azure/core-amqp";
+import { ConnectionConfig } from "@azure/core-amqp";
 import { TokenCredential, NamedKeyCredential, SASCredential } from "@azure/core-auth";
 import {
   ServiceBusClientOptions,
@@ -438,19 +438,6 @@ export class ServiceBusClient {
       options3
     );
 
-    const operationTimeout =
-      this._clientOptions?.retryOptions?.timeoutInMs ?? Constants.defaultOperationTimeoutInMs;
-    // The number of milliseconds to use as the basis for calculating a random jitter amount
-    // opening receiver links. This is intended to ensure that multiple
-    // session operations don't timeout at the same exact moment.
-    const jitterBaseInMs = Math.min(operationTimeout * 0.01, 100);
-    // Subtract a random amount up to 100ms from the operation timeout as the jitter when attempting to open next available session link.
-    // This prevents excessive resource usage when using high amounts of concurrency and accepting the next available session.
-    // Take the min of 1% of the total timeout and the base jitter amount so that we don't end up subtracting more than 1% of the total timeout.
-    const timeoutWithJitterInMs = operationTimeout - jitterBaseInMs * Math.random();
-    // We set the operation timeout on the properties not only to include the jitter, but also because the server will otherwise
-    // restrict the maximum timeout to 1 minute and 5 seconds, regardless of the client timeout. We only do this for accepting next available
-    // session as this is the only long-polling scenario.
     const messageSession = await MessageSession.create(
       ensureValidIdentifier(entityPath, options?.identifier),
       this._connectionContext,
@@ -460,7 +447,7 @@ export class ServiceBusClient {
         maxAutoLockRenewalDurationInMs: options?.maxAutoLockRenewalDurationInMs,
         receiveMode,
         abortSignal: options?.abortSignal,
-        retryOptions: { ...this._clientOptions.retryOptions, timeoutInMs: timeoutWithJitterInMs },
+        retryOptions: this._clientOptions.retryOptions,
         skipParsingBodyAsJson: options?.skipParsingBodyAsJson ?? false,
       }
     );


### PR DESCRIPTION
This is ported from .NET PR https://github.com/Azure/azure-sdk-for-net/pull/30963

The service hardcodes a max of 1 minute and 5 seconds when accepting a session. This means the retry timeout the user specifies in the client is ignored if they specify a value higher than this. We should specify the timeout property in the link settings properties when opening a link for next available session to support long polling.

### Packages impacted by this PR
`@azure/service-bus`

### Issues associated with this PR
#23118 
