### PR TITLE
[core-rest-pipeline] Fix bug in Pipeline.clone()

### DIFF
--- a/sdk/core/core-rest-pipeline/CHANGELOG.md
+++ b/sdk/core/core-rest-pipeline/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Fixed an issue where policies added to a cloned Pipeline would also be added to the original (and vice versa) until policies were removed from either. [#23316](https://github.com/Azure/azure-sdk-for-js/pull/23316)
+
 ### Other Changes
 
 ## 1.9.2 (2022-09-01)

--- a/sdk/core/core-rest-pipeline/src/pipeline.ts
+++ b/sdk/core/core-rest-pipeline/src/pipeline.ts
@@ -120,8 +120,8 @@ class HttpPipeline implements Pipeline {
   private _policies: PipelineDescriptor[] = [];
   private _orderedPolicies?: PipelinePolicy[];
 
-  private constructor(policies: PipelineDescriptor[] = []) {
-    this._policies = policies;
+  private constructor(policies?: PipelineDescriptor[]) {
+    this._policies = policies?.slice(0) ?? [];
     this._orderedPolicies = undefined;
   }
 

--- a/sdk/core/core-rest-pipeline/test/pipeline.spec.ts
+++ b/sdk/core/core-rest-pipeline/test/pipeline.spec.ts
@@ -305,8 +305,6 @@ describe("HttpsPipeline", function () {
 
     const pipeline2 = pipeline.clone();
 
-    pipeline.removePolicy({ name: testPolicy.name });
-
     const testPolicy2: PipelinePolicy = {
       sendRequest: (request, next) => next(request),
       name: "test2",
@@ -319,6 +317,8 @@ describe("HttpsPipeline", function () {
     };
 
     pipeline2.addPolicy(testPolicy3);
+
+    pipeline.removePolicy({ name: testPolicy.name });
 
     const policies = pipeline.getOrderedPolicies();
     assert.strictEqual(policies.length, 1);


### PR DESCRIPTION
Reference re-use caused cloned pipelines to not be independent unless policies were first removed.

### Packages impacted by this PR

`@azure/core-rest-pipeline`

### Issues associated with this PR

#23313

### Describe the problem that is addressed by this PR

When cloning a Pipeline, we re-used the internal policy array. This bug wasn't caught by unit tests as we first removed a policy before adding them, which internally causes us to recreate the array.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?

We could also recreate the array when adding new policies, but this felt like overkill, so instead I chose to copy the array on construction.


### Are there test cases added in this PR? _(If not, why?)_

Updated existing test to cover this problem.
