### PR TITLE
[monitor-ingestion] Change default concurrency to 5

### DIFF
--- a/sdk/monitor/monitor-ingestion/CHANGELOG.md
+++ b/sdk/monitor/monitor-ingestion/CHANGELOG.md
@@ -17,6 +17,9 @@
 
 ### Other Changes
 
+- Increased the default maximum number of concurrent requests to 5 when uploading in batches. The level of concurrency can
+  be customized using the `maxConcurrency` option passed to the `upload` method.
+
 ## 1.0.0-beta.2 (2022-08-22)
 
 ### Features Added

--- a/sdk/monitor/monitor-ingestion/README.md
+++ b/sdk/monitor/monitor-ingestion/README.md
@@ -5,10 +5,11 @@ The Azure Monitor Ingestion client library is used to send custom logs to [Azure
 This library allows you to send data from virtually any source to supported built-in tables or to custom tables that you create in Log Analytics workspace. You can even extend the schema of built-in tables with custom columns.
 
 **Resources:**
-* [Source code](https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/monitor/monitor-ingestion/src)
-* [Package (NPM)](https://www.npmjs.com/)
-* [Service documentation][azure_monitor_overview]
-* [Change log](https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/monitor/monitor-ingestion/CHANGELOG.md)
+
+- [Source code](https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/monitor/monitor-ingestion/src)
+- [Package (NPM)](https://www.npmjs.com/)
+- [Service documentation][azure_monitor_overview]
+- [Change log](https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/monitor/monitor-ingestion/CHANGELOG.md)
 
 ## Getting started
 
@@ -50,8 +51,8 @@ const logsIngestionClient = new LogsIngestionClient(logsIngestionEndpoint, crede
 
 ### Data Collection Endpoint
 
-Data Collection Endpoints (DCEs) allow you to uniquely configure ingestion settings for Azure Monitor. [This 
-article][data_collection_endpoint] provides an overview of data collection endpoints including their contents and 
+Data Collection Endpoints (DCEs) allow you to uniquely configure ingestion settings for Azure Monitor. [This
+article][data_collection_endpoint] provides an overview of data collection endpoints including their contents and
 structure and how you can create and work with them.
 
 ### Data Collection Rule
@@ -68,7 +69,7 @@ For more details, refer to [Data collection rules in Azure Monitor][data_collect
 
 ### Log Analytics workspace tables
 
-Custom logs can send data to any custom table that you create and to certain built-in tables in your Log Analytics 
+Custom logs can send data to any custom table that you create and to certain built-in tables in your Log Analytics
 workspace. The target table must exist before you can send data to it. The following built-in tables are currently supported:
 
 - [CommonSecurityLog](https://docs.microsoft.com/azure/azure-monitor/reference/tables/commonsecuritylog)
@@ -127,9 +128,10 @@ main().catch((err) => {
 
 module.exports = { main };
 ```
+
 ### Verify logs
 
-You can verify that your data has been uploaded correctly by using the [@azure/monitor-query](https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/monitor/monitor-query/README.md#install-the-package) library. Run the [Upload custom logs](#upload-custom-logs) sample first before verifying the logs. 
+You can verify that your data has been uploaded correctly by using the [@azure/monitor-query](https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/monitor/monitor-query/README.md#install-the-package) library. Run the [Upload custom logs](#upload-custom-logs) sample first before verifying the logs.
 
 ```js
 // Copyright (c) Microsoft Corporation.
@@ -174,8 +176,53 @@ main().catch((err) => {
 });
 
 module.exports = { main };
-
 ```
+
+### Uploading large batches of logs
+
+When uploading more than 1MB of logs in a single call to the `upload` method on `LogsIngestionClient`, the upload will be split into several smaller batches, each no larger than 1MB. By default, these batches will be uploaded in parallel, with a maximum of 5 batches being uploaded concurrently. It may be desirable to decrease the maximum concurrency if memory usage is a concern. The maximum number of concurrent uploads can be controlled using the `maxConcurrency` option, as shown in this example:
+
+```js
+const { DefaultAzureCredential } = require("@azure/identity");
+const { LogsIngestionClient } = require("@azure/monitor-ingestion");
+
+require("dotenv").config();
+
+async function main() {
+  const logsIngestionEndpoint = process.env.LOGS_INGESTION_ENDPOINT || "logs_ingestion_endpoint";
+  const ruleId = process.env.DATA_COLLECTION_RULE_ID || "data_collection_rule_id";
+  const streamName = process.env.STREAM_NAME || "data_stream_name";
+  const credential = new DefaultAzureCredential();
+  const client = new LogsIngestionClient(logsIngestionEndpoint, credential);
+
+  // Constructing a large number of logs to ensure batching takes place
+  const logs = [];
+  for (let i = 0; i < 100000; ++i) {
+    logs.push({
+      Time: "2021-12-08T23:51:14.1104269Z",
+      Computer: "Computer1",
+      AdditionalContext: `context-${i}`,
+    });
+  }
+
+  // Set the maximum concurrency to 1 to prevent concurrent requests entirely
+  const result = await client.upload(ruleId, streamName, logs, { maxConcurrency: 1 });
+  if (result.uploadStatus !== "Success") {
+    console.log("Some logs have failed to complete ingestion. Upload status=", result.uploadStatus);
+    for (const errors of result.errors) {
+      console.log(`Error - ${JSON.stringify(errors.responseError)}`);
+      console.log(`Log - ${JSON.stringify(errors.failedLogs)}`);
+    }
+  }
+}
+main().catch((err) => {
+  console.error("The sample encountered an error:", err);
+  process.exit(1);
+});
+
+module.exports = { main };
+```
+
 ## Troubleshooting
 
 ### Logging
@@ -191,6 +238,7 @@ setLogLevel("info");
 For detailed instructions on how to enable logs, see the [@azure/logger package docs](https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/core/logger).
 
 ## Next steps
+
 To learn more about Azure Monitor, see the [Azure Monitor service documentation][azure_monitor_overview].
 
 ## Contributing
@@ -198,8 +246,10 @@ To learn more about Azure Monitor, see the [Azure Monitor service documentation]
 If you'd like to contribute to this library, please read the [contributing guide](https://github.com/Azure/azure-sdk-for-js/blob/main/CONTRIBUTING.md) to learn more about how to build and test the code.
 
 <!-- LINKS -->
+
 [azure_monitor_overview]: https://docs.microsoft.com/azure/azure-monitor/overview
 [data_collection_endpoint]: https://docs.microsoft.com/azure/azure-monitor/essentials/data-collection-endpoint-overview
 [data_collection_rule]: https://docs.microsoft.com/azure/azure-monitor/essentials/data-collection-rule-overview
 
 ![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js/sdk/monitor/monitor-ingestion/README.png)
+

--- a/sdk/monitor/monitor-ingestion/README.md
+++ b/sdk/monitor/monitor-ingestion/README.md
@@ -113,10 +113,10 @@ async function main() {
     },
   ];
   const result = await client.upload(ruleId, streamName, logs);
-  if (result.uploadStatus !== "Success") {
-    console.log("Some logs have failed to complete ingestion. Upload status=", result.uploadStatus);
+  if (result.status !== "Success") {
+    console.log("Some logs have failed to complete ingestion. Upload status=", result.status);
     for (const errors of result.errors) {
-      console.log(`Error - ${JSON.stringify(errors.responseError)}`);
+      console.log(`Error - ${JSON.stringify(errors.cause)}`);
       console.log(`Log - ${JSON.stringify(errors.failedLogs)}`);
     }
   }
@@ -207,11 +207,11 @@ async function main() {
 
   // Set the maximum concurrency to 1 to prevent concurrent requests entirely
   const result = await client.upload(ruleId, streamName, logs, { maxConcurrency: 1 });
-  if (result.uploadStatus !== "Success") {
-    console.log("Some logs have failed to complete ingestion. Upload status=", result.uploadStatus);
-    for (const errors of result.errors) {
-      console.log(`Error - ${JSON.stringify(errors.responseError)}`);
-      console.log(`Log - ${JSON.stringify(errors.failedLogs)}`);
+  if (result.status !== "Success") {
+    console.log("Some logs have failed to complete ingestion. Upload status=", result.status);
+    for (const error of result.errors) {
+      console.log(`Error - ${JSON.stringify(error.cause)}`);
+      console.log(`Log - ${JSON.stringify(error.failedLogs)}`);
     }
   }
 }
@@ -252,4 +252,3 @@ If you'd like to contribute to this library, please read the [contributing guide
 [data_collection_rule]: https://docs.microsoft.com/azure/azure-monitor/essentials/data-collection-rule-overview
 
 ![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js/sdk/monitor/monitor-ingestion/README.png)
-

--- a/sdk/monitor/monitor-ingestion/samples-dev/concurrency.ts
+++ b/sdk/monitor/monitor-ingestion/samples-dev/concurrency.ts
@@ -1,0 +1,46 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+/**
+ * @summary Demonstrates uploading a large number of logs where the logs are split into multiple batches and uploaded concurrently.
+ */
+
+import { DefaultAzureCredential } from "@azure/identity";
+import { LogsIngestionClient } from "@azure/monitor-ingestion";
+
+require("dotenv").config();
+
+async function main() {
+  const logsIngestionEndpoint = process.env.LOGS_INGESTION_ENDPOINT || "logs_ingestion_endpoint";
+  const ruleId = process.env.DATA_COLLECTION_RULE_ID || "data_collection_rule_id";
+  const streamName = process.env.STREAM_NAME || "data_stream_name";
+  const credential = new DefaultAzureCredential();
+  const client = new LogsIngestionClient(logsIngestionEndpoint, credential);
+
+  // Constructing a large number of logs to ensure batching takes place
+  const logs = [];
+  for (let i = 0; i < 100000; ++i) {
+    logs.push({
+      Time: "2021-12-08T23:51:14.1104269Z",
+      Computer: "Computer1",
+      AdditionalContext: `context-${i}`,
+    });
+  }
+
+  // The logs will be split into multiple batches and uploaded concurrently. By default,
+  // the maximum number of concurrent uploads is 5.
+  const result = await client.upload(ruleId, streamName, logs);
+  if (result.status !== "Success") {
+    console.log("Some logs have failed to complete ingestion. Upload status=", result.status);
+    for (const errors of result.errors) {
+      console.log(`Error - ${JSON.stringify(errors.cause)}`);
+      console.log(`Log - ${JSON.stringify(errors.failedLogs)}`);
+    }
+  }
+}
+main().catch((err) => {
+  console.error("The sample encountered an error:", err);
+  process.exit(1);
+});
+
+module.exports = { main };

--- a/sdk/monitor/monitor-ingestion/samples-dev/logsIngestionClient.ts
+++ b/sdk/monitor/monitor-ingestion/samples-dev/logsIngestionClient.ts
@@ -25,9 +25,9 @@ export async function main() {
     console.log("All the logs provided are successfully ingested");
   } else {
     console.log("Some logs have failed to complete ingestion");
-    for (const errors of result.errors) {
-      console.log(`Error - ${JSON.stringify(errors.cause)}`);
-      console.log(`Log - ${JSON.stringify(errors.failedLogs)}`);
+    for (const error of result.errors) {
+      console.log(`Error - ${JSON.stringify(error.cause)}`);
+      console.log(`Log - ${JSON.stringify(error.failedLogs)}`);
     }
   }
 }

--- a/sdk/monitor/monitor-ingestion/samples-dev/maxConcurrency.ts
+++ b/sdk/monitor/monitor-ingestion/samples-dev/maxConcurrency.ts
@@ -1,0 +1,45 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+/**
+ * @summary Demonstrates how to control the number of concurrent requests using the maxConcurrency option
+ */
+
+import { DefaultAzureCredential } from "@azure/identity";
+import { LogsIngestionClient } from "@azure/monitor-ingestion";
+
+require("dotenv").config();
+
+async function main() {
+  const logsIngestionEndpoint = process.env.LOGS_INGESTION_ENDPOINT || "logs_ingestion_endpoint";
+  const ruleId = process.env.DATA_COLLECTION_RULE_ID || "data_collection_rule_id";
+  const streamName = process.env.STREAM_NAME || "data_stream_name";
+  const credential = new DefaultAzureCredential();
+  const client = new LogsIngestionClient(logsIngestionEndpoint, credential);
+
+  // Constructing a large number of logs to ensure batching takes place
+  const logs = [];
+  for (let i = 0; i < 100000; ++i) {
+    logs.push({
+      Time: "2021-12-08T23:51:14.1104269Z",
+      Computer: "Computer1",
+      AdditionalContext: `context-${i}`,
+    });
+  }
+
+  // Set the maximum concurrency to 1 to prevent concurrent requests entirely
+  const result = await client.upload(ruleId, streamName, logs, { maxConcurrency: 1 });
+  if (result.status !== "Success") {
+    console.log("Some logs have failed to complete ingestion. Upload status=", result.status);
+    for (const errors of result.errors) {
+      console.log(`Error - ${JSON.stringify(errors.cause)}`);
+      console.log(`Log - ${JSON.stringify(errors.failedLogs)}`);
+    }
+  }
+}
+main().catch((err) => {
+  console.error("The sample encountered an error:", err);
+  process.exit(1);
+});
+
+module.exports = { main };

--- a/sdk/monitor/monitor-ingestion/samples/v1-beta/javascript/README.md
+++ b/sdk/monitor/monitor-ingestion/samples/v1-beta/javascript/README.md
@@ -2,10 +2,11 @@
 
 These sample programs show how to use the JavaScript client libraries for Monitor Ingestion in some common scenarios.
 
-| **File Name**                                 | **Description**                                                                 |
-| --------------------------------------------- | ------------------------------------------------------------------------------- |
-| [logsIngestionClient.js][logsingestionclient] | Demonstrates how to upload logs to a Monitor Resource (Log Analytics workspace) |
-| [uploadCustomLogs.js][uploadcustomlogs]       | Demonstrates how to upload logs to a Monitor Resource (Log Analytics workspace) |
+| **File Name**                                 | **Description**                                                                               |
+| --------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| [logsIngestionClient.js][logsingestionclient] | Demonstrates how to upload logs to a Monitor Resource (Log Analytics workspace)               |
+| [maxConcurrency.js][maxconcurrency]           | Demonstrates how to control the number of concurrent requests using the maxConcurrency option |
+| [uploadCustomLogs.js][uploadcustomlogs]       | Demonstrates how to upload logs to a Monitor Resource (Log Analytics workspace)               |
 
 ## Prerequisites
 
@@ -48,6 +49,7 @@ npx cross-env LOGS_INGESTION_ENDPOINT="<logs ingestion endpoint>" DATA_COLLECTIO
 Take a look at our [API Documentation][apiref] for more information about the APIs that are available in the clients.
 
 [logsingestionclient]: https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/monitor/monitor-ingestion/samples/v1-beta/javascript/logsIngestionClient.js
+[maxconcurrency]: https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/monitor/monitor-ingestion/samples/v1-beta/javascript/maxConcurrency.js
 [uploadcustomlogs]: https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/monitor/monitor-ingestion/samples/v1-beta/javascript/uploadCustomLogs.js
 [apiref]: https://docs.microsoft.com/javascript/api/
 [freesub]: https://azure.microsoft.com/free/

--- a/sdk/monitor/monitor-ingestion/samples/v1-beta/javascript/README.md
+++ b/sdk/monitor/monitor-ingestion/samples/v1-beta/javascript/README.md
@@ -2,11 +2,12 @@
 
 These sample programs show how to use the JavaScript client libraries for Monitor Ingestion in some common scenarios.
 
-| **File Name**                                 | **Description**                                                                               |
-| --------------------------------------------- | --------------------------------------------------------------------------------------------- |
-| [logsIngestionClient.js][logsingestionclient] | Demonstrates how to upload logs to a Monitor Resource (Log Analytics workspace)               |
-| [maxConcurrency.js][maxconcurrency]           | Demonstrates how to control the number of concurrent requests using the maxConcurrency option |
-| [uploadCustomLogs.js][uploadcustomlogs]       | Demonstrates how to upload logs to a Monitor Resource (Log Analytics workspace)               |
+| **File Name**                                 | **Description**                                                                                                         |
+| --------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| [concurrency.js][concurrency]                 | Demonstrates uploading a large number of logs where the logs are split into multiple batches and uploaded concurrently. |
+| [logsIngestionClient.js][logsingestionclient] | Demonstrates how to upload logs to a Monitor Resource (Log Analytics workspace)                                         |
+| [maxConcurrency.js][maxconcurrency]           | Demonstrates how to control the number of concurrent requests using the maxConcurrency option                           |
+| [uploadCustomLogs.js][uploadcustomlogs]       | Demonstrates how to upload logs to a Monitor Resource (Log Analytics workspace)                                         |
 
 ## Prerequisites
 
@@ -35,19 +36,20 @@ npm install
 3. Run whichever samples you like (note that some samples may require additional setup, see the table above):
 
 ```bash
-node logsIngestionClient.js
+node concurrency.js
 ```
 
 Alternatively, run a single sample with the correct environment variables set (setting up the `.env` file is not required if you do this), for example (cross-platform):
 
 ```bash
-npx cross-env LOGS_INGESTION_ENDPOINT="<logs ingestion endpoint>" DATA_COLLECTION_RULE_ID="<data collection rule id>" STREAM_NAME="<stream name>" node logsIngestionClient.js
+npx cross-env LOGS_INGESTION_ENDPOINT="<logs ingestion endpoint>" DATA_COLLECTION_RULE_ID="<data collection rule id>" STREAM_NAME="<stream name>" node concurrency.js
 ```
 
 ## Next Steps
 
 Take a look at our [API Documentation][apiref] for more information about the APIs that are available in the clients.
 
+[concurrency]: https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/monitor/monitor-ingestion/samples/v1-beta/javascript/concurrency.js
 [logsingestionclient]: https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/monitor/monitor-ingestion/samples/v1-beta/javascript/logsIngestionClient.js
 [maxconcurrency]: https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/monitor/monitor-ingestion/samples/v1-beta/javascript/maxConcurrency.js
 [uploadcustomlogs]: https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/monitor/monitor-ingestion/samples/v1-beta/javascript/uploadCustomLogs.js

--- a/sdk/monitor/monitor-ingestion/samples/v1-beta/javascript/concurrency.js
+++ b/sdk/monitor/monitor-ingestion/samples/v1-beta/javascript/concurrency.js
@@ -1,0 +1,46 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+/**
+ * @summary Demonstrates uploading a large number of logs where the logs are split into multiple batches and uploaded concurrently.
+ */
+
+const { DefaultAzureCredential } = require("@azure/identity");
+const { LogsIngestionClient } = require("@azure/monitor-ingestion");
+
+require("dotenv").config();
+
+async function main() {
+  const logsIngestionEndpoint = process.env.LOGS_INGESTION_ENDPOINT || "logs_ingestion_endpoint";
+  const ruleId = process.env.DATA_COLLECTION_RULE_ID || "data_collection_rule_id";
+  const streamName = process.env.STREAM_NAME || "data_stream_name";
+  const credential = new DefaultAzureCredential();
+  const client = new LogsIngestionClient(logsIngestionEndpoint, credential);
+
+  // Constructing a large number of logs to ensure batching takes place
+  const logs = [];
+  for (let i = 0; i < 100000; ++i) {
+    logs.push({
+      Time: "2021-12-08T23:51:14.1104269Z",
+      Computer: "Computer1",
+      AdditionalContext: `context-${i}`,
+    });
+  }
+
+  // The logs will be split into multiple batches and uploaded concurrently. By default,
+  // the maximum number of concurrent uploads is 5.
+  const result = await client.upload(ruleId, streamName, logs);
+  if (result.status !== "Success") {
+    console.log("Some logs have failed to complete ingestion. Upload status=", result.status);
+    for (const errors of result.errors) {
+      console.log(`Error - ${JSON.stringify(errors.cause)}`);
+      console.log(`Log - ${JSON.stringify(errors.failedLogs)}`);
+    }
+  }
+}
+main().catch((err) => {
+  console.error("The sample encountered an error:", err);
+  process.exit(1);
+});
+
+module.exports = { main };

--- a/sdk/monitor/monitor-ingestion/samples/v1-beta/javascript/logsIngestionClient.js
+++ b/sdk/monitor/monitor-ingestion/samples/v1-beta/javascript/logsIngestionClient.js
@@ -24,9 +24,9 @@ async function main() {
     console.log("All the logs provided are successfully ingested");
   } else {
     console.log("Some logs have failed to complete ingestion");
-    for (const errors of result.errors) {
-      console.log(`Error - ${JSON.stringify(errors.cause)}`);
-      console.log(`Log - ${JSON.stringify(errors.failedLogs)}`);
+    for (const error of result.errors) {
+      console.log(`Error - ${JSON.stringify(error.cause)}`);
+      console.log(`Log - ${JSON.stringify(error.failedLogs)}`);
     }
   }
 }

--- a/sdk/monitor/monitor-ingestion/samples/v1-beta/javascript/maxConcurrency.js
+++ b/sdk/monitor/monitor-ingestion/samples/v1-beta/javascript/maxConcurrency.js
@@ -1,0 +1,45 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+/**
+ * @summary Demonstrates how to control the number of concurrent requests using the maxConcurrency option
+ */
+
+const { DefaultAzureCredential } = require("@azure/identity");
+const { LogsIngestionClient } = require("@azure/monitor-ingestion");
+
+require("dotenv").config();
+
+async function main() {
+  const logsIngestionEndpoint = process.env.LOGS_INGESTION_ENDPOINT || "logs_ingestion_endpoint";
+  const ruleId = process.env.DATA_COLLECTION_RULE_ID || "data_collection_rule_id";
+  const streamName = process.env.STREAM_NAME || "data_stream_name";
+  const credential = new DefaultAzureCredential();
+  const client = new LogsIngestionClient(logsIngestionEndpoint, credential);
+
+  // Constructing a large number of logs to ensure batching takes place
+  const logs = [];
+  for (let i = 0; i < 100000; ++i) {
+    logs.push({
+      Time: "2021-12-08T23:51:14.1104269Z",
+      Computer: "Computer1",
+      AdditionalContext: `context-${i}`,
+    });
+  }
+
+  // Set the maximum concurrency to 1 to prevent concurrent requests entirely
+  const result = await client.upload(ruleId, streamName, logs, { maxConcurrency: 1 });
+  if (result.status !== "Success") {
+    console.log("Some logs have failed to complete ingestion. Upload status=", result.status);
+    for (const errors of result.errors) {
+      console.log(`Error - ${JSON.stringify(errors.cause)}`);
+      console.log(`Log - ${JSON.stringify(errors.failedLogs)}`);
+    }
+  }
+}
+main().catch((err) => {
+  console.error("The sample encountered an error:", err);
+  process.exit(1);
+});
+
+module.exports = { main };

--- a/sdk/monitor/monitor-ingestion/samples/v1-beta/typescript/README.md
+++ b/sdk/monitor/monitor-ingestion/samples/v1-beta/typescript/README.md
@@ -2,10 +2,11 @@
 
 These sample programs show how to use the TypeScript client libraries for Monitor Ingestion in some common scenarios.
 
-| **File Name**                                 | **Description**                                                                 |
-| --------------------------------------------- | ------------------------------------------------------------------------------- |
-| [logsIngestionClient.ts][logsingestionclient] | Demonstrates how to upload logs to a Monitor Resource (Log Analytics workspace) |
-| [uploadCustomLogs.ts][uploadcustomlogs]       | Demonstrates how to upload logs to a Monitor Resource (Log Analytics workspace) |
+| **File Name**                                 | **Description**                                                                               |
+| --------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| [logsIngestionClient.ts][logsingestionclient] | Demonstrates how to upload logs to a Monitor Resource (Log Analytics workspace)               |
+| [maxConcurrency.ts][maxconcurrency]           | Demonstrates how to control the number of concurrent requests using the maxConcurrency option |
+| [uploadCustomLogs.ts][uploadcustomlogs]       | Demonstrates how to upload logs to a Monitor Resource (Log Analytics workspace)               |
 
 ## Prerequisites
 
@@ -60,6 +61,7 @@ npx cross-env LOGS_INGESTION_ENDPOINT="<logs ingestion endpoint>" DATA_COLLECTIO
 Take a look at our [API Documentation][apiref] for more information about the APIs that are available in the clients.
 
 [logsingestionclient]: https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/monitor/monitor-ingestion/samples/v1-beta/typescript/src/logsIngestionClient.ts
+[maxconcurrency]: https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/monitor/monitor-ingestion/samples/v1-beta/typescript/src/maxConcurrency.ts
 [uploadcustomlogs]: https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/monitor/monitor-ingestion/samples/v1-beta/typescript/src/uploadCustomLogs.ts
 [apiref]: https://docs.microsoft.com/javascript/api/
 [freesub]: https://azure.microsoft.com/free/

--- a/sdk/monitor/monitor-ingestion/samples/v1-beta/typescript/README.md
+++ b/sdk/monitor/monitor-ingestion/samples/v1-beta/typescript/README.md
@@ -2,11 +2,12 @@
 
 These sample programs show how to use the TypeScript client libraries for Monitor Ingestion in some common scenarios.
 
-| **File Name**                                 | **Description**                                                                               |
-| --------------------------------------------- | --------------------------------------------------------------------------------------------- |
-| [logsIngestionClient.ts][logsingestionclient] | Demonstrates how to upload logs to a Monitor Resource (Log Analytics workspace)               |
-| [maxConcurrency.ts][maxconcurrency]           | Demonstrates how to control the number of concurrent requests using the maxConcurrency option |
-| [uploadCustomLogs.ts][uploadcustomlogs]       | Demonstrates how to upload logs to a Monitor Resource (Log Analytics workspace)               |
+| **File Name**                                 | **Description**                                                                                                         |
+| --------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| [concurrency.ts][concurrency]                 | Demonstrates uploading a large number of logs where the logs are split into multiple batches and uploaded concurrently. |
+| [logsIngestionClient.ts][logsingestionclient] | Demonstrates how to upload logs to a Monitor Resource (Log Analytics workspace)                                         |
+| [maxConcurrency.ts][maxconcurrency]           | Demonstrates how to control the number of concurrent requests using the maxConcurrency option                           |
+| [uploadCustomLogs.ts][uploadcustomlogs]       | Demonstrates how to upload logs to a Monitor Resource (Log Analytics workspace)                                         |
 
 ## Prerequisites
 
@@ -47,19 +48,20 @@ npm run build
 4. Run whichever samples you like (note that some samples may require additional setup, see the table above):
 
 ```bash
-node dist/logsIngestionClient.js
+node dist/concurrency.js
 ```
 
 Alternatively, run a single sample with the correct environment variables set (setting up the `.env` file is not required if you do this), for example (cross-platform):
 
 ```bash
-npx cross-env LOGS_INGESTION_ENDPOINT="<logs ingestion endpoint>" DATA_COLLECTION_RULE_ID="<data collection rule id>" STREAM_NAME="<stream name>" node dist/logsIngestionClient.js
+npx cross-env LOGS_INGESTION_ENDPOINT="<logs ingestion endpoint>" DATA_COLLECTION_RULE_ID="<data collection rule id>" STREAM_NAME="<stream name>" node dist/concurrency.js
 ```
 
 ## Next Steps
 
 Take a look at our [API Documentation][apiref] for more information about the APIs that are available in the clients.
 
+[concurrency]: https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/monitor/monitor-ingestion/samples/v1-beta/typescript/src/concurrency.ts
 [logsingestionclient]: https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/monitor/monitor-ingestion/samples/v1-beta/typescript/src/logsIngestionClient.ts
 [maxconcurrency]: https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/monitor/monitor-ingestion/samples/v1-beta/typescript/src/maxConcurrency.ts
 [uploadcustomlogs]: https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/monitor/monitor-ingestion/samples/v1-beta/typescript/src/uploadCustomLogs.ts

--- a/sdk/monitor/monitor-ingestion/samples/v1-beta/typescript/package.json
+++ b/sdk/monitor/monitor-ingestion/samples/v1-beta/typescript/package.json
@@ -33,7 +33,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.0.0",
-    "typescript": "~4.6.0",
+    "typescript": "~4.8.0",
     "rimraf": "latest"
   }
 }

--- a/sdk/monitor/monitor-ingestion/samples/v1-beta/typescript/src/concurrency.ts
+++ b/sdk/monitor/monitor-ingestion/samples/v1-beta/typescript/src/concurrency.ts
@@ -1,0 +1,46 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+/**
+ * @summary Demonstrates uploading a large number of logs where the logs are split into multiple batches and uploaded concurrently.
+ */
+
+import { DefaultAzureCredential } from "@azure/identity";
+import { LogsIngestionClient } from "@azure/monitor-ingestion";
+
+require("dotenv").config();
+
+async function main() {
+  const logsIngestionEndpoint = process.env.LOGS_INGESTION_ENDPOINT || "logs_ingestion_endpoint";
+  const ruleId = process.env.DATA_COLLECTION_RULE_ID || "data_collection_rule_id";
+  const streamName = process.env.STREAM_NAME || "data_stream_name";
+  const credential = new DefaultAzureCredential();
+  const client = new LogsIngestionClient(logsIngestionEndpoint, credential);
+
+  // Constructing a large number of logs to ensure batching takes place
+  const logs = [];
+  for (let i = 0; i < 100000; ++i) {
+    logs.push({
+      Time: "2021-12-08T23:51:14.1104269Z",
+      Computer: "Computer1",
+      AdditionalContext: `context-${i}`,
+    });
+  }
+
+  // The logs will be split into multiple batches and uploaded concurrently. By default,
+  // the maximum number of concurrent uploads is 5.
+  const result = await client.upload(ruleId, streamName, logs);
+  if (result.status !== "Success") {
+    console.log("Some logs have failed to complete ingestion. Upload status=", result.status);
+    for (const errors of result.errors) {
+      console.log(`Error - ${JSON.stringify(errors.cause)}`);
+      console.log(`Log - ${JSON.stringify(errors.failedLogs)}`);
+    }
+  }
+}
+main().catch((err) => {
+  console.error("The sample encountered an error:", err);
+  process.exit(1);
+});
+
+module.exports = { main };

--- a/sdk/monitor/monitor-ingestion/samples/v1-beta/typescript/src/logsIngestionClient.ts
+++ b/sdk/monitor/monitor-ingestion/samples/v1-beta/typescript/src/logsIngestionClient.ts
@@ -25,9 +25,9 @@ export async function main() {
     console.log("All the logs provided are successfully ingested");
   } else {
     console.log("Some logs have failed to complete ingestion");
-    for (const errors of result.errors) {
-      console.log(`Error - ${JSON.stringify(errors.cause)}`);
-      console.log(`Log - ${JSON.stringify(errors.failedLogs)}`);
+    for (const error of result.errors) {
+      console.log(`Error - ${JSON.stringify(error.cause)}`);
+      console.log(`Log - ${JSON.stringify(error.failedLogs)}`);
     }
   }
 }

--- a/sdk/monitor/monitor-ingestion/samples/v1-beta/typescript/src/maxConcurrency.ts
+++ b/sdk/monitor/monitor-ingestion/samples/v1-beta/typescript/src/maxConcurrency.ts
@@ -1,0 +1,45 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+/**
+ * @summary Demonstrates how to control the number of concurrent requests using the maxConcurrency option
+ */
+
+import { DefaultAzureCredential } from "@azure/identity";
+import { LogsIngestionClient } from "@azure/monitor-ingestion";
+
+require("dotenv").config();
+
+async function main() {
+  const logsIngestionEndpoint = process.env.LOGS_INGESTION_ENDPOINT || "logs_ingestion_endpoint";
+  const ruleId = process.env.DATA_COLLECTION_RULE_ID || "data_collection_rule_id";
+  const streamName = process.env.STREAM_NAME || "data_stream_name";
+  const credential = new DefaultAzureCredential();
+  const client = new LogsIngestionClient(logsIngestionEndpoint, credential);
+
+  // Constructing a large number of logs to ensure batching takes place
+  const logs = [];
+  for (let i = 0; i < 100000; ++i) {
+    logs.push({
+      Time: "2021-12-08T23:51:14.1104269Z",
+      Computer: "Computer1",
+      AdditionalContext: `context-${i}`,
+    });
+  }
+
+  // Set the maximum concurrency to 1 to prevent concurrent requests entirely
+  const result = await client.upload(ruleId, streamName, logs, { maxConcurrency: 1 });
+  if (result.status !== "Success") {
+    console.log("Some logs have failed to complete ingestion. Upload status=", result.status);
+    for (const errors of result.errors) {
+      console.log(`Error - ${JSON.stringify(errors.cause)}`);
+      console.log(`Log - ${JSON.stringify(errors.failedLogs)}`);
+    }
+  }
+}
+main().catch((err) => {
+  console.error("The sample encountered an error:", err);
+  process.exit(1);
+});
+
+module.exports = { main };

--- a/sdk/monitor/monitor-ingestion/src/logsIngestionClient.ts
+++ b/sdk/monitor/monitor-ingestion/src/logsIngestionClient.ts
@@ -17,7 +17,7 @@ export interface LogsIngestionClientOptions extends CommonClientOptions {
   apiVersion?: string;
 }
 const defaultIngestionScope = "https://monitor.azure.com//.default";
-const DEFAULT_MAX_CONCURRENCY = 1;
+const DEFAULT_MAX_CONCURRENCY = 5;
 
 /**
  * Client for Monitor Logs Ingestion
@@ -68,10 +68,7 @@ export class LogsIngestionClient {
     // This splits logs into 1MB chunks
     const chunkArray = splitDataToChunks(logs);
     const noOfChunks = chunkArray.length;
-    const concurrency = Math.max(
-      options?.maxConcurrency ?? DEFAULT_MAX_CONCURRENCY,
-      DEFAULT_MAX_CONCURRENCY
-    );
+    const concurrency = Math.max(options?.maxConcurrency ?? DEFAULT_MAX_CONCURRENCY, 1);
 
     const uploadResultErrors: Array<UploadLogsError> = [];
     await concurrentRun(concurrency, chunkArray, async (eachChunk): Promise<void> => {


### PR DESCRIPTION
### Packages impacted by this PR

- `@azure/monitor-ingestion`

### Describe the problem that is addressed by this PR

The default concurrency value was discussed in the arch board review. After doing some perf analysis and a follow-up discussion with Jose, we settled on setting the concurrency to 5 by default (in line with .NET). This PR implements that plus adds a bit of documentation and a sample.