### PR TITLE
[doc] fix nodejs lts broken link

### DIFF
--- a/documentation/test-quickstart.md
+++ b/documentation/test-quickstart.md
@@ -31,7 +31,7 @@ At the moment, tests in our repo depend on one of the two different versions of 
   - When running the tests, ensure the Docker daemon is running and you have permission to use it.
 - Rush 5.x
   - Install/update Rush globally via `npm install -g @microsoft/rush`
-- Any of [the LTS versions of Node.js](https://nodejs.org/en/about/releases/)
+- Any of [the LTS versions of Node.js](https://github.com/nodejs/release#release-schedule)
 - A C++ compiler toolchain and Python (for compiling machine-code modules)
   - Refer [here](https://github.com/Azure/azure-sdk-for-js/blob/main/CONTRIBUTING.md#prerequisites) for more details
 

--- a/sdk/communication/communication-job-router/README.md
+++ b/sdk/communication/communication-job-router/README.md
@@ -50,7 +50,7 @@ Install IDE such as [VSCode](https://code.visualstudio.com/download) or [Webstor
 
 ###Install NodeJS if you haven't
 LTS or Current version, either is ok.
-https://nodejs.org/en/about/releases/
+https://github.com/nodejs/release#release-schedule
 
 ### Create a new NodeJS Express server
 

--- a/sdk/eventhub/eventhubs-checkpointstore-table/README.md
+++ b/sdk/eventhub/eventhubs-checkpointstore-table/README.md
@@ -11,7 +11,7 @@ Key Links:
 ## Getting started
 
 ### Currently supported environments
-- [LTS versions of Node.js](https://nodejs.org/en/about/releases/)
+- [LTS versions of Node.js](https://github.com/nodejs/release#release-schedule)
 - Latest versions of Safari, Chrome, Edge, and Firefox.
 
 See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.


### PR DESCRIPTION
Three instances missed previous PR in find-and-replace because of "en/" locale in the link.
