### PR TITLE
revert credential scops for mgmt plane sdks b-c

### DIFF
--- a/sdk/batch/arm-batch/CHANGELOG.md
+++ b/sdk/batch/arm-batch/CHANGELOG.md
@@ -1,10 +1,14 @@
 # Release History
 
-## 7.2.1 (2022-09-30)
+## 7.2.1 (Unreleased)
 
-**Bugs Fixed**
+### Features Added
 
-  -  fix better user experience of credential scopes in government cloud
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
 
 ## 7.2.0 (2022-07-19)
     

--- a/sdk/batch/arm-batch/src/batchManagementClient.ts
+++ b/sdk/batch/arm-batch/src/batchManagementClient.ts
@@ -77,6 +77,9 @@ export class BatchManagementClient extends coreClient.ServiceClient {
         ? `${options.userAgentOptions.userAgentPrefix} ${packageDetails}`
         : `${packageDetails}`;
 
+    if (!options.credentialScopes) {
+      options.credentialScopes = ["https://management.azure.com/.default"];
+    }
     const optionsWithDefaults = {
       ...defaults,
       ...options,

--- a/sdk/billing/arm-billing/CHANGELOG.md
+++ b/sdk/billing/arm-billing/CHANGELOG.md
@@ -1,10 +1,14 @@
 # Release History
 
-## 4.0.2 (2022-09-30)
+## 4.0.2 (Unreleased)
 
-**Bugs Fixed**
+### Features Added
 
-  -  fix better user experience of credential scopes in government cloud
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
 
 ## 4.0.1 (2022-04-11)
 

--- a/sdk/billing/arm-billing/src/billingManagementClient.ts
+++ b/sdk/billing/arm-billing/src/billingManagementClient.ts
@@ -93,7 +93,9 @@ export class BillingManagementClient extends coreClient.ServiceClient {
         ? `${options.userAgentOptions.userAgentPrefix} ${packageDetails}`
         : `${packageDetails}`;
 
-    image.png
+    if (!options.credentialScopes) {
+      options.credentialScopes = ["https://management.azure.com/.default"];
+    }
     const optionsWithDefaults = {
       ...defaults,
       ...options,

--- a/sdk/billing/arm-billing/src/billingManagementClient.ts
+++ b/sdk/billing/arm-billing/src/billingManagementClient.ts
@@ -93,6 +93,7 @@ export class BillingManagementClient extends coreClient.ServiceClient {
         ? `${options.userAgentOptions.userAgentPrefix} ${packageDetails}`
         : `${packageDetails}`;
 
+    image.png
     const optionsWithDefaults = {
       ...defaults,
       ...options,

--- a/sdk/botservice/arm-botservice/CHANGELOG.md
+++ b/sdk/botservice/arm-botservice/CHANGELOG.md
@@ -1,10 +1,14 @@
 # Release History
 
-## 4.0.0-beta.5 (2022-09-30)
+## 4.0.0-beta.5 (Unreleased)
 
-**Bugs Fixed**
+### Features Added
 
-  -  fix better user experience of credential scopes in government cloud
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
 
 ## 4.0.0-beta.4 (2022-04-20)
 

--- a/sdk/botservice/arm-botservice/src/azureBotService.ts
+++ b/sdk/botservice/arm-botservice/src/azureBotService.ts
@@ -71,6 +71,9 @@ export class AzureBotService extends coreClient.ServiceClient {
         ? `${options.userAgentOptions.userAgentPrefix} ${packageDetails}`
         : `${packageDetails}`;
 
+    if (!options.credentialScopes) {
+      options.credentialScopes = ["https://management.azure.com/.default"];
+    }
     const optionsWithDefaults = {
       ...defaults,
       ...options,

--- a/sdk/cdn/arm-cdn/CHANGELOG.md
+++ b/sdk/cdn/arm-cdn/CHANGELOG.md
@@ -1,11 +1,5 @@
 # Release History
 
-## 7.0.2 (2022-09-30)
-
-**Bugs Fixed**
-
-  -  fix better user experience of credential scopes in government cloud
-
 ## 7.0.1 (2022-04-21)
 
 **Features**

--- a/sdk/cdn/arm-cdn/package.json
+++ b/sdk/cdn/arm-cdn/package.json
@@ -3,7 +3,7 @@
   "sdk-type": "mgmt",
   "author": "Microsoft Corporation",
   "description": "A generated SDK for CdnManagementClient.",
-  "version": "7.0.2",
+  "version": "7.0.1",
   "engines": {
     "node": ">=12.0.0"
   },

--- a/sdk/cdn/arm-cdn/src/cdnManagementClient.ts
+++ b/sdk/cdn/arm-cdn/src/cdnManagementClient.ts
@@ -105,12 +105,15 @@ export class CdnManagementClient extends coreClient.ServiceClient {
       credential: credentials
     };
 
-    const packageDetails = `azsdk-js-arm-cdn/7.0.2`;
+    const packageDetails = `azsdk-js-arm-cdn/7.0.1`;
     const userAgentPrefix =
       options.userAgentOptions && options.userAgentOptions.userAgentPrefix
         ? `${options.userAgentOptions.userAgentPrefix} ${packageDetails}`
         : `${packageDetails}`;
 
+    if (!options.credentialScopes) {
+      options.credentialScopes = ["https://management.azure.com/.default"];
+    }
     const optionsWithDefaults = {
       ...defaults,
       ...options,

--- a/sdk/changeanalysis/arm-changeanalysis/CHANGELOG.md
+++ b/sdk/changeanalysis/arm-changeanalysis/CHANGELOG.md
@@ -1,10 +1,14 @@
 # Release History
 
-## 2.0.2 (2022-09-30)
+## 2.0.2 (Unreleased)
 
-**Bugs Fixed**
+### Features Added
 
-  -  fix better user experience of credential scopes in government cloud
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
 
 ## 2.0.1 (2022-04-11)
 

--- a/sdk/changeanalysis/arm-changeanalysis/src/azureChangeAnalysisManagementClient.ts
+++ b/sdk/changeanalysis/arm-changeanalysis/src/azureChangeAnalysisManagementClient.ts
@@ -50,6 +50,9 @@ export class AzureChangeAnalysisManagementClient extends coreClient.ServiceClien
         ? `${options.userAgentOptions.userAgentPrefix} ${packageDetails}`
         : `${packageDetails}`;
 
+    if (!options.credentialScopes) {
+      options.credentialScopes = ["https://management.azure.com/.default"];
+    }
     const optionsWithDefaults = {
       ...defaults,
       ...options,

--- a/sdk/changes/arm-changes/CHANGELOG.md
+++ b/sdk/changes/arm-changes/CHANGELOG.md
@@ -1,10 +1,14 @@
 # Release History
 
-## 1.0.1 (2022-09-30)
+## 1.0.1 (Unreleased)
 
-**Bugs Fixed**
+### Features Added
 
-  -  fix better user experience of credential scopes in government cloud
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
 
 ## 1.0.0 (2022-05-09)
 

--- a/sdk/changes/arm-changes/src/changesClient.ts
+++ b/sdk/changes/arm-changes/src/changesClient.ts
@@ -52,6 +52,9 @@ export class ChangesClient extends coreClient.ServiceClient {
         ? `${options.userAgentOptions.userAgentPrefix} ${packageDetails}`
         : `${packageDetails}`;
 
+    if (!options.credentialScopes) {
+      options.credentialScopes = ["https://management.azure.com/.default"];
+    }
     const optionsWithDefaults = {
       ...defaults,
       ...options,

--- a/sdk/chaos/arm-chaos/CHANGELOG.md
+++ b/sdk/chaos/arm-chaos/CHANGELOG.md
@@ -1,10 +1,14 @@
 # Release History
 
-## 1.0.0-beta.2 (2022-09-30)
+## 1.0.0-beta.2 (Unreleased)
 
-**Bugs Fixed**
+### Features Added
 
-  -  fix better user experience of credential scopes in government cloud
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
 
 ## 1.0.0-beta.1 (2022-09-13)
 

--- a/sdk/chaos/arm-chaos/src/chaosManagementClient.ts
+++ b/sdk/chaos/arm-chaos/src/chaosManagementClient.ts
@@ -70,6 +70,9 @@ export class ChaosManagementClient extends coreClient.ServiceClient {
         ? `${options.userAgentOptions.userAgentPrefix} ${packageDetails}`
         : `${packageDetails}`;
 
+    if (!options.credentialScopes) {
+      options.credentialScopes = ["https://management.azure.com/.default"];
+    }
     const optionsWithDefaults = {
       ...defaults,
       ...options,

--- a/sdk/cognitiveservices/arm-cognitiveservices/CHANGELOG.md
+++ b/sdk/cognitiveservices/arm-cognitiveservices/CHANGELOG.md
@@ -1,10 +1,4 @@
 # Release History
-    
-## 7.2.1 (2022-09-30)
-
-**Bugs Fixed**
-
-  -  fix better user experience of credential scopes in government cloud
 
 ## 7.2.0 (2022-06-10)
     

--- a/sdk/cognitiveservices/arm-cognitiveservices/package.json
+++ b/sdk/cognitiveservices/arm-cognitiveservices/package.json
@@ -3,7 +3,7 @@
   "sdk-type": "mgmt",
   "author": "Microsoft Corporation",
   "description": "A generated SDK for CognitiveServicesManagementClient.",
-  "version": "7.2.1",
+  "version": "7.2.0",
   "engines": {
     "node": ">=12.0.0"
   },

--- a/sdk/cognitiveservices/arm-cognitiveservices/src/cognitiveServicesManagementClient.ts
+++ b/sdk/cognitiveservices/arm-cognitiveservices/src/cognitiveServicesManagementClient.ts
@@ -78,12 +78,15 @@ export class CognitiveServicesManagementClient extends coreClient.ServiceClient 
       credential: credentials
     };
 
-    const packageDetails = `azsdk-js-arm-cognitiveservices/7.2.1`;
+    const packageDetails = `azsdk-js-arm-cognitiveservices/7.2.0`;
     const userAgentPrefix =
       options.userAgentOptions && options.userAgentOptions.userAgentPrefix
         ? `${options.userAgentOptions.userAgentPrefix} ${packageDetails}`
         : `${packageDetails}`;
 
+    if (!options.credentialScopes) {
+      options.credentialScopes = ["https://management.azure.com/.default"];
+    }
     const optionsWithDefaults = {
       ...defaults,
       ...options,

--- a/sdk/commerce/arm-commerce/CHANGELOG.md
+++ b/sdk/commerce/arm-commerce/CHANGELOG.md
@@ -1,10 +1,14 @@
 # Release History
 
-## 4.0.0-beta.3 (2022-09-30)
+## 4.0.0-beta.3 (Unreleased)
 
-**Bugs Fixed**
+### Features Added
 
-  -  fix better user experience of credential scopes in government cloud
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
 
 ## 4.0.0-beta.2 (2022-04-11)
 

--- a/sdk/commerce/arm-commerce/src/usageManagementClient.ts
+++ b/sdk/commerce/arm-commerce/src/usageManagementClient.ts
@@ -51,6 +51,9 @@ export class UsageManagementClient extends coreClient.ServiceClient {
         ? `${options.userAgentOptions.userAgentPrefix} ${packageDetails}`
         : `${packageDetails}`;
 
+    if (!options.credentialScopes) {
+      options.credentialScopes = ["https://management.azure.com/.default"];
+    }
     const optionsWithDefaults = {
       ...defaults,
       ...options,

--- a/sdk/communication/arm-communication/CHANGELOG.md
+++ b/sdk/communication/arm-communication/CHANGELOG.md
@@ -1,11 +1,14 @@
 # Release History
 
-## 4.0.0-beta.3 (2022-09-30)
+## 4.0.0-beta.3 (Unreleased)
 
-**Bugs Fixed**
+### Features Added
 
-  -  fix better user experience of credential scopes in government cloud
+### Breaking Changes
 
+### Bugs Fixed
+
+### Other Changes
 ## 4.0.0-beta.2 (2022-08-19)
     
 **Features**

--- a/sdk/communication/arm-communication/src/communicationServiceManagementClient.ts
+++ b/sdk/communication/arm-communication/src/communicationServiceManagementClient.ts
@@ -66,6 +66,9 @@ export class CommunicationServiceManagementClient extends coreClient.ServiceClie
         ? `${options.userAgentOptions.userAgentPrefix} ${packageDetails}`
         : `${packageDetails}`;
 
+    if (!options.credentialScopes) {
+      options.credentialScopes = ["https://management.azure.com/.default"];
+    }
     const optionsWithDefaults = {
       ...defaults,
       ...options,

--- a/sdk/compute/arm-compute/CHANGELOG.md
+++ b/sdk/compute/arm-compute/CHANGELOG.md
@@ -1,10 +1,14 @@
 # Release History
 
-## 19.2.1 (2022-09-30)
+## 19.2.1 (Unreleased)
 
-**Bugs Fixed**
+### Features Added
 
-  -  fix better user experience of credential scopes in government cloud
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
 
 ## 19.2.0 (2022-09-21)
     

--- a/sdk/compute/arm-compute/src/computeManagementClient.ts
+++ b/sdk/compute/arm-compute/src/computeManagementClient.ts
@@ -151,6 +151,9 @@ export class ComputeManagementClient extends coreClient.ServiceClient {
         ? `${options.userAgentOptions.userAgentPrefix} ${packageDetails}`
         : `${packageDetails}`;
 
+    if (!options.credentialScopes) {
+      options.credentialScopes = ["https://management.azure.com/.default"];
+    }
     const optionsWithDefaults = {
       ...defaults,
       ...options,

--- a/sdk/confidentialledger/arm-confidentialledger/CHANGELOG.md
+++ b/sdk/confidentialledger/arm-confidentialledger/CHANGELOG.md
@@ -1,10 +1,14 @@
 # Release History
 
-## 1.1.1 (2022-09-30)
+## 1.1.1 (Unreleased)
 
-**Bugs Fixed**
+### Features Added
 
-  -  fix better user experience of credential scopes in government cloud
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
 
 ## 1.1.0 (2022-07-05)
     

--- a/sdk/confidentialledger/arm-confidentialledger/src/confidentialLedgerClient.ts
+++ b/sdk/confidentialledger/arm-confidentialledger/src/confidentialLedgerClient.ts
@@ -64,6 +64,9 @@ export class ConfidentialLedgerClient extends coreClient.ServiceClient {
         ? `${options.userAgentOptions.userAgentPrefix} ${packageDetails}`
         : `${packageDetails}`;
 
+    if (!options.credentialScopes) {
+      options.credentialScopes = ["https://management.azure.com/.default"];
+    }
     const optionsWithDefaults = {
       ...defaults,
       ...options,

--- a/sdk/confluent/arm-confluent/CHANGELOG.md
+++ b/sdk/confluent/arm-confluent/CHANGELOG.md
@@ -1,10 +1,14 @@
 # Release History
 
-## 3.0.0-beta.3 (2022-09-30)
+## 3.0.0-beta.3 (Unreleased)
 
-**Bugs Fixed**
+### Features Added
 
-  -  fix better user experience of credential scopes in government cloud
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
 
 ## 3.0.0-beta.2 (2022-04-12)
 

--- a/sdk/confluent/arm-confluent/src/confluentManagementClient.ts
+++ b/sdk/confluent/arm-confluent/src/confluentManagementClient.ts
@@ -60,6 +60,9 @@ export class ConfluentManagementClient extends coreClient.ServiceClient {
         ? `${options.userAgentOptions.userAgentPrefix} ${packageDetails}`
         : `${packageDetails}`;
 
+    if (!options.credentialScopes) {
+      options.credentialScopes = ["https://management.azure.com/.default"];
+    }
     const optionsWithDefaults = {
       ...defaults,
       ...options,

--- a/sdk/connectedvmware/arm-connectedvmware/CHANGELOG.md
+++ b/sdk/connectedvmware/arm-connectedvmware/CHANGELOG.md
@@ -1,10 +1,15 @@
 # Release History
 
-## 1.0.0-beta.2 (2022-09-30)
+## 1.0.0-beta.2 (Unreleased)
 
-**Bugs Fixed**
+### Features Added
 
-  -  fix better user experience of credential scopes in government cloud
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
+
 ## 1.0.0-beta.1 (2022-08-15)
 
 The package of @azure/arm-connectedvmware is using our next generation design principles. To learn more, please refer to our documentation [Quick Start](https://aka.ms/js-track2-quickstart).

--- a/sdk/connectedvmware/arm-connectedvmware/src/azureArcVMwareManagementServiceAPI.ts
+++ b/sdk/connectedvmware/arm-connectedvmware/src/azureArcVMwareManagementServiceAPI.ts
@@ -84,6 +84,9 @@ export class AzureArcVMwareManagementServiceAPI extends coreClient.ServiceClient
         ? `${options.userAgentOptions.userAgentPrefix} ${packageDetails}`
         : `${packageDetails}`;
 
+    if (!options.credentialScopes) {
+      options.credentialScopes = ["https://management.azure.com/.default"];
+    }
     const optionsWithDefaults = {
       ...defaults,
       ...options,

--- a/sdk/consumption/arm-consumption/CHANGELOG.md
+++ b/sdk/consumption/arm-consumption/CHANGELOG.md
@@ -1,10 +1,14 @@
 # Release History
 
-## 9.1.1 (2022-09-30)
+## 9.1.1 (Unreleased)
 
-**Bugs Fixed**
+### Features Added
 
-  -  fix better user experience of credential scopes in government cloud
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
 
 ## 9.1.0 (2022-09-05)
     

--- a/sdk/consumption/arm-consumption/src/consumptionManagementClient.ts
+++ b/sdk/consumption/arm-consumption/src/consumptionManagementClient.ts
@@ -92,6 +92,9 @@ export class ConsumptionManagementClient extends coreClient.ServiceClient {
         ? `${options.userAgentOptions.userAgentPrefix} ${packageDetails}`
         : `${packageDetails}`;
 
+    if (!options.credentialScopes) {
+      options.credentialScopes = ["https://management.azure.com/.default"];
+    }
     const optionsWithDefaults = {
       ...defaults,
       ...options,

--- a/sdk/containerinstance/arm-containerinstance/CHANGELOG.md
+++ b/sdk/containerinstance/arm-containerinstance/CHANGELOG.md
@@ -1,10 +1,14 @@
 # Release History
 
-## 9.0.1 (2022-09-30)
+## 9.0.1 (Unreleased)
 
-**Bugs Fixed**
+### Features Added
 
-  -  fix better user experience of credential scopes in government cloud
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
 
 ## 9.0.0 (2022-08-30)
     

--- a/sdk/containerinstance/arm-containerinstance/src/containerInstanceManagementClient.ts
+++ b/sdk/containerinstance/arm-containerinstance/src/containerInstanceManagementClient.ts
@@ -69,6 +69,9 @@ export class ContainerInstanceManagementClient extends coreClient.ServiceClient 
         ? `${options.userAgentOptions.userAgentPrefix} ${packageDetails}`
         : `${packageDetails}`;
 
+    if (!options.credentialScopes) {
+      options.credentialScopes = ["https://management.azure.com/.default"];
+    }
     const optionsWithDefaults = {
       ...defaults,
       ...options,

--- a/sdk/containerregistry/arm-containerregistry/CHANGELOG.md
+++ b/sdk/containerregistry/arm-containerregistry/CHANGELOG.md
@@ -1,10 +1,14 @@
 # Release History
 
-## 10.1.0-beta.4 (2022-09-30)
+## 10.1.0-beta.4 (Unreleased)
 
-**Bugs Fixed**
+### Features Added
 
-  -  fix better user experience of credential scopes in government cloud
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
 
 ## 10.1.0-beta.3 (2022-05-18)
     

--- a/sdk/containerregistry/arm-containerregistry/src/containerRegistryManagementClient.ts
+++ b/sdk/containerregistry/arm-containerregistry/src/containerRegistryManagementClient.ts
@@ -82,6 +82,9 @@ export class ContainerRegistryManagementClient extends coreClient.ServiceClient 
         ? `${options.userAgentOptions.userAgentPrefix} ${packageDetails}`
         : `${packageDetails}`;
 
+    if (!options.credentialScopes) {
+      options.credentialScopes = ["https://management.azure.com/.default"];
+    }
     const optionsWithDefaults = {
       ...defaults,
       ...options,

--- a/sdk/containerservice/arm-containerservice/CHANGELOG.md
+++ b/sdk/containerservice/arm-containerservice/CHANGELOG.md
@@ -1,10 +1,14 @@
 # Release History
 
-## 18.0.0-beta.3 (2022-09-30)
+## 18.0.0-beta.3 (Unreleased)
 
-**Bugs Fixed**
+### Features Added
 
-  -  fix better user experience of credential scopes in government cloud
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
 
 ## 18.0.0-beta.2 (2022-09-29)
     

--- a/sdk/containerservice/arm-containerservice/src/containerServiceClient.ts
+++ b/sdk/containerservice/arm-containerservice/src/containerServiceClient.ts
@@ -78,6 +78,9 @@ export class ContainerServiceClient extends coreClient.ServiceClient {
         ? `${options.userAgentOptions.userAgentPrefix} ${packageDetails}`
         : `${packageDetails}`;
 
+    if (!options.credentialScopes) {
+      options.credentialScopes = ["https://management.azure.com/.default"];
+    }
     const optionsWithDefaults = {
       ...defaults,
       ...options,

--- a/sdk/cosmosdb/arm-cosmosdb/CHANGELOG.md
+++ b/sdk/cosmosdb/arm-cosmosdb/CHANGELOG.md
@@ -1,10 +1,14 @@
 # Release History
 
-## 15.2.1 (2022-09-30)
+## 15.2.1 (Unreleased)
 
-**Bugs Fixed**
+### Features Added
 
-  -  fix better user experience of credential scopes in government cloud
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
 
 ## 15.2.0 (2022-09-05)
     

--- a/sdk/cosmosdb/arm-cosmosdb/src/cosmosDBManagementClient.ts
+++ b/sdk/cosmosdb/arm-cosmosdb/src/cosmosDBManagementClient.ts
@@ -122,6 +122,9 @@ export class CosmosDBManagementClient extends coreClient.ServiceClient {
         ? `${options.userAgentOptions.userAgentPrefix} ${packageDetails}`
         : `${packageDetails}`;
 
+    if (!options.credentialScopes) {
+      options.credentialScopes = ["https://management.azure.com/.default"];
+    }
     const optionsWithDefaults = {
       ...defaults,
       ...options,

--- a/sdk/customer-insights/arm-customerinsights/CHANGELOG.md
+++ b/sdk/customer-insights/arm-customerinsights/CHANGELOG.md
@@ -1,10 +1,14 @@
 # Release History
 
-## 4.0.2 (2022-09-30)
+## 4.0.2 (Unreleased)
 
-**Bugs Fixed**
+### Features Added
 
-  -  fix better user experience of credential scopes in government cloud
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
 
 ## 4.0.1 (2022-04-15)
 

--- a/sdk/customer-insights/arm-customerinsights/src/customerInsightsManagementClient.ts
+++ b/sdk/customer-insights/arm-customerinsights/src/customerInsightsManagementClient.ts
@@ -88,6 +88,9 @@ export class CustomerInsightsManagementClient extends coreClient.ServiceClient {
         ? `${options.userAgentOptions.userAgentPrefix} ${packageDetails}`
         : `${packageDetails}`;
 
+    if (!options.credentialScopes) {
+      options.credentialScopes = ["https://management.azure.com/.default"];
+    }
     const optionsWithDefaults = {
       ...defaults,
       ...options,


### PR DESCRIPTION
https://github.com/Azure/azure-sdk-for-js/pull/23358
revert credential scopes in these sdk folders:
batch
billing
botservice
cdn
changeanalysis
changes
chaos
cognitiverservices
commerce
communication
compute
confidentialledger
confluent
connectedvmware
consumption
containerinstance
containerregistry
containerservice
cosmosdb
customer-insights