### PR TITLE
[engsys] increase search live test pipeline timeout to 90 minutes

### DIFF
--- a/sdk/search/search-documents/tests.yml
+++ b/sdk/search/search-documents/tests.yml
@@ -5,6 +5,7 @@ stages:
     parameters:
       PackageName: "@azure/search-documents"
       ServiceDirectory: search
+      TimeoutInMinutes: 90
       # TODO: change 'Preview' cloud back to public after search RP fixes deletion metadata issue
       Clouds: 'Preview'
       SupportedClouds: 'Preview,UsGov,China'


### PR DESCRIPTION
Recently the test resource deployment step for search live test pipeline can take more than 40 minutes to finish, while the integration test step only takes less than 10  minutes. We have contacted service team about deployment issue.

Still it is better to let the pipeline finish running than canceling the run after all these time spent on test resource deployment.
