### PR TITLE
[ServiceBus] correct core-paging dependency version

### DIFF
--- a/sdk/servicebus/service-bus/package.json
+++ b/sdk/servicebus/service-bus/package.json
@@ -115,7 +115,7 @@
     "@azure/core-client": "^1.0.0",
     "@azure/core-rest-pipeline": "^1.1.0",
     "@azure/core-tracing": "^1.0.0",
-    "@azure/core-paging": "^1.3.1",
+    "@azure/core-paging": "^1.4.0",
     "@azure/core-util": "^1.1.1",
     "@azure/core-xml": "^1.0.0",
     "@azure/logger": "^1.0.0",


### PR DESCRIPTION
It should've been updated to 1.4.0 when merging main but was missed.
