### PR TITLE
[ServiceBus] bring back `open()` as `preconnect()`

### DIFF
--- a/sdk/servicebus/service-bus/review/service-bus.api.md
+++ b/sdk/servicebus/service-bus/review/service-bus.api.md
@@ -523,6 +523,7 @@ export interface ServiceBusSender {
     entityPath: string;
     identifier: string;
     isClosed: boolean;
+    preconnect(options?: OperationOptionsBase): Promise<void>;
     scheduleMessages(messages: ServiceBusMessage | ServiceBusMessage[] | AmqpAnnotatedMessage | AmqpAnnotatedMessage[], scheduledEnqueueTimeUtc: Date, options?: OperationOptionsBase): Promise<Long[]>;
     sendMessages(messages: ServiceBusMessage | ServiceBusMessage[] | ServiceBusMessageBatch | AmqpAnnotatedMessage | AmqpAnnotatedMessage[], options?: OperationOptionsBase): Promise<void>;
 }

--- a/sdk/servicebus/service-bus/src/sender.ts
+++ b/sdk/servicebus/service-bus/src/sender.ts
@@ -85,17 +85,16 @@ export interface ServiceBusSender {
    */
   createMessageBatch(options?: CreateMessageBatchOptions): Promise<ServiceBusMessageBatch>;
 
-  // TODO: Commented out to come up with an alternative name
-  // /**
-  //  * Opens the AMQP link to Azure Service Bus from the sender.
-  //  *
-  //  * It is not necessary to call this method in order to use the sender. It is
-  //  * recommended to call this before your first sendMessages() call if you
-  //  * want to front load the work of setting up the AMQP link to the service.
-  //  *
-  //  * @param options - Options to configure tracing and the abortSignal.
-  //  */
-  // open(options?: OperationOptionsBase): Promise<void>;
+  /**
+   * Pre-establish the AMQP link to Azure Service Bus from the sender.
+   *
+   * It is not necessary to call this method in order to use the sender. It is
+   * recommended to call this before your first sendMessages() call if you
+   * want to front load the work of setting up the AMQP link to the service.
+   *
+   * @param options - Options to configure tracing and the abortSignal.
+   */
+  preconnect(options?: OperationOptionsBase): Promise<void>;
 
   /**
    * Returns `true` if either the sender or the client that created it has been closed.
@@ -351,20 +350,19 @@ export class ServiceBusSenderImpl implements ServiceBusSender {
     return retry<void>(config);
   }
 
-  // async open(options?: OperationOptionsBase): Promise<void> {
-  //   this._throwIfSenderOrConnectionClosed();
+  async preconnect(options?: OperationOptionsBase): Promise<void> {
+    this._throwIfSenderOrConnectionClosed();
 
-  //   const config: RetryConfig<void> = {
-  //     // TODO: Pass tracing options too
-  //     operation: () => this._sender.open(undefined, options?.abortSignal),
-  //     connectionId: this._context.connectionId,
-  //     operationType: RetryOperationType.senderLink,
-  //     retryOptions: this._retryOptions,
-  //     abortSignal: options?.abortSignal
-  //   };
+    const config: RetryConfig<void> = {
+      operation: () => this._sender.open(undefined, options?.abortSignal),
+      connectionId: this._context.connectionId,
+      operationType: RetryOperationType.senderLink,
+      retryOptions: this._retryOptions,
+      abortSignal: options?.abortSignal,
+    };
 
-  //   return retry<void>(config);
-  // }
+    return retry<void>(config);
+  }
 
   async close(): Promise<void> {
     try {

--- a/sdk/servicebus/service-bus/test/internal/connectionManagement.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/connectionManagement.spec.ts
@@ -1,97 +1,79 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-// import chai from "chai";
-// const assert = chai.assert;
-// import chaiAsPromised from "chai-as-promised";
-// import { delay } from "../src";
-// import { ServiceBusClientForTests, createServiceBusClientForTests } from "./utils/testutils2";
-// import { defaultLock } from "@azure/core-amqp";
-// import { TestClientType } from "./utils/testUtils";
-// import { ServiceBusSenderImpl } from "../src/sender";
-// import { AbortController } from "@azure/abort-controller";
+import chai from "chai";
+const assert = chai.assert;
+import chaiAsPromised from "chai-as-promised";
+import {
+  ServiceBusClientForTests,
+  createServiceBusClientForTests,
+} from "../public/utils/testutils2";
+import { TestClientType } from "../public/utils/testUtils";
+import { ServiceBusSenderImpl } from "../../src/sender";
+import { getErrorMessage } from "@azure/core-util";
 
-// chai.use(chaiAsPromised);
+chai.use(chaiAsPromised);
 
-// describe("controlled connection initialization", () => {
-//   let sender: ServiceBusSenderImpl;
-//   let senderEntityPath: string;
-//   let serviceBusClient: ServiceBusClientForTests;
+describe("controlled connection initialization", () => {
+  let sender: ServiceBusSenderImpl;
+  let senderEntityPath: string;
+  let serviceBusClient: ServiceBusClientForTests;
+  beforeEach(async () => {
+    serviceBusClient = createServiceBusClientForTests();
 
-//   beforeEach(async () => {
-//     serviceBusClient = createServiceBusClientForTests();
+    // there's nothing entity specific about what I'm doing here so it can be any
+    // entity...
+    const { queue } = await serviceBusClient.test.createTestEntities(
+      TestClientType.UnpartitionedQueue
+    );
 
-//     // there's nothing entity specific about what I'm doing here so it can be any
-//     // entity...
-//     const { queue } = await serviceBusClient.test.createTestEntities(
-//       TestClientType.UnpartitionedQueue
-//     );
+    if (queue == null) {
+      throw new Error("queue name should not be null");
+    }
 
-//     if (queue == null) {
-//       throw new Error("queue name should not be null");
-//     }
+    senderEntityPath = queue!;
+  });
 
-//     // casting because I need access to 'open' and the return type of createSender() is an
-//     // interface.
-//     sender = serviceBusClient.createSender(queue!) as ServiceBusSenderImpl;
-//     senderEntityPath = queue!;
-//   });
+  afterEach(async () => {
+    await serviceBusClient.test.afterEach();
+    // Cleaning the client as well since we are using a new client for each test
+    await serviceBusClient.test.after();
+  });
 
-//   afterEach(async () => {
-//     await serviceBusClient.test.afterEach();
-//     // Cleaning the client as well since we are using a new client for each test
-//     await serviceBusClient.test.after();
-//   });
+  it("preconnect() establishes the link up front", async () => {
+    try {
+      // casting because I need access to 'open' and the return type of createSender() is an
+      // interface.
+      sender = serviceBusClient.createSender(senderEntityPath) as ServiceBusSenderImpl;
+      await sender.preconnect();
+      assert.ok(sender["_sender"]["isOpen"](), "Expecting link being opened");
+      await sender.sendMessages({ body: "hello" });
+    } finally {
+      sender.close();
+    }
+  });
 
-//   it("open() properly locks to prevent multiple in-flight open() calls", async () => {
-//     // open uses a lock (at the sender level) that helps us not to have overlapping open() calls.
-//     let secondOpenCallPromise: Promise<void> | undefined;
+  it("open() doesn't re-open a sender when it's been close()'d", async () => {
+    // casting because I need access to 'open' and the return type of createSender() is an
+    // interface.
+    sender = serviceBusClient.createSender(senderEntityPath) as ServiceBusSenderImpl;
+    sender["_sender"]["_negotiateClaim"] = async () => {
+      // this is a decent way to tell that we tried to open the connection
+      throw new Error(
+        "_negotiateClaim(): We won't get here until _after_ the lock has been released"
+      );
+    };
+    // we can't revive a sender.
+    await sender.close();
 
-//     // acquire the same lock that open() uses and then, while it's 100% locked,
-//     // attempt to call .open() and see that it just blocks...
-//     await defaultLock.acquire(sender["_sender"]["_openLock"], async () => {
-//       // we need to fake the connection being closed or else `open()` won't attempt to acquire
-//       // the lock.
-//       sender["_sender"]["isOpen"] = () => false;
-
-//       sender["_sender"]["_negotiateClaim"] = async () => {
-//         // this is a decent way to tell that we tried to open the connection
-//         throw new Error("We won't get here until _after_ the lock has been released");
-//       };
-
-//       secondOpenCallPromise = sender.open();
-//       const ret = await Promise.race([delayThatReturns999(), secondOpenCallPromise]);
-
-//       // this time the delay() call wins since our open() call is blocked on the lock internally
-//       assert.equal(typeof ret, "number");
-//     });
-
-//     // now that we're outside of the lock we can await on the Promise and it should proceed
-//     try {
-//       await secondOpenCallPromise;
-//       assert.fail("Should have thrown once we reached our stubbed out _negotiateClaim() call");
-//     } catch (err) {
-//       assert.equal(err.message, "We won't get here until _after_ the lock has been released");
-//     }
-//   });
-
-//   it("open() doesn't re-open a sender when it's been close()'d", async () => {
-//     // we can't revive a sender.
-//     await sender.close();
-
-//     try {
-//       await sender.open();
-//       assert.fail("Should have thrown once we reached our stubbed out _negotiateClaim() call");
-//     } catch (err) {
-//       assert.equal(
-//         err.message,
-//         `The sender for "${senderEntityPath}" has been closed and can no longer be used. Please create a new sender using the "createSender" method on the ServiceBusClient.`
-//       );
-//     }
-//   });
-// });
-
-// function delayThatReturns999(): Promise<void> | Promise<number> {
-//   const ac = new AbortController();
-//   return delay(1000, ac.signal, "ignored", 999);
-// }
+    try {
+      await sender.preconnect();
+      assert.fail("Should have thrown once we reached our stubbed out _negotiateClaim() call");
+    } catch (err) {
+      assert.equal(
+        getErrorMessage(err),
+        `The sender for "${senderEntityPath}" has been closed and can no longer be used. Please create a new sender using the "createSender" method on the ServiceBusClient.`
+      );
+    }
+  });
+});


### PR DESCRIPTION
This allows sender to establish the link up front instead of delaying that until sending messages. This should help reduce initial latency of sending first batch of message(s) in performance-critical scenarios.

### Packages impacted by this PR
`@azure/service-bus`

### Issues associated with this PR
https://github.com/Azure/azure-sdk-for-js/issues/12611
