### PR TITLE
remove strict mode to unblock scheduled pipeline runs

### DIFF
--- a/eng/scripts/Create-ApiReview.ps1
+++ b/eng/scripts/Create-ApiReview.ps1
@@ -22,7 +22,6 @@ Param (
   [string] $Language
 )
 
-Set-StrictMode -Version 3
 . (Join-Path $PSScriptRoot ".." common scripts common.ps1)
 
 # Submit API review request and return status whether current revision is approved or pending or failed to create review

--- a/eng/scripts/Create-ApiReview.ps1
+++ b/eng/scripts/Create-ApiReview.ps1
@@ -63,7 +63,7 @@ function ProcessPackage($PackageName)
     Write-Host "Source branch: $($SourceBranch)"
     Write-Host "Config File directory: $($ConfigFileDir)"
 
-    $reviewFileName = "$($PackageName)_$($Language).json"
+    $reviewFileName = "$($PackageName)_$($LanguageShort).json"
 
     $packages = @{}
     if ($FindArtifactForApiReviewFn -and (Test-Path "Function:$FindArtifactForApiReviewFn"))


### PR DESCRIPTION
Remove strict mode to unblock script failure in create api review step.