### PR TITLE
Add georedundant retry option to TableClient

### DIFF
--- a/sdk/core/core-rest-pipeline/review/core-rest-pipeline.api.md
+++ b/sdk/core/core-rest-pipeline/review/core-rest-pipeline.api.md
@@ -399,6 +399,9 @@ export interface ThrottlingRetryPolicyOptions {
 }
 
 // @public
+export function throttlingRetryStrategy(): RetryStrategy;
+
+// @public
 export function tlsPolicy(tlsSettings?: TlsSettings): PipelinePolicy;
 
 // @public

--- a/sdk/core/core-rest-pipeline/src/index.ts
+++ b/sdk/core/core-rest-pipeline/src/index.ts
@@ -87,3 +87,4 @@ export {
   AuthorizeRequestOnChallengeOptions,
 } from "./policies/bearerTokenAuthenticationPolicy";
 export { ndJsonPolicy, ndJsonPolicyName } from "./policies/ndJsonPolicy";
+export { throttlingRetryStrategy } from "./retryStrategies/throttlingRetryStrategy";

--- a/sdk/core/core-rest-pipeline/src/policies/retryPolicy.ts
+++ b/sdk/core/core-rest-pipeline/src/policies/retryPolicy.ts
@@ -116,20 +116,20 @@ export function retryPolicy(
             );
             throw errorToThrow;
           }
+          if (redirectTo || retryAfterInMs || retryAfterInMs === 0) {
+            if (retryAfterInMs || retryAfterInMs === 0) {
+              strategyLogger.info(
+                `Retry ${retryCount}: Retry strategy ${strategy.name} retries after ${retryAfterInMs}`
+              );
+              await delay(retryAfterInMs, undefined, { abortSignal: request.abortSignal });
+            }
 
-          if (retryAfterInMs || retryAfterInMs === 0) {
-            strategyLogger.info(
-              `Retry ${retryCount}: Retry strategy ${strategy.name} retries after ${retryAfterInMs}`
-            );
-            await delay(retryAfterInMs, undefined, { abortSignal: request.abortSignal });
-            continue retryRequest;
-          }
-
-          if (redirectTo) {
-            strategyLogger.info(
-              `Retry ${retryCount}: Retry strategy ${strategy.name} redirects to ${redirectTo}`
-            );
-            request.url = redirectTo;
+            if (redirectTo) {
+              strategyLogger.info(
+                `Retry ${retryCount}: Retry strategy ${strategy.name} redirects to ${redirectTo}`
+              );
+              request.url = redirectTo;
+            }
             continue retryRequest;
           }
         }

--- a/sdk/core/core-rest-pipeline/src/retryStrategies/throttlingRetryStrategy.ts
+++ b/sdk/core/core-rest-pipeline/src/retryStrategies/throttlingRetryStrategy.ts
@@ -63,6 +63,15 @@ export function isThrottlingRetryResponse(response?: PipelineResponse): boolean 
   return Number.isFinite(getRetryAfterInMs(response));
 }
 
+/**
+ * A retry strategy for throttling retry responses. A response is a retry response if it has a throttling status
+ * code (429 or 503), as long as one of the [ "Retry-After" or "retry-after-ms" or "x-ms-retry-after-ms" ] headers
+ * has a valid value.
+ *
+ * @returns A strategy which delays a retry for the time specified in a throttling retry response's retry header,
+ * if valid.
+ */
+
 export function throttlingRetryStrategy(): RetryStrategy {
   return {
     name: "throttlingRetryStrategy",

--- a/sdk/tables/data-tables/review/data-tables.api.md
+++ b/sdk/tables/data-tables/review/data-tables.api.md
@@ -12,6 +12,7 @@ import { NamedKeyCredential } from '@azure/core-auth';
 import { OperationOptions } from '@azure/core-client';
 import { PagedAsyncIterableIterator } from '@azure/core-paging';
 import { Pipeline } from '@azure/core-rest-pipeline';
+import { PipelineRetryOptions } from '@azure/core-rest-pipeline';
 import { RestError } from '@azure/core-rest-pipeline';
 import { SASCredential } from '@azure/core-auth';
 import { TokenCredential } from '@azure/core-auth';
@@ -94,6 +95,12 @@ export function generateAccountSas(credential: NamedKeyCredential, options?: Acc
 
 // @public
 export function generateTableSas(tableName: string, credential: NamedKeyCredential, options?: TableSasSignatureValues): string;
+
+// @public
+export interface GeoredundantRetryOptions extends PipelineRetryOptions {
+    readHosts?: string[];
+    writeHosts?: string[];
+}
 
 // @public
 export interface GeoReplication {
@@ -395,6 +402,7 @@ export class TableServiceClient {
 export type TableServiceClientOptions = CommonClientOptions & {
     endpoint?: string;
     version?: string;
+    georedundantRetryOptions?: GeoredundantRetryOptions;
 };
 
 // @public

--- a/sdk/tables/data-tables/src/index.ts
+++ b/sdk/tables/data-tables/src/index.ts
@@ -11,3 +11,4 @@ export { TableClient } from "./TableClient";
 export { odata } from "./odata";
 export { AzureNamedKeyCredential, AzureSASCredential, NamedKeyCredential } from "@azure/core-auth";
 export { RestError } from "@azure/core-rest-pipeline";
+export { GeoredundantRetryOptions } from "./policies/georedundantRetryStrategy";

--- a/sdk/tables/data-tables/src/models.ts
+++ b/sdk/tables/data-tables/src/models.ts
@@ -3,6 +3,7 @@
 
 import { CommonClientOptions, OperationOptions } from "@azure/core-client";
 import { TableGetAccessPolicyHeaders, TableInsertEntityHeaders } from "./generated/models";
+import { GeoredundantRetryOptions } from "./policies/georedundantRetryStrategy";
 
 /**
  * Represents the Create or Delete Entity operation to be included in a Transaction request
@@ -28,6 +29,7 @@ export type TransactionAction = CreateDeleteEntityAction | UpdateEntityAction;
 export type TableServiceClientOptions = CommonClientOptions & {
   endpoint?: string;
   version?: string;
+  georedundantRetryOptions?: GeoredundantRetryOptions;
 };
 
 /**
@@ -107,7 +109,7 @@ export type TableEntityResult<T> = T & {
    */
   rowKey?: string;
   /**
-   * Timestamp property. This property is assinged by the service on entity creation
+   * Timestamp property. This property is assigned by the service on entity creation
    * Omitted if a select filter is set and this property is not requested
    */
   timestamp?: string;

--- a/sdk/tables/data-tables/src/policies/georedundantRetryStrategy.ts
+++ b/sdk/tables/data-tables/src/policies/georedundantRetryStrategy.ts
@@ -1,0 +1,81 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { PipelineRetryOptions, RetryModifiers, RetryStrategy } from "@azure/core-rest-pipeline";
+
+/**
+ * Options for the georedundant retry strategy
+ */
+export declare interface GeoredundantRetryOptions extends PipelineRetryOptions {
+  /**
+   * List of fallback hosts for read operations
+   */
+  readHosts?: string[];
+  /**
+   * List of fallback hosts for write operations
+   */
+  writeHosts?: string[];
+}
+
+/**
+ *
+ * @param options - Lists of fallback endpoints for read/write operations
+ * @returns An exponential retry strategy with support for multiple endpoints
+ */
+export function georedundantRetryStrategy(options: GeoredundantRetryOptions): RetryStrategy {
+  // Store each host with the timestamp when it should be retried
+  const readHostState: { host: string; retryAt?: number }[] = [];
+  for (const host of options.readHosts ?? []) {
+    readHostState.push({ host });
+  }
+  const writeHostState: { host: string; retryAt?: number }[] = [];
+  for (const host of options.writeHosts ?? []) {
+    writeHostState.push({ host });
+  }
+
+  const retryDelayInMs = options.retryDelayInMs ?? 1000;
+  const maxRetryDelayInMs = options.maxRetryDelayInMs ?? 64000;
+
+  return {
+    name: "georedundantRetryStrategy",
+    retry({ retryCount, response }) {
+      // Only fallback to another host on a 5xx response
+      if (!(response && 500 <= response.status && response.status < 600)) {
+        return { skipStrategy: true };
+      }
+
+      // Determine whether this is a read or write operation and use the corresponding host list
+      const isReadOperation =
+        response.request.method === "GET" || response.request.method === "HEAD";
+      const hostState = isReadOperation ? readHostState : writeHostState;
+
+      // Skip if there are no fallback hosts
+      if (hostState.length === 0) {
+        return { skipStrategy: true };
+      }
+
+      // Fallback should wrap around if there are more retry attempts than hosts
+      const index = retryCount % hostState.length;
+      const modifiers: RetryModifiers = { redirectTo: hostState[index].host };
+
+      // If this is not the first request to this host, delay the retry
+      const now = Date.now();
+      if (retryCount >= hostState.length) {
+        const retryAfterInMs = hostState[index].retryAt ?? 0 - now;
+        if (retryAfterInMs > 0) {
+          modifiers.retryAfterInMs = retryAfterInMs;
+        }
+      }
+
+      // Store the timestamp of this response to calculate the delay of the next retry
+      hostState[index].retryAt =
+        now +
+        Math.min(
+          retryDelayInMs * 2 ** Math.floor(retryCount / hostState.length),
+          maxRetryDelayInMs
+        );
+
+      return modifiers;
+    },
+  };
+}

--- a/sdk/tables/data-tables/test/internal/georedundantRetryStrategy.spec.ts
+++ b/sdk/tables/data-tables/test/internal/georedundantRetryStrategy.spec.ts
@@ -1,0 +1,116 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { PipelineRequest, RetryStrategy, createHttpHeaders } from "@azure/core-rest-pipeline";
+import { assert } from "@azure/test-utils";
+import { georedundantRetryStrategy } from "../../src/policies/georedundantRetryStrategy";
+import sinon from "sinon";
+
+describe(`georedundantRetryStrategy`, () => {
+  const options = {
+    maxRetries: 10,
+    maxRetryDelayInMs: 1600,
+    readHosts: ["read1.azure", "read2.azure", "read3.azure"],
+    writeHosts: ["write1.azure", "write2.azure"],
+    retryDelayInMs: 100,
+  };
+  const now = 0;
+
+  let strategy: RetryStrategy;
+  let stub: sinon.SinonStub;
+  beforeEach(() => {
+    strategy = georedundantRetryStrategy(options);
+    stub = sinon.stub(Date, "now").callsFake(() => 0);
+  });
+  afterEach(() => {
+    stub.restore();
+  });
+
+  it("should redirect and delay correctly", () => {
+    const modifiers = [];
+    for (let retryCount = 0; retryCount < options.maxRetries; retryCount++) {
+      const modifier = strategy.retry({
+        retryCount,
+        response: {
+          headers: createHttpHeaders(),
+          request: {
+            headers: createHttpHeaders(),
+            method: "GET",
+            url: "https://localhost",
+            requestId: "",
+            timeout: 1000,
+            withCredentials: false,
+          },
+          status: 500,
+        },
+      });
+      modifiers.push(modifier);
+    }
+    assert.deepEqual(modifiers, [
+      { redirectTo: "read1.azure" },
+      { redirectTo: "read2.azure" },
+      { redirectTo: "read3.azure" },
+      { redirectTo: "read1.azure", retryAfterInMs: now + 100 },
+      { redirectTo: "read2.azure", retryAfterInMs: now + 100 },
+      { redirectTo: "read3.azure", retryAfterInMs: now + 100 },
+      { redirectTo: "read1.azure", retryAfterInMs: now + 200 },
+      { redirectTo: "read2.azure", retryAfterInMs: now + 200 },
+      { redirectTo: "read3.azure", retryAfterInMs: now + 200 },
+      { redirectTo: "read1.azure", retryAfterInMs: now + 400 },
+    ]);
+  });
+  it("should use the correct set of fallback endpoints", () => {
+    const modifiers = [];
+    const getRequest: PipelineRequest = {
+      headers: createHttpHeaders(),
+      method: "GET",
+      url: "https://localhost",
+      requestId: "",
+      timeout: 1000,
+      withCredentials: false,
+    };
+    const postRequest: PipelineRequest = {
+      headers: createHttpHeaders(),
+      method: "POST",
+      url: "https://localhost",
+      requestId: "",
+      timeout: 1000,
+      withCredentials: false,
+    };
+    for (const request of [getRequest, postRequest]) {
+      for (let retryCount = 0; retryCount < options.maxRetries; retryCount++) {
+        const modifier = strategy.retry({
+          retryCount,
+          response: {
+            headers: createHttpHeaders(),
+            request: request,
+            status: 500,
+          },
+        });
+        modifiers.push(modifier);
+      }
+    }
+    assert.deepEqual(modifiers, [
+      { redirectTo: "read1.azure" },
+      { redirectTo: "read2.azure" },
+      { redirectTo: "read3.azure" },
+      { redirectTo: "read1.azure", retryAfterInMs: now + 100 },
+      { redirectTo: "read2.azure", retryAfterInMs: now + 100 },
+      { redirectTo: "read3.azure", retryAfterInMs: now + 100 },
+      { redirectTo: "read1.azure", retryAfterInMs: now + 200 },
+      { redirectTo: "read2.azure", retryAfterInMs: now + 200 },
+      { redirectTo: "read3.azure", retryAfterInMs: now + 200 },
+      { redirectTo: "read1.azure", retryAfterInMs: now + 400 },
+      { redirectTo: "write1.azure" },
+      { redirectTo: "write2.azure" },
+      { redirectTo: "write1.azure", retryAfterInMs: now + 100 },
+      { redirectTo: "write2.azure", retryAfterInMs: now + 100 },
+      { redirectTo: "write1.azure", retryAfterInMs: now + 200 },
+      { redirectTo: "write2.azure", retryAfterInMs: now + 200 },
+      { redirectTo: "write1.azure", retryAfterInMs: now + 400 },
+      { redirectTo: "write2.azure", retryAfterInMs: now + 400 },
+      { redirectTo: "write1.azure", retryAfterInMs: now + 800 },
+      { redirectTo: "write2.azure", retryAfterInMs: now + 800 },
+    ]);
+  });
+});


### PR DESCRIPTION
This change allows for a user to specify a list of failover endpoints to read/modify the table which backs a TableClient. It defines and implements a custom retry strategy, based on the existing default exponential retry strategy, which cycles through the list of user-defined endpoints on any 500 response.

Fixes #23098 