### PR TITLE
[core-lro] Increase accuracy of termination detection and handle bad status field

### DIFF
--- a/sdk/core/core-lro/CHANGELOG.md
+++ b/sdk/core/core-lro/CHANGELOG.md
@@ -8,6 +8,9 @@
 
 ### Bugs Fixed
 
+- Precisely detect when an operation failed without relying on exceptions raised by the underlying core library.
+- Handle bad status fields.
+
 ### Other Changes
 
 ## 2.3.1 (2022-09-09)

--- a/sdk/core/core-lro/src/http/models.ts
+++ b/sdk/core/core-lro/src/http/models.ts
@@ -15,11 +15,11 @@ export type LroResourceLocationConfig = "azure-async-operation" | "location" | "
 
 export interface ResponseBody extends Record<string, unknown> {
   /** The status of the operation. */
-  status?: string;
+  status?: unknown;
   /** The state of the provisioning process */
-  provisioningState?: string;
+  provisioningState?: unknown;
   /** The properties of the provisioning process */
-  properties?: { provisioningState?: string } & Record<string, unknown>;
+  properties?: { provisioningState?: unknown } & Record<string, unknown>;
 }
 
 /**

--- a/sdk/core/core-lro/src/http/operation.ts
+++ b/sdk/core/core-lro/src/http/operation.ts
@@ -110,10 +110,11 @@ export function inferLroMode(inputs: {
 
 function transformStatus(inputs: { status: unknown; statusCode: number }): OperationStatus {
   const { status, statusCode } = inputs;
-  if (typeof status !== "string" && status !== undefined)
+  if (typeof status !== "string" && status !== undefined) {
     throw new Error(
       `Polling was unsuccessful. Expected status to have a string value or no value but it has instead: ${status}. This doesn't necessarily indicate the operation has failed. Check your Azure subscription or resource status for more information.`
     );
+  }
   switch (status?.toLocaleLowerCase()) {
     case undefined:
       return toOperationStatus(statusCode);

--- a/sdk/core/core-lro/src/http/operation.ts
+++ b/sdk/core/core-lro/src/http/operation.ts
@@ -113,7 +113,7 @@ function transformStatus(status: unknown): OperationStatus {
     throw new Error(
       `Polling was unsuccessfull. Expected status to have a string value or no value but it has instead: ${status}. This doesn't necessarily indicate the operation has failed. Check your Azure subscription or resource status for more information.`
     );
-  switch (status) {
+  switch (status?.toLocaleLowerCase()) {
     case undefined:
     case "succeeded":
       return "succeeded";

--- a/sdk/core/core-lro/src/http/operation.ts
+++ b/sdk/core/core-lro/src/http/operation.ts
@@ -108,8 +108,12 @@ export function inferLroMode(inputs: {
   }
 }
 
-function transformStatus(status: string | undefined): OperationStatus {
-  switch (status?.toLowerCase()) {
+function transformStatus(status: unknown): OperationStatus {
+  if (typeof status !== "string" && status !== undefined)
+    throw new Error(
+      `Polling was unsuccessfull. Expected status to have a string value or no value but it has instead: ${status}. This doesn't necessarily indicate the operation has failed. Check your Azure subscription or resource status for more information.`
+    );
+  switch (status) {
     case undefined:
     case "succeeded":
       return "succeeded";
@@ -117,6 +121,7 @@ function transformStatus(status: string | undefined): OperationStatus {
       return "failed";
     case "running":
     case "accepted":
+    case "started":
     case "canceling":
     case "cancelling":
       return "running";

--- a/sdk/core/core-lro/src/http/poller.ts
+++ b/sdk/core/core-lro/src/http/poller.ts
@@ -7,6 +7,7 @@ import {
   getOperationLocation,
   getOperationStatus,
   getResourceLocation,
+  getStatusFromInitialResponse,
   inferLroMode,
   parseRetryAfter,
 } from "./operation";
@@ -32,13 +33,7 @@ export async function createHttpPoller<TResult, TState extends OperationState<TR
     withOperationLocation,
   } = options || {};
   return buildCreatePoller<LroResponse, TResult, TState>({
-    getStatusFromInitialResponse: (response, state) => {
-      const mode = state.config.metadata?.["mode"];
-      return mode === undefined ||
-        (mode === "Body" && getOperationStatus(response, state) === "succeeded")
-        ? "succeeded"
-        : "running";
-    },
+    getStatusFromInitialResponse,
     getStatusFromPollResponse: getOperationStatus,
     getOperationLocation,
     getResourceLocation,

--- a/sdk/core/core-lro/src/legacy/lroEngine/operation.ts
+++ b/sdk/core/core-lro/src/legacy/lroEngine/operation.ts
@@ -68,7 +68,7 @@ export class GenericPollOperation<TResult, TState extends PollOperationState<TRe
     const updateState = this.updateState;
     const isDone = this.isDone;
 
-    if (!this.state.isCompleted) {
+    if (!this.state.isCompleted && this.state.error === undefined) {
       await pollHttpOperation({
         lro: this.lro,
         state: this.state,

--- a/sdk/core/core-lro/src/poller/models.ts
+++ b/sdk/core/core-lro/src/poller/models.ts
@@ -79,10 +79,11 @@ export interface BuildCreatePollerOptions<TResponse, TState> {
    * operation was initialized. Note that the operation could be already in
    * a terminal state at this time.
    */
-  getStatusFromInitialResponse: (
-    response: TResponse,
-    state: RestorableOperationState<TState>
-  ) => OperationStatus;
+  getStatusFromInitialResponse: (inputs: {
+    response: TResponse;
+    state: RestorableOperationState<TState>;
+    operationLocation?: string;
+  }) => OperationStatus;
   /**
    * Gets the status of the operation from a response received when the
    * operation was polled.

--- a/sdk/core/core-lro/test/lro.spec.ts
+++ b/sdk/core/core-lro/test/lro.spec.ts
@@ -3,9 +3,9 @@
 
 import {
   ImplementationName,
+  assertDivergentBehavior,
   assertError,
   createDoubleHeaders,
-  assertDivergentBehavior,
 } from "./utils/utils";
 import { assert, matrix } from "@azure/test-utils";
 import { createRunLroWith, createTestPoller } from "./utils/router";

--- a/sdk/core/core-lro/test/lro.spec.ts
+++ b/sdk/core/core-lro/test/lro.spec.ts
@@ -1686,7 +1686,7 @@ matrix(
                   method: "GET",
                   path: pollingPath,
                   status: 400,
-                  body: `{ "message" : "Expected bad request message" }`,
+                  body: `{ "message" : "Expected bad request message", "status": 400 }`,
                 },
               ],
             }),
@@ -1695,7 +1695,7 @@ matrix(
               statusCode: 400,
             },
             notThrowing: {
-              messagePattern: /The long-running operation has failed/,
+              messagePattern: /Polling was unsuccessful/,
             },
           });
         });

--- a/sdk/core/core-lro/test/lro.spec.ts
+++ b/sdk/core/core-lro/test/lro.spec.ts
@@ -1,1125 +1,865 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { ImplementationName, assertError, createDoubleHeaders } from "./utils/utils";
+import {
+  ImplementationName,
+  assertError,
+  createDoubleHeaders,
+  assertDivergentBehavior,
+} from "./utils/utils";
 import { assert, matrix } from "@azure/test-utils";
-import { createRunLroWithImpl, createTestPoller } from "./utils/router";
+import { createRunLroWith, createTestPoller } from "./utils/router";
 import { AbortController } from "@azure/abort-controller";
 
-matrix([["createPoller", "LroEngine"]] as const, async function (implName: ImplementationName) {
-  const runLro = createRunLroWithImpl(implName);
-  describe(implName, function () {
-    describe("No polling", () => {
-      it("should handle delete204Succeeded", async () => {
-        const response = await runLro({
-          routes: [{ method: "DELETE", status: 204 }],
+matrix(
+  [
+    ["createPoller", "LroEngine"],
+    [true, false],
+  ] as const,
+  async function (implName: ImplementationName, throwOnNon2xxResponse: boolean) {
+    const runLro = createRunLroWith({ implName, throwOnNon2xxResponse });
+    describe(`${implName} (throwOnNon2xxResponse = ${throwOnNon2xxResponse})`, function () {
+      describe("No polling", () => {
+        it("should handle delete204Succeeded", async () => {
+          const response = await runLro({
+            routes: [{ method: "DELETE", status: 204 }],
+          });
+          assert.equal(response.statusCode, 204);
         });
-        assert.equal(response.statusCode, 204);
-      });
 
-      it("put201Succeeded", async function () {
-        const result = await runLro({
-          routes: [
-            {
-              method: "PUT",
-              status: 201,
-              body: `{ "properties": { "provisioningState": "Succeeded"}, "id": "100", "name": "foo" }`,
-            },
-          ],
-        });
-        assert.equal(result.id, "100");
-        assert.equal(result.name, "foo");
-        assert.equal(result.properties?.provisioningState, "Succeeded");
-      });
-
-      it("should handle post202Retry200", async () => {
-        const path = "/post/202/retry/200";
-        const newPath = "/post/newuri/202/retry/200";
-        const response = await runLro({
-          routes: [
-            {
-              method: "POST",
-              path,
-              status: 202,
-              headers: {
-                location: path,
-                "retry-after": "0",
-              },
-            },
-            {
-              method: "GET",
-              path,
-              status: 202,
-              headers: {
-                location: newPath,
-              },
-            },
-            {
-              method: "GET",
-              path: newPath,
-              status: 200,
-              body: `{"properties":{"provisioningState":"Succeeded"},"id":"100","name":"foo"}`,
-            },
-          ],
-        });
-        assert.equal(response.statusCode, 200);
-      });
-
-      it("should handle post202NoRetry204", async () => {
-        const path = "/post/202/noretry/204";
-        const pollingPath = "/post/newuri/202/noretry/204";
-        const response = await runLro({
-          routes: [
-            {
-              method: "POST",
-              path,
-              status: 202,
-              headers: {
-                location: path,
-              },
-            },
-            {
-              method: "GET",
-              path,
-              status: 202,
-              headers: {
-                location: pollingPath,
-              },
-            },
-            {
-              method: "GET",
-              path: pollingPath,
-              status: 204,
-            },
-          ],
-        });
-        assert.equal(response.statusCode, 204);
-      });
-
-      it("should handle deleteNoHeaderInRetry", async () => {
-        const pollingPath = "/delete/noheader/operationresults/123";
-        const response = await runLro({
-          routes: [
-            {
-              method: "DELETE",
-              status: 200,
-              headers: { Location: pollingPath },
-            },
-            { method: "GET", path: pollingPath, status: 202 },
-            { method: "GET", path: pollingPath, status: 204 },
-          ],
-        });
-        assert.equal(response.statusCode, 204);
-      });
-
-      it("should handle put202Retry200", async () => {
-        const pollingPath = "/put/202/retry/operationResults/200";
-        const response = await runLro({
-          routes: [
-            {
-              method: "PUT",
-              status: 202,
-              headers: { Location: pollingPath },
-            },
-            {
-              method: "GET",
-              path: pollingPath,
-              status: 200,
-              body: `{"id": "100", "name": "foo" }`,
-            },
-          ],
-        });
-        assert.equal(response.statusCode, 200);
-      });
-
-      it("should handle putNoHeaderInRetry", async () => {
-        const pollingPath = "/put/noheader/operationresults";
-        const result = await runLro({
-          routes: [
-            {
-              method: "PUT",
-              status: 202,
-              body: `{ "properties": { "provisioningState": "Accepted"}, "id": "100", "name": "foo" }`,
-              headers: { Location: pollingPath },
-            },
-            { method: "GET", path: pollingPath, status: 202 },
-            {
-              method: "GET",
-              path: pollingPath,
-              status: 200,
-              body: `{ "properties": { "provisioningState": "Succeeded"}, "id": "100", "name": "foo" }`,
-            },
-          ],
-        });
-        assert.equal(result.id, "100");
-        assert.equal(result.name, "foo");
-        assert.equal(result.properties?.provisioningState, "Succeeded");
-      });
-
-      it("should handle putSubResource", async () => {
-        const pollingPath = "/putsubresource/operationresults";
-        const result = await runLro({
-          routes: [
-            {
-              method: "PUT",
-              status: 202,
-              body: `{ "properties": { "provisioningState": "Accepted"}, "id": "100", "subresource": "sub1" }`,
-              headers: { Location: pollingPath },
-            },
-            { method: "GET", path: pollingPath, status: 202 },
-            {
-              method: "GET",
-              path: pollingPath,
-              status: 200,
-              body: `{ "properties": { "provisioningState": "Succeeded"}, "id": "100", "subresource": "sub1" }`,
-            },
-          ],
-        });
-        assert.equal(result.id, "100");
-        assert.equal(result.properties?.provisioningState, "Succeeded");
-      });
-
-      it("should handle putNonResource", async () => {
-        const pollingPath = "/putnonresource/operationresults";
-        const result = await runLro({
-          routes: [
-            {
-              method: "PUT",
-              status: 202,
-              headers: { Location: pollingPath },
-            },
-            { method: "GET", path: pollingPath, status: 202 },
-            {
-              method: "GET",
-              path: pollingPath,
-              status: 200,
-              body: `{ "name": "sku" , "id": "100" }`,
-            },
-          ],
-        });
-        assert.equal(result.id, "100");
-        assert.equal(result.name, "sku");
-      });
-
-      it("should handle delete202Retry200", async () => {
-        const path = "/delete/202/retry/200";
-        const pollingPath = "/delete/newuri/202/retry/200";
-        const response = await runLro({
-          routes: [
-            {
-              method: "DELETE",
-              path,
-              status: 202,
-              headers: {
-                location: path,
-                "retry-after": "0",
-              },
-            },
-            {
-              method: "GET",
-              path,
-              status: 202,
-              headers: {
-                location: pollingPath,
-                "retry-after": "0",
-              },
-            },
-            {
-              method: "GET",
-              path: pollingPath,
-              status: 200,
-            },
-          ],
-        });
-        assert.equal(response.statusCode, 200);
-      });
-
-      it("should handle delete202NoRetry204", async () => {
-        const path = "/delete/202/noretry/204";
-        const newPath = "/delete/newuri/202/noretry/204";
-        const response = await runLro({
-          routes: [
-            {
-              method: "DELETE",
-              path,
-              status: 202,
-              headers: {
-                location: path,
-              },
-            },
-            {
-              method: "GET",
-              path,
-              status: 202,
-              headers: {
-                location: newPath,
-              },
-            },
-            {
-              method: "GET",
-              path: newPath,
-              status: 204,
-            },
-          ],
-        });
-        assert.equal(response.statusCode, 204);
-      });
-
-      it("should handle deleteProvisioning202Accepted200Succeeded", async () => {
-        const pollingPath = "/delete/provisioning/202/accepted/200/succeeded";
-        const response = await runLro({
-          routes: [
-            {
-              method: "DELETE",
-              status: 202,
-              headers: {
-                location: pollingPath,
-                "retry-after": "0",
-              },
-              body: `{"properties":{"provisioningState":"Accepted"},"id":"100","name":"foo"}`,
-            },
-            {
-              method: "GET",
-              path: pollingPath,
-              status: 200,
-              body: `{"properties":{"provisioningState":"Succeeded"},"id":"100","name":"foo"}`,
-            },
-          ],
-        });
-        assert.equal(response.statusCode, 200);
-      });
-
-      it("should handle deleteProvisioning202DeletingFailed200", async () => {
-        const path = "/delete/provisioning/202/deleting/200/failed";
-        const response = await runLro({
-          routes: [
-            {
-              method: "DELETE",
-              path,
-              status: 202,
-              headers: {
-                location: path,
-                "retry-after": "0",
-              },
-              body: `{"properties":{"provisioningState":"Deleting"},"id":"100","name":"foo"}`,
-            },
-            {
-              method: "GET",
-              path,
-              status: 200,
-              body: `{"properties":{"provisioningState":"Failed"},"id":"100","name":"foo"}`,
-            },
-          ],
-        });
-        assert.equal(response.statusCode, 200);
-        assert.equal(response.properties?.provisioningState, "Failed");
-      });
-
-      it("should handle deleteProvisioning202Deletingcanceled200", async () => {
-        const path = "/delete/provisioning/202/deleting/200/canceled";
-        const response = await runLro({
-          routes: [
-            {
-              method: "DELETE",
-              path,
-              status: 202,
-              headers: {
-                location: path,
-                "retry-after": "0",
-              },
-              body: `{"properties":{"provisioningState":"Deleting"},"id":"100","name":"foo"}`,
-            },
-            {
-              method: "GET",
-              path,
-              status: 200,
-              body: `{"properties":{"provisioningState":"Canceled"},"id":"100","name":"foo"}`,
-            },
-          ],
-        });
-        assert.equal(response.statusCode, 200);
-        assert.equal(response.properties?.provisioningState, "Canceled");
-      });
-    });
-
-    describe("Polling from body", () => {
-      it("put200Succeeded", async function () {
-        const result = await runLro({
-          routes: [
-            {
-              method: "PUT",
-              status: 200,
-              body: `{ "properties": { "provisioningState": "Succeeded"}, "id": "100", "name": "foo" }`,
-            },
-          ],
-        });
-        assert.equal(result.properties?.provisioningState, "Succeeded");
-      });
-
-      it("should handle initial response with terminal state without provisioning State", async () => {
-        const result = await runLro({
-          routes: [
-            {
-              method: "PUT",
-              status: 200,
-              body: `{"id": "100", "name": "foo" }`,
-            },
-          ],
-        });
-        assert.deepEqual(result.id, "100");
-        assert.deepEqual(result.name, "foo");
-      });
-
-      it("should handle initial response creating followed by success through an Azure Resource", async () => {
-        const path = "/put/201/creating/succeeded/200";
-        const result = await runLro({
-          routes: [
-            {
-              method: "PUT",
-              path,
-              status: 201,
-              body: `{"properties":{"provisioningState":"Creating"},"id":"100","name":"foo"}`,
-            },
-            {
-              method: "GET",
-              path,
-              status: 200,
-              body: `{"properties":{"provisioningState":"Succeeded"},"id":"100","name":"foo"}`,
-            },
-          ],
-        });
-        assert.deepEqual(result.properties?.provisioningState, "Succeeded");
-        assert.deepEqual(result.id, "100");
-        assert.deepEqual(result.name, "foo");
-      });
-
-      it("should handle put200Acceptedcanceled200", async () => {
-        const path = "/put/200/accepted/canceled/200";
-        await assertError(
-          runLro({
+        it("put201Succeeded", async function () {
+          const result = await runLro({
             routes: [
               {
                 method: "PUT",
+                status: 201,
+                body: `{ "properties": { "provisioningState": "Succeeded"}, "id": "100", "name": "foo" }`,
+              },
+            ],
+          });
+          assert.equal(result.id, "100");
+          assert.equal(result.name, "foo");
+          assert.equal(result.properties?.provisioningState, "Succeeded");
+        });
+
+        it("should handle post202Retry200", async () => {
+          const path = "/post/202/retry/200";
+          const newPath = "/post/newuri/202/retry/200";
+          const response = await runLro({
+            routes: [
+              {
+                method: "POST",
                 path,
+                status: 202,
+                headers: {
+                  location: path,
+                  "retry-after": "0",
+                },
+              },
+              {
+                method: "GET",
+                path,
+                status: 202,
+                headers: {
+                  location: newPath,
+                },
+              },
+              {
+                method: "GET",
+                path: newPath,
                 status: 200,
+                body: `{"properties":{"provisioningState":"Succeeded"},"id":"100","name":"foo"}`,
+              },
+            ],
+          });
+          assert.equal(response.statusCode, 200);
+        });
+
+        it("should handle post202NoRetry204", async () => {
+          const path = "/post/202/noretry/204";
+          const pollingPath = "/post/newuri/202/noretry/204";
+          const response = await runLro({
+            routes: [
+              {
+                method: "POST",
+                path,
+                status: 202,
+                headers: {
+                  location: path,
+                },
+              },
+              {
+                method: "GET",
+                path,
+                status: 202,
+                headers: {
+                  location: pollingPath,
+                },
+              },
+              {
+                method: "GET",
+                path: pollingPath,
+                status: 204,
+              },
+            ],
+          });
+          assert.equal(response.statusCode, 204);
+        });
+
+        it("should handle deleteNoHeaderInRetry", async () => {
+          const pollingPath = "/delete/noheader/operationresults/123";
+          const response = await runLro({
+            routes: [
+              {
+                method: "DELETE",
+                status: 200,
+                headers: { Location: pollingPath },
+              },
+              { method: "GET", path: pollingPath, status: 202 },
+              { method: "GET", path: pollingPath, status: 204 },
+            ],
+          });
+          assert.equal(response.statusCode, 204);
+        });
+
+        it("should handle put202Retry200", async () => {
+          const pollingPath = "/put/202/retry/operationResults/200";
+          const response = await runLro({
+            routes: [
+              {
+                method: "PUT",
+                status: 202,
+                headers: { Location: pollingPath },
+              },
+              {
+                method: "GET",
+                path: pollingPath,
+                status: 200,
+                body: `{"id": "100", "name": "foo" }`,
+              },
+            ],
+          });
+          assert.equal(response.statusCode, 200);
+        });
+
+        it("should handle putNoHeaderInRetry", async () => {
+          const pollingPath = "/put/noheader/operationresults";
+          const result = await runLro({
+            routes: [
+              {
+                method: "PUT",
+                status: 202,
+                body: `{ "properties": { "provisioningState": "Accepted"}, "id": "100", "name": "foo" }`,
+                headers: { Location: pollingPath },
+              },
+              { method: "GET", path: pollingPath, status: 202 },
+              {
+                method: "GET",
+                path: pollingPath,
+                status: 200,
+                body: `{ "properties": { "provisioningState": "Succeeded"}, "id": "100", "name": "foo" }`,
+              },
+            ],
+          });
+          assert.equal(result.id, "100");
+          assert.equal(result.name, "foo");
+          assert.equal(result.properties?.provisioningState, "Succeeded");
+        });
+
+        it("should handle putSubResource", async () => {
+          const pollingPath = "/putsubresource/operationresults";
+          const result = await runLro({
+            routes: [
+              {
+                method: "PUT",
+                status: 202,
+                body: `{ "properties": { "provisioningState": "Accepted"}, "id": "100", "subresource": "sub1" }`,
+                headers: { Location: pollingPath },
+              },
+              { method: "GET", path: pollingPath, status: 202 },
+              {
+                method: "GET",
+                path: pollingPath,
+                status: 200,
+                body: `{ "properties": { "provisioningState": "Succeeded"}, "id": "100", "subresource": "sub1" }`,
+              },
+            ],
+          });
+          assert.equal(result.id, "100");
+          assert.equal(result.properties?.provisioningState, "Succeeded");
+        });
+
+        it("should handle putNonResource", async () => {
+          const pollingPath = "/putnonresource/operationresults";
+          const result = await runLro({
+            routes: [
+              {
+                method: "PUT",
+                status: 202,
+                headers: { Location: pollingPath },
+              },
+              { method: "GET", path: pollingPath, status: 202 },
+              {
+                method: "GET",
+                path: pollingPath,
+                status: 200,
+                body: `{ "name": "sku" , "id": "100" }`,
+              },
+            ],
+          });
+          assert.equal(result.id, "100");
+          assert.equal(result.name, "sku");
+        });
+
+        it("should handle delete202Retry200", async () => {
+          const path = "/delete/202/retry/200";
+          const pollingPath = "/delete/newuri/202/retry/200";
+          const response = await runLro({
+            routes: [
+              {
+                method: "DELETE",
+                path,
+                status: 202,
+                headers: {
+                  location: path,
+                  "retry-after": "0",
+                },
+              },
+              {
+                method: "GET",
+                path,
+                status: 202,
+                headers: {
+                  location: pollingPath,
+                  "retry-after": "0",
+                },
+              },
+              {
+                method: "GET",
+                path: pollingPath,
+                status: 200,
+              },
+            ],
+          });
+          assert.equal(response.statusCode, 200);
+        });
+
+        it("should handle delete202NoRetry204", async () => {
+          const path = "/delete/202/noretry/204";
+          const newPath = "/delete/newuri/202/noretry/204";
+          const response = await runLro({
+            routes: [
+              {
+                method: "DELETE",
+                path,
+                status: 202,
+                headers: {
+                  location: path,
+                },
+              },
+              {
+                method: "GET",
+                path,
+                status: 202,
+                headers: {
+                  location: newPath,
+                },
+              },
+              {
+                method: "GET",
+                path: newPath,
+                status: 204,
+              },
+            ],
+          });
+          assert.equal(response.statusCode, 204);
+        });
+
+        it("should handle deleteProvisioning202Accepted200Succeeded", async () => {
+          const pollingPath = "/delete/provisioning/202/accepted/200/succeeded";
+          const response = await runLro({
+            routes: [
+              {
+                method: "DELETE",
+                status: 202,
+                headers: {
+                  location: pollingPath,
+                  "retry-after": "0",
+                },
                 body: `{"properties":{"provisioningState":"Accepted"},"id":"100","name":"foo"}`,
+              },
+              {
+                method: "GET",
+                path: pollingPath,
+                status: 200,
+                body: `{"properties":{"provisioningState":"Succeeded"},"id":"100","name":"foo"}`,
+              },
+            ],
+          });
+          assert.equal(response.statusCode, 200);
+        });
+
+        it("should handle deleteProvisioning202DeletingFailed200", async () => {
+          const path = "/delete/provisioning/202/deleting/200/failed";
+          const response = await runLro({
+            routes: [
+              {
+                method: "DELETE",
+                path,
+                status: 202,
+                headers: {
+                  location: path,
+                  "retry-after": "0",
+                },
+                body: `{"properties":{"provisioningState":"Deleting"},"id":"100","name":"foo"}`,
               },
               {
                 method: "GET",
                 path,
                 status: 200,
-                body: `{"properties":{"provisioningState":"Canceled"}}`,
+                body: `{"properties":{"provisioningState":"Failed"},"id":"100","name":"foo"}`,
               },
             ],
-          }),
-          {
-            messagePattern: /Operation was canceled/,
-          }
-        );
-      });
-
-      it("should handle put200UpdatingSucceeded204", async () => {
-        const path = "/put/200/updating/succeeded/200";
-        const result = await runLro({
-          routes: [
-            {
-              method: "PUT",
-              path,
-              status: 200,
-              body: `{"properties":{"provisioningState":"Updating"},"id":"100","name":"foo"}`,
-            },
-            {
-              method: "GET",
-              path,
-              status: 200,
-              body: `{"properties":{"provisioningState":"Succeeded"},"id":"100","name":"foo"}`,
-            },
-          ],
+          });
+          assert.equal(response.statusCode, 200);
+          assert.equal(response.properties?.provisioningState, "Failed");
         });
-        assert.deepEqual(result.properties?.provisioningState, "Succeeded");
-        assert.deepEqual(result.id, "100");
-        assert.deepEqual(result.name, "foo");
+
+        it("should handle deleteProvisioning202Deletingcanceled200", async () => {
+          const path = "/delete/provisioning/202/deleting/200/canceled";
+          const response = await runLro({
+            routes: [
+              {
+                method: "DELETE",
+                path,
+                status: 202,
+                headers: {
+                  location: path,
+                  "retry-after": "0",
+                },
+                body: `{"properties":{"provisioningState":"Deleting"},"id":"100","name":"foo"}`,
+              },
+              {
+                method: "GET",
+                path,
+                status: 200,
+                body: `{"properties":{"provisioningState":"Canceled"},"id":"100","name":"foo"}`,
+              },
+            ],
+          });
+          assert.equal(response.statusCode, 200);
+          assert.equal(response.properties?.provisioningState, "Canceled");
+        });
       });
 
-      it("should handle put201CreatingFailed200", async () => {
-        const path = "/put/201/created/failed/200";
-        await assertError(
-          runLro({
+      describe("Polling from body", () => {
+        it("put200Succeeded", async function () {
+          const result = await runLro({
+            routes: [
+              {
+                method: "PUT",
+                status: 200,
+                body: `{ "properties": { "provisioningState": "Succeeded"}, "id": "100", "name": "foo" }`,
+              },
+            ],
+          });
+          assert.equal(result.properties?.provisioningState, "Succeeded");
+        });
+
+        it("should handle initial response with terminal state without provisioning State", async () => {
+          const result = await runLro({
+            routes: [
+              {
+                method: "PUT",
+                status: 200,
+                body: `{"id": "100", "name": "foo" }`,
+              },
+            ],
+          });
+          assert.deepEqual(result.id, "100");
+          assert.deepEqual(result.name, "foo");
+        });
+
+        it("should handle initial response creating followed by success through an Azure Resource", async () => {
+          const path = "/put/201/creating/succeeded/200";
+          const result = await runLro({
             routes: [
               {
                 method: "PUT",
                 path,
                 status: 201,
-                body: `{"properties":{"provisioningState":"Created"},"id":"100","name":"foo"}`,
+                body: `{"properties":{"provisioningState":"Creating"},"id":"100","name":"foo"}`,
               },
               {
                 method: "GET",
                 path,
                 status: 200,
-                body: `{"properties":{"provisioningState":"Failed"}}`,
+                body: `{"properties":{"provisioningState":"Succeeded"},"id":"100","name":"foo"}`,
               },
             ],
-          }),
-          {
-            messagePattern: /The long-running operation has failed/,
-          }
-        );
-      });
-
-      it("should handle post200WithPayload", async () => {
-        const path = `/post/payload/200`;
-        const result = await runLro({
-          routes: [
-            {
-              method: "POST",
-              path,
-              status: 202,
-              headers: { Location: path, "Retry-After": "0" },
-            },
-            { method: "GET", path, status: 200, body: `{"id":"1", "name":"product"}` },
-          ],
+          });
+          assert.deepEqual(result.properties?.provisioningState, "Succeeded");
+          assert.deepEqual(result.id, "100");
+          assert.deepEqual(result.name, "foo");
         });
-        assert.equal(result.id, "1");
-        assert.equal(result.name, "product");
-      });
-    });
 
-    matrix(
-      [["Azure-AsyncOperation", "Operation-Location"]] as const,
-      async function (headerName: string) {
-        describe(`Polling from ${headerName}`, function () {
-          it("should handle postDoubleHeadersFinalLocationGet", async () => {
-            const operationLocationPath = "/LROPostDoubleHeadersFinalLocationGet/asyncOperationUrl";
-            const resourceLocationPath = `/LROPostDoubleHeadersFinalLocationGet/location`;
-            const result = await runLro({
-              routes: [
-                {
-                  method: "POST",
-                  status: 202,
-                  headers: {
-                    Location: resourceLocationPath,
-                    [headerName]: operationLocationPath,
-                  },
-                },
-                {
-                  method: "GET",
-                  path: operationLocationPath,
-                  status: 200,
-                  body: `{ "status": "succeeded" }`,
-                },
-                {
-                  method: "GET",
-                  path: resourceLocationPath,
-                  status: 200,
-                  body: `{ "id": "100", "name": "foo" }`,
-                },
-              ],
-            });
-            assert.equal(result.id, "100");
-            assert.equal(result.name, "foo");
-          });
-
-          it("should handle getDoubleHeadersFinalLocationGet", async () => {
-            const operationLocationPath = "/LROPostDoubleHeadersFinalLocationGet/asyncOperationUrl";
-            const resourceLocationPath = `/LROPostDoubleHeadersFinalLocationGet/location`;
-            const result = await runLro({
-              routes: [
-                {
-                  method: "GET",
-                  status: 202,
-                  headers: {
-                    Location: resourceLocationPath,
-                    [headerName]: operationLocationPath,
-                  },
-                },
-                {
-                  method: "GET",
-                  path: operationLocationPath,
-                  status: 200,
-                  body: `{ "status": "running" }`,
-                },
-                {
-                  method: "GET",
-                  path: operationLocationPath,
-                  status: 200,
-                  body: `{ "status": "succeeded" }`,
-                },
-                {
-                  method: "GET",
-                  path: resourceLocationPath,
-                  status: 200,
-                  body: `{ "id": "100", "name": "foo" }`,
-                },
-              ],
-            });
-            assert.equal(result.id, "100");
-            assert.equal(result.name, "foo");
-          });
-
-          it("should handle getDoubleHeaders", async () => {
-            const operationLocationPath = "/LROPostDoubleHeadersFinalLocationGet/asyncOperationUrl";
-            const result = await runLro({
-              routes: [
-                {
-                  method: "GET",
-                  status: 202,
-                  headers: {
-                    [headerName]: operationLocationPath,
-                  },
-                },
-                {
-                  method: "GET",
-                  path: operationLocationPath,
-                  status: 200,
-                  body: `{ "status": "running" }`,
-                },
-                {
-                  method: "GET",
-                  path: operationLocationPath,
-                  status: 200,
-                  body: `{ "status": "succeeded", "id": "100", "name": "foo" }`,
-                },
-              ],
-            });
-            assert.equal(result.id, "100");
-            assert.equal(result.name, "foo");
-          });
-
-          it("should handle get200", async () => {
-            const result = await runLro({
-              routes: [
-                {
-                  method: "GET",
-                  status: 200,
-                  body: `{ "id": "100", "name": "foo" }`,
-                },
-              ],
-            });
-            assert.equal(result.id, "100");
-            assert.equal(result.name, "foo");
-          });
-
-          it("should handle postUpdatedPollingUrl", async () => {
-            const operationLocationPath1 = "path1";
-            const operationLocationPath2 = "path2";
-            const result = await runLro({
-              routes: [
-                {
-                  method: "POST",
-                  status: 200,
-                  headers: {
-                    [headerName]: operationLocationPath1,
-                  },
-                },
-                {
-                  method: "GET",
-                  path: operationLocationPath1,
-                  status: 200,
-                  body: `{ "status": "running" }`,
-                  headers: {
-                    [headerName]: operationLocationPath2,
-                  },
-                },
-                {
-                  method: "GET",
-                  path: operationLocationPath2,
-                  status: 200,
-                  body: `{ "status": "succeeded", "id": "100", "name": "foo" }`,
-                },
-              ],
-            });
-            assert.equal(result.id, "100");
-            assert.equal(result.name, "foo");
-          });
-
-          it("should handle postDoubleHeadersFinalAzureHeaderGet", async () => {
-            const locationPath = `/LROPostDoubleHeadersFinalAzureHeaderGet/location`;
-            const operationLocationPath = `/LROPostDoubleHeadersFinalAzureHeaderGet/asyncOperationUrl`;
-            const result = await runLro({
-              routes: [
-                {
-                  method: "POST",
-                  status: 202,
-                  body: "",
-                  headers: {
-                    Location: locationPath,
-                    [headerName]: operationLocationPath,
-                  },
-                },
-                {
-                  method: "GET",
-                  path: operationLocationPath,
-                  status: 200,
-                  body: `{ "status": "succeeded", "id": "100"}`,
-                },
-                {
-                  method: "GET",
-                  path: locationPath,
-                  status: 400,
-                },
-              ],
-              resourceLocationConfig: "azure-async-operation",
-            });
-            assert.equal(result.statusCode, 200);
-            assert.equal(result.id, "100");
-          });
-
-          it("should handle postDoubleHeadersFinalAzureHeaderGetDefault", async () => {
-            const resourceLocationPath = "/LROPostDoubleHeadersFinalAzureHeaderGetDefault/location";
-            const pollingPath = "/LROPostDoubleHeadersFinalAzureHeaderGetDefault/asyncOperationUrl";
-            const result = await runLro({
-              routes: [
-                {
-                  method: "POST",
-                  status: 202,
-                  body: "",
-                  headers: {
-                    Location: resourceLocationPath,
-                    [headerName]: pollingPath,
-                  },
-                },
-                {
-                  method: "GET",
-                  path: pollingPath,
-                  status: 200,
-                  body: `{ "status": "succeeded"}`,
-                },
-                {
-                  method: "GET",
-                  path: resourceLocationPath,
-                  status: 200,
-                  body: `{ "id": "100", "name": "foo" }`,
-                },
-              ],
-            });
-            assert.equal(result.id, "100");
-            assert.equal(result.statusCode, 200);
-          });
-
-          it("should handle deleteAsyncRetrySucceeded", async () => {
-            const pollingPath = "/deleteasync/retry/succeeded/operationResults/200/";
-            const response = await runLro({
-              routes: [
-                {
-                  method: "DELETE",
-                  status: 202,
-                  headers: {
-                    location: pollingPath,
-                    [headerName]: pollingPath,
-                    "retry-after": "0",
-                  },
-                },
-                {
-                  method: "GET",
-                  path: pollingPath,
-                  status: 202,
-                  headers: {
-                    location: pollingPath,
-                    [headerName]: pollingPath,
-                    "retry-after": "0",
-                  },
-                  body: `{"status":"Accepted"}`,
-                },
-                {
-                  method: "GET",
-                  path: pollingPath,
-                  status: 200,
-                  body: `{"status":"Succeeded"}`,
-                },
-              ],
-            });
-            assert.equal(response.statusCode, 200);
-          });
-
-          it("should handle deleteAsyncNoRetrySucceeded", async () => {
-            const pollingPath = "/deleteasync/noretry/succeeded/operationResults/200/";
-            const response = await runLro({
-              routes: [
-                {
-                  method: "DELETE",
-                  status: 202,
-                  headers: {
-                    location: pollingPath,
-                    [headerName]: pollingPath,
-                  },
-                },
-                {
-                  method: "GET",
-                  path: pollingPath,
-                  status: 202,
-                  headers: {
-                    location: pollingPath,
-                    [headerName]: pollingPath,
-                  },
-                  body: `{"status":"Accepted"}`,
-                },
-                {
-                  method: "GET",
-                  path: pollingPath,
-                  status: 200,
-                  body: `{"status":"Succeeded"}`,
-                },
-              ],
-            });
-            assert.equal(response.statusCode, 200);
-          });
-
-          it("should handle deleteAsyncRetrycanceled", async () => {
-            const pollingPath = "/deletelocation/retry/canceled/operationResults/200/";
-            await assertError(
-              runLro({
-                routes: [
-                  {
-                    method: "DELETE",
-                    status: 202,
-                    headers: {
-                      location: pollingPath,
-                      [headerName]: pollingPath,
-                      "retry-after": "0",
-                    },
-                  },
-                  {
-                    method: "GET",
-                    path: pollingPath,
-                    status: 202,
-                    body: `{"status":"Accepted"}`,
-                  },
-                  {
-                    method: "GET",
-                    path: pollingPath,
-                    status: 200,
-                    body: `{"status":"Canceled"}`,
-                  },
-                ],
-              }),
-              {
-                messagePattern: /Operation was canceled/,
-              }
-            );
-          });
-
-          it("should handle DeleteAsyncRetryFailed", async () => {
-            const pollingPath = "/deleteasync/retry/failed/operationResults/200/";
-            await assertError(
-              runLro({
-                routes: [
-                  {
-                    method: "DELETE",
-                    status: 202,
-                    headers: {
-                      location: pollingPath,
-                      [headerName]: pollingPath,
-                      "retry-after": "0",
-                    },
-                  },
-                  {
-                    method: "GET",
-                    path: pollingPath,
-                    status: 202,
-                    headers: {
-                      location: pollingPath,
-                      [headerName]: pollingPath,
-                      "retry-after": "0",
-                    },
-                    body: `{"status":"Accepted"}`,
-                  },
-                  {
-                    method: "GET",
-                    path: pollingPath,
-                    status: 200,
-                    body: `{"status":"Failed"}`,
-                  },
-                ],
-              }),
-              {
-                messagePattern: /The long-running operation has failed/,
-              }
-            );
-          });
-
-          it("should handle putAsyncRetrySucceeded", async () => {
-            const path = `/put/noretry/succeeded`;
-            const pollingPath = "/putasync/noretry/succeeded/operationResults/200/";
-            const result = await runLro({
+        it("should handle put200Acceptedcanceled200", async () => {
+          const path = "/put/200/accepted/canceled/200";
+          await assertError(
+            runLro({
               routes: [
                 {
                   method: "PUT",
                   path,
                   status: 200,
-                  headers: {
-                    location: pollingPath,
-                    [headerName]: pollingPath,
-                  },
                   body: `{"properties":{"provisioningState":"Accepted"},"id":"100","name":"foo"}`,
                 },
                 {
                   method: "GET",
-                  path: pollingPath,
-                  status: 202,
-                  headers: {
-                    location: pollingPath,
-                    [headerName]: pollingPath,
-                  },
-                  body: `{"status":"Accepted"}`,
-                },
-                {
-                  method: "GET",
-                  path: pollingPath,
-                  status: 200,
-                  body: `{"status":"Succeeded"}`,
-                },
-                {
-                  method: "GET",
                   path,
                   status: 200,
-                  body: `{"properties":{"provisioningState":"Succeeded"},"id":"100","name":"foo"}`,
+                  body: `{"properties":{"provisioningState":"Canceled"}}`,
                 },
               ],
-            });
-            assert.equal(result.id, "100");
-            assert.equal(result.name, "foo");
-            assert.equal(result.properties?.provisioningState, "Succeeded");
-          });
+            }),
+            {
+              messagePattern: /Operation was canceled/,
+            }
+          );
+        });
 
-          it("should handle post202List", async () => {
-            const resourceLocationPath = `/list/finalGet`;
-            const pollingPath = `/list/pollingGet`;
-            const result = await runLro({
-              routes: [
-                {
-                  method: "POST",
-                  status: 200,
-                  headers: {
-                    Location: resourceLocationPath,
-                    [headerName]: pollingPath,
-                  },
-                },
-                {
-                  method: "GET",
-                  path: pollingPath,
-                  status: 200,
-                  body: `{ "status": "Succeeded" }`,
-                },
-                {
-                  method: "GET",
-                  path: resourceLocationPath,
-                  status: 200,
-                  body: `[{ "id": "100", "name": "foo" }]`,
-                },
-              ],
-            });
-            assert.equal((result as any)[0].id, "100");
-            assert.equal((result as any)[0].name, "foo");
-          });
-
-          it("should handle putAsyncRetryFailed", async () => {
-            const pollingPath = "/putlocation/retry/failed/operationResults/200/";
-            await assertError(
-              runLro({
-                routes: [
-                  {
-                    method: "PUT",
-                    status: 200,
-                    body: `{"properties":{"provisioningState":"Accepted"},"id":"100","name":"foo"}`,
-                    headers: {
-                      location: pollingPath,
-                      [headerName]: pollingPath,
-                      "retry-after": "0",
-                    },
-                  },
-                  {
-                    method: "GET",
-                    path: pollingPath,
-                    status: 202,
-                    headers: {
-                      location: pollingPath,
-                      [headerName]: pollingPath,
-                      "retry-after": "0",
-                    },
-                    body: `{"status":"Accepted"}`,
-                  },
-                  {
-                    method: "GET",
-                    path: pollingPath,
-                    status: 200,
-                    body: `{"status":"Failed"}`,
-                  },
-                ],
-              }),
+        it("should handle put200UpdatingSucceeded204", async () => {
+          const path = "/put/200/updating/succeeded/200";
+          const result = await runLro({
+            routes: [
               {
-                messagePattern: /The long-running operation has failed/,
-              }
-            );
+                method: "PUT",
+                path,
+                status: 200,
+                body: `{"properties":{"provisioningState":"Updating"},"id":"100","name":"foo"}`,
+              },
+              {
+                method: "GET",
+                path,
+                status: 200,
+                body: `{"properties":{"provisioningState":"Succeeded"},"id":"100","name":"foo"}`,
+              },
+            ],
           });
+          assert.deepEqual(result.properties?.provisioningState, "Succeeded");
+          assert.deepEqual(result.id, "100");
+          assert.deepEqual(result.name, "foo");
+        });
 
-          it("should handle putAsyncNonResource", async () => {
-            const path = `/putnonresource/202/200`;
-            const pollingUrl = `/putnonresourceasync/operationresults/123`;
-            const result = await runLro({
-              routes: [
-                {
-                  method: "PUT",
-                  path,
-                  status: 202,
-                  headers: {
-                    Location: `somethingBadWhichShouldNotBeUsed`,
-                    [headerName]: pollingUrl,
-                  },
-                },
-                {
-                  method: "GET",
-                  path: pollingUrl,
-                  status: 200,
-                  body: `{ "status": "InProgress"}`,
-                },
-                {
-                  method: "GET",
-                  path: pollingUrl,
-                  status: 200,
-                  body: `{ "status": "Succeeded"}`,
-                },
-                {
-                  method: "GET",
-                  path,
-                  status: 200,
-                  body: `{ "name": "sku" , "id": "100" }`,
-                },
-              ],
-            });
-            assert.equal(result.name, "sku");
-            assert.equal(result.id, "100");
-          });
-
-          it("should handle patchAsync", async () => {
-            const resourceLocationPath = `/patchasync/succeeded`;
-            const pollingPath = `/patchasync/operationresults/123`;
-            const result = await runLro({
-              routes: [
-                {
-                  method: "PATCH",
-                  status: 202,
-                  headers: {
-                    Location: resourceLocationPath,
-                    [headerName]: pollingPath,
-                  },
-                },
-                {
-                  method: "GET",
-                  path: pollingPath,
-                  status: 200,
-                  body: `{ "status": "InProgress"}`,
-                  headers: {
-                    "Azure-AsyncOperation": pollingPath,
-                  },
-                },
-                {
-                  method: "GET",
-                  path: pollingPath,
-                  status: 200,
-                  body: `{ "status": "Succeeded"}`,
-                },
-                {
-                  method: "GET",
-                  path: resourceLocationPath,
-                  status: 200,
-                  body: `{ "name": "sku" , "id": "100" }`,
-                },
-              ],
-            });
-            assert.equal(result.name, "sku");
-            assert.equal(result.id, "100");
-          });
-
-          it("should handle putAsyncNoHeaderInRetry", async () => {
-            const path = `/put/noheader/201/200`;
-            const pollingPath = `/putasync/noheader/operationresults/123`;
-            const result = await runLro({
+        it("should handle put201CreatingFailed200", async () => {
+          const path = "/put/201/created/failed/200";
+          await assertError(
+            runLro({
               routes: [
                 {
                   method: "PUT",
                   path,
                   status: 201,
-                  body: `{ "properties": { "provisioningState": "Accepted"}, "id": "100", "name": "foo" }`,
-                  headers: {
-                    Location: `somethingBadWhichShouldNotBeUsed`,
-                    [headerName]: pollingPath,
-                  },
-                },
-                {
-                  method: "GET",
-                  path: pollingPath,
-                  status: 200,
-                  body: `{ "status": "InProgress"}`,
-                },
-                {
-                  method: "GET",
-                  path: pollingPath,
-                  status: 200,
-                  body: `{ "status": "Succeeded"}`,
+                  body: `{"properties":{"provisioningState":"Created"},"id":"100","name":"foo"}`,
                 },
                 {
                   method: "GET",
                   path,
                   status: 200,
-                  body: `{ "properties": { "provisioningState": "Succeeded"}, "id": "100", "name": "foo" }`,
+                  body: `{"properties":{"provisioningState":"Failed"}}`,
                 },
               ],
-            });
-            assert.equal(result.name, "foo");
-            assert.equal(result.id, "100");
-            assert.deepEqual(result.properties?.provisioningState, "Succeeded");
-          });
+            }),
+            {
+              messagePattern: /The long-running operation has failed/,
+            }
+          );
+        });
 
-          it("should handle putAsyncNoRetrySucceeded", async () => {
-            const path = `/put/noretry/succeeded`;
-            const pollingPath = "/putlocation/noretry/succeeded/operationResults/200/";
-            const result = await runLro({
-              routes: [
-                {
-                  method: "PUT",
-                  path,
-                  status: 200,
-                  headers: {
-                    location: pollingPath,
-                    [headerName]: pollingPath,
-                  },
-                  body: `{"properties":{"provisioningState":"Accepted"},"id":"100","name":"foo"}`,
-                },
-                {
-                  method: "GET",
-                  path: pollingPath,
-                  status: 202,
-                  headers: {
-                    location: pollingPath,
-                    [headerName]: pollingPath,
-                  },
-                  body: `{"status":"Accepted"}`,
-                },
-                {
-                  method: "GET",
-                  path: pollingPath,
-                  status: 200,
-                  body: `{"status":"Succeeded"}`,
-                },
-                {
-                  method: "GET",
-                  path,
-                  status: 200,
-                  body: `{"properties":{"provisioningState":"Succeeded"},"id":"100","name":"foo"}`,
-                },
-              ],
-            });
-            assert.equal(result.name, "foo");
-            assert.equal(result.id, "100");
+        it("should handle post200WithPayload", async () => {
+          const path = `/post/payload/200`;
+          const result = await runLro({
+            routes: [
+              {
+                method: "POST",
+                path,
+                status: 202,
+                headers: { Location: path, "Retry-After": "0" },
+              },
+              { method: "GET", path, status: 200, body: `{"id":"1", "name":"product"}` },
+            ],
           });
+          assert.equal(result.id, "1");
+          assert.equal(result.name, "product");
+        });
+      });
 
-          it("should handle putAsyncNoRetrycanceled", async () => {
-            const pollingPath = "/putlocation/noretry/canceled/operationResults/200/";
-            await assertError(
-              runLro({
+      matrix(
+        [["Azure-AsyncOperation", "Operation-Location"]] as const,
+        async function (headerName: string) {
+          describe(`Polling from ${headerName}`, function () {
+            it("should handle postDoubleHeadersFinalLocationGet", async () => {
+              const operationLocationPath =
+                "/LROPostDoubleHeadersFinalLocationGet/asyncOperationUrl";
+              const resourceLocationPath = `/LROPostDoubleHeadersFinalLocationGet/location`;
+              const result = await runLro({
+                routes: [
+                  {
+                    method: "POST",
+                    status: 202,
+                    headers: {
+                      Location: resourceLocationPath,
+                      [headerName]: operationLocationPath,
+                    },
+                  },
+                  {
+                    method: "GET",
+                    path: operationLocationPath,
+                    status: 200,
+                    body: `{ "status": "succeeded" }`,
+                  },
+                  {
+                    method: "GET",
+                    path: resourceLocationPath,
+                    status: 200,
+                    body: `{ "id": "100", "name": "foo" }`,
+                  },
+                ],
+              });
+              assert.equal(result.id, "100");
+              assert.equal(result.name, "foo");
+            });
+
+            it("should handle getDoubleHeadersFinalLocationGet", async () => {
+              const operationLocationPath =
+                "/LROPostDoubleHeadersFinalLocationGet/asyncOperationUrl";
+              const resourceLocationPath = `/LROPostDoubleHeadersFinalLocationGet/location`;
+              const result = await runLro({
+                routes: [
+                  {
+                    method: "GET",
+                    status: 202,
+                    headers: {
+                      Location: resourceLocationPath,
+                      [headerName]: operationLocationPath,
+                    },
+                  },
+                  {
+                    method: "GET",
+                    path: operationLocationPath,
+                    status: 200,
+                    body: `{ "status": "running" }`,
+                  },
+                  {
+                    method: "GET",
+                    path: operationLocationPath,
+                    status: 200,
+                    body: `{ "status": "succeeded" }`,
+                  },
+                  {
+                    method: "GET",
+                    path: resourceLocationPath,
+                    status: 200,
+                    body: `{ "id": "100", "name": "foo" }`,
+                  },
+                ],
+              });
+              assert.equal(result.id, "100");
+              assert.equal(result.name, "foo");
+            });
+
+            it("should handle getDoubleHeaders", async () => {
+              const operationLocationPath =
+                "/LROPostDoubleHeadersFinalLocationGet/asyncOperationUrl";
+              const result = await runLro({
+                routes: [
+                  {
+                    method: "GET",
+                    status: 202,
+                    headers: {
+                      [headerName]: operationLocationPath,
+                    },
+                  },
+                  {
+                    method: "GET",
+                    path: operationLocationPath,
+                    status: 200,
+                    body: `{ "status": "running" }`,
+                  },
+                  {
+                    method: "GET",
+                    path: operationLocationPath,
+                    status: 200,
+                    body: `{ "status": "succeeded", "id": "100", "name": "foo" }`,
+                  },
+                ],
+              });
+              assert.equal(result.id, "100");
+              assert.equal(result.name, "foo");
+            });
+
+            it("should handle get200", async () => {
+              const result = await runLro({
+                routes: [
+                  {
+                    method: "GET",
+                    status: 200,
+                    body: `{ "id": "100", "name": "foo" }`,
+                  },
+                ],
+              });
+              assert.equal(result.id, "100");
+              assert.equal(result.name, "foo");
+            });
+
+            it("should handle postUpdatedPollingUrl", async () => {
+              const operationLocationPath1 = "path1";
+              const operationLocationPath2 = "path2";
+              const result = await runLro({
+                routes: [
+                  {
+                    method: "POST",
+                    status: 200,
+                    headers: {
+                      [headerName]: operationLocationPath1,
+                    },
+                  },
+                  {
+                    method: "GET",
+                    path: operationLocationPath1,
+                    status: 200,
+                    body: `{ "status": "running" }`,
+                    headers: {
+                      [headerName]: operationLocationPath2,
+                    },
+                  },
+                  {
+                    method: "GET",
+                    path: operationLocationPath2,
+                    status: 200,
+                    body: `{ "status": "succeeded", "id": "100", "name": "foo" }`,
+                  },
+                ],
+              });
+              assert.equal(result.id, "100");
+              assert.equal(result.name, "foo");
+            });
+
+            it("should handle postDoubleHeadersFinalAzureHeaderGet", async () => {
+              const locationPath = `/LROPostDoubleHeadersFinalAzureHeaderGet/location`;
+              const operationLocationPath = `/LROPostDoubleHeadersFinalAzureHeaderGet/asyncOperationUrl`;
+              const result = await runLro({
+                routes: [
+                  {
+                    method: "POST",
+                    status: 202,
+                    body: "",
+                    headers: {
+                      Location: locationPath,
+                      [headerName]: operationLocationPath,
+                    },
+                  },
+                  {
+                    method: "GET",
+                    path: operationLocationPath,
+                    status: 200,
+                    body: `{ "status": "succeeded", "id": "100"}`,
+                  },
+                  {
+                    method: "GET",
+                    path: locationPath,
+                    status: 400,
+                  },
+                ],
+                resourceLocationConfig: "azure-async-operation",
+              });
+              assert.equal(result.statusCode, 200);
+              assert.equal(result.id, "100");
+            });
+
+            it("should handle postDoubleHeadersFinalAzureHeaderGetDefault", async () => {
+              const resourceLocationPath =
+                "/LROPostDoubleHeadersFinalAzureHeaderGetDefault/location";
+              const pollingPath =
+                "/LROPostDoubleHeadersFinalAzureHeaderGetDefault/asyncOperationUrl";
+              const result = await runLro({
+                routes: [
+                  {
+                    method: "POST",
+                    status: 202,
+                    body: "",
+                    headers: {
+                      Location: resourceLocationPath,
+                      [headerName]: pollingPath,
+                    },
+                  },
+                  {
+                    method: "GET",
+                    path: pollingPath,
+                    status: 200,
+                    body: `{ "status": "succeeded"}`,
+                  },
+                  {
+                    method: "GET",
+                    path: resourceLocationPath,
+                    status: 200,
+                    body: `{ "id": "100", "name": "foo" }`,
+                  },
+                ],
+              });
+              assert.equal(result.id, "100");
+              assert.equal(result.statusCode, 200);
+            });
+
+            it("should handle deleteAsyncRetrySucceeded", async () => {
+              const pollingPath = "/deleteasync/retry/succeeded/operationResults/200/";
+              const response = await runLro({
+                routes: [
+                  {
+                    method: "DELETE",
+                    status: 202,
+                    headers: {
+                      location: pollingPath,
+                      [headerName]: pollingPath,
+                      "retry-after": "0",
+                    },
+                  },
+                  {
+                    method: "GET",
+                    path: pollingPath,
+                    status: 202,
+                    headers: {
+                      location: pollingPath,
+                      [headerName]: pollingPath,
+                      "retry-after": "0",
+                    },
+                    body: `{"status":"Accepted"}`,
+                  },
+                  {
+                    method: "GET",
+                    path: pollingPath,
+                    status: 200,
+                    body: `{"status":"Succeeded"}`,
+                  },
+                ],
+              });
+              assert.equal(response.statusCode, 200);
+            });
+
+            it("should handle deleteAsyncNoRetrySucceeded", async () => {
+              const pollingPath = "/deleteasync/noretry/succeeded/operationResults/200/";
+              const response = await runLro({
+                routes: [
+                  {
+                    method: "DELETE",
+                    status: 202,
+                    headers: {
+                      location: pollingPath,
+                      [headerName]: pollingPath,
+                    },
+                  },
+                  {
+                    method: "GET",
+                    path: pollingPath,
+                    status: 202,
+                    headers: {
+                      location: pollingPath,
+                      [headerName]: pollingPath,
+                    },
+                    body: `{"status":"Accepted"}`,
+                  },
+                  {
+                    method: "GET",
+                    path: pollingPath,
+                    status: 200,
+                    body: `{"status":"Succeeded"}`,
+                  },
+                ],
+              });
+              assert.equal(response.statusCode, 200);
+            });
+
+            it("should handle deleteAsyncRetrycanceled", async () => {
+              const pollingPath = "/deletelocation/retry/canceled/operationResults/200/";
+              await assertError(
+                runLro({
+                  routes: [
+                    {
+                      method: "DELETE",
+                      status: 202,
+                      headers: {
+                        location: pollingPath,
+                        [headerName]: pollingPath,
+                        "retry-after": "0",
+                      },
+                    },
+                    {
+                      method: "GET",
+                      path: pollingPath,
+                      status: 202,
+                      body: `{"status":"Accepted"}`,
+                    },
+                    {
+                      method: "GET",
+                      path: pollingPath,
+                      status: 200,
+                      body: `{"status":"Canceled"}`,
+                    },
+                  ],
+                }),
+                {
+                  messagePattern: /Operation was canceled/,
+                }
+              );
+            });
+
+            it("should handle DeleteAsyncRetryFailed", async () => {
+              const pollingPath = "/deleteasync/retry/failed/operationResults/200/";
+              await assertError(
+                runLro({
+                  routes: [
+                    {
+                      method: "DELETE",
+                      status: 202,
+                      headers: {
+                        location: pollingPath,
+                        [headerName]: pollingPath,
+                        "retry-after": "0",
+                      },
+                    },
+                    {
+                      method: "GET",
+                      path: pollingPath,
+                      status: 202,
+                      headers: {
+                        location: pollingPath,
+                        [headerName]: pollingPath,
+                        "retry-after": "0",
+                      },
+                      body: `{"status":"Accepted"}`,
+                    },
+                    {
+                      method: "GET",
+                      path: pollingPath,
+                      status: 200,
+                      body: `{"status":"Failed"}`,
+                    },
+                  ],
+                }),
+                {
+                  messagePattern: /The long-running operation has failed/,
+                }
+              );
+            });
+
+            it("should handle putAsyncRetrySucceeded", async () => {
+              const path = `/put/noretry/succeeded`;
+              const pollingPath = "/putasync/noretry/succeeded/operationResults/200/";
+              const result = await runLro({
                 routes: [
                   {
                     method: "PUT",
+                    path,
                     status: 200,
                     headers: {
                       location: pollingPath,
@@ -1141,139 +881,443 @@ matrix([["createPoller", "LroEngine"]] as const, async function (implName: Imple
                     method: "GET",
                     path: pollingPath,
                     status: 200,
+                    body: `{"status":"Succeeded"}`,
+                  },
+                  {
+                    method: "GET",
+                    path,
+                    status: 200,
+                    body: `{"properties":{"provisioningState":"Succeeded"},"id":"100","name":"foo"}`,
+                  },
+                ],
+              });
+              assert.equal(result.id, "100");
+              assert.equal(result.name, "foo");
+              assert.equal(result.properties?.provisioningState, "Succeeded");
+            });
+
+            it("should handle post202List", async () => {
+              const resourceLocationPath = `/list/finalGet`;
+              const pollingPath = `/list/pollingGet`;
+              const result = await runLro({
+                routes: [
+                  {
+                    method: "POST",
+                    status: 200,
+                    headers: {
+                      Location: resourceLocationPath,
+                      [headerName]: pollingPath,
+                    },
+                  },
+                  {
+                    method: "GET",
+                    path: pollingPath,
+                    status: 200,
+                    body: `{ "status": "Succeeded" }`,
+                  },
+                  {
+                    method: "GET",
+                    path: resourceLocationPath,
+                    status: 200,
+                    body: `[{ "id": "100", "name": "foo" }]`,
+                  },
+                ],
+              });
+              assert.equal((result as any)[0].id, "100");
+              assert.equal((result as any)[0].name, "foo");
+            });
+
+            it("should handle putAsyncRetryFailed", async () => {
+              const pollingPath = "/putlocation/retry/failed/operationResults/200/";
+              await assertError(
+                runLro({
+                  routes: [
+                    {
+                      method: "PUT",
+                      status: 200,
+                      body: `{"properties":{"provisioningState":"Accepted"},"id":"100","name":"foo"}`,
+                      headers: {
+                        location: pollingPath,
+                        [headerName]: pollingPath,
+                        "retry-after": "0",
+                      },
+                    },
+                    {
+                      method: "GET",
+                      path: pollingPath,
+                      status: 202,
+                      headers: {
+                        location: pollingPath,
+                        [headerName]: pollingPath,
+                        "retry-after": "0",
+                      },
+                      body: `{"status":"Accepted"}`,
+                    },
+                    {
+                      method: "GET",
+                      path: pollingPath,
+                      status: 200,
+                      body: `{"status":"Failed"}`,
+                    },
+                  ],
+                }),
+                {
+                  messagePattern: /The long-running operation has failed/,
+                }
+              );
+            });
+
+            it("should handle putAsyncNonResource", async () => {
+              const path = `/putnonresource/202/200`;
+              const pollingUrl = `/putnonresourceasync/operationresults/123`;
+              const result = await runLro({
+                routes: [
+                  {
+                    method: "PUT",
+                    path,
+                    status: 202,
+                    headers: {
+                      Location: `somethingBadWhichShouldNotBeUsed`,
+                      [headerName]: pollingUrl,
+                    },
+                  },
+                  {
+                    method: "GET",
+                    path: pollingUrl,
+                    status: 200,
+                    body: `{ "status": "InProgress"}`,
+                  },
+                  {
+                    method: "GET",
+                    path: pollingUrl,
+                    status: 200,
+                    body: `{ "status": "Succeeded"}`,
+                  },
+                  {
+                    method: "GET",
+                    path,
+                    status: 200,
+                    body: `{ "name": "sku" , "id": "100" }`,
+                  },
+                ],
+              });
+              assert.equal(result.name, "sku");
+              assert.equal(result.id, "100");
+            });
+
+            it("should handle patchAsync", async () => {
+              const resourceLocationPath = `/patchasync/succeeded`;
+              const pollingPath = `/patchasync/operationresults/123`;
+              const result = await runLro({
+                routes: [
+                  {
+                    method: "PATCH",
+                    status: 202,
+                    headers: {
+                      Location: resourceLocationPath,
+                      [headerName]: pollingPath,
+                    },
+                  },
+                  {
+                    method: "GET",
+                    path: pollingPath,
+                    status: 200,
+                    body: `{ "status": "InProgress"}`,
+                    headers: {
+                      "Azure-AsyncOperation": pollingPath,
+                    },
+                  },
+                  {
+                    method: "GET",
+                    path: pollingPath,
+                    status: 200,
+                    body: `{ "status": "Succeeded"}`,
+                  },
+                  {
+                    method: "GET",
+                    path: resourceLocationPath,
+                    status: 200,
+                    body: `{ "name": "sku" , "id": "100" }`,
+                  },
+                ],
+              });
+              assert.equal(result.name, "sku");
+              assert.equal(result.id, "100");
+            });
+
+            it("should handle putAsyncNoHeaderInRetry", async () => {
+              const path = `/put/noheader/201/200`;
+              const pollingPath = `/putasync/noheader/operationresults/123`;
+              const result = await runLro({
+                routes: [
+                  {
+                    method: "PUT",
+                    path,
+                    status: 201,
+                    body: `{ "properties": { "provisioningState": "Accepted"}, "id": "100", "name": "foo" }`,
+                    headers: {
+                      Location: `somethingBadWhichShouldNotBeUsed`,
+                      [headerName]: pollingPath,
+                    },
+                  },
+                  {
+                    method: "GET",
+                    path: pollingPath,
+                    status: 200,
+                    body: `{ "status": "InProgress"}`,
+                  },
+                  {
+                    method: "GET",
+                    path: pollingPath,
+                    status: 200,
+                    body: `{ "status": "Succeeded"}`,
+                  },
+                  {
+                    method: "GET",
+                    path,
+                    status: 200,
+                    body: `{ "properties": { "provisioningState": "Succeeded"}, "id": "100", "name": "foo" }`,
+                  },
+                ],
+              });
+              assert.equal(result.name, "foo");
+              assert.equal(result.id, "100");
+              assert.deepEqual(result.properties?.provisioningState, "Succeeded");
+            });
+
+            it("should handle putAsyncNoRetrySucceeded", async () => {
+              const path = `/put/noretry/succeeded`;
+              const pollingPath = "/putlocation/noretry/succeeded/operationResults/200/";
+              const result = await runLro({
+                routes: [
+                  {
+                    method: "PUT",
+                    path,
+                    status: 200,
                     headers: {
                       location: pollingPath,
                       [headerName]: pollingPath,
                     },
-                    body: `{"status":"Canceled"}`,
+                    body: `{"properties":{"provisioningState":"Accepted"},"id":"100","name":"foo"}`,
+                  },
+                  {
+                    method: "GET",
+                    path: pollingPath,
+                    status: 202,
+                    headers: {
+                      location: pollingPath,
+                      [headerName]: pollingPath,
+                    },
+                    body: `{"status":"Accepted"}`,
+                  },
+                  {
+                    method: "GET",
+                    path: pollingPath,
+                    status: 200,
+                    body: `{"status":"Succeeded"}`,
+                  },
+                  {
+                    method: "GET",
+                    path,
+                    status: 200,
+                    body: `{"properties":{"provisioningState":"Succeeded"},"id":"100","name":"foo"}`,
                   },
                 ],
-              }),
-              {
-                messagePattern: /Operation was canceled/,
-              }
-            );
-          });
-
-          it("should handle putAsyncSubResource", async () => {
-            const pollingPath = `/putsubresourceasync/operationresults/123`;
-            const path = `/putsubresource/202/200`;
-            const result = await runLro({
-              routes: [
-                {
-                  method: "PUT",
-                  path,
-                  status: 202,
-                  body: `{ "properties": { "provisioningState": "Accepted"}, "id": "100", "subresource": "sub1" }`,
-                  headers: {
-                    Location: `somethingBadWhichShouldNotBeUsed`,
-                    [headerName]: pollingPath,
-                  },
-                },
-                {
-                  method: "GET",
-                  path: pollingPath,
-                  status: 200,
-                  body: `{ "status": "InProgress"}`,
-                },
-                {
-                  method: "GET",
-                  path: pollingPath,
-                  status: 200,
-                  body: `{ "status": "Succeeded"}`,
-                },
-                {
-                  method: "GET",
-                  path: path,
-                  status: 200,
-                  body: `{ "properties": { "provisioningState": "Succeeded"}, "id": "100", "subresource": "sub1" }`,
-                },
-              ],
+              });
+              assert.equal(result.name, "foo");
+              assert.equal(result.id, "100");
             });
-            assert.equal(result.id, "100");
-            assert.equal(result.properties?.provisioningState, "Succeeded");
-          });
 
-          it("should handle deleteAsyncNoHeaderInRetry", async () => {
-            const pollingPath = `/deleteasync/noheader/operationresults/123`;
-            const response = await runLro({
-              routes: [
+            it("should handle putAsyncNoRetrycanceled", async () => {
+              const pollingPath = "/putlocation/noretry/canceled/operationResults/200/";
+              await assertError(
+                runLro({
+                  routes: [
+                    {
+                      method: "PUT",
+                      status: 200,
+                      headers: {
+                        location: pollingPath,
+                        [headerName]: pollingPath,
+                      },
+                      body: `{"properties":{"provisioningState":"Accepted"},"id":"100","name":"foo"}`,
+                    },
+                    {
+                      method: "GET",
+                      path: pollingPath,
+                      status: 202,
+                      headers: {
+                        location: pollingPath,
+                        [headerName]: pollingPath,
+                      },
+                      body: `{"status":"Accepted"}`,
+                    },
+                    {
+                      method: "GET",
+                      path: pollingPath,
+                      status: 200,
+                      headers: {
+                        location: pollingPath,
+                        [headerName]: pollingPath,
+                      },
+                      body: `{"status":"Canceled"}`,
+                    },
+                  ],
+                }),
                 {
-                  method: "DELETE",
-                  status: 202,
-                  headers: {
-                    Location: `somethingBadWhichShouldNotBeUsed`,
-                    [headerName]: pollingPath,
-                  },
-                },
-                {
-                  method: "GET",
-                  path: pollingPath,
-                  status: 200,
-                  body: `{ "status": "InProgress"}`,
-                },
-                {
-                  method: "GET",
-                  path: pollingPath,
-                  status: 200,
-                  body: `{ "status": "Succeeded"}`,
-                },
-              ],
+                  messagePattern: /Operation was canceled/,
+                }
+              );
             });
-            assert.equal(response.statusCode, 200);
-          });
 
-          it("should handle postAsyncNoRetrySucceeded", async () => {
-            const locationPath = "/postlocation/noretry/succeeded/operationResults/foo/200/";
-            const pollingPath = "/postasync/noretry/succeeded/operationResults/foo/200/";
-            const result = await runLro({
-              routes: [
-                {
-                  method: "POST",
-                  status: 202,
-                  headers: {
-                    location: locationPath,
-                    [headerName]: pollingPath,
+            it("should handle putAsyncSubResource", async () => {
+              const pollingPath = `/putsubresourceasync/operationresults/123`;
+              const path = `/putsubresource/202/200`;
+              const result = await runLro({
+                routes: [
+                  {
+                    method: "PUT",
+                    path,
+                    status: 202,
+                    body: `{ "properties": { "provisioningState": "Accepted"}, "id": "100", "subresource": "sub1" }`,
+                    headers: {
+                      Location: `somethingBadWhichShouldNotBeUsed`,
+                      [headerName]: pollingPath,
+                    },
                   },
-                  body: `{"properties":{"provisioningState":"Accepted"},"id":"100","name":"foo"}`,
-                },
-                {
-                  method: "GET",
-                  path: pollingPath,
-                  status: 202,
-                  body: `{"status":"Accepted"}`,
-                  headers: {
-                    location: locationPath,
-                    [headerName]: pollingPath,
+                  {
+                    method: "GET",
+                    path: pollingPath,
+                    status: 200,
+                    body: `{ "status": "InProgress"}`,
                   },
-                },
-                {
-                  method: "GET",
-                  path: pollingPath,
-                  status: 200,
-                  body: `{"properties":{"provisioningState":"Succeeded"},"id":"100","name":"foo"}`,
-                },
-                {
-                  method: "GET",
-                  path: locationPath,
-                  status: 200,
-                  body: `{"properties":{"provisioningState":"Succeeded"},"id":"100","name":"foo"}`,
-                },
-              ],
+                  {
+                    method: "GET",
+                    path: pollingPath,
+                    status: 200,
+                    body: `{ "status": "Succeeded"}`,
+                  },
+                  {
+                    method: "GET",
+                    path: path,
+                    status: 200,
+                    body: `{ "properties": { "provisioningState": "Succeeded"}, "id": "100", "subresource": "sub1" }`,
+                  },
+                ],
+              });
+              assert.equal(result.id, "100");
+              assert.equal(result.properties?.provisioningState, "Succeeded");
             });
-            assert.deepInclude(result, { id: "100", name: "foo" });
-          });
 
-          it("should handle postAsyncRetryFailed", async () => {
-            const pollingPath = "/postlocation/retry/succeeded/operationResults/200/";
-            await assertError(
-              runLro({
+            it("should handle deleteAsyncNoHeaderInRetry", async () => {
+              const pollingPath = `/deleteasync/noheader/operationresults/123`;
+              const response = await runLro({
+                routes: [
+                  {
+                    method: "DELETE",
+                    status: 202,
+                    headers: {
+                      Location: `somethingBadWhichShouldNotBeUsed`,
+                      [headerName]: pollingPath,
+                    },
+                  },
+                  {
+                    method: "GET",
+                    path: pollingPath,
+                    status: 200,
+                    body: `{ "status": "InProgress"}`,
+                  },
+                  {
+                    method: "GET",
+                    path: pollingPath,
+                    status: 200,
+                    body: `{ "status": "Succeeded"}`,
+                  },
+                ],
+              });
+              assert.equal(response.statusCode, 200);
+            });
+
+            it("should handle postAsyncNoRetrySucceeded", async () => {
+              const locationPath = "/postlocation/noretry/succeeded/operationResults/foo/200/";
+              const pollingPath = "/postasync/noretry/succeeded/operationResults/foo/200/";
+              const result = await runLro({
                 routes: [
                   {
                     method: "POST",
                     status: 202,
                     headers: {
-                      location: "/postlocation/retry/succeeded/operationResults/foo/200/",
+                      location: locationPath,
+                      [headerName]: pollingPath,
+                    },
+                    body: `{"properties":{"provisioningState":"Accepted"},"id":"100","name":"foo"}`,
+                  },
+                  {
+                    method: "GET",
+                    path: pollingPath,
+                    status: 202,
+                    body: `{"status":"Accepted"}`,
+                    headers: {
+                      location: locationPath,
+                      [headerName]: pollingPath,
+                    },
+                  },
+                  {
+                    method: "GET",
+                    path: pollingPath,
+                    status: 200,
+                    body: `{"properties":{"provisioningState":"Succeeded"},"id":"100","name":"foo"}`,
+                  },
+                  {
+                    method: "GET",
+                    path: locationPath,
+                    status: 200,
+                    body: `{"properties":{"provisioningState":"Succeeded"},"id":"100","name":"foo"}`,
+                  },
+                ],
+              });
+              assert.deepInclude(result, { id: "100", name: "foo" });
+            });
+
+            it("should handle postAsyncRetryFailed", async () => {
+              const pollingPath = "/postlocation/retry/succeeded/operationResults/200/";
+              await assertError(
+                runLro({
+                  routes: [
+                    {
+                      method: "POST",
+                      status: 202,
+                      headers: {
+                        location: "/postlocation/retry/succeeded/operationResults/foo/200/",
+                        [headerName]: pollingPath,
+                        "retry-after": "0",
+                      },
+                      body: `{"properties":{"provisioningState":"Accepted"},"id":"100","name":"foo"}`,
+                    },
+                    {
+                      method: "GET",
+                      path: pollingPath,
+                      status: 200,
+                      body: `{"status":"Failed"}`,
+                    },
+                  ],
+                }),
+                {
+                  messagePattern: /The long-running operation has failed/,
+                }
+              );
+            });
+
+            it("should handle postAsyncRetrySucceeded", async () => {
+              const locationPath = "/postlocation/retry/succeeded/operationResults/foo/200/";
+              const pollingPath = "/postlocation/retry/succeeded/operationResults/200/";
+              const result = await runLro({
+                routes: [
+                  {
+                    method: "POST",
+                    status: 202,
+                    headers: {
+                      location: locationPath,
                       [headerName]: pollingPath,
                       "retry-after": "0",
                     },
@@ -1282,198 +1326,400 @@ matrix([["createPoller", "LroEngine"]] as const, async function (implName: Imple
                   {
                     method: "GET",
                     path: pollingPath,
-                    status: 200,
-                    body: `{"status":"Failed"}`,
-                  },
-                ],
-              }),
-              {
-                messagePattern: /The long-running operation has failed/,
-              }
-            );
-          });
-
-          it("should handle postAsyncRetrySucceeded", async () => {
-            const locationPath = "/postlocation/retry/succeeded/operationResults/foo/200/";
-            const pollingPath = "/postlocation/retry/succeeded/operationResults/200/";
-            const result = await runLro({
-              routes: [
-                {
-                  method: "POST",
-                  status: 202,
-                  headers: {
-                    location: locationPath,
-                    [headerName]: pollingPath,
-                    "retry-after": "0",
-                  },
-                  body: `{"properties":{"provisioningState":"Accepted"},"id":"100","name":"foo"}`,
-                },
-                {
-                  method: "GET",
-                  path: pollingPath,
-                  status: 202,
-                  headers: {
-                    location: locationPath,
-                    [headerName]: pollingPath,
-                    "retry-after": "0",
-                  },
-                  body: `{"status":"Accepted"}`,
-                },
-                {
-                  method: "GET",
-                  path: pollingPath,
-                  status: 200,
-                  body: `{"properties":{"provisioningState":"Succeeded"},"id":"100","name":"foo"}`,
-                },
-                {
-                  method: "GET",
-                  path: locationPath,
-                  status: 200,
-                  body: `{"properties":{"provisioningState":"Succeeded"},"id":"100","name":"foo"}`,
-                },
-              ],
-            });
-            assert.deepInclude(result, { id: "100", name: "foo" });
-          });
-
-          it("should handle postAsyncResourceLocation", async () => {
-            const locationPath = "/postlocation/retry/succeeded/operationResults/foo/200/";
-            const pollingPath = "/postlocation/retry/succeeded/operationResults/200/";
-            const result = await runLro({
-              routes: [
-                {
-                  method: "POST",
-                  status: 202,
-                  headers: {
-                    [headerName]: pollingPath,
-                    "retry-after": "0",
-                  },
-                  body: `{"status":"Accepted"}`,
-                },
-                {
-                  method: "GET",
-                  path: pollingPath,
-                  status: 202,
-                  headers: {
-                    location: locationPath,
-                    [headerName]: pollingPath,
-                    "retry-after": "0",
-                  },
-                  body: `{"status":"Accepted"}`,
-                },
-                {
-                  method: "GET",
-                  path: pollingPath,
-                  status: 200,
-                  body: `{"status":"Succeeded", "resourceLocation": "${locationPath}"}`,
-                },
-                {
-                  method: "GET",
-                  path: locationPath,
-                  status: 200,
-                  body: `{"id":"100","name":"foo"}`,
-                },
-              ],
-            });
-            assert.deepInclude(result, { id: "100", name: "foo" });
-          });
-
-          it("should handle postAsyncRetrycanceled", async () => {
-            const pollingPath = "/postasync/retry/canceled/operationResults/200/";
-            await assertError(
-              runLro({
-                routes: [
-                  {
-                    method: "POST",
                     status: 202,
                     headers: {
-                      location: "/postasync/retry/succeeded/operationResults/foo/200/",
+                      location: locationPath,
                       [headerName]: pollingPath,
                       "retry-after": "0",
                     },
-                    body: `{ "properties": { "provisioningState": "Accepted"}, "id": "100", "name": "foo"}`,
+                    body: `{"status":"Accepted"}`,
                   },
                   {
                     method: "GET",
                     path: pollingPath,
                     status: 200,
-                    body: `{"status":"Canceled"}`,
+                    body: `{"properties":{"provisioningState":"Succeeded"},"id":"100","name":"foo"}`,
+                  },
+                  {
+                    method: "GET",
+                    path: locationPath,
+                    status: 200,
+                    body: `{"properties":{"provisioningState":"Succeeded"},"id":"100","name":"foo"}`,
                   },
                 ],
-              }),
-              {
-                messagePattern: /Operation was canceled/,
-              }
-            );
+              });
+              assert.deepInclude(result, { id: "100", name: "foo" });
+            });
+
+            it("should handle postAsyncResourceLocation", async () => {
+              const locationPath = "/postlocation/retry/succeeded/operationResults/foo/200/";
+              const pollingPath = "/postlocation/retry/succeeded/operationResults/200/";
+              const result = await runLro({
+                routes: [
+                  {
+                    method: "POST",
+                    status: 202,
+                    headers: {
+                      [headerName]: pollingPath,
+                      "retry-after": "0",
+                    },
+                    body: `{"status":"Accepted"}`,
+                  },
+                  {
+                    method: "GET",
+                    path: pollingPath,
+                    status: 202,
+                    headers: {
+                      location: locationPath,
+                      [headerName]: pollingPath,
+                      "retry-after": "0",
+                    },
+                    body: `{"status":"Accepted"}`,
+                  },
+                  {
+                    method: "GET",
+                    path: pollingPath,
+                    status: 200,
+                    body: `{"status":"Succeeded", "resourceLocation": "${locationPath}"}`,
+                  },
+                  {
+                    method: "GET",
+                    path: locationPath,
+                    status: 200,
+                    body: `{"id":"100","name":"foo"}`,
+                  },
+                ],
+              });
+              assert.deepInclude(result, { id: "100", name: "foo" });
+            });
+
+            it("should handle postAsyncRetrycanceled", async () => {
+              const pollingPath = "/postasync/retry/canceled/operationResults/200/";
+              await assertError(
+                runLro({
+                  routes: [
+                    {
+                      method: "POST",
+                      status: 202,
+                      headers: {
+                        location: "/postasync/retry/succeeded/operationResults/foo/200/",
+                        [headerName]: pollingPath,
+                        "retry-after": "0",
+                      },
+                      body: `{ "properties": { "provisioningState": "Accepted"}, "id": "100", "name": "foo"}`,
+                    },
+                    {
+                      method: "GET",
+                      path: pollingPath,
+                      status: 200,
+                      body: `{"status":"Canceled"}`,
+                    },
+                  ],
+                }),
+                {
+                  messagePattern: /Operation was canceled/,
+                }
+              );
+            });
+          });
+        }
+      );
+
+      describe("LRO Sad scenarios", () => {
+        it("should handle PutNonRetry400 ", async () => {
+          await assertDivergentBehavior({
+            op: runLro({ routes: [{ method: "PUT", status: 400 }] }),
+            throwOnNon2xxResponse,
+            throwing: {
+              statusCode: 400,
+            },
+            notThrowing: {
+              messagePattern: /The long-running operation has failed/,
+            },
           });
         });
-      }
-    );
 
-    describe("LRO Sad scenarios", () => {
-      it("should handle PutNonRetry400 ", async () => {
-        await assertError(runLro({ routes: [{ method: "PUT", status: 400 }] }), {
-          statusCode: 400,
+        it("should handle putNonRetry201Creating400 ", async () => {
+          const path = "/nonretryerror/put/201/creating/400";
+          await assertDivergentBehavior({
+            op: runLro({
+              routes: [
+                {
+                  method: "PUT",
+                  path,
+                  status: 201,
+                  body: `{ "properties": { "provisioningState": "Creating"}, "id": "100", "name": "foo" }`,
+                },
+                {
+                  method: "GET",
+                  path,
+                  status: 400,
+                  body: `{ "message": "Error from the server" }`,
+                },
+              ],
+            }),
+            throwOnNon2xxResponse,
+            throwing: {
+              statusCode: 400,
+            },
+            notThrowing: {
+              messagePattern: /The long-running operation has failed/,
+            },
+          });
         });
-      });
 
-      it("should handle putNonRetry201Creating400 ", async () => {
-        const path = "/nonretryerror/put/201/creating/400";
-        await assertError(
-          runLro({
+        it("should throw with putNonRetry201Creating400InvalidJson ", async () => {
+          const path = "/nonretryerror/put/201/creating/400/invalidjson";
+          await assertDivergentBehavior({
+            op: runLro({
+              routes: [
+                {
+                  method: "PUT",
+                  path,
+                  status: 201,
+                  body: `{ "properties": { "provisioningState": "Creating"}, "id": "100", "name": "foo" }`,
+                },
+                {
+                  method: "GET",
+                  path,
+                  status: 400,
+                  body: `{ "message": "Error from the server" }`,
+                },
+              ],
+            }),
+            throwOnNon2xxResponse,
+            throwing: {
+              statusCode: 400,
+            },
+            notThrowing: {
+              messagePattern: /The long-running operation has failed/,
+            },
+          });
+        });
+
+        it("should handle putAsyncRelativeRetry400 ", async () => {
+          const pollingPath = `/nonretryerror/putasync/retry/failed/operationResults/400`;
+          await assertDivergentBehavior({
+            op: runLro({
+              routes: [
+                {
+                  method: "PUT",
+                  status: 200,
+                  body: `{ "properties": { "provisioningState": "Creating"}, "id": "100", "name": "foo" }`,
+                  headers: createDoubleHeaders({
+                    pollingPath,
+                    headers: { "Retry-After": "0" },
+                  }),
+                },
+                {
+                  method: "GET",
+                  path: pollingPath,
+                  status: 400,
+                },
+              ],
+            }),
+            throwOnNon2xxResponse,
+            throwing: {
+              statusCode: 400,
+            },
+            notThrowing: {
+              messagePattern: /The long-running operation has failed/,
+            },
+          });
+        });
+
+        it("should handle delete202NonRetry400 ", async () => {
+          const path = "/nonretryerror/delete/202/retry/400";
+          await assertDivergentBehavior({
+            op: runLro({
+              routes: [
+                {
+                  method: "DELETE",
+                  path,
+                  status: 202,
+                  body: `{ "properties": { "provisioningState": "Creating"}, "id": "100", "name": "foo" }`,
+                  headers: {
+                    Location: path,
+                    "Retry-After": "0",
+                  },
+                },
+                {
+                  method: "GET",
+                  path,
+                  status: 400,
+                  body: `{ "message" : "Expected bad request message" }`,
+                },
+              ],
+            }),
+            throwOnNon2xxResponse,
+            throwing: {
+              statusCode: 400,
+            },
+            notThrowing: {
+              messagePattern: /The long-running operation has failed/,
+            },
+          });
+        });
+
+        it("should handle deleteNonRetry400 ", async () => {
+          await assertDivergentBehavior({
+            op: runLro({
+              routes: [
+                {
+                  method: "DELETE",
+                  status: 400,
+                  body: `{ "message" : "Expected bad request message" }`,
+                },
+              ],
+            }),
+            throwOnNon2xxResponse,
+            throwing: {
+              statusCode: 400,
+            },
+            notThrowing: {
+              messagePattern: /The long-running operation has failed/,
+            },
+          });
+        });
+
+        it("should handle deleteAsyncRelativeRetry400 ", async () => {
+          const pollingPath = `/nonretryerror/deleteasync/retry/failed/operationResults/400`;
+          await assertDivergentBehavior({
+            op: runLro({
+              routes: [
+                {
+                  method: "DELETE",
+                  status: 202,
+                  body: `{ "properties": { "provisioningState": "Creating"}, "id": "100", "name": "foo" }`,
+                  headers: createDoubleHeaders({
+                    pollingPath,
+                    headers: { "Retry-After": "0" },
+                  }),
+                },
+                {
+                  method: "GET",
+                  path: pollingPath,
+                  status: 400,
+                  body: `{ "message" : "Expected bad request message", "status": 200 }`,
+                },
+              ],
+            }),
+            throwOnNon2xxResponse,
+            throwing: {
+              statusCode: 400,
+            },
+            notThrowing: {
+              messagePattern: /Polling was unsuccessful/,
+            },
+          });
+        });
+
+        it("should handle postNonRetry400 ", async () => {
+          await assertDivergentBehavior({
+            op: runLro({
+              routes: [
+                {
+                  method: "POST",
+                  status: 400,
+                  body: `{ "message" : "Expected bad request message" }`,
+                },
+              ],
+            }),
+            throwOnNon2xxResponse,
+            throwing: {
+              statusCode: 400,
+            },
+            notThrowing: {
+              messagePattern: /The long-running operation has failed/,
+            },
+          });
+        });
+
+        it("should handle post202NonRetry400 ", async () => {
+          const path = `/nonretryerror/post/202/retry/400`;
+          await assertDivergentBehavior({
+            op: runLro({
+              routes: [
+                {
+                  method: "POST",
+                  path,
+                  status: 202,
+                  body: `{ "properties": { "provisioningState": "Creating"}, "id": "100", "name": "foo" }`,
+                  headers: {
+                    Location: path,
+                    "Retry-After": "0",
+                  },
+                },
+                {
+                  method: "GET",
+                  path,
+                  status: 400,
+                  body: `{ "message" : "Expected bad request message" }`,
+                },
+              ],
+            }),
+            throwOnNon2xxResponse,
+            throwing: {
+              statusCode: 400,
+            },
+            notThrowing: {
+              messagePattern: /The long-running operation has failed/,
+            },
+          });
+        });
+
+        it("should handle postAsyncRelativeRetry400 ", async () => {
+          const pollingPath = `/nonretryerror/postasync/retry/failed/operationResults/400`;
+          await assertDivergentBehavior({
+            op: runLro({
+              routes: [
+                {
+                  method: "POST",
+                  status: 202,
+                  body: `{ "properties": { "provisioningState": "Creating"}, "id": "100", "name": "foo" }`,
+                  headers: createDoubleHeaders({
+                    pollingPath,
+                    headers: { "Retry-After": "0" },
+                  }),
+                },
+                {
+                  method: "GET",
+                  path: pollingPath,
+                  status: 400,
+                  body: `{ "message" : "Expected bad request message" }`,
+                },
+              ],
+            }),
+            throwOnNon2xxResponse,
+            throwing: {
+              statusCode: 400,
+            },
+            notThrowing: {
+              messagePattern: /The long-running operation has failed/,
+            },
+          });
+        });
+
+        it("should handle PutError201NoProvisioningStatePayload ", async () => {
+          const response = await runLro({
             routes: [
               {
                 method: "PUT",
-                path,
                 status: 201,
-                body: `{ "properties": { "provisioningState": "Creating"}, "id": "100", "name": "foo" }`,
-              },
-              {
-                method: "GET",
-                path,
-                status: 400,
-                body: `{ "message" : "Error from the server" }`,
               },
             ],
-          }),
-          {
-            statusCode: 400,
-          }
-        );
-      });
+          });
+          assert.equal(response.statusCode, 201); // weird!
+        });
 
-      it("should throw with putNonRetry201Creating400InvalidJson ", async () => {
-        const path = "/nonretryerror/put/201/creating/400/invalidjson";
-        await assertError(
-          runLro({
+        it("should handle putAsyncRelativeRetryNoStatusPayload ", async () => {
+          const pollingPath = `/error/putasync/retry/failed/operationResults/nostatuspayload`;
+          const path = "/error/putasync/retry/nostatuspayload";
+          const response = await runLro({
             routes: [
               {
                 method: "PUT",
                 path,
-                status: 201,
-                body: `{ "properties": { "provisioningState": "Creating"}, "id": "100", "name": "foo" }`,
-              },
-              {
-                method: "GET",
-                path,
-                status: 400,
-                body: `{ "message" : "Error from the server" }`,
-              },
-            ],
-          }),
-          {
-            statusCode: 400,
-          }
-        );
-      });
-
-      it("should handle putAsyncRelativeRetry400 ", async () => {
-        const pollingPath = `/nonretryerror/putasync/retry/failed/operationResults/400`;
-        await assertError(
-          runLro({
-            routes: [
-              {
-                method: "PUT",
                 status: 200,
                 body: `{ "properties": { "provisioningState": "Creating"}, "id": "100", "name": "foo" }`,
                 headers: createDoubleHeaders({
@@ -1484,866 +1730,679 @@ matrix([["createPoller", "LroEngine"]] as const, async function (implName: Imple
               {
                 method: "GET",
                 path: pollingPath,
-                status: 400,
+                status: 200,
+              },
+              {
+                method: "GET",
+                path: path,
+                status: 200,
               },
             ],
-          }),
-          {
-            statusCode: 400,
-          }
-        );
-      });
+          });
+          assert.equal(response.statusCode, 200);
+        });
 
-      it("should handle delete202NonRetry400 ", async () => {
-        const path = "/nonretryerror/delete/202/retry/400";
-        await assertError(
-          runLro({
+        it("should handle putAsyncRelativeRetryNoStatus ", async () => {
+          const path = "/error/putasync/retry/nostatus";
+          const pollingPath = `/error/putasync/retry/failed/operationResults/nostatus`;
+          const response = await runLro({
+            routes: [
+              {
+                method: "PUT",
+                path,
+                status: 200,
+                body: `{ "properties": { "provisioningState": "Creating"}, "id": "100", "name": "foo" }`,
+                headers: createDoubleHeaders({
+                  pollingPath,
+                  headers: { "Retry-After": "0" },
+                }),
+              },
+              {
+                method: "GET",
+                path,
+                status: 200,
+                body: `{ }`,
+              },
+              {
+                method: "GET",
+                path: pollingPath,
+                status: 200,
+                body: `{ }`,
+              },
+            ],
+          });
+          assert.equal(response.statusCode, 200);
+        });
+
+        it("should handle delete204Succeeded ", async () => {
+          const response = await runLro({
             routes: [
               {
                 method: "DELETE",
-                path,
+                status: 204,
+              },
+            ],
+          });
+          assert.equal(response.statusCode, 204);
+        });
+
+        it("should handle deleteAsyncRelativeRetryNoStatus ", async () => {
+          const pollingPath = `/error/deleteasync/retry/failed/operationResults/nostatus`;
+          const response = await runLro({
+            routes: [
+              {
+                method: "DELETE",
                 status: 202,
-                body: `{ "properties": { "provisioningState": "Creating"}, "id": "100", "name": "foo" }`,
-                headers: {
-                  Location: path,
-                  "Retry-After": "0",
+                headers: createDoubleHeaders({
+                  pollingPath,
+                  headers: { "Retry-After": "0" },
+                }),
+              },
+              {
+                method: "GET",
+                path: pollingPath,
+                status: 200,
+                body: `{ }`,
+              },
+            ],
+          });
+          assert.equal(response.statusCode, 200);
+        });
+
+        it("should handle post202NoLocation ", async () => {
+          const response = await runLro({
+            routes: [
+              {
+                method: "POST",
+                status: 202,
+              },
+            ],
+          });
+          assert.equal(response.statusCode, 202);
+        });
+
+        it("should handle postAsyncRelativeRetryNoPayload ", async () => {
+          const pollingPath = `/error/postasync/retry/failed/operationResults/nopayload`;
+          const response = await runLro({
+            routes: [
+              {
+                method: "POST",
+                status: 202,
+                headers: createDoubleHeaders({
+                  pollingPath,
+                  headers: { "Retry-After": "0" },
+                }),
+              },
+              {
+                method: "GET",
+                path: pollingPath,
+                status: 200,
+              },
+              {
+                method: "GET",
+                path: pollingPath,
+                status: 200,
+              },
+            ],
+          });
+          assert.equal(response.statusCode, 200);
+        });
+
+        it("should handle put200InvalidJson ", async () => {
+          await assertError(
+            runLro({
+              routes: [
+                {
+                  method: "PUT",
+                  status: 200,
+                  body: `{ "properties": { "provisioningState": "Creating"}, "id": "100", "name": "foo"`,
                 },
-              },
-              {
-                method: "GET",
-                path,
-                status: 400,
-                body: `{ "message" : "Expected bad request message" }`,
-              },
-            ],
-          }),
-          {
-            statusCode: 400,
-          }
-        );
-      });
-
-      it("should handle deleteNonRetry400 ", async () => {
-        await assertError(
-          runLro({
-            routes: [
-              {
-                method: "DELETE",
-                status: 400,
-                body: `{ "message" : "Expected bad request message" }`,
-              },
-            ],
-          }),
-          {
-            statusCode: 400,
-          }
-        );
-      });
-
-      it("should handle deleteAsyncRelativeRetry400 ", async () => {
-        const pollingPath = `/nonretryerror/deleteasync/retry/failed/operationResults/400`;
-        await assertError(
-          runLro({
-            routes: [
-              {
-                method: "DELETE",
-                status: 202,
-                body: `{ "properties": { "provisioningState": "Creating"}, "id": "100", "name": "foo" }`,
-                headers: createDoubleHeaders({
-                  pollingPath,
-                  headers: { "Retry-After": "0" },
-                }),
-              },
-              {
-                method: "GET",
-                path: pollingPath,
-                status: 400,
-                body: `{ "message" : "Expected bad request message", "status": 200 }`,
-              },
-            ],
-          }),
-          {
-            statusCode: 400,
-          }
-        );
-      });
-
-      it("should handle postNonRetry400 ", async () => {
-        await assertError(
-          runLro({
-            routes: [
-              {
-                method: "POST",
-                status: 400,
-                body: `{ "message" : "Expected bad request message" }`,
-              },
-            ],
-          }),
-          {
-            statusCode: 400,
-          }
-        );
-      });
-
-      it("should handle post202NonRetry400 ", async () => {
-        const path = `/nonretryerror/post/202/retry/400`;
-        await assertError(
-          runLro({
-            routes: [
-              {
-                method: "POST",
-                path,
-                status: 202,
-                body: `{ "properties": { "provisioningState": "Creating"}, "id": "100", "name": "foo" }`,
-                headers: {
-                  Location: path,
-                  "Retry-After": "0",
-                },
-              },
-              {
-                method: "GET",
-                path,
-                status: 400,
-                body: `{ "message" : "Expected bad request message" }`,
-              },
-            ],
-          }),
-          {
-            statusCode: 400,
-          }
-        );
-      });
-
-      it("should handle postAsyncRelativeRetry400 ", async () => {
-        const pollingPath = `/nonretryerror/postasync/retry/failed/operationResults/400`;
-        await assertError(
-          runLro({
-            routes: [
-              {
-                method: "POST",
-                status: 202,
-                body: `{ "properties": { "provisioningState": "Creating"}, "id": "100", "name": "foo" }`,
-                headers: createDoubleHeaders({
-                  pollingPath,
-                  headers: { "Retry-After": "0" },
-                }),
-              },
-              {
-                method: "GET",
-                path: pollingPath,
-                status: 400,
-                body: `{ "message" : "Expected bad request message" }`,
-              },
-            ],
-          }),
-          {
-            statusCode: 400,
-          }
-        );
-      });
-
-      it("should handle PutError201NoProvisioningStatePayload ", async () => {
-        const response = await runLro({
-          routes: [
+              ],
+            }),
             {
-              method: "PUT",
-              status: 201,
-            },
-          ],
-        });
-        assert.equal(response.statusCode, 201); // weird!
-      });
-
-      it("should handle putAsyncRelativeRetryNoStatusPayload ", async () => {
-        const pollingPath = `/error/putasync/retry/failed/operationResults/nostatuspayload`;
-        const path = "/error/putasync/retry/nostatuspayload";
-        const response = await runLro({
-          routes: [
-            {
-              method: "PUT",
-              path,
-              status: 200,
-              body: `{ "properties": { "provisioningState": "Creating"}, "id": "100", "name": "foo" }`,
-              headers: createDoubleHeaders({
-                pollingPath,
-                headers: { "Retry-After": "0" },
-              }),
-            },
-            {
-              method: "GET",
-              path: pollingPath,
-              status: 200,
-            },
-            {
-              method: "GET",
-              path: path,
-              status: 200,
-            },
-          ],
-        });
-        assert.equal(response.statusCode, 200);
-      });
-
-      it("should handle putAsyncRelativeRetryNoStatus ", async () => {
-        const path = "/error/putasync/retry/nostatus";
-        const pollingPath = `/error/putasync/retry/failed/operationResults/nostatus`;
-        const response = await runLro({
-          routes: [
-            {
-              method: "PUT",
-              path,
-              status: 200,
-              body: `{ "properties": { "provisioningState": "Creating"}, "id": "100", "name": "foo" }`,
-              headers: createDoubleHeaders({
-                pollingPath,
-                headers: { "Retry-After": "0" },
-              }),
-            },
-            {
-              method: "GET",
-              path,
-              status: 200,
-              body: `{ }`,
-            },
-            {
-              method: "GET",
-              path: pollingPath,
-              status: 200,
-              body: `{ }`,
-            },
-          ],
-        });
-        assert.equal(response.statusCode, 200);
-      });
-
-      it("should handle delete204Succeeded ", async () => {
-        const response = await runLro({
-          routes: [
-            {
-              method: "DELETE",
-              status: 204,
-            },
-          ],
-        });
-        assert.equal(response.statusCode, 204);
-      });
-
-      it("should handle deleteAsyncRelativeRetryNoStatus ", async () => {
-        const pollingPath = `/error/deleteasync/retry/failed/operationResults/nostatus`;
-        const response = await runLro({
-          routes: [
-            {
-              method: "DELETE",
-              status: 202,
-              headers: createDoubleHeaders({
-                pollingPath,
-                headers: { "Retry-After": "0" },
-              }),
-            },
-            {
-              method: "GET",
-              path: pollingPath,
-              status: 200,
-              body: `{ }`,
-            },
-          ],
-        });
-        assert.equal(response.statusCode, 200);
-      });
-
-      it("should handle post202NoLocation ", async () => {
-        const response = await runLro({
-          routes: [
-            {
-              method: "POST",
-              status: 202,
-            },
-          ],
-        });
-        assert.equal(response.statusCode, 202);
-      });
-
-      it("should handle postAsyncRelativeRetryNoPayload ", async () => {
-        const pollingPath = `/error/postasync/retry/failed/operationResults/nopayload`;
-        const response = await runLro({
-          routes: [
-            {
-              method: "POST",
-              status: 202,
-              headers: createDoubleHeaders({
-                pollingPath,
-                headers: { "Retry-After": "0" },
-              }),
-            },
-            {
-              method: "GET",
-              path: pollingPath,
-              status: 200,
-            },
-            {
-              method: "GET",
-              path: pollingPath,
-              status: 200,
-            },
-          ],
-        });
-        assert.equal(response.statusCode, 200);
-      });
-
-      it("should handle put200InvalidJson ", async () => {
-        await assertError(
-          runLro({
-            routes: [
-              {
-                method: "PUT",
-                status: 200,
-                body: `{ "properties": { "provisioningState": "Creating"}, "id": "100", "name": "foo"`,
-              },
-            ],
-          }),
-          {
-            messagePattern: /Unexpected end of JSON input/,
-          }
-        );
-      });
-
-      it("should handle putAsyncRelativeRetryInvalidHeader ", async () => {
-        await assertError(
-          runLro({
-            routes: [
-              {
-                method: "PUT",
-                status: 200,
-                body: `{ "properties": { "provisioningState": "Creating"}, "id": "100", "name": "foo" }`,
-                headers: createDoubleHeaders({
-                  pollingPath: "/foo",
-                  headers: { "Retry-After": "/bar" },
-                }),
-              },
-            ],
-          }),
-          {
-            statusCode: 404,
-          }
-        );
-      });
-
-      it("should handle putAsyncRelativeRetryInvalidJsonPolling ", async () => {
-        const pollingPath = `/error/putasync/retry/failed/operationResults/invalidjsonpolling`;
-        await assertError(
-          runLro({
-            routes: [
-              {
-                method: "PUT",
-                status: 200,
-                body: `{ "properties": { "provisioningState": "Creating"}, "id": "100", "name": "foo" }`,
-                headers: createDoubleHeaders({
-                  pollingPath,
-                  headers: { "Retry-After": "0" },
-                }),
-              },
-              {
-                method: "GET",
-                path: pollingPath,
-                status: 200,
-                body: `{ "status": "Accepted"`,
-              },
-            ],
-          }),
-          {
-            messagePattern: /Unexpected end of JSON input/,
-          }
-        );
-      });
-
-      it("should handle delete202RetryInvalidHeader ", async () => {
-        await assertError(
-          runLro({
-            routes: [
-              {
-                method: "DELETE",
-                status: 202,
-                headers: {
-                  Location: `/foo`,
-                  "Retry-After": "/bar",
-                },
-              },
-            ],
-          }),
-          {
-            statusCode: 404,
-          }
-        );
-      });
-
-      it("should handle deleteAsyncRelativeRetryInvalidHeader ", async () => {
-        await assertError(
-          runLro({
-            routes: [
-              {
-                method: "DELETE",
-                status: 202,
-                headers: createDoubleHeaders({
-                  pollingPath: "/foo",
-                  headers: { "Retry-After": "/bar" },
-                }),
-              },
-            ],
-          }),
-          {
-            statusCode: 404,
-          }
-        );
-      });
-
-      it("should handle DeleteAsyncRelativeRetryInvalidJsonPolling ", async () => {
-        const pollingPath = `/error/deleteasync/retry/failed/operationResults/invalidjsonpolling`;
-        await assertError(
-          runLro({
-            routes: [
-              {
-                method: "DELETE",
-                status: 202,
-                headers: createDoubleHeaders({
-                  pollingPath,
-                  headers: { "Retry-After": "0" },
-                }),
-              },
-              {
-                method: "GET",
-                path: pollingPath,
-                status: 200,
-                body: `{ "status": "Accepted"`,
-              },
-            ],
-          }),
-          {
-            messagePattern: /Unexpected end of JSON input/,
-          }
-        );
-      });
-
-      it("should handle post202RetryInvalidHeader ", async () => {
-        await assertError(
-          runLro({
-            routes: [
-              {
-                method: "POST",
-                status: 202,
-                headers: {
-                  Location: `/foo`,
-                  "Retry-After": "/bar",
-                },
-              },
-            ],
-          }),
-          {
-            statusCode: 404,
-          }
-        );
-      });
-
-      it("should handle postAsyncRelativeRetryInvalidHeader ", async () => {
-        await assertError(
-          runLro({
-            routes: [
-              {
-                method: "POST",
-                status: 202,
-                headers: createDoubleHeaders({
-                  pollingPath: "/foo",
-                  headers: { "Retry-After": "/bar" },
-                }),
-              },
-            ],
-          }),
-          {
-            statusCode: 404,
-          }
-        );
-      });
-
-      it("should handle postAsyncRelativeRetryInvalidJsonPolling ", async () => {
-        const pollingPath = `/error/postasync/retry/failed/operationResults/invalidjsonpolling`;
-        await assertError(
-          runLro({
-            routes: [
-              {
-                method: "POST",
-                status: 202,
-                headers: createDoubleHeaders({
-                  pollingPath,
-                  headers: { "Retry-After": "/bar" },
-                }),
-              },
-              {
-                method: "GET",
-                path: pollingPath,
-                status: 200,
-                body: `{ "status": "Accepted"`,
-              },
-            ],
-          }),
-          {
-            messagePattern: /Unexpected end of JSON input/,
-          }
-        );
-      });
-    });
-
-    describe("serialized state", () => {
-      let state: any, serializedState: string;
-      it("should handle serializing the state", async () => {
-        const poller = await createTestPoller({
-          routes: [
-            {
-              method: "PUT",
-              status: 200,
-              body: `{ "properties": { "provisioningState": "Succeeded"}, "id": "100", "name": "foo" }`,
-            },
-          ],
-          implName,
-        });
-        poller.onProgress((currentState) => {
-          if (state === undefined && serializedState === undefined) {
-            state = currentState;
-            serializedState = JSON.stringify({ state: currentState });
-            assert.equal(serializedState, poller.toString());
-          }
-        });
-        await poller.pollUntilDone();
-      });
-    });
-
-    describe("mutate state", () => {
-      it("The state can be mutated in onProgress", async () => {
-        let setState = false;
-        let check = false;
-        const pollingPath = `pollingPath`;
-        await runLro({
-          routes: [
-            {
-              method: "POST",
-              status: 202,
-              headers: {
-                "Operation-Location": pollingPath,
-              },
-            },
-            {
-              method: "GET",
-              path: pollingPath,
-              status: 200,
-              body: `{"status":"running"}`,
-            },
-            {
-              method: "GET",
-              path: pollingPath,
-              status: 200,
-              body: `{"status":"running"}`,
-            },
-            {
-              method: "GET",
-              path: pollingPath,
-              status: 200,
-              body: `{"status":"succeeded"}`,
-            },
-          ],
-          onProgress: (state) => {
-            if (!setState) {
-              (state as any).x = 1;
-              setState = true;
-            } else {
-              assert.ok((state as any).x);
-              check = true;
+              messagePattern: /Unexpected end of JSON input/,
             }
-          },
+          );
         });
-        assert.isTrue(check);
-      });
 
-      it("The state can be mutated in updateState", async () => {
-        let setState = false;
-        let check = false;
-        const pollingPath = `pollingPath`;
-        await runLro({
-          routes: [
+        it("should handle putAsyncRelativeRetryInvalidHeader ", async () => {
+          await assertError(
+            runLro({
+              routes: [
+                {
+                  method: "PUT",
+                  status: 200,
+                  body: `{ "properties": { "provisioningState": "Creating"}, "id": "100", "name": "foo" }`,
+                  headers: createDoubleHeaders({
+                    pollingPath: "/foo",
+                    headers: { "Retry-After": "/bar" },
+                  }),
+                },
+              ],
+            }),
             {
-              method: "POST",
-              status: 202,
-              headers: {
-                "Operation-Location": pollingPath,
-              },
-            },
-            {
-              method: "GET",
-              path: pollingPath,
-              status: 200,
-              body: `{"status":"running"}`,
-            },
-            {
-              method: "GET",
-              path: pollingPath,
-              status: 200,
-              body: `{"status":"running"}`,
-            },
-            {
-              method: "GET",
-              path: pollingPath,
-              status: 200,
-              body: `{"status":"succeeded"}`,
-            },
-          ],
-          updateState: (state: any) => {
-            if (!setState) {
-              (state as any).x = 1;
-              setState = true;
-            } else {
-              assert.ok((state as any).x);
-              check = true;
+              statusCode: 404,
             }
-          },
+          );
         });
-        assert.isTrue(check);
-      });
-    });
 
-    describe("process result", () => {
-      it("From a location response", async () => {
-        const locationPath = "/postlocation/noretry/succeeded/operationResults/foo/200/";
-        const pollingPath = "/postasync/noretry/succeeded/operationResults/foo/200/";
-        const headerName = "Operation-Location";
-        const result = await runLro({
-          routes: [
-            {
-              method: "POST",
-              status: 202,
-              headers: {
-                location: locationPath,
-                [headerName]: pollingPath,
-              },
-              body: `{"properties":{"provisioningState":"Accepted"},"id":"100","name":"foo"}`,
-            },
-            {
-              method: "GET",
-              path: pollingPath,
-              status: 202,
-              body: `{"status":"Accepted"}`,
-              headers: {
-                location: locationPath,
-                [headerName]: pollingPath,
-              },
-            },
-            {
-              method: "GET",
-              path: pollingPath,
-              status: 200,
-              body: `{"properties":{"provisioningState":"Succeeded"},"id":"100","name":"foo"}`,
-            },
-            {
-              method: "GET",
-              path: locationPath,
-              status: 200,
-              body: `{"properties":{"provisioningState":"Succeeded"},"id":"100","name":"foo"}`,
-            },
-          ],
-          processResult: (res: unknown) => {
-            assert.equal((res as any).id, "100");
-            return { ...(res as any), id: "200" };
-          },
-        });
-        assert.deepInclude(result, { id: "200", name: "foo" });
-      });
-
-      it("From the initial response", async () => {
-        const result = await runLro({
-          routes: [
-            {
-              method: "PUT",
-              status: 200,
-              body: `{"properties":{"provisioningState":"Succeeded"},"id":"100","name":"foo"}`,
-            },
-          ],
-          processResult: (res: unknown) => {
-            assert.equal((res as any).id, "100");
-            return { ...(res as any), id: "200" };
-          },
-        });
-        assert.deepInclude(result, { id: "200", name: "foo" });
-      });
-    });
-
-    describe("poller cancellation", () => {
-      it("cancelled poller gives access to partial results", async () => {
-        const pollingPath = "/LROPostDoubleHeadersFinalAzureHeaderGetDefault/asyncOperationUrl";
-        const poller = await createTestPoller({
-          routes: [
-            {
-              method: "POST",
-              status: 202,
-              body: "",
-              headers: {
-                "Operation-Location": pollingPath,
-              },
-            },
-            {
-              method: "GET",
-              path: pollingPath,
-              status: 200,
-              body: `{ "status": "running"}`,
-            },
-            {
-              method: "GET",
-              path: pollingPath,
-              status: 200,
-              body: `{ "status": "canceled", "results": [1,2] }`,
-            },
-          ],
-          implName,
-        });
-        await assertError(poller.pollUntilDone(), { messagePattern: /Operation was canceled/ });
-        const result = poller.getResult();
-        assert.deepEqual(result!.results, [1, 2]);
-      });
-    });
-    describe("abort signals", function () {
-      it("poll can be aborted", async () => {
-        let pollCount = 0;
-        const pollingPath = "pollingPath";
-        const poller = await createTestPoller({
-          routes: [
-            {
-              method: "POST",
-              status: 202,
-              headers: {
-                "Operation-Location": pollingPath,
-              },
-            },
-            ...Array(10).fill({
-              method: "GET",
-              path: pollingPath,
-              body: `{ "status": "running"}`,
-              status: 200,
+        it("should handle putAsyncRelativeRetryInvalidJsonPolling ", async () => {
+          const pollingPath = `/error/putasync/retry/failed/operationResults/invalidjsonpolling`;
+          await assertError(
+            runLro({
+              routes: [
+                {
+                  method: "PUT",
+                  status: 200,
+                  body: `{ "properties": { "provisioningState": "Creating"}, "id": "100", "name": "foo" }`,
+                  headers: createDoubleHeaders({
+                    pollingPath,
+                    headers: { "Retry-After": "0" },
+                  }),
+                },
+                {
+                  method: "GET",
+                  path: pollingPath,
+                  status: 200,
+                  body: `{ "status": "Accepted"`,
+                },
+              ],
             }),
             {
-              method: "GET",
-              path: pollingPath,
-              body: `{ "status": "succeeded"}`,
-              status: 200,
-            },
-          ],
-          implName,
-          updateState: () => {
-            pollCount++;
-          },
+              messagePattern: /Unexpected end of JSON input/,
+            }
+          );
         });
-        const abortController = new AbortController();
-        await poller.poll();
-        abortController.abort();
-        assert.equal(pollCount, 1);
-        await assertError(
-          poller.poll({
-            abortSignal: abortController.signal,
-          }),
-          {
+
+        it("should handle delete202RetryInvalidHeader ", async () => {
+          await assertError(
+            runLro({
+              routes: [
+                {
+                  method: "DELETE",
+                  status: 202,
+                  headers: {
+                    Location: `/foo`,
+                    "Retry-After": "/bar",
+                  },
+                },
+              ],
+            }),
+            {
+              statusCode: 404,
+            }
+          );
+        });
+
+        it("should handle deleteAsyncRelativeRetryInvalidHeader ", async () => {
+          await assertError(
+            runLro({
+              routes: [
+                {
+                  method: "DELETE",
+                  status: 202,
+                  headers: createDoubleHeaders({
+                    pollingPath: "/foo",
+                    headers: { "Retry-After": "/bar" },
+                  }),
+                },
+              ],
+            }),
+            {
+              statusCode: 404,
+            }
+          );
+        });
+
+        it("should handle DeleteAsyncRelativeRetryInvalidJsonPolling ", async () => {
+          const pollingPath = `/error/deleteasync/retry/failed/operationResults/invalidjsonpolling`;
+          await assertError(
+            runLro({
+              routes: [
+                {
+                  method: "DELETE",
+                  status: 202,
+                  headers: createDoubleHeaders({
+                    pollingPath,
+                    headers: { "Retry-After": "0" },
+                  }),
+                },
+                {
+                  method: "GET",
+                  path: pollingPath,
+                  status: 200,
+                  body: `{ "status": "Accepted"`,
+                },
+              ],
+            }),
+            {
+              messagePattern: /Unexpected end of JSON input/,
+            }
+          );
+        });
+
+        it("should handle post202RetryInvalidHeader ", async () => {
+          await assertError(
+            runLro({
+              routes: [
+                {
+                  method: "POST",
+                  status: 202,
+                  headers: {
+                    Location: `/foo`,
+                    "Retry-After": "/bar",
+                  },
+                },
+              ],
+            }),
+            {
+              statusCode: 404,
+            }
+          );
+        });
+
+        it("should handle postAsyncRelativeRetryInvalidHeader ", async () => {
+          await assertError(
+            runLro({
+              routes: [
+                {
+                  method: "POST",
+                  status: 202,
+                  headers: createDoubleHeaders({
+                    pollingPath: "/foo",
+                    headers: { "Retry-After": "/bar" },
+                  }),
+                },
+              ],
+            }),
+            {
+              statusCode: 404,
+            }
+          );
+        });
+
+        it("should handle postAsyncRelativeRetryInvalidJsonPolling ", async () => {
+          const pollingPath = `/error/postasync/retry/failed/operationResults/invalidjsonpolling`;
+          await assertError(
+            runLro({
+              routes: [
+                {
+                  method: "POST",
+                  status: 202,
+                  headers: createDoubleHeaders({
+                    pollingPath,
+                    headers: { "Retry-After": "/bar" },
+                  }),
+                },
+                {
+                  method: "GET",
+                  path: pollingPath,
+                  status: 200,
+                  body: `{ "status": "Accepted"`,
+                },
+              ],
+            }),
+            {
+              messagePattern: /Unexpected end of JSON input/,
+            }
+          );
+        });
+      });
+
+      describe("serialized state", () => {
+        let state: any, serializedState: string;
+        it("should handle serializing the state", async () => {
+          const poller = await createTestPoller({
+            routes: [
+              {
+                method: "PUT",
+                status: 200,
+                body: `{ "properties": { "provisioningState": "Succeeded"}, "id": "100", "name": "foo" }`,
+              },
+            ],
+            implName,
+          });
+          poller.onProgress((currentState) => {
+            if (state === undefined && serializedState === undefined) {
+              state = currentState;
+              serializedState = JSON.stringify({ state: currentState });
+              assert.equal(serializedState, poller.toString());
+            }
+          });
+          await poller.pollUntilDone();
+        });
+      });
+
+      describe("mutate state", () => {
+        it("The state can be mutated in onProgress", async () => {
+          let setState = false;
+          let check = false;
+          const pollingPath = `pollingPath`;
+          await runLro({
+            routes: [
+              {
+                method: "POST",
+                status: 202,
+                headers: {
+                  "Operation-Location": pollingPath,
+                },
+              },
+              {
+                method: "GET",
+                path: pollingPath,
+                status: 200,
+                body: `{"status":"running"}`,
+              },
+              {
+                method: "GET",
+                path: pollingPath,
+                status: 200,
+                body: `{"status":"running"}`,
+              },
+              {
+                method: "GET",
+                path: pollingPath,
+                status: 200,
+                body: `{"status":"succeeded"}`,
+              },
+            ],
+            onProgress: (state) => {
+              if (!setState) {
+                (state as any).x = 1;
+                setState = true;
+              } else {
+                assert.ok((state as any).x);
+                check = true;
+              }
+            },
+          });
+          assert.isTrue(check);
+        });
+
+        it("The state can be mutated in updateState", async () => {
+          let setState = false;
+          let check = false;
+          const pollingPath = `pollingPath`;
+          await runLro({
+            routes: [
+              {
+                method: "POST",
+                status: 202,
+                headers: {
+                  "Operation-Location": pollingPath,
+                },
+              },
+              {
+                method: "GET",
+                path: pollingPath,
+                status: 200,
+                body: `{"status":"running"}`,
+              },
+              {
+                method: "GET",
+                path: pollingPath,
+                status: 200,
+                body: `{"status":"running"}`,
+              },
+              {
+                method: "GET",
+                path: pollingPath,
+                status: 200,
+                body: `{"status":"succeeded"}`,
+              },
+            ],
+            updateState: (state: any) => {
+              if (!setState) {
+                (state as any).x = 1;
+                setState = true;
+              } else {
+                assert.ok((state as any).x);
+                check = true;
+              }
+            },
+          });
+          assert.isTrue(check);
+        });
+      });
+
+      describe("process result", () => {
+        it("From a location response", async () => {
+          const locationPath = "/postlocation/noretry/succeeded/operationResults/foo/200/";
+          const pollingPath = "/postasync/noretry/succeeded/operationResults/foo/200/";
+          const headerName = "Operation-Location";
+          const result = await runLro({
+            routes: [
+              {
+                method: "POST",
+                status: 202,
+                headers: {
+                  location: locationPath,
+                  [headerName]: pollingPath,
+                },
+                body: `{"properties":{"provisioningState":"Accepted"},"id":"100","name":"foo"}`,
+              },
+              {
+                method: "GET",
+                path: pollingPath,
+                status: 202,
+                body: `{"status":"Accepted"}`,
+                headers: {
+                  location: locationPath,
+                  [headerName]: pollingPath,
+                },
+              },
+              {
+                method: "GET",
+                path: pollingPath,
+                status: 200,
+                body: `{"properties":{"provisioningState":"Succeeded"},"id":"100","name":"foo"}`,
+              },
+              {
+                method: "GET",
+                path: locationPath,
+                status: 200,
+                body: `{"properties":{"provisioningState":"Succeeded"},"id":"100","name":"foo"}`,
+              },
+            ],
+            processResult: (res: unknown) => {
+              assert.equal((res as any).id, "100");
+              return { ...(res as any), id: "200" };
+            },
+          });
+          assert.deepInclude(result, { id: "200", name: "foo" });
+        });
+
+        it("From the initial response", async () => {
+          const result = await runLro({
+            routes: [
+              {
+                method: "PUT",
+                status: 200,
+                body: `{"properties":{"provisioningState":"Succeeded"},"id":"100","name":"foo"}`,
+              },
+            ],
+            processResult: (res: unknown) => {
+              assert.equal((res as any).id, "100");
+              return { ...(res as any), id: "200" };
+            },
+          });
+          assert.deepInclude(result, { id: "200", name: "foo" });
+        });
+      });
+
+      describe("poller cancellation", () => {
+        it("cancelled poller gives access to partial results", async () => {
+          const pollingPath = "/LROPostDoubleHeadersFinalAzureHeaderGetDefault/asyncOperationUrl";
+          const poller = await createTestPoller({
+            routes: [
+              {
+                method: "POST",
+                status: 202,
+                body: "",
+                headers: {
+                  "Operation-Location": pollingPath,
+                },
+              },
+              {
+                method: "GET",
+                path: pollingPath,
+                status: 200,
+                body: `{ "status": "running"}`,
+              },
+              {
+                method: "GET",
+                path: pollingPath,
+                status: 200,
+                body: `{ "status": "canceled", "results": [1,2] }`,
+              },
+            ],
+            implName,
+          });
+          await assertError(poller.pollUntilDone(), { messagePattern: /Operation was canceled/ });
+          const result = poller.getResult();
+          assert.deepEqual(result!.results, [1, 2]);
+        });
+      });
+      describe("abort signals", function () {
+        it("poll can be aborted", async () => {
+          let pollCount = 0;
+          const pollingPath = "pollingPath";
+          const poller = await createTestPoller({
+            routes: [
+              {
+                method: "POST",
+                status: 202,
+                headers: {
+                  "Operation-Location": pollingPath,
+                },
+              },
+              ...Array(10).fill({
+                method: "GET",
+                path: pollingPath,
+                body: `{ "status": "running"}`,
+                status: 200,
+              }),
+              {
+                method: "GET",
+                path: pollingPath,
+                body: `{ "status": "succeeded"}`,
+                status: 200,
+              },
+            ],
+            implName,
+            updateState: () => {
+              pollCount++;
+            },
+          });
+          const abortController = new AbortController();
+          await poller.poll();
+          abortController.abort();
+          assert.equal(pollCount, 1);
+          await assertError(
+            poller.poll({
+              abortSignal: abortController.signal,
+            }),
+            {
+              messagePattern: /The operation was aborted/,
+            }
+          );
+          await assertError(poller.pollUntilDone(), {
             messagePattern: /The operation was aborted/,
-          }
-        );
-        await assertError(poller.pollUntilDone(), {
-          messagePattern: /The operation was aborted/,
+          });
+          assert.equal(pollCount, 1);
+          assert.ok(poller.isDone());
         });
-        assert.equal(pollCount, 1);
-        assert.ok(poller.isDone());
-      });
 
-      it("pollUntilDone can be aborted", async () => {
-        let pollCount = 0;
-        const pollingPath = "pollingPath";
-        const poller = await createTestPoller({
-          routes: [
-            {
-              method: "POST",
-              status: 202,
-              headers: {
-                "Operation-Location": pollingPath,
+        it("pollUntilDone can be aborted", async () => {
+          let pollCount = 0;
+          const pollingPath = "pollingPath";
+          const poller = await createTestPoller({
+            routes: [
+              {
+                method: "POST",
+                status: 202,
+                headers: {
+                  "Operation-Location": pollingPath,
+                },
               },
+              ...Array(10).fill({
+                method: "GET",
+                path: pollingPath,
+                body: `{ "status": "running"}`,
+                status: 200,
+              }),
+              {
+                method: "GET",
+                path: pollingPath,
+                body: `{ "status": "succeeded"}`,
+                status: 200,
+              },
+            ],
+            implName,
+            updateState: () => {
+              pollCount++;
             },
-            ...Array(10).fill({
-              method: "GET",
-              path: pollingPath,
-              body: `{ "status": "running"}`,
-              status: 200,
+          });
+          const abortController = new AbortController();
+          await poller.poll();
+          abortController.abort();
+          assert.equal(pollCount, 1);
+          await assertError(
+            poller.pollUntilDone({
+              abortSignal: abortController.signal,
             }),
             {
-              method: "GET",
-              path: pollingPath,
-              body: `{ "status": "succeeded"}`,
-              status: 200,
-            },
-          ],
-          implName,
-          updateState: () => {
-            pollCount++;
-          },
+              messagePattern: /The operation was aborted/,
+            }
+          );
+          assert.equal(pollCount, 1);
+          assert.ok(poller.isDone());
         });
-        const abortController = new AbortController();
-        await poller.poll();
-        abortController.abort();
-        assert.equal(pollCount, 1);
-        await assertError(
-          poller.pollUntilDone({
-            abortSignal: abortController.signal,
-          }),
-          {
-            messagePattern: /The operation was aborted/,
-          }
-        );
-        assert.equal(pollCount, 1);
-        assert.ok(poller.isDone());
-      });
 
-      it("pollUntilDone is aborted when stopPolling() gets called", async () => {
-        let pollCount = 0;
-        const pollingPath = "pollingPath";
-        const poller = await createTestPoller({
-          routes: [
-            {
-              method: "POST",
-              status: 202,
-              headers: {
-                "Operation-Location": pollingPath,
+        it("pollUntilDone is aborted when stopPolling() gets called", async () => {
+          let pollCount = 0;
+          const pollingPath = "pollingPath";
+          const poller = await createTestPoller({
+            routes: [
+              {
+                method: "POST",
+                status: 202,
+                headers: {
+                  "Operation-Location": pollingPath,
+                },
               },
+              ...Array(10).fill({
+                method: "GET",
+                path: pollingPath,
+                body: `{ "status": "running"}`,
+                status: 200,
+              }),
+              {
+                method: "GET",
+                path: pollingPath,
+                body: `{ "status": "succeeded"}`,
+                status: 200,
+              },
+            ],
+            implName,
+            updateState: () => {
+              pollCount++;
             },
-            ...Array(10).fill({
-              method: "GET",
-              path: pollingPath,
-              body: `{ "status": "running"}`,
-              status: 200,
-            }),
-            {
-              method: "GET",
-              path: pollingPath,
-              body: `{ "status": "succeeded"}`,
-              status: 200,
-            },
-          ],
-          implName,
-          updateState: () => {
-            pollCount++;
-          },
+          });
+          const abortController = new AbortController();
+          await poller.poll();
+          abortController.abort();
+          assert.equal(pollCount, 1);
+          const promise = poller.pollUntilDone();
+          poller.stopPolling();
+          await assertError(promise);
+          /**
+           * There is a behavior difference in how each poller is being stopped.
+           * TODO: revisit this if it becomes an issue.
+           */
+          assert.equal(pollCount, implName === "createPoller" ? 2 : 1);
         });
-        const abortController = new AbortController();
-        await poller.poll();
-        abortController.abort();
-        assert.equal(pollCount, 1);
-        const promise = poller.pollUntilDone();
-        poller.stopPolling();
-        await assertError(promise);
-        /**
-         * There is a behavior difference in how each poller is being stopped.
-         * TODO: revisit this if it becomes an issue.
-         */
-        assert.equal(pollCount, implName === "createPoller" ? 2 : 1);
       });
     });
-  });
-});
+  }
+);

--- a/sdk/core/core-lro/test/utils/router.ts
+++ b/sdk/core/core-lro/test/utils/router.ts
@@ -68,7 +68,11 @@ function toLroProcessors(responses: LroResponseSpec[]): RouteProcessor[] {
 function createRouteKey({ method, path }: { path: string; method: string }): string {
   return method + ":" + path;
 }
-function createClient(routes: RouteProcessor[]): HttpClient {
+function createClient(inputs: {
+  routes: RouteProcessor[];
+  throwOnNon2xxResponse?: boolean;
+}): HttpClient {
+  const { routes, throwOnNon2xxResponse = true } = inputs;
   const routesTable = new Map(routes.map((route) => [createRouteKey(route), route]));
   return {
     async sendRequest(request: PipelineRequest): Promise<PipelineResponse> {
@@ -80,12 +84,11 @@ function createClient(routes: RouteProcessor[]): HttpClient {
       const route = routesTable.get(createRouteKey({ method, path }));
       if (route !== undefined) {
         const response = getYieldedValue(route.process.next())(request);
-        if (response.status >= 400) {
-          const error = new RestError(
+        if (response.status >= 400 && throwOnNon2xxResponse) {
+          throw new RestError(
             `Received unexpected HTTP status code ${response.status} while polling. This may indicate a server issue.`,
             { statusCode: response.status }
           );
-          throw error;
         }
         return response;
       }
@@ -123,6 +126,7 @@ export function createTestPoller(settings: {
   processResult?: (result: unknown, state: State) => Result;
   updateState?: (state: State, lastResponse: LroResponse<Result>) => void;
   implName?: ImplementationName;
+  throwOnNon2xxResponse?: boolean;
 }): Promise<SimplePollerLike<State, Result>> {
   const {
     routes,
@@ -130,8 +134,9 @@ export function createTestPoller(settings: {
     processResult,
     updateState,
     implName = "createPoller",
+    throwOnNon2xxResponse = true,
   } = settings;
-  const client = createClient(toLroProcessors(routes));
+  const client = createClient({ routes: toLroProcessors(routes), throwOnNon2xxResponse });
   const { method: requestMethod, path = initialPath } = routes[0];
   const lro = createCoreRestPipelineLro({
     sendOperationFn: createSendOp({ client }),
@@ -179,6 +184,7 @@ async function runLro<TState>(settings: {
   processResult?: (result: unknown, state: TState) => Result;
   updateState?: (state: TState, lastResponse: RawResponse) => void;
   implName?: ImplementationName;
+  throwOnNon2xxResponse?: boolean;
 }): Promise<Result> {
   const {
     routes,
@@ -187,6 +193,7 @@ async function runLro<TState>(settings: {
     processResult,
     updateState,
     implName = "createPoller",
+    throwOnNon2xxResponse = true,
   } = settings;
   const poller = await createTestPoller({
     routes,
@@ -194,6 +201,7 @@ async function runLro<TState>(settings: {
     processResult,
     updateState: (state, { rawResponse }) => updateState?.(state, rawResponse),
     implName,
+    throwOnNon2xxResponse,
   });
   if (onProgress !== undefined) {
     poller.onProgress(onProgress);
@@ -201,8 +209,8 @@ async function runLro<TState>(settings: {
   return poller.pollUntilDone();
 }
 
-export const createRunLroWithImpl =
-  <TState>(implName: ImplementationName) =>
+export const createRunLroWith =
+  <TState>(variables: { implName: ImplementationName; throwOnNon2xxResponse?: boolean }) =>
   (settings: {
     routes: LroResponseSpec[];
     onProgress?: (state: TState) => void;
@@ -210,4 +218,4 @@ export const createRunLroWithImpl =
     processResult?: (result: unknown, state: TState) => Result;
     updateState?: (state: TState, lastResponse: RawResponse) => void;
   }): Promise<Result> =>
-    runLro({ ...settings, implName });
+    runLro({ ...settings, ...variables });

--- a/sdk/core/core-lro/test/utils/utils.ts
+++ b/sdk/core/core-lro/test/utils/utils.ts
@@ -90,3 +90,43 @@ export async function assertError(
     }
   }
 }
+
+export async function assertDivergentBehavior(inputs: {
+  op: Promise<Result>;
+  throwOnNon2xxResponse: boolean;
+  throwing: {
+    statusCode?: number;
+    messagePattern?: RegExp;
+  };
+  notThrowing: {
+    result?: any;
+    statusCode?: number;
+    messagePattern?: RegExp;
+  };
+}): Promise<void> {
+  const {
+    op,
+    throwOnNon2xxResponse,
+    throwing: { messagePattern, statusCode },
+    notThrowing: {
+      messagePattern: notThrowingMessagePattern,
+      statusCode: notThrowingStatusCode,
+      result,
+    },
+  } = inputs;
+  if (throwOnNon2xxResponse) {
+    await assertError(op, {
+      statusCode,
+      messagePattern,
+    });
+  } else {
+    if (notThrowingStatusCode !== undefined || notThrowingMessagePattern !== undefined) {
+      await assertError(op, {
+        statusCode: notThrowingStatusCode,
+        messagePattern: notThrowingMessagePattern,
+      });
+    } else {
+      assert.deepEqual(await op, result);
+    }
+  }
+}


### PR DESCRIPTION
Adds more smarts to core-lro to
- precisely detect when an operation failed without relying on raised exceptions thrown by the underlying core library when receiving non 2xx responses
- handle non-string status fields