### PR TITLE
[core-lro] Prepare release

### DIFF
--- a/sdk/core/core-lro/CHANGELOG.md
+++ b/sdk/core/core-lro/CHANGELOG.md
@@ -1,19 +1,15 @@
 # Release History
 
-## 2.4.0 (Unreleased)
+## 2.4.0 (2022-09-29)
 
 ### Features Added
 
-- Add `resolveOnUnsuccessful` to `CreatePollerOptions` and `LroEngineOptions` to control whether to throw an error if the operation failed or was canceled.
-
-### Breaking Changes
+- Add `resolveOnUnsuccessful` to `CreateHttpPollerOptions` and `LroEngineOptions` to control whether to throw an error if the operation failed or was canceled.
 
 ### Bugs Fixed
 
 - Precisely detect when an operation failed without relying on exceptions raised by the underlying core library.
 - Handle bad status fields.
-
-### Other Changes
 
 ## 2.3.1 (2022-09-09)
 


### PR DESCRIPTION
Release the addition of `resolveOnUnsuccessful` flag today.

[API View](https://apiview.dev/Assemblies/Review/df21e9c5d8714b978c0d09c47f2d5cbc?diffRevisionId=049a16a7322348abbc3b36b9b47d106b&doc=False&diffOnly=False&revisionId=e200c5415eb749afbabe14f7dfcad092)