### PR TITLE
[notification hubs] Prepare NH Beta 5

### DIFF
--- a/sdk/notificationhubs/notification-hubs/CHANGELOG.md
+++ b/sdk/notificationhubs/notification-hubs/CHANGELOG.md
@@ -1,14 +1,11 @@
 # Release History
 
-## 1.0.0-beta.5 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
+## 1.0.0-beta.5 (2022-09-16)
 
 ### Bugs Fixed
 
-### Other Changes
+- #23222 - `deleteRegistration` not exported on service client.
+- #23218 - single item on registration feed causes error.
 
 ## 1.0.0-beta.4 (2022-09-09)
 

--- a/sdk/notificationhubs/notification-hubs/review/notification-hubs.api.md
+++ b/sdk/notificationhubs/notification-hubs/review/notification-hubs.api.md
@@ -556,6 +556,7 @@ export class NotificationHubsServiceClient {
     createRegistration(registration: RegistrationDescription, options?: OperationOptions): Promise<RegistrationDescription>;
     createRegistrationId(options?: OperationOptions): Promise<string>;
     deleteInstallation(installationId: string, options?: OperationOptions): Promise<NotificationHubsResponse>;
+    deleteRegistration(registrationId: string, options?: EntityOperationOptions): Promise<NotificationHubsResponse>;
     getFeedbackContainerUrl(options?: OperationOptions): Promise<string>;
     getInstallation(installationId: string, options?: OperationOptions): Promise<Installation>;
     getNotificationHubJob(jobId: string, options?: OperationOptions): Promise<NotificationHubJob>;

--- a/sdk/notificationhubs/notification-hubs/samples-dev/listRegistrations.ts
+++ b/sdk/notificationhubs/notification-hubs/samples-dev/listRegistrations.ts
@@ -23,7 +23,7 @@ const hubName = process.env.NOTIFICATION_HUB_NAME || "<hub name>";
 // Define message constants
 const DUMMY_DEVICE = "00fc13adff785122b4ad28809a3420982341241421348097878e577c991de8f0";
 const devicetoken = process.env.APNS_DEVICE_TOKEN || DUMMY_DEVICE;
-const FILTER = `DeviceToken eq "${devicetoken}"`;
+const FILTER = `DeviceToken eq '${devicetoken.toLocaleUpperCase()}'`;
 
 const TOP = 100;
 

--- a/sdk/notificationhubs/notification-hubs/src/notificationHubsClient.ts
+++ b/sdk/notificationhubs/notification-hubs/src/notificationHubsClient.ts
@@ -9,6 +9,7 @@ import {
 } from "./models/notificationDetails.js";
 import { NotificationHubsClientContext, createClientContext } from "./client/index.js";
 import {
+  EntityOperationOptions,
   NotificationHubsClientOptions,
   RegistrationQueryLimitOptions,
   RegistrationQueryOptions,
@@ -25,6 +26,7 @@ import { createOrUpdateRegistration as createOrUpdateRegistrationMethod } from "
 import { createRegistrationId as createRegistrationIdMethod } from "./client/createRegistrationId.js";
 import { createRegistration as createRegistrationMethod } from "./client/createRegistration.js";
 import { deleteInstallation as deleteInstallationMethod } from "./client/deleteInstallation.js";
+import { deleteRegistration } from "./client/deleteRegistration.js";
 import { getFeedbackContainerUrl as getFeedbackContainerUrlMethod } from "./client/getFeedbackContainerUrl.js";
 import { getInstallation as getInstallationMethod } from "./client/getInstallation.js";
 import { getNotificationHubJob as getNotificationHubJobMethod } from "./client/getNotificationHubJob.js";
@@ -161,6 +163,20 @@ export class NotificationHubsServiceClient {
     options: OperationOptions = {}
   ): Promise<RegistrationDescription> {
     return updateRegistrationMethod(this._client, registration, options);
+  }
+
+  /**
+   * Deletes a registration with the given registration ID.
+   * @param context - The Notification Hubs client.
+   * @param registrationId - The registration ID of the registration to delete.
+   * @param options - The options for delete operations including the ETag
+   * @returns A NotificationHubResponse with the tracking ID, correlation ID and location.
+   */
+  deleteRegistration(
+    registrationId: string,
+    options: EntityOperationOptions = {}
+  ): Promise<NotificationHubsResponse> {
+    return deleteRegistration(this._client, registrationId, options);
   }
 
   /**

--- a/sdk/notificationhubs/notification-hubs/src/serializers/notificationHubJobSerializer.ts
+++ b/sdk/notificationhubs/notification-hubs/src/serializers/notificationHubJobSerializer.ts
@@ -58,7 +58,9 @@ export async function parseNotificationHubJobFeed(bodyText: string): Promise<Not
     return results;
   }
 
-  for (const item of xml.feed.entry) {
+  const entries = Array.isArray(xml.feed.entry) ? xml.feed.entry : [xml.feed.entry];
+
+  for (const item of entries) {
     results.push(createNotificationHubJob(item.content.NotificationHubJob));
   }
 

--- a/sdk/notificationhubs/notification-hubs/src/serializers/registrationSerializer.ts
+++ b/sdk/notificationhubs/notification-hubs/src/serializers/registrationSerializer.ts
@@ -176,7 +176,9 @@ export const registrationDescriptionParser: RegistrationDescriptionParser = {
       return results;
     }
 
-    for (const entry of xml.feed.entry) {
+    const entries = Array.isArray(xml.feed.entry) ? xml.feed.entry : [xml.feed.entry];
+
+    for (const entry of entries) {
       delete entry.content["$"];
 
       const keyName = Object.keys(entry.content)[0];

--- a/sdk/notificationhubs/notification-hubs/test/internal/unit/notificationHubJobSerializer.spec.ts
+++ b/sdk/notificationhubs/notification-hubs/test/internal/unit/notificationHubJobSerializer.spec.ts
@@ -148,6 +148,42 @@ const HUB_JOB_FEED = `<feed xmlns="http://www.w3.org/2005/Atom">
 </entry>
 </feed>`;
 
+const SINGLE_JOB_FEED = `<feed xmlns="http://www.w3.org/2005/Atom">
+<title type="text">jobs</title>
+<id>https://test.servicebus.windows.net/hub/jobs</id>
+<updated>2014-12-06T06:17:24Z</updated>
+<link rel="self" href="https://test.servicebus.windows.net/adm-hub/jobs"/>
+<entry xmlns="http://www.w3.org/2005/Atom">
+  <id>https://test.servicebus.windows.net/hub/jobs/1?api-version=2014-09</id>
+  <title type="text">1</title>
+  <published>2014-12-06T01:48:55Z</published>
+  <updated>2014-12-06T01:48:55Z</updated>
+  <link rel="self" href="https://test.servicebus.windows.net/hub/jobs/1?api-version=2014-09"/>
+  <content type="application/xml">
+    <NotificationHubJob xmlns="http://schemas.microsoft.com/netservices/2010/10/servicebus/connect" xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+      <JobId>3</JobId>
+      <Progress>99.99</Progress>
+      <Type>ImportCreateRegistrations</Type>
+      <Status>Completed</Status>
+      <OutputContainerUri>https://test.blob.core.windows.net/testjobs</OutputContainerUri>
+      <ImportFileUri>https://test.blob.core.windows.net/testjobs/CreateFile.txt</ImportFileUri>
+      <OutputProperties xmlns:d3p1="http://schemas.microsoft.com/2003/10/Serialization/Arrays">
+        <d3p1:KeyValueOfstringstring>
+          <d3p1:Key>OutputFilePath</d3p1:Key>
+          <d3p1:Value>test//hub/3/Output.txt</d3p1:Value>
+        </d3p1:KeyValueOfstringstring>
+        <d3p1:KeyValueOfstringstring>
+          <d3p1:Key>FailedFilePath</d3p1:Key>
+          <d3p1:Value>test//hub/3/Failed.txt</d3p1:Value>
+        </d3p1:KeyValueOfstringstring>
+      </OutputProperties>
+      <CreatedAt>2014-12-06T01:48:49.9874484Z</CreatedAt>
+      <UpdatedAt>2014-12-06T01:48:54.4501165Z</UpdatedAt>
+    </NotificationHubJob>
+  </content>
+</entry>
+</feed>`;
+
 const EMPTY_JOB_FEED = `<feed xmlns="http://www.w3.org/2005/Atom">
 <title type="text">jobs</title>
 <id>https://test.servicebus.windows.net/hub/jobs</id>
@@ -189,6 +225,22 @@ describe("parseNotificationHubJobFeed", () => {
     const parsed = await parseNotificationHubJobFeed(EMPTY_JOB_FEED);
 
     assert.equal(parsed.length, 0);
+  });
+
+  it("should parse a single notification job from feed", async () => {
+    const parsed = await parseNotificationHubJobFeed(SINGLE_JOB_FEED);
+
+    assert.equal(parsed.length, 1);
+
+    const job = parsed[0];
+    assert.equal(job.jobId, "3");
+    assert.equal(job.progress, 99.99);
+    assert.equal(job.type, "ImportCreateRegistrations");
+    assert.equal(job.status, "Completed");
+    assert.equal(job.outputContainerUrl, "https://test.blob.core.windows.net/testjobs");
+    assert.equal(job.importFileUrl, "https://test.blob.core.windows.net/testjobs/CreateFile.txt");
+    assert.equal(job.outputProperties!["OutputFilePath"], "test//hub/3/Output.txt");
+    assert.equal(job.outputProperties!["FailedFilePath"], "test//hub/3/Failed.txt");
   });
 
   it("should parse a notification job feed", async () => {

--- a/sdk/notificationhubs/notification-hubs/test/internal/unit/registrationSerializer.spec.ts
+++ b/sdk/notificationhubs/notification-hubs/test/internal/unit/registrationSerializer.spec.ts
@@ -447,6 +447,25 @@ const EMPTY_REGISTRATION_FEED = `<?xml version="1.0" encoding="utf-8" ?>
   <link rel="self" href="https://testns.servicebus.windows.net/testhub/registrations/?api-version=2020-06" />
 </feed>`;
 
+const SINGLE_REGISTRATION_FEED = `<?xml version="1.0" encoding="utf-8" ?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title type="text">Registrations</title>
+  <id>https://testns.servicebus.windows.net/testhub/registrations/?api-version=2020-06</id>
+  <updated>2022-09-06T20:06:33Z</updated>
+  <link rel="self" href="https://testns.servicebus.windows.net/testhub/registrations/?api-version=2020-06" />
+  <entry xmlns="http://www.w3.org/2005/Atom">
+    <content type="application/xml">
+      <AppleTemplateRegistrationDescription xmlns:i="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://schemas.microsoft.com/netservices/2010/10/servicebus/connect">
+          <Tags>myTag,myOtherTag</Tags>
+          <RegistrationId>{Registration Id}</RegistrationId>
+          <DeviceToken>{DeviceToken}</DeviceToken>
+          <BodyTemplate><![CDATA[{Template for the body}]]></BodyTemplate>
+          <Expiry>2011-10-05T14:48:00.000Z</Expiry>
+      </AppleTemplateRegistrationDescription>
+    </content>
+  </entry>
+</feed>`;
+
 describe("parseRegistrationFeed", () => {
   it("should parse a registration feed", async () => {
     const registrations = await registrationDescriptionParser.parseRegistrationFeed(
@@ -460,6 +479,20 @@ describe("parseRegistrationFeed", () => {
     assert.deepEqual(windowsRegistration.tags, ["myTag", "myOtherTag"]);
 
     const appleRegistration = registrations[1] as AppleTemplateRegistrationDescription;
+    assert.equal(appleRegistration.type, "AppleTemplate");
+    assert.equal(appleRegistration.registrationId, "{Registration Id}");
+    assert.equal(appleRegistration.deviceToken, "{DeviceToken}");
+    assert.deepEqual(appleRegistration.tags, ["myTag", "myOtherTag"]);
+  });
+
+  it("should parse a feed with one item", async () => {
+    const registrations = await registrationDescriptionParser.parseRegistrationFeed(
+      SINGLE_REGISTRATION_FEED
+    );
+
+    assert.equal(registrations.length, 1);
+
+    const appleRegistration = registrations[0] as AppleTemplateRegistrationDescription;
     assert.equal(appleRegistration.type, "AppleTemplate");
     assert.equal(appleRegistration.registrationId, "{Registration Id}");
     assert.equal(appleRegistration.deviceToken, "{DeviceToken}");


### PR DESCRIPTION
### Packages impacted by this PR

- [notification hubs]

### Issues associated with this PR

- #23222
- #23218 

### Describe the problem that is addressed by this PR

- Fixes customer reported issue of `deleteRegistration` not being exported on the `NotifcationHubsServiceClient`.
- Fixes customer reported issue of a single item registration feed not being iterable.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_

Yes

### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [x] Added a changelog (if necessary)
