### PR TITLE
[core-paging] add to-elements method

### DIFF
--- a/sdk/core/core-paging/CHANGELOG.md
+++ b/sdk/core/core-paging/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Release History
 
-## 1.3.1 (Unreleased)
+## 1.4.0 (Unreleased)
 
 ### Features Added
+
+- Add `toElements` function to convert a page to a list of elements
 
 ### Breaking Changes
 

--- a/sdk/core/core-paging/package.json
+++ b/sdk/core/core-paging/package.json
@@ -2,7 +2,7 @@
   "name": "@azure/core-paging",
   "author": "Microsoft Corporation",
   "sdk-type": "client",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "description": "Core types for paging async iterable iterators",
   "tags": [
     "microsoft",

--- a/sdk/core/core-paging/review/core-paging.api.md
+++ b/sdk/core/core-paging/review/core-paging.api.md
@@ -15,13 +15,14 @@ export interface PagedAsyncIterableIterator<T, PageT = T[], PageSettingsT = Page
 }
 
 // @public
-export interface PagedResult<TPage, TPageSettings = PageSettings, TLink = string> {
+export interface PagedResult<TPage, TPageSettings = PageSettings, TLink = string, T = unknown> {
     byPage?: (settings?: TPageSettings) => AsyncIterableIterator<TPage>;
     firstPageLink: TLink;
     getPage: (pageLink: TLink, maxPageSize?: number) => Promise<{
         page: TPage;
         nextPageLink?: TLink;
     }>;
+    toElements?: (page: TPage) => T[];
 }
 
 // @public

--- a/sdk/core/core-paging/review/core-paging.api.md
+++ b/sdk/core/core-paging/review/core-paging.api.md
@@ -15,14 +15,14 @@ export interface PagedAsyncIterableIterator<TElement, TPage = TElement[], TPageS
 }
 
 // @public
-export interface PagedResult<TPage, TPageSettings = PageSettings, TLink = string, TElement = unknown> {
+export interface PagedResult<TPage, TPageSettings = PageSettings, TLink = string> {
     byPage?: (settings?: TPageSettings) => AsyncIterableIterator<TPage>;
     firstPageLink: TLink;
     getPage: (pageLink: TLink, maxPageSize?: number) => Promise<{
         page: TPage;
         nextPageLink?: TLink;
     }>;
-    toElements?: (page: TPage) => TElement[];
+    toElements?: (page: TPage) => unknown[];
 }
 
 // @public

--- a/sdk/core/core-paging/review/core-paging.api.md
+++ b/sdk/core/core-paging/review/core-paging.api.md
@@ -8,21 +8,21 @@
 export function getPagedAsyncIterator<TElement, TPage = TElement[], TPageSettings = PageSettings, TLink = string>(pagedResult: PagedResult<TPage, TPageSettings, TLink>): PagedAsyncIterableIterator<TElement, TPage, TPageSettings>;
 
 // @public
-export interface PagedAsyncIterableIterator<T, PageT = T[], PageSettingsT = PageSettings> {
-    [Symbol.asyncIterator](): PagedAsyncIterableIterator<T, PageT, PageSettingsT>;
-    byPage: (settings?: PageSettingsT) => AsyncIterableIterator<PageT>;
-    next(): Promise<IteratorResult<T>>;
+export interface PagedAsyncIterableIterator<TElement, TPage = TElement[], TPageSettings = PageSettings> {
+    [Symbol.asyncIterator](): PagedAsyncIterableIterator<TElement, TPage, TPageSettings>;
+    byPage: (settings?: TPageSettings) => AsyncIterableIterator<TPage>;
+    next(): Promise<IteratorResult<TElement>>;
 }
 
 // @public
-export interface PagedResult<TPage, TPageSettings = PageSettings, TLink = string, T = unknown> {
+export interface PagedResult<TPage, TPageSettings = PageSettings, TLink = string, TElement = unknown> {
     byPage?: (settings?: TPageSettings) => AsyncIterableIterator<TPage>;
     firstPageLink: TLink;
     getPage: (pageLink: TLink, maxPageSize?: number) => Promise<{
         page: TPage;
         nextPageLink?: TLink;
     }>;
-    toElements?: (page: TPage) => T[];
+    toElements?: (page: TPage) => TElement[];
 }
 
 // @public

--- a/sdk/core/core-paging/src/getPagedAsyncIterator.ts
+++ b/sdk/core/core-paging/src/getPagedAsyncIterator.ts
@@ -18,14 +18,6 @@ export function getPagedAsyncIterator<
   TLink = string
 >(
   pagedResult: PagedResult<TPage, TPageSettings, TLink>
-): PagedAsyncIterableIterator<TElement, TPage, TPageSettings>;
-export function getPagedAsyncIterator<
-  TElement,
-  TPage = TElement[],
-  TPageSettings = PageSettings,
-  TLink = string
->(
-  pagedResult: PagedResult<TPage, TPageSettings, TLink>
 ): PagedAsyncIterableIterator<TElement, TPage, TPageSettings> {
   const iter = getItemAsyncIterator<TElement, TPage, TLink, TPageSettings>(pagedResult);
   return {

--- a/sdk/core/core-paging/src/getPagedAsyncIterator.ts
+++ b/sdk/core/core-paging/src/getPagedAsyncIterator.ts
@@ -47,8 +47,8 @@ async function* getItemAsyncIterator<TElement, TPage, TLink, TPageSettings>(
   // if the result does not have an array shape, i.e. TPage = TElement, then we return it as is
   if (!Array.isArray(firstVal.value)) {
     // can extract elements from this page
-    const toElements = pagedResult.toElements;
-    if (toElements !== undefined) {
+    const { toElements } = pagedResult;
+    if (toElements) {
       yield* toElements(firstVal.value) as TElement[];
       for await (const page of pages) {
         yield* toElements(page) as TElement[];

--- a/sdk/core/core-paging/src/models.ts
+++ b/sdk/core/core-paging/src/models.ts
@@ -39,12 +39,7 @@ export interface PagedAsyncIterableIterator<
 /**
  * An interface that describes how to communicate with the service.
  */
-export interface PagedResult<
-  TPage,
-  TPageSettings = PageSettings,
-  TLink = string,
-  TElement = unknown
-> {
+export interface PagedResult<TPage, TPageSettings = PageSettings, TLink = string> {
   /**
    * Link to the first page of results.
    */
@@ -65,5 +60,5 @@ export interface PagedResult<
   /**
    * A function to extract elements from a page.
    */
-  toElements?: (page: TPage) => TElement[];
+  toElements?: (page: TPage) => unknown[];
 }

--- a/sdk/core/core-paging/src/models.ts
+++ b/sdk/core/core-paging/src/models.ts
@@ -35,7 +35,7 @@ export interface PagedAsyncIterableIterator<T, PageT = T[], PageSettingsT = Page
 /**
  * An interface that describes how to communicate with the service.
  */
-export interface PagedResult<TPage, TPageSettings = PageSettings, TLink = string> {
+export interface PagedResult<TPage, TPageSettings = PageSettings, TLink = string, T = unknown> {
   /**
    * Link to the first page of results.
    */
@@ -52,4 +52,9 @@ export interface PagedResult<TPage, TPageSettings = PageSettings, TLink = string
    * one that sets the `maxPageSizeParam` from `settings.maxPageSize`.
    */
   byPage?: (settings?: TPageSettings) => AsyncIterableIterator<TPage>;
+
+  /**
+   * A function to extract elements from a page.
+   */
+  toElements?: (page: TPage) => T[];
 }

--- a/sdk/core/core-paging/src/models.ts
+++ b/sdk/core/core-paging/src/models.ts
@@ -17,25 +17,34 @@ export interface PageSettings {
 /**
  * An interface that allows async iterable iteration both to completion and by page.
  */
-export interface PagedAsyncIterableIterator<T, PageT = T[], PageSettingsT = PageSettings> {
+export interface PagedAsyncIterableIterator<
+  TElement,
+  TPage = TElement[],
+  TPageSettings = PageSettings
+> {
   /**
    * The next method, part of the iteration protocol
    */
-  next(): Promise<IteratorResult<T>>;
+  next(): Promise<IteratorResult<TElement>>;
   /**
    * The connection to the async iterator, part of the iteration protocol
    */
-  [Symbol.asyncIterator](): PagedAsyncIterableIterator<T, PageT, PageSettingsT>;
+  [Symbol.asyncIterator](): PagedAsyncIterableIterator<TElement, TPage, TPageSettings>;
   /**
    * Return an AsyncIterableIterator that works a page at a time
    */
-  byPage: (settings?: PageSettingsT) => AsyncIterableIterator<PageT>;
+  byPage: (settings?: TPageSettings) => AsyncIterableIterator<TPage>;
 }
 
 /**
  * An interface that describes how to communicate with the service.
  */
-export interface PagedResult<TPage, TPageSettings = PageSettings, TLink = string, T = unknown> {
+export interface PagedResult<
+  TPage,
+  TPageSettings = PageSettings,
+  TLink = string,
+  TElement = unknown
+> {
   /**
    * Link to the first page of results.
    */
@@ -56,5 +65,5 @@ export interface PagedResult<TPage, TPageSettings = PageSettings, TLink = string
   /**
    * A function to extract elements from a page.
    */
-  toElements?: (page: TPage) => T[];
+  toElements?: (page: TPage) => TElement[];
 }

--- a/sdk/core/core-paging/test/getPagedAsyncIterator.spec.ts
+++ b/sdk/core/core-paging/test/getPagedAsyncIterator.spec.ts
@@ -7,9 +7,7 @@ import { getPagedAsyncIterator, PagedResult, PageSettings } from "../src";
 function buildIterator<T>(input: T) {
   return getPagedAsyncIterator({
     firstPageLink: 0,
-    async getPage() {
-      return Promise.resolve({ page: input });
-    },
+    getPage: () => Promise.resolve({ page: input }),
   });
 }
 
@@ -136,9 +134,7 @@ describe("getPagedAsyncIterator", function () {
       };
       const pagedResult: PagedResult<collectionObject, PageSettings, number, number> = {
         firstPageLink: 0,
-        async getPage() {
-          return Promise.resolve({ page: collection });
-        },
+        getPage: () => Promise.resolve({ page: collection }),
         toElements: (page) => page.elements,
       };
       const iterator = getPagedAsyncIterator(pagedResult);

--- a/sdk/core/core-paging/test/getPagedAsyncIterator.spec.ts
+++ b/sdk/core/core-paging/test/getPagedAsyncIterator.spec.ts
@@ -129,7 +129,7 @@ describe("getPagedAsyncIterator", function () {
       next: number;
     }
 
-    it.only("should return an iterator over an object that can extract elements", async function () {
+    it("should return an iterator over an object that can extract elements", async function () {
       const collection: collectionObject = {
         elements: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
         next: 0,
@@ -147,19 +147,6 @@ describe("getPagedAsyncIterator", function () {
         expected.push(val);
       }
       assert.deepEqual(expected, collection.elements);
-    });
-
-    it.only("Should return an iterator over a non-extractable object", async function () {
-      const collection = {
-        num: 1,
-        text: "abc",
-      };
-      const iterator = buildIterator(collection);
-      const expected = [];
-      for await (const val of iterator) {
-        expected.push(val);
-      }
-      assert.deepEqual(expected, [collection]);
     });
   });
 

--- a/sdk/core/core-paging/test/getPagedAsyncIterator.spec.ts
+++ b/sdk/core/core-paging/test/getPagedAsyncIterator.spec.ts
@@ -7,7 +7,7 @@ import { getPagedAsyncIterator, PagedResult, PageSettings } from "../src";
 function buildIterator<T>(input: T) {
   return getPagedAsyncIterator({
     firstPageLink: 0,
-    getPage: () => Promise.resolve({ page: input }),
+    getPage: async () => ({ page: input }),
   });
 }
 
@@ -134,7 +134,7 @@ describe("getPagedAsyncIterator", function () {
       };
       const pagedResult: PagedResult<collectionObject, PageSettings, number, number> = {
         firstPageLink: 0,
-        getPage: () => Promise.resolve({ page: collection }),
+        getPage: async () => ({ page: collection }),
         toElements: (page) => page.elements,
       };
       const iterator = getPagedAsyncIterator(pagedResult);

--- a/sdk/core/core-paging/test/getPagedAsyncIterator.spec.ts
+++ b/sdk/core/core-paging/test/getPagedAsyncIterator.spec.ts
@@ -132,7 +132,7 @@ describe("getPagedAsyncIterator", function () {
         elements: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
         next: 0,
       };
-      const pagedResult: PagedResult<collectionObject, PageSettings, number, number> = {
+      const pagedResult: PagedResult<collectionObject, PageSettings, number> = {
         firstPageLink: 0,
         getPage: async () => ({ page: collection }),
         toElements: (page) => page.elements,

--- a/sdk/core/core-paging/test/getPagedAsyncIterator.spec.ts
+++ b/sdk/core/core-paging/test/getPagedAsyncIterator.spec.ts
@@ -123,6 +123,46 @@ describe("getPagedAsyncIterator", function () {
     assert.deepEqual([].concat(...receivedPages), collection);
   });
 
+  describe("Iterator over object", function () {
+    interface collectionObject {
+      elements: number[];
+      next: number;
+    }
+
+    it.only("should return an iterator over an object that can extract elements", async function () {
+      const collection: collectionObject = {
+        elements: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+        next: 0,
+      };
+      const pagedResult: PagedResult<collectionObject, PageSettings, number, number> = {
+        firstPageLink: 0,
+        async getPage() {
+          return Promise.resolve({ page: collection });
+        },
+        toElements: (page) => page.elements,
+      };
+      const iterator = getPagedAsyncIterator(pagedResult);
+      const expected = [];
+      for await (const val of iterator) {
+        expected.push(val);
+      }
+      assert.deepEqual(expected, collection.elements);
+    });
+
+    it.only("Should return an iterator over a non-extractable object", async function () {
+      const collection = {
+        num: 1,
+        text: "abc",
+      };
+      const iterator = buildIterator(collection);
+      const expected = [];
+      for await (const val of iterator) {
+        expected.push(val);
+      }
+      assert.deepEqual(expected, [collection]);
+    });
+  });
+
   describe("Strong typing experience", function () {
     type IsAny<T> = boolean extends (T extends never ? true : false) ? true : false;
     function assertNotAny<T extends IsAny<T> extends true ? never : any>(_: T): void {}


### PR DESCRIPTION
### Packages impacted by this PR
core-paging

### Issues associated with this PR


### Describe the problem that is addressed by this PR
In many cases (app-configuration for example), the page is not a list of elements, and we need an iterator over elements.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?
Added an optional function `to-elements` to extract elements from a page

### Are there test cases added in this PR? _(If not, why?)_
To be added

### Provide a list of related PRs _(if any)_
https://github.com/Azure/azure-sdk-for-js/pull/23333

### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [ ] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
