### PR TITLE
[Core,AbortController] support `AbortSignal.reason` and `AbortSignal.throwIfAborted()`

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -15997,7 +15997,7 @@ packages:
     dev: false
 
   file:projects/core-http.tgz:
-    resolution: {integrity: sha512-N01s8G0U7FDaKX51dr+TKxoqjN/sW/9yvfa1WPb+krcdlYj/HTvhfmWzSf0IymbgYWqbBkorNyHqRanOMySLBA==, tarball: file:projects/core-http.tgz}
+    resolution: {integrity: sha512-Ow99GS+DT8qWCkxDFFB3WTplq7iiCecGme2oFQM3DBCem2QN/WzKE62ohKkLe2tHXFSMCay7/QGl8RgcCL3cpQ==, tarball: file:projects/core-http.tgz}
     name: '@rush-temp/core-http'
     version: 0.0.0
     dependencies:
@@ -16043,10 +16043,10 @@ packages:
       shx: 0.3.4
       sinon: 9.2.4
       tough-cookie: 4.1.2
-      ts-node: 10.9.1_b5bd4a8e238709e15d0171692055b18b
+      ts-node: 10.9.1_f73aca07a5ebb34bfc1f3abee339dfba
       tslib: 2.4.0
       tunnel: 0.0.6
-      typescript: 4.6.4
+      typescript: 4.8.3
       uglify-js: 3.17.0
       uuid: 8.3.2
       xhr-mock: 2.5.1
@@ -16136,7 +16136,7 @@ packages:
     dev: false
 
   file:projects/core-rest-pipeline.tgz:
-    resolution: {integrity: sha512-LnUhzRQ6t3pPy65pSTXa7e3dhpzj2vytYtyHRuslLDNHdNvxGmwKBT7hjnW9aX8Zym+7bKtFhgYKFxnkyhUl8w==, tarball: file:projects/core-rest-pipeline.tgz}
+    resolution: {integrity: sha512-gRMYvYuwLY4nkzI2vQ/V2JCJNiuAk3PheGzAsIAsNy2v9cs0N6VNNgEM0VVzjCenZz7pCNN9PasHJE3WuMPbtw==, tarball: file:projects/core-rest-pipeline.tgz}
     name: '@rush-temp/core-rest-pipeline'
     version: 0.0.0
     dependencies:
@@ -16176,7 +16176,7 @@ packages:
       sinon: 9.2.4
       source-map-support: 0.5.21
       tslib: 2.4.0
-      typescript: 4.6.4
+      typescript: 4.8.3
       util: 0.12.4
       uuid: 8.3.2
     transitivePeerDependencies:

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -10002,7 +10002,7 @@ packages:
     dev: false
 
   file:projects/app-configuration.tgz:
-    resolution: {integrity: sha512-kOkIGSYiBZ5Xrta9Iwhz788p5QSt6g8JcQ6BrMR0DijPqxSW6vNmD8qhIEplvWXu9n6RNdAXcV0R9FU9YNtl2Q==, tarball: file:projects/app-configuration.tgz}
+    resolution: {integrity: sha512-v8kFG5tbVb1pzprfr5w0Uo+DWn14H0YbAJyHg6+QukIbjd+FIzwzyp2s2/o3mU/KL0kkBZ5BZn0LcdOhn4FixQ==, tarball: file:projects/app-configuration.tgz}
     name: '@rush-temp/app-configuration'
     version: 0.0.0
     dependencies:
@@ -18527,7 +18527,7 @@ packages:
     dev: false
 
   file:projects/storage-blob.tgz:
-    resolution: {integrity: sha512-RJu7eKVpXWjwSVT0fXR6oTPLtQ5omcoo4L+yIXWqxU2uSNpkeZ+yLXCoE9h1xUDOTG3RK9IjsNxpEzUSW2GsUQ==, tarball: file:projects/storage-blob.tgz}
+    resolution: {integrity: sha512-OdsJUy/H6J8h09Tca5FynvmlPa7pcejkVlnWBTnO/VOqcr2ebqORUALqdmAoasEb00+mSfAAPnPMwg55vwvM6g==, tarball: file:projects/storage-blob.tgz}
     name: '@rush-temp/storage-blob'
     version: 0.0.0
     dependencies:
@@ -18568,9 +18568,9 @@ packages:
       puppeteer: 14.4.1
       rimraf: 3.0.2
       source-map-support: 0.5.21
-      ts-node: 10.9.1_b5bd4a8e238709e15d0171692055b18b
+      ts-node: 10.9.1_f73aca07a5ebb34bfc1f3abee339dfba
       tslib: 2.4.0
-      typescript: 4.6.4
+      typescript: 4.8.3
       util: 0.12.4
     transitivePeerDependencies:
       - '@swc/core'
@@ -18694,7 +18694,7 @@ packages:
     dev: false
 
   file:projects/storage-internal-avro.tgz:
-    resolution: {integrity: sha512-C2HBOVOkL6RFML/+TWUeIY+Lj24L01+m1MKbo48O/Rh3X9FAmt/meR9zw0sp1xN53e+LKjXEr5Ri8pAOI2IjFQ==, tarball: file:projects/storage-internal-avro.tgz}
+    resolution: {integrity: sha512-JP+bcdVAOrkoONKHbUoBtiVxHqPFmzVY+9Pb8LPthqamLruQoPvLWuDDwtEgaca1BhtSNhYhba7uoKnxLjYByQ==, tarball: file:projects/storage-internal-avro.tgz}
     name: '@rush-temp/storage-internal-avro'
     version: 0.0.0
     dependencies:
@@ -18730,9 +18730,9 @@ packages:
       puppeteer: 14.4.1
       rimraf: 3.0.2
       source-map-support: 0.5.21
-      ts-node: 10.9.1_b5bd4a8e238709e15d0171692055b18b
+      ts-node: 10.9.1_f73aca07a5ebb34bfc1f3abee339dfba
       tslib: 2.4.0
-      typescript: 4.6.4
+      typescript: 4.8.3
       util: 0.12.4
     transitivePeerDependencies:
       - '@swc/core'

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -2993,7 +2993,7 @@ packages:
     dev: false
 
   /array-flatten/1.1.1:
-    resolution: {integrity: sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==}
+    resolution: {integrity: sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=}
     dev: false
 
   /array-includes/3.1.5:
@@ -3248,7 +3248,7 @@ packages:
     dev: false
 
   /buffer-equal-constant-time/1.0.1:
-    resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
+    resolution: {integrity: sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk=}
     dev: false
 
   /buffer-from/1.1.2:
@@ -3398,7 +3398,7 @@ packages:
     dev: false
 
   /charenc/0.0.2:
-    resolution: {integrity: sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==}
+    resolution: {integrity: sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc=}
     dev: false
 
   /check-error/1.0.2:
@@ -3532,7 +3532,7 @@ packages:
     dev: false
 
   /concat-map/0.0.1:
-    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+    resolution: {integrity: sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=}
     dev: false
 
   /concurrently/6.5.1:
@@ -3595,7 +3595,7 @@ packages:
     dev: false
 
   /cookie-signature/1.0.6:
-    resolution: {integrity: sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==}
+    resolution: {integrity: sha1-4wOogrNCzD7oylE6eZmXNNqzriw=}
     dev: false
 
   /cookie/0.4.2:
@@ -3697,7 +3697,7 @@ packages:
     dev: false
 
   /crypt/0.0.2:
-    resolution: {integrity: sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==}
+    resolution: {integrity: sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs=}
     dev: false
 
   /csv-parse/5.3.0:
@@ -3951,7 +3951,7 @@ packages:
     dependencies:
       semver: 7.3.7
       shelljs: 0.8.5
-      typescript: 4.9.0-dev.20220912
+      typescript: 4.9.0-dev.20220915
     dev: false
 
   /ecdsa-sig-formatter/1.0.11:
@@ -3961,11 +3961,11 @@ packages:
     dev: false
 
   /edge-launcher/1.2.2:
-    resolution: {integrity: sha512-JcD5WBi3BHZXXVSSeEhl6sYO8g5cuynk/hifBzds2Bp4JdzCGLNMHgMCKu5DvrO1yatMgF0goFsxXRGus0yh1g==}
+    resolution: {integrity: sha1-60Cq+9Bnpup27/+rBke81VCbN7I=}
     dev: false
 
   /ee-first/1.1.1:
-    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
+    resolution: {integrity: sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=}
     dev: false
 
   /electron-to-chromium/1.4.247:
@@ -4849,7 +4849,7 @@ packages:
     dev: false
 
   /fresh/0.5.2:
-    resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}
+    resolution: {integrity: sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=}
     engines: {node: '>= 0.6'}
     dev: false
 
@@ -4989,7 +4989,7 @@ packages:
     dev: false
 
   /github-from-package/0.0.0:
-    resolution: {integrity: sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==}
+    resolution: {integrity: sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4=}
     dev: false
 
   /glob-parent/5.1.2:
@@ -6386,7 +6386,7 @@ packages:
     dev: false
 
   /media-typer/0.3.0:
-    resolution: {integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==}
+    resolution: {integrity: sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=}
     engines: {node: '>= 0.6'}
     dev: false
 
@@ -6396,7 +6396,7 @@ packages:
     dev: false
 
   /merge-descriptors/1.0.1:
-    resolution: {integrity: sha512-cCi6g3/Zr1iqQi6ySbseM1Xvooa98N0w31jzUYrXPX2xqObmFGHJ0tQ5u74H3mVh7wLouTseZyYIq39g8cNp1w==}
+    resolution: {integrity: sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=}
     dev: false
 
   /merge-source-map/1.1.0:
@@ -6817,7 +6817,7 @@ packages:
     dev: false
 
   /noms/0.0.0:
-    resolution: {integrity: sha512-lNDU9VJaOPxUmXcLb+HQFeUgQQPtMI24Gt6hgfuMHRJgMRHMF/qZ4HJD3GDru4sSw9IQl2jPjAYnQrdIeLbwow==}
+    resolution: {integrity: sha1-2o69nzr51nYJGbJ9nNyAkqczKFk=}
     dependencies:
       inherits: 2.0.4
       readable-stream: 1.0.34
@@ -8883,8 +8883,8 @@ packages:
     hasBin: true
     dev: false
 
-  /typescript/4.9.0-dev.20220912:
-    resolution: {integrity: sha512-B1WnNBtZgqkG48/Z1v4VQWxZSjJl+iJdgafU/8mLFOZyinS5Jejz04TucADMOTufHaIc4USMcYALrAg03Twg1A==}
+  /typescript/4.9.0-dev.20220915:
+    resolution: {integrity: sha512-LF91yAKWayNiea7oza0gyHyPEVIkorxhbjWV6k/nDtseepQxGM8MZVjKGFleko0Ve4Fha8vQhnxRPkF8NftIHA==}
     engines: {node: '>=4.2.0'}
     hasBin: true
     dev: false
@@ -9007,7 +9007,7 @@ packages:
     dev: false
 
   /utils-merge/1.0.1:
-    resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
+    resolution: {integrity: sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=}
     engines: {node: '>= 0.4.0'}
     dev: false
 
@@ -9439,7 +9439,7 @@ packages:
     dev: false
 
   file:projects/abort-controller.tgz:
-    resolution: {integrity: sha512-iZ7aJXlaj+pycKC8gu2w6clXeEfFrqK9jteeEu+3CtzAfYbn9QJLuA/fDCjje7rLkpL5jb/29J4j/m+t6fZVhQ==, tarball: file:projects/abort-controller.tgz}
+    resolution: {integrity: sha512-cbLtGuGxjb5UjT1uogw5yxJix1xgQIbkHX409ZkUY2dOJp+XRwvld9uC/iZg8xtXbUtvLLPVTqbIbuSbzmFXRg==, tarball: file:projects/abort-controller.tgz}
     name: '@rush-temp/abort-controller'
     version: 0.0.0
     dependencies:
@@ -9467,9 +9467,9 @@ packages:
       nyc: 15.1.0
       prettier: 2.7.1
       rimraf: 3.0.2
-      ts-node: 10.9.1_b5bd4a8e238709e15d0171692055b18b
+      ts-node: 10.9.1_f73aca07a5ebb34bfc1f3abee339dfba
       tslib: 2.4.0
-      typescript: 4.6.4
+      typescript: 4.8.3
     transitivePeerDependencies:
       - '@swc/core'
       - '@swc/wasm'
@@ -10790,7 +10790,7 @@ packages:
     dev: false
 
   file:projects/arm-chaos.tgz:
-    resolution: {integrity: sha512-MsUqKhZRz/N+z9NC1YYRwfPG2mSfZ4aUMCk9SGJrfJFGkShEp0UD3ElcLfi5AabL1ZXPT0L4EZKOT5PfvxC3bg==, tarball: file:projects/arm-chaos.tgz}
+    resolution: {integrity: sha512-Os8pMeUKWkeL03AHySA5scua/kJrrBFs4eHqqZJqSYnLwWMcIHI4gexC+64ARilvJ0Q6UUcmUpDWkJ2g6FHCiQ==, tarball: file:projects/arm-chaos.tgz}
     name: '@rush-temp/arm-chaos'
     version: 0.0.0
     dependencies:
@@ -17986,7 +17986,7 @@ packages:
     dev: false
 
   file:projects/perf-storage-blob.tgz:
-    resolution: {integrity: sha512-ACRt0wrz261MTNDcEEtDfYkqhDTiiRw20AhsdJ2nkKTQwtECihm6lxFOuC3n+/2WSWp9qgEpi8bSIHrN1n/r2w==, tarball: file:projects/perf-storage-blob.tgz}
+    resolution: {integrity: sha512-YpnKzYo6JuUUrhzh2YmZJba2rxDSueRobUdxEUOAcpCzQX4lSqzQp5/4tC/6e6ZQjL+UNxoC9nLTBeGMic9ybw==, tarball: file:projects/perf-storage-blob.tgz}
     name: '@rush-temp/perf-storage-blob'
     version: 0.0.0
     dependencies:
@@ -18011,7 +18011,7 @@ packages:
     dev: false
 
   file:projects/perf-storage-file-datalake.tgz:
-    resolution: {integrity: sha512-dewHjtVi92xQNZXFTBBg2mElIhlItaacuMnkQC0ow0RMJWfyBwd6nVuONNPG0SKH1653tZGysRT3a54qdiejqg==, tarball: file:projects/perf-storage-file-datalake.tgz}
+    resolution: {integrity: sha512-Ox0X3U3YxqUTmWjuhPnBzrxvEGtjVbFLu9iYrHtt3k/pYhEd3Xw1Oos/cFo0KVysPW7hqzK8mFDjHRsoAhb/uA==, tarball: file:projects/perf-storage-file-datalake.tgz}
     name: '@rush-temp/perf-storage-file-datalake'
     version: 0.0.0
     dependencies:
@@ -18029,12 +18029,11 @@ packages:
     transitivePeerDependencies:
       - '@swc/core'
       - '@swc/wasm'
-      - encoding
       - supports-color
     dev: false
 
   file:projects/perf-storage-file-share.tgz:
-    resolution: {integrity: sha512-9KuLR0nT5kWloC46ScHq4HD/VJXATHFewmRU1tK6WWqeyqhlSrWLgRcZ93H1Mn7v2bK6Njb7BMl2cmvZrpb1BQ==, tarball: file:projects/perf-storage-file-share.tgz}
+    resolution: {integrity: sha512-yDs9WjNGJcxpAl1fEm06qafAKla/DIUw+gOt2Wp1HDM79rJUXubFJv99W0Kr+K/+3ljFE86F/qEUEOe9RSm22w==, tarball: file:projects/perf-storage-file-share.tgz}
     name: '@rush-temp/perf-storage-file-share'
     version: 0.0.0
     dependencies:

--- a/sdk/appconfiguration/app-configuration/package.json
+++ b/sdk/appconfiguration/app-configuration/package.json
@@ -84,7 +84,7 @@
     "@azure/core-client": "^1.5.0",
     "@azure/core-http-compat": "^1.2.0",
     "@azure/core-paging": "^1.1.1",
-    "@azure/core-rest-pipeline": "^1.6.0",
+    "@azure/core-rest-pipeline": "^1.9.3",
     "@azure/core-tracing": "^1.0.0",
     "@azure/core-auth": "^1.3.0",
     "@azure/core-util": "^1.1.0",

--- a/sdk/appconfiguration/app-configuration/test/internal/helpers.spec.ts
+++ b/sdk/appconfiguration/app-configuration/test/internal/helpers.spec.ts
@@ -184,10 +184,9 @@ describe("helper methods", () => {
         url: "unused",
         abortSignal: {
           aborted: true,
-          // eslint-disable-next-line @typescript-eslint/no-empty-function
-          addEventListener: () => {},
-          // eslint-disable-next-line @typescript-eslint/no-empty-function
-          removeEventListener: () => {},
+          throwIfAborted: () => { /* no-op */ },
+          addEventListener: () => { /* no-op */ },
+          removeEventListener: () => { /* no-op */ },
         },
         method: "GET",
         withCredentials: false,

--- a/sdk/core/abort-controller/CHANGELOG.md
+++ b/sdk/core/abort-controller/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Release History
 
-## 1.1.1 (Unreleased)
+## 1.2.0 (Unreleased)
 
 ### Features Added
+
+- Add support for `AbortSignal.reason` and `AbortSignal.throwIfAborted()`
 
 ### Breaking Changes
 

--- a/sdk/core/abort-controller/package.json
+++ b/sdk/core/abort-controller/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@azure/abort-controller",
   "sdk-type": "client",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "Microsoft Azure SDK for JavaScript - Aborter",
   "main": "./dist/index.js",
   "module": "dist-esm/src/index.js",
@@ -99,6 +99,6 @@
     "prettier": "^2.5.1",
     "rimraf": "^3.0.0",
     "ts-node": "^10.0.0",
-    "typescript": "~4.6.0"
+    "typescript": "~4.8.0"
   }
 }

--- a/sdk/core/abort-controller/review/abort-controller.api.md
+++ b/sdk/core/abort-controller/review/abort-controller.api.md
@@ -8,7 +8,7 @@
 export class AbortController {
     constructor(parentSignals?: AbortSignalLike[]);
     constructor(...parentSignals: AbortSignalLike[]);
-    abort(): void;
+    abort(reason?: any): void;
     get signal(): AbortSignal;
     static timeout(ms: number): AbortSignal;
 }
@@ -26,16 +26,19 @@ export class AbortSignal implements AbortSignalLike {
     dispatchEvent(_event: Event): boolean;
     static get none(): AbortSignal;
     onabort: ((ev?: Event) => any) | null;
+    get reason(): any | undefined;
     removeEventListener(_type: "abort", listener: (this: AbortSignalLike, ev: any) => any): void;
+    throwIfAborted(): void;
 }
 
 // @public
 export interface AbortSignalLike {
     readonly aborted: boolean;
     addEventListener(type: "abort", listener: (this: AbortSignalLike, ev: any) => any, options?: any): void;
+    readonly reason?: any;
     removeEventListener(type: "abort", listener: (this: AbortSignalLike, ev: any) => any, options?: any): void;
+    throwIfAborted(): void;
 }
-
 
 // (No @packageDocumentation comment for this package)
 

--- a/sdk/core/abort-controller/src/AbortController.ts
+++ b/sdk/core/abort-controller/src/AbortController.ts
@@ -4,31 +4,6 @@
 import { AbortSignal, AbortSignalLike, abortSignal } from "./AbortSignal";
 
 /**
- * This error is thrown when an asynchronous operation has been aborted.
- * Check for this error by testing the `name` that the name property of the
- * error matches `"AbortError"`.
- *
- * @example
- * ```ts
- * const controller = new AbortController();
- * controller.abort();
- * try {
- *   doAsyncWork(controller.signal)
- * } catch (e) {
- *   if (e.name === 'AbortError') {
- *     // handle abort error here.
- *   }
- * }
- * ```
- */
-export class AbortError extends Error {
-  constructor(message?: string) {
-    super(message);
-    this.name = "AbortError";
-  }
-}
-
-/**
  * An AbortController provides an AbortSignal and the associated controls to signal
  * that an asynchronous operation should be aborted.
  *
@@ -113,8 +88,9 @@ export class AbortController {
    * Signal that any operations passed this controller's associated abort signal
    * to cancel any remaining work and throw an `AbortError`.
    */
-  abort(): void {
-    abortSignal(this._signal);
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+  abort(reason?: any): void {
+    abortSignal(this._signal, reason);
   }
 
   /**

--- a/sdk/core/abort-controller/src/AbortError.ts
+++ b/sdk/core/abort-controller/src/AbortError.ts
@@ -1,0 +1,27 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+/**
+ * This error is thrown when an asynchronous operation has been aborted.
+ * Check for this error by testing the `name` that the name property of the
+ * error matches `"AbortError"`.
+ *
+ * @example
+ * ```ts
+ * const controller = new AbortController();
+ * controller.abort();
+ * try {
+ *   doAsyncWork(controller.signal)
+ * } catch (e) {
+ *   if (e.name === 'AbortError') {
+ *     // handle abort error here.
+ *   }
+ * }
+ * ```
+ */
+export class AbortError extends Error {
+  constructor(message?: string) {
+    super(message);
+    this.name = "AbortError";
+  }
+}

--- a/sdk/core/abort-controller/src/index.ts
+++ b/sdk/core/abort-controller/src/index.ts
@@ -10,5 +10,6 @@
 // Potential changes to align with DOM Spec
 // * dispatchEvent on Signal
 
-export { AbortController, AbortError } from "./AbortController";
+export { AbortError } from "./AbortError";
+export { AbortController } from "./AbortController";
 export { AbortSignal, AbortSignalLike } from "./AbortSignal";

--- a/sdk/core/abort-controller/test/aborter.spec.ts
+++ b/sdk/core/abort-controller/test/aborter.spec.ts
@@ -35,6 +35,8 @@ describe("AbortController", () => {
     const controller = new AbortController();
     const aborter = controller.signal;
     const response = doAsyncOperation(aborter);
+    // should be no-op
+    aborter.throwIfAborted();
     controller.abort();
     try {
       const rs = await response;
@@ -42,6 +44,37 @@ describe("AbortController", () => {
       assert.fail();
     } catch (err: any) {
       assert.strictEqual(err.name, "AbortError");
+      // if not specified, abortSingal.reason defaults to AbortError
+      assert.strictEqual(aborter.reason.name, "AbortError");
+    }
+    try {
+      aborter.throwIfAborted();
+      assert.fail();
+    } catch (err: any) {
+      assert.strictEqual(err.name, "AbortError");
+    }
+  });
+
+  it("should abort with reason", async () => {
+    const controller = new AbortController();
+    const aborter = controller.signal;
+    const response = doAsyncOperation(aborter);
+    // should be no-op
+    aborter.throwIfAborted();
+    controller.abort({ prop: "abort reason" });
+    try {
+      const rs = await response;
+      console.log("got result", rs);
+      assert.fail();
+    } catch (err: any) {
+      assert.strictEqual(err.name, "AbortError");
+      assert.deepEqual(aborter.reason, { prop: "abort reason" });
+    }
+    try {
+      aborter.throwIfAborted();
+      assert.fail();
+    } catch (err: any) {
+      assert.deepEqual(aborter.reason, { prop: "abort reason" });
     }
   });
 

--- a/sdk/core/core-http/package.json
+++ b/sdk/core/core-http/package.json
@@ -116,7 +116,7 @@
     ]
   },
   "dependencies": {
-    "@azure/abort-controller": "^1.0.0",
+    "@azure/abort-controller": "^1.2.0",
     "@azure/core-auth": "^1.3.0",
     "@azure/core-tracing": "1.0.0-preview.13",
     "@azure/core-util": "^1.1.1",
@@ -171,7 +171,7 @@
     "shx": "^0.3.2",
     "sinon": "^9.0.2",
     "ts-node": "^10.0.0",
-    "typescript": "~4.6.0",
+    "typescript": "~4.8.0",
     "uglify-js": "^3.4.9",
     "xhr-mock": "^2.4.1"
   }

--- a/sdk/core/core-rest-pipeline/package.json
+++ b/sdk/core/core-rest-pipeline/package.json
@@ -85,7 +85,7 @@
     ]
   },
   "dependencies": {
-    "@azure/abort-controller": "^1.0.0",
+    "@azure/abort-controller": "^1.2.0",
     "@azure/core-auth": "^1.4.0",
     "@azure/core-tracing": "^1.0.1",
     "@azure/core-util": "^1.0.0",
@@ -131,7 +131,7 @@
     "rimraf": "^3.0.0",
     "sinon": "^9.0.2",
     "source-map-support": "^0.5.9",
-    "typescript": "~4.6.0",
+    "typescript": "~4.8.0",
     "util": "^0.12.1"
   },
   "//sampleConfiguration": {

--- a/sdk/storage/storage-blob/package.json
+++ b/sdk/storage/storage-blob/package.json
@@ -181,7 +181,7 @@
     "rimraf": "^3.0.0",
     "source-map-support": "^0.5.9",
     "ts-node": "^10.0.0",
-    "typescript": "~4.6.0",
+    "typescript": "~4.8.0",
     "util": "^0.12.1"
   }
 }

--- a/sdk/storage/storage-internal-avro/package.json
+++ b/sdk/storage/storage-internal-avro/package.json
@@ -103,7 +103,7 @@
     "rimraf": "^3.0.0",
     "source-map-support": "^0.5.9",
     "ts-node": "^10.0.0",
-    "typescript": "~4.6.0",
+    "typescript": "~4.8.0",
     "util": "^0.12.1"
   }
 }


### PR DESCRIPTION
TypeScript v4.8.3 has AbortSingal typing update that adds new required API. This PR adds the support of them in our implementation.

### Packages impacted by this PR
`@azure/abort-controller`
