### PR TITLE
[engsys] turn off `sort-imports` linter rule

### DIFF
--- a/common/tools/eslint-plugin-azure-sdk/.eslintrc.json
+++ b/common/tools/eslint-plugin-azure-sdk/.eslintrc.json
@@ -34,7 +34,6 @@
     "no-multi-spaces": "error",
     "no-redeclare": "error",
     "no-useless-escape": "off",
-    "prefer-template": "error",
-    "sort-imports": "error"
+    "prefer-template": "error"
   }
 }

--- a/common/tools/eslint-plugin-azure-sdk/src/configs/azure-sdk-base.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/configs/azure-sdk-base.ts
@@ -66,7 +66,7 @@ export default {
         "no-var": "error",
         "one-var-declaration-per-line": "error",
         "prefer-const": "error",
-        "sort-imports": "warn",
+        "sort-imports": "off",
         "spaced-comment": ["error", "always", { markers: ["/"] }],
         "space-infix-ops": ["error", { int32Hint: false }],
         "use-isnan": "error",

--- a/sdk/core/abort-controller/.eslintrc.json
+++ b/sdk/core/abort-controller/.eslintrc.json
@@ -2,7 +2,6 @@
   "plugins": ["@azure/azure-sdk"],
   "extends": ["plugin:@azure/azure-sdk/azure-sdk-base"],
   "rules": {
-    "@azure/azure-sdk/ts-package-json-types": "off",
-    "sort-imports": "error"
+    "@azure/azure-sdk/ts-package-json-types": "off"
   }
 }

--- a/sdk/core/core-amqp/.eslintrc.json
+++ b/sdk/core/core-amqp/.eslintrc.json
@@ -1,7 +1,0 @@
-{
-  "plugins": ["@azure/azure-sdk"],
-  "extends": ["plugin:@azure/azure-sdk/azure-sdk-base"],
-  "rules": {
-    "sort-imports": "error"
-  }
-}

--- a/sdk/core/core-auth/.eslintrc.json
+++ b/sdk/core/core-auth/.eslintrc.json
@@ -1,7 +1,0 @@
-{
-  "plugins": ["@azure/azure-sdk"],
-  "extends": ["plugin:@azure/azure-sdk/azure-sdk-base"],
-  "rules": {
-    "sort-imports": "error"
-  }
-}

--- a/sdk/core/core-client/.eslintrc.json
+++ b/sdk/core/core-client/.eslintrc.json
@@ -1,7 +1,0 @@
-{
-  "plugins": ["@azure/azure-sdk"],
-  "extends": ["plugin:@azure/azure-sdk/azure-sdk-base"],
-  "rules": {
-    "sort-imports": "error"
-  }
-}

--- a/sdk/core/core-http/.eslintrc.json
+++ b/sdk/core/core-http/.eslintrc.json
@@ -6,7 +6,6 @@
     "@azure/azure-sdk/ts-apiextractor-json-types": "off",
     "@azure/azure-sdk/ts-package-json-types": "off",
     "@azure/azure-sdk/ts-package-json-module": "off",
-    "@azure/azure-sdk/ts-package-json-files-required": "off",
-    "sort-imports": "error"
+    "@azure/azure-sdk/ts-package-json-files-required": "off"
   }
 }

--- a/sdk/core/core-lro/.eslintrc.json
+++ b/sdk/core/core-lro/.eslintrc.json
@@ -1,7 +1,0 @@
-{
-  "plugins": ["@azure/azure-sdk"],
-  "extends": ["plugin:@azure/azure-sdk/azure-sdk-base"],
-  "rules": {
-    "sort-imports": "error"
-  }
-}

--- a/sdk/core/core-paging/.eslintrc.json
+++ b/sdk/core/core-paging/.eslintrc.json
@@ -4,7 +4,6 @@
   "rules": {
     // `package.json`'s sideEffects has to be true because this package loads a
     // polyfill.
-    "@azure/azure-sdk/ts-package-json-sideeffects": "off",
-    "sort-imports": "error"
+    "@azure/azure-sdk/ts-package-json-sideeffects": "off"
   }
 }

--- a/sdk/core/core-tracing/.eslintrc.json
+++ b/sdk/core/core-tracing/.eslintrc.json
@@ -3,7 +3,6 @@
   "extends": ["plugin:@azure/azure-sdk/azure-sdk-base"],
   "rules": {
     "@azure/azure-sdk/ts-no-const-enums": "off",
-    "@azure/azure-sdk/ts-versioning-semver": "warn",
-    "sort-imports": "error"
+    "@azure/azure-sdk/ts-versioning-semver": "warn"
   }
 }

--- a/sdk/core/core-util/.eslintrc.json
+++ b/sdk/core/core-util/.eslintrc.json
@@ -1,7 +1,0 @@
-{
-  "plugins": ["@azure/azure-sdk"],
-  "extends": ["plugin:@azure/azure-sdk/azure-sdk-base"],
-  "rules": {
-    "sort-imports": "error"
-  }
-}

--- a/sdk/core/core-xml/.eslintrc.json
+++ b/sdk/core/core-xml/.eslintrc.json
@@ -1,7 +1,0 @@
-{
-  "plugins": ["@azure/azure-sdk"],
-  "extends": ["plugin:@azure/azure-sdk/azure-sdk-base"],
-  "rules": {
-    "sort-imports": "error"
-  }
-}

--- a/sdk/core/logger/.eslintrc.json
+++ b/sdk/core/logger/.eslintrc.json
@@ -1,7 +1,0 @@
-{
-  "plugins": ["@azure/azure-sdk"],
-  "extends": ["plugin:@azure/azure-sdk/azure-sdk-base"],
-  "rules": {
-    "sort-imports": "error"
-  }
-}

--- a/sdk/eventhub/eventhubs-checkpointstore-table/.eslintrc.json
+++ b/sdk/eventhub/eventhubs-checkpointstore-table/.eslintrc.json
@@ -1,7 +1,0 @@
-{
-  "plugins": ["@azure/azure-sdk"],
-  "extends": ["plugin:@azure/azure-sdk/azure-sdk-base"],
-  "rules": {
-    "sort-imports": "error"
-  }
-}

--- a/sdk/eventhub/mock-hub/.eslintrc.json
+++ b/sdk/eventhub/mock-hub/.eslintrc.json
@@ -1,7 +1,0 @@
-{
-  "plugins": ["@azure/azure-sdk"],
-  "extends": ["plugin:@azure/azure-sdk/azure-sdk-base"],
-  "rules": {
-    "sort-imports": "error"
-  }
-}

--- a/sdk/identity/identity-cache-persistence/.eslintrc.json
+++ b/sdk/identity/identity-cache-persistence/.eslintrc.json
@@ -2,7 +2,6 @@
   "plugins": ["@azure/azure-sdk"],
   "extends": ["plugin:@azure/azure-sdk/azure-sdk-base"],
   "rules": {
-    "@azure/azure-sdk/ts-package-json-module": "off",
-    "sort-imports": "error"
+    "@azure/azure-sdk/ts-package-json-module": "off"
   }
 }

--- a/sdk/identity/identity-vscode/.eslintrc.json
+++ b/sdk/identity/identity-vscode/.eslintrc.json
@@ -2,7 +2,6 @@
   "plugins": ["@azure/azure-sdk"],
   "extends": ["plugin:@azure/azure-sdk/azure-sdk-base"],
   "rules": {
-    "@azure/azure-sdk/ts-package-json-module": "off",
-    "sort-imports": "error"
+    "@azure/azure-sdk/ts-package-json-module": "off"
   }
 }

--- a/sdk/identity/identity/src/credentials/managedIdentityCredential/arcMsi.ts
+++ b/sdk/identity/identity/src/credentials/managedIdentityCredential/arcMsi.ts
@@ -1,4 +1,3 @@
-
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 

--- a/sdk/keyvault/keyvault-admin/.eslintrc.json
+++ b/sdk/keyvault/keyvault-admin/.eslintrc.json
@@ -5,7 +5,6 @@
   "rules": {
     "@azure/azure-sdk/ts-package-json-module": "warn",
     "@typescript-eslint/no-this-alias": "off",
-    "no-use-before-define": "warn",
-    "sort-imports": "error"
+    "no-use-before-define": "warn"
   }
 }

--- a/sdk/keyvault/keyvault-common/.eslintrc.json
+++ b/sdk/keyvault/keyvault-common/.eslintrc.json
@@ -13,7 +13,6 @@
     // this package does not have type declaration file.
     "@azure/azure-sdk/ts-package-json-types": "off",
     // this package does not have a homepage
-    "@azure/azure-sdk/ts-package-json-homepage": "off",
-    "sort-imports": "error"
+    "@azure/azure-sdk/ts-package-json-homepage": "off"
   }
 }

--- a/sdk/mixedreality/mixed-reality-authentication/.eslintrc.json
+++ b/sdk/mixedreality/mixed-reality-authentication/.eslintrc.json
@@ -1,7 +1,0 @@
-{
-  "plugins": ["@azure/azure-sdk"],
-  "extends": ["plugin:@azure/azure-sdk/azure-sdk-base"],
-  "rules": {
-    "sort-imports": "error"
-  }
-}

--- a/sdk/tables/data-tables/.eslintrc.json
+++ b/sdk/tables/data-tables/.eslintrc.json
@@ -2,7 +2,6 @@
   "plugins": ["@azure/azure-sdk"],
   "extends": ["plugin:@azure/azure-sdk/azure-sdk-base"],
   "rules": {
-    "@typescript-eslint/ban-types": "warn",
-    "sort-imports": "error"
+    "@typescript-eslint/ban-types": "warn"
   }
 }


### PR DESCRIPTION
- the default sorting rules are strange
- no automation to fix all the violations
- benefit not worth the effort required to maintain
