### PR TITLE
revert credential scops for mgmt plane sdks a

### DIFF
--- a/sdk/advisor/arm-advisor/CHANGELOG.md
+++ b/sdk/advisor/arm-advisor/CHANGELOG.md
@@ -1,14 +1,10 @@
 # Release History
 
-## 3.0.3 (Unreleased)
+## 3.0.3 (2022-10-08)
 
-### Features Added
+**Bugs Fixed**
 
-### Breaking Changes
-
-### Bugs Fixed
-
-### Other Changes
+  -  revert credential scopes 
 
 ## 3.0.2 (2022-09-30)
 

--- a/sdk/advisor/arm-advisor/src/advisorManagementClient.ts
+++ b/sdk/advisor/arm-advisor/src/advisorManagementClient.ts
@@ -62,6 +62,10 @@ export class AdvisorManagementClient extends coreClient.ServiceClient {
         ? `${options.userAgentOptions.userAgentPrefix} ${packageDetails}`
         : `${packageDetails}`;
 
+    if (!options.credentialScopes) {
+      options.credentialScopes = ["https://management.azure.com/.default"];
+    }
+
     const optionsWithDefaults = {
       ...defaults,
       ...options,

--- a/sdk/agrifood/arm-agrifood/CHANGELOG.md
+++ b/sdk/agrifood/arm-agrifood/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 1.0.0-beta.3 (2022-10-08)
+
+**Bugs Fixed**
+
+  -  revert credential scopes
+
 ## 1.0.0-beta.2 (2022-09-30)
 
 **Bugs Fixed**

--- a/sdk/agrifood/arm-agrifood/package.json
+++ b/sdk/agrifood/arm-agrifood/package.json
@@ -3,7 +3,7 @@
   "sdk-type": "mgmt",
   "author": "Microsoft Corporation",
   "description": "A generated SDK for AgriFoodMgmtClient.",
-  "version": "1.0.0-beta.2",
+  "version": "1.0.0-beta.3",
   "engines": {
     "node": ">=12.0.0"
   },

--- a/sdk/agrifood/arm-agrifood/src/agriFoodMgmtClient.ts
+++ b/sdk/agrifood/arm-agrifood/src/agriFoodMgmtClient.ts
@@ -66,12 +66,15 @@ export class AgriFoodMgmtClient extends coreClient.ServiceClient {
       credential: credentials
     };
 
-    const packageDetails = `azsdk-js-arm-agrifood/1.0.0-beta.2`;
+    const packageDetails = `azsdk-js-arm-agrifood/1.0.0-beta.3`;
     const userAgentPrefix =
       options.userAgentOptions && options.userAgentOptions.userAgentPrefix
         ? `${options.userAgentOptions.userAgentPrefix} ${packageDetails}`
         : `${packageDetails}`;
 
+    if (!options.credentialScopes) {
+      options.credentialScopes = ["https://management.azure.com/.default"];
+    }
     const optionsWithDefaults = {
       ...defaults,
       ...options,

--- a/sdk/analysisservices/arm-analysisservices/CHANGELOG.md
+++ b/sdk/analysisservices/arm-analysisservices/CHANGELOG.md
@@ -1,14 +1,10 @@
 # Release History
 
-## 4.1.2 (Unreleased)
+## 4.1.2 (2022-10-08)
 
-### Features Added
+**Bugs Fixed**
 
-### Breaking Changes
-
-### Bugs Fixed
-
-### Other Changes
+  -  revert credential scopes
 
 ## 4.1.1 (2022-09-30)
 

--- a/sdk/analysisservices/arm-analysisservices/src/azureAnalysisServices.ts
+++ b/sdk/analysisservices/arm-analysisservices/src/azureAnalysisServices.ts
@@ -57,6 +57,9 @@ export class AzureAnalysisServices extends coreClient.ServiceClient {
         ? `${options.userAgentOptions.userAgentPrefix} ${packageDetails}`
         : `${packageDetails}`;
 
+    if (!options.credentialScopes) {
+      options.credentialScopes = ["https://management.azure.com/.default"];
+    }
     const optionsWithDefaults = {
       ...defaults,
       ...options,

--- a/sdk/apimanagement/arm-apimanagement/CHANGELOG.md
+++ b/sdk/apimanagement/arm-apimanagement/CHANGELOG.md
@@ -1,14 +1,10 @@
 # Release History
 
-## 8.1.2 (Unreleased)
+## 8.1.2 (2022-10-08)
 
-### Features Added
+**Bugs Fixed**
 
-### Breaking Changes
-
-### Bugs Fixed
-
-### Other Changes
+  -  revert credential scopes
 
 ## 8.1.1 (2022-09-30)
 

--- a/sdk/apimanagement/arm-apimanagement/src/apiManagementClient.ts
+++ b/sdk/apimanagement/arm-apimanagement/src/apiManagementClient.ts
@@ -216,6 +216,9 @@ export class ApiManagementClient extends coreClient.ServiceClient {
         ? `${options.userAgentOptions.userAgentPrefix} ${packageDetails}`
         : `${packageDetails}`;
 
+    if (!options.credentialScopes) {
+      options.credentialScopes = ["https://management.azure.com/.default"];
+    }
     const optionsWithDefaults = {
       ...defaults,
       ...options,

--- a/sdk/app/arm-app/CHANGELOG.md
+++ b/sdk/app/arm-app/CHANGELOG.md
@@ -1,14 +1,10 @@
 # Release History
 
-## 1.0.0-beta.3 (Unreleased)
+## 1.0.0-beta.3 (2022-10-08)
 
-### Features Added
+**Bugs Fixed**
 
-### Breaking Changes
-
-### Bugs Fixed
-
-### Other Changes
+  -  revert credential scopes
 
 ## 1.0.0-beta.2 (2022-09-30)
 

--- a/sdk/app/arm-app/src/containerAppsAPIClient.ts
+++ b/sdk/app/arm-app/src/containerAppsAPIClient.ts
@@ -72,6 +72,9 @@ export class ContainerAppsAPIClient extends coreClient.ServiceClient {
         ? `${options.userAgentOptions.userAgentPrefix} ${packageDetails}`
         : `${packageDetails}`;
 
+    if (!options.credentialScopes) {
+      options.credentialScopes = ["https://management.azure.com/.default"];
+    }
     const optionsWithDefaults = {
       ...defaults,
       ...options,

--- a/sdk/appconfiguration/arm-appconfiguration/CHANGELOG.md
+++ b/sdk/appconfiguration/arm-appconfiguration/CHANGELOG.md
@@ -1,14 +1,10 @@
 # Release History
 
-## 3.0.2 (Unreleased)
+## 3.0.2 (2022-10-08)
 
-### Features Added
+**Bugs Fixed**
 
-### Breaking Changes
-
-### Bugs Fixed
-
-### Other Changes
+  -  revert credential scopes
 
 ## 3.0.1 (2022-09-30)
 

--- a/sdk/appconfiguration/arm-appconfiguration/src/appConfigurationManagementClient.ts
+++ b/sdk/appconfiguration/arm-appconfiguration/src/appConfigurationManagementClient.ts
@@ -68,6 +68,9 @@ export class AppConfigurationManagementClient extends coreClient.ServiceClient {
         ? `${options.userAgentOptions.userAgentPrefix} ${packageDetails}`
         : `${packageDetails}`;
 
+    if (!options.credentialScopes) {
+      options.credentialScopes = ["https://management.azure.com/.default"];
+    }
     const optionsWithDefaults = {
       ...defaults,
       ...options,

--- a/sdk/appcontainers/arm-appcontainers/CHANGELOG.md
+++ b/sdk/appcontainers/arm-appcontainers/CHANGELOG.md
@@ -1,14 +1,10 @@
 # Release History
 
-## 1.1.2 (Unreleased)
+## 1.1.2 (2022-10-08)
 
-### Features Added
+**Bugs Fixed**
 
-### Breaking Changes
-
-### Bugs Fixed
-
-### Other Changes
+  -  revert credential scopes
 
 ## 1.1.1 (2022-09-30)
 

--- a/sdk/appcontainers/arm-appcontainers/src/containerAppsAPIClient.ts
+++ b/sdk/appcontainers/arm-appcontainers/src/containerAppsAPIClient.ts
@@ -80,6 +80,9 @@ export class ContainerAppsAPIClient extends coreClient.ServiceClient {
         ? `${options.userAgentOptions.userAgentPrefix} ${packageDetails}`
         : `${packageDetails}`;
 
+    if (!options.credentialScopes) {
+      options.credentialScopes = ["https://management.azure.com/.default"];
+    }
     const optionsWithDefaults = {
       ...defaults,
       ...options,

--- a/sdk/applicationinsights/arm-appinsights/CHANGELOG.md
+++ b/sdk/applicationinsights/arm-appinsights/CHANGELOG.md
@@ -1,14 +1,10 @@
 # Release History
 
-## 5.0.0-beta.6 (Unreleased)
+## 5.0.0-beta.6 (2022-10-08)
 
-### Features Added
+**Bugs Fixed**
 
-### Breaking Changes
-
-### Bugs Fixed
-
-### Other Changes
+  -  revert credential scopes
 
 ## 5.0.0-beta.5 (2022-09-30)
 

--- a/sdk/applicationinsights/arm-appinsights/src/applicationInsightsManagementClient.ts
+++ b/sdk/applicationinsights/arm-appinsights/src/applicationInsightsManagementClient.ts
@@ -90,6 +90,9 @@ export class ApplicationInsightsManagementClient extends coreClient.ServiceClien
         ? `${options.userAgentOptions.userAgentPrefix} ${packageDetails}`
         : `${packageDetails}`;
 
+    if (!options.credentialScopes) {
+      options.credentialScopes = ["https://management.azure.com/.default"];
+    }
     const optionsWithDefaults = {
       ...defaults,
       ...options,

--- a/sdk/appplatform/arm-appplatform/CHANGELOG.md
+++ b/sdk/appplatform/arm-appplatform/CHANGELOG.md
@@ -1,14 +1,10 @@
 # Release History
 
-## 2.1.0-beta.3 (Unreleased)
+## 2.1.0-beta.3 (2022-10-08)
 
-### Features Added
+**Bugs Fixed**
 
-### Breaking Changes
-
-### Bugs Fixed
-
-### Other Changes
+  -  revert credential scopes
 
 ## 2.1.0-beta.2 (2022-09-30)
 

--- a/sdk/appplatform/arm-appplatform/src/appPlatformManagementClient.ts
+++ b/sdk/appplatform/arm-appplatform/src/appPlatformManagementClient.ts
@@ -105,6 +105,9 @@ export class AppPlatformManagementClient extends coreClient.ServiceClient {
         ? `${options.userAgentOptions.userAgentPrefix} ${packageDetails}`
         : `${packageDetails}`;
 
+    if (!options.credentialScopes) {
+      options.credentialScopes = ["https://management.azure.com/.default"];
+    }
     const optionsWithDefaults = {
       ...defaults,
       ...options,

--- a/sdk/appservice/arm-appservice/CHANGELOG.md
+++ b/sdk/appservice/arm-appservice/CHANGELOG.md
@@ -1,14 +1,10 @@
 # Release History
 
-## 13.0.2 (Unreleased)
+## 13.0.2 (2022-10-08)
 
-### Features Added
+**Bugs Fixed**
 
-### Breaking Changes
-
-### Bugs Fixed
-
-### Other Changes
+  -  revert credential scopes
 
 ## 13.0.1 (2022-09-30)
 

--- a/sdk/appservice/arm-appservice/src/webSiteManagementClient.ts
+++ b/sdk/appservice/arm-appservice/src/webSiteManagementClient.ts
@@ -179,6 +179,9 @@ export class WebSiteManagementClient extends coreClient.ServiceClient {
         ? `${options.userAgentOptions.userAgentPrefix} ${packageDetails}`
         : `${packageDetails}`;
 
+    if (!options.credentialScopes) {
+      options.credentialScopes = ["https://management.azure.com/.default"];
+    }
     const optionsWithDefaults = {
       ...defaults,
       ...options,

--- a/sdk/attestation/arm-attestation/CHANGELOG.md
+++ b/sdk/attestation/arm-attestation/CHANGELOG.md
@@ -1,14 +1,10 @@
 # Release History
 
-## 2.0.2 (Unreleased)
+## 2.0.2 (2022-10-08)
 
-### Features Added
+**Bugs Fixed**
 
-### Breaking Changes
-
-### Bugs Fixed
-
-### Other Changes
+  -  revert credential scopes
 
 ## 2.0.1 (2022-09-30)
 

--- a/sdk/attestation/arm-attestation/src/attestationManagementClient.ts
+++ b/sdk/attestation/arm-attestation/src/attestationManagementClient.ts
@@ -58,6 +58,9 @@ export class AttestationManagementClient extends coreClient.ServiceClient {
         ? `${options.userAgentOptions.userAgentPrefix} ${packageDetails}`
         : `${packageDetails}`;
 
+    if (!options.credentialScopes) {
+      options.credentialScopes = ["https://management.azure.com/.default"];
+    }
     const optionsWithDefaults = {
       ...defaults,
       ...options,

--- a/sdk/authorization/arm-authorization/CHANGELOG.md
+++ b/sdk/authorization/arm-authorization/CHANGELOG.md
@@ -1,14 +1,10 @@
 # Release History
 
-## 9.0.0-beta.3 (Unreleased)
+## 9.0.0-beta.3 (2022-10-08)
 
-### Features Added
+**Bugs Fixed**
 
-### Breaking Changes
-
-### Bugs Fixed
-
-### Other Changes
+  -  revert credential scopes
 
 ## 9.0.0-beta.2 (2022-09-30)
 

--- a/sdk/authorization/arm-authorization/src/authorizationManagementClientContext.ts
+++ b/sdk/authorization/arm-authorization/src/authorizationManagementClientContext.ts
@@ -48,6 +48,9 @@ export class AuthorizationManagementClientContext extends coreClient.ServiceClie
         ? `${options.userAgentOptions.userAgentPrefix} ${packageDetails}`
         : `${packageDetails}`;
 
+    if (!options.credentialScopes) {
+      options.credentialScopes = ["https://management.azure.com/.default"];
+    }
     const optionsWithDefaults = {
       ...defaults,
       ...options,

--- a/sdk/automanage/arm-automanage/CHANGELOG.md
+++ b/sdk/automanage/arm-automanage/CHANGELOG.md
@@ -1,14 +1,10 @@
 # Release History
 
-## 1.0.2 (Unreleased)
+## 1.0.2 (2022-10-08)
 
-### Features Added
+**Bugs Fixed**
 
-### Breaking Changes
-
-### Bugs Fixed
-
-### Other Changes
+  -  revert credential scopes
 
 ## 1.0.1 (2022-09-30)
 

--- a/sdk/automanage/arm-automanage/src/automanageClient.ts
+++ b/sdk/automanage/arm-automanage/src/automanageClient.ts
@@ -82,6 +82,9 @@ export class AutomanageClient extends coreClient.ServiceClient {
         ? `${options.userAgentOptions.userAgentPrefix} ${packageDetails}`
         : `${packageDetails}`;
 
+    if (!options.credentialScopes) {
+      options.credentialScopes = ["https://management.azure.com/.default"];
+    }
     const optionsWithDefaults = {
       ...defaults,
       ...options,

--- a/sdk/automation/arm-automation/CHANGELOG.md
+++ b/sdk/automation/arm-automation/CHANGELOG.md
@@ -1,14 +1,10 @@
 # Release History
 
-## 11.0.0-beta.3 (Unreleased)
+## 11.0.0-beta.3 (2022-10-08)
 
-### Features Added
+**Bugs Fixed**
 
-### Breaking Changes
-
-### Bugs Fixed
-
-### Other Changes
+  -  revert credential scopes
 
 ## 11.0.0-beta.2 (2022-09-30)
 

--- a/sdk/automation/arm-automation/review/arm-automation.api.md
+++ b/sdk/automation/arm-automation/review/arm-automation.api.md
@@ -535,7 +535,7 @@ export interface ConnectionOperations {
 }
 
 // @public
-interface ConnectionType_2 {
+export interface ConnectionType {
     readonly creationTime?: Date;
     description?: string;
     readonly fieldDefinitions?: {
@@ -547,7 +547,6 @@ interface ConnectionType_2 {
     readonly name?: string;
     readonly type?: string;
 }
-export { ConnectionType_2 as ConnectionType }
 
 // @public
 export interface ConnectionTypeAssociationProperty {
@@ -568,7 +567,7 @@ export interface ConnectionTypeCreateOrUpdateParameters {
 }
 
 // @public
-export type ConnectionTypeCreateOrUpdateResponse = ConnectionType_2;
+export type ConnectionTypeCreateOrUpdateResponse = ConnectionType;
 
 // @public
 export interface ConnectionTypeDeleteOptionalParams extends coreClient.OperationOptions {
@@ -579,7 +578,7 @@ export interface ConnectionTypeGetOptionalParams extends coreClient.OperationOpt
 }
 
 // @public
-export type ConnectionTypeGetResponse = ConnectionType_2;
+export type ConnectionTypeGetResponse = ConnectionType;
 
 // @public
 export interface ConnectionTypeListByAutomationAccountNextOptionalParams extends coreClient.OperationOptions {
@@ -598,7 +597,7 @@ export type ConnectionTypeListByAutomationAccountResponse = ConnectionTypeListRe
 // @public
 export interface ConnectionTypeListResult {
     nextLink?: string;
-    value?: ConnectionType_2[];
+    value?: ConnectionType[];
 }
 
 // @public
@@ -606,7 +605,7 @@ export interface ConnectionTypeOperations {
     createOrUpdate(resourceGroupName: string, automationAccountName: string, connectionTypeName: string, parameters: ConnectionTypeCreateOrUpdateParameters, options?: ConnectionTypeCreateOrUpdateOptionalParams): Promise<ConnectionTypeCreateOrUpdateResponse>;
     delete(resourceGroupName: string, automationAccountName: string, connectionTypeName: string, options?: ConnectionTypeDeleteOptionalParams): Promise<void>;
     get(resourceGroupName: string, automationAccountName: string, connectionTypeName: string, options?: ConnectionTypeGetOptionalParams): Promise<ConnectionTypeGetResponse>;
-    listByAutomationAccount(resourceGroupName: string, automationAccountName: string, options?: ConnectionTypeListByAutomationAccountOptionalParams): PagedAsyncIterableIterator<ConnectionType_2>;
+    listByAutomationAccount(resourceGroupName: string, automationAccountName: string, options?: ConnectionTypeListByAutomationAccountOptionalParams): PagedAsyncIterableIterator<ConnectionType>;
 }
 
 // @public

--- a/sdk/automation/arm-automation/src/automationClient.ts
+++ b/sdk/automation/arm-automation/src/automationClient.ts
@@ -150,6 +150,9 @@ export class AutomationClient extends coreClient.ServiceClient {
         ? `${options.userAgentOptions.userAgentPrefix} ${packageDetails}`
         : `${packageDetails}`;
 
+    if (!options.credentialScopes) {
+      options.credentialScopes = ["https://management.azure.com/.default"];
+    }
     const optionsWithDefaults = {
       ...defaults,
       ...options,

--- a/sdk/avs/arm-avs/CHANGELOG.md
+++ b/sdk/avs/arm-avs/CHANGELOG.md
@@ -1,14 +1,10 @@
 # Release History
 
-## 3.1.2 (Unreleased)
+## 3.1.2 (2022-10-08)
 
-### Features Added
+**Bugs Fixed**
 
-### Breaking Changes
-
-### Bugs Fixed
-
-### Other Changes
+  -  revert credential scopes
 
 ## 3.1.1 (2022-09-30)
 

--- a/sdk/avs/arm-avs/src/azureVMwareSolutionAPI.ts
+++ b/sdk/avs/arm-avs/src/azureVMwareSolutionAPI.ts
@@ -90,6 +90,9 @@ export class AzureVMwareSolutionAPI extends coreClient.ServiceClient {
         ? `${options.userAgentOptions.userAgentPrefix} ${packageDetails}`
         : `${packageDetails}`;
 
+    if (!options.credentialScopes) {
+      options.credentialScopes = ["https://management.azure.com/.default"];
+    }
     const optionsWithDefaults = {
       ...defaults,
       ...options,

--- a/sdk/azureadexternalidentities/arm-azureadexternalidentities/CHANGELOG.md
+++ b/sdk/azureadexternalidentities/arm-azureadexternalidentities/CHANGELOG.md
@@ -1,14 +1,10 @@
 # Release History
 
-## 1.0.2 (Unreleased)
+## 1.0.2 (2022-10-08)
 
-### Features Added
+**Bugs Fixed**
 
-### Breaking Changes
-
-### Bugs Fixed
-
-### Other Changes
+  -  revert credential scopes
 
 ## 1.0.1 (2022-09-30)
 

--- a/sdk/azureadexternalidentities/arm-azureadexternalidentities/src/externalIdentitiesConfigurationClient.ts
+++ b/sdk/azureadexternalidentities/arm-azureadexternalidentities/src/externalIdentitiesConfigurationClient.ts
@@ -51,6 +51,9 @@ export class ExternalIdentitiesConfigurationClient extends coreClient.ServiceCli
         ? `${options.userAgentOptions.userAgentPrefix} ${packageDetails}`
         : `${packageDetails}`;
 
+    if (!options.credentialScopes) {
+      options.credentialScopes = ["https://management.azure.com/.default"];
+    }
     const optionsWithDefaults = {
       ...defaults,
       ...options,

--- a/sdk/azurestack/arm-azurestack/CHANGELOG.md
+++ b/sdk/azurestack/arm-azurestack/CHANGELOG.md
@@ -1,14 +1,10 @@
 # Release History
 
-## 3.0.0-beta.4 (Unreleased)
+## 3.0.0-beta.4 (2022-10-08)
 
-### Features Added
+**Bugs Fixed**
 
-### Breaking Changes
-
-### Bugs Fixed
-
-### Other Changes
+  -  revert credential scopes
 
 ## 3.0.0-beta.3 (2022-09-30)
 

--- a/sdk/azurestack/arm-azurestack/src/azureStackManagementClient.ts
+++ b/sdk/azurestack/arm-azurestack/src/azureStackManagementClient.ts
@@ -65,6 +65,9 @@ export class AzureStackManagementClient extends coreClient.ServiceClient {
         ? `${options.userAgentOptions.userAgentPrefix} ${packageDetails}`
         : `${packageDetails}`;
 
+    if (!options.credentialScopes) {
+      options.credentialScopes = ["https://management.azure.com/.default"];
+    }
     const optionsWithDefaults = {
       ...defaults,
       ...options,

--- a/sdk/azurestackhci/arm-azurestackhci/CHANGELOG.md
+++ b/sdk/azurestackhci/arm-azurestackhci/CHANGELOG.md
@@ -1,14 +1,10 @@
 # Release History
 
-## 3.0.2 (Unreleased)
+## 3.0.2 (2022-10-08)
 
-### Features Added
+**Bugs Fixed**
 
-### Breaking Changes
-
-### Bugs Fixed
-
-### Other Changes
+  -  revert credential scopes
 
 ## 3.0.1 (2022-09-30)
 

--- a/sdk/azurestackhci/arm-azurestackhci/src/azureStackHCIClient.ts
+++ b/sdk/azurestackhci/arm-azurestackhci/src/azureStackHCIClient.ts
@@ -61,6 +61,9 @@ export class AzureStackHCIClient extends coreClient.ServiceClient {
         ? `${options.userAgentOptions.userAgentPrefix} ${packageDetails}`
         : `${packageDetails}`;
 
+    if (!options.credentialScopes) {
+      options.credentialScopes = ["https://management.azure.com/.default"];
+    }
     const optionsWithDefaults = {
       ...defaults,
       ...options,


### PR DESCRIPTION
https://github.com/Azure/azure-sdk-for-js/pull/23357
revert credential scopes in these sdk folders:
advisor
agrifood
analysisservices
apimanagement
app
appconfiguration
appcontainers
applicationinsights
appplatform
appservice
attestation
authorization
automanage
autpmation
avs
azureadexternalidentities
azurestack
azurestackhci