### PR TITLE
[core-lro] add a flag to control whether to throw when the operation is unsuccessful

### DIFF
--- a/sdk/core/core-lro/CHANGELOG.md
+++ b/sdk/core/core-lro/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features Added
 
-- Add `errorOnUnsuccessful` to `CreatePollerOptions` and `LroEngineOptions` to control whether to throw an error if the operation failed or was canceled.
+- Add `resolveOnUnsuccessful` to `CreatePollerOptions` and `LroEngineOptions` to control whether to throw an error if the operation failed or was canceled.
 
 ### Breaking Changes
 

--- a/sdk/core/core-lro/CHANGELOG.md
+++ b/sdk/core/core-lro/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Release History
 
-## 2.3.2 (Unreleased)
+## 2.4.0 (Unreleased)
 
 ### Features Added
+
+- Add `errorOnUnsuccessful` to `CreatePollerOptions` and `LroEngineOptions` to control whether to throw an error if the operation failed or was canceled.
 
 ### Breaking Changes
 

--- a/sdk/core/core-lro/package.json
+++ b/sdk/core/core-lro/package.json
@@ -2,7 +2,7 @@
   "name": "@azure/core-lro",
   "author": "Microsoft Corporation",
   "sdk-type": "client",
-  "version": "2.3.2",
+  "version": "2.4.0",
   "description": "Isomorphic client library for supporting long-running operations in node.js and browser.",
   "tags": [
     "isomorphic",

--- a/sdk/core/core-lro/review/core-lro.api.md
+++ b/sdk/core/core-lro/review/core-lro.api.md
@@ -14,6 +14,7 @@ export function createHttpPoller<TResult, TState extends OperationState<TResult>
 
 // @public
 export interface CreateHttpPollerOptions<TResult, TState> {
+    errorOnUnsuccessful?: boolean;
     intervalInMs?: number;
     processResult?: (result: unknown, state: TState) => TResult;
     resourceLocationConfig?: LroResourceLocationConfig;
@@ -40,6 +41,7 @@ export class LroEngine<TResult, TState extends PollOperationState<TResult>> exte
 
 // @public
 export interface LroEngineOptions<TResult, TState> {
+    errorOnUnsuccessful?: boolean;
     intervalInMs?: number;
     isDone?: (lastResponse: unknown, state: TState) => boolean;
     lroResourceLocationConfig?: LroResourceLocationConfig;

--- a/sdk/core/core-lro/review/core-lro.api.md
+++ b/sdk/core/core-lro/review/core-lro.api.md
@@ -14,9 +14,9 @@ export function createHttpPoller<TResult, TState extends OperationState<TResult>
 
 // @public
 export interface CreateHttpPollerOptions<TResult, TState> {
-    errorOnUnsuccessful?: boolean;
     intervalInMs?: number;
     processResult?: (result: unknown, state: TState) => TResult;
+    resolveOnUnsuccessful?: boolean;
     resourceLocationConfig?: LroResourceLocationConfig;
     restoreFrom?: string;
     updateState?: (state: TState, response: LroResponse) => void;
@@ -41,11 +41,11 @@ export class LroEngine<TResult, TState extends PollOperationState<TResult>> exte
 
 // @public
 export interface LroEngineOptions<TResult, TState> {
-    errorOnUnsuccessful?: boolean;
     intervalInMs?: number;
     isDone?: (lastResponse: unknown, state: TState) => boolean;
     lroResourceLocationConfig?: LroResourceLocationConfig;
     processResult?: (result: unknown, state: TState) => TResult;
+    resolveOnUnsuccessful?: boolean;
     resumeFrom?: string;
     updateState?: (state: TState, lastResponse: RawResponse) => void;
 }
@@ -88,6 +88,7 @@ export abstract class Poller<TState extends PollOperationState<TResult>, TResult
     pollUntilDone(pollOptions?: {
         abortSignal?: AbortSignalLike;
     }): Promise<TResult>;
+    protected resolveOnUnsuccessful: boolean;
     stopPolling(): void;
     toString(): string;
 }

--- a/sdk/core/core-lro/src/http/models.ts
+++ b/sdk/core/core-lro/src/http/models.ts
@@ -106,7 +106,7 @@ export interface CreateHttpPollerOptions<TResult, TState> {
    */
   withOperationLocation?: (operationLocation: string) => void;
   /**
-   * Control whether to throw an exception when the operation has failed or been canceled.
+   * Control whether to throw an exception if the operation failed or was canceled.
    */
-  errorOnUnsuccessful?: boolean;
+  resolveOnUnsuccessful?: boolean;
 }

--- a/sdk/core/core-lro/src/http/models.ts
+++ b/sdk/core/core-lro/src/http/models.ts
@@ -105,4 +105,8 @@ export interface CreateHttpPollerOptions<TResult, TState> {
    * service.
    */
   withOperationLocation?: (operationLocation: string) => void;
+  /**
+   * Control whether to throw an exception when the operation has failed or been canceled.
+   */
+  errorOnUnsuccessful?: boolean;
 }

--- a/sdk/core/core-lro/src/http/poller.ts
+++ b/sdk/core/core-lro/src/http/poller.ts
@@ -31,7 +31,7 @@ export async function createHttpPoller<TResult, TState extends OperationState<TR
     restoreFrom,
     updateState,
     withOperationLocation,
-    errorOnUnsuccessful = true,
+    resolveOnUnsuccessful = false,
   } = options || {};
   return buildCreatePoller<LroResponse, TResult, TState>({
     getStatusFromInitialResponse,
@@ -39,7 +39,7 @@ export async function createHttpPoller<TResult, TState extends OperationState<TR
     getOperationLocation,
     getResourceLocation,
     getPollingInterval: parseRetryAfter,
-    errorOnUnsuccessful,
+    resolveOnUnsuccessful,
   })(
     {
       init: async () => {

--- a/sdk/core/core-lro/src/http/poller.ts
+++ b/sdk/core/core-lro/src/http/poller.ts
@@ -31,6 +31,7 @@ export async function createHttpPoller<TResult, TState extends OperationState<TR
     restoreFrom,
     updateState,
     withOperationLocation,
+    errorOnUnsuccessful = true,
   } = options || {};
   return buildCreatePoller<LroResponse, TResult, TState>({
     getStatusFromInitialResponse,
@@ -38,6 +39,7 @@ export async function createHttpPoller<TResult, TState extends OperationState<TR
     getOperationLocation,
     getResourceLocation,
     getPollingInterval: parseRetryAfter,
+    errorOnUnsuccessful,
   })(
     {
       init: async () => {

--- a/sdk/core/core-lro/src/legacy/lroEngine/lroEngine.ts
+++ b/sdk/core/core-lro/src/legacy/lroEngine/lroEngine.ts
@@ -20,20 +20,29 @@ export class LroEngine<TResult, TState extends PollOperationState<TResult>> exte
   private config: PollerConfig;
 
   constructor(lro: LongRunningOperation<TResult>, options?: LroEngineOptions<TResult, TState>) {
-    const { intervalInMs = POLL_INTERVAL_IN_MS, resumeFrom } = options || {};
+    const {
+      intervalInMs = POLL_INTERVAL_IN_MS,
+      resumeFrom,
+      errorOnUnsuccessful = true,
+      isDone,
+      lroResourceLocationConfig,
+      processResult,
+      updateState,
+    } = options || {};
     const state: RestorableOperationState<TState> = resumeFrom
       ? deserializeState(resumeFrom)
       : ({} as RestorableOperationState<TState>);
-
     const operation = new GenericPollOperation(
       state,
       lro,
-      options?.lroResourceLocationConfig,
-      options?.processResult,
-      options?.updateState,
-      options?.isDone
+      errorOnUnsuccessful,
+      lroResourceLocationConfig,
+      processResult,
+      updateState,
+      isDone
     );
     super(operation);
+    this.errorOnUnsuccessful = errorOnUnsuccessful;
 
     this.config = { intervalInMs: intervalInMs };
     operation.setPollerConfig(this.config);

--- a/sdk/core/core-lro/src/legacy/lroEngine/lroEngine.ts
+++ b/sdk/core/core-lro/src/legacy/lroEngine/lroEngine.ts
@@ -23,7 +23,7 @@ export class LroEngine<TResult, TState extends PollOperationState<TResult>> exte
     const {
       intervalInMs = POLL_INTERVAL_IN_MS,
       resumeFrom,
-      errorOnUnsuccessful = true,
+      resolveOnUnsuccessful = false,
       isDone,
       lroResourceLocationConfig,
       processResult,
@@ -35,14 +35,14 @@ export class LroEngine<TResult, TState extends PollOperationState<TResult>> exte
     const operation = new GenericPollOperation(
       state,
       lro,
-      errorOnUnsuccessful,
+      !resolveOnUnsuccessful,
       lroResourceLocationConfig,
       processResult,
       updateState,
       isDone
     );
     super(operation);
-    this.errorOnUnsuccessful = errorOnUnsuccessful;
+    this.resolveOnUnsuccessful = resolveOnUnsuccessful;
 
     this.config = { intervalInMs: intervalInMs };
     operation.setPollerConfig(this.config);

--- a/sdk/core/core-lro/src/legacy/lroEngine/models.ts
+++ b/sdk/core/core-lro/src/legacy/lroEngine/models.ts
@@ -31,6 +31,10 @@ export interface LroEngineOptions<TResult, TState> {
    * A predicate to determine whether the LRO finished processing.
    */
   isDone?: (lastResponse: unknown, state: TState) => boolean;
+  /**
+   * Control whether to throw an exception when the operation has failed or been canceled.
+   */
+  errorOnUnsuccessful?: boolean;
 }
 
 export interface PollerConfig {

--- a/sdk/core/core-lro/src/legacy/lroEngine/models.ts
+++ b/sdk/core/core-lro/src/legacy/lroEngine/models.ts
@@ -32,9 +32,9 @@ export interface LroEngineOptions<TResult, TState> {
    */
   isDone?: (lastResponse: unknown, state: TState) => boolean;
   /**
-   * Control whether to throw an exception when the operation has failed or been canceled.
+   * Control whether to throw an exception if the operation failed or was canceled.
    */
-  errorOnUnsuccessful?: boolean;
+  resolveOnUnsuccessful?: boolean;
 }
 
 export interface PollerConfig {

--- a/sdk/core/core-lro/src/legacy/lroEngine/operation.ts
+++ b/sdk/core/core-lro/src/legacy/lroEngine/operation.ts
@@ -39,6 +39,7 @@ export class GenericPollOperation<TResult, TState extends PollOperationState<TRe
   constructor(
     public state: RestorableOperationState<TState>,
     private lro: LongRunningOperation,
+    private setErrorAsResult: boolean,
     private lroResourceLocationConfig?: LroResourceLocationConfig,
     private processResult?: (result: unknown, state: TState) => TResult,
     private updateState?: (state: TState, lastResponse: RawResponse) => void,
@@ -62,6 +63,7 @@ export class GenericPollOperation<TResult, TState extends PollOperationState<TRe
           stateProxy,
           resourceLocationConfig: this.lroResourceLocationConfig,
           processResult: this.processResult,
+          setErrorAsResult: this.setErrorAsResult,
         })),
       };
     }
@@ -84,6 +86,7 @@ export class GenericPollOperation<TResult, TState extends PollOperationState<TRe
         setDelay: (intervalInMs) => {
           this.pollerConfig!.intervalInMs = intervalInMs;
         },
+        setErrorAsResult: this.setErrorAsResult,
       });
     }
     options?.fireProgress?.(this.state);

--- a/sdk/core/core-lro/src/legacy/poller.ts
+++ b/sdk/core/core-lro/src/legacy/poller.ts
@@ -102,6 +102,7 @@ export class PollerCancelledError extends Error {
 export abstract class Poller<TState extends PollOperationState<TResult>, TResult>
   implements PollerLike<TState, TResult>
 {
+  protected errorOnUnsuccessful: boolean = true;
   private stopped: boolean = true;
   private resolve?: (value: TResult) => void;
   private reject?: (error: PollerStoppedError | PollerCancelledError | Error) => void;
@@ -247,14 +248,10 @@ export abstract class Poller<TState extends PollOperationState<TResult>, TResult
    */
   private async pollOnce(options: { abortSignal?: AbortSignalLike } = {}): Promise<void> {
     if (!this.isDone()) {
-      try {
-        this.operation = await this.operation.update({
-          abortSignal: options.abortSignal,
-          fireProgress: this.fireProgress.bind(this),
-        });
-      } catch (e: any) {
-        this.operation.state.error = e;
-      }
+      this.operation = await this.operation.update({
+        abortSignal: options.abortSignal,
+        fireProgress: this.fireProgress.bind(this),
+      });
     }
     this.processUpdatedState();
   }
@@ -302,21 +299,26 @@ export abstract class Poller<TState extends PollOperationState<TResult>, TResult
   private processUpdatedState(): void {
     if (this.operation.state.error) {
       this.stopped = true;
-      this.reject!(this.operation.state.error);
-      throw this.operation.state.error;
+      if (this.errorOnUnsuccessful) {
+        this.reject!(this.operation.state.error);
+        throw this.operation.state.error;
+      }
     }
     if (this.operation.state.isCancelled) {
       this.stopped = true;
-      const error = new PollerCancelledError("Operation was canceled");
-      this.reject!(error);
-      throw error;
-    } else if (this.isDone() && this.resolve) {
+      if (this.errorOnUnsuccessful) {
+        const error = new PollerCancelledError("Operation was canceled");
+        this.reject!(error);
+        throw error;
+      }
+    }
+    if (this.isDone() && this.resolve) {
       // If the poller has finished polling, this means we now have a result.
       // However, it can be the case that TResult is instantiated to void, so
       // we are not expecting a result anyway. To assert that we might not
       // have a result eventually after finishing polling, we cast the result
       // to TResult.
-      this.resolve(this.operation.state.result as TResult);
+      this.resolve(this.getResult() as TResult);
     }
   }
 

--- a/sdk/core/core-lro/src/poller/models.ts
+++ b/sdk/core/core-lro/src/poller/models.ts
@@ -112,9 +112,9 @@ export interface BuildCreatePollerOptions<TResponse, TState> {
    */
   getPollingInterval?: (response: TResponse) => number | undefined;
   /**
-   * Control whether to throw an exception when the operation failed or was canceled.
+   * Control whether to throw an exception if the operation failed or was canceled.
    */
-  errorOnUnsuccessful: boolean;
+  resolveOnUnsuccessful: boolean;
 }
 
 /**

--- a/sdk/core/core-lro/src/poller/models.ts
+++ b/sdk/core/core-lro/src/poller/models.ts
@@ -111,6 +111,10 @@ export interface BuildCreatePollerOptions<TResponse, TState> {
    * wait before sending the next polling request.
    */
   getPollingInterval?: (response: TResponse) => number | undefined;
+  /**
+   * Control whether to throw an exception when the operation failed or was canceled.
+   */
+  errorOnUnsuccessful: boolean;
 }
 
 /**

--- a/sdk/core/core-lro/test/lro.spec.ts
+++ b/sdk/core/core-lro/test/lro.spec.ts
@@ -405,8 +405,9 @@ matrix(
 
         it("should handle put200Acceptedcanceled200", async () => {
           const path = "/put/200/accepted/canceled/200";
-          await assertError(
-            runLro({
+          const body = { properties: { provisioningState: "Canceled" } };
+          await assertDivergentBehavior({
+            op: runLro({
               routes: [
                 {
                   method: "PUT",
@@ -418,14 +419,21 @@ matrix(
                   method: "GET",
                   path,
                   status: 200,
-                  body: `{"properties":{"provisioningState":"Canceled"}}`,
+                  body: JSON.stringify(body),
                 },
               ],
             }),
-            {
+            throwOnNon2xxResponse,
+            throwing: {
               messagePattern: /Operation was canceled/,
-            }
-          );
+            },
+            notThrowing: {
+              result: {
+                ...body,
+                statusCode: 200,
+              },
+            },
+          });
         });
 
         it("should handle put200UpdatingSucceeded204", async () => {
@@ -453,8 +461,13 @@ matrix(
 
         it("should handle put201CreatingFailed200", async () => {
           const path = "/put/201/created/failed/200";
-          await assertError(
-            runLro({
+          const body = {
+            properties: {
+              provisioningState: "Failed",
+            },
+          };
+          await assertDivergentBehavior({
+            op: runLro({
               routes: [
                 {
                   method: "PUT",
@@ -466,14 +479,18 @@ matrix(
                   method: "GET",
                   path,
                   status: 200,
-                  body: `{"properties":{"provisioningState":"Failed"}}`,
+                  body: JSON.stringify(body),
                 },
               ],
             }),
-            {
+            throwOnNon2xxResponse,
+            throwing: {
               messagePattern: /The long-running operation has failed/,
-            }
-          );
+            },
+            notThrowing: {
+              result: { ...body, statusCode: 200 },
+            },
+          });
         });
 
         it("should handle post200WithPayload", async () => {
@@ -781,8 +798,9 @@ matrix(
 
             it("should handle deleteAsyncRetrycanceled", async () => {
               const pollingPath = "/deletelocation/retry/canceled/operationResults/200/";
-              await assertError(
-                runLro({
+              const body = { status: "Canceled" };
+              await assertDivergentBehavior({
+                op: runLro({
                   routes: [
                     {
                       method: "DELETE",
@@ -803,20 +821,25 @@ matrix(
                       method: "GET",
                       path: pollingPath,
                       status: 200,
-                      body: `{"status":"Canceled"}`,
+                      body: JSON.stringify(body),
                     },
                   ],
                 }),
-                {
+                throwOnNon2xxResponse,
+                throwing: {
                   messagePattern: /Operation was canceled/,
-                }
-              );
+                },
+                notThrowing: {
+                  result: { ...body, statusCode: 200 },
+                },
+              });
             });
 
             it("should handle DeleteAsyncRetryFailed", async () => {
               const pollingPath = "/deleteasync/retry/failed/operationResults/200/";
-              await assertError(
-                runLro({
+              const body = { status: "Failed" };
+              await assertDivergentBehavior({
+                op: runLro({
                   routes: [
                     {
                       method: "DELETE",
@@ -842,14 +865,18 @@ matrix(
                       method: "GET",
                       path: pollingPath,
                       status: 200,
-                      body: `{"status":"Failed"}`,
+                      body: JSON.stringify(body),
                     },
                   ],
                 }),
-                {
+                throwOnNon2xxResponse,
+                throwing: {
                   messagePattern: /The long-running operation has failed/,
-                }
-              );
+                },
+                notThrowing: {
+                  result: { ...body, statusCode: 200 },
+                },
+              });
             });
 
             it("should handle putAsyncRetrySucceeded", async () => {
@@ -929,8 +956,9 @@ matrix(
 
             it("should handle putAsyncRetryFailed", async () => {
               const pollingPath = "/putlocation/retry/failed/operationResults/200/";
-              await assertError(
-                runLro({
+              const body = { status: "Failed" };
+              await assertDivergentBehavior({
+                op: runLro({
                   routes: [
                     {
                       method: "PUT",
@@ -957,14 +985,18 @@ matrix(
                       method: "GET",
                       path: pollingPath,
                       status: 200,
-                      body: `{"status":"Failed"}`,
+                      body: JSON.stringify(body),
                     },
                   ],
                 }),
-                {
+                throwOnNon2xxResponse,
+                throwing: {
                   messagePattern: /The long-running operation has failed/,
-                }
-              );
+                },
+                notThrowing: {
+                  result: { ...body, statusCode: 200 },
+                },
+              });
             });
 
             it("should handle putAsyncNonResource", async () => {
@@ -1130,8 +1162,9 @@ matrix(
 
             it("should handle putAsyncNoRetrycanceled", async () => {
               const pollingPath = "/putlocation/noretry/canceled/operationResults/200/";
-              await assertError(
-                runLro({
+              const body = { status: "Canceled" };
+              await assertDivergentBehavior({
+                op: runLro({
                   routes: [
                     {
                       method: "PUT",
@@ -1160,14 +1193,23 @@ matrix(
                         location: pollingPath,
                         [headerName]: pollingPath,
                       },
-                      body: `{"status":"Canceled"}`,
+                      body: JSON.stringify(body),
                     },
                   ],
                 }),
-                {
+                throwOnNon2xxResponse,
+                throwing: {
                   messagePattern: /Operation was canceled/,
-                }
-              );
+                },
+                notThrowing: {
+                  result: {
+                    ...body,
+                    location: pollingPath,
+                    [headerName.toLocaleLowerCase()]: pollingPath,
+                    statusCode: 200,
+                  },
+                },
+              });
             });
 
             it("should handle putAsyncSubResource", async () => {
@@ -1281,8 +1323,9 @@ matrix(
 
             it("should handle postAsyncRetryFailed", async () => {
               const pollingPath = "/postlocation/retry/succeeded/operationResults/200/";
-              await assertError(
-                runLro({
+              const body = { status: "Failed" };
+              await assertDivergentBehavior({
+                op: runLro({
                   routes: [
                     {
                       method: "POST",
@@ -1298,14 +1341,18 @@ matrix(
                       method: "GET",
                       path: pollingPath,
                       status: 200,
-                      body: `{"status":"Failed"}`,
+                      body: JSON.stringify(body),
                     },
                   ],
                 }),
-                {
+                throwOnNon2xxResponse,
+                throwing: {
                   messagePattern: /The long-running operation has failed/,
-                }
-              );
+                },
+                notThrowing: {
+                  result: { ...body, statusCode: 200 },
+                },
+              });
             });
 
             it("should handle postAsyncRetrySucceeded", async () => {
@@ -1395,8 +1442,9 @@ matrix(
 
             it("should handle postAsyncRetrycanceled", async () => {
               const pollingPath = "/postasync/retry/canceled/operationResults/200/";
-              await assertError(
-                runLro({
+              const body = { status: "Canceled" };
+              await assertDivergentBehavior({
+                op: runLro({
                   routes: [
                     {
                       method: "POST",
@@ -1412,14 +1460,18 @@ matrix(
                       method: "GET",
                       path: pollingPath,
                       status: 200,
-                      body: `{"status":"Canceled"}`,
+                      body: JSON.stringify(body),
                     },
                   ],
                 }),
-                {
+                throwOnNon2xxResponse,
+                throwing: {
                   messagePattern: /Operation was canceled/,
-                }
-              );
+                },
+                notThrowing: {
+                  result: { ...body, statusCode: 200 },
+                },
+              });
             });
           });
         }
@@ -1434,13 +1486,15 @@ matrix(
               statusCode: 400,
             },
             notThrowing: {
-              messagePattern: /The long-running operation has failed/,
+              result: { statusCode: 400 },
             },
           });
         });
 
         it("should handle putNonRetry201Creating400 ", async () => {
           const path = "/nonretryerror/put/201/creating/400";
+          const body = { message: "Error from the server" };
+          const statusCode = 400;
           await assertDivergentBehavior({
             op: runLro({
               routes: [
@@ -1453,23 +1507,25 @@ matrix(
                 {
                   method: "GET",
                   path,
-                  status: 400,
-                  body: `{ "message": "Error from the server" }`,
+                  status: statusCode,
+                  body: JSON.stringify(body),
                 },
               ],
             }),
             throwOnNon2xxResponse,
             throwing: {
-              statusCode: 400,
+              statusCode,
             },
             notThrowing: {
-              messagePattern: /The long-running operation has failed/,
+              result: { ...body, statusCode },
             },
           });
         });
 
         it("should throw with putNonRetry201Creating400InvalidJson ", async () => {
           const path = "/nonretryerror/put/201/creating/400/invalidjson";
+          const body = { message: "Error from the server" };
+          const statusCode = 400;
           await assertDivergentBehavior({
             op: runLro({
               routes: [
@@ -1482,23 +1538,24 @@ matrix(
                 {
                   method: "GET",
                   path,
-                  status: 400,
-                  body: `{ "message": "Error from the server" }`,
+                  status: statusCode,
+                  body: JSON.stringify(body),
                 },
               ],
             }),
             throwOnNon2xxResponse,
             throwing: {
-              statusCode: 400,
+              statusCode,
             },
             notThrowing: {
-              messagePattern: /The long-running operation has failed/,
+              result: { ...body, statusCode },
             },
           });
         });
 
         it("should handle putAsyncRelativeRetry400 ", async () => {
           const pollingPath = `/nonretryerror/putasync/retry/failed/operationResults/400`;
+          const statusCode = 400;
           await assertDivergentBehavior({
             op: runLro({
               routes: [
@@ -1514,22 +1571,24 @@ matrix(
                 {
                   method: "GET",
                   path: pollingPath,
-                  status: 400,
+                  status: statusCode,
                 },
               ],
             }),
             throwOnNon2xxResponse,
             throwing: {
-              statusCode: 400,
+              statusCode,
             },
             notThrowing: {
-              messagePattern: /The long-running operation has failed/,
+              result: { statusCode },
             },
           });
         });
 
         it("should handle delete202NonRetry400 ", async () => {
           const path = "/nonretryerror/delete/202/retry/400";
+          const body = { message: "Expected bad request message" };
+          const statusCode = 400;
           await assertDivergentBehavior({
             op: runLro({
               routes: [
@@ -1546,38 +1605,40 @@ matrix(
                 {
                   method: "GET",
                   path,
-                  status: 400,
-                  body: `{ "message" : "Expected bad request message" }`,
+                  status: statusCode,
+                  body: JSON.stringify(body),
                 },
               ],
             }),
             throwOnNon2xxResponse,
             throwing: {
-              statusCode: 400,
+              statusCode,
             },
             notThrowing: {
-              messagePattern: /The long-running operation has failed/,
+              result: { ...body, statusCode },
             },
           });
         });
 
         it("should handle deleteNonRetry400 ", async () => {
+          const body = { message: "Expected bad request message" };
+          const statusCode = 400;
           await assertDivergentBehavior({
             op: runLro({
               routes: [
                 {
                   method: "DELETE",
-                  status: 400,
-                  body: `{ "message" : "Expected bad request message" }`,
+                  status: statusCode,
+                  body: JSON.stringify(body),
                 },
               ],
             }),
             throwOnNon2xxResponse,
             throwing: {
-              statusCode: 400,
+              statusCode,
             },
             notThrowing: {
-              messagePattern: /The long-running operation has failed/,
+              result: { ...body, statusCode },
             },
           });
         });
@@ -1615,28 +1676,32 @@ matrix(
         });
 
         it("should handle postNonRetry400 ", async () => {
+          const body = { message: "Expected bad request message" };
+          const statusCode = 400;
           await assertDivergentBehavior({
             op: runLro({
               routes: [
                 {
                   method: "POST",
-                  status: 400,
-                  body: `{ "message" : "Expected bad request message" }`,
+                  status: statusCode,
+                  body: JSON.stringify(body),
                 },
               ],
             }),
             throwOnNon2xxResponse,
             throwing: {
-              statusCode: 400,
+              statusCode,
             },
             notThrowing: {
-              messagePattern: /The long-running operation has failed/,
+              result: { ...body, statusCode },
             },
           });
         });
 
         it("should handle post202NonRetry400 ", async () => {
           const path = `/nonretryerror/post/202/retry/400`;
+          const body = { message: "Expected bad request message" };
+          const statusCode = 400;
           await assertDivergentBehavior({
             op: runLro({
               routes: [
@@ -1653,17 +1718,17 @@ matrix(
                 {
                   method: "GET",
                   path,
-                  status: 400,
-                  body: `{ "message" : "Expected bad request message" }`,
+                  status: statusCode,
+                  body: JSON.stringify(body),
                 },
               ],
             }),
             throwOnNon2xxResponse,
             throwing: {
-              statusCode: 400,
+              statusCode,
             },
             notThrowing: {
-              messagePattern: /The long-running operation has failed/,
+              result: { ...body, statusCode },
             },
           });
         });

--- a/sdk/core/core-lro/test/lro.spec.ts
+++ b/sdk/core/core-lro/test/lro.spec.ts
@@ -1931,8 +1931,8 @@ matrix(
         });
 
         it("should handle putAsyncRelativeRetryInvalidHeader ", async () => {
-          await assertError(
-            runLro({
+          await assertDivergentBehavior({
+            op: runLro({
               routes: [
                 {
                   method: "PUT",
@@ -1945,10 +1945,16 @@ matrix(
                 },
               ],
             }),
-            {
+            throwOnNon2xxResponse,
+            throwing: {
               statusCode: 404,
-            }
-          );
+            },
+            notThrowing: {
+              partResult: {
+                statusCode: 404,
+              },
+            },
+          });
         });
 
         it("should handle putAsyncRelativeRetryInvalidJsonPolling ", async () => {
@@ -1980,8 +1986,8 @@ matrix(
         });
 
         it("should handle delete202RetryInvalidHeader ", async () => {
-          await assertError(
-            runLro({
+          await assertDivergentBehavior({
+            op: runLro({
               routes: [
                 {
                   method: "DELETE",
@@ -1993,15 +1999,21 @@ matrix(
                 },
               ],
             }),
-            {
+            throwOnNon2xxResponse,
+            throwing: {
               statusCode: 404,
-            }
-          );
+            },
+            notThrowing: {
+              partResult: {
+                statusCode: 404,
+              },
+            },
+          });
         });
 
         it("should handle deleteAsyncRelativeRetryInvalidHeader ", async () => {
-          await assertError(
-            runLro({
+          await assertDivergentBehavior({
+            op: runLro({
               routes: [
                 {
                   method: "DELETE",
@@ -2013,10 +2025,16 @@ matrix(
                 },
               ],
             }),
-            {
+            throwOnNon2xxResponse,
+            throwing: {
               statusCode: 404,
-            }
-          );
+            },
+            notThrowing: {
+              partResult: {
+                statusCode: 404,
+              },
+            },
+          });
         });
 
         it("should handle DeleteAsyncRelativeRetryInvalidJsonPolling ", async () => {
@@ -2047,8 +2065,8 @@ matrix(
         });
 
         it("should handle post202RetryInvalidHeader ", async () => {
-          await assertError(
-            runLro({
+          await assertDivergentBehavior({
+            op: runLro({
               routes: [
                 {
                   method: "POST",
@@ -2060,15 +2078,21 @@ matrix(
                 },
               ],
             }),
-            {
+            throwOnNon2xxResponse,
+            throwing: {
               statusCode: 404,
-            }
-          );
+            },
+            notThrowing: {
+              partResult: {
+                statusCode: 404,
+              },
+            },
+          });
         });
 
         it("should handle postAsyncRelativeRetryInvalidHeader ", async () => {
-          await assertError(
-            runLro({
+          await assertDivergentBehavior({
+            op: runLro({
               routes: [
                 {
                   method: "POST",
@@ -2080,10 +2104,16 @@ matrix(
                 },
               ],
             }),
-            {
+            throwOnNon2xxResponse,
+            throwing: {
               statusCode: 404,
-            }
-          );
+            },
+            notThrowing: {
+              partResult: {
+                statusCode: 404,
+              },
+            },
+          });
         });
 
         it("should handle postAsyncRelativeRetryInvalidJsonPolling ", async () => {

--- a/sdk/core/core-lro/test/utils/router.ts
+++ b/sdk/core/core-lro/test/utils/router.ts
@@ -92,9 +92,17 @@ function createClient(inputs: {
         }
         return response;
       }
-      throw new RestError(`Route for ${method} request to ${path} was not found`, {
-        statusCode: 404,
-      });
+      const message = `Route for ${method} request to ${path} was not found`;
+      if (throwOnNon2xxResponse)
+        throw new RestError(message, {
+          statusCode: 404,
+        });
+      return {
+        bodyAsText: JSON.stringify({ message }),
+        status: 404,
+        request,
+        headers: createHttpHeaders(),
+      };
     },
   };
 }

--- a/sdk/core/core-lro/test/utils/router.ts
+++ b/sdk/core/core-lro/test/utils/router.ts
@@ -93,10 +93,11 @@ function createClient(inputs: {
         return response;
       }
       const message = `Route for ${method} request to ${path} was not found`;
-      if (throwOnNon2xxResponse)
+      if (throwOnNon2xxResponse) {
         throw new RestError(message, {
           statusCode: 404,
         });
+      }
       return {
         bodyAsText: JSON.stringify({ message }),
         status: 404,

--- a/sdk/core/core-lro/test/utils/router.ts
+++ b/sdk/core/core-lro/test/utils/router.ts
@@ -158,6 +158,7 @@ export function createTestPoller(settings: {
         updateState: updateState as
           | ((state: any, lastResponse: LroResponse<unknown>) => void)
           | undefined,
+        errorOnUnsuccessful: throwOnNon2xxResponse,
       });
     }
     case "LroEngine": {
@@ -168,6 +169,7 @@ export function createTestPoller(settings: {
           processResult,
           updateState: (state, rawResponse) =>
             updateState?.(state, { rawResponse, flatResponse: undefined as any }),
+          errorOnUnsuccessful: throwOnNon2xxResponse,
         })
       );
     }

--- a/sdk/core/core-lro/test/utils/router.ts
+++ b/sdk/core/core-lro/test/utils/router.ts
@@ -167,7 +167,7 @@ export function createTestPoller(settings: {
         updateState: updateState as
           | ((state: any, lastResponse: LroResponse<unknown>) => void)
           | undefined,
-        errorOnUnsuccessful: throwOnNon2xxResponse,
+        resolveOnUnsuccessful: !throwOnNon2xxResponse,
       });
     }
     case "LroEngine": {
@@ -178,7 +178,7 @@ export function createTestPoller(settings: {
           processResult,
           updateState: (state, rawResponse) =>
             updateState?.(state, { rawResponse, flatResponse: undefined as any }),
-          errorOnUnsuccessful: throwOnNon2xxResponse,
+          resolveOnUnsuccessful: !throwOnNon2xxResponse,
         })
       );
     }

--- a/sdk/core/core-lro/test/utils/utils.ts
+++ b/sdk/core/core-lro/test/utils/utils.ts
@@ -100,6 +100,7 @@ export async function assertDivergentBehavior(inputs: {
   };
   notThrowing: {
     result?: any;
+    partResult?: any;
     statusCode?: number;
     messagePattern?: RegExp;
   };
@@ -112,6 +113,7 @@ export async function assertDivergentBehavior(inputs: {
       messagePattern: notThrowingMessagePattern,
       statusCode: notThrowingStatusCode,
       result,
+      partResult,
     },
   } = inputs;
   if (throwOnNon2xxResponse) {
@@ -125,6 +127,8 @@ export async function assertDivergentBehavior(inputs: {
         statusCode: notThrowingStatusCode,
         messagePattern: notThrowingMessagePattern,
       });
+    } else if (partResult !== undefined) {
+      assert.deepInclude(await op, partResult);
     } else {
       assert.deepEqual(await op, result);
     }


### PR DESCRIPTION
Adds `resolveOnUnsuccessful` flag that controls whether to throw an error if the operation failed or was canceled. This flag is turned off by default but REST-level clients should turn it on to maintain the direction of not raising exceptions when receiving unexpected responses.