### PR TITLE
[doc][credscan] update guideline on how to handle credscan errors

### DIFF
--- a/documentation/credscan-process.md
+++ b/documentation/credscan-process.md
@@ -44,21 +44,22 @@ false alarm. CredScan allows you to suppress fake credentials by either suppress
 warnings for a whole file. **Files that contain more than just fake credentials shouldn't be suppressed.**
 
 Credential warnings are suppressed in [eng/CredScanSuppression.json][suppression_file]. Suppressed string values are in
-the `"placeholder"` list, and suppressed files are in the `"file"` list under `"suppressions"`.
+the `"placeholder"` list, and suppressed files are in the `"file"` lists under `"suppressions"`.
 
 If you have a fake credential flagged by CredScan, try one of the following (listed from most to least preferable):
-  - Import and use a suitable credential from a file that's already suppressed in [eng/CredScanSuppression.json][suppression_file].
+  - Import and use a suitable credential from a file that's already suppressed in [eng/CredScanSuppression.json][suppression_file]. If the fake credential will be used by multiple packages, consider adding and exporting it in the `test-utils` package.
+  - If the test credentials are specific to your package, create a `fakeTestSecrets.ts` file under your `test` folder, add and export the fake secrets from this file, and add the file path to the list of suppressed files if necessary.
   - Replace the credential with a string value that's already suppressed in [eng/CredScanSuppression.json][suppression_file]. "SecretPlaceholder" is a good one to use.
-  - Move the credential into a `fakeCredentials.ts` file in your package, and add the file path to the list of suppressed files if necessary.
-  - Add the credential to the list of suppressed string values.
+  - Add the string that uses credential to the list of suppressed string values. For examples, `"password: fakeTestSecretPlaceholder,"`
 
 Ideally, fake credential files -- which contain nothing but fake secrets -- should be suppressed and their fake
 credentials shouldn't appear in any other files. Sanitizers should be used to keep fake credentials out of test
 recordings when possible. String value suppression should be avoided unless the string appears in many files.
 
 Suppressing string values will disable warnings no matter where the string comes up during a scan, but is inefficient
-and inconvenient for lengthy strings. Suppressing warnings in a file is convenient for fake credential files, but
-strings in that file will still trigger warnings if present in another unsuppressed file.
+and inconvenient for lengthy strings. **Note** due to current limitation of the CredScan tool, a whole text line is suppress if the line matches one suppression pattern, which means if a real secret and a suppressed string value are in the same line, the real secret are not reported! We should be very careful when adding a suppressing string value.
+
+Suppressing warnings in a file is convenient for fake credential files, but strings in that file will still trigger warnings if present in another unsuppressed file.
 
 [aggregate_reports]: https://dev.azure.com/azure-sdk/internal/_build?definitionId=1394&_a=summary
 [credscan_doc]: https://aka.ms/credscan


### PR DESCRIPTION
- prefer suppressing fake secrets files over string values
- add notes about CredScan tool limitation on suppressing string values
