### PR TITLE
[instrumentation] rename of environment variable AZURE_HTTP_TRACING_DISABLED

### DIFF
--- a/sdk/instrumentation/opentelemetry-instrumentation-azure-sdk/CHANGELOG.md
+++ b/sdk/instrumentation/opentelemetry-instrumentation-azure-sdk/CHANGELOG.md
@@ -1,15 +1,11 @@
 # Release History
 
-## 1.0.0-beta.2 (Unreleased)
+## 1.0.0-beta.2 (2020-10-19)
 
 ### Features Added
 
 - Added the ability to disable Azure SDK Spans from being recorded by setting the `AZURE_TRACING_DISABLED` environment variable to true.
-- Added support for `AZURE_HTTP_TRACING_DISABLED` environment variable which allows disabling all children of our core HTTP spans from being recorded.
-
-### Breaking Changes
-
-### Bugs Fixed
+- Added support for `AZURE_HTTP_TRACING_CHILDREN_DISABLED` environment variable which allows disabling all children of our core HTTP spans from being recorded.
 
 ### Other Changes
 

--- a/sdk/instrumentation/opentelemetry-instrumentation-azure-sdk/CHANGELOG.md
+++ b/sdk/instrumentation/opentelemetry-instrumentation-azure-sdk/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.0.0-beta.2 (2020-10-19)
+## 1.0.0-beta.2 (2020-10-20)
 
 ### Features Added
 

--- a/sdk/instrumentation/opentelemetry-instrumentation-azure-sdk/CHANGELOG.md
+++ b/sdk/instrumentation/opentelemetry-instrumentation-azure-sdk/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.0.0-beta.2 (2020-10-20)
+## 1.0.0-beta.2 (2022-10-22)
 
 ### Features Added
 

--- a/sdk/instrumentation/opentelemetry-instrumentation-azure-sdk/src/configuration.ts
+++ b/sdk/instrumentation/opentelemetry-instrumentation-azure-sdk/src/configuration.ts
@@ -8,7 +8,7 @@ export const SDK_VERSION: string = "1.0.0-beta.2";
  *
  * Keys of known environment variables we look up.
  */
-export type KnownEnvironmentKey = "AZURE_HTTP_TRACING_DISABLED" | "AZURE_TRACING_DISABLED";
+export type KnownEnvironmentKey = "AZURE_HTTP_TRACING_CHILDREN_DISABLED" | "AZURE_TRACING_DISABLED";
 
 /**
  * @internal

--- a/sdk/instrumentation/opentelemetry-instrumentation-azure-sdk/src/instrumenter.ts
+++ b/sdk/instrumentation/opentelemetry-instrumentation-azure-sdk/src/instrumenter.ts
@@ -41,7 +41,10 @@ export class OpenTelemetryInstrumenter implements Instrumenter {
         .getTracer(spanOptions.packageName, spanOptions.packageVersion)
         .startSpan(name, toSpanOptions(spanOptions), ctx);
 
-      if (envVarToBoolean("AZURE_HTTP_TRACING_DISABLED") && name.toUpperCase().startsWith("HTTP")) {
+      if (
+        envVarToBoolean("AZURE_HTTP_TRACING_CHILDREN_DISABLED") &&
+        name.toUpperCase().startsWith("HTTP")
+      ) {
         // disable downstream spans
         ctx = suppressTracing(ctx);
       }

--- a/sdk/instrumentation/opentelemetry-instrumentation-azure-sdk/test/public/instrumenter.spec.ts
+++ b/sdk/instrumentation/opentelemetry-instrumentation-azure-sdk/test/public/instrumenter.spec.ts
@@ -203,9 +203,9 @@ describe("OpenTelemetryInstrumenter", () => {
         });
       });
 
-      describe("when AZURE_HTTP_TRACING_DISABLED is set", () => {
+      describe("when AZURE_HTTP_TRACING_CHILDREN_DISABLED is set", () => {
         beforeEach(() => {
-          environmentCache.set("AZURE_HTTP_TRACING_DISABLED", "1");
+          environmentCache.set("AZURE_HTTP_TRACING_CHILDREN_DISABLED", "1");
         });
 
         it("suppresses tracing for downstream spans", () => {
@@ -227,10 +227,10 @@ describe("OpenTelemetryInstrumenter", () => {
         });
       });
 
-      describe("when both AZURE_TRACING_DISABLED and AZURE_HTTP_TRACING_DISABLED are set", () => {
+      describe("when both AZURE_TRACING_DISABLED and AZURE_HTTP_TRACING_CHILDREN_DISABLED are set", () => {
         beforeEach(() => {
           environmentCache.set("AZURE_TRACING_DISABLED", "true");
-          environmentCache.set("AZURE_HTTP_TRACING_DISABLED", "True");
+          environmentCache.set("AZURE_HTTP_TRACING_CHILDREN_DISABLED", "True");
         });
 
         it("creates a non-recording span", () => {


### PR DESCRIPTION
### Packages impacted by this PR

- [@azure/opentelemetry-instrumentation-azure-sdk]

### Issues associated with this PR

- #20834

### Describe the problem that is addressed by this PR

Renamed `AZURE_HTTP_TRACING_DISABLED` to `AZURE_HTTP_TRACING_CHILDREN_DISABLED` based upon recommendation by @xirzec on https://github.com/Azure/azure-sdk-for-js/pull/20776#discussion_r826428637

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?

Chose easiest rename option.


### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_

- #20776

### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [x] Added a changelog (if necessary)
