### PR TITLE
Fixing missing pipeline integration for CosmosClient in patch api

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -16547,7 +16547,7 @@ packages:
     dev: false
 
   file:projects/cosmos.tgz:
-    resolution: {integrity: sha512-kJdqp2WP/SZxX4tZTMkW1upEoWFcTp7nFJ6kJaqts/sbqc5aonQDh28ueet7uRjrIDqxCSx/SyDURukpF/6W5Q==, tarball: file:projects/cosmos.tgz}
+    resolution: {integrity: sha512-D+HffgwtzN9H1lWrz0/h1q575LoHLpoUuBW7ktq2dC8PP++MmezwbS3bOzoFc9/qak9kwqw9gaWFFQEcXCYbuw==, tarball: file:projects/cosmos.tgz}
     name: '@rush-temp/cosmos'
     version: 0.0.0
     dependencies:
@@ -16572,6 +16572,7 @@ packages:
       jsbi: 3.2.5
       mocha: 7.2.0
       mocha-junit-reporter: 2.1.0_mocha@7.2.0
+      nock: 12.0.3
       node-abort-controller: 3.0.1
       prettier: 2.7.1
       priorityqueuejs: 1.0.0

--- a/sdk/cosmosdb/cosmos/consumer-test.js
+++ b/sdk/cosmosdb/cosmos/consumer-test.js
@@ -1,9 +1,9 @@
 const execa = require("execa");
 
-let versions = ["3.9"];
+let tsVersionsToCheckCompatibility = ["4.1"];
 
 if (!process.env.SKIP_LATEST) {
-  versions.push("latest");
+  tsVersionsToCheckCompatibility.push("latest");
 }
 
 async function exec(cmd) {
@@ -15,8 +15,8 @@ async function exec(cmd) {
 
 (async () => {
   try {
-    console.log("Running typescript consumer test against", versions);
-    for (const version of versions) {
+    console.log("Running typescript consumer test against", tsVersionsToCheckCompatibility);
+    for (const version of tsVersionsToCheckCompatibility) {
       console.log(`Compiling with typescript@${version} - Basic`);
       await exec(
         `npx -p typescript@${version} tsc ./test.ts --allowSyntheticDefaultImports true --target ES5`

--- a/sdk/cosmosdb/cosmos/package.json
+++ b/sdk/cosmosdb/cosmos/package.json
@@ -149,7 +149,7 @@
       "QueryThroughput.ts",
       "SasTokenAuth.ts",
       "ServerSideScripts.ts",
-      "Shared/handleError.ts"
+      "handleError.ts"
     ],
     "productName": "Azure Cosmos DB",
     "productSlugs": [

--- a/sdk/cosmosdb/cosmos/package.json
+++ b/sdk/cosmosdb/cosmos/package.json
@@ -132,7 +132,8 @@
     "sinon": "^9.0.2",
     "source-map-support": "^0.5.9",
     "ts-node": "^10.0.0",
-    "typescript": "~4.6.0"
+    "typescript": "~4.6.0",
+    "nock": "^12.0.3"
   },
   "//sampleConfiguration": {
     "skip": [

--- a/sdk/cosmosdb/cosmos/package.json
+++ b/sdk/cosmosdb/cosmos/package.json
@@ -58,7 +58,7 @@
     "check:src:strict": "tsc --pretty --project tsconfig.strict.json",
     "build:src": "echo Using TypeScript && tsc --version && tsc -b --pretty",
     "build:test": "tsc",
-    "build:types": "downlevel-dts dist/types/latest dist/types/3.1",
+    "build:types": "downlevel-dts dist/types/latest dist/types/4.1 --to=4.1",
     "build": "npm run clean && npm run extract-api && npm run build:types && npm run bundle",
     "bundle": "dev-tool run bundle",
     "bundle-types": "node bundle-types.js",

--- a/sdk/cosmosdb/cosmos/src/ClientContext.ts
+++ b/sdk/cosmosdb/cosmos/src/ClientContext.ts
@@ -24,7 +24,7 @@ import { FeedOptions, RequestOptions, Response } from "./request";
 import { PartitionedQueryExecutionInfo } from "./request/ErrorResponse";
 import { getHeaders } from "./request/request";
 import { RequestContext } from "./request/RequestContext";
-import { request as executeRequest } from "./request/RequestHandler";
+import { RequestHandler } from "./request/RequestHandler";
 import { SessionContainer } from "./session/sessionContainer";
 import { SessionContext } from "./session/SessionContext";
 import { BulkOptions } from "./utils/batch";
@@ -111,7 +111,7 @@ export class ClientContext {
         request.resourceType,
         request.operationType
       );
-      const response = await executePlugins(request, executeRequest, PluginOn.operation);
+      const response = await executePlugins(request, RequestHandler.request, PluginOn.operation);
       this.captureSessionToken(undefined, path, OperationType.Read, response.headers);
       return response;
     } catch (err: any) {
@@ -184,7 +184,7 @@ export class ClientContext {
     );
     logger.verbose(request);
     const start = Date.now();
-    const response = await executeRequest(request);
+    const response = await RequestHandler.request(request);
     logger.info("query " + requestId + " finished - " + (Date.now() - start) + "ms");
     this.captureSessionToken(undefined, path, OperationType.Query, response.headers);
     return this.processQueryFeedResponse(response, !!query, resultFn);
@@ -228,7 +228,7 @@ export class ClientContext {
     }
 
     this.applySessionToken(request);
-    const response = await executeRequest(request);
+    const response = await RequestHandler.request(request);
     this.captureSessionToken(undefined, path, OperationType.Query, response.headers);
     return response as any;
   }
@@ -290,7 +290,7 @@ export class ClientContext {
         request.resourceType,
         request.operationType
       );
-      const response = await executePlugins(request, executeRequest, PluginOn.operation);
+      const response = await executePlugins(request, RequestHandler.request, PluginOn.operation);
       if (parseLink(path).type !== "colls") {
         this.captureSessionToken(undefined, path, OperationType.Delete, response.headers);
       } else {
@@ -333,6 +333,7 @@ export class ClientContext {
         options,
         plugins: this.cosmosClientOptions.plugins,
         partitionKey,
+        pipeline: this.pipeline,
       };
 
       request.headers = await this.buildHeaders(request);
@@ -343,7 +344,7 @@ export class ClientContext {
         request.resourceType,
         request.operationType
       );
-      const response = await executePlugins(request, executeRequest, PluginOn.operation);
+      const response = await executePlugins(request, RequestHandler.request, PluginOn.operation);
       this.captureSessionToken(undefined, path, OperationType.Patch, response.headers);
       return response;
     } catch (err: any) {
@@ -393,7 +394,7 @@ export class ClientContext {
         request.resourceType,
         request.operationType
       );
-      const response = await executePlugins(request, executeRequest, PluginOn.operation);
+      const response = await executePlugins(request, RequestHandler.request, PluginOn.operation);
       this.captureSessionToken(undefined, path, OperationType.Create, response.headers);
       return response;
     } catch (err: any) {
@@ -482,7 +483,7 @@ export class ClientContext {
         request.resourceType,
         request.operationType
       );
-      const response = await executePlugins(request, executeRequest, PluginOn.operation);
+      const response = await executePlugins(request, RequestHandler.request, PluginOn.operation);
       this.captureSessionToken(undefined, path, OperationType.Replace, response.headers);
       return response;
     } catch (err: any) {
@@ -533,7 +534,7 @@ export class ClientContext {
         request.resourceType,
         request.operationType
       );
-      const response = await executePlugins(request, executeRequest, PluginOn.operation);
+      const response = await executePlugins(request, RequestHandler.request, PluginOn.operation);
       this.captureSessionToken(undefined, path, OperationType.Upsert, response.headers);
       return response;
     } catch (err: any) {
@@ -584,7 +585,7 @@ export class ClientContext {
       request.resourceType,
       request.operationType
     );
-    return executePlugins(request, executeRequest, PluginOn.operation);
+    return executePlugins(request, RequestHandler.request, PluginOn.operation);
   }
 
   /**
@@ -613,7 +614,11 @@ export class ClientContext {
 
     request.headers = await this.buildHeaders(request);
     // await options.beforeOperation({ endpoint, request, headers: requestHeaders });
-    const { result, headers } = await executePlugins(request, executeRequest, PluginOn.operation);
+    const { result, headers } = await executePlugins(
+      request,
+      RequestHandler.request,
+      PluginOn.operation
+    );
 
     const databaseAccount = new DatabaseAccount(result, headers);
 
@@ -677,7 +682,7 @@ export class ClientContext {
         request.resourceType,
         request.operationType
       );
-      const response = await executePlugins(request, executeRequest, PluginOn.operation);
+      const response = await executePlugins(request, RequestHandler.request, PluginOn.operation);
       this.captureSessionToken(undefined, path, OperationType.Batch, response.headers);
       return response;
     } catch (err: any) {
@@ -731,7 +736,7 @@ export class ClientContext {
         request.resourceType,
         request.operationType
       );
-      const response = await executePlugins(request, executeRequest, PluginOn.operation);
+      const response = await executePlugins(request, RequestHandler.request, PluginOn.operation);
       this.captureSessionToken(undefined, path, OperationType.Batch, response.headers);
       return response;
     } catch (err: any) {

--- a/sdk/cosmosdb/cosmos/src/request/RequestHandler.ts
+++ b/sdk/cosmosdb/cosmos/src/request/RequestHandler.ts
@@ -152,7 +152,7 @@ async function httpRequest(requestContext: RequestContext): Promise<{
 /**
  * @hidden
  */
-export async function request<T>(requestContext: RequestContext): Promise<CosmosResponse<T>> {
+async function request<T>(requestContext: RequestContext): Promise<CosmosResponse<T>> {
   if (requestContext.body) {
     requestContext.body = bodyFromData(requestContext.body);
     if (!requestContext.body) {
@@ -165,3 +165,7 @@ export async function request<T>(requestContext: RequestContext): Promise<Cosmos
     executeRequest,
   });
 }
+
+export const RequestHandler = {
+  request,
+};

--- a/sdk/cosmosdb/cosmos/test/internal/unit/client.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/internal/unit/client.spec.ts
@@ -1,0 +1,259 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import {
+  Container,
+  CosmosClient,
+  PatchOperationType,
+  RequestContext,
+  ResourceType,
+} from "../../../src";
+import assert from "assert";
+import { Suite } from "mocha";
+import Sinon, { SinonSandbox, SinonSpy } from "sinon";
+import { getTestContainer } from "../../public/common/TestHelpers";
+import { AccessToken, TokenCredential } from "@azure/identity";
+import nock from "nock";
+import { RequestHandler } from "../../../src/request/RequestHandler";
+import { masterKey } from "../../public/common/_fakeTestSecrets";
+import { endpoint } from "../../public/common/_testConfig";
+
+class MockCredential implements TokenCredential {
+  constructor(public returnPromise: Promise<AccessToken | null>) {}
+
+  getToken(): Promise<AccessToken | null> {
+    return this.returnPromise;
+  }
+}
+const requiredHeadersForAADAuth = {
+  reqheaders: {
+    authorization: "type=aad&ver=1.0&sig=aadToken",
+  },
+};
+const database1Definition = {
+  id: "db1",
+};
+const container1Definition = {
+  id: "col1",
+};
+const item1Definition = {
+  id: "item1",
+  value: "item1Value",
+};
+const item1patchRequest = {
+  op: PatchOperationType.add,
+  path: "/value",
+  value: "patched_value",
+};
+const testDataset = {
+  databaseGetResponse: {
+    body: database1Definition,
+    path: "",
+    resourceType: ResourceType.database,
+    resourceId: "db1",
+  },
+  containerGetResponse: {
+    body: container1Definition,
+    path: "",
+    resourceType: ResourceType.container,
+    resourceId: "col1",
+  },
+  itemGetResponse: {
+    body: item1Definition,
+    path: "",
+    resourceType: ResourceType.item,
+    resourceId: "item1",
+  },
+  itemPatchResponse: {
+    body: item1Definition,
+    path: "",
+    resourceType: ResourceType.item,
+    resourceId: "item1",
+  },
+};
+
+describe("Testing Credentials integration for Client", function (this: Suite) {
+  // endpoint for mock server, which doesn't conflict with emulator's endpoints.
+  const mockedEndpoint = "https://localhost:8082";
+  const aadToken = "aadToken";
+  let sandbox: SinonSandbox;
+  let spy: SinonSpy;
+  beforeEach(function () {
+    sandbox = Sinon.createSandbox();
+  });
+  function setupSpyOnRequestHandler() {
+    spy = sandbox.spy(RequestHandler, "request");
+  }
+
+  afterEach(function () {
+    sandbox.restore();
+  });
+  describe("Client Test With AAD Credentials", function () {
+    let client: CosmosClient;
+    beforeEach(function () {
+      client = new CosmosClient({
+        endpoint: mockedEndpoint,
+        aadCredentials: new MockCredential(
+          Promise.resolve({ token: aadToken, expiresOnTimestamp: 0 })
+        ),
+      });
+    });
+    afterEach(function () {
+      nock.restore();
+      nock.cleanAll();
+      nock.enableNetConnect();
+    });
+    it("Test pipeline setup for items.create for aadCredentials", async function () {
+      setupMockResponse();
+      const container: Container = await getTestContainer("Test Container", client);
+      setupSpyOnRequestHandler();
+      await container.items.create(item1Definition);
+      assert(
+        spy.calledWithMatch(
+          Sinon.match(function (arg: RequestContext) {
+            return !!arg?.pipeline;
+          })
+        )
+      );
+    });
+    it("Test pipeline setup for items.read for aadCredentials", async function () {
+      setupMockResponse();
+      const container: Container = await getTestContainer("Test Container", client);
+      await container.items.create(item1Definition);
+      setupSpyOnRequestHandler();
+      await container.item(item1Definition.id, "dummy_partition_key").read();
+      assert(
+        spy.calledWithMatch(
+          Sinon.match(function (arg: RequestContext) {
+            return !!arg?.pipeline;
+          })
+        )
+      );
+    });
+    it("Test pipeline setup for items.patch", async function () {
+      setupMockResponse();
+      const container: Container = await getTestContainer("Test Container", client);
+      await container.items.create(item1Definition);
+      setupSpyOnRequestHandler();
+      await container.item(item1Definition.id).patch([item1patchRequest]);
+      assert(
+        spy.calledWithMatch(
+          Sinon.match(function (arg: RequestContext) {
+            return !!arg?.pipeline;
+          })
+        )
+      );
+    });
+    it("Test pipeline setup for items.replace", async function () {
+      setupMockResponse();
+      const container: Container = await getTestContainer("Test Container", client);
+      setupSpyOnRequestHandler();
+      await container
+        .item(item1Definition.id, "dummy_partition_key")
+        .replace(testDataset.itemGetResponse);
+      assert(
+        spy.calledWithMatch(
+          Sinon.match(function (arg: RequestContext) {
+            return !!arg?.pipeline;
+          })
+        )
+      );
+    });
+    it("Test pipeline setup for items.upsert", async function () {
+      setupMockResponse();
+      const container: Container = await getTestContainer("Test Container", client);
+      setupSpyOnRequestHandler();
+      await container.items.upsert(testDataset.itemGetResponse);
+      assert(
+        spy.calledWithMatch(
+          Sinon.match(function (arg: RequestContext) {
+            return !!arg?.pipeline;
+          })
+        )
+      );
+    });
+    it("Test pipeline setup for items.delete", async function () {
+      setupMockResponse();
+      const container: Container = await getTestContainer("Test Container", client);
+      await container.items.create(item1Definition);
+      setupSpyOnRequestHandler();
+      await container.item(item1Definition.id, "dummy_partition_key").delete();
+      assert(
+        spy.calledWithMatch(
+          Sinon.match(function (arg: RequestContext) {
+            return !!arg?.pipeline;
+          })
+        )
+      );
+    });
+    it("Test pipeline setup for items.batch", async function () {
+      setupMockResponse();
+      const container: Container = await getTestContainer("Test Container", client);
+      setupSpyOnRequestHandler();
+      await container.items.batch([]);
+      assert(
+        spy.calledWithMatch(
+          Sinon.match(function (arg: RequestContext) {
+            return !!arg?.pipeline;
+          })
+        )
+      );
+    });
+
+    function setupMockResponse() {
+      if (!nock.isActive()) {
+        nock.activate();
+      }
+      nock(mockedEndpoint).persist(true).get("/").reply(200, {});
+      // headersWithAADAuthToken contains required aad token, nock will only intercept requests if this token is present.
+      nock(mockedEndpoint, requiredHeadersForAADAuth)
+        .persist(true)
+        .post("/dbs")
+        .reply(200, testDataset.databaseGetResponse);
+      nock(mockedEndpoint, requiredHeadersForAADAuth)
+        .persist(true)
+        .post(/\/dbs\/[^/]+\/colls/)
+        .reply(200, testDataset.containerGetResponse);
+      nock(mockedEndpoint, requiredHeadersForAADAuth)
+        .persist(true)
+        .get(/\/dbs\/[^/]+\/colls\/[^/]+/)
+        .reply(200, testDataset.containerGetResponse);
+      nock(mockedEndpoint, requiredHeadersForAADAuth)
+        .persist(true)
+        .post(/\/dbs\/[^/]+\/colls\/[^/]+/)
+        .reply(200, testDataset.containerGetResponse);
+      nock(mockedEndpoint, requiredHeadersForAADAuth)
+        .persist(true)
+        .patch(/\/dbs\/[^/]+\/colls\/[^/]+\/docs\/[^/]+/)
+        .reply(200, testDataset.itemPatchResponse);
+      nock(mockedEndpoint, requiredHeadersForAADAuth)
+        .persist(true)
+        .delete(/\/dbs\/[^/]+\/colls\/[^/]+\/docs\/[^/]+/)
+        .reply(200, testDataset.itemPatchResponse);
+      nock(mockedEndpoint, requiredHeadersForAADAuth)
+        .persist(true)
+        .put(/\/dbs\/[^/]+\/colls\/[^/]+\/docs\/[^/]+/)
+        .reply(200, testDataset.itemGetResponse);
+    }
+  });
+  describe("Client Test With key", function () {
+    it("Test items.create for tokens", async function () {
+      const client = new CosmosClient({
+        endpoint: endpoint,
+        key: masterKey,
+      });
+      const container = await getTestContainer("Test Container", client);
+      setupSpyOnRequestHandler();
+      await container.items.create(item1Definition);
+      assert(
+        spy.calledWithMatch(
+          Sinon.match(function (arg: RequestContext) {
+            const AUTH_PREFIX = `type%3Dmaster%26ver%3D1`;
+            const authHeader: string = arg?.headers["authorization"]?.toString() || "";
+            return authHeader.includes(AUTH_PREFIX);
+          })
+        )
+      );
+    });
+  });
+});

--- a/sdk/cosmosdb/cosmos/tsconfig.strict.json
+++ b/sdk/cosmosdb/cosmos/tsconfig.strict.json
@@ -144,6 +144,7 @@
     "test/internal/unit/utils/batch.spec.ts",
     "test/internal/unit/utils/checkURL.spec.ts",
     "test/internal/unit/utils/offer.spec.ts",
+    "test/internal/unit/client.spec.ts",
     "test/public/common/BaselineTest.PathParser.ts",
     "test/public/common/TestData.ts",
     "test/public/common/setup.ts",


### PR DESCRIPTION
### Packages impacted by this PR
@azure/cosmos

### Issues associated with this PR
https://github.com/Azure/azure-sdk-for-js/issues/20824

### Describe the problem that is addressed by this PR
CosmosClient's patch api is failing for AADCredentials, (It was reported for Managed Identity Credentials). This was due to missing pipeline (responsible for actually fetching auth token) for patch api.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_
Yes

### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [ ] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
