### PR TITLE
[keyvault] Update version policy for keyvault-common

### DIFF
--- a/rush.json
+++ b/rush.json
@@ -589,7 +589,7 @@
     {
       "packageName": "@azure/keyvault-common",
       "projectFolder": "sdk/keyvault/keyvault-common",
-      "versionPolicyName": "utility"
+      "versionPolicyName": "client"
     },
     {
       "packageName": "@azure/keyvault-admin",


### PR DESCRIPTION
### Packages impacted by this PR

- `@azure/keyvault-common`

### Issues associated with this PR

- #22705
- #23355 

### Describe the problem that is addressed by this PR

Forgot to change this property in `rush.json`. Setting this should let the pipeline publish an alpha for `keyvault-common`.