### PR TITLE
[Schema Registry] Simplify getSchemaByVersion

### DIFF
--- a/sdk/schemaregistry/schema-registry-avro/test/public/utils/mockedRegistryClient.ts
+++ b/sdk/schemaregistry/schema-registry-avro/test/public/utils/mockedRegistryClient.ts
@@ -17,6 +17,8 @@ import { isLive } from "./isLive";
 import { testSchemaIds } from "./dummies";
 import { v4 as uuid } from "uuid";
 
+type UpdatedSchemaDescription = Required<Omit<SchemaDescription, "version">>;
+
 function getEnvVar(name: string): string {
   const value = env[name];
   if (!value) {
@@ -59,7 +61,7 @@ function createMockedTestRegistry(): SchemaRegistry {
   return { registerSchema, getSchemaProperties, getSchema };
 
   async function registerSchema(
-    schema: SchemaDescription,
+    schema: UpdatedSchemaDescription,
     _options?: RegisterSchemaOptions
   ): Promise<SchemaProperties> {
     let result = mapByContent.get(schema.definition);
@@ -93,7 +95,7 @@ function createMockedTestRegistry(): SchemaRegistry {
   }
 
   async function getSchemaProperties(
-    schema: SchemaDescription,
+    schema: UpdatedSchemaDescription,
     _options?: GetSchemaPropertiesOptions
   ): Promise<SchemaProperties> {
     const storedSchema = mapByContent.get(schema.definition);

--- a/sdk/schemaregistry/schema-registry/CHANGELOG.md
+++ b/sdk/schemaregistry/schema-registry/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features Added
 
-- `getSchemaByVersion` is added to query schemas by their version.
+- An overload of `getSchema` is added that queries schemas by their version.
 - `version` property is added to `SchemaProperties`.
 
 ## 1.1.0 (2022-05-10)

--- a/sdk/schemaregistry/schema-registry/README.md
+++ b/sdk/schemaregistry/schema-registry/README.md
@@ -125,7 +125,7 @@ const { DefaultAzureCredential } = require("@azure/identity");
 const { SchemaRegistryClient } = require("@azure/schema-registry");
 
 const client = new SchemaRegistryClient("<fullyQualifiedNamespace>", new DefaultAzureCredential());
-const foundSchema = await client.getSchemaByVersion({ name:"<schema name>", groupName: "group name", version });
+const foundSchema = await client.getSchema({ name:"<schema name>", groupName: "group name", version });
 if (foundSchema) {
   console.log(`Got schema definition=${foundSchema.definition}`);
 }

--- a/sdk/schemaregistry/schema-registry/review/schema-registry.api.md
+++ b/sdk/schemaregistry/schema-registry/review/schema-registry.api.md
@@ -9,10 +9,6 @@ import { OperationOptions } from '@azure/core-client';
 import { TokenCredential } from '@azure/core-auth';
 
 // @public
-export interface GetSchemaByVersionOptions extends OperationOptions {
-}
-
-// @public
 export interface GetSchemaOptions extends OperationOptions {
 }
 
@@ -32,10 +28,11 @@ export interface Schema {
 
 // @public
 export interface SchemaDescription {
-    definition: string;
-    format: string;
+    definition?: string;
+    format?: string;
     groupName: string;
     name: string;
+    version?: number;
 }
 
 // @public
@@ -59,7 +56,7 @@ export class SchemaRegistryClient implements SchemaRegistry {
     constructor(fullyQualifiedNamespace: string, credential: TokenCredential, options?: SchemaRegistryClientOptions);
     readonly fullyQualifiedNamespace: string;
     getSchema(schemaId: string, options?: GetSchemaOptions): Promise<Schema>;
-    getSchemaByVersion(schemaVersion: SchemaVersion, options?: GetSchemaByVersionOptions): Promise<Schema>;
+    getSchema(schemaDescription: SchemaDescription, options?: GetSchemaOptions): Promise<Schema>;
     getSchemaProperties(schema: SchemaDescription, options?: GetSchemaPropertiesOptions): Promise<SchemaProperties>;
     registerSchema(schema: SchemaDescription, options?: RegisterSchemaOptions): Promise<SchemaProperties>;
 }
@@ -67,13 +64,6 @@ export class SchemaRegistryClient implements SchemaRegistry {
 // @public
 export interface SchemaRegistryClientOptions extends CommonClientOptions {
     apiVersion?: string;
-}
-
-// @public
-export interface SchemaVersion {
-    groupName: string;
-    name: string;
-    version: number;
 }
 
 // (No @packageDocumentation comment for this package)

--- a/sdk/schemaregistry/schema-registry/samples-dev/getSchemaByVersion.ts
+++ b/sdk/schemaregistry/schema-registry/samples-dev/getSchemaByVersion.ts
@@ -55,7 +55,7 @@ export async function main() {
   );
 
   // Get definition of existing schema by its version
-  const foundSchema = await client.getSchemaByVersion({
+  const foundSchema = await client.getSchema({
     groupName,
     name,
     version,

--- a/sdk/schemaregistry/schema-registry/src/models.ts
+++ b/sdk/schemaregistry/schema-registry/src/models.ts
@@ -26,22 +26,6 @@ export interface SchemaProperties {
 }
 
 /**
- * Version of a schema
- */
-export interface SchemaVersion {
-  /**
-   * Version of the schema
-   */
-  version: number;
-
-  /** Schema group under which schema is or should be registered. */
-  groupName: string;
-
-  /** Name of schema.*/
-  name: string;
-}
-
-/**
  * Schema definition with its name, format, and group.
  */
 export interface SchemaDescription {
@@ -54,10 +38,13 @@ export interface SchemaDescription {
   /**
    * The format of schema and it must match the serialization type of the schema's group.
    */
-  format: string;
+  format?: string;
 
   /** String representation of schema. */
-  definition: string;
+  definition?: string;
+
+  /** Version of schema */
+  version?: number;
 }
 
 /**
@@ -94,11 +81,6 @@ export interface GetSchemaPropertiesOptions extends OperationOptions {}
  * Options to configure SchemaRegistryClient.getSchema.
  */
 export interface GetSchemaOptions extends OperationOptions {}
-
-/**
- * Options to configure SchemaRegistryClient.getSchemaByVersion.
- */
-export interface GetSchemaByVersionOptions extends OperationOptions {}
 
 /**
  * Represents a store of registered schemas.

--- a/sdk/schemaregistry/schema-registry/src/utils.ts
+++ b/sdk/schemaregistry/schema-registry/src/utils.ts
@@ -1,0 +1,17 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+type WithRequired<T, K extends keyof T> = T & { [P in K]-?: T[P] };
+
+export const isDefined = <T extends Record<string, any>, V extends Array<keyof T>>(
+  obj: T,
+  props: V
+): WithRequired<T, V[number]> => {
+  for (const prop of props) {
+    if (obj[prop] === undefined) {
+      throw new Error(`Expected ${String(prop)} to be present`);
+    }
+  }
+
+  return obj as WithRequired<T, V[number]>;
+};

--- a/sdk/schemaregistry/schema-registry/test/public/schemaRegistry.spec.ts
+++ b/sdk/schemaregistry/schema-registry/test/public/schemaRegistry.spec.ts
@@ -215,7 +215,7 @@ describe("SchemaRegistryClient", function () {
   it("gets schema by version", async () => {
     const registered = await client.registerSchema(schema, options);
     assertIsValidSchemaProperties(registered);
-    const found = await client.getSchemaByVersion(
+    const found = await client.getSchema(
       {
         groupName: registered.groupName,
         name: registered.name,
@@ -232,7 +232,7 @@ describe("SchemaRegistryClient", function () {
   });
 
   it("schema with whitespace", async () => {
-    const schema2: SchemaDescription = {
+    const schema2 = {
       name: "azsdk_js_test2",
       groupName: assertEnvironmentVariable("SCHEMA_REGISTRY_GROUP"),
       format: "Avro",

--- a/sdk/schemaregistry/schema-registry/test/public/schemaRegistry.spec.ts
+++ b/sdk/schemaregistry/schema-registry/test/public/schemaRegistry.spec.ts
@@ -188,10 +188,6 @@ describe("SchemaRegistryClient", function () {
     // NOTE: IDs may differ here as we could get a different version with same definition.
   });
 
-  it("fails to get schema by ID when given invalid ID", async () => {
-    await isRejected(client.getSchema(null!), { messagePattern: /null/ });
-  });
-
   it("fails to get schema when no schema exists with given ID", async () => {
     await isRejected(client.getSchema("ffffffffffffffffffffffffffffffff", errorOptions), {
       statusCode: 404,


### PR DESCRIPTION
Re-work the design for `getSchemaByVersion` to re-use `SchemaDescription` instead of creating a new input type.