### PR TITLE
Updating python 3.6 to 3.9

### DIFF
--- a/eng/pipelines/templates/steps/common.yml
+++ b/eng/pipelines/templates/steps/common.yml
@@ -4,8 +4,8 @@ steps:
       AgentImage: $(OSVmImage)
 
   - task: UsePythonVersion@0
-    displayName: "Use Python 3.6"
+    displayName: "Use Python 3.9"
     inputs:
-      versionSpec: "3.6"
+      versionSpec: "3.9"
 
   - template: use-node-version.yml


### PR DESCRIPTION
macOS 11 and macOS 12 don't include Python 3.6 as a pre-installed Python version which is leading to macOS pipelines producing the warning "[warning]You should provide GitHub token if you want to download a python release. Otherwise you may hit the GitHub anonymous download limit."