### PR TITLE
delete credential scopes for mgmt plane sdks a

### DIFF
--- a/sdk/advisor/arm-advisor/CHANGELOG.md
+++ b/sdk/advisor/arm-advisor/CHANGELOG.md
@@ -1,14 +1,10 @@
 # Release History
 
-## 3.0.2 (Unreleased)
+## 3.0.2 (2022-09-30)
 
-### Features Added
+**Bugs Fixed**
 
-### Breaking Changes
-
-### Bugs Fixed
-
-### Other Changes
+  -  fix better user experience of credential scopes in government cloud
 
 ## 3.0.1 (2022-03-22)
 

--- a/sdk/advisor/arm-advisor/src/advisorManagementClient.ts
+++ b/sdk/advisor/arm-advisor/src/advisorManagementClient.ts
@@ -62,9 +62,6 @@ export class AdvisorManagementClient extends coreClient.ServiceClient {
         ? `${options.userAgentOptions.userAgentPrefix} ${packageDetails}`
         : `${packageDetails}`;
 
-    if (!options.credentialScopes) {
-      options.credentialScopes = ["https://management.azure.com/.default"];
-    }
     const optionsWithDefaults = {
       ...defaults,
       ...options,

--- a/sdk/agrifood/arm-agrifood/CHANGELOG.md
+++ b/sdk/agrifood/arm-agrifood/CHANGELOG.md
@@ -1,14 +1,10 @@
 # Release History
 
-## 1.0.0-beta.2 (Unreleased)
+## 1.0.0-beta.2 (2022-09-30)
 
-### Features Added
+**Bugs Fixed**
 
-### Breaking Changes
-
-### Bugs Fixed
-
-### Other Changes
+  -  fix better user experience of credential scopes in government cloud
 
 ## 1.0.0-beta.1 (2022-08-31)
 

--- a/sdk/agrifood/arm-agrifood/src/agriFoodMgmtClient.ts
+++ b/sdk/agrifood/arm-agrifood/src/agriFoodMgmtClient.ts
@@ -72,9 +72,6 @@ export class AgriFoodMgmtClient extends coreClient.ServiceClient {
         ? `${options.userAgentOptions.userAgentPrefix} ${packageDetails}`
         : `${packageDetails}`;
 
-    if (!options.credentialScopes) {
-      options.credentialScopes = ["https://management.azure.com/.default"];
-    }
     const optionsWithDefaults = {
       ...defaults,
       ...options,

--- a/sdk/analysisservices/arm-analysisservices/CHANGELOG.md
+++ b/sdk/analysisservices/arm-analysisservices/CHANGELOG.md
@@ -1,14 +1,10 @@
 # Release History
 
-## 4.1.1 (Unreleased)
+## 4.1.1 (2022-09-30)
 
-### Features Added
+**Bugs Fixed**
 
-### Breaking Changes
-
-### Bugs Fixed
-
-### Other Changes
+  -  fix better user experience of credential scopes in government cloud
 
 ## 4.1.0 (2022-06-29)
     

--- a/sdk/analysisservices/arm-analysisservices/src/azureAnalysisServices.ts
+++ b/sdk/analysisservices/arm-analysisservices/src/azureAnalysisServices.ts
@@ -57,9 +57,6 @@ export class AzureAnalysisServices extends coreClient.ServiceClient {
         ? `${options.userAgentOptions.userAgentPrefix} ${packageDetails}`
         : `${packageDetails}`;
 
-    if (!options.credentialScopes) {
-      options.credentialScopes = ["https://management.azure.com/.default"];
-    }
     const optionsWithDefaults = {
       ...defaults,
       ...options,

--- a/sdk/apimanagement/arm-apimanagement/CHANGELOG.md
+++ b/sdk/apimanagement/arm-apimanagement/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
     
+## 8.1.1 (2022-09-30)
+
+**Bugs Fixed**
+
+  -  fix better user experience of credential scopes in government cloud
+
 ## 8.1.0 (2022-08-03)
     
 **Features**

--- a/sdk/apimanagement/arm-apimanagement/package.json
+++ b/sdk/apimanagement/arm-apimanagement/package.json
@@ -3,7 +3,7 @@
   "sdk-type": "mgmt",
   "author": "Microsoft Corporation",
   "description": "A generated SDK for ApiManagementClient.",
-  "version": "8.1.0",
+  "version": "8.1.1",
   "engines": {
     "node": ">=12.0.0"
   },

--- a/sdk/apimanagement/arm-apimanagement/src/apiManagementClient.ts
+++ b/sdk/apimanagement/arm-apimanagement/src/apiManagementClient.ts
@@ -210,15 +210,12 @@ export class ApiManagementClient extends coreClient.ServiceClient {
       credential: credentials
     };
 
-    const packageDetails = `azsdk-js-arm-apimanagement/8.1.0`;
+    const packageDetails = `azsdk-js-arm-apimanagement/8.1.1`;
     const userAgentPrefix =
       options.userAgentOptions && options.userAgentOptions.userAgentPrefix
         ? `${options.userAgentOptions.userAgentPrefix} ${packageDetails}`
         : `${packageDetails}`;
 
-    if (!options.credentialScopes) {
-      options.credentialScopes = ["https://management.azure.com/.default"];
-    }
     const optionsWithDefaults = {
       ...defaults,
       ...options,

--- a/sdk/app/arm-app/CHANGELOG.md
+++ b/sdk/app/arm-app/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
     
+## 1.0.0-beta.2 (2022-09-30)
+
+**Bugs Fixed**
+
+  -  fix better user experience of credential scopes in government cloud
+
 ## 1.0.0-beta.1 (2022-03-23)
 
 The package of @azure/arm-app is using our next generation design principles. To learn more, please refer to our documentation [Quick Start](https://aka.ms/js-track2-quickstart).

--- a/sdk/app/arm-app/package.json
+++ b/sdk/app/arm-app/package.json
@@ -3,7 +3,7 @@
   "sdk-type": "mgmt",
   "author": "Microsoft Corporation",
   "description": "A generated SDK for ContainerAppsAPIClient.",
-  "version": "1.0.0-beta.1",
+  "version": "1.0.0-beta.2",
   "engines": {
     "node": ">=12.0.0"
   },

--- a/sdk/app/arm-app/src/containerAppsAPIClient.ts
+++ b/sdk/app/arm-app/src/containerAppsAPIClient.ts
@@ -66,15 +66,12 @@ export class ContainerAppsAPIClient extends coreClient.ServiceClient {
       credential: credentials
     };
 
-    const packageDetails = `azsdk-js-arm-app/1.0.0-beta.1`;
+    const packageDetails = `azsdk-js-arm-app/1.0.0-beta.2`;
     const userAgentPrefix =
       options.userAgentOptions && options.userAgentOptions.userAgentPrefix
         ? `${options.userAgentOptions.userAgentPrefix} ${packageDetails}`
         : `${packageDetails}`;
 
-    if (!options.credentialScopes) {
-      options.credentialScopes = ["https://management.azure.com/.default"];
-    }
     const optionsWithDefaults = {
       ...defaults,
       ...options,

--- a/sdk/appconfiguration/arm-appconfiguration/CHANGELOG.md
+++ b/sdk/appconfiguration/arm-appconfiguration/CHANGELOG.md
@@ -1,14 +1,10 @@
 # Release History
 
-## 3.0.1 (Unreleased)
+## 3.0.1 (2022-09-30)
 
-### Features Added
+**Bugs Fixed**
 
-### Breaking Changes
-
-### Bugs Fixed
-
-### Other Changes
+  -  fix better user experience of credential scopes in government cloud
 
 ## 3.0.0 (2022-06-10)
 

--- a/sdk/appconfiguration/arm-appconfiguration/src/appConfigurationManagementClient.ts
+++ b/sdk/appconfiguration/arm-appconfiguration/src/appConfigurationManagementClient.ts
@@ -68,9 +68,6 @@ export class AppConfigurationManagementClient extends coreClient.ServiceClient {
         ? `${options.userAgentOptions.userAgentPrefix} ${packageDetails}`
         : `${packageDetails}`;
 
-    if (!options.credentialScopes) {
-      options.credentialScopes = ["https://management.azure.com/.default"];
-    }
     const optionsWithDefaults = {
       ...defaults,
       ...options,

--- a/sdk/appcontainers/arm-appcontainers/CHANGELOG.md
+++ b/sdk/appcontainers/arm-appcontainers/CHANGELOG.md
@@ -1,14 +1,10 @@
 # Release History
 
-## 1.1.1 (Unreleased)
+## 1.1.1 (2022-09-30)
 
-### Features Added
+**Bugs Fixed**
 
-### Breaking Changes
-
-### Bugs Fixed
-
-### Other Changes
+  -  fix better user experience of credential scopes in government cloud
 
 ## 1.1.0 (2022-08-02)
     

--- a/sdk/appcontainers/arm-appcontainers/src/containerAppsAPIClient.ts
+++ b/sdk/appcontainers/arm-appcontainers/src/containerAppsAPIClient.ts
@@ -80,9 +80,6 @@ export class ContainerAppsAPIClient extends coreClient.ServiceClient {
         ? `${options.userAgentOptions.userAgentPrefix} ${packageDetails}`
         : `${packageDetails}`;
 
-    if (!options.credentialScopes) {
-      options.credentialScopes = ["https://management.azure.com/.default"];
-    }
     const optionsWithDefaults = {
       ...defaults,
       ...options,

--- a/sdk/applicationinsights/arm-appinsights/CHANGELOG.md
+++ b/sdk/applicationinsights/arm-appinsights/CHANGELOG.md
@@ -1,14 +1,10 @@
 # Release History
 
-## 5.0.0-beta.5 (Unreleased)
+## 5.0.0-beta.5 (2022-09-30)
 
-### Features Added
+**Bugs Fixed**
 
-### Breaking Changes
-
-### Bugs Fixed
-
-### Other Changes
+  -  fix better user experience of credential scopes in government cloud
 
 ## 5.0.0-beta.4 (2022-06-01)
 

--- a/sdk/applicationinsights/arm-appinsights/src/applicationInsightsManagementClient.ts
+++ b/sdk/applicationinsights/arm-appinsights/src/applicationInsightsManagementClient.ts
@@ -90,9 +90,6 @@ export class ApplicationInsightsManagementClient extends coreClient.ServiceClien
         ? `${options.userAgentOptions.userAgentPrefix} ${packageDetails}`
         : `${packageDetails}`;
 
-    if (!options.credentialScopes) {
-      options.credentialScopes = ["https://management.azure.com/.default"];
-    }
     const optionsWithDefaults = {
       ...defaults,
       ...options,

--- a/sdk/appplatform/arm-appplatform/CHANGELOG.md
+++ b/sdk/appplatform/arm-appplatform/CHANGELOG.md
@@ -1,14 +1,10 @@
 # Release History
 
-## 2.1.0-beta.2 (Unreleased)
+## 2.1.0-beta.2 (2022-09-30)
 
-### Features Added
+**Bugs Fixed**
 
-### Breaking Changes
-
-### Bugs Fixed
-
-### Other Changes
+  -  fix better user experience of credential scopes in government cloud
 
 ## 2.1.0-beta.1 (2022-09-09)
     

--- a/sdk/appplatform/arm-appplatform/src/appPlatformManagementClient.ts
+++ b/sdk/appplatform/arm-appplatform/src/appPlatformManagementClient.ts
@@ -105,9 +105,6 @@ export class AppPlatformManagementClient extends coreClient.ServiceClient {
         ? `${options.userAgentOptions.userAgentPrefix} ${packageDetails}`
         : `${packageDetails}`;
 
-    if (!options.credentialScopes) {
-      options.credentialScopes = ["https://management.azure.com/.default"];
-    }
     const optionsWithDefaults = {
       ...defaults,
       ...options,

--- a/sdk/appservice/arm-appservice/CHANGELOG.md
+++ b/sdk/appservice/arm-appservice/CHANGELOG.md
@@ -1,14 +1,10 @@
 # Release History
 
-## 13.0.1 (Unreleased)
+## 13.0.1 (2022-09-30)
 
-### Features Added
+**Bugs Fixed**
 
-### Breaking Changes
-
-### Bugs Fixed
-
-### Other Changes
+  -  fix better user experience of credential scopes in government cloud
 
 ## 13.0.0 (2022-07-06)
     

--- a/sdk/appservice/arm-appservice/src/webSiteManagementClient.ts
+++ b/sdk/appservice/arm-appservice/src/webSiteManagementClient.ts
@@ -179,9 +179,6 @@ export class WebSiteManagementClient extends coreClient.ServiceClient {
         ? `${options.userAgentOptions.userAgentPrefix} ${packageDetails}`
         : `${packageDetails}`;
 
-    if (!options.credentialScopes) {
-      options.credentialScopes = ["https://management.azure.com/.default"];
-    }
     const optionsWithDefaults = {
       ...defaults,
       ...options,

--- a/sdk/attestation/arm-attestation/CHANGELOG.md
+++ b/sdk/attestation/arm-attestation/CHANGELOG.md
@@ -1,10 +1,10 @@
 # Release History
 
-## 2.0.1 (Unreleased)
+## 2.0.1 (2022-09-30)
 
-**features**
+**Bugs Fixed**
 
-  - Bug fix
+  -  fix better user experience of credential scopes in government cloud
 
 ## 2.0.0 (2021-12-30)
 

--- a/sdk/attestation/arm-attestation/src/attestationManagementClient.ts
+++ b/sdk/attestation/arm-attestation/src/attestationManagementClient.ts
@@ -58,9 +58,6 @@ export class AttestationManagementClient extends coreClient.ServiceClient {
         ? `${options.userAgentOptions.userAgentPrefix} ${packageDetails}`
         : `${packageDetails}`;
 
-    if (!options.credentialScopes) {
-      options.credentialScopes = ["https://management.azure.com/.default"];
-    }
     const optionsWithDefaults = {
       ...defaults,
       ...options,

--- a/sdk/authorization/arm-authorization/CHANGELOG.md
+++ b/sdk/authorization/arm-authorization/CHANGELOG.md
@@ -1,14 +1,10 @@
 # Release History
 
-## 9.0.0-beta.2 (Unreleased)
+## 9.0.0-beta.2 (2022-09-30)
 
-### Features Added
+**Bugs Fixed**
 
-### Breaking Changes
-
-### Bugs Fixed
-
-### Other Changes
+  -  fix better user experience of credential scopes in government cloud
 
 ## 9.0.0-beta.1 (2021-10-09)
 

--- a/sdk/authorization/arm-authorization/src/authorizationManagementClientContext.ts
+++ b/sdk/authorization/arm-authorization/src/authorizationManagementClientContext.ts
@@ -48,9 +48,6 @@ export class AuthorizationManagementClientContext extends coreClient.ServiceClie
         ? `${options.userAgentOptions.userAgentPrefix} ${packageDetails}`
         : `${packageDetails}`;
 
-    if (!options.credentialScopes) {
-      options.credentialScopes = ["https://management.azure.com/.default"];
-    }
     const optionsWithDefaults = {
       ...defaults,
       ...options,

--- a/sdk/automanage/arm-automanage/CHANGELOG.md
+++ b/sdk/automanage/arm-automanage/CHANGELOG.md
@@ -1,14 +1,10 @@
 # Release History
 
-## 1.0.1 (Unreleased)
+## 1.0.1 (2022-09-30)
 
-### Features Added
+**Bugs Fixed**
 
-### Breaking Changes
-
-### Bugs Fixed
-
-### Other Changes
+  -  fix better user experience of credential scopes in government cloud
 
 ## 1.0.0 (2022-08-03)
 

--- a/sdk/automanage/arm-automanage/src/automanageClient.ts
+++ b/sdk/automanage/arm-automanage/src/automanageClient.ts
@@ -82,9 +82,6 @@ export class AutomanageClient extends coreClient.ServiceClient {
         ? `${options.userAgentOptions.userAgentPrefix} ${packageDetails}`
         : `${packageDetails}`;
 
-    if (!options.credentialScopes) {
-      options.credentialScopes = ["https://management.azure.com/.default"];
-    }
     const optionsWithDefaults = {
       ...defaults,
       ...options,

--- a/sdk/automation/arm-automation/CHANGELOG.md
+++ b/sdk/automation/arm-automation/CHANGELOG.md
@@ -1,14 +1,10 @@
 # Release History
 
-## 11.0.0-beta.2 (Unreleased)
+## 11.0.0-beta.2 (2022-09-30)
 
-### Features Added
+**Bugs Fixed**
 
-### Breaking Changes
-
-### Bugs Fixed
-
-### Other Changes
+  -  fix better user experience of credential scopes in government cloud
 
 ## 11.0.0-beta.1 (2022-07-25)
 

--- a/sdk/automation/arm-automation/src/automationClient.ts
+++ b/sdk/automation/arm-automation/src/automationClient.ts
@@ -150,9 +150,6 @@ export class AutomationClient extends coreClient.ServiceClient {
         ? `${options.userAgentOptions.userAgentPrefix} ${packageDetails}`
         : `${packageDetails}`;
 
-    if (!options.credentialScopes) {
-      options.credentialScopes = ["https://management.azure.com/.default"];
-    }
     const optionsWithDefaults = {
       ...defaults,
       ...options,

--- a/sdk/avs/arm-avs/CHANGELOG.md
+++ b/sdk/avs/arm-avs/CHANGELOG.md
@@ -1,14 +1,10 @@
 # Release History
 
-## 3.1.1 (Unreleased)
+## 3.1.1 (2022-09-30)
 
-### Features Added
+**Bugs Fixed**
 
-### Breaking Changes
-
-### Bugs Fixed
-
-### Other Changes
+  -  fix better user experience of credential scopes in government cloud
 
 ## 3.1.0 (2022-07-05)
     

--- a/sdk/avs/arm-avs/src/azureVMwareSolutionAPI.ts
+++ b/sdk/avs/arm-avs/src/azureVMwareSolutionAPI.ts
@@ -90,9 +90,6 @@ export class AzureVMwareSolutionAPI extends coreClient.ServiceClient {
         ? `${options.userAgentOptions.userAgentPrefix} ${packageDetails}`
         : `${packageDetails}`;
 
-    if (!options.credentialScopes) {
-      options.credentialScopes = ["https://management.azure.com/.default"];
-    }
     const optionsWithDefaults = {
       ...defaults,
       ...options,

--- a/sdk/azureadexternalidentities/arm-azureadexternalidentities/CHANGELOG.md
+++ b/sdk/azureadexternalidentities/arm-azureadexternalidentities/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
     
+## 1.0.1 (2022-09-30)
+
+**Bugs Fixed**
+
+  -  fix better user experience of credential scopes in government cloud
+
 ## 1.0.0 (2022-04-06)
 
 The package of @azure/arm-azureadexternalidentities is using our next generation design principles. To learn more, please refer to our documentation [Quick Start](https://aka.ms/js-track2-quickstart).

--- a/sdk/azureadexternalidentities/arm-azureadexternalidentities/package.json
+++ b/sdk/azureadexternalidentities/arm-azureadexternalidentities/package.json
@@ -3,7 +3,7 @@
   "sdk-type": "mgmt",
   "author": "Microsoft Corporation",
   "description": "A generated SDK for ExternalIdentitiesConfigurationClient.",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "engines": {
     "node": ">=12.0.0"
   },

--- a/sdk/azureadexternalidentities/arm-azureadexternalidentities/src/externalIdentitiesConfigurationClient.ts
+++ b/sdk/azureadexternalidentities/arm-azureadexternalidentities/src/externalIdentitiesConfigurationClient.ts
@@ -45,15 +45,12 @@ export class ExternalIdentitiesConfigurationClient extends coreClient.ServiceCli
       credential: credentials
     };
 
-    const packageDetails = `azsdk-js-arm-azureadexternalidentities/1.0.0`;
+    const packageDetails = `azsdk-js-arm-azureadexternalidentities/1.0.1`;
     const userAgentPrefix =
       options.userAgentOptions && options.userAgentOptions.userAgentPrefix
         ? `${options.userAgentOptions.userAgentPrefix} ${packageDetails}`
         : `${packageDetails}`;
 
-    if (!options.credentialScopes) {
-      options.credentialScopes = ["https://management.azure.com/.default"];
-    }
     const optionsWithDefaults = {
       ...defaults,
       ...options,

--- a/sdk/azurestack/arm-azurestack/CHANGELOG.md
+++ b/sdk/azurestack/arm-azurestack/CHANGELOG.md
@@ -1,14 +1,10 @@
 # Release History
 
-## 3.0.0-beta.3 (Unreleased)
+## 3.0.0-beta.3 (2022-09-30)
 
-### Features Added
+**Bugs Fixed**
 
-### Breaking Changes
-
-### Bugs Fixed
-
-### Other Changes
+  -  fix better user experience of credential scopes in government cloud
 
 ## 3.0.0-beta.2 (2022-04-11)
 

--- a/sdk/azurestack/arm-azurestack/src/azureStackManagementClient.ts
+++ b/sdk/azurestack/arm-azurestack/src/azureStackManagementClient.ts
@@ -65,9 +65,6 @@ export class AzureStackManagementClient extends coreClient.ServiceClient {
         ? `${options.userAgentOptions.userAgentPrefix} ${packageDetails}`
         : `${packageDetails}`;
 
-    if (!options.credentialScopes) {
-      options.credentialScopes = ["https://management.azure.com/.default"];
-    }
     const optionsWithDefaults = {
       ...defaults,
       ...options,

--- a/sdk/azurestackhci/arm-azurestackhci/CHANGELOG.md
+++ b/sdk/azurestackhci/arm-azurestackhci/CHANGELOG.md
@@ -1,14 +1,10 @@
 # Release History
 
-## 3.0.1 (Unreleased)
+## 3.0.1 (2022-09-30)
 
-### Features Added
+**Bugs Fixed**
 
-### Breaking Changes
-
-### Bugs Fixed
-
-### Other Changes
+  -  fix better user experience of credential scopes in government cloud
 
 ## 3.0.0 (2022-05-17)
     

--- a/sdk/azurestackhci/arm-azurestackhci/src/azureStackHCIClient.ts
+++ b/sdk/azurestackhci/arm-azurestackhci/src/azureStackHCIClient.ts
@@ -61,9 +61,6 @@ export class AzureStackHCIClient extends coreClient.ServiceClient {
         ? `${options.userAgentOptions.userAgentPrefix} ${packageDetails}`
         : `${packageDetails}`;
 
-    if (!options.credentialScopes) {
-      options.credentialScopes = ["https://management.azure.com/.default"];
-    }
     const optionsWithDefaults = {
       ...defaults,
       ...options,


### PR DESCRIPTION
https://github.com/Azure/azure-sdk-for-js/issues/23134
delete credential scopes in these sdk folders:
advisor
agrifood
analysisservices
app
appconfiguration
appcontainers
applicationinsights
appplatform
appservice
attestation
authorization
automanage
autpmation
avs
azureadexternalidentities
azurestack
azurestackhci